### PR TITLE
EES-4996 Fix various test issues from data catalogue work

### DIFF
--- a/src/explore-education-statistics-common/src/components/UrlContainer.tsx
+++ b/src/explore-education-statistics-common/src/components/UrlContainer.tsx
@@ -16,7 +16,7 @@ export default function UrlContainer({
   id,
   label = 'URL',
   labelHidden = true,
-  testId,
+  testId = id,
   url,
 }: Props) {
   return (

--- a/src/explore-education-statistics-frontend/server.js
+++ b/src/explore-education-statistics-frontend/server.js
@@ -30,10 +30,10 @@ if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
 
 const cspConnectSrc = [
   "'self'",
-  process.env.CONTENT_API_BASE_URL,
-  process.env.DATA_API_BASE_URL,
-  process.env.NOTIFICATION_API_BASE_URL,
-  process.env.PUBLIC_API_BASE_URL,
+  `${process.env.CONTENT_API_BASE_URL}/`,
+  `${process.env.DATA_API_BASE_URL}/`,
+  `${process.env.NOTIFICATION_API_BASE_URL}/`,
+  `${process.env.PUBLIC_API_BASE_URL}/`,
   'https://*.googletagmanager.com',
   'https://*.google-analytics.com',
   'https://*.analytics.google.com',

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiVersionHistory.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiVersionHistory.test.tsx
@@ -5,7 +5,7 @@ import {
 } from '@frontend/modules/data-catalogue/__data__/testDataSets';
 import DataSetFileApiVersionHistory from '@frontend/modules/data-catalogue/components/DataSetFileApiVersionHistory';
 import _apiDataSetService from '@frontend/services/apiDataSetService';
-import { screen, waitFor, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { times } from 'lodash';
 import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider';
 import React, { ReactElement } from 'react';
@@ -31,7 +31,9 @@ describe('DataSetFileApiVersionHistory', () => {
       screen.getByRole('heading', { name: 'API data set version history' }),
     ).toBeInTheDocument();
 
-    const table = within(await screen.findByRole('table'));
+    expect(await screen.findByText('Version')).toBeInTheDocument();
+
+    const table = within(screen.getByRole('table'));
 
     const rows = table.getAllByRole('row');
     expect(rows).toHaveLength(4);
@@ -81,7 +83,9 @@ describe('DataSetFileApiVersionHistory', () => {
       />,
     );
 
-    const table = within(await screen.findByRole('table'));
+    expect(await screen.findByText('Version')).toBeInTheDocument();
+
+    const table = within(screen.getByRole('table'));
 
     const rows = table.getAllByRole('row');
     expect(rows).toHaveLength(4);
@@ -130,7 +134,9 @@ describe('DataSetFileApiVersionHistory', () => {
       />,
     );
 
-    let table = within(await screen.findByRole('table'));
+    expect(await screen.findByText('Version')).toBeInTheDocument();
+
+    let table = within(screen.getByRole('table'));
 
     let rows = table.getAllByRole('row');
     expect(rows).toHaveLength(4);
@@ -148,7 +154,7 @@ describe('DataSetFileApiVersionHistory', () => {
     expect(within(rows[3]).getByText('2.0 (current)')).toBeInTheDocument();
 
     const pagination = within(
-      await screen.findByRole('navigation', {
+      screen.getByRole('navigation', {
         name: 'Version history pagination',
       }),
     );
@@ -170,9 +176,7 @@ describe('DataSetFileApiVersionHistory', () => {
 
     await user.click(pagination.getByRole('link', { name: 'Next page' }));
 
-    await waitFor(() => {
-      expect(screen.getByText('1.1')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('1.1')).toBeInTheDocument();
 
     table = within(screen.getByRole('table'));
 


### PR DESCRIPTION
This PR:

- Fixes inefficient `findByRole` selectors being used in unit tests
- Fixes CSP `connect-src` URLs being incorrect - these require a trailing slash to work correctly. This currently prevents fetching data from most of the APIs in the public frontend when running in production mode.
- Fixes missing `UrlContainer` testids causing lots of failures across Robot tests