### PR TITLE
EES-5139 Add API data set details to data set file endpoints

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetCandidatesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetCandidatesControllerTests.cs
@@ -18,7 +18,7 @@ using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Public.Data;
 
-public class DataSetCandidatesControllerTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+public abstract class DataSetCandidatesControllerTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
 {
     private const string BaseUrl = "api/public-data/data-set-candidates";
 
@@ -161,7 +161,7 @@ public class DataSetCandidatesControllerTests(TestApplicationFactory testApp) : 
 
             File file = DataFixture
                 .DefaultFile()
-                .WithPublicDataSetVersionId(Guid.NewGuid());
+                .WithPublicApiDataSetId(Guid.NewGuid());
 
             var releaseVersion = release.Versions.Single();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240514011937_EES5139_ReplaceFilePublicDataSetVersionIdWithSeparateColumns.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240514011937_EES5139_ReplaceFilePublicDataSetVersionIdWithSeparateColumns.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240514011937_EES5139_ReplaceFilePublicDataSetVersionIdWithSeparateColumns")]
+    partial class EES5139_ReplaceFilePublicDataSetVersionIdWithSeparateColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240514011937_EES5139_ReplaceFilePublicDataSetVersionIdWithSeparateColumns.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240514011937_EES5139_ReplaceFilePublicDataSetVersionIdWithSeparateColumns.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES5139_ReplaceFilePublicDataSetVersionIdWithSeparateColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Files_PublicDataSetVersionId",
+                table: "Files");
+
+            migrationBuilder.DropColumn(
+                name: "PublicDataSetVersionId",
+                table: "Files");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "PublicApiDataSetId",
+                table: "Files",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PublicApiDataSetVersion",
+                table: "Files",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Files_PublicApiDataSetId_PublicApiDataSetVersion",
+                table: "Files",
+                columns: new[] { "PublicApiDataSetId", "PublicApiDataSetVersion" },
+                unique: true,
+                filter: "[PublicApiDataSetId] IS NOT NULL AND [PublicApiDataSetVersion] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Files_PublicApiDataSetId_PublicApiDataSetVersion",
+                table: "Files");
+
+            migrationBuilder.DropColumn(
+                name: "PublicApiDataSetVersion",
+                table: "Files");
+
+            migrationBuilder.DropColumn(
+                name: "PublicApiDataSetId",
+                table: "Files");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "PublicDataSetVersionId",
+                table: "Files");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Files_PublicDataSetVersionId",
+                table: "Files",
+                column: "PublicDataSetVersionId");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ReleaseService.cs
@@ -40,13 +40,14 @@ public class ReleaseService(
             .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId, cancellationToken: cancellationToken);
     }
 
-    private async Task<Either<ActionResult, IReadOnlyList<ApiDataSetCandidateViewModel>>> GetApiDataSetCandidates(Guid releaseVersionId)
+    private async Task<Either<ActionResult, IReadOnlyList<ApiDataSetCandidateViewModel>>> GetApiDataSetCandidates(
+        Guid releaseVersionId)
     {
         return await contentDbContext.ReleaseFiles
             .AsNoTracking()
             .Where(rf => rf.ReleaseVersionId == releaseVersionId)
             .Where(rf => rf.File.Type == FileType.Data)
-            .Where(rf => rf.File.PublicDataSetVersionId == null)
+            .Where(rf => rf.File.PublicApiDataSetId == null)
             .Where(rf => rf.File.ReplacedById == null)
             .Where(rf => rf.File.ReplacingId == null)
             .Select(rf => new ApiDataSetCandidateViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
@@ -22,7 +22,7 @@ using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers;
 
-public class DataSetFilesControllerCachingTests
+public static class DataSetFilesControllerCachingTests
 {
     public class ListDataSetsTests : CacheServiceTestFixture
     {
@@ -44,6 +44,7 @@ public class DataSetFilesControllerCachingTests
             {
                 new()
                 {
+                    Id = Guid.NewGuid(),
                     FileId = Guid.NewGuid(),
                     Filename = "Filename.csv",
                     FileSize = "1 Mb",
@@ -64,9 +65,14 @@ public class DataSetFilesControllerCachingTests
                         Id = Guid.NewGuid(),
                         Title = "Academic year 2001/02"
                     },
+                    Api = new DataSetFileApiViewModel
+                    {
+                        Id = Guid.NewGuid(),
+                        Version = "1.0.0"
+                    },
+                    Meta = new DataSetFileMetaViewModel(),
                     LatestData = true,
                     Published = DateTime.UtcNow,
-                    HasApiDataSet = true
                 }
             }, 1, 1, 10);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -698,8 +698,8 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                 var releaseVersionFiles = _fixture.DefaultReleaseFile()
                     .WithReleaseVersion(publication.ReleaseVersions[0])
                     .WithFiles(_fixture.DefaultFile()
-                        .ForIndex(0, s => s.SetPublicDataSetVersionId(Guid.NewGuid()))
-                        .ForIndex(1, s => s.SetPublicDataSetVersionId(Guid.NewGuid()))
+                        .ForIndex(0, s => s.SetPublicApiDataSetId(Guid.NewGuid()))
+                        .ForIndex(1, s => s.SetPublicApiDataSetId(Guid.NewGuid()))
                         .GenerateList(5))
                     .GenerateList();
 
@@ -722,7 +722,7 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                 var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>();
 
                 var expectedReleaseFiles = releaseVersionFiles
-                    .Where(rf => rf.File.PublicDataSetVersionId.HasValue)
+                    .Where(rf => rf.File.PublicApiDataSetId.HasValue)
                     .OrderBy(rf => rf.Name)
                     .ToList();
 
@@ -746,8 +746,8 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                 var releaseVersionFiles = _fixture.DefaultReleaseFile()
                     .WithReleaseVersion(publication.ReleaseVersions[0])
                     .WithFiles(_fixture.DefaultFile()
-                        .ForIndex(0, s => s.SetPublicDataSetVersionId(Guid.NewGuid()))
-                        .ForIndex(1, s => s.SetPublicDataSetVersionId(Guid.NewGuid()))
+                        .ForIndex(0, s => s.SetPublicApiDataSetId(Guid.NewGuid()))
+                        .ForIndex(1, s => s.SetPublicApiDataSetId(Guid.NewGuid()))
                         .GenerateList(5))
                     .GenerateList();
 
@@ -1782,8 +1782,7 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                     () => Assert.Equal(releaseVersion.Id == publication.LatestPublishedReleaseVersionId,
                         viewModel.LatestData),
                     () => Assert.Equal(releaseFile.ReleaseVersion.Published!.Value, viewModel.Published),
-                    () => Assert.Equal(releaseFile.File.PublicDataSetVersionId.HasValue,
-                        viewModel.HasApiDataSet)
+                    () => Assert.Equal(releaseFile.File.PublicApiDataSetId.HasValue, viewModel.HasApiDataSet)
                 );
             });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -49,12 +49,8 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
         {
         }
 
-        public class FilterTests : ListDataSetFilesTests
+        public class FilterTests(TestApplicationFactory<TestStartup> testApp) : ListDataSetFilesTests(testApp)
         {
-            public FilterTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
-            {
-            }
-
             [Fact]
             public async Task FilterByReleaseId_Success()
             {
@@ -698,8 +694,12 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                 var releaseVersionFiles = _fixture.DefaultReleaseFile()
                     .WithReleaseVersion(publication.ReleaseVersions[0])
                     .WithFiles(_fixture.DefaultFile()
-                        .ForIndex(0, s => s.SetPublicApiDataSetId(Guid.NewGuid()))
-                        .ForIndex(1, s => s.SetPublicApiDataSetId(Guid.NewGuid()))
+                        .ForIndex(0, s => s
+                            .SetPublicApiDataSetId(Guid.NewGuid())
+                            .SetPublicApiDataSetVersion(major: 1, minor: 0))
+                        .ForIndex(1, s => s
+                            .SetPublicApiDataSetId(Guid.NewGuid())
+                            .SetPublicApiDataSetVersion(major: 2, minor: 0))
                         .GenerateList(5))
                     .GenerateList();
 
@@ -746,8 +746,12 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                 var releaseVersionFiles = _fixture.DefaultReleaseFile()
                     .WithReleaseVersion(publication.ReleaseVersions[0])
                     .WithFiles(_fixture.DefaultFile()
-                        .ForIndex(0, s => s.SetPublicApiDataSetId(Guid.NewGuid()))
-                        .ForIndex(1, s => s.SetPublicApiDataSetId(Guid.NewGuid()))
+                        .ForIndex(0, s => s
+                            .SetPublicApiDataSetId(Guid.NewGuid())
+                            .SetPublicApiDataSetVersion(major: 1, minor: 1))
+                        .ForIndex(1, s => s
+                            .SetPublicApiDataSetId(Guid.NewGuid())
+                            .SetPublicApiDataSetVersion(major: 2, minor: 0))
                         .GenerateList(5))
                     .GenerateList();
 
@@ -817,12 +821,8 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
             }
         }
 
-        public class SortByTests : ListDataSetFilesTests
+        public class SortByTests(TestApplicationFactory<TestStartup> testApp) : ListDataSetFilesTests(testApp)
         {
-            public SortByTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
-            {
-            }
-
             [Theory]
             [InlineData(SortDirection.Asc)]
             [InlineData(null)]
@@ -1238,12 +1238,9 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
             }
         }
 
-        public class SupersededPublicationTests : ListDataSetFilesTests
+        public class SupersededPublicationTests(TestApplicationFactory<TestStartup> testApp)
+            : ListDataSetFilesTests(testApp)
         {
-            public SupersededPublicationTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
-            {
-            }
-
             [Fact]
             public async Task PublicationIsSuperseded_DataSetsOfSupersededPublicationsAreExcluded()
             {
@@ -1386,12 +1383,8 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
             }
         }
 
-        public class ValidationTests : ListDataSetFilesTests
+        public class ValidationTests(TestApplicationFactory<TestStartup> testApp) : ListDataSetFilesTests(testApp)
         {
-            public ValidationTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
-            {
-            }
-
             [Theory]
             [InlineData(0)]
             [InlineData(-1)]
@@ -1588,12 +1581,8 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
             }
         }
 
-        public class MiscellaneousTests : ListDataSetFilesTests
+        public class MiscellaneousTests(TestApplicationFactory<TestStartup> testApp) : ListDataSetFilesTests(testApp)
         {
-            public MiscellaneousTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
-            {
-            }
-
             [Fact]
             public async Task DataSetFileMetaCorrectlyReturned_Success()
             {
@@ -1765,6 +1754,7 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                 var releaseVersion = releaseFile.ReleaseVersion;
                 var publication = releaseVersion.Publication;
                 var theme = publication.Topic.Theme;
+                var publicApiDataSetVersion = releaseFile.File.PublicApiDataSetVersion;
 
                 Assert.Multiple(
                     () => Assert.Equal(releaseFile.FileId, viewModel.FileId),
@@ -1782,7 +1772,12 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                     () => Assert.Equal(releaseVersion.Id == publication.LatestPublishedReleaseVersionId,
                         viewModel.LatestData),
                     () => Assert.Equal(releaseFile.ReleaseVersion.Published!.Value, viewModel.Published),
-                    () => Assert.Equal(releaseFile.File.PublicApiDataSetId.HasValue, viewModel.HasApiDataSet)
+                    () => Assert.Equal(releaseFile.File.PublicApiDataSetId, viewModel.Api?.Id),
+                    () => Assert.Equal(
+                        publicApiDataSetVersion is not null
+                            ? $"{publicApiDataSetVersion.Major}.{publicApiDataSetVersion.Minor}"
+                            : null,
+                        viewModel.Api?.Version)
                 );
             });
         }
@@ -1815,12 +1810,8 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
         }
     }
 
-    public class GetDataSetFileTests : DataSetFilesControllerTests
+    public class GetDataSetFileTests(TestApplicationFactory<TestStartup> testApp) : DataSetFilesControllerTests(testApp)
     {
-        public GetDataSetFileTests(TestApplicationFactory<TestStartup> testApp) : base(testApp)
-        {
-        }
-
         [Fact]
         public async Task FetchDataSetDetails_Success()
         {
@@ -1834,7 +1825,10 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
             ReleaseFile releaseFile = _fixture.DefaultReleaseFile()
                 .WithReleaseVersion(publication.ReleaseVersions[0])
                 .WithFile(_fixture.DefaultFile()
-                    .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()));
+                    .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta())
+                    .WithPublicApiDataSetId(Guid.NewGuid())
+                    .WithPublicApiDataSetVersion(major: 1, minor: 0)
+                );
 
             var client = BuildApp()
                 .AddContentDbTestData(context =>
@@ -1868,6 +1862,12 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
             Assert.Equal(publication.Title, viewModel.Release.Publication.Title);
             Assert.Equal(publication.Slug, viewModel.Release.Publication.Slug);
             Assert.Equal(publication.Topic.Theme.Title, viewModel.Release.Publication.ThemeTitle);
+
+            Assert.NotNull(viewModel.Api);
+            Assert.Equal(file.PublicApiDataSetId, viewModel.Api.Id);
+            Assert.Equal(
+                $"{file.PublicApiDataSetVersion!.Major}.{file.PublicApiDataSetVersion.Minor}",
+                viewModel.Api.Version);
 
             var dataSetFileMeta = file.DataSetFileMeta;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
@@ -50,7 +50,7 @@ public class DataSetFilesController : ControllerBase
     }
 
     [HttpGet("data-set-files/{dataSetFileId:guid}")]
-    public async Task<ActionResult<DataSetFileViewModel>> GetDataSet(
+    public async Task<ActionResult<DataSetFileViewModel>> GetDataSetFile(
         Guid dataSetFileId)
     {
         return await _dataSetFileService

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 
@@ -68,10 +69,22 @@ public static class FileGeneratorExtensions
         Guid replacedById)
         => generator.ForInstance(s => s.SetReplacedById(replacedById));
 
-    public static Generator<File> WithPublicDataSetVersionId(
+    public static Generator<File> WithPublicApiDataSetId(
         this Generator<File> generator,
-        Guid publicDataSetVersionId)
-        => generator.ForInstance(s => s.SetPublicDataSetVersionId(publicDataSetVersionId));
+        Guid publicDataSetId)
+        => generator.ForInstance(s => s.SetPublicApiDataSetId(publicDataSetId));
+
+    public static Generator<File> WithPublicApiDataSetVersion(
+        this Generator<File> generator,
+        int major,
+        int minor,
+        int patch = 0)
+        => generator.ForInstance(s => s.SetPublicApiDataSetVersion(major, minor, patch));
+
+    public static Generator<File> WithPublicApiDataSetVersion(
+        this Generator<File> generator,
+        SemVersion version)
+        => generator.ForInstance(s => s.SetPublicApiDataSetVersion(version));
 
     public static Generator<File> WithRootPath(
         this Generator<File> generator,
@@ -129,10 +142,24 @@ public static class FileGeneratorExtensions
         Guid replacedById)
         => setters.Set(f => f.ReplacedById, replacedById);
 
-    public static InstanceSetters<File> SetPublicDataSetVersionId(
+    public static InstanceSetters<File> SetPublicApiDataSetId(
         this InstanceSetters<File> setters,
-        Guid publicDataSetVersionId)
-        => setters.Set(f => f.PublicDataSetVersionId, publicDataSetVersionId);
+        Guid publicDataSetId)
+        => setters.Set(f => f.PublicApiDataSetId, publicDataSetId);
+
+    public static InstanceSetters<File> SetPublicApiDataSetVersion(
+        this InstanceSetters<File> setters,
+        int major,
+        int minor,
+        int patch = 0)
+        => setters.Set(
+            f => f.PublicApiDataSetVersion,
+            new SemVersion(major: major, minor: minor, patch: patch));
+
+    public static InstanceSetters<File> SetPublicApiDataSetVersion(
+        this InstanceSetters<File> setters,
+        SemVersion version)
+        => setters.Set(f => f.PublicApiDataSetVersion, version);
 
     public static InstanceSetters<File> SetReplacing(
         this InstanceSetters<File> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Newtonsoft.Json;
+using Semver;
 
 // ReSharper disable StringLiteralTypo
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
@@ -432,7 +433,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     .HasConversion(
                         v => JsonConvert.SerializeObject(v),
                         v => JsonConvert.DeserializeObject<DataSetFileMeta>(v));
-                entity.HasIndex(f => f.PublicDataSetVersionId);
+
+                entity.Property(f => f.PublicApiDataSetVersion)
+                    .HasMaxLength(20)
+                    .HasConversion(
+                        v => v.ToString(),
+                        v => SemVersion.Parse(v, SemVersionStyles.Strict, 20)
+                    );
+
+                entity.HasIndex(f => new {
+                        PublicDataSetId = f.PublicApiDataSetId, PublicDataSetVersion = f.PublicApiDataSetVersion })
+                    .IsUnique();
             });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -48,5 +48,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public User? CreatedBy { get; set; }
 
         public Guid? CreatedById { get; set; }
+
+        public string? PublicApiVersionString => PublicApiDataSetVersion is not null
+                ? $"{PublicApiDataSetVersion.Major}.{PublicApiDataSetVersion.Minor}"
+                : null;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
@@ -22,9 +23,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public int? DataSetFileVersion { get; set; }
 
-        public DataSetFileMeta?  DataSetFileMeta { get; set; }
+        public DataSetFileMeta? DataSetFileMeta { get; set; }
 
-        public Guid? PublicDataSetVersionId { get; set; }
+        public Guid? PublicApiDataSetId { get; set; }
+
+        public SemVersion? PublicApiDataSetVersion { get; set; }
 
         public Guid? ReplacedById { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.SortDirection;
 using static GovUk.Education.ExploreEducationStatistics.Content.Requests.DataSetsListRequestSortBy;
+using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
 using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
@@ -118,7 +119,7 @@ public class DataSetFileService : IDataSetFileService
                 LatestData = result.Value.ReleaseVersionId ==
                              result.Value.ReleaseVersion.Publication.LatestPublishedReleaseVersionId,
                 Published = result.Value.ReleaseVersion.Published!.Value,
-                HasApiDataSet = result.Value.File.PublicApiDataSetId.HasValue,
+                Api = BuildDataSetFileApiViewModel(result.Value.File),
                 Meta = BuildDataSetFileMetaViewModel(
                     result.Value.File.DataSetFileMeta,
                     result.Value.FilterSequence,
@@ -191,6 +192,7 @@ public class DataSetFileService : IDataSetFileService
                 releaseFile.File.DataSetFileMeta,
                 releaseFile.FilterSequence,
                 releaseFile.IndicatorSequence),
+            Api = BuildDataSetFileApiViewModel(releaseFile.File)
         };
     }
 
@@ -244,6 +246,20 @@ public class DataSetFileService : IDataSetFileService
                 .OrderBy(i => Array.IndexOf(indicatorSequence, i.Id));
 
         return indicators.Select(i => i.Label).ToList();
+    }
+
+    private static DataSetFileApiViewModel? BuildDataSetFileApiViewModel(File file)
+    {
+        if (file.PublicApiDataSetId is null || file.PublicApiVersionString is null)
+        {
+            return null;
+        }
+
+        return new DataSetFileApiViewModel
+        {
+            Id = file.PublicApiDataSetId.Value,
+            Version = file.PublicApiVersionString,
+        };
     }
 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -118,7 +118,7 @@ public class DataSetFileService : IDataSetFileService
                 LatestData = result.Value.ReleaseVersionId ==
                              result.Value.ReleaseVersion.Publication.LatestPublishedReleaseVersionId,
                 Published = result.Value.ReleaseVersion.Published!.Value,
-                HasApiDataSet = result.Value.File.PublicDataSetVersionId.HasValue,
+                HasApiDataSet = result.Value.File.PublicApiDataSetId.HasValue,
                 Meta = BuildDataSetFileMetaViewModel(
                     result.Value.File.DataSetFileMeta,
                     result.Value.FilterSequence,
@@ -343,7 +343,7 @@ internal static class ReleaseFileQueryableExtensions
         return dataSetType switch
         {
             DataSetType.All => query,
-            DataSetType.Api => query.Where(rf => rf.File.PublicDataSetVersionId.HasValue),
+            DataSetType.Api => query.Where(rf => rf.File.PublicApiDataSetId.HasValue),
             _ => throw new ArgumentOutOfRangeException(nameof(dataSetType)),
         };
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileApiViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileApiViewModel.cs
@@ -1,0 +1,8 @@
+namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+
+public record DataSetFileApiViewModel
+{
+    public required Guid Id { get; init; }
+
+    public required string Version { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileSummaryViewModel.cs
@@ -4,31 +4,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 
 public record DataSetFileSummaryViewModel
 {
-    public Guid Id { get; init; }
+    public required Guid Id { get; init; }
 
-    public Guid FileId { get; init; }
+    public required Guid FileId { get; init; }
 
-    public string Filename { get; init; } = string.Empty;
+    public required string Filename { get; init; }
 
-    public string FileSize { get; init; } = string.Empty;
+    public required string FileSize { get; init; }
 
     public string FileExtension => Path.GetExtension(Filename).TrimStart('.');
 
-    public string Title { get; init; } = string.Empty;
+    public required string Title { get; init; }
 
-    public string Content { get; init; } = string.Empty;
+    public required string Content { get; init; }
 
-    public IdTitleViewModel Theme { get; init; } = null!;
+    public required IdTitleViewModel Theme { get; init; }
 
-    public IdTitleViewModel Publication { get; init; } = null!;
+    public required IdTitleViewModel Publication { get; init; }
 
-    public IdTitleViewModel Release { get; init; } = null!;
+    public required IdTitleViewModel Release { get; init; }
 
-    public bool LatestData { get; init; }
+    public required bool LatestData { get; init; }
 
-    public DateTime Published { get; init; }
+    public required DateTime Published { get; init; }
 
-    public bool HasApiDataSet { get; init; }
+    public required DataSetFileMetaViewModel Meta { get; init; }
 
-    public DataSetFileMetaViewModel Meta { get; init; } = null!;
+    public DataSetFileApiViewModel? Api { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileViewModel.cs
@@ -6,53 +6,55 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 
 public record DataSetFileViewModel
 {
-    public Guid Id { get; init; }
+    public required Guid Id { get; init; }
 
-    public string Title { get; init; } = string.Empty;
+    public required string Title { get; init; }
 
-    public string Summary { get; init; } = string.Empty;
+    public required string Summary { get; init; }
 
-    public DataSetFileFileViewModel File { get; init; } = null!;
+    public required DataSetFileFileViewModel File { get; init; }
 
-    public DataSetFileReleaseViewModel Release { get; init; } = null!;
+    public required DataSetFileReleaseViewModel Release { get; init; }
 
-    public DataSetFileMetaViewModel Meta { get; init; } = null!;
+    public required DataSetFileMetaViewModel Meta { get; init; }
+
+    public DataSetFileApiViewModel? Api { get; set; }
 }
 
 public record DataSetFilePublicationViewModel
 {
-    public Guid Id { get; init; }
+    public required Guid Id { get; init; }
 
-    public string Title { get; init; } = string.Empty;
+    public required string Title { get; init; }
 
-    public string Slug { get; init; } = string.Empty;
+    public required string Slug { get; init; }
 
-    public string ThemeTitle { get; init; } = string.Empty;
+    public required string ThemeTitle { get; init; }
 }
 
 public record DataSetFileReleaseViewModel
 {
-    public Guid Id { get; init; }
+    public required Guid Id { get; init; }
 
-    public string Title { get; init; } = string.Empty;
+    public required string Title { get; init; }
 
-    public string Slug { get; init; } = string.Empty;
+    public required string Slug { get; init; }
 
     [JsonConverter(typeof(StringEnumConverter))]
-    public ReleaseType Type { get; init; }
+    public required ReleaseType Type { get; init; }
 
-    public bool IsLatestPublishedRelease { get; init; }
+    public required bool IsLatestPublishedRelease { get; init; }
 
-    public DateTime Published { get; init; }
+    public required DateTime Published { get; init; }
 
-    public DataSetFilePublicationViewModel Publication { get; init; } = null!;
+    public required DataSetFilePublicationViewModel Publication { get; init; }
 }
 
 public record DataSetFileFileViewModel
 {
-    public Guid Id { get; init; }
+    public required Guid Id { get; init; }
 
-    public string Name { get; init; } = string.Empty;
+    public required string Name { get; init; }
 
-    public string Size { get; init; } = string.Empty;
+    public required string Size { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
@@ -66,6 +67,8 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
     public DateTimeOffset? Updated { get; set; }
 
     public string Version => $"{VersionMajor}.{VersionMinor}";
+
+    public SemVersion FullSemanticVersion() => new(major: VersionMajor, minor: VersionMinor, patch: VersionPatch);
 
     public DataSetVersionType VersionType
         => VersionMinor == 0 ? DataSetVersionType.Major : DataSetVersionType.Minor;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetService.cs
@@ -148,7 +148,8 @@ public class DataSetService(
         DataSetVersion dataSetVersion,
         CancellationToken cancellationToken)
     {
-        releaseFile.File.PublicDataSetVersionId = dataSetVersion.Id;
+        releaseFile.File.PublicApiDataSetId = dataSetVersion.DataSetId;
+        releaseFile.File.PublicApiDataSetVersion = dataSetVersion.FullSemanticVersion();
         await contentDbContext.SaveChangesAsync(cancellationToken);
     }
 

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
@@ -5,7 +5,10 @@ import {
 
 export const testDataSetFileSummaries: DataSetFileSummary[] = [
   {
-    hasApiDataSet: true,
+    api: {
+      id: 'api-data-set-id-1',
+      version: '1.0',
+    },
     id: 'datasetfile-id-1',
     fileExtension: 'csv',
     fileId: 'file-id-1',
@@ -39,7 +42,6 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     title: 'Data set 1',
   },
   {
-    hasApiDataSet: false,
     id: 'datasetfile-id-2',
     fileExtension: 'csv',
     fileId: 'file-id-2',

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
@@ -48,7 +48,7 @@ export default function DataSetFileSummary({
       geographicLevels = [],
       indicators = [],
     },
-    hasApiDataSet,
+    api,
     latestData,
     publication,
     published,
@@ -111,7 +111,7 @@ export default function DataSetFileSummary({
         compact
         noBorder
       >
-        {(showLatestDataTag || hasApiDataSet) && (
+        {(showLatestDataTag || api) && (
           <SummaryListItem term="Status">
             <TagGroup>
               {showLatestDataTag && (
@@ -121,7 +121,7 @@ export default function DataSetFileSummary({
                     : 'This is not the latest data'}
                 </Tag>
               )}
-              {hasApiDataSet && <Tag colour="grey">Available by API</Tag>}
+              {api && <Tag colour="grey">Available by API</Tag>}
             </TagGroup>
           </SummaryListItem>
         )}

--- a/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
+++ b/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
@@ -8,7 +8,6 @@ export interface DataSetFile {
   title: string;
   summary: string;
   file: { id: string; name: string; size: string };
-  hasApiDataSet?: boolean;
   release: {
     id: string;
     isLatestPublishedRelease: boolean;
@@ -23,6 +22,7 @@ export interface DataSetFile {
     title: string;
     type: ReleaseType;
   };
+  api?: DataSetFileApi;
   meta: {
     geographicLevels: string[];
     timePeriod: {
@@ -41,7 +41,6 @@ export interface DataSetFileSummary {
   filename: string;
   fileSize: string;
   fileExtension: string;
-  hasApiDataSet?: boolean;
   title: string;
   content: string;
   theme: {
@@ -58,6 +57,7 @@ export interface DataSetFileSummary {
   };
   latestData: boolean;
   published: Date;
+  api?: DataSetFileApi;
   meta: {
     geographicLevels: string[];
     timePeriod: {
@@ -68,6 +68,11 @@ export interface DataSetFileSummary {
     filters: string[];
     indicators: string[];
   };
+}
+
+export interface DataSetFileApi {
+  id: string;
+  version: string;
 }
 
 export const dataSetFileSortOptions = [


### PR DESCRIPTION
This PR adds missing API data set details to view models returned from the data set file endpoints in the content API. This essentially adds the following to the respective view models:

```json
{
  "api": {
    "id": "api-data-set-id",
    "version": "1.0"
  }
}
```

To implement this, we have updated `File` entity to have `PublicApiDataSetId` and `PublicApiDataSetVersion` columns instead of a single `PublicDataSetVersionId` column. This allows us to circumvent making an additional public API query to get the version number.

