### PR TITLE
EES-5161 Add noindex,nofollow tags to all pages in non-production environments

### DIFF
--- a/src/explore-education-statistics-admin/public/index.html
+++ b/src/explore-education-statistics-admin/public/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <meta charset="UTF-8" />
+    <meta name="robots" content="noindex,nofollow" />
 
     <link
       rel="icon"

--- a/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
@@ -30,6 +30,12 @@ const PageMeta = ({
         content="jWf4Mg_pzTOgXDWccGcv9stMsdyptYwHeVpODHdesoY"
       />
 
+      {process.env.APP_ENV !== 'Production' && (
+        <>
+          <meta name="robots" content="noindex,nofollow" />
+          <meta name="googlebot" content="noindex,nofollow" />
+        </>
+      )}
       {/* <!-- Open Graph / Facebook --> */}
       <meta property="og:type" content="website" />
       <meta property="og:title" content={title} />

--- a/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
@@ -31,10 +31,7 @@ const PageMeta = ({
       />
 
       {process.env.APP_ENV !== 'Production' && (
-        <>
-          <meta name="robots" content="noindex,nofollow" />
-          <meta name="googlebot" content="noindex,nofollow" />
-        </>
+        <meta name="robots" content="noindex,nofollow" />
       )}
       {/* <!-- Open Graph / Facebook --> */}
       <meta property="og:type" content="website" />

--- a/src/explore-education-statistics-frontend/src/modules/subscriptions/ConfirmSubscriptionPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/subscriptions/ConfirmSubscriptionPage.tsx
@@ -63,7 +63,6 @@ const ConfirmSubscriptionPage: NextPage<Props> = ({
     >
       <Head>
         <meta name="robots" content="noindex,nofollow" />
-        <meta name="googlebot" content="noindex,nofollow" />
       </Head>
       {confirmedSubscription ? (
         <SubscriptionStatusMessage

--- a/src/explore-education-statistics-frontend/src/modules/subscriptions/ConfirmUnsubscriptionPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/subscriptions/ConfirmUnsubscriptionPage.tsx
@@ -54,7 +54,6 @@ const ConfirmUnsubscriptionPage: NextPage<Props> = ({
     >
       <Head>
         <meta name="robots" content="noindex,nofollow" />
-        <meta name="googlebot" content="noindex,nofollow" />
       </Head>
       {unsubscribedSubscription ? (
         <SubscriptionStatusMessage


### PR DESCRIPTION
As the [brief ](https://dfedigital.atlassian.net/browse/EES-5161) says, all sites on the `dev` and `pre-production` environments should bear the `noindex, nofollow` tags for all robots. 