### PR TITLE
EES-5143 Fix remove ref line check in UI test

### DIFF
--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -536,7 +536,7 @@ Edit reference line
 
 Remove reference line
     user clicks button containing text    Remove    testId:referenceLines
-    user waits until parent does not contain element    id:chartBuilderPreview    Edited reference line
+    user waits until parent does not contain    id:chartBuilderPreview    Edited reference line
 
 Save chart and validate marked as 'Has chart' in data blocks list
     user saves chart configuration

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -553,6 +553,11 @@ user waits until parent does not contain button
     user waits until parent does not contain element    ${parent}
     ...    xpath:.//button[text()="${text}" or .//*[text()="${text}"]]    ${wait}
 
+user waits until parent does not contain
+    [Arguments]    ${parent}    ${text}    ${wait}=${timeout}
+    user waits until parent does not contain element    ${parent}
+    ...    .//*[contains(text(),"${text}")]    ${wait}
+
 user gets button element
     [Arguments]    ${text}    ${parent}=css:body
     user waits until parent contains button    ${parent}    ${text}


### PR DESCRIPTION
This fixes a UI test case where we weren't actually checking that the reference line had been removed.