### PR TITLE
EES-5140 Fix DataSetFileMeta / Add TimePeriodRangeMeta

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
@@ -15,7 +15,6 @@ using GovUk.Education.ExploreEducationStatistics.Data.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
-using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataImportServiceTests.cs
@@ -15,7 +15,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
 using Moq;
-using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Data.Processor.Model.ProcessorQueues;
 using static Moq.MockBehavior;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataSetFileMetaMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/DataSetFileMetaMigrationController.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -35,7 +34,6 @@ public class DataSetFileMetaMigrationController : ControllerBase
     {
         public bool IsDryRun;
         public int Processed;
-        public int LeftToProcess;
         public List<string> Errors;
     }
 
@@ -45,25 +43,18 @@ public class DataSetFileMetaMigrationController : ControllerBase
         public TimeIdentifier TimeIdentifier;
     }
 
-    [HttpPatch("bau/migrate-datasetfilemeta")]
+    [HttpPatch("bau/migrate-datasetfilemeta-timeperiodrange")]
     public async Task<DataSetFileMetaMigrationResult> MigrateReleaseSeries(
         [FromQuery] bool dryRun = true,
-        [FromQuery] int? num = null,
         CancellationToken cancellationToken = default)
     {
-        var filesQueryable = _contentDbContext.Files
+        var files = await _contentDbContext.Files
             .Where(f =>
-                f.DataSetFileMeta == null
-                && f.Type == FileType.Data);
+                f.DataSetFileMeta != null
+                && f.Type == FileType.Data)
+            .ToListAsync();
 
-        if (num is > 0)
-        {
-            filesQueryable = filesQueryable.Take(num.Value);
-        }
-
-        var files = await filesQueryable.ToListAsync(cancellationToken: cancellationToken);
-
-        var numDataSetFileMetaSet = 0;
+        var numTimePeriodRangeSet = 0;
         var errors = new List<string>();
 
         foreach (var file in files)
@@ -73,9 +64,10 @@ public class DataSetFileMetaMigrationController : ControllerBase
                 .Where(o => o.SubjectId == file.SubjectId);
 
             var timePeriods = await observations
-                .Select(o => new TimePeriod{ Year = o.Year, TimeIdentifier = o.TimeIdentifier })
+                .Select(o => new TimePeriodRangeBoundMeta{ Year = o.Year, TimeIdentifier = o.TimeIdentifier })
                 .Distinct()
                 .OrderBy(tp => tp.Year)
+                .ThenBy(tp => tp.TimeIdentifier)
                 .ToListAsync(cancellationToken: cancellationToken);
 
             if (timePeriods.Count == 0)
@@ -85,46 +77,17 @@ public class DataSetFileMetaMigrationController : ControllerBase
                 continue;
             }
 
-            var geographicLevels = await observations
-                .Select(o => o.Location.GeographicLevel)
-                .Distinct()
-                .OrderBy(gl => gl)
-                .ToListAsync(cancellationToken: cancellationToken);
+            _contentDbContext.Update(file);
 
-            var filters = await _statisticsDbContext.Filter
-                .Where(f => f.SubjectId == file.SubjectId)
-                .OrderBy(f => f.Label)
-                .Select(f => new FilterMeta
-                {
-                    Id = f.Id,
-                    Label = f.Label,
-                    Hint = f.Hint,
-                    ColumnName = f.Name,
-                })
-                .ToListAsync(cancellationToken: cancellationToken);
-
-            var indicators = await _statisticsDbContext.Indicator
-                .Where(i => i.IndicatorGroup.SubjectId == file.SubjectId)
-                .Select(i => new IndicatorMeta
-                {
-                    Id = i.Id,
-                    Label = i.Label,
-                    ColumnName = i.Name,
-                })
-                .OrderBy(i => i.Label)
-                .ToListAsync(cancellationToken: cancellationToken);
-
-            file.DataSetFileMeta = new DataSetFileMeta
+            file.DataSetFileMeta.TimePeriodRange = new TimePeriodRangeMeta
             {
-                GeographicLevels = geographicLevels
-                    .Select(gl => gl.GetEnumLabel()).ToList(),
-                TimeIdentifier = timePeriods[0].TimeIdentifier,
-                Years = timePeriods.Select(tp => tp.Year).ToList(),
-                Filters = filters,
-                Indicators = indicators,
+                Start = timePeriods.First(),
+                End = timePeriods.Last(),
             };
+            file.DataSetFileMeta.TimeIdentifier = null;
+            file.DataSetFileMeta.Years = null;
 
-            numDataSetFileMetaSet++;
+            numTimePeriodRangeSet++;
         }
 
         if (!dryRun)
@@ -135,11 +98,7 @@ public class DataSetFileMetaMigrationController : ControllerBase
         return new DataSetFileMetaMigrationResult
         {
             IsDryRun = dryRun,
-            Processed = numDataSetFileMetaSet,
-            LeftToProcess = _contentDbContext.Files
-                .Count(f =>
-                    f.DataSetFileMeta == null
-                    && f.Type == FileType.Data),
+            Processed = numTimePeriodRangeSet,
             Errors = errors,
         };
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/GeographicLevelsListJsonConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Converters/GeographicLevelsListJsonConverter.cs
@@ -1,0 +1,51 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Converters;
+
+public class GeographicLevelsListJsonConverter : JsonConverter<IList<GeographicLevel>>
+{
+    public override void WriteJson(JsonWriter writer, IList<GeographicLevel>? value, JsonSerializer serializer)
+    {
+        writer.WriteStartArray();
+        if (value != null)
+        {
+            foreach (var gl in value)
+            {
+                writer.WriteValue(gl.GetEnumValue());
+            }
+        }
+        writer.WriteEndArray();
+    }
+
+    public override List<GeographicLevel>? ReadJson(
+        JsonReader reader,
+        Type objectType,
+        IList<GeographicLevel>? existingValue,
+        bool hasExistingValue,
+        JsonSerializer serializer)
+    {
+        var geographicLevels = (GeographicLevel[])Enum.GetValues(typeof(GeographicLevel));
+        var result = new List<GeographicLevel>();
+
+        while (reader.Read() && reader.TokenType == JsonToken.String)
+        {
+            var value = (string)reader.Value;
+            var geographicLevel = geographicLevels.First(gl => gl.GetEnumValue() == value
+                                                               || gl.GetEnumLabel() == value); // EES-4670 Can be removed after migration done in EES-5140
+            result.Add(geographicLevel);
+        }
+
+        if (reader.TokenType != JsonToken.EndArray)
+        {
+            return null;
+        }
+
+        return result;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/TimePeriodLabelFormatter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/TimePeriodLabelFormatter.cs
@@ -22,6 +22,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
         }
 
         public static string Format(
+            string period,
+            TimeIdentifier timeIdentifier,
+            TimePeriodLabelFormat? overridingLabelFormat = null)
+        {
+            var year = int.Parse(period); // Will change in the future - see EES-3109
+            return FormatterFor(timeIdentifier, overridingLabelFormat).FormatInternal(year, timeIdentifier);
+        }
+
+        public static string Format(
             int year,
             TimeIdentifier timeIdentifier,
             TimePeriodLabelFormat? overridingLabelFormat = null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
@@ -2,7 +2,9 @@
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
@@ -68,7 +70,17 @@ public abstract class DataSetFilesControllerCachingTests : CacheServiceTestFixtu
                         Id = Guid.NewGuid(),
                         Version = "1.0.0"
                     },
-                    Meta = new DataSetFileMetaViewModel(),
+                    Meta = new DataSetFileMetaViewModel
+                    {
+                        GeographicLevels = [GeographicLevel.Country.GetEnumLabel()],
+                        TimePeriodRange = new DataSetFileTimePeriodRangeViewModel
+                        {
+                            From = "2000",
+                            To = "2001",
+                        },
+                        Filters = ["Filter 1"],
+                        Indicators = ["Indicator 1"],
+                    },
                     LatestData = true,
                     Published = DateTime.UtcNow,
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
@@ -1599,29 +1600,21 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                     .WithFile(_fixture.DefaultFile()
                         .WithType(FileType.Data)
                         .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
-                            .WithGeographicLevels(["National", "Local authority"])
-                            .WithTimePeriodRange(new TimePeriodRangeMeta
-                            {
-                                Start = new TimePeriodRangeBoundMeta
-                                {
-                                    TimeIdentifier = TimeIdentifier.AcademicYear,
-                                    Year = 2000,
-                                },
-                                End = new TimePeriodRangeBoundMeta
-                                {
-                                    TimeIdentifier = TimeIdentifier.AcademicYear,
-                                    Year = 2002,
-                                },
-                            })
+                            .WithGeographicLevels([GeographicLevel.Country, GeographicLevel.LocalAuthority])
+                            .WithTimePeriodRange(
+                                _fixture.DefaultTimePeriodRangeMeta()
+                                    .WithStart("2000", TimeIdentifier.AcademicYear)
+                                    .WithEnd("2002", TimeIdentifier.AcademicYear)
+                            )
                             .WithFilters([
-                                new FilterMeta { Label = "Filter 1" },
-                                new FilterMeta { Label = "Filter 2" },
-                                new FilterMeta { Label = "Filter 3" },
+                                new FilterMeta { Id = Guid.NewGuid(), Label = "Filter 1", ColumnName = "filter_1", },
+                                new FilterMeta { Id = Guid.NewGuid(), Label = "Filter 2", ColumnName = "filter_2", },
+                                new FilterMeta { Id = Guid.NewGuid(), Label = "Filter 3", ColumnName = "filter_3", },
                             ])
                             .WithIndicators([
-                                new IndicatorMeta { Label = "Indicator 1" },
-                                new IndicatorMeta { Label = "Indicator 2" },
-                                new IndicatorMeta { Label = "Indicator 3" },
+                                new IndicatorMeta { Id = Guid.NewGuid(), Label = "Indicator 1", ColumnName = "indicator_1", },
+                                new IndicatorMeta { Id = Guid.NewGuid(), Label = "Indicator 2", ColumnName = "indicator_2", },
+                                new IndicatorMeta { Id = Guid.NewGuid(), Label = "Indicator 3", ColumnName = "indicator_3", },
                             ])
                         ))
                     .Generate();
@@ -1649,29 +1642,31 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
 
                 var originalMeta = releaseFile.File.DataSetFileMeta;
 
-                dataSetFileMetaViewModel.GeographicLevels
-                    .AssertDeepEqualTo(originalMeta!.GeographicLevels);
+                Assert.Equal(originalMeta!.GeographicLevels
+                        .Select(gl => gl.GetEnumLabel())
+                        .ToList(),
+                    dataSetFileMetaViewModel.GeographicLevels);
 
-                dataSetFileMetaViewModel.TimePeriodRange.AssertDeepEqualTo(
-                    new DataSetFileTimePeriodRangeViewModel
+                Assert.Equal(new DataSetFileTimePeriodRangeViewModel
                     {
                         From = TimePeriodLabelFormatter.Format(
-                            originalMeta.TimePeriodRange.Start.Year,
+                            originalMeta.TimePeriodRange.Start.Period,
                             originalMeta.TimePeriodRange.Start.TimeIdentifier),
                         To = TimePeriodLabelFormatter.Format(
-                            originalMeta.TimePeriodRange.End.Year,
+                            originalMeta.TimePeriodRange.End.Period,
                             originalMeta.TimePeriodRange.End.TimeIdentifier),
-                    });
+                    },
+                    dataSetFileMetaViewModel.TimePeriodRange);
 
-                dataSetFileMetaViewModel.Filters
-                    .AssertDeepEqualTo(originalMeta.Filters
+                Assert.Equal(originalMeta.Filters
                         .Select(f => f.Label)
-                        .ToList());
+                        .ToList(),
+                    dataSetFileMetaViewModel.Filters);
 
-                dataSetFileMetaViewModel.Indicators
-                    .AssertDeepEqualTo(originalMeta.Indicators
+                Assert.Equal(originalMeta.Indicators
                         .Select(i => i.Label)
-                        .ToList());
+                        .ToList(),
+                    dataSetFileMetaViewModel.Indicators);
             }
 
             [Fact]
@@ -1839,7 +1834,12 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
             ReleaseFile releaseFile = _fixture.DefaultReleaseFile()
                 .WithReleaseVersion(publication.ReleaseVersions[0])
                 .WithFile(_fixture.DefaultFile()
-                    .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta())
+                    .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
+                        .WithTimePeriodRange(
+                        _fixture.DefaultTimePeriodRangeMeta()
+                            .WithStart("2000", TimeIdentifier.CalendarYear)
+                            .WithEnd("2001", TimeIdentifier.CalendarYear)
+                        ))
                     .WithPublicApiDataSetId(Guid.NewGuid())
                     .WithPublicApiDataSetVersion(major: 1, minor: 0)
                     .WithSubjectId(Guid.NewGuid())
@@ -1887,29 +1887,31 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
 
             var dataSetFileMeta = file.DataSetFileMeta;
 
-            viewModel.Meta.GeographicLevels
-                .AssertDeepEqualTo(dataSetFileMeta!.GeographicLevels);
+            Assert.Equal(dataSetFileMeta!.GeographicLevels
+                    .Select(gl => gl.GetEnumLabel())
+                    .ToList(),
+                viewModel.Meta.GeographicLevels);
 
-            viewModel.Meta.TimePeriodRange.AssertDeepEqualTo(
-                new DataSetFileTimePeriodRangeViewModel
+            Assert.Equal(new DataSetFileTimePeriodRangeViewModel
                 {
                     From = TimePeriodLabelFormatter.Format(
-                        dataSetFileMeta.TimePeriodRange.Start.Year,
-                        dataSetFileMeta.TimePeriodRange.Start.TimeIdentifier),
+                        "2000",
+                        TimeIdentifier.CalendarYear),
                     To = TimePeriodLabelFormatter.Format(
-                        dataSetFileMeta.TimePeriodRange.End.Year,
-                        dataSetFileMeta.TimePeriodRange.End.TimeIdentifier),
-                });
+                        "2001",
+                        TimeIdentifier.CalendarYear),
+                },
+                viewModel.Meta.TimePeriodRange);
 
-            viewModel.Meta.Filters
-                .AssertDeepEqualTo(dataSetFileMeta.Filters
+            Assert.Equal(dataSetFileMeta.Filters
                     .Select(f => f.Label)
-                    .ToList());
+                    .ToList(),
+                viewModel.Meta.Filters);
 
-            viewModel.Meta.Indicators
-                .AssertDeepEqualTo(dataSetFileMeta.Indicators
-                    .Select(i => i.Label)
-                    .ToList());
+            Assert.Equal(dataSetFileMeta.Indicators
+                .Select(i => i.Label)
+                .ToList(),
+                viewModel.Meta.Indicators);
         }
 
         [Fact]
@@ -1937,9 +1939,9 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                     .WithSubjectId(Guid.NewGuid())
                     .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
                         .WithFilters([
-                            new FilterMeta { Id = filter3Id, Label = "Filter 3", },
-                            new FilterMeta { Id = filter1Id, Label = "Filter 1", },
-                            new FilterMeta { Id = filter2Id, Label = "Filter 2", },
+                            new FilterMeta { Id = filter3Id, Label = "Filter 3", ColumnName = "filter_3", },
+                            new FilterMeta { Id = filter1Id, Label = "Filter 1", ColumnName = "filter_1", },
+                            new FilterMeta { Id = filter2Id, Label = "Filter 2", ColumnName = "filter_2", },
                         ])));
 
             var client = BuildApp()
@@ -1989,10 +1991,10 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                     .WithSubjectId(Guid.NewGuid())
                     .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
                         .WithIndicators([
-                            new IndicatorMeta { Id = indicator3Id, Label = "Indicator 3", },
-                            new IndicatorMeta { Id = indicator2Id, Label = "Indicator 2", },
-                            new IndicatorMeta { Id = indicator1Id, Label = "Indicator 1", },
-                            new IndicatorMeta { Id = indicator4Id, Label = "Indicator 4", },
+                            new IndicatorMeta { Id = indicator3Id, Label = "Indicator 3", ColumnName = "indicator_3", },
+                            new IndicatorMeta { Id = indicator2Id, Label = "Indicator 2", ColumnName = "indicator_2", },
+                            new IndicatorMeta { Id = indicator1Id, Label = "Indicator 1", ColumnName = "indicator_1", },
+                            new IndicatorMeta { Id = indicator4Id, Label = "Indicator 4", ColumnName = "indicator_4", },
                         ])));
 
             var client = BuildApp()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -1600,8 +1600,19 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                         .WithType(FileType.Data)
                         .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
                             .WithGeographicLevels(["National", "Local authority"])
-                            .WithTimeIdentifier(TimeIdentifier.AcademicYear)
-                            .WithYears([2000, 2001, 2002])
+                            .WithTimePeriodRange(new TimePeriodRangeMeta
+                            {
+                                Start = new TimePeriodRangeBoundMeta
+                                {
+                                    TimeIdentifier = TimeIdentifier.AcademicYear,
+                                    Year = 2000,
+                                },
+                                End = new TimePeriodRangeBoundMeta
+                                {
+                                    TimeIdentifier = TimeIdentifier.AcademicYear,
+                                    Year = 2002,
+                                },
+                            })
                             .WithFilters([
                                 new FilterMeta { Label = "Filter 1" },
                                 new FilterMeta { Label = "Filter 2" },
@@ -1641,12 +1652,15 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
                 dataSetFileMetaViewModel.GeographicLevels
                     .AssertDeepEqualTo(originalMeta!.GeographicLevels);
 
-                dataSetFileMetaViewModel.TimePeriod.AssertDeepEqualTo(
-                    new DataSetFileTimePeriodViewModel
+                dataSetFileMetaViewModel.TimePeriodRange.AssertDeepEqualTo(
+                    new DataSetFileTimePeriodRangeViewModel
                     {
-                        TimeIdentifier = originalMeta.TimeIdentifier.GetEnumLabel(),
-                        From = TimePeriodLabelFormatter.Format(originalMeta.Years.First(), originalMeta.TimeIdentifier),
-                        To = TimePeriodLabelFormatter.Format(originalMeta.Years.Last(), originalMeta.TimeIdentifier),
+                        From = TimePeriodLabelFormatter.Format(
+                            originalMeta.TimePeriodRange.Start.Year,
+                            originalMeta.TimePeriodRange.Start.TimeIdentifier),
+                        To = TimePeriodLabelFormatter.Format(
+                            originalMeta.TimePeriodRange.End.Year,
+                            originalMeta.TimePeriodRange.End.TimeIdentifier),
                     });
 
                 dataSetFileMetaViewModel.Filters
@@ -1876,13 +1890,15 @@ public class DataSetFilesControllerTests : IntegrationTest<TestStartup>
             viewModel.Meta.GeographicLevels
                 .AssertDeepEqualTo(dataSetFileMeta!.GeographicLevels);
 
-            viewModel.Meta.TimePeriod.AssertDeepEqualTo(
-                new DataSetFileTimePeriodViewModel
+            viewModel.Meta.TimePeriodRange.AssertDeepEqualTo(
+                new DataSetFileTimePeriodRangeViewModel
                 {
-                    TimeIdentifier = dataSetFileMeta.TimeIdentifier.GetEnumLabel(),
                     From = TimePeriodLabelFormatter.Format(
-                        dataSetFileMeta.Years.First(), dataSetFileMeta.TimeIdentifier),
-                    To = TimePeriodLabelFormatter.Format(dataSetFileMeta.Years.Last(), dataSetFileMeta.TimeIdentifier),
+                        dataSetFileMeta.TimePeriodRange.Start.Year,
+                        dataSetFileMeta.TimePeriodRange.Start.TimeIdentifier),
+                    To = TimePeriodLabelFormatter.Format(
+                        dataSetFileMeta.TimePeriodRange.End.Year,
+                        dataSetFileMeta.TimePeriodRange.End.TimeIdentifier),
                 });
 
             viewModel.Meta.Filters

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
@@ -15,8 +15,11 @@ public static class DataSetFileMetaGeneratorExtensions
     public static InstanceSetters<DataSetFileMeta> SetDefaults(this InstanceSetters<DataSetFileMeta> setters)
         => setters
             .SetGeographicLevels(new List<string> { "National " })
-            .SetTimeIdentifier(TimeIdentifier.AcademicYear)
-            .SetYears(new List<int> { 2000, 2001 })
+            .SetTimePeriodRange(new TimePeriodRangeMeta
+            {
+                Start = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Year = 2000, },
+                End = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Year = 2001, },
+            })
             .SetFilters(new List<FilterMeta> { new() { Label = "Filter 1" }, })
             .SetIndicators(new List<IndicatorMeta> { new() { Label = "Indicator 1" }, });
 
@@ -25,15 +28,10 @@ public static class DataSetFileMetaGeneratorExtensions
         List<string> geographicLevels)
         => generator.ForInstance(s => s.SetGeographicLevels(geographicLevels));
 
-    public static Generator<DataSetFileMeta> WithTimeIdentifier(
+    public static Generator<DataSetFileMeta> WithTimePeriodRange(
         this Generator<DataSetFileMeta> generator,
-        TimeIdentifier timeIdentifier)
-        => generator.ForInstance(s => s.SetTimeIdentifier(timeIdentifier));
-
-    public static Generator<DataSetFileMeta> WithYears(
-        this Generator<DataSetFileMeta> generator,
-        List<int> years)
-        => generator.ForInstance(s => s.SetYears(years));
+        TimePeriodRangeMeta timePeriodRange)
+        => generator.ForInstance(s => s.SetTimePeriodRange(timePeriodRange));
 
     public static Generator<DataSetFileMeta> WithFilters(
         this Generator<DataSetFileMeta> generator,
@@ -50,15 +48,10 @@ public static class DataSetFileMetaGeneratorExtensions
         List<string> geographicLevels)
         => setters.Set(s => s.GeographicLevels, geographicLevels);
 
-    public static InstanceSetters<DataSetFileMeta> SetTimeIdentifier(
+    public static InstanceSetters<DataSetFileMeta> SetTimePeriodRange(
         this InstanceSetters<DataSetFileMeta> setters,
-        TimeIdentifier timeIdentifier)
-        => setters.Set(s => s.TimeIdentifier, timeIdentifier);
-
-    public static InstanceSetters<DataSetFileMeta> SetYears(
-        this InstanceSetters<DataSetFileMeta> setters,
-        List<int> years)
-        => setters.Set(s => s.Years, years);
+        TimePeriodRangeMeta timePeriodRange)
+        => setters.Set(s => s.TimePeriodRange, timePeriodRange);
 
     public static InstanceSetters<DataSetFileMeta> SetFilters(
         this InstanceSetters<DataSetFileMeta> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
@@ -14,18 +16,30 @@ public static class DataSetFileMetaGeneratorExtensions
 
     public static InstanceSetters<DataSetFileMeta> SetDefaults(this InstanceSetters<DataSetFileMeta> setters)
         => setters
-            .SetGeographicLevels(new List<string> { "National " })
+            .SetGeographicLevels([GeographicLevel.Country])
             .SetTimePeriodRange(new TimePeriodRangeMeta
             {
-                Start = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Year = 2000, },
-                End = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Year = 2001, },
+                Start = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2000", },
+                End = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2001", },
             })
-            .SetFilters(new List<FilterMeta> { new() { Label = "Filter 1" }, })
-            .SetIndicators(new List<IndicatorMeta> { new() { Label = "Indicator 1" }, });
+            .SetFilters([ new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Filter 1",
+                    ColumnName = "filter_1",
+                },
+            ])
+            .SetIndicators([ new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Indicator 1",
+                    ColumnName = "indicator_1",
+                },
+            ]);
 
     public static Generator<DataSetFileMeta> WithGeographicLevels(
         this Generator<DataSetFileMeta> generator,
-        List<string> geographicLevels)
+        List<GeographicLevel> geographicLevels)
         => generator.ForInstance(s => s.SetGeographicLevels(geographicLevels));
 
     public static Generator<DataSetFileMeta> WithTimePeriodRange(
@@ -45,7 +59,7 @@ public static class DataSetFileMetaGeneratorExtensions
 
     public static InstanceSetters<DataSetFileMeta> SetGeographicLevels(
         this InstanceSetters<DataSetFileMeta> setters,
-        List<string> geographicLevels)
+        List<GeographicLevel> geographicLevels)
         => setters.Set(s => s.GeographicLevels, geographicLevels);
 
     public static InstanceSetters<DataSetFileMeta> SetTimePeriodRange(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
@@ -26,14 +26,14 @@ public static class FileGeneratorExtensions
             .SetDefault(f => f.Filename)
             .SetDataSetFileMeta(new DataSetFileMeta
             {
-                GeographicLevels = [GeographicLevel.Country.GetEnumLabel()],
+                GeographicLevels = [GeographicLevel.Country],
                 TimePeriodRange = new TimePeriodRangeMeta
                 {
-                    Start = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Year = 2000, },
-                    End = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Year = 2001, }
+                    Start = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2000", },
+                    End = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2001", }
                 },
-                Filters = [new() { Id = Guid.NewGuid(), Label = "Filter 1", }],
-                Indicators = [new() { Id = Guid.NewGuid(), }],
+                Filters = [new() { Id = Guid.NewGuid(), Label = "Filter 1", ColumnName = "filter_1", }],
+                Indicators = [new() { Id = Guid.NewGuid(), Label = "Indicator 1", ColumnName = "indicator_1", }],
             })
             .Set(f => f.Filename, (_, f) => $"{f.Filename}.csv");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
@@ -27,8 +27,11 @@ public static class FileGeneratorExtensions
             .SetDataSetFileMeta(new DataSetFileMeta
             {
                 GeographicLevels = [GeographicLevel.Country.GetEnumLabel()],
-                TimeIdentifier = TimeIdentifier.CalendarYear,
-                Years = [ 2000, 2001 ],
+                TimePeriodRange = new TimePeriodRangeMeta
+                {
+                    Start = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Year = 2000, },
+                    End = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Year = 2001, }
+                },
                 Filters = [new() { Id = Guid.NewGuid(), Label = "Filter 1", }],
                 Indicators = [new() { Id = Guid.NewGuid(), }],
             })

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/TimePeriodRangeMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/TimePeriodRangeMetaGeneratorExtensions.cs
@@ -1,0 +1,50 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+
+public static class TimePeriodRangeMetaGeneratorExtensions
+{
+    public static Generator<TimePeriodRangeMeta> DefaultTimePeriodRangeMeta(this DataFixture fixture)
+        => fixture.Generator<TimePeriodRangeMeta>().WithDefaults();
+
+    public static Generator<TimePeriodRangeMeta> WithDefaults(this Generator<TimePeriodRangeMeta> generator)
+        => generator.ForInstance(d => d.SetDefaults());
+
+    public static Generator<TimePeriodRangeMeta> WithStart(
+        this Generator<TimePeriodRangeMeta> generator,
+        string period,
+        TimeIdentifier timeIdentifier)
+        => generator.ForInstance(s => s.SetStart(period, timeIdentifier));
+
+    public static Generator<TimePeriodRangeMeta> WithEnd(
+        this Generator<TimePeriodRangeMeta> generator,
+        string period,
+        TimeIdentifier timeIdentifier)
+        => generator.ForInstance(s => s.SetEnd(period, timeIdentifier));
+
+    public static InstanceSetters<TimePeriodRangeMeta> SetDefaults(this InstanceSetters<TimePeriodRangeMeta> setters)
+        => setters
+            .SetStart("2000", TimeIdentifier.CalendarYear)
+            .SetEnd("2001", TimeIdentifier.CalendarYear);
+
+    public static InstanceSetters<TimePeriodRangeMeta> SetStart(
+        this InstanceSetters<TimePeriodRangeMeta> setters,
+        string period,
+        TimeIdentifier timeIdentifier)
+        => setters.Set(s => s.Start, new TimePeriodRangeBoundMeta
+        {
+            Period = period,
+            TimeIdentifier = timeIdentifier,
+        });
+
+    public static InstanceSetters<TimePeriodRangeMeta> SetEnd(
+        this InstanceSetters<TimePeriodRangeMeta> setters,
+        string period,
+        TimeIdentifier timeIdentifier)
+        => setters.Set(s => s.End, new TimePeriodRangeBoundMeta
+        {
+            Period = period,
+            TimeIdentifier = timeIdentifier,
+        });
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -11,31 +12,52 @@ public class DataSetFileMeta
     public List<string> GeographicLevels { get; set; } = new();
 
     [JsonConverter(typeof(TimeIdentifierJsonConverter))]
-    public TimeIdentifier TimeIdentifier { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public TimeIdentifier? TimeIdentifier { get; set; } // EES-4918 to remove
 
-    public List<int> Years { get; set; } = new();
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public List<int>? Years { get; set; } = new(); // EES-4918 to remove
+
+    public TimePeriodRangeMeta TimePeriodRange { get; set; } = null!;
 
     public List<FilterMeta> Filters { get; set; } = new();
 
     public List<IndicatorMeta> Indicators { get; set; } = new();
 }
 
+public class TimePeriodRangeMeta
+{
+    public TimePeriodRangeBoundMeta Start { get; set; } = null!;
+
+    public TimePeriodRangeBoundMeta End { get; set; } = null!;
+}
+
+public class TimePeriodRangeBoundMeta
+{
+    [JsonConverter(typeof(TimeIdentifierJsonConverter))]
+    public TimeIdentifier TimeIdentifier { get; set; }
+
+    public int Year { get; set; }
+}
+
 public class FilterMeta
 {
     public Guid Id { get; set; }
-    public string Label { get; set; }
 
-    public string? Hint { get; set; }
+    public string Label { get; set; } = string.Empty;
 
-    public string ColumnName { get; set; }
+    public string? Hint { get; set; } = string.Empty;
+
+    public string ColumnName { get; set; } = string.Empty;
 }
 
 public class IndicatorMeta
 {
     public Guid Id { get; set; }
-    public string Label { get; set; }
 
-    public string ColumnName { get; set; }
+    public string Label { get; set; } = string.Empty;
+
+    public string ColumnName { get; set; } = string.Empty;
 }
 
 public class TimePeriodMeta

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -3,13 +3,15 @@ using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 public class DataSetFileMeta
 {
-    public List<string> GeographicLevels { get; set; } = new();
+    [JsonConverter(typeof(GeographicLevelsListJsonConverter))]
+    public required List<GeographicLevel> GeographicLevels { get; set; }
 
     [JsonConverter(typeof(TimeIdentifierJsonConverter))]
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -18,51 +20,44 @@ public class DataSetFileMeta
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public List<int>? Years { get; set; } = new(); // EES-4918 to remove
 
-    public TimePeriodRangeMeta TimePeriodRange { get; set; } = null!;
+    public required TimePeriodRangeMeta TimePeriodRange { get; set; }
 
-    public List<FilterMeta> Filters { get; set; } = new();
+    public required List<FilterMeta> Filters { get; set; }
 
-    public List<IndicatorMeta> Indicators { get; set; } = new();
+    public required List<IndicatorMeta> Indicators { get; set; }
 }
 
 public class TimePeriodRangeMeta
 {
-    public TimePeriodRangeBoundMeta Start { get; set; } = null!;
+    public required TimePeriodRangeBoundMeta Start { get; set; }
 
-    public TimePeriodRangeBoundMeta End { get; set; } = null!;
+    public required TimePeriodRangeBoundMeta End { get; set; }
 }
 
 public class TimePeriodRangeBoundMeta
 {
     [JsonConverter(typeof(TimeIdentifierJsonConverter))]
-    public TimeIdentifier TimeIdentifier { get; set; }
+    public required TimeIdentifier TimeIdentifier { get; set; }
 
-    public int Year { get; set; }
+    public required string Period { get; set; }
 }
 
 public class FilterMeta
 {
-    public Guid Id { get; set; }
+    public required Guid Id { get; set; }
 
-    public string Label { get; set; } = string.Empty;
+    public required string Label { get; set; }
 
-    public string? Hint { get; set; } = string.Empty;
+    public string? Hint { get; set; }
 
-    public string ColumnName { get; set; } = string.Empty;
+    public required string ColumnName { get; set; }
 }
 
 public class IndicatorMeta
 {
-    public Guid Id { get; set; }
+    public required Guid Id { get; set; }
 
-    public string Label { get; set; } = string.Empty;
+    public required string Label { get; set; }
 
-    public string ColumnName { get; set; } = string.Empty;
+    public required string ColumnName { get; set; }
 }
-
-public class TimePeriodMeta
-{
-    public int Year;
-    public TimeIdentifier TimeIdentifier;
-}
-

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -430,7 +430,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                             ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
                             : null);
                 entity.Property(p => p.DataSetFileMeta)
-                    .HasConversion(
+                    .HasConversion( // You might want to use EF8 JSON support instead of this
                         v => JsonConvert.SerializeObject(v),
                         v => JsonConvert.DeserializeObject<DataSetFileMeta>(v));
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -209,14 +209,16 @@ public class DataSetFileService : IDataSetFileService
 
         return new DataSetFileMetaViewModel
         {
-            GeographicLevels = meta.GeographicLevels,
+            GeographicLevels = meta.GeographicLevels
+                .Select(gl => gl.GetEnumLabel())
+                .ToList(),
             TimePeriodRange = new DataSetFileTimePeriodRangeViewModel
             {
                 From = TimePeriodLabelFormatter.Format(
-                    meta.TimePeriodRange.Start.Year,
+                    meta.TimePeriodRange.Start.Period,
                     meta.TimePeriodRange.Start.TimeIdentifier),
                 To = TimePeriodLabelFormatter.Format(
-                    meta.TimePeriodRange.End.Year,
+                    meta.TimePeriodRange.End.Period,
                     meta.TimePeriodRange.End.TimeIdentifier),
             },
             Filters = GetOrderedFilters(meta.Filters, filterSequence),

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -210,11 +210,14 @@ public class DataSetFileService : IDataSetFileService
         return new DataSetFileMetaViewModel
         {
             GeographicLevels = meta.GeographicLevels,
-            TimePeriod = new DataSetFileTimePeriodViewModel
+            TimePeriodRange = new DataSetFileTimePeriodRangeViewModel
             {
-                TimeIdentifier = meta.TimeIdentifier.GetEnumLabel(),
-                From = TimePeriodLabelFormatter.Format(meta.Years.First(), meta.TimeIdentifier),
-                To = TimePeriodLabelFormatter.Format(meta.Years.Last(), meta.TimeIdentifier),
+                From = TimePeriodLabelFormatter.Format(
+                    meta.TimePeriodRange.Start.Year,
+                    meta.TimePeriodRange.Start.TimeIdentifier),
+                To = TimePeriodLabelFormatter.Format(
+                    meta.TimePeriodRange.End.Year,
+                    meta.TimePeriodRange.End.TimeIdentifier),
             },
             Filters = GetOrderedFilters(meta.Filters, filterSequence),
             Indicators = GetOrderedIndicators(meta.Indicators, indicatorGroupSequence),

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
@@ -2,15 +2,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 
 public record DataSetFileMetaViewModel
 {
-    public List<string> GeographicLevels { get; init; } = new();
-
-    public DataSetFileTimePeriodRangeViewModel TimePeriodRange { get; init; } = null!;
-    public List<string> Filters { get; init; } = new();
-    public List<string> Indicators { get; init; } = new();
+    public required List<string> GeographicLevels { get; init; }
+    public required DataSetFileTimePeriodRangeViewModel TimePeriodRange { get; init; }
+    public required List<string> Filters { get; init; }
+    public required List<string> Indicators { get; init; }
 }
 
 public record DataSetFileTimePeriodRangeViewModel
 {
-    public string From { get; init; } = string.Empty;
-    public string To { get; init; } = string.Empty;
+    public required string From { get; init; }
+    public required string To { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
@@ -3,14 +3,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 public record DataSetFileMetaViewModel
 {
     public List<string> GeographicLevels { get; init; } = new();
-    public DataSetFileTimePeriodViewModel TimePeriod { get; init; } = new();
+
+    public DataSetFileTimePeriodRangeViewModel TimePeriodRange { get; init; } = null!;
     public List<string> Filters { get; init; } = new();
     public List<string> Indicators { get; init; } = new();
 }
 
-public record DataSetFileTimePeriodViewModel
+public record DataSetFileTimePeriodRangeViewModel
 {
-    public string TimeIdentifier { get; init; } = string.Empty;
     public string From { get; init; } = string.Empty;
     public string To { get; init; } = string.Empty;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/ObservationGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/Fixtures/ObservationGeneratorExtensions.cs
@@ -36,6 +36,12 @@ public static class ObservationGeneratorExtensions
         IEnumerable<string> measures)
         => generator.ForInstance(s => s.SetMeasures(indicators, measures));
 
+    public static Generator<Observation> WithTimePeriod(
+        this Generator<Observation> generator,
+        int year,
+        TimeIdentifier identifier)
+        => generator.ForInstance(s => s.SetTimePeriod(year, identifier));
+
     public static InstanceSetters<Observation> SetDefaults(this InstanceSetters<Observation> setters)
         => setters
             .SetDefault(o => o.Id)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -299,9 +299,13 @@ public class ProcessorStage3Tests
             // Checking against contents of small-csv.csv in Resources directory / _subject
             var geographicLevel = Assert.Single(file.DataSetFileMeta.GeographicLevels);
             Assert.Equal("Local authority", geographicLevel);
-            Assert.Equal(TimeIdentifier.CalendarYear, file.DataSetFileMeta.TimeIdentifier);
-            file.DataSetFileMeta.Years
-                .AssertDeepEqualTo([2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025]);
+
+            Assert.Equal(TimeIdentifier.CalendarYear,
+                file.DataSetFileMeta.TimePeriodRange.Start.TimeIdentifier);
+            Assert.Equal(TimeIdentifier.CalendarYear,
+                file.DataSetFileMeta.TimePeriodRange.End.TimeIdentifier);
+            Assert.Equal(2018, file.DataSetFileMeta.TimePeriodRange.Start.Year);
+            Assert.Equal(2025, file.DataSetFileMeta.TimePeriodRange.End.Year);
 
             // Checking against contents of small-csv.meta.csv / _subject
             file.DataSetFileMeta.Filters

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -298,14 +298,14 @@ public class ProcessorStage3Tests
 
             // Checking against contents of small-csv.csv in Resources directory / _subject
             var geographicLevel = Assert.Single(file.DataSetFileMeta.GeographicLevels);
-            Assert.Equal("Local authority", geographicLevel);
+            Assert.Equal(GeographicLevel.LocalAuthority, geographicLevel);
 
             Assert.Equal(TimeIdentifier.CalendarYear,
                 file.DataSetFileMeta.TimePeriodRange.Start.TimeIdentifier);
             Assert.Equal(TimeIdentifier.CalendarYear,
                 file.DataSetFileMeta.TimePeriodRange.End.TimeIdentifier);
-            Assert.Equal(2018, file.DataSetFileMeta.TimePeriodRange.Start.Year);
-            Assert.Equal(2025, file.DataSetFileMeta.TimePeriodRange.End.Year);
+            Assert.Equal("2018", file.DataSetFileMeta.TimePeriodRange.Start.Period);
+            Assert.Equal("2025", file.DataSetFileMeta.TimePeriodRange.End.Period);
 
             // Checking against contents of small-csv.meta.csv / _subject
             file.DataSetFileMeta.Filters

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -9,7 +9,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -169,10 +168,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 .ToList();
 
             var timePeriods = observations
-                .Select(o => new TimePeriodRangeBoundMeta { Year = o.Year, TimeIdentifier = o.TimeIdentifier })
+                .Select(o => new { o.Year, o.TimeIdentifier, })
                 .Distinct()
-                .OrderBy(tp => tp.Year)
-                .ThenBy(tp => tp.TimeIdentifier)
+                .OrderBy(o => o.Year)
+                .ThenBy(o => o.TimeIdentifier)
+                .ToList()
+                .Select(tp => new TimePeriodRangeBoundMeta
+                {
+                    Period = tp.Year.ToString(),
+                    TimeIdentifier = tp.TimeIdentifier,
+                })
                 .ToList();
 
             var filters = await statisticsDbContext.Filter
@@ -202,8 +207,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
             var dataSetFileMeta = new DataSetFileMeta
             {
-                GeographicLevels = geographicLevels
-                    .Select(gl => gl.GetEnumLabel()).ToList(),
+                GeographicLevels = geographicLevels,
                 TimePeriodRange = new TimePeriodRangeMeta
                 {
                     Start = timePeriods.First(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -169,9 +169,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 .ToList();
 
             var timePeriods = observations
-                .Select(o => new TimePeriodMeta { Year = o.Year, TimeIdentifier = o.TimeIdentifier })
+                .Select(o => new TimePeriodRangeBoundMeta { Year = o.Year, TimeIdentifier = o.TimeIdentifier })
                 .Distinct()
                 .OrderBy(tp => tp.Year)
+                .ThenBy(tp => tp.TimeIdentifier)
                 .ToList();
 
             var filters = await statisticsDbContext.Filter
@@ -203,8 +204,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             {
                 GeographicLevels = geographicLevels
                     .Select(gl => gl.GetEnumLabel()).ToList(),
-                TimeIdentifier = timePeriods[0].TimeIdentifier,
-                Years = timePeriods.Select(tp => tp.Year).ToList(),
+                TimePeriodRange = new TimePeriodRangeMeta
+                {
+                    Start = timePeriods.First(),
+                    End = timePeriods.Last(),
+                },
                 Filters = filters,
                 Indicators = indicators,
             };

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
@@ -20,8 +20,7 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     filename: 'file-name-1',
     fileSize: '100 kb',
     meta: {
-      timePeriod: {
-        timeIdentifier: 'Calendar year',
+      timePeriodRange: {
         from: '2010',
         to: '2020',
       },
@@ -53,8 +52,7 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     filename: 'file-name-2',
     fileSize: '100 kb',
     meta: {
-      timePeriod: {
-        timeIdentifier: 'Calendar year',
+      timePeriodRange: {
         from: '2010',
         to: '2020',
       },
@@ -86,8 +84,7 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
     filename: 'file-name-3',
     fileSize: '100 kb',
     meta: {
-      timePeriod: {
-        timeIdentifier: 'Calendar year',
+      timePeriodRange: {
         from: '2010',
         to: '2020',
       },
@@ -139,8 +136,7 @@ export const testDataSetFile: DataSetFile = {
   summary: 'Data set 1 summary',
   title: 'Data set 1',
   meta: {
-    timePeriod: {
-      timeIdentifier: 'Calendar year',
+    timePeriodRange: {
       from: '2023',
       to: '2024',
     },

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileDetails.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileDetails.tsx
@@ -21,7 +21,7 @@ interface Props {
 export default function DataSetFileDetails({ dataSetFile }: Props) {
   const {
     release,
-    meta: { timePeriod, filters, geographicLevels, indicators },
+    meta: { timePeriodRange, filters, geographicLevels, indicators },
     title,
   } = dataSetFile;
 
@@ -100,9 +100,9 @@ export default function DataSetFileDetails({ dataSetFile }: Props) {
             </CollapsibleList>
           </SummaryListItem>
         )}
-        {timePeriod && (timePeriod.from || timePeriod.to) && (
+        {timePeriodRange && (timePeriodRange.from || timePeriodRange.to) && (
           <SummaryListItem term="Time period">
-            {getTimePeriodString(timePeriod)}
+            {getTimePeriodString(timePeriodRange)}
           </SummaryListItem>
         )}
       </SummaryList>

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
@@ -39,8 +39,7 @@ export default function DataSetFileSummary({
     content,
     fileId,
     meta: {
-      timePeriod = {
-        timeIdentifier: undefined,
+      timePeriodRange = {
         from: undefined,
         to: undefined,
       },
@@ -189,14 +188,14 @@ export default function DataSetFileSummary({
             </CollapsibleList>
           </SummaryListItem>
         )}
-        {(timePeriod.from || timePeriod.to) && (
+        {(timePeriodRange.from || timePeriodRange.to) && (
           <SummaryListItem
             className={classNames({
               'dfe-js-hidden': !showDetails,
             })}
             term="Time period"
           >
-            {getTimePeriodString(timePeriod)}
+            {getTimePeriodString(timePeriodRange)}
           </SummaryListItem>
         )}
         <SummaryListItem

--- a/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
+++ b/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
@@ -25,8 +25,7 @@ export interface DataSetFile {
   api?: DataSetFileApi;
   meta: {
     geographicLevels: string[];
-    timePeriod: {
-      timeIdentifier: string;
+    timePeriodRange: {
       from: string;
       to: string;
     };
@@ -60,8 +59,7 @@ export interface DataSetFileSummary {
   api?: DataSetFileApi;
   meta: {
     geographicLevels: string[];
-    timePeriod: {
-      timeIdentifier: string;
+    timePeriodRange: {
       from: string;
       to: string;
     };


### PR DESCRIPTION
Copy of this PR, since I accidentally blitzed my changes :fearful: 

This PR fixes an issue where DataSetFileMeta only stored one TimeIdentifier for a whole data set. This assumption I made is incorrect - a data set can have multiple TimeIdentifier's e.g. months.

File.DataSetFileMeta now has a TimePeriodRangeMeta which stores the data set's starting and ending TimeIdentifier/Year.

We are finished with the DataSetFileMeta migration endpoint, so I repurposed it in this PR to set the new TimePeriodRange field and remove TimeIdentifier and Years.

The TimeIdentifier and Year fields in DataSetFileMeta can be removed after this migration. I've added a note to do so to EES-4918.