### PR TITLE
EES-5129: Update missed link in robot test

### DIFF
--- a/src/explore-education-statistics-admin/src/prototypes/PrototypeDashboard.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/PrototypeDashboard.tsx
@@ -25,7 +25,7 @@ const PrototypeReleaseData = () => {
                 <dd className="govuk-summary-list__value">
                   <a
                     data-testid="subscription-children-looked-after-in-england-including-adoptions"
-                    href="/subscriptions?slug=children-looked-after-in-england-including-adoptions"
+                    href="/subscriptions/new-subscription/children-looked-after-in-england-including-adoptions"
                     className="govuk-link govuk-link--no-visited-state dfe-print-hidden"
                   >
                     Sign up for email alerts

--- a/src/explore-education-statistics-admin/src/prototypes/PrototypeDashboard2.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/PrototypeDashboard2.tsx
@@ -98,7 +98,7 @@ const PrototypeReleaseData = () => {
                     <dd className="govuk-summary-list__value">
                       <a
                         data-testid="subscription-children-looked-after-in-england-including-adoptions"
-                        href="/subscriptions?slug=children-looked-after-in-england-including-adoptions"
+                        href="/subscriptions/new-subscription/children-looked-after-in-england-including-adoptions"
                         className="govuk-link govuk-link--no-visited-state dfe-print-hidden"
                       >
                         Sign up for email alerts

--- a/src/explore-education-statistics-admin/src/prototypes/PrototypeRelease.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/PrototypeRelease.tsx
@@ -102,7 +102,7 @@ const PrototypeRelease = () => {
                   <strong>
                     <a
                       data-testid="subscription-children-looked-after-in-england-including-adoptions"
-                      href="/subscriptions?slug=children-looked-after-in-england-including-adoptions"
+                      href="/subscriptions/new-subscription/children-looked-after-in-england-including-adoptions"
                       className="govuk-link govuk-link--no-visited-state govuk-!-display-none-print"
                     >
                       Sign up for email alerts

--- a/src/explore-education-statistics-admin/src/prototypes/PrototypeReleaseData.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/PrototypeReleaseData.tsx
@@ -107,7 +107,7 @@ const PrototypeReleaseData = () => {
                 <dd className="govuk-summary-list__value">
                   <a
                     data-testid="subscription-children-looked-after-in-england-including-adoptions"
-                    href="/subscriptions?slug=children-looked-after-in-england-including-adoptions"
+                    href="/subscriptions/new-subscription/children-looked-after-in-england-including-adoptions"
                     className="govuk-link govuk-link--no-visited-state dfe-print-hidden"
                   >
                     Sign up for email alerts

--- a/src/explore-education-statistics-admin/src/prototypes/PrototypeReleaseData2.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/PrototypeReleaseData2.tsx
@@ -104,7 +104,7 @@ const PrototypeReleaseData = () => {
                   <strong>
                     <a
                       data-testid="subscription-children-looked-after-in-england-including-adoptions"
-                      href="/subscriptions?slug=children-looked-after-in-england-including-adoptions"
+                      href="/subscriptions/new-subscription/children-looked-after-in-england-including-adoptions"
                       className="govuk-link govuk-link--no-visited-state dfe-print-hidden"
                     >
                       Sign up for email alerts

--- a/src/explore-education-statistics-admin/src/prototypes/components/PrototypeSectionExamples.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/components/PrototypeSectionExamples.tsx
@@ -1083,7 +1083,7 @@ const ExampleSection = ({
                 <dd className="govuk-summary-list__value">
                   <a
                     data-testid="subscription-children-looked-after-in-england-including-adoptions"
-                    href="/subscriptions?slug=children-looked-after-in-england-including-adoptions"
+                    href="/subscriptions/new-subscription/children-looked-after-in-england-including-adoptions"
                     className="govuk-link govuk-link--no-visited-state dfe-print-hidden"
                   >
                     <strong>Sign up for email alerts</strong>
@@ -1333,7 +1333,7 @@ const ExampleSection = ({
                 <dd className="govuk-summary-list__value">
                   <a
                     data-testid="subscription-children-looked-after-in-england-including-adoptions"
-                    href="/subscriptions?slug=children-looked-after-in-england-including-adoptions"
+                    href="/subscriptions/new-subscription/children-looked-after-in-england-including-adoptions"
                     className="govuk-link govuk-link--no-visited-state dfe-print-hidden"
                   >
                     <strong>Sign up for email alerts</strong>

--- a/src/explore-education-statistics-frontend/src/pages/accessibility-statement.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/accessibility-statement.tsx
@@ -221,7 +221,7 @@ function AcccessibilityStatementPage() {
                 <Link to="/glossary">glossary page</Link>
               </li>
               <li>
-                <Link to="/subscriptions?slug=pupil-absence-in-schools-in-england">
+                <Link to="/subscriptions/new-subscription/pupil-absence-in-schools-in-england">
                   notify me page
                 </Link>
               </li>

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -42,7 +42,7 @@ Validate Next update date
 
 Validate Email alerts link
     user checks page contains link with text and url    Sign up for email alerts
-    ...    /subscriptions?slug=${PUPIL_ABSENCE_PUBLICATION_SLUG}
+    ...    /subscriptions/new-subscription/${PUPIL_ABSENCE_PUBLICATION_SLUG}
 
 Validate "About these statistics" -- Number of other releases
     [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-4269


### PR DESCRIPTION
My last PR changed the route for requesting a new subscription from `subscriptions?slug=[slug]` to `subscriptions/new-subscription/[slug]`.

I missed a robot test which asserts on the link contained within the email to users, so this PR corrects that. 

I've also noticed some of the admin prototypes have links to this page so have updated those too. 