### PR TITLE
EES-4366, EES-4994 Add initial API data set admin pages

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetCandidatesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetCandidatesControllerTests.cs
@@ -52,12 +52,9 @@ public abstract class DataSetCandidatesControllerTests(TestApplicationFactory te
 
             Assert.NotNull(candidates);
             Assert.Equal(3, candidates.Count);
-
-            Assert.All(releaseFiles, releaseFile =>
-                Assert.Contains(candidates, candidate =>
-                    candidate.FileId == releaseFile.Id
-                    && candidate.Title == releaseFile.Name)
-            );
+            Assert.Contains(releaseFiles, releaseFile =>
+                candidates.Any(candidate => candidate.ReleaseFileId == releaseFile.Id
+                                                && candidate.Title == releaseFile.Name));
         }
 
         [Theory]
@@ -95,10 +92,10 @@ public abstract class DataSetCandidatesControllerTests(TestApplicationFactory te
 
             var response = await GetDataSetCandidates(releaseVersion.Id);
 
-            var viewModel = response.AssertOk<List<DataSetCandidateViewModel>>();
+            var candidates = response.AssertOk<List<DataSetCandidateViewModel>>();
 
-            Assert.NotNull(viewModel);
-            Assert.Empty(viewModel);
+            Assert.NotNull(candidates);
+            Assert.Empty(candidates);
         }
 
 
@@ -123,10 +120,10 @@ public abstract class DataSetCandidatesControllerTests(TestApplicationFactory te
 
             var response = await GetDataSetCandidates(releaseVersion.Id);
 
-            var viewModel = response.AssertOk<List<DataSetCandidateViewModel>>();
+            var candidates = response.AssertOk<List<DataSetCandidateViewModel>>();
 
-            Assert.NotNull(viewModel);
-            Assert.Empty(viewModel);
+            Assert.NotNull(candidates);
+            Assert.Empty(candidates);
         }
 
         [Fact]
@@ -150,10 +147,10 @@ public abstract class DataSetCandidatesControllerTests(TestApplicationFactory te
 
             var response = await GetDataSetCandidates(releaseVersion.Id);
 
-            var viewModel = response.AssertOk<List<DataSetCandidateViewModel>>();
+            var candidates = response.AssertOk<List<DataSetCandidateViewModel>>();
 
-            Assert.NotNull(viewModel);
-            Assert.Empty(viewModel);
+            Assert.NotNull(candidates);
+            Assert.Empty(candidates);
         }
 
         [Fact]
@@ -177,10 +174,10 @@ public abstract class DataSetCandidatesControllerTests(TestApplicationFactory te
 
             var response = await GetDataSetCandidates(releaseVersion.Id);
 
-            var viewModel = response.AssertOk<List<DataSetCandidateViewModel>>();
+            var candidates = response.AssertOk<List<DataSetCandidateViewModel>>();
 
-            Assert.NotNull(viewModel);
-            Assert.Empty(viewModel);
+            Assert.NotNull(candidates);
+            Assert.Empty(candidates);
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetCandidatesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetCandidatesControllerTests.cs
@@ -22,7 +22,7 @@ public abstract class DataSetCandidatesControllerTests(TestApplicationFactory te
 {
     private const string BaseUrl = "api/public-data/data-set-candidates";
 
-    public class ListApiDataSetCandidatesTests(TestApplicationFactory testApp) : DataSetsControllerTests(testApp)
+    public class ListDataSetCandidatesTests(TestApplicationFactory testApp) : DataSetsControllerTests(testApp)
     {
         [Fact]
         public async Task Success()
@@ -48,13 +48,16 @@ public abstract class DataSetCandidatesControllerTests(TestApplicationFactory te
 
             var response = await GetDataSetCandidates(releaseVersion.Id);
 
-            var content = response.AssertOk<List<ApiDataSetCandidateViewModel>>();
+            var candidates = response.AssertOk<List<DataSetCandidateViewModel>>();
 
-            Assert.NotNull(content);
-            Assert.NotEmpty(content);
-            Assert.Equal(3, content.Count);
+            Assert.NotNull(candidates);
+            Assert.Equal(3, candidates.Count);
+
             Assert.All(releaseFiles, releaseFile =>
-                content.Any(apiDataSetCandidate => apiDataSetCandidate.FileId == releaseFile.FileId && apiDataSetCandidate.Title == releaseFile.Name));
+                Assert.Contains(candidates, candidate =>
+                    candidate.FileId == releaseFile.Id
+                    && candidate.Title == releaseFile.Name)
+            );
         }
 
         [Theory]
@@ -92,10 +95,10 @@ public abstract class DataSetCandidatesControllerTests(TestApplicationFactory te
 
             var response = await GetDataSetCandidates(releaseVersion.Id);
 
-            var content = response.AssertOk<List<ApiDataSetCandidateViewModel>>();
+            var viewModel = response.AssertOk<List<DataSetCandidateViewModel>>();
 
-            Assert.NotNull(content);
-            Assert.Empty(content);
+            Assert.NotNull(viewModel);
+            Assert.Empty(viewModel);
         }
 
 
@@ -120,10 +123,10 @@ public abstract class DataSetCandidatesControllerTests(TestApplicationFactory te
 
             var response = await GetDataSetCandidates(releaseVersion.Id);
 
-            var content = response.AssertOk<List<ApiDataSetCandidateViewModel>>();
+            var viewModel = response.AssertOk<List<DataSetCandidateViewModel>>();
 
-            Assert.NotNull(content);
-            Assert.Empty(content);
+            Assert.NotNull(viewModel);
+            Assert.Empty(viewModel);
         }
 
         [Fact]
@@ -147,14 +150,14 @@ public abstract class DataSetCandidatesControllerTests(TestApplicationFactory te
 
             var response = await GetDataSetCandidates(releaseVersion.Id);
 
-            var content = response.AssertOk<List<ApiDataSetCandidateViewModel>>();
+            var viewModel = response.AssertOk<List<DataSetCandidateViewModel>>();
 
-            Assert.NotNull(content);
-            Assert.Empty(content);
+            Assert.NotNull(viewModel);
+            Assert.Empty(viewModel);
         }
 
         [Fact]
-        public async Task ReleaseFileHasAssociatedApiDataSet_NotReturned()
+        public async Task ReleaseFileHasAssociatedDataSet_NotReturned()
         {
             Release release = DataFixture
                 .DefaultRelease(publishedVersions: 0, draftVersion: true);
@@ -174,10 +177,10 @@ public abstract class DataSetCandidatesControllerTests(TestApplicationFactory te
 
             var response = await GetDataSetCandidates(releaseVersion.Id);
 
-            var content = response.AssertOk<List<ApiDataSetCandidateViewModel>>();
+            var viewModel = response.AssertOk<List<DataSetCandidateViewModel>>();
 
-            Assert.NotNull(content);
-            Assert.Empty(content);
+            Assert.NotNull(viewModel);
+            Assert.Empty(viewModel);
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetsControllerTests.cs
@@ -546,7 +546,8 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
             Assert.Equal(liveDataSetVersion.VersionType, viewModel.LatestLiveVersion.Type);
             Assert.Equal(liveDataSetVersion.TotalResults, viewModel.LatestLiveVersion.TotalResults);
             Assert.Equal(liveDataSetVersion.Published.TruncateNanoseconds(), viewModel.LatestLiveVersion.Published);
-            Assert.Equal(liveReleaseFile.File.DataSetFileId, viewModel.LatestLiveVersion.DataSetFileId);
+            Assert.Equal(liveReleaseFile.File.DataSetFileId, viewModel.LatestLiveVersion.File.Id);
+            Assert.Equal(liveReleaseFile.Name, viewModel.LatestLiveVersion.File.Title);
 
             Assert.Equal(
                 liveDataSetVersion.MetaSummary!.GeographicLevels.Select(l => l.GetEnumLabel()),
@@ -569,7 +570,8 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
             Assert.Equal(draftDataSetVersion.Status, viewModel.DraftVersion.Status);
             Assert.Equal(draftDataSetVersion.VersionType, viewModel.DraftVersion.Type);
             Assert.Equal(draftDataSetVersion.TotalResults, viewModel.DraftVersion.TotalResults);
-            Assert.Equal(draftReleaseFile.File.DataSetFileId, viewModel.DraftVersion.DataSetFileId);
+            Assert.Equal(draftReleaseFile.File.DataSetFileId, viewModel.DraftVersion.File.Id);
+            Assert.Equal(draftReleaseFile.Name, viewModel.DraftVersion.File.Title);
 
             Assert.Equal(draftReleaseVersion.Id, viewModel.DraftVersion.ReleaseVersion.Id);
             Assert.Equal(draftReleaseVersion.Title, viewModel.DraftVersion.ReleaseVersion.Title);
@@ -654,8 +656,9 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
 
             Assert.Equal(dataSet.Id, viewModel.Id);
 
-            Assert.Equal(file.DataSetFileId, viewModel.LatestLiveVersion!.DataSetFileId);
-            Assert.Equal(file.DataSetFileId, viewModel.DraftVersion!.DataSetFileId);
+            Assert.Equal(viewModel.LatestLiveVersion!.File.Id, viewModel.DraftVersion!.File.Id);
+            Assert.Equal(liveReleaseFile.File.DataSetFileId, viewModel.LatestLiveVersion!.File.Id);
+            Assert.Equal(draftReleaseFile.File.DataSetFileId, viewModel.DraftVersion!.File.Id);
         }
 
         [Fact]
@@ -715,7 +718,8 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
             Assert.Equal(dataSetVersion.Version, viewModel.LatestLiveVersion.Version);
             Assert.Equal(dataSetVersion.Status, viewModel.LatestLiveVersion.Status);
             Assert.Equal(dataSetVersion.VersionType, viewModel.LatestLiveVersion.Type);
-            Assert.Equal(releaseFile.File.DataSetFileId, viewModel.LatestLiveVersion.DataSetFileId);
+            Assert.Equal(releaseFile.File.DataSetFileId, viewModel.LatestLiveVersion!.File.Id);
+            Assert.Equal(releaseFile.Name, viewModel.LatestLiveVersion!.File.Title);
 
             Assert.Null(viewModel.DraftVersion);
         }
@@ -777,7 +781,8 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
             Assert.Equal(dataSetVersion.Version, viewModel.DraftVersion.Version);
             Assert.Equal(dataSetVersion.Status, viewModel.DraftVersion.Status);
             Assert.Equal(dataSetVersion.VersionType, viewModel.DraftVersion.Type);
-            Assert.Equal(releaseFile.File.DataSetFileId, viewModel.DraftVersion.DataSetFileId);
+            Assert.Equal(releaseFile.File.DataSetFileId, viewModel.DraftVersion!.File.Id);
+            Assert.Equal(releaseFile.Name, viewModel.DraftVersion!.File.Title);
 
             Assert.Null(viewModel.LatestLiveVersion);
         }
@@ -992,7 +997,8 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
             Assert.Equal(dataSetVersion.Version, content.DraftVersion!.Version);
             Assert.Equal(dataSetVersion.Status, content.DraftVersion!.Status);
             Assert.Equal(dataSetVersion.VersionType, content.DraftVersion!.Type);
-            Assert.Equal(draftReleaseFile.File.DataSetFileId!.Value, content.DraftVersion!.DataSetFileId);
+            Assert.Equal(draftReleaseFile.File.DataSetFileId, content.DraftVersion!.File.Id);
+            Assert.Equal(draftReleaseFile.Name, content.DraftVersion!.File.Title);
             Assert.Equal(draftReleaseVersion.Id, content.DraftVersion!.ReleaseVersion.Id);
             Assert.Equal(draftReleaseVersion.Title, content.DraftVersion!.ReleaseVersion.Title);
             Assert.Null(content.DraftVersion!.GeographicLevels);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetCandidatesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetCandidatesController.cs
@@ -14,16 +14,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Publi
 [Authorize]
 [ApiController]
 [Route("api/public-data/data-set-candidates")]
-public class DataSetCandidatesController(IReleaseService releaseService) : ControllerBase
+public class DataSetCandidatesController(IDataSetCandidateService dataSetCandidateService) : ControllerBase
 {
     [HttpGet]
     [Produces("application/json")]
-    public async Task<ActionResult<IReadOnlyList<ApiDataSetCandidateViewModel>>> ListApiDataSetCandidates(
+    public async Task<ActionResult<IReadOnlyList<DataSetCandidateViewModel>>> ListDataSetCandidates(
         [FromQuery] Guid releaseVersionId,
         CancellationToken cancellationToken)
     {
-        return await releaseService
-            .ListApiDataSetCandidates(releaseVersionId, cancellationToken)
+        return await dataSetCandidateService
+            .ListCandidates(releaseVersionId, cancellationToken)
             .HandleFailuresOrOk();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetCandidateService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetCandidateService.cs
@@ -9,9 +9,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 
-public interface IReleaseService
+public interface IDataSetCandidateService
 {
-    Task<Either<ActionResult, IReadOnlyList<ApiDataSetCandidateViewModel>>> ListApiDataSetCandidates(
+    Task<Either<ActionResult, IReadOnlyList<DataSetCandidateViewModel>>> ListCandidates(
         Guid releaseVersionId,
         CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetCandidateService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetCandidateService.cs
@@ -53,7 +53,7 @@ internal class DataSetCandidateService(
             .Where(rf => rf.File.ReplacingId == null)
             .Select(rf => new DataSetCandidateViewModel
             {
-                FileId = rf.FileId,
+                ReleaseFileId = rf.Id,
                 Title = rf.Name!,
             })
             .OrderBy(rf => rf.Title)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
@@ -204,7 +204,7 @@ internal class DataSetService(
             Version = dataSetVersion.Version,
             Status = dataSetVersion.Status,
             Type = dataSetVersion.VersionType,
-            DataSetFileId = releaseFile.File.DataSetFileId!.Value,
+            File = MapVersionFile(releaseFile),
             ReleaseVersion = MapReleaseVersion(releaseFile.ReleaseVersion),
             TotalResults = dataSetVersion.TotalResults,
             GeographicLevels = dataSetVersion.MetaSummary?.GeographicLevels
@@ -228,7 +228,7 @@ internal class DataSetService(
             Version = dataSetVersion.Version,
             Status = dataSetVersion.Status,
             Type = dataSetVersion.VersionType,
-            DataSetFileId = releaseFile.File.DataSetFileId!.Value,
+            File = MapVersionFile(releaseFile),
             Published = dataSetVersion.Published!.Value,
             TotalResults = dataSetVersion.TotalResults,
             ReleaseVersion = MapReleaseVersion(releaseFile.ReleaseVersion),
@@ -247,6 +247,15 @@ internal class DataSetService(
         {
             Id = releaseVersion.Id,
             Title = releaseVersion.Title,
+        };
+    }
+
+    private static IdTitleViewModel MapVersionFile(ReleaseFile releaseFile)
+    {
+        return new IdTitleViewModel
+        {
+            Id = releaseFile.File.DataSetFileId!.Value,
+            Title = releaseFile.Name ?? string.Empty,
         };
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -473,7 +473,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IUserPublicationInviteRepository, UserPublicationInviteRepository>();
             services.AddTransient<IRedirectsCacheService, RedirectsCacheService>();
             services.AddTransient<IRedirectsService, RedirectsService>();
-            services.AddTransient<Services.Interfaces.Public.Data.IReleaseService, Services.Public.Data.ReleaseService>();
+            services.AddTransient<IDataSetCandidateService, DataSetCandidateService>();
 
             services.AddHttpClient<IProcessorClient, ProcessorClient>((provider, httpClient) =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetCandidateViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetCandidateViewModel.cs
@@ -5,7 +5,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Dat
 
 public record DataSetCandidateViewModel
 {
-    public required Guid FileId { get; init; }
+    public required Guid ReleaseFileId { get; init; }
 
     public required string Title { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetCandidateViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetCandidateViewModel.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 
-public record ApiDataSetCandidateViewModel
+public record DataSetCandidateViewModel
 {
     public required Guid FileId { get; init; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
@@ -20,7 +20,7 @@ public record DataSetVersionViewModel
     [JsonConverter(typeof(StringEnumConverter))]
     public required DataSetVersionType Type { get; init; }
 
-    public required Guid DataSetFileId { get; init; }
+    public required IdTitleViewModel File { get; init; }
 
     public required IdTitleViewModel ReleaseVersion { get; init; }
 

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -6,6 +6,7 @@ import ProtectedRoute from '@admin/components/ProtectedRoute';
 import { useAuthContext } from '@admin/contexts/AuthContext';
 import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
 import { getReleaseApprovalStatusLabel } from '@admin/pages/release/utils/releaseSummaryUtil';
+import releaseQueries from '@admin/queries/releaseQueries';
 import {
   releaseContentRoute,
   releaseDataBlockCreateRoute,
@@ -29,10 +30,9 @@ import {
   releaseApiDataSetsRoute,
   releaseApiDataSetDetailsRoute,
 } from '@admin/routes/releaseRoutes';
-import releaseService from '@admin/services/releaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Tag from '@common/components/Tag';
-import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import { useQuery } from '@tanstack/react-query';
 import React, { useMemo } from 'react';
 import { generatePath, RouteComponentProps, Switch } from 'react-router';
 import { publicationReleasesRoute } from '@admin/routes/publicationRoutes';
@@ -79,13 +79,10 @@ const ReleasePageContainer = ({
   const { user } = useAuthContext();
 
   const {
-    value: release,
-    setState: setRelease,
+    data: release,
     isLoading: loadingRelease,
-  } = useAsyncHandledRetry(
-    () => releaseService.getRelease(releaseId),
-    [releaseId],
-  );
+    refetch,
+  } = useQuery(releaseQueries.get(releaseId));
 
   const navRoutes = useMemo(() => {
     return allNavRoutes.filter(route => {
@@ -193,12 +190,7 @@ const ReleasePageContainer = ({
             label="Release"
           />
 
-          <ReleaseContextProvider
-            release={release}
-            onReleaseChange={nextRelease => {
-              setRelease({ value: nextRelease });
-            }}
-          >
+          <ReleaseContextProvider release={release} onReleaseChange={refetch}>
             <Switch>
               {routes.map(route => (
                 <ProtectedRoute exact key={route.path} {...route} />

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -27,6 +27,7 @@ import {
   releaseSummaryRoute,
   releaseTableToolRoute,
   releaseApiDataSetsRoute,
+  releaseApiDataSetDetailsRoute,
 } from '@admin/routes/releaseRoutes';
 import releaseService from '@admin/services/releaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -61,6 +62,7 @@ const routes = [
   releaseTableToolRoute,
   releaseDataBlockCreateRoute,
   releaseDataBlockEditRoute,
+  releaseApiDataSetDetailsRoute,
 ];
 
 interface MatchProps {

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -26,6 +26,7 @@ import {
   releaseSummaryEditRoute,
   releaseSummaryRoute,
   releaseTableToolRoute,
+  releaseApiDataSetsRoute,
 } from '@admin/routes/releaseRoutes';
 import releaseService from '@admin/services/releaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -44,6 +45,7 @@ const allNavRoutes = [
   releaseContentRoute,
   releaseStatusRoute,
   releasePreReleaseAccessRoute,
+  releaseApiDataSetsRoute,
 ];
 
 const routes = [

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -7,7 +7,10 @@ import ReleaseStatusEditPage from '@admin/pages/release/ReleaseStatusEditPage';
 import permissionService, {
   ReleaseStatusPermissions,
 } from '@admin/services/permissionService';
-import releaseService, { ReleaseStatus } from '@admin/services/releaseService';
+import releaseService, {
+  ReleaseStageStatus,
+  ReleaseStatus,
+} from '@admin/services/releaseService';
 import Button from '@common/components/Button';
 import FormattedDate from '@common/components/FormattedDate';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -33,7 +36,7 @@ const statusMap: {
   Approved: 'Approved',
 };
 
-const ReleaseStatusPage = () => {
+export default function ReleaseStatusPage() {
   const [isEditing, toggleEditing] = useToggle(false);
 
   const location = useLocation();
@@ -64,6 +67,12 @@ const ReleaseStatusPage = () => {
 
   const { publicAppUrl } = useConfig();
 
+  const handlePublishingStatusChange = (status: ReleaseStageStatus) => {
+    if (status.overallStage === 'Complete') {
+      onReleaseChange();
+    }
+  };
+
   if (!release) {
     return <LoadingSpinner />;
   }
@@ -80,7 +89,7 @@ const ReleaseStatusPage = () => {
         onCancel={toggleEditing.off}
         onUpdate={nextRelease => {
           setRelease({ value: nextRelease });
-          onReleaseChange(nextRelease);
+          onReleaseChange();
           toggleEditing.off();
         }}
       />
@@ -112,6 +121,7 @@ const ReleaseStatusPage = () => {
             <ReleasePublishingStatus
               releaseId={releaseId}
               refreshPeriod={1000}
+              onChange={handlePublishingStatusChange}
             />
           </SummaryListItem>
         )}
@@ -188,6 +198,4 @@ const ReleaseStatusPage = () => {
       )}
     </>
   );
-};
-
-export default ReleaseStatusPage;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
@@ -13,7 +13,9 @@ import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import React from 'react';
 import { generatePath, RouteComponentProps, useLocation } from 'react-router';
 
-const ReleaseSummaryEditPage = ({ history }: RouteComponentProps) => {
+export default function ReleaseSummaryEditPage({
+  history,
+}: RouteComponentProps) {
   const location = useLocation();
   const lastLocation = useLastLocation();
 
@@ -36,7 +38,7 @@ const ReleaseSummaryEditPage = ({ history }: RouteComponentProps) => {
       throw new Error('Could not update missing release');
     }
 
-    const nextRelease = await releaseService.updateRelease(releaseId, {
+    await releaseService.updateRelease(releaseId, {
       year: Number(values.timePeriodCoverageStartYear),
       timePeriodCoverage: {
         value: values.timePeriodCoverageCode,
@@ -45,7 +47,7 @@ const ReleaseSummaryEditPage = ({ history }: RouteComponentProps) => {
       preReleaseAccessList: release.preReleaseAccessList,
     });
 
-    onReleaseChange(nextRelease);
+    onReleaseChange();
 
     history.push(
       generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
@@ -88,6 +90,4 @@ const ReleaseSummaryEditPage = ({ history }: RouteComponentProps) => {
       )}
     </LoadingSpinner>
   );
-};
-
-export default ReleaseSummaryEditPage;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/ReleaseApiDataSetDetailsPage.tsx
@@ -1,0 +1,197 @@
+import Link from '@admin/components/Link';
+import { useConfig } from '@admin/contexts/ConfigContext';
+import ApiDataSetVersionSummaryList from '@admin/pages/release/api-data-sets/components/ApiDataSetVersionSummaryList';
+import { useReleaseContext } from '@admin/pages/release/contexts/ReleaseContext';
+import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
+import {
+  releaseApiDataSetsRoute,
+  ReleaseDataSetRouteParams,
+  ReleaseRouteParams,
+} from '@admin/routes/releaseRoutes';
+import ButtonText from '@common/components/ButtonText';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import SummaryCard from '@common/components/SummaryCard';
+import Tag from '@common/components/Tag';
+import TaskList from '@common/components/TaskList';
+import TaskListItem from '@common/components/TaskListItem';
+import { useQuery } from '@tanstack/react-query';
+import React from 'react';
+import { generatePath, useParams } from 'react-router-dom';
+
+// TODO: EES-4370
+const showRemoveDraft = false;
+// TODO: Version mapping
+const showDraftVersionTasks = false;
+
+// TODO: EES-4367
+const showChangelog = false;
+// TODO: EES-4382
+const showVersionHistory = false;
+
+export default function ReleaseApiDataSetDetailsPage() {
+  const { dataSetId } = useParams<ReleaseDataSetRouteParams>();
+  const { publicAppUrl } = useConfig();
+  const { release } = useReleaseContext();
+
+  const { data: dataSet, isLoading } = useQuery({
+    ...apiDataSetQueries.get(dataSetId),
+    refetchInterval: data => {
+      return data?.draftVersion?.status === 'Processing' ? 3000 : false;
+    },
+  });
+
+  const columnSizeClassName =
+    dataSet?.latestLiveVersion && dataSet?.draftVersion
+      ? 'govuk-grid-column-one-half-from-desktop'
+      : 'govuk-grid-column-two-thirds-from-desktop';
+
+  const draftVersionSummary = dataSet?.draftVersion ? (
+    <ApiDataSetVersionSummaryList
+      dataSetVersion={dataSet?.draftVersion}
+      id="draft-version-summary"
+      publicationId={release.publicationId}
+      collapsibleButtonHiddenText="for draft version"
+      actions={
+        showRemoveDraft ? (
+          <ul className="govuk-list">
+            <li>
+              <ButtonText variant="warning">Remove draft version</ButtonText>
+            </li>
+          </ul>
+        ) : undefined
+      }
+    />
+  ) : null;
+
+  const liveVersionSummary = dataSet?.latestLiveVersion ? (
+    <ApiDataSetVersionSummaryList
+      dataSetVersion={dataSet.latestLiveVersion}
+      id="live-version-summary"
+      publicationId={release.publicationId}
+      collapsibleButtonHiddenText="for latest live version"
+      actions={
+        <ul className="govuk-list">
+          <li>
+            <a
+              href={`${publicAppUrl}/data-catalogue/data-set/${dataSet.latestLiveVersion.file.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View live data set (opens in new tab)
+            </a>
+          </li>
+          {showChangelog && (
+            <li>
+              <Link to="/todo">View changelog and guidance notes</Link>
+            </li>
+          )}
+          {showVersionHistory && (
+            <li>
+              <Link to="/todo">View version history</Link>
+            </li>
+          )}
+        </ul>
+      }
+    />
+  ) : null;
+
+  return (
+    <>
+      <Link
+        back
+        className="govuk-!-margin-bottom-6"
+        to={generatePath<ReleaseRouteParams>(releaseApiDataSetsRoute.path, {
+          releaseId: release.id,
+          publicationId: release.publicationId,
+        })}
+      >
+        Back to API data sets
+      </Link>
+
+      <LoadingSpinner loading={isLoading}>
+        {dataSet && (
+          <>
+            <span className="govuk-caption-l">API data set details</span>
+            <h2>{dataSet.title}</h2>
+
+            {dataSet.draftVersion?.status === 'Mapping' &&
+              showDraftVersionTasks && (
+                <div className="govuk-grid-row">
+                  <div className={columnSizeClassName}>
+                    <h3>Draft version tasks</h3>
+
+                    <p>
+                      To publish the draft version of the API data set, the
+                      following tasks need to be completed:
+                    </p>
+
+                    <TaskList className="govuk-!-margin-bottom-8">
+                      <TaskListItem
+                        id="map-locations-task"
+                        status={<Tag colour="red">Incomplete</Tag>}
+                        hint="Define the changes to locations in this version."
+                      >
+                        {props => (
+                          <Link {...props} to="/todo">
+                            Map locations
+                          </Link>
+                        )}
+                      </TaskListItem>
+                      <TaskListItem
+                        id="map-filters-task"
+                        status={<Tag colour="blue">Complete</Tag>}
+                        hint="Define the changes to filters in this version."
+                      >
+                        {props => (
+                          <Link {...props} to="/todo">
+                            Map filters
+                          </Link>
+                        )}
+                      </TaskListItem>
+                    </TaskList>
+                  </div>
+                </div>
+              )}
+
+            <div className="govuk-grid-row">
+              {draftVersionSummary && (
+                <div className={columnSizeClassName}>
+                  {dataSet.latestLiveVersion ? (
+                    <SummaryCard
+                      heading="Draft version details"
+                      headingTag="h3"
+                    >
+                      {draftVersionSummary}
+                    </SummaryCard>
+                  ) : (
+                    <>
+                      <h3>Draft version details</h3>
+                      {draftVersionSummary}
+                    </>
+                  )}
+                </div>
+              )}
+              {liveVersionSummary && (
+                <div className={columnSizeClassName}>
+                  {dataSet.draftVersion ? (
+                    <SummaryCard
+                      heading="Latest live version details"
+                      headingTag="h3"
+                    >
+                      {liveVersionSummary}
+                    </SummaryCard>
+                  ) : (
+                    <>
+                      <h3>Latest live version details</h3>
+                      {liveVersionSummary}
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </LoadingSpinner>
+    </>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/ReleaseApiDataSetsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/ReleaseApiDataSetsPage.tsx
@@ -1,0 +1,122 @@
+import { useAuthContext } from '@admin/contexts/AuthContext';
+import ApiDataSetCreateModal from '@admin/pages/release/api-data-sets/components/ApiDataSetCreateModal';
+import DraftApiDataSetsTable, {
+  DraftApiDataSetSummary,
+} from '@admin/pages/release/api-data-sets/components/DraftApiDataSetsTable';
+import LiveApiDataSetsTable, {
+  LiveApiDataSetSummary,
+} from '@admin/pages/release/api-data-sets/components/LiveApiDataSetsTable';
+import { useReleaseContext } from '@admin/pages/release/contexts/ReleaseContext';
+import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
+import InsetText from '@common/components/InsetText';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import WarningMessage from '@common/components/WarningMessage';
+import { useQuery } from '@tanstack/react-query';
+import React from 'react';
+
+export default function ReleaseApiDataSetsPage() {
+  const { release } = useReleaseContext();
+  const { user } = useAuthContext();
+
+  const { data: dataSets = [], isLoading: hasDataSetsLoading } = useQuery({
+    ...apiDataSetQueries.list(release.publicationId),
+    refetchInterval: 20_000,
+  });
+
+  const draftDataSets = dataSets.filter(
+    dataSet => dataSet.draftVersion,
+  ) as DraftApiDataSetSummary[];
+
+  const liveDataSets = dataSets.filter(
+    dataSet => dataSet.latestLiveVersion && !dataSet.draftVersion,
+  ) as LiveApiDataSetSummary[];
+
+  const canUpdateRelease = release.approvalStatus !== 'Approved';
+
+  return (
+    <>
+      <h2>API data sets</h2>
+
+      <InsetText className="govuk-!-width-three-quarters">
+        <h3>Before you start</h3>
+
+        <p>
+          API data sets are data sets that can be consumed by third-party
+          applications via the platform's public API.
+        </p>
+
+        <p>
+          An API data set should ideally be a long-lived data series where the
+          data structure is expected to remain stable between each release. New
+          versions of the API data set containing any updates can be published
+          with future releases.
+        </p>
+
+        <p>
+          If the structure of your data set will not be stable with future
+          releases, you are advised to avoid using an API data set. Users can
+          still download and explore your data by creating their own tables.
+        </p>
+
+        {!release.published && (
+          <strong>
+            Changes will not be made in the public API until this release has
+            been published.
+          </strong>
+        )}
+      </InsetText>
+
+      <LoadingSpinner loading={hasDataSetsLoading}>
+        {/* TODO: Update when non-BAU users can create API data sets  */}
+        {user?.permissions.isBauUser && (
+          <>
+            {canUpdateRelease ? (
+              <ApiDataSetCreateModal
+                publicationId={release.publicationId}
+                releaseId={release.id}
+              />
+            ) : (
+              <WarningMessage>
+                This release has been approved and API data sets can no longer
+                be created for it.
+              </WarningMessage>
+            )}
+          </>
+        )}
+
+        {dataSets.length > 0 ? (
+          <>
+            {draftDataSets.length > 0 && (
+              <>
+                <h3>Draft API data sets</h3>
+
+                <DraftApiDataSetsTable
+                  dataSets={draftDataSets}
+                  publicationId={release.publicationId}
+                  releaseId={release.id}
+                />
+              </>
+            )}
+
+            {liveDataSets.length > 0 && (
+              <>
+                <h3>Current live API data sets</h3>
+
+                <LiveApiDataSetsTable
+                  canUpdateRelease={canUpdateRelease}
+                  dataSets={liveDataSets}
+                  publicationId={release.publicationId}
+                  releaseId={release.id}
+                />
+              </>
+            )}
+          </>
+        ) : (
+          <InsetText>
+            No API data sets have been created for this publication.
+          </InsetText>
+        )}
+      </LoadingSpinner>
+    </>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -1,0 +1,299 @@
+import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
+import { testRelease } from '@admin/pages/release/__data__/testRelease';
+import ReleaseApiDataSetDetailsPage from '@admin/pages/release/api-data-sets/ReleaseApiDataSetDetailsPage';
+import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
+import {
+  releaseApiDataSetDetailsRoute,
+  ReleaseDataSetRouteParams,
+} from '@admin/routes/releaseRoutes';
+import _apiDataSetService, {
+  ApiDataSet,
+  ApiDataSetDraftVersion,
+  ApiDataSetLiveVersion,
+} from '@admin/services/apiDataSetService';
+import { Release } from '@admin/services/releaseService';
+import render from '@common-test/render';
+import { screen, within } from '@testing-library/react';
+import React from 'react';
+import { generatePath, MemoryRouter, Route } from 'react-router-dom';
+
+jest.mock('@admin/services/apiDataSetService');
+
+const apiDataSetService = jest.mocked(_apiDataSetService);
+
+describe('ReleaseApiDataSetDetailsPage', () => {
+  const testDataSet: ApiDataSet = {
+    id: 'data-set-id',
+    title: 'Data set title',
+    summary: 'Data set summary',
+    status: 'Published',
+  };
+
+  const testLiveVersion: ApiDataSetLiveVersion = {
+    id: 'live-version-id',
+    version: '1.0',
+    type: 'Minor',
+    status: 'Published',
+    totalResults: 10_000,
+    published: '2024-03-01T09:30:00+00:00',
+    releaseVersion: {
+      id: 'release-1-id',
+      title: 'Test release 1',
+    },
+    file: {
+      id: 'live-file-id',
+      title: 'Test live file',
+    },
+    filters: ['Test live filter'],
+    geographicLevels: ['National', 'Local authority'],
+    indicators: ['Test live indicator'],
+    timePeriods: {
+      start: '2018',
+      end: '2023',
+    },
+  };
+
+  const testProcessingVersion: ApiDataSetDraftVersion = {
+    id: 'processing-version-id',
+    version: '2.0',
+    status: 'Processing',
+    type: 'Minor',
+    totalResults: 0,
+    releaseVersion: {
+      id: 'release-2-id',
+      title: 'Test release 2',
+    },
+    file: {
+      id: 'processing-file-id',
+      title: 'Test processing file',
+    },
+  };
+
+  const testDraftVersion: ApiDataSetDraftVersion = {
+    id: 'draft-version-id',
+    version: '2.0',
+    status: 'Draft',
+    type: 'Major',
+    totalResults: 20_000,
+    releaseVersion: {
+      id: 'release-2-id',
+      title: 'Test release 2',
+    },
+    file: {
+      id: 'draft-file-id',
+      title: 'Test draft file',
+    },
+    filters: ['Test draft filter'],
+    geographicLevels: ['National', 'Local authority'],
+    indicators: ['Test draft indicator'],
+    timePeriods: {
+      start: '2018',
+      end: '2024',
+    },
+  };
+
+  test('renders correctly with processing version only', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      draftVersion: testProcessingVersion,
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('Draft version details'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: 'Draft version details' }),
+    ).toBeInTheDocument();
+
+    const summary = within(screen.getByTestId('draft-version-summary'));
+
+    expect(summary.getByTestId('Version')).toHaveTextContent('v2.0');
+    expect(summary.getByTestId('Status')).toHaveTextContent('Processing');
+
+    expect(summary.queryByTestId('Time periods')).not.toBeInTheDocument();
+    expect(summary.queryByTestId('Geographic levels')).not.toBeInTheDocument();
+    expect(summary.queryByTestId('Indicators')).not.toBeInTheDocument();
+    expect(summary.queryByTestId('Filters')).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('heading', { name: 'Latest live version details' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correctly with draft version only', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      draftVersion: testDraftVersion,
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('Draft version details'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: 'Draft version details' }),
+    ).toBeInTheDocument();
+
+    const summary = within(screen.getByTestId('draft-version-summary'));
+
+    expect(summary.getByTestId('Version')).toHaveTextContent('v2.0');
+    expect(summary.getByTestId('Status')).toHaveTextContent('Ready');
+    expect(summary.getByTestId('Time periods')).toHaveTextContent(
+      '2018 to 2024',
+    );
+    expect(summary.getByTestId('Geographic levels')).toHaveTextContent(
+      'National, Local authority',
+    );
+    expect(summary.getByTestId('Indicators')).toHaveTextContent(
+      'Test draft indicator',
+    );
+    expect(summary.getByTestId('Filters')).toHaveTextContent(
+      'Test draft filter',
+    );
+
+    expect(
+      screen.queryByRole('heading', { name: 'Latest live version details' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correctly with latest live version only', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      latestLiveVersion: testLiveVersion,
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('Latest live version details'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: 'Latest live version details' }),
+    ).toBeInTheDocument();
+
+    const summary = within(screen.getByTestId('live-version-summary'));
+
+    expect(summary.getByTestId('Version')).toHaveTextContent('v1.0');
+    expect(summary.getByTestId('Status')).toHaveTextContent('Published');
+    expect(summary.getByTestId('Time periods')).toHaveTextContent(
+      '2018 to 2023',
+    );
+    expect(summary.getByTestId('Indicators')).toHaveTextContent(
+      'Test live indicator',
+    );
+    expect(summary.getByTestId('Filters')).toHaveTextContent(
+      'Test live filter',
+    );
+    expect(
+      within(summary.getByTestId('Actions')).getByRole('link', {
+        name: /View live data set/,
+      }),
+    ).toHaveAttribute(
+      'href',
+      'http://localhost/data-catalogue/data-set/live-file-id',
+    );
+
+    expect(
+      screen.queryByRole('heading', { name: 'Draft version details' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correctly with draft and latest live version', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      draftVersion: testDraftVersion,
+      latestLiveVersion: testLiveVersion,
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('Draft version details'),
+    ).toBeInTheDocument();
+
+    // Draft version
+
+    expect(
+      screen.getByRole('heading', { name: 'Draft version details' }),
+    ).toBeInTheDocument();
+
+    const draftSummary = within(screen.getByTestId('draft-version-summary'));
+
+    expect(draftSummary.getByTestId('Version')).toHaveTextContent('v2.0');
+    expect(draftSummary.getByTestId('Status')).toHaveTextContent('Ready');
+    expect(draftSummary.getByTestId('Time periods')).toHaveTextContent(
+      '2018 to 2024',
+    );
+    expect(draftSummary.getByTestId('Geographic levels')).toHaveTextContent(
+      'National, Local authority',
+    );
+    expect(draftSummary.getByTestId('Indicators')).toHaveTextContent(
+      'Test draft indicator',
+    );
+    expect(draftSummary.getByTestId('Filters')).toHaveTextContent(
+      'Test draft filter',
+    );
+
+    // Latest live version
+
+    expect(
+      screen.getByRole('heading', { name: 'Latest live version details' }),
+    ).toBeInTheDocument();
+
+    const liveSummary = within(screen.getByTestId('live-version-summary'));
+
+    expect(liveSummary.getByTestId('Version')).toHaveTextContent('v1.0');
+    expect(liveSummary.getByTestId('Status')).toHaveTextContent('Published');
+    expect(liveSummary.getByTestId('Time periods')).toHaveTextContent(
+      '2018 to 2023',
+    );
+    expect(liveSummary.getByTestId('Indicators')).toHaveTextContent(
+      'Test live indicator',
+    );
+    expect(liveSummary.getByTestId('Filters')).toHaveTextContent(
+      'Test live filter',
+    );
+    expect(
+      within(liveSummary.getByTestId('Actions')).getByRole('link', {
+        name: /View live data set/,
+      }),
+    ).toHaveAttribute(
+      'href',
+      'http://localhost/data-catalogue/data-set/live-file-id',
+    );
+  });
+
+  function renderPage(options?: { release?: Release; dataSetId?: string }) {
+    const { release = testRelease, dataSetId = 'data-set-id' } = options ?? {};
+
+    render(
+      <TestConfigContextProvider>
+        <ReleaseContextProvider release={release}>
+          <MemoryRouter
+            initialEntries={[
+              generatePath<ReleaseDataSetRouteParams>(
+                releaseApiDataSetDetailsRoute.path,
+                {
+                  publicationId: release.publicationId,
+                  releaseId: release.id,
+                  dataSetId,
+                },
+              ),
+            ]}
+          >
+            <Route
+              component={ReleaseApiDataSetDetailsPage}
+              path={releaseApiDataSetDetailsRoute.path}
+            />
+          </MemoryRouter>
+        </ReleaseContextProvider>
+      </TestConfigContextProvider>,
+    );
+  }
+});

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/__tests__/ReleaseApiDataSetsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/__tests__/ReleaseApiDataSetsPage.test.tsx
@@ -1,0 +1,258 @@
+import { AuthContextTestProvider, User } from '@admin/contexts/AuthContext';
+import { testRelease } from '@admin/pages/release/__data__/testRelease';
+import ReleaseApiDataSetsPage from '@admin/pages/release/api-data-sets/ReleaseApiDataSetsPage';
+import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
+import {
+  releaseApiDataSetsRoute,
+  ReleaseRouteParams,
+} from '@admin/routes/releaseRoutes';
+import _apiDataSetCandidateService, {
+  ApiDataSetCandidate,
+} from '@admin/services/apiDataSetCandidateService';
+import _apiDataSetService, {
+  ApiDataSetSummary,
+} from '@admin/services/apiDataSetService';
+import { GlobalPermissions } from '@admin/services/authService';
+import { Release } from '@admin/services/releaseService';
+import render, { CustomRenderResult } from '@common-test/render';
+import { screen, within } from '@testing-library/react';
+import { generatePath, MemoryRouter, Route } from 'react-router-dom';
+
+jest.mock('@admin/services/apiDataSetService');
+jest.mock('@admin/services/apiDataSetCandidateService');
+
+const apiDataSetCandidateService = jest.mocked(_apiDataSetCandidateService);
+const apiDataSetService = jest.mocked(_apiDataSetService);
+
+describe('ReleaseApiDataSetsPage', () => {
+  const testBauUser: User = {
+    id: 'user-id-1',
+    name: 'BAU user',
+    permissions: {
+      isBauUser: true,
+    } as GlobalPermissions,
+  };
+
+  const testAnalystUser: User = {
+    id: 'user-id-1',
+    name: 'Analyst user',
+    permissions: {
+      isBauUser: false,
+    } as GlobalPermissions,
+  };
+
+  const testDataSets: ApiDataSetSummary[] = [
+    {
+      id: 'data-set-1',
+      title: 'Data set 1 title',
+      summary: 'Data set 1 summary',
+      status: 'Published',
+      draftVersion: {
+        id: 'version-1',
+        version: '1.0',
+        status: 'Draft',
+        type: 'Major',
+      },
+    },
+    {
+      id: 'data-set-2',
+      title: 'Data set 2 title',
+      summary: 'Data set 2 summary',
+      status: 'Published',
+      draftVersion: {
+        id: 'version-2',
+        version: '1.1',
+        status: 'Draft',
+        type: 'Minor',
+      },
+      latestLiveVersion: {
+        id: 'version-3',
+        version: '1.0',
+        status: 'Published',
+        type: 'Major',
+        published: '2024-05-01T09:30:00+00:00',
+      },
+    },
+    {
+      id: 'data-set-3',
+      title: 'Data set 3 title',
+      summary: 'Data set 3 summary',
+      status: 'Published',
+      latestLiveVersion: {
+        id: 'version-4',
+        version: '1.0',
+        status: 'Published',
+        type: 'Major',
+        published: '2024-05-01T09:30:00+00:00',
+      },
+    },
+  ];
+
+  const testCandidates: ApiDataSetCandidate[] = [
+    {
+      releaseFileId: 'release-file-1',
+      title: 'Test data set 1',
+    },
+    {
+      releaseFileId: 'release-file-2',
+      title: 'Test data set 2',
+    },
+  ];
+
+  test('renders draft and live data set tables correctly', async () => {
+    apiDataSetCandidateService.listCandidates.mockResolvedValue([]);
+    apiDataSetService.listDataSets.mockResolvedValue(testDataSets);
+
+    renderPage();
+
+    expect(await screen.findByText('Draft API data sets')).toBeInTheDocument();
+
+    const draftsTable = within(screen.getByTestId('draft-api-data-sets'));
+
+    const draftRows = draftsTable.getAllByRole('row');
+    expect(draftRows).toHaveLength(3);
+
+    const draftRow1Cells = within(draftRows[1]).getAllByRole('cell');
+    expect(draftRow1Cells[0]).toHaveTextContent('v1.0');
+    expect(draftRow1Cells[1]).toHaveTextContent('N/A');
+    expect(draftRow1Cells[2]).toHaveTextContent('Data set 1 title');
+
+    const draftRow2Cells = within(draftRows[2]).getAllByRole('cell');
+    expect(draftRow2Cells[0]).toHaveTextContent('v1.1');
+    expect(draftRow2Cells[1]).toHaveTextContent('v1.0');
+    expect(draftRow2Cells[2]).toHaveTextContent('Data set 2 title');
+
+    expect(screen.getByText('Current live API data sets')).toBeInTheDocument();
+
+    const liveTable = within(screen.getByTestId('live-api-data-sets'));
+
+    const liveRows = liveTable.getAllByRole('row');
+    expect(liveRows).toHaveLength(2);
+
+    const liveRows1Cells = within(liveRows[1]).getAllByRole('cell');
+    expect(liveRows1Cells[0]).toHaveTextContent('v1.0');
+    expect(liveRows1Cells[1]).toHaveTextContent('Data set 3 title');
+  });
+
+  test('renders correctly when no data sets exist', async () => {
+    apiDataSetCandidateService.listCandidates.mockResolvedValue([]);
+    apiDataSetService.listDataSets.mockResolvedValue(testDataSets);
+
+    renderPage();
+
+    expect(await screen.findByText('Draft API data sets')).toBeInTheDocument();
+    expect(screen.getByText('Current live API data sets')).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(
+        'No API data sets have been created for this publication.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders info message when release has not been published', async () => {
+    apiDataSetCandidateService.listCandidates.mockResolvedValue([]);
+    apiDataSetService.listDataSets.mockResolvedValue([]);
+
+    renderPage();
+
+    expect(
+      await screen.findByText(
+        'Changes will not be made in the public API until this release has been published.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('renders warning message when release has been approved and data sets cannot be created', async () => {
+    apiDataSetCandidateService.listCandidates.mockResolvedValue([]);
+    apiDataSetService.listDataSets.mockResolvedValue([]);
+
+    renderPage({
+      release: {
+        ...testRelease,
+        approvalStatus: 'Approved',
+      },
+    });
+
+    expect(
+      await screen.findByText(
+        'This release has been approved and API data sets can no longer be created for it.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', { name: 'Create API data set' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not render create button when user is not BAU', async () => {
+    apiDataSetCandidateService.listCandidates.mockResolvedValue([]);
+    apiDataSetService.listDataSets.mockResolvedValue([]);
+
+    renderPage({ user: testAnalystUser });
+
+    expect(
+      await screen.findByText(
+        'No API data sets have been created for this publication.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByText('Create API data set')).not.toBeInTheDocument();
+  });
+
+  test('clicking the create button opens modal form to create API data set', async () => {
+    apiDataSetCandidateService.listCandidates.mockResolvedValue(testCandidates);
+    apiDataSetService.listDataSets.mockResolvedValue([]);
+
+    const { user } = renderPage();
+
+    expect(await screen.findByText('Create API data set')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Create API data set' }),
+    );
+
+    expect(
+      await screen.findByText('Create a new API data set'),
+    ).toBeInTheDocument();
+
+    const modal = within(screen.getByRole('dialog'));
+
+    expect(
+      modal.getByRole('heading', { name: 'Create a new API data set' }),
+    ).toBeInTheDocument();
+
+    expect(modal.getByLabelText('Data set')).toBeInTheDocument();
+
+    expect(
+      modal.getByRole('button', { name: 'Confirm new API data set' }),
+    ).toBeInTheDocument();
+  });
+
+  function renderPage(options?: {
+    release?: Release;
+    user?: User;
+  }): CustomRenderResult {
+    const { release = testRelease, user = testBauUser } = options ?? {};
+
+    return render(
+      <AuthContextTestProvider user={user}>
+        <ReleaseContextProvider release={release}>
+          <MemoryRouter
+            initialEntries={[
+              generatePath<ReleaseRouteParams>(releaseApiDataSetsRoute.path, {
+                publicationId: testRelease.publicationId,
+                releaseId: testRelease.id,
+              }),
+            ]}
+          >
+            <Route
+              path={releaseApiDataSetsRoute.path}
+              component={ReleaseApiDataSetsPage}
+            />
+          </MemoryRouter>
+        </ReleaseContextProvider>
+      </AuthContextTestProvider>,
+    );
+  }
+});

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/ApiDataSetCreateForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/ApiDataSetCreateForm.tsx
@@ -1,0 +1,71 @@
+import { ApiDataSetCandidate } from '@admin/services/apiDataSetCandidateService';
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import ButtonText from '@common/components/ButtonText';
+import { Form, FormFieldSelect } from '@common/components/form';
+import FormProvider from '@common/components/form/FormProvider';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import Yup from '@common/validation/yup';
+import React, { useMemo } from 'react';
+import { ObjectSchema } from 'yup';
+
+export interface ApiDataSetCreateFormValues {
+  releaseFileId: string;
+}
+
+export interface ApiDataSetCreateFormProps {
+  dataSetCandidates: ApiDataSetCandidate[];
+  onCancel: () => void;
+  onSubmit: (values: ApiDataSetCreateFormValues) => void;
+}
+
+export default function ApiDataSetCreateForm({
+  dataSetCandidates,
+  onCancel,
+  onSubmit,
+}: ApiDataSetCreateFormProps) {
+  const validationSchema = useMemo<
+    ObjectSchema<ApiDataSetCreateFormValues>
+  >(() => {
+    return Yup.object({
+      releaseFileId: Yup.string().required('Choose a data set'),
+    });
+  }, []);
+
+  return (
+    <FormProvider validationSchema={validationSchema}>
+      {({ formState }) => {
+        return (
+          <Form id="apiDataSetCreateForm" onSubmit={onSubmit}>
+            <FormFieldSelect<ApiDataSetCreateFormValues>
+              name="releaseFileId"
+              label="Data set"
+              options={dataSetCandidates.map(candidate => ({
+                label: candidate.title,
+                value: candidate.releaseFileId,
+              }))}
+              placeholder="Choose a data set"
+            />
+
+            <ButtonGroup>
+              <Button type="submit" ariaDisabled={formState.isSubmitting}>
+                Confirm new API data set
+              </Button>
+              <ButtonText
+                ariaDisabled={formState.isSubmitting}
+                onClick={onCancel}
+              >
+                Cancel
+              </ButtonText>
+              <LoadingSpinner
+                inline
+                loading={formState.isSubmitting}
+                size="sm"
+              />
+            </ButtonGroup>
+          </Form>
+        );
+      }}
+    </FormProvider>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/ApiDataSetCreateModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/ApiDataSetCreateModal.tsx
@@ -4,7 +4,9 @@ import ApiDataSetCreateForm, {
 } from '@admin/pages/release/api-data-sets/components/ApiDataSetCreateForm';
 import apiDataSetCandidateQueries from '@admin/queries/apiDataSetCandidateQueries';
 import {
+  releaseApiDataSetDetailsRoute,
   releaseDataRoute,
+  ReleaseDataSetRouteParams,
   ReleaseRouteParams,
 } from '@admin/routes/releaseRoutes';
 import apiDataSetService from '@admin/services/apiDataSetService';
@@ -14,7 +16,7 @@ import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import { useQuery } from '@tanstack/react-query';
 import React from 'react';
-import { generatePath } from 'react-router-dom';
+import { generatePath, useHistory } from 'react-router-dom';
 
 interface Props {
   publicationId: string;
@@ -25,6 +27,7 @@ export default function ApiDataSetCreateModal({
   publicationId,
   releaseId,
 }: Props) {
+  const history = useHistory();
   const [isOpen, toggleOpen] = useToggle(false);
 
   const {
@@ -41,9 +44,20 @@ export default function ApiDataSetCreateModal({
   const handleSubmit = async ({
     releaseFileId,
   }: ApiDataSetCreateFormValues) => {
-    await apiDataSetService.createDataSet({
+    const dataSet = await apiDataSetService.createDataSet({
       releaseFileId,
     });
+
+    history.push(
+      generatePath<ReleaseDataSetRouteParams>(
+        releaseApiDataSetDetailsRoute.path,
+        {
+          publicationId,
+          releaseId,
+          dataSetId: dataSet.id,
+        },
+      ),
+    );
   };
 
   if (isLoading) {

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/ApiDataSetCreateModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/ApiDataSetCreateModal.tsx
@@ -1,0 +1,93 @@
+import Link from '@admin/components/Link';
+import ApiDataSetCreateForm, {
+  ApiDataSetCreateFormValues,
+} from '@admin/pages/release/api-data-sets/components/ApiDataSetCreateForm';
+import apiDataSetCandidateQueries from '@admin/queries/apiDataSetCandidateQueries';
+import {
+  releaseDataRoute,
+  ReleaseRouteParams,
+} from '@admin/routes/releaseRoutes';
+import apiDataSetService from '@admin/services/apiDataSetService';
+import Button from '@common/components/Button';
+import Modal from '@common/components/Modal';
+import WarningMessage from '@common/components/WarningMessage';
+import useToggle from '@common/hooks/useToggle';
+import { useQuery } from '@tanstack/react-query';
+import React from 'react';
+import { generatePath } from 'react-router-dom';
+
+interface Props {
+  publicationId: string;
+  releaseId: string;
+}
+
+export default function ApiDataSetCreateModal({
+  publicationId,
+  releaseId,
+}: Props) {
+  const [isOpen, toggleOpen] = useToggle(false);
+
+  const {
+    data: dataSetCandidates = [],
+    isLoading,
+    refetch,
+  } = useQuery(apiDataSetCandidateQueries.list(releaseId));
+
+  const handleTriggerClick = async () => {
+    toggleOpen.on();
+    await refetch();
+  };
+
+  const handleSubmit = async ({
+    releaseFileId,
+  }: ApiDataSetCreateFormValues) => {
+    await apiDataSetService.createDataSet({
+      releaseFileId,
+    });
+  };
+
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <Modal
+      open={isOpen}
+      title="Create a new API data set"
+      triggerButton={
+        <Button onClick={handleTriggerClick}>Create API data set</Button>
+      }
+    >
+      <p>
+        Select a data set to become an API data set. This will be made available
+        for third-party applications to consume via the public API.
+      </p>
+
+      {dataSetCandidates.length > 0 ? (
+        <ApiDataSetCreateForm
+          dataSetCandidates={dataSetCandidates}
+          onCancel={toggleOpen.off}
+          onSubmit={handleSubmit}
+        />
+      ) : (
+        <>
+          <WarningMessage>
+            No API data sets can be created as there are no candidates data
+            files available. New candidate data files can be uploaded in the{' '}
+            <Link
+              to={generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
+                publicationId,
+                releaseId,
+              })}
+            >
+              Data and files
+            </Link>{' '}
+            section.
+          </WarningMessage>
+
+          <Button onClick={toggleOpen.off}>Close</Button>
+        </>
+      )}
+    </Modal>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/ApiDataSetVersionSummaryList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/ApiDataSetVersionSummaryList.tsx
@@ -1,0 +1,114 @@
+import Link from '@admin/components/Link';
+import getVersionStatusTagColour from '@admin/pages/release/api-data-sets/utils/getVersionStatusColour';
+import getVersionStatusText from '@admin/pages/release/api-data-sets/utils/getVersionStatusText';
+import {
+  ReleaseRouteParams,
+  releaseSummaryRoute,
+} from '@admin/routes/releaseRoutes';
+import {
+  ApiDataSetDraftVersion,
+  ApiDataSetLiveVersion,
+} from '@admin/services/apiDataSetService';
+import CollapsibleList from '@common/components/CollapsibleList';
+import SummaryList from '@common/components/SummaryList';
+import SummaryListItem from '@common/components/SummaryListItem';
+import Tag from '@common/components/Tag';
+import getTimePeriodString from '@common/modules/table-tool/utils/getTimePeriodString';
+import React, { ReactNode } from 'react';
+import { generatePath } from 'react-router';
+
+interface ApiDataSetVersionSummaryListProps {
+  actions?: ReactNode;
+  collapsibleButtonHiddenText?: string;
+  dataSetVersion: ApiDataSetDraftVersion | ApiDataSetLiveVersion;
+  id: string;
+  publicationId: string;
+  testId?: string;
+}
+
+export default function ApiDataSetVersionSummaryList({
+  actions,
+  collapsibleButtonHiddenText,
+  dataSetVersion,
+  id,
+  publicationId,
+  testId = id,
+}: ApiDataSetVersionSummaryListProps) {
+  return (
+    <SummaryList id={id} testId={testId}>
+      <SummaryListItem term="Version">
+        <Tag
+          colour={getVersionStatusTagColour(dataSetVersion.status)}
+        >{`v${dataSetVersion.version}`}</Tag>
+      </SummaryListItem>
+      <SummaryListItem term="Status">
+        <Tag colour={getVersionStatusTagColour(dataSetVersion.status)}>
+          {getVersionStatusText(dataSetVersion.status)}
+        </Tag>
+      </SummaryListItem>
+      <SummaryListItem term="Release">
+        <Link
+          to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
+            releaseId: dataSetVersion.releaseVersion.id,
+            publicationId,
+          })}
+        >
+          {dataSetVersion.releaseVersion.title}
+        </Link>
+      </SummaryListItem>
+      <SummaryListItem term="Data set file">
+        {dataSetVersion.file.title}
+      </SummaryListItem>
+      {dataSetVersion.geographicLevels && (
+        <SummaryListItem term="Geographic levels">
+          {dataSetVersion.geographicLevels.join(', ')}
+        </SummaryListItem>
+      )}
+      {dataSetVersion.timePeriods && (
+        <SummaryListItem term="Time periods">
+          {getTimePeriodString({
+            from: dataSetVersion.timePeriods.start,
+            to: dataSetVersion.timePeriods.end,
+          })}
+        </SummaryListItem>
+      )}
+      {dataSetVersion.indicators && dataSetVersion.indicators.length > 0 && (
+        <SummaryListItem term="Indicators">
+          <CollapsibleList
+            buttonClassName="govuk-!-margin-bottom-1"
+            buttonHiddenText={collapsibleButtonHiddenText}
+            collapseAfter={3}
+            id={`${id}-indicators`}
+            itemName="indicator"
+            itemNamePlural="indicators"
+            listClassName="govuk-!-margin-top-0 govuk-!-margin-bottom-1"
+          >
+            {dataSetVersion.indicators.map((indicator, index) => (
+              <li key={`indicator-${index.toString()}`}>{indicator}</li>
+            ))}
+          </CollapsibleList>
+        </SummaryListItem>
+      )}
+      {dataSetVersion.filters && dataSetVersion.filters.length > 0 && (
+        <SummaryListItem term="Filters">
+          <CollapsibleList
+            buttonClassName="govuk-!-margin-bottom-1"
+            buttonHiddenText={collapsibleButtonHiddenText}
+            collapseAfter={3}
+            id={`${id}-filters`}
+            itemName="filter"
+            itemNamePlural="filters"
+            listClassName="govuk-!-margin-top-0 govuk-!-margin-bottom-1"
+          >
+            {dataSetVersion.filters.map((filter, index) => (
+              <li key={`filter-${index.toString()}`}>{filter}</li>
+            ))}
+          </CollapsibleList>
+        </SummaryListItem>
+      )}
+      {actions ? (
+        <SummaryListItem term="Actions">{actions}</SummaryListItem>
+      ) : null}
+    </SummaryList>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/DraftApiDataSetsTable.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/DraftApiDataSetsTable.module.scss
@@ -1,0 +1,29 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.table {
+  thead th {
+    vertical-align: bottom;
+  }
+
+  td {
+    padding-bottom: govuk-spacing(4);
+    padding-top: govuk-spacing(4);
+    vertical-align: middle;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    td {
+      padding-bottom: govuk-spacing(5);
+      padding-top: govuk-spacing(5);
+    }
+  }
+}
+
+.rowHighlight {
+  border-left: 5px solid govuk-colour('red');
+}
+
+.versionTag {
+  text-align: center;
+  width: 100%;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/DraftApiDataSetsTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/DraftApiDataSetsTable.tsx
@@ -1,0 +1,128 @@
+import Link from '@admin/components/Link';
+import getVersionStatusTagColour from '@admin/pages/release/api-data-sets/utils/getVersionStatusColour';
+import getVersionStatusText from '@admin/pages/release/api-data-sets/utils/getVersionStatusText';
+import {
+  releaseApiDataSetDetailsRoute,
+  ReleaseDataSetRouteParams,
+} from '@admin/routes/releaseRoutes';
+import {
+  ApiDataSetDraftVersionSummary,
+  ApiDataSetSummary,
+} from '@admin/services/apiDataSetService';
+import ButtonGroup from '@common/components/ButtonGroup';
+import ButtonText from '@common/components/ButtonText';
+import InsetText from '@common/components/InsetText';
+import Tag from '@common/components/Tag';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import classNames from 'classnames';
+import orderBy from 'lodash/orderBy';
+import React from 'react';
+import { generatePath } from 'react-router-dom';
+import styles from './DraftApiDataSetsTable.module.scss';
+
+export interface DraftApiDataSetSummary extends ApiDataSetSummary {
+  draftVersion: ApiDataSetDraftVersionSummary;
+}
+
+interface Props {
+  dataSets: DraftApiDataSetSummary[];
+  publicationId: string;
+  releaseId: string;
+}
+
+export default function DraftApiDataSetsTable({
+  dataSets,
+  publicationId,
+  releaseId,
+}: Props) {
+  if (!dataSets.length) {
+    return <InsetText>No draft API data sets for this publication.</InsetText>;
+  }
+
+  const hasLiveDataSets = dataSets.some(dataSet => dataSet.latestLiveVersion);
+  const orderedDataSets = orderBy(dataSets, dataSet => dataSet.title);
+
+  return (
+    <table className={styles.table} data-testid="draft-api-data-sets">
+      <thead>
+        <tr>
+          <th scope="col" style={{ width: '5%' }}>
+            Draft version
+          </th>
+          {hasLiveDataSets && <th style={{ width: '5%' }}>Live version</th>}
+          <th scope="col">Name</th>
+          <th scope="col">Status</th>
+          <th scope="col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {orderedDataSets.map(
+          ({ draftVersion, latestLiveVersion, ...dataSet }) => (
+            <tr
+              key={dataSet.id}
+              className={classNames({
+                [styles.rowHighlight]:
+                  draftVersion.status === 'Failed' ||
+                  draftVersion.status === 'Cancelled' ||
+                  draftVersion.status === 'Mapping',
+              })}
+            >
+              <td className="govuk-!-padding-left-1">
+                <Tag
+                  className={styles.versionTag}
+                  colour={getVersionStatusTagColour(draftVersion.status)}
+                >
+                  {`v${draftVersion.version}`}
+                </Tag>
+              </td>
+              {hasLiveDataSets ? (
+                <td>
+                  <Tag
+                    className={styles.versionTag}
+                    colour={latestLiveVersion ? 'blue' : 'grey'}
+                  >
+                    {latestLiveVersion?.version
+                      ? `v${latestLiveVersion?.version}`
+                      : 'N/A'}
+                  </Tag>
+                </td>
+              ) : null}
+              <td>{dataSet.title}</td>
+              <td>
+                <Tag colour={getVersionStatusTagColour(draftVersion.status)}>
+                  {getVersionStatusText(draftVersion.status)}
+                </Tag>
+              </td>
+              <td>
+                <ButtonGroup
+                  className="govuk-!-margin-bottom-0"
+                  horizontalSpacing="m"
+                >
+                  {draftVersion.status !== 'Processing' && (
+                    <ButtonText variant="warning">
+                      Remove draft
+                      <VisuallyHidden> for {dataSet.title}</VisuallyHidden>
+                    </ButtonText>
+                  )}
+                  <Link
+                    to={generatePath<ReleaseDataSetRouteParams>(
+                      releaseApiDataSetDetailsRoute.path,
+                      {
+                        publicationId,
+                        releaseId,
+                        dataSetId: dataSet.id,
+                      },
+                    )}
+                  >
+                    View / edit draft
+                    <VisuallyHidden>for {dataSet.title}</VisuallyHidden>
+                  </Link>
+                </ButtonGroup>
+              </td>
+            </tr>
+          ),
+        )}
+      </tbody>
+    </table>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/LiveApiDataSetsTable.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/LiveApiDataSetsTable.module.scss
@@ -1,0 +1,9 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.table {
+  td {
+    padding-bottom: govuk-spacing(4);
+    padding-top: govuk-spacing(4);
+    vertical-align: middle;
+  }
+}

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/LiveApiDataSetsTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/LiveApiDataSetsTable.tsx
@@ -1,0 +1,93 @@
+import Link from '@admin/components/Link';
+import {
+  releaseApiDataSetDetailsRoute,
+  ReleaseDataSetRouteParams,
+} from '@admin/routes/releaseRoutes';
+import {
+  ApiDataSetLiveVersionSummary,
+  ApiDataSetSummary,
+} from '@admin/services/apiDataSetService';
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import InsetText from '@common/components/InsetText';
+import Tag from '@common/components/Tag';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import orderBy from 'lodash/orderBy';
+import React from 'react';
+import { generatePath } from 'react-router-dom';
+import styles from './LiveApiDataSetsTable.module.scss';
+
+export interface LiveApiDataSetSummary extends ApiDataSetSummary {
+  latestLiveVersion: ApiDataSetLiveVersionSummary;
+}
+
+interface Props {
+  // TODO: EES-4374 Remove when new versions can be created
+  canCreateNewVersions?: boolean;
+  canUpdateRelease?: boolean;
+  dataSets: LiveApiDataSetSummary[];
+  publicationId: string;
+  releaseId: string;
+}
+
+export default function LiveApiDataSetsTable({
+  canCreateNewVersions,
+  canUpdateRelease,
+  dataSets,
+  publicationId,
+  releaseId,
+}: Props) {
+  if (!dataSets.length) {
+    return <InsetText>No live API data sets for this publication.</InsetText>;
+  }
+
+  const orderedDataSets = orderBy(dataSets, dataSet => dataSet.title);
+
+  return (
+    <table className={styles.table} data-testid="live-api-data-sets">
+      <thead>
+        <tr>
+          <th scope="col">Version</th>
+          <th scope="col">Name</th>
+          <th scope="col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {orderedDataSets.map(({ latestLiveVersion, ...dataSet }) => (
+          <tr key={dataSet.id}>
+            <td>
+              <Tag>{`v${latestLiveVersion.version}`}</Tag>
+            </td>
+            <td>{dataSet.title}</td>
+            <td>
+              <ButtonGroup
+                className="govuk-!-margin-bottom-0"
+                horizontalSpacing="l"
+              >
+                <Link
+                  to={generatePath<ReleaseDataSetRouteParams>(
+                    releaseApiDataSetDetailsRoute.path,
+                    {
+                      publicationId,
+                      releaseId,
+                      dataSetId: dataSet.id,
+                    },
+                  )}
+                >
+                  View details
+                  <VisuallyHidden> for {dataSet.title}</VisuallyHidden>
+                </Link>
+                {canUpdateRelease && canCreateNewVersions && (
+                  <Button>
+                    Create new version
+                    <VisuallyHidden> for {dataSet.title}</VisuallyHidden>
+                  </Button>
+                )}
+              </ButtonGroup>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/__tests__/ApiDataSetCreateForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/__tests__/ApiDataSetCreateForm.test.tsx
@@ -1,0 +1,151 @@
+import ApiDataSetCreateForm, {
+  ApiDataSetCreateFormProps,
+} from '@admin/pages/release/api-data-sets/components/ApiDataSetCreateForm';
+import { ApiDataSetCandidate } from '@admin/services/apiDataSetCandidateService';
+import render from '@common-test/render';
+import { screen, waitFor, within } from '@testing-library/react';
+import noop from 'lodash/noop';
+
+describe('ApiDataSetCreateForm', () => {
+  const testCandidates: ApiDataSetCandidate[] = [
+    {
+      releaseFileId: 'release-file-id-1',
+      title: 'Test data set 1',
+    },
+    {
+      releaseFileId: 'release-file-id-2',
+      title: 'Test data set 2',
+    },
+    {
+      releaseFileId: 'release-file-id-3',
+      title: 'Test data set 2',
+    },
+  ];
+
+  test('renders form correctly', () => {
+    render(
+      <ApiDataSetCreateForm
+        dataSetCandidates={testCandidates}
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    const options = within(screen.getByLabelText('Data set')).getAllByRole(
+      'option',
+    );
+
+    expect(options).toHaveLength(4);
+
+    expect(options[0]).toHaveValue('');
+    expect(options[0]).toHaveTextContent('Choose a data set');
+
+    expect(options[1]).toHaveValue(testCandidates[0].releaseFileId);
+    expect(options[1]).toHaveTextContent(testCandidates[0].title);
+
+    expect(options[2]).toHaveValue(testCandidates[1].releaseFileId);
+    expect(options[2]).toHaveTextContent(testCandidates[1].title);
+
+    expect(options[3]).toHaveValue(testCandidates[2].releaseFileId);
+    expect(options[3]).toHaveTextContent(testCandidates[2].title);
+  });
+
+  test('shows validation error when no data set selected', async () => {
+    const { user } = render(
+      <ApiDataSetCreateForm
+        dataSetCandidates={testCandidates}
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('Data set'));
+    await user.tab();
+
+    expect(
+      await screen.findByText('Choose a data set', {
+        selector: '#apiDataSetCreateForm-releaseFileId-error',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('shows validation error if submitted without selecting data set', async () => {
+    const { user } = render(
+      <ApiDataSetCreateForm
+        dataSetCandidates={testCandidates}
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'Confirm new API data set' }),
+    );
+
+    expect(
+      await screen.findByText('Choose a data set', {
+        selector: '#apiDataSetCreateForm-releaseFileId-error',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('submitting form successfully calls `onSubmit` handler', async () => {
+    const handleSubmit = jest.fn();
+
+    const { user } = render(
+      <ApiDataSetCreateForm
+        dataSetCandidates={testCandidates}
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    await user.selectOptions(
+      screen.getByLabelText('Data set'),
+      'Test data set 2',
+    );
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Confirm new API data set' }),
+    );
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+      expect(handleSubmit).toHaveBeenCalledWith<
+        Parameters<ApiDataSetCreateFormProps['onSubmit']>
+      >({
+        releaseFileId: testCandidates[1].releaseFileId,
+      });
+    });
+  });
+
+  test('submitting form with validation error does not call `onSubmit` handler', async () => {
+    const handleSubmit = jest.fn();
+
+    const { user } = render(
+      <ApiDataSetCreateForm
+        dataSetCandidates={testCandidates}
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Confirm new API data set' }),
+    );
+
+    expect(
+      await screen.findByText('Choose a data set', {
+        selector: '#apiDataSetCreateForm-releaseFileId-error',
+      }),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/__tests__/ApiDataSetCreateModal.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/__tests__/ApiDataSetCreateModal.test.tsx
@@ -1,0 +1,127 @@
+import ApiDataSetCreateModal from '@admin/pages/release/api-data-sets/components/ApiDataSetCreateModal';
+import _apiDataSetCandidateService, {
+  ApiDataSetCandidate,
+} from '@admin/services/apiDataSetCandidateService';
+import _apiDataSetService from '@admin/services/apiDataSetService';
+import baseRender from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
+import { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('@admin/services/apiDataSetService');
+jest.mock('@admin/services/apiDataSetCandidateService');
+
+const apiDataSetCandidateService = jest.mocked(_apiDataSetCandidateService);
+const apiDataSetService = jest.mocked(_apiDataSetService);
+
+describe('ApiDataSetCreateModal', () => {
+  const testCandidates: ApiDataSetCandidate[] = [
+    {
+      releaseFileId: 'release-file-1',
+      title: 'Test data set 1',
+    },
+    {
+      releaseFileId: 'release-file-2',
+      title: 'Test data set 2',
+    },
+  ];
+
+  test('renders warning message in modal when no candidates', async () => {
+    apiDataSetCandidateService.listCandidates.mockResolvedValue([]);
+
+    const { user } = render(
+      <ApiDataSetCreateModal
+        publicationId="publication-id"
+        releaseId="release-id"
+      />,
+    );
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Create API data set' }),
+    );
+
+    expect(
+      await screen.findByText(
+        /No API data sets can be created as there are no candidates data files available/,
+      ),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+
+  test('renders form in modal when there are candidates', async () => {
+    apiDataSetCandidateService.listCandidates.mockResolvedValue(testCandidates);
+
+    const { user } = render(
+      <ApiDataSetCreateModal
+        publicationId="publication-id"
+        releaseId="release-id"
+      />,
+    );
+
+    expect(await screen.findByText('Create API data set')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Create API data set' }),
+    );
+
+    expect(
+      await screen.findByText('Create a new API data set'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: 'Create a new API data set' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByLabelText('Data set')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Confirm new API data set' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', { name: 'Close' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('submitting the form calls correct service', async () => {
+    apiDataSetCandidateService.listCandidates.mockResolvedValue(testCandidates);
+
+    const { user } = render(
+      <ApiDataSetCreateModal
+        publicationId="publication-id"
+        releaseId="release-id"
+      />,
+    );
+
+    expect(await screen.findByText('Create API data set')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Create API data set' }),
+    );
+
+    await user.selectOptions(
+      await screen.findByLabelText('Data set'),
+      testCandidates[0].releaseFileId,
+    );
+
+    expect(apiDataSetService.createDataSet).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Confirm new API data set' }),
+    );
+
+    await waitFor(() => {
+      expect(apiDataSetService.createDataSet).toHaveBeenCalledTimes(1);
+      expect(apiDataSetService.createDataSet).toHaveBeenCalledWith<
+        Parameters<typeof apiDataSetService.createDataSet>
+      >({
+        releaseFileId: testCandidates[0].releaseFileId,
+      });
+    });
+  });
+
+  function render(ui: ReactElement) {
+    return baseRender(<MemoryRouter>{ui}</MemoryRouter>);
+  }
+});

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/__tests__/ApiDataSetCreateModal.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/__tests__/ApiDataSetCreateModal.test.tsx
@@ -5,8 +5,9 @@ import _apiDataSetCandidateService, {
 import _apiDataSetService from '@admin/services/apiDataSetService';
 import baseRender from '@common-test/render';
 import { screen, waitFor } from '@testing-library/react';
+import { createMemoryHistory, History } from 'history';
 import { ReactElement } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { Router } from 'react-router-dom';
 
 jest.mock('@admin/services/apiDataSetService');
 jest.mock('@admin/services/apiDataSetCandidateService');
@@ -84,14 +85,23 @@ describe('ApiDataSetCreateModal', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('submitting the form calls correct service', async () => {
+  test('submitting the form calls correct service and redirects to next page', async () => {
     apiDataSetCandidateService.listCandidates.mockResolvedValue(testCandidates);
+    apiDataSetService.createDataSet.mockResolvedValue({
+      id: 'data-set-id',
+      title: 'Test title',
+      summary: 'Test summary',
+      status: 'Draft',
+    });
+
+    const history = createMemoryHistory();
 
     const { user } = render(
       <ApiDataSetCreateModal
         publicationId="publication-id"
         releaseId="release-id"
       />,
+      { history },
     );
 
     expect(await screen.findByText('Create API data set')).toBeInTheDocument();
@@ -119,9 +129,20 @@ describe('ApiDataSetCreateModal', () => {
         releaseFileId: testCandidates[0].releaseFileId,
       });
     });
+
+    expect(history.location.pathname).toBe(
+      '/publication/publication-id/release/release-id/api-data-sets/data-set-id',
+    );
   });
 
-  function render(ui: ReactElement) {
-    return baseRender(<MemoryRouter>{ui}</MemoryRouter>);
+  function render(
+    ui: ReactElement,
+    options?: {
+      history: History;
+    },
+  ) {
+    const { history = createMemoryHistory() } = options ?? {};
+
+    return baseRender(<Router history={history}>{ui}</Router>);
   }
 });

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/__tests__/ApiDataSetVersionSummaryList.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/__tests__/ApiDataSetVersionSummaryList.test.tsx
@@ -1,0 +1,317 @@
+import ApiDataSetVersionSummaryList from '@admin/pages/release/api-data-sets/components/ApiDataSetVersionSummaryList';
+import { ApiDataSetDraftVersion } from '@admin/services/apiDataSetService';
+import { render as baseRender, screen, within } from '@testing-library/react';
+import { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('ApiDataSetVersionSummaryList', () => {
+  const testBaseVersion: ApiDataSetDraftVersion = {
+    id: 'version-id',
+    status: 'Draft',
+    version: '1.0',
+    type: 'Major',
+    file: {
+      id: 'file-id',
+      title: 'Test data set file',
+    },
+    releaseVersion: {
+      id: 'release-id',
+      title: 'Test release',
+    },
+    totalResults: 0,
+  };
+
+  test('renders correctly when data set version is missing facets', () => {
+    render(
+      <ApiDataSetVersionSummaryList
+        dataSetVersion={testBaseVersion}
+        id="version-details"
+        publicationId="publication-id"
+      />,
+    );
+
+    expect(screen.getByTestId('Version')).toHaveTextContent('v1.0');
+    expect(screen.getByTestId('Status')).toHaveTextContent('Ready');
+    expect(
+      within(screen.getByTestId('Release')).getByRole('link', {
+        name: 'Test release',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-id/release/release-id/summary',
+    );
+    expect(screen.getByTestId('Data set file')).toHaveTextContent(
+      'Test data set file',
+    );
+
+    expect(screen.queryByTestId('Geographic levels')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('Time periods')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('Indicators')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('Filters')).not.toBeInTheDocument();
+
+    expect(screen.queryByTestId('Actions')).not.toBeInTheDocument();
+  });
+
+  test('renders correctly when data set version has facets', () => {
+    render(
+      <ApiDataSetVersionSummaryList
+        dataSetVersion={{
+          ...testBaseVersion,
+          geographicLevels: ['National', 'Local authority'],
+          timePeriods: {
+            start: '2018',
+            end: '2024',
+          },
+          indicators: ['Test indicator 1', 'Test indicator 2'],
+          filters: ['Test filter 1', 'Test filter 2'],
+        }}
+        id="version-details"
+        publicationId="publication-id"
+      />,
+    );
+
+    expect(screen.getByTestId('Version')).toHaveTextContent('v1.0');
+    expect(screen.getByTestId('Status')).toHaveTextContent('Ready');
+    expect(
+      within(screen.getByTestId('Release')).getByRole('link', {
+        name: 'Test release',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-id/release/release-id/summary',
+    );
+    expect(screen.getByTestId('Data set file')).toHaveTextContent(
+      'Test data set file',
+    );
+
+    expect(screen.getByTestId('Geographic levels')).toHaveTextContent(
+      'National, Local authority',
+    );
+    expect(screen.getByTestId('Time periods')).toHaveTextContent(
+      '2018 to 2024',
+    );
+
+    const indicators = within(screen.getByTestId('Indicators')).getAllByRole(
+      'listitem',
+    );
+
+    expect(indicators).toHaveLength(2);
+    expect(indicators[0]).toHaveTextContent('Test indicator 1');
+    expect(indicators[1]).toHaveTextContent('Test indicator 2');
+
+    const filters = within(screen.getByTestId('Filters')).getAllByRole(
+      'listitem',
+    );
+
+    expect(filters).toHaveLength(2);
+    expect(filters[0]).toHaveTextContent('Test filter 1');
+    expect(filters[1]).toHaveTextContent('Test filter 2');
+
+    expect(screen.queryByTestId('Actions')).not.toBeInTheDocument();
+  });
+
+  test('renders indicators as collapsible list', () => {
+    render(
+      <ApiDataSetVersionSummaryList
+        dataSetVersion={{
+          ...testBaseVersion,
+          indicators: [
+            'Test indicator 1',
+            'Test indicator 2',
+            'Test indicator 3',
+            'Test indicator 4',
+          ],
+        }}
+        id="version-details"
+        publicationId="publication-id"
+      />,
+    );
+
+    const indicators = within(screen.getByTestId('Indicators')).getAllByRole(
+      'listitem',
+    );
+
+    expect(indicators).toHaveLength(3);
+    expect(indicators[0]).toHaveTextContent('Test indicator 1');
+    expect(indicators[1]).toHaveTextContent('Test indicator 2');
+    expect(indicators[2]).toHaveTextContent('Test indicator 3');
+
+    expect(
+      within(screen.getByTestId('Indicators')).getByRole('button', {
+        name: 'Show 1 more indicator',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders indicators as pluralised collapsible list', () => {
+    render(
+      <ApiDataSetVersionSummaryList
+        dataSetVersion={{
+          ...testBaseVersion,
+          indicators: [
+            'Test indicator 1',
+            'Test indicator 2',
+            'Test indicator 3',
+            'Test indicator 4',
+            'Test indicator 5',
+          ],
+        }}
+        id="version-details"
+        publicationId="publication-id"
+      />,
+    );
+
+    const indicators = within(screen.getByTestId('Indicators')).getAllByRole(
+      'listitem',
+    );
+
+    expect(indicators).toHaveLength(3);
+    expect(indicators[0]).toHaveTextContent('Test indicator 1');
+    expect(indicators[1]).toHaveTextContent('Test indicator 2');
+    expect(indicators[2]).toHaveTextContent('Test indicator 3');
+
+    expect(
+      within(screen.getByTestId('Indicators')).getByRole('button', {
+        name: 'Show 2 more indicators',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders collapsible indicators list button with hidden text', () => {
+    render(
+      <ApiDataSetVersionSummaryList
+        dataSetVersion={{
+          ...testBaseVersion,
+          indicators: [
+            'Test indicator 1',
+            'Test indicator 2',
+            'Test indicator 3',
+            'Test indicator 4',
+          ],
+        }}
+        collapsibleButtonHiddenText="for draft version"
+        id="version-details"
+        publicationId="publication-id"
+      />,
+    );
+
+    expect(
+      within(screen.getByTestId('Indicators')).getByRole('button', {
+        name: 'Show 1 more indicator for draft version',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders filters as collapsible list', () => {
+    render(
+      <ApiDataSetVersionSummaryList
+        dataSetVersion={{
+          ...testBaseVersion,
+          filters: [
+            'Test filter 1',
+            'Test filter 2',
+            'Test filter 3',
+            'Test filter 4',
+          ],
+        }}
+        id="version-details"
+        publicationId="publication-id"
+      />,
+    );
+
+    const filters = within(screen.getByTestId('Filters')).getAllByRole(
+      'listitem',
+    );
+
+    expect(filters).toHaveLength(3);
+    expect(filters[0]).toHaveTextContent('Test filter 1');
+    expect(filters[1]).toHaveTextContent('Test filter 2');
+    expect(filters[2]).toHaveTextContent('Test filter 3');
+
+    expect(
+      within(screen.getByTestId('Filters')).getByRole('button', {
+        name: 'Show 1 more filter',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders filters as pluralised collapsible list', () => {
+    render(
+      <ApiDataSetVersionSummaryList
+        dataSetVersion={{
+          ...testBaseVersion,
+          filters: [
+            'Test filter 1',
+            'Test filter 2',
+            'Test filter 3',
+            'Test filter 4',
+            'Test filter 5',
+          ],
+        }}
+        id="version-details"
+        publicationId="publication-id"
+      />,
+    );
+
+    const filters = within(screen.getByTestId('Filters')).getAllByRole(
+      'listitem',
+    );
+
+    expect(filters).toHaveLength(3);
+    expect(filters[0]).toHaveTextContent('Test filter 1');
+    expect(filters[1]).toHaveTextContent('Test filter 2');
+    expect(filters[2]).toHaveTextContent('Test filter 3');
+
+    expect(
+      within(screen.getByTestId('Filters')).getByRole('button', {
+        name: 'Show 2 more filters',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders collapsible filters list button with hidden text', () => {
+    render(
+      <ApiDataSetVersionSummaryList
+        dataSetVersion={{
+          ...testBaseVersion,
+          filters: [
+            'Test filter 1',
+            'Test filter 2',
+            'Test filter 3',
+            'Test filter 4',
+          ],
+        }}
+        collapsibleButtonHiddenText="for draft version"
+        id="version-details"
+        publicationId="publication-id"
+      />,
+    );
+
+    expect(
+      within(screen.getByTestId('Filters')).getByRole('button', {
+        name: 'Show 1 more filter for draft version',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders additional actions', () => {
+    render(
+      <ApiDataSetVersionSummaryList
+        dataSetVersion={testBaseVersion}
+        id="version-details"
+        publicationId="publication-id"
+        actions={<button type="button">Some action</button>}
+      />,
+    );
+
+    expect(
+      within(screen.getByTestId('Actions')).getByRole('button', {
+        name: 'Some action',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  function render(ui: ReactElement) {
+    return baseRender(<MemoryRouter>{ui}</MemoryRouter>);
+  }
+});

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/__tests__/DraftApiDataSetsTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/__tests__/DraftApiDataSetsTable.test.tsx
@@ -1,0 +1,253 @@
+import DraftApiDataSetsTable, {
+  DraftApiDataSetSummary,
+} from '@admin/pages/release/api-data-sets/components/DraftApiDataSetsTable';
+import { render as baseRender, screen, within } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('DraftApiDataSetsTable', () => {
+  const testDataSets: DraftApiDataSetSummary[] = [
+    {
+      id: 'data-set-4',
+      title: 'Data set 4 title',
+      summary: 'Data set 4 summary',
+      status: 'Published',
+      draftVersion: {
+        id: 'version-6',
+        version: '1.0',
+        status: 'Draft',
+        type: 'Major',
+      },
+    },
+    {
+      id: 'data-set-3',
+      title: 'Data set 3 title',
+      summary: 'Data set 3 summary',
+      status: 'Published',
+      draftVersion: {
+        id: 'version-5',
+        version: '1.0',
+        status: 'Processing',
+        type: 'Major',
+      },
+    },
+    {
+      id: 'data-set-2',
+      title: 'Data set 2 title',
+      summary: 'Data set 2 summary',
+      status: 'Published',
+      draftVersion: {
+        id: 'version-4',
+        version: '2.0',
+        status: 'Draft',
+        type: 'Major',
+      },
+      latestLiveVersion: {
+        published: '2024-02-01T09:30:00+00:00',
+        id: 'version-3',
+        version: '1.0',
+        status: 'Published',
+        type: 'Major',
+      },
+    },
+    {
+      id: 'data-set-1',
+      title: 'Data set 1 title',
+      summary: 'Data set 1 summary',
+      status: 'Published',
+      draftVersion: {
+        id: 'version-2',
+        version: '1.1',
+        status: 'Mapping',
+        type: 'Minor',
+      },
+      latestLiveVersion: {
+        published: '2024-02-01T09:30:00+00:00',
+        id: 'version-1',
+        version: '1.0',
+        status: 'Published',
+        type: 'Major',
+      },
+    },
+    {
+      id: 'data-set-6',
+      title: 'Data set 6 title',
+      summary: 'Data set 6 summary',
+      status: 'Published',
+      draftVersion: {
+        id: 'version-8',
+        version: '1.0',
+        status: 'Cancelled',
+        type: 'Major',
+      },
+    },
+    {
+      id: 'data-set-5',
+      title: 'Data set 5 title',
+      summary: 'Data set 5 summary',
+      status: 'Published',
+      draftVersion: {
+        id: 'version-7',
+        version: '1.0',
+        status: 'Failed',
+        type: 'Major',
+      },
+    },
+  ];
+
+  test('renders draft data set rows correctly', () => {
+    render(
+      <DraftApiDataSetsTable
+        dataSets={testDataSets}
+        publicationId="publication-1"
+        releaseId="release-1"
+      />,
+    );
+
+    const baseDataSetUrl =
+      '/publication/publication-1/release/release-1/api-data-sets';
+
+    const rows = within(screen.getByRole('table')).getAllByRole('row');
+
+    expect(rows).toHaveLength(7);
+
+    // Row 1
+
+    const row1Cells = within(rows[1]).getAllByRole('cell');
+
+    expect(row1Cells[0]).toHaveTextContent('v1.1');
+    expect(row1Cells[1]).toHaveTextContent('v1.0');
+    expect(row1Cells[2]).toHaveTextContent('Data set 1 title');
+    expect(row1Cells[3]).toHaveTextContent('Action required');
+
+    expect(
+      within(row1Cells[4]).getByRole('link', {
+        name: 'View / edit draft for Data set 1 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-1`);
+    expect(
+      within(row1Cells[4]).getByRole('button', {
+        name: 'Remove draft for Data set 1 title',
+      }),
+    ).toBeInTheDocument();
+
+    // Row 2
+
+    const row2Cells = within(rows[2]).getAllByRole('cell');
+
+    expect(row2Cells[0]).toHaveTextContent('v2.0');
+    expect(row2Cells[1]).toHaveTextContent('v1.0');
+    expect(row2Cells[2]).toHaveTextContent('Data set 2 title');
+    expect(row2Cells[3]).toHaveTextContent('Ready');
+
+    expect(
+      within(row2Cells[4]).getByRole('link', {
+        name: 'View / edit draft for Data set 2 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-2`);
+
+    expect(
+      within(row2Cells[4]).getByRole('button', {
+        name: 'Remove draft for Data set 2 title',
+      }),
+    ).toBeInTheDocument();
+
+    // Row 3
+
+    const row3Cells = within(rows[3]).getAllByRole('cell');
+
+    expect(row3Cells[0]).toHaveTextContent('v1.0');
+    expect(row3Cells[1]).toHaveTextContent('N/A');
+    expect(row3Cells[2]).toHaveTextContent('Data set 3 title');
+    expect(row3Cells[3]).toHaveTextContent('Processing');
+
+    expect(
+      within(row3Cells[4]).getByRole('link', {
+        name: 'View / edit draft for Data set 3 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-3`);
+    expect(
+      within(row3Cells[4]).queryByRole('button', { name: /Remove draft/ }),
+    ).not.toBeInTheDocument();
+
+    // Row 4
+
+    const row4Cells = within(rows[4]).getAllByRole('cell');
+
+    expect(row4Cells[0]).toHaveTextContent('v1.0');
+    expect(row4Cells[1]).toHaveTextContent('N/A');
+    expect(row4Cells[2]).toHaveTextContent('Data set 4 title');
+    expect(row4Cells[3]).toHaveTextContent('Ready');
+
+    expect(
+      within(row4Cells[4]).getByRole('link', {
+        name: 'View / edit draft for Data set 4 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-4`);
+
+    expect(
+      within(row4Cells[4]).getByRole('button', {
+        name: 'Remove draft for Data set 4 title',
+      }),
+    ).toBeInTheDocument();
+
+    // Row 5
+
+    const row5Cells = within(rows[5]).getAllByRole('cell');
+
+    expect(row5Cells[0]).toHaveTextContent('v1.0');
+    expect(row5Cells[1]).toHaveTextContent('N/A');
+    expect(row5Cells[2]).toHaveTextContent('Data set 5 title');
+    expect(row5Cells[3]).toHaveTextContent('Failed');
+
+    expect(
+      within(row5Cells[4]).getByRole('link', {
+        name: 'View / edit draft for Data set 5 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-5`);
+
+    expect(
+      within(row5Cells[4]).getByRole('button', {
+        name: 'Remove draft for Data set 5 title',
+      }),
+    ).toBeInTheDocument();
+
+    // Row 6
+
+    const row6Cells = within(rows[6]).getAllByRole('cell');
+
+    expect(row6Cells[0]).toHaveTextContent('v1.0');
+    expect(row6Cells[1]).toHaveTextContent('N/A');
+    expect(row6Cells[2]).toHaveTextContent('Data set 6 title');
+    expect(row6Cells[3]).toHaveTextContent('Cancelled');
+
+    expect(
+      within(row6Cells[4]).getByRole('link', {
+        name: 'View / edit draft for Data set 6 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-6`);
+
+    expect(
+      within(row6Cells[4]).getByRole('button', {
+        name: 'Remove draft for Data set 6 title',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders message when no data sets', () => {
+    render(
+      <DraftApiDataSetsTable
+        dataSets={[]}
+        publicationId="publication-1"
+        releaseId="release-1"
+      />,
+    );
+
+    expect(screen.getByText(/No draft API data sets/)).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  function render(element: ReactNode) {
+    return baseRender(<MemoryRouter>{element}</MemoryRouter>);
+  }
+});

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/__tests__/LiveApiDataSetsTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/components/__tests__/LiveApiDataSetsTable.test.tsx
@@ -1,0 +1,159 @@
+import LiveApiDataSetsTable, {
+  LiveApiDataSetSummary,
+} from '@admin/pages/release/api-data-sets/components/LiveApiDataSetsTable';
+import { render as baseRender, screen, within } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('LiveApiDataSetsTable', () => {
+  const testDataSets: LiveApiDataSetSummary[] = [
+    {
+      id: 'data-set-2',
+      title: 'Data set 2 title',
+      summary: 'Data set 2 summary',
+      status: 'Published',
+      latestLiveVersion: {
+        published: '2024-02-01T09:30:00+00:00',
+        id: 'version-2',
+        version: '1.0',
+        status: 'Published',
+        type: 'Major',
+      },
+    },
+    {
+      id: 'data-set-1',
+      title: 'Data set 1 title',
+      summary: 'Data set 1 summary',
+      status: 'Published',
+      latestLiveVersion: {
+        published: '2024-02-01T09:30:00+00:00',
+        id: 'version-1',
+        version: '2.0',
+        status: 'Published',
+        type: 'Major',
+      },
+    },
+    {
+      id: 'data-set-3',
+      title: 'Data set 3 title',
+      summary: 'Data set 3 summary',
+      status: 'Published',
+      latestLiveVersion: {
+        published: '2024-02-01T09:30:00+00:00',
+        id: 'version-3',
+        version: '1.2',
+        status: 'Published',
+        type: 'Minor',
+      },
+    },
+  ];
+
+  test('renders live data set rows correctly', () => {
+    render(
+      <LiveApiDataSetsTable
+        canCreateNewVersions
+        canUpdateRelease
+        dataSets={testDataSets}
+        publicationId="publication-1"
+        releaseId="release-1"
+      />,
+    );
+
+    const baseDataSetUrl =
+      '/publication/publication-1/release/release-1/api-data-sets';
+
+    const rows = within(screen.getByRole('table')).getAllByRole('row');
+
+    expect(rows).toHaveLength(4);
+
+    // Row 1
+
+    const row1Cells = within(rows[1]).getAllByRole('cell');
+
+    expect(row1Cells[0]).toHaveTextContent('v2.0');
+    expect(row1Cells[1]).toHaveTextContent('Data set 1 title');
+
+    expect(
+      within(row1Cells[2]).getByRole('link', {
+        name: 'View details for Data set 1 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-1`);
+
+    expect(
+      within(row1Cells[2]).getByRole('button', {
+        name: 'Create new version for Data set 1 title',
+      }),
+    ).toBeInTheDocument();
+
+    // Row 2
+
+    const row2Cells = within(rows[2]).getAllByRole('cell');
+
+    expect(row2Cells[0]).toHaveTextContent('v1.0');
+    expect(row2Cells[1]).toHaveTextContent('Data set 2 title');
+
+    expect(
+      within(row2Cells[2]).getByRole('link', {
+        name: 'View details for Data set 2 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-2`);
+
+    expect(
+      within(row2Cells[2]).getByRole('button', {
+        name: 'Create new version for Data set 2 title',
+      }),
+    ).toBeInTheDocument();
+
+    // Row 3
+
+    const row3Cells = within(rows[3]).getAllByRole('cell');
+
+    expect(row3Cells[0]).toHaveTextContent('v1.2');
+    expect(row3Cells[1]).toHaveTextContent('Data set 3 title');
+
+    expect(
+      within(row3Cells[2]).getByRole('link', {
+        name: 'View details for Data set 3 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-3`);
+
+    expect(
+      within(row3Cells[2]).getByRole('button', {
+        name: 'Create new version for Data set 3 title',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test("does not render 'Create new version' buttons when release cannot be updated", () => {
+    render(
+      <LiveApiDataSetsTable
+        canCreateNewVersions
+        canUpdateRelease={false}
+        dataSets={testDataSets}
+        publicationId="publication-1"
+        releaseId="release-1"
+      />,
+    );
+
+    expect(
+      screen.queryAllByRole('button', { name: /Create new version/ }),
+    ).toHaveLength(0);
+  });
+
+  test('renders message when no data sets', () => {
+    render(
+      <LiveApiDataSetsTable
+        dataSets={[]}
+        publicationId="publication-1"
+        releaseId="release-1"
+      />,
+    );
+
+    expect(screen.getByText(/No live API data sets/)).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  function render(element: ReactNode) {
+    return baseRender(<MemoryRouter>{element}</MemoryRouter>);
+  }
+});

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/utils/getVersionStatusColour.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/utils/getVersionStatusColour.ts
@@ -1,0 +1,25 @@
+import { DataSetVersionStatus } from '@admin/services/apiDataSetService';
+import { TagProps } from '@common/components/Tag';
+
+export default function getVersionStatusTagColour(
+  status: DataSetVersionStatus,
+): TagProps['colour'] {
+  switch (status) {
+    case 'Published':
+      return 'blue';
+    case 'Deprecated':
+      return 'light-blue';
+    case 'Withdrawn':
+      return 'grey';
+    case 'Draft':
+      return 'green';
+    case 'Cancelled':
+    case 'Failed':
+    case 'Mapping':
+      return 'red';
+    case 'Processing':
+      return 'yellow';
+    default:
+      return 'grey';
+  }
+}

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/utils/getVersionStatusText.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/utils/getVersionStatusText.ts
@@ -1,0 +1,14 @@
+import { DataSetVersionStatus } from '@admin/services/apiDataSetService';
+
+export default function getVersionStatusText(
+  status: DataSetVersionStatus,
+): string {
+  switch (status) {
+    case 'Draft':
+      return 'Ready';
+    case 'Mapping':
+      return 'Action required';
+    default:
+      return status;
+  }
+}

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStages.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStages.tsx
@@ -1,6 +1,6 @@
 import StatusBlock from '@admin/components/StatusBlock';
 import getStatusDetail from '@admin/pages/release/utils/getStatusDetail';
-import { ReleaseStageStatuses } from '@admin/services/releaseService';
+import { ReleaseStageStatus } from '@admin/services/releaseService';
 import Details from '@common/components/Details';
 import React from 'react';
 
@@ -8,15 +8,15 @@ const notStartedStatuses = ['Validating', 'Invalid'];
 
 interface Props {
   checklistStyle?: boolean;
-  currentStatus?: ReleaseStageStatuses;
+  currentStatus?: ReleaseStageStatus;
   includeScheduled?: boolean;
 }
 
-const ReleasePublishingStages = ({
+export default function ReleasePublishingStages({
   checklistStyle = false,
   currentStatus,
   includeScheduled = false,
-}: Props) => {
+}: Props) {
   if (
     !currentStatus ||
     (includeScheduled
@@ -79,6 +79,4 @@ const ReleasePublishingStages = ({
       )}
     </Details>
   );
-};
-
-export default ReleasePublishingStages;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStatus.tsx
@@ -1,33 +1,33 @@
 import useReleasePublishingStatus from '@admin/pages/release/hooks/useReleasePublishingStatus';
 import ReleasePublishingStatusTag from '@admin/pages/release/components/ReleasePublishingStatusTag';
 import ReleasePublishingStages from '@admin/pages/release/components/ReleasePublishingStages';
+import { ReleaseStageStatus } from '@admin/services/releaseService';
 import React from 'react';
 
 interface ReleasePublishingStatusProps {
-  isApproved?: boolean;
   releaseId: string;
   refreshPeriod?: number;
+  onChange?: (status: ReleaseStageStatus) => void;
 }
 
-const ReleasePublishingStatus = ({
-  isApproved = false,
+export default function ReleasePublishingStatus({
   releaseId,
   refreshPeriod,
-}: ReleasePublishingStatusProps) => {
+  onChange,
+}: ReleasePublishingStatusProps) {
   const { currentStatus, currentStatusDetail } = useReleasePublishingStatus({
     releaseId,
     refreshPeriod,
+    onChange,
   });
+
   return (
     <>
       <ReleasePublishingStatusTag
         currentStatus={currentStatus}
         color={currentStatusDetail.color}
-        isApproved={isApproved}
       />
       <ReleasePublishingStages currentStatus={currentStatus} />
     </>
   );
-};
-
-export default ReleasePublishingStatus;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStatusTag.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStatusTag.tsx
@@ -1,5 +1,5 @@
 import StatusBlock, { StatusBlockColors } from '@admin/components/StatusBlock';
-import { ReleaseStageStatuses } from '@admin/services/releaseService';
+import { ReleaseStageStatus } from '@admin/services/releaseService';
 import React from 'react';
 import Tag from '@common/components/Tag';
 
@@ -7,15 +7,15 @@ const approvedStatuses = ['Complete', 'Scheduled'];
 
 interface Props {
   color?: StatusBlockColors;
-  currentStatus?: ReleaseStageStatuses;
+  currentStatus?: ReleaseStageStatus;
   isApproved?: boolean;
 }
 
-const ReleasePublishingStatusTag = ({
+export default function ReleasePublishingStatusTag({
   color,
   currentStatus,
   isApproved = false,
-}: Props) => {
+}: Props) {
   if (!currentStatus) {
     return null;
   }
@@ -43,6 +43,4 @@ const ReleasePublishingStatusTag = ({
       />
     </>
   );
-};
-
-export default ReleasePublishingStatusTag;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleasePublishingStatus.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleasePublishingStatus.test.tsx
@@ -1,0 +1,138 @@
+import ReleasePublishingStatus from '@admin/pages/release/components/ReleasePublishingStatus';
+import _releaseService from '@admin/services/releaseService';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('@admin/services/releaseService');
+
+const releaseService = jest.mocked(_releaseService);
+
+describe('ReleasePublishingStatus', () => {
+  test('renders correctly with initial status', async () => {
+    releaseService.getReleaseStatus.mockResolvedValue({
+      overallStage: 'Started',
+      filesStage: 'Queued',
+      contentStage: 'Complete',
+      publishingStage: 'NotStarted',
+    });
+
+    render(<ReleasePublishingStatus releaseId="release-1" />);
+
+    expect(await screen.findByText('Started')).toBeInTheDocument();
+
+    expect(screen.getByText('Files - queued')).toBeInTheDocument();
+    expect(screen.getByText('Content - complete')).toBeInTheDocument();
+    expect(screen.getByText('Publishing - not started')).toBeInTheDocument();
+  });
+
+  test('re-renders correctly when status changes to complete', async () => {
+    jest.useFakeTimers();
+
+    releaseService.getReleaseStatus.mockResolvedValue({
+      overallStage: 'Started',
+    });
+
+    render(<ReleasePublishingStatus releaseId="release-1" />);
+
+    expect(await screen.findByText('Started')).toBeInTheDocument();
+
+    releaseService.getReleaseStatus.mockResolvedValue({
+      overallStage: 'Complete',
+      contentStage: 'Complete',
+      publishingStage: 'Complete',
+      filesStage: 'Complete',
+    });
+
+    jest.runOnlyPendingTimers();
+
+    expect(await screen.findByText('Complete')).toBeInTheDocument();
+
+    expect(screen.getByText('Content - complete')).toBeInTheDocument();
+    expect(screen.getByText('Files - complete')).toBeInTheDocument();
+    expect(screen.getByText('Publishing - complete')).toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
+  test('calls `onChange` only when status changes', async () => {
+    jest.useFakeTimers();
+
+    releaseService.getReleaseStatus.mockResolvedValue({
+      overallStage: 'Started',
+    });
+
+    const handleChange = jest.fn();
+
+    render(
+      <ReleasePublishingStatus releaseId="release-1" onChange={handleChange} />,
+    );
+
+    expect(await screen.findByText('Started')).toBeInTheDocument();
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+
+    jest.runOnlyPendingTimers();
+
+    expect(await screen.findByText('Started')).toBeInTheDocument();
+
+    // Not called again because the status hasn't changed
+    expect(handleChange).toHaveBeenCalledTimes(1);
+
+    releaseService.getReleaseStatus.mockResolvedValue({
+      overallStage: 'Complete',
+      contentStage: 'Complete',
+      publishingStage: 'Complete',
+      filesStage: 'Complete',
+    });
+
+    jest.runOnlyPendingTimers();
+
+    expect(await screen.findByText('Complete')).toBeInTheDocument();
+
+    expect(handleChange).toHaveBeenCalledTimes(2);
+
+    jest.useRealTimers();
+  });
+
+  test('does not re-render or call service after overall status is no longer `Started`', async () => {
+    jest.useFakeTimers();
+
+    releaseService.getReleaseStatus.mockResolvedValue({
+      overallStage: 'Started',
+    });
+
+    const handleChange = jest.fn();
+
+    render(
+      <ReleasePublishingStatus releaseId="release-1" onChange={handleChange} />,
+    );
+
+    expect(await screen.findByText('Started')).toBeInTheDocument();
+
+    expect(releaseService.getReleaseStatus).toHaveBeenCalledTimes(1);
+
+    releaseService.getReleaseStatus.mockResolvedValue({
+      overallStage: 'Complete',
+    });
+
+    jest.runOnlyPendingTimers();
+
+    expect(await screen.findByText('Complete')).toBeInTheDocument();
+
+    expect(releaseService.getReleaseStatus).toHaveBeenCalledTimes(2);
+
+    // Can't really transition from Complete to Failed, but
+    // just simulating a change for the test.
+    releaseService.getReleaseStatus.mockResolvedValue({
+      overallStage: 'Failed',
+    });
+
+    jest.runOnlyPendingTimers();
+
+    expect(await screen.findByText('Complete')).toBeInTheDocument();
+
+    expect(releaseService.getReleaseStatus).toHaveBeenCalledTimes(2);
+
+    jest.useRealTimers();
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -251,7 +251,7 @@ const ReleaseContent = ({
                   <li>
                     <Button
                       className="govuk-!-margin-bottom-3"
-                      disableDoubleClick
+                      preventDoubleClick
                       onClick={() =>
                         releaseFileService.downloadAllFilesZip(release.id)
                       }
@@ -407,7 +407,7 @@ const ReleaseContent = ({
           hasDataGuidance={release.hasDataGuidance}
           renderAllFilesLink={
             <ButtonText
-              disableDoubleClick
+              preventDoubleClick
               onClick={() => releaseFileService.downloadAllFilesZip(release.id)}
             >
               Download all data (ZIP)

--- a/src/explore-education-statistics-admin/src/pages/release/contexts/ReleaseContext.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/contexts/ReleaseContext.tsx
@@ -5,7 +5,7 @@ import React, { createContext, ReactNode, useContext, useMemo } from 'react';
 export interface ReleaseContextState {
   release: Release;
   releaseId: string;
-  onReleaseChange: (nextRelease: Release) => void;
+  onReleaseChange: () => void;
 }
 
 const ReleaseContext = createContext<ReleaseContextState | undefined>(
@@ -15,7 +15,7 @@ const ReleaseContext = createContext<ReleaseContextState | undefined>(
 interface ReleaseContextProviderProps {
   children: ReactNode;
   release: Release;
-  onReleaseChange?: (nextRelease: Release) => void;
+  onReleaseChange?: () => void;
 }
 
 export const ReleaseContextProvider = ({
@@ -44,5 +44,6 @@ export function useReleaseContext() {
       'useReleaseContext must be used within a ReleaseContextProvider',
     );
   }
+
   return context;
 }

--- a/src/explore-education-statistics-admin/src/pages/release/hooks/useReleasePublishingStatus.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/hooks/useReleasePublishingStatus.ts
@@ -1,8 +1,9 @@
 import { StatusBlockProps } from '@admin/components/StatusBlock';
 import getStatusDetail from '@admin/pages/release/utils/getStatusDetail';
 import releaseService, {
-  ReleaseStageStatuses,
+  ReleaseStageStatus,
 } from '@admin/services/releaseService';
+import isEqual from 'lodash/isEqual';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { forceCheck } from 'react-lazyload';
 
@@ -14,6 +15,7 @@ export interface StatusDetail {
 interface Options {
   refreshPeriod?: number;
   releaseId: string;
+  onChange?: (status: ReleaseStageStatus) => void;
 }
 
 /**
@@ -22,11 +24,12 @@ interface Options {
 export default function useReleasePublishingStatus({
   refreshPeriod = 10000,
   releaseId,
+  onChange,
 }: Options): {
-  currentStatus?: ReleaseStageStatuses;
+  currentStatus?: ReleaseStageStatus;
   currentStatusDetail: StatusDetail;
 } {
-  const [currentStatus, setCurrentStatus] = useState<ReleaseStageStatuses>();
+  const [currentStatus, setCurrentStatus] = useState<ReleaseStageStatus>();
   const [currentStatusDetail, setStatusDetail] = useState<StatusDetail>({
     color: 'blue',
     text: '',
@@ -34,45 +37,57 @@ export default function useReleasePublishingStatus({
 
   const timeoutRef = useRef<NodeJS.Timeout>();
 
-  const fetchReleasePublishingStatus = useCallback(async () => {
+  const fetchNextStatus = useCallback(async () => {
     const status = await releaseService.getReleaseStatus(releaseId);
+
+    const setNextStatus = (nextStatus: ReleaseStageStatus) => {
+      setCurrentStatus(prevStatus => {
+        if (onChange && !isEqual(prevStatus, nextStatus)) {
+          onChange(nextStatus);
+        }
+
+        return nextStatus;
+      });
+    };
+
     if (!status) {
       // 204 response waiting for status
-      setCurrentStatus({ overallStage: 'Validating' });
-      timeoutRef.current = setTimeout(
-        fetchReleasePublishingStatus,
-        refreshPeriod,
-      );
+      setNextStatus({ overallStage: 'Validating' });
+
+      timeoutRef.current = setTimeout(fetchNextStatus, refreshPeriod);
     } else {
-      setCurrentStatus(status);
+      setNextStatus(status);
+
       if (status && status.overallStage === 'Started') {
-        timeoutRef.current = setTimeout(
-          fetchReleasePublishingStatus,
-          refreshPeriod,
-        );
+        timeoutRef.current = setTimeout(fetchNextStatus, refreshPeriod);
       }
     }
     forceCheck();
-  }, [releaseId, refreshPeriod]);
+  }, [releaseId, onChange, refreshPeriod]);
 
   function cancelTimer() {
-    if (timeoutRef.current) clearInterval(timeoutRef.current);
+    if (timeoutRef.current) {
+      clearInterval(timeoutRef.current);
+    }
   }
 
   useEffect(() => {
-    fetchReleasePublishingStatus();
+    fetchNextStatus();
+
     return () => {
       // cleans up the timeout
       cancelTimer();
     };
-  }, [fetchReleasePublishingStatus]);
+  }, [fetchNextStatus]);
 
   useEffect(() => {
     if (currentStatus && currentStatus.overallStage) {
       const status = getStatusDetail(currentStatus.overallStage);
+
       if (status.color === 'red' || status.color === 'green') {
         cancelTimer();
       }
+
       setStatusDetail(status);
     }
   }, [currentStatus]);

--- a/src/explore-education-statistics-admin/src/prototypes/components/PrototypeDataReplace.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/components/PrototypeDataReplace.tsx
@@ -364,13 +364,13 @@ const PrototypeMetaPreview = () => {
                   <ButtonText
                     className="govuk-!-margin-right-6"
                     onClick={() => {
-                      return (
-                        replaceInProgress &&
-                          (setOriginalData(true),
-                          setReplaceData(false),
-                          setReplaceInProgress(false)),
-                        (originalData || updatedData) && setReplaceData(true)
-                      );
+                      if (replaceInProgress) {
+                        setOriginalData(true);
+                        setReplaceData(false);
+                        setReplaceInProgress(false);
+                      } else if (originalData || updatedData) {
+                        setReplaceData(true);
+                      }
                     }}
                   >
                     {(originalData || updatedData) && 'Replace data files'}

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContent.tsx
@@ -213,7 +213,7 @@ const PrototypeReleaseContent = ({
                   <li>
                     <Button
                       className="govuk-!-margin-bottom-3"
-                      disableDoubleClick
+                      preventDoubleClick
                       onClick={() =>
                         releaseFileService.downloadAllFilesZip(release.id)
                       }
@@ -369,7 +369,7 @@ const PrototypeReleaseContent = ({
           hasDataGuidance={release.hasDataGuidance}
           renderAllFilesLink={
             <ButtonText
-              disableDoubleClick
+              preventDoubleClick
               onClick={() => releaseFileService.downloadAllFilesZip(release.id)}
             >
               Download all data (ZIP)

--- a/src/explore-education-statistics-admin/src/queries/apiDataSetCandidateQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/apiDataSetCandidateQueries.ts
@@ -1,0 +1,14 @@
+import apiDataSetCandidateService from '@admin/services/apiDataSetCandidateService';
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+const apiDataSetCandidateQueries = createQueryKeys('apiDataSetCandidates', {
+  list(releaseVersionId: string) {
+    return {
+      queryKey: [releaseVersionId],
+      queryFn: () =>
+        apiDataSetCandidateService.listCandidates(releaseVersionId),
+    };
+  },
+});
+
+export default apiDataSetCandidateQueries;

--- a/src/explore-education-statistics-admin/src/queries/apiDataSetQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/apiDataSetQueries.ts
@@ -1,0 +1,13 @@
+import apiDataSetService from '@admin/services/apiDataSetService';
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+const apiDataSetQueries = createQueryKeys('apiDataSetQueries', {
+  list(publicationId: string) {
+    return {
+      queryKey: [publicationId],
+      queryFn: () => apiDataSetService.listDataSets(publicationId),
+    };
+  },
+});
+
+export default apiDataSetQueries;

--- a/src/explore-education-statistics-admin/src/queries/apiDataSetQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/apiDataSetQueries.ts
@@ -8,6 +8,12 @@ const apiDataSetQueries = createQueryKeys('apiDataSetQueries', {
       queryFn: () => apiDataSetService.listDataSets(publicationId),
     };
   },
+  get(dataSetId: string) {
+    return {
+      queryKey: [dataSetId],
+      queryFn: () => apiDataSetService.getDataSet(dataSetId),
+    };
+  },
 });
 
 export default apiDataSetQueries;

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -1,4 +1,5 @@
 import { ProtectedRouteProps } from '@admin/components/ProtectedRoute';
+import ReleaseApiDataSetDetailsPage from '@admin/pages/release/api-data-sets/ReleaseApiDataSetDetailsPage';
 import ReleaseApiDataSetsPage from '@admin/pages/release/api-data-sets/ReleaseApiDataSetsPage';
 import ReleaseContentPage from '@admin/pages/release/content/ReleaseContentPage';
 import ReleaseDataFilePage from '@admin/pages/release/data/ReleaseDataFilePage';
@@ -170,5 +171,6 @@ export const releaseApiDataSetsRoute: ReleaseRouteProps = {
 export const releaseApiDataSetDetailsRoute: ReleaseRouteProps = {
   path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId',
   title: 'API data set details',
+  component: ReleaseApiDataSetDetailsPage,
   protectionAction: permissions => permissions.isBauUser,
 };

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -1,3 +1,4 @@
+import { ProtectedRouteProps } from '@admin/components/ProtectedRoute';
 import ReleaseContentPage from '@admin/pages/release/content/ReleaseContentPage';
 import ReleaseDataFilePage from '@admin/pages/release/data/ReleaseDataFilePage';
 import ReleaseAncillaryFilePage from '@admin/pages/release/data/ReleaseAncillaryFilePage';
@@ -15,7 +16,6 @@ import ReleasePreReleaseAccessPage from '@admin/pages/release/pre-release/Releas
 import ReleasePublishStatusPage from '@admin/pages/release/ReleaseStatusPage';
 import ReleaseSummaryEditPage from '@admin/pages/release/ReleaseSummaryEditPage';
 import ReleaseSummaryPage from '@admin/pages/release/ReleaseSummaryPage';
-import { RouteProps } from 'react-router';
 
 export type ReleaseRouteParams = {
   publicationId: string;
@@ -42,7 +42,7 @@ export type ReleaseFootnoteRouteParams = ReleaseRouteParams & {
   footnoteId: string;
 };
 
-export interface ReleaseRouteProps extends RouteProps {
+export interface ReleaseRouteProps extends ProtectedRouteProps {
   title: string;
   path: string;
 }

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -1,4 +1,5 @@
 import { ProtectedRouteProps } from '@admin/components/ProtectedRoute';
+import ReleaseApiDataSetsPage from '@admin/pages/release/api-data-sets/ReleaseApiDataSetsPage';
 import ReleaseContentPage from '@admin/pages/release/content/ReleaseContentPage';
 import ReleaseDataFilePage from '@admin/pages/release/data/ReleaseDataFilePage';
 import ReleaseAncillaryFilePage from '@admin/pages/release/data/ReleaseAncillaryFilePage';
@@ -40,6 +41,10 @@ export type ReleaseDataFileReplaceRouteParams = ReleaseRouteParams & {
 
 export type ReleaseFootnoteRouteParams = ReleaseRouteParams & {
   footnoteId: string;
+};
+
+export type ReleaseDataSetRouteParams = ReleaseRouteParams & {
+  dataSetId: string;
 };
 
 export interface ReleaseRouteProps extends ProtectedRouteProps {
@@ -153,4 +158,17 @@ export const releasePreReleaseAccessRoute: ReleaseRouteProps = {
   path: '/publication/:publicationId/release/:releaseId/prerelease-access',
   title: 'Pre-release access',
   component: ReleasePreReleaseAccessPage,
+};
+
+export const releaseApiDataSetsRoute: ReleaseRouteProps = {
+  path: '/publication/:publicationId/release/:releaseId/api-data-sets',
+  title: 'API data sets',
+  component: ReleaseApiDataSetsPage,
+  protectionAction: permissions => permissions.isBauUser,
+};
+
+export const releaseApiDataSetDetailsRoute: ReleaseRouteProps = {
+  path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId',
+  title: 'API data set details',
+  protectionAction: permissions => permissions.isBauUser,
 };

--- a/src/explore-education-statistics-admin/src/services/apiDataSetCandidateService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetCandidateService.ts
@@ -1,0 +1,18 @@
+import client from '@admin/services/utils/service';
+
+export interface ApiDataSetCandidate {
+  releaseFileId: string;
+  title: string;
+}
+
+const apiDataSetCandidateService = {
+  listCandidates(releaseVersionId: string): Promise<ApiDataSetCandidate[]> {
+    return client.get(`/public-data/data-set-candidates`, {
+      params: {
+        releaseVersionId,
+      },
+    });
+  },
+};
+
+export default apiDataSetCandidateService;

--- a/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
@@ -1,0 +1,109 @@
+import { IdTitlePair } from '@admin/services/types/common';
+import client from '@admin/services/utils/service';
+import { PaginatedList } from '@common/services/types/pagination';
+
+export interface ApiDataSetSummary {
+  id: string;
+  title: string;
+  summary: string;
+  status: DataSetStatus;
+  supersedingDataSetId?: string;
+  draftVersion?: ApiDataSetDraftVersionSummary;
+  latestLiveVersion?: ApiDataSetLiveVersionSummary;
+}
+
+export interface ApiDataSetVersionSummary {
+  id: string;
+  version: string;
+  type: DataSetVersionType;
+}
+
+export interface ApiDataSetDraftVersionSummary
+  extends ApiDataSetVersionSummary {
+  status: DataSetDraftVersionStatus;
+}
+
+export interface ApiDataSetLiveVersionSummary extends ApiDataSetVersionSummary {
+  published: string;
+  status: DataSetLiveVersionStatus;
+}
+
+export interface ApiDataSet {
+  id: string;
+  title: string;
+  summary: string;
+  status: DataSetStatus;
+  supersedingDataSetId?: string;
+  draftVersion?: ApiDataSetDraftVersion;
+  latestLiveVersion?: ApiDataSetLiveVersion;
+}
+
+export interface ApiDataSetVersion {
+  id: string;
+  version: string;
+  status: DataSetVersionStatus;
+  type: DataSetVersionType;
+  dataSetFileId: string;
+  releaseVersion: IdTitlePair;
+  totalResults: number;
+}
+
+export interface ApiDataSetDraftVersion extends ApiDataSetVersion {
+  status: DataSetDraftVersionStatus;
+  timePeriods?: TimePeriodRange;
+  geographicLevels?: string[];
+  filters?: string[];
+  indicators?: string[];
+}
+
+export interface ApiDataSetLiveVersion extends ApiDataSetVersion {
+  status: DataSetLiveVersionStatus;
+  published: string;
+  timePeriods: TimePeriodRange;
+  geographicLevels: string[];
+  filters: string[];
+  indicators: string[];
+}
+
+export interface TimePeriodRange {
+  start: string;
+  end: string;
+}
+
+export type DataSetStatus = 'Draft' | 'Published' | 'Deprecated' | 'Withdrawn';
+
+export type DataSetDraftVersionStatus =
+  | 'Processing'
+  | 'Failed'
+  | 'Mapping'
+  | 'Draft'
+  | 'Cancelled';
+
+export type DataSetLiveVersionStatus = 'Published' | 'Deprecated' | 'Withdrawn';
+
+export type DataSetVersionStatus =
+  | DataSetDraftVersionStatus
+  | DataSetLiveVersionStatus;
+
+export type DataSetVersionType = 'Major' | 'Minor';
+
+const apiDataSetService = {
+  async listDataSets(publicationId: string): Promise<ApiDataSetSummary[]> {
+    const { results } = await client.get<PaginatedList<ApiDataSetSummary>>(
+      '/public-data/data-sets',
+      {
+        params: {
+          publicationId,
+          pageSize: 100,
+        },
+      },
+    );
+
+    return results;
+  },
+  createDataSet(data: { releaseFileId: string }): Promise<ApiDataSet> {
+    return client.post('/public-data/data-sets', data);
+  },
+};
+
+export default apiDataSetService;

--- a/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
@@ -43,7 +43,7 @@ export interface ApiDataSetVersion {
   version: string;
   status: DataSetVersionStatus;
   type: DataSetVersionType;
-  dataSetFileId: string;
+  file: IdTitlePair;
   releaseVersion: IdTitlePair;
   totalResults: number;
 }
@@ -103,6 +103,9 @@ const apiDataSetService = {
   },
   createDataSet(data: { releaseFileId: string }): Promise<ApiDataSet> {
     return client.post('/public-data/data-sets', data);
+  },
+  getDataSet(dataSetId: string): Promise<ApiDataSet> {
+    return client.get(`/public-data/data-sets/${dataSetId}`);
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -129,7 +129,7 @@ type TaskStage =
   | 'Started'
   | 'Scheduled';
 
-export interface ReleaseStageStatuses {
+export interface ReleaseStageStatus {
   releaseId?: string;
   contentStage?: TaskStage;
   filesStage?: TaskStage;
@@ -261,8 +261,8 @@ const releaseService = {
     );
   },
 
-  getReleaseStatus(releaseId: string): Promise<ReleaseStageStatuses> {
-    return client.get<ReleaseStageStatuses>(
+  getReleaseStatus(releaseId: string): Promise<ReleaseStageStatus> {
+    return client.get<ReleaseStageStatus>(
       `/releases/${releaseId}/stage-status`,
     );
   },

--- a/src/explore-education-statistics-common/src/components/Button.tsx
+++ b/src/explore-education-statistics-common/src/components/Button.tsx
@@ -3,10 +3,15 @@ import useButton, { ButtonOptions } from '@common/hooks/useButton';
 import classNames from 'classnames';
 import React, { forwardRef, Ref } from 'react';
 
-function Button(props: ButtonOptions, ref: Ref<HTMLButtonElement>) {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { className, isDisabled, underline, variant, ...button } =
-    useButton(props);
+export interface ButtonProps extends ButtonOptions {
+  variant?: 'secondary' | 'warning';
+}
+
+function Button(
+  { variant, ...props }: ButtonProps,
+  ref: Ref<HTMLButtonElement>,
+) {
+  const { className, ...button } = useButton(props);
 
   return (
     // eslint-disable-next-line react/button-has-type
@@ -16,7 +21,7 @@ function Button(props: ButtonOptions, ref: Ref<HTMLButtonElement>) {
       className={classNames(
         'govuk-button',
         {
-          [styles.disabled]: isDisabled,
+          [styles.disabled]: button.disabled || button['aria-disabled'],
           'govuk-button--secondary': variant === 'secondary',
           'govuk-button--warning': variant === 'warning',
         },

--- a/src/explore-education-statistics-common/src/components/ButtonGroup.module.scss
+++ b/src/explore-education-statistics-common/src/components/ButtonGroup.module.scss
@@ -1,29 +1,45 @@
 @import '~govuk-frontend/dist/govuk/base';
 
 .group {
+  --horizontalSpacing: #{govuk-spacing(2)};
+  --verticalSpacing: #{govuk-spacing(2)};
+
   align-items: center;
   display: flex;
   flex-direction: column;
   margin-bottom: govuk-spacing(6);
 
-  > a,
-  > button {
-    margin-bottom: govuk-spacing(4);
-    margin-left: 0;
+  > * {
+    margin-bottom: 0;
   }
 
-  // stylelint-disable-next-line order/order
+  > * + * {
+    margin-left: 0;
+    margin-top: var(--verticalSpacing);
+  }
+
   @include govuk-media-query($from: tablet) {
     flex-direction: row;
 
-    > a,
-    > button {
-      margin-bottom: 0;
-      margin-left: govuk-spacing(2);
+    > * + * {
+      margin-left: var(--horizontalSpacing);
+      margin-top: 0;
     }
   }
+}
 
-  > :first-child {
-    margin-left: 0;
-  }
+.horizontalSpacing--m {
+  --horizontalSpacing: #{govuk-spacing(4)};
+}
+
+.verticalSpacing--m {
+  --verticalSpacing: #{govuk-spacing(4)};
+}
+
+.horizontalSpacing--l {
+  --horizontalSpacing: #{govuk-spacing(6)};
+}
+
+.verticalSpacing--l {
+  --verticalSpacing: #{govuk-spacing(6)};
 }

--- a/src/explore-education-statistics-common/src/components/ButtonGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/ButtonGroup.tsx
@@ -5,10 +5,26 @@ import styles from './ButtonGroup.module.scss';
 interface Props {
   children: ReactNode;
   className?: string;
+  horizontalSpacing?: 'l' | 'm' | 's';
+  verticalSpacing?: 'l' | 'm' | 's';
 }
 
-const ButtonGroup = ({ children, className }: Props) => {
-  return <div className={classNames(styles.group, className)}>{children}</div>;
-};
-
-export default ButtonGroup;
+export default function ButtonGroup({
+  children,
+  className,
+  horizontalSpacing = 's',
+  verticalSpacing = 's',
+}: Props) {
+  return (
+    <div
+      className={classNames(
+        styles.group,
+        styles[`horizontalSpacing--${horizontalSpacing}`],
+        styles[`verticalSpacing--${verticalSpacing}`],
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/ButtonText.module.scss
+++ b/src/explore-education-statistics-common/src/components/ButtonText.module.scss
@@ -27,9 +27,12 @@
   }
 
   &.disabled {
-    color: govuk-colour('light-blue');
     cursor: not-allowed;
     text-decoration: none;
+  }
+
+  &[disabled] {
+    color: govuk-colour('light-blue');
   }
 }
 

--- a/src/explore-education-statistics-common/src/components/ButtonText.tsx
+++ b/src/explore-education-statistics-common/src/components/ButtonText.tsx
@@ -3,9 +3,16 @@ import useButton, { ButtonOptions } from '@common/hooks/useButton';
 import classNames from 'classnames';
 import React, { forwardRef, Ref } from 'react';
 
-const ButtonText = (props: ButtonOptions, ref: Ref<HTMLButtonElement>) => {
-  const { className, isDisabled, underline, variant, ...button } =
-    useButton(props);
+export interface ButtonTextProps extends ButtonOptions {
+  underline?: boolean;
+  variant?: 'secondary' | 'warning';
+}
+
+const ButtonText = (
+  { underline = true, variant, ...props }: ButtonTextProps,
+  ref: Ref<HTMLButtonElement>,
+) => {
+  const { className, ...button } = useButton(props);
 
   return (
     // eslint-disable-next-line react/button-has-type
@@ -17,7 +24,7 @@ const ButtonText = (props: ButtonOptions, ref: Ref<HTMLButtonElement>) => {
         {
           [styles.noUnderline]: !underline,
           [styles.warning]: variant === 'warning',
-          [styles.disabled]: isDisabled,
+          [styles.disabled]: button.disabled || button['aria-disabled'],
         },
         className,
       )}

--- a/src/explore-education-statistics-common/src/components/StartButton.tsx
+++ b/src/explore-education-statistics-common/src/components/StartButton.tsx
@@ -1,8 +1,7 @@
-import { ButtonOptions } from '@common/hooks/useButton';
-import Button from '@common/components/Button';
+import Button, { ButtonProps } from '@common/components/Button';
 import React from 'react';
 
-interface Props extends Omit<ButtonOptions, 'children'> {
+interface Props extends Omit<ButtonProps, 'children'> {
   label: string;
 }
 

--- a/src/explore-education-statistics-common/src/components/SummaryCard.tsx
+++ b/src/explore-education-statistics-common/src/components/SummaryCard.tsx
@@ -1,0 +1,28 @@
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+
+export interface SummaryCardProps {
+  actions?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  heading: ReactNode;
+  headingTag: 'h2' | 'h3' | 'h4';
+}
+
+export default function SummaryCard({
+  actions,
+  children,
+  className,
+  heading,
+  headingTag: Heading = 'h2',
+}: SummaryCardProps) {
+  return (
+    <div className={classNames('govuk-summary-card', className)}>
+      <div className="govuk-summary-card__title-wrapper">
+        <Heading className="govuk-summary-card__title">{heading}</Heading>
+        {actions && <ul className="govuk-summary-card__actions">{actions}</ul>}
+      </div>
+      <div className="govuk-summary-card__content">{children}</div>
+    </div>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/SummaryCardAction.tsx
+++ b/src/explore-education-statistics-common/src/components/SummaryCardAction.tsx
@@ -1,0 +1,18 @@
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+
+interface SummaryCardActionProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function SummaryCardAction({
+  children,
+  className,
+}: SummaryCardActionProps) {
+  return (
+    <li className={classNames('govuk-summary-card__action', className)}>
+      {children}
+    </li>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/SummaryList.tsx
+++ b/src/explore-education-statistics-common/src/components/SummaryList.tsx
@@ -10,6 +10,7 @@ interface Props {
   id?: string;
   noBorder?: boolean;
   smallKey?: boolean;
+  testId?: string;
 }
 
 const SummaryList = ({
@@ -20,6 +21,7 @@ const SummaryList = ({
   id,
   noBorder,
   smallKey = false,
+  testId,
 }: Props) => {
   return (
     <dl
@@ -29,6 +31,7 @@ const SummaryList = ({
         [styles.smallKey]: smallKey,
         'govuk-summary-list--no-border': noBorder,
       })}
+      data-testid={testId}
       id={id}
     >
       {children}

--- a/src/explore-education-statistics-common/src/components/TaskList.tsx
+++ b/src/explore-education-statistics-common/src/components/TaskList.tsx
@@ -1,0 +1,23 @@
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+
+export interface TaskListProps {
+  children: ReactNode;
+  className?: string;
+  testId?: string;
+}
+
+export default function TaskList({
+  children,
+  className,
+  testId,
+}: TaskListProps) {
+  return (
+    <ul
+      className={classNames('govuk-task-list', className)}
+      data-testid={testId}
+    >
+      {children}
+    </ul>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/TaskListItem.module.scss
+++ b/src/explore-education-statistics-common/src/components/TaskListItem.module.scss
@@ -1,0 +1,25 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.item {
+  // Can automatically figure this out with CSS instead of having to
+  // manually apply `govuk-task-list__item--with-link`.
+  &:has(a, button):hover {
+    background: govuk-colour('light-grey');
+  }
+}
+
+.nameAndHint {
+  // Copy of `govuk-task-list__link` class that adds a
+  // transparent box pseudo-element in the child element
+  // allowing the entire row to be clickable.
+  a::after,
+  button::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+}

--- a/src/explore-education-statistics-common/src/components/TaskListItem.tsx
+++ b/src/explore-education-statistics-common/src/components/TaskListItem.tsx
@@ -1,0 +1,52 @@
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+import styles from './TaskListItem.module.scss';
+
+export interface TaskListItemRenderProps {
+  'aria-describedby': string;
+}
+
+export interface TaskListItemProps {
+  children: (props: TaskListItemRenderProps) => ReactNode;
+  className?: string;
+  hint?: string;
+  id: string;
+  status: ReactNode;
+}
+
+export default function TaskListItem({
+  children,
+  className,
+  hint,
+  id,
+  status,
+}: TaskListItemProps) {
+  const statusId = `${id}-status`;
+  const hintId = `${id}-hint`;
+
+  return (
+    <li className={classNames('govuk-task-list__item', styles.item, className)}>
+      <div
+        className={classNames(
+          'govuk-task-list__name-and-hint',
+          styles.nameAndHint,
+        )}
+      >
+        {children({
+          'aria-describedby': classNames(statusId, {
+            [hintId]: !!hint,
+          }),
+        })}
+
+        {hint && (
+          <div className="govuk-task-list__hint" id={hintId}>
+            {hint}
+          </div>
+        )}
+      </div>
+      <div className="govuk-task-list__status" id={statusId}>
+        {status}
+      </div>
+    </li>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/__tests__/Button.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Button.test.tsx
@@ -43,64 +43,70 @@ describe('Button', () => {
 
     const button = screen.getByRole('button', { name: 'Test button' });
 
-    expect(button).not.toBeDisabled();
+    expect(button).toBeDisabled();
     expect(button).toBeAriaDisabled();
   });
 
-  test('disabled if current `onClick` handler is processing', async () => {
+  test('aria-disabled if current `onClick` handler is processing', async () => {
     const handleClick = jest.fn(async () => delay(100));
 
     render(<Button onClick={handleClick}>Test button</Button>);
 
     const button = screen.getByRole('button', { name: 'Test button' });
 
+    expect(button).not.toBeAriaDisabled();
     expect(button).toBeEnabled();
 
     await userEvent.click(button);
 
     expect(handleClick).toHaveBeenCalledTimes(1);
-    expect(button).toBeDisabled();
 
-    // Button is still disabled
-    expect(button).toBeDisabled();
+    expect(button).toBeAriaDisabled();
+    expect(button).toBeEnabled();
   });
 
-  test('enabled if current `onClick` handler is processing and `disableDoubleClick` is false', async () => {
+  test('not aria-disabled if current `onClick` handler is processing and `preventDoubleClick` is false', async () => {
     const handleClick = jest.fn(async () => delay(100));
 
     render(
-      <Button disableDoubleClick={false} onClick={handleClick}>
+      <Button preventDoubleClick={false} onClick={handleClick}>
         Test button
       </Button>,
     );
 
     const button = screen.getByRole('button', { name: 'Test button' });
 
+    expect(button).not.toBeAriaDisabled();
     expect(button).toBeEnabled();
 
     await userEvent.click(button);
 
     expect(handleClick).toHaveBeenCalledTimes(1);
-    expect(button).toBeEnabled();
 
-    // Button is still enabled
+    expect(button).not.toBeAriaDisabled();
     expect(button).toBeEnabled();
   });
 
-  test('enabled once the current `onClick` handler has finished', async () => {
+  test('not aria-disabled once the current `onClick` handler has finished', async () => {
     const handleClick = jest.fn(async () => delay(100));
 
     render(<Button onClick={handleClick}>Test button</Button>);
 
     const button = screen.getByRole('button', { name: 'Test button' });
 
+    expect(button).not.toBeAriaDisabled();
+    expect(button).toBeEnabled();
+
     await userEvent.click(button);
 
     expect(handleClick).toHaveBeenCalledTimes(1);
-    expect(button).toBeDisabled();
+
+    expect(button).toBeAriaDisabled();
+    expect(button).toBeEnabled();
 
     // Task has completed, so button is now enabled
     await waitFor(() => {
+      expect(button).not.toBeAriaDisabled();
       expect(button).toBeEnabled();
     });
   });

--- a/src/explore-education-statistics-common/src/components/__tests__/ButtonText.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ButtonText.test.tsx
@@ -43,64 +43,70 @@ describe('ButtonText', () => {
 
     const button = screen.getByRole('button', { name: 'Test button' });
 
-    expect(button).not.toBeDisabled();
+    expect(button).toBeDisabled();
     expect(button).toBeAriaDisabled();
   });
 
-  test('disabled if current `onClick` handler is processing', async () => {
+  test('aria-disabled if current `onClick` handler is processing', async () => {
     const handleClick = jest.fn(async () => delay(100));
 
     render(<ButtonText onClick={handleClick}>Test button</ButtonText>);
 
     const button = screen.getByRole('button', { name: 'Test button' });
 
+    expect(button).not.toBeAriaDisabled();
     expect(button).toBeEnabled();
 
     await userEvent.click(button);
 
     expect(handleClick).toHaveBeenCalledTimes(1);
-    expect(button).toBeDisabled();
 
-    // Button is still disabled
-    expect(button).toBeDisabled();
+    expect(button).toBeAriaDisabled();
+    expect(button).toBeEnabled();
   });
 
-  test('enabled if current `onClick` handler is processing and `disableDoubleClick` is false', async () => {
+  test('not aria-disabled if current `onClick` handler is processing and `preventDoubleClick` is false', async () => {
     const handleClick = jest.fn(async () => delay(100));
 
     render(
-      <ButtonText disableDoubleClick={false} onClick={handleClick}>
+      <ButtonText preventDoubleClick={false} onClick={handleClick}>
         Test button
       </ButtonText>,
     );
 
     const button = screen.getByRole('button', { name: 'Test button' });
 
+    expect(button).not.toBeAriaDisabled();
     expect(button).toBeEnabled();
 
     await userEvent.click(button);
 
     expect(handleClick).toHaveBeenCalledTimes(1);
-    expect(button).toBeEnabled();
 
-    // Button is still enabled
+    expect(button).not.toBeAriaDisabled();
     expect(button).toBeEnabled();
   });
 
-  test('enabled once the current `onClick` handler has finished', async () => {
+  test('not aria-disabled once the current `onClick` handler has finished', async () => {
     const handleClick = jest.fn(async () => delay(100));
 
     render(<ButtonText onClick={handleClick}>Test button</ButtonText>);
 
     const button = screen.getByRole('button', { name: 'Test button' });
 
+    expect(button).not.toBeAriaDisabled();
+    expect(button).toBeEnabled();
+
     await userEvent.click(button);
 
     expect(handleClick).toHaveBeenCalledTimes(1);
-    expect(button).toBeDisabled();
+
+    expect(button).toBeAriaDisabled();
+    expect(button).toBeEnabled();
 
     // Task has completed, so button is now enabled
     await waitFor(() => {
+      expect(button).not.toBeAriaDisabled();
       expect(button).toBeEnabled();
     });
   });

--- a/src/explore-education-statistics-common/src/components/__tests__/TaskListItem.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/TaskListItem.test.tsx
@@ -1,0 +1,42 @@
+import { getAllDescribedBy, getDescribedBy } from '@common-test/queries';
+import TaskListItem from '@common/components/TaskListItem';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+describe('TaskListItem', () => {
+  test('provides correct `aria-describedby` render prop when `hint` is set', () => {
+    render(
+      <TaskListItem hint="Test hint" id="test" status="Completed">
+        {props => (
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          <a {...props} href="/">
+            Test
+          </a>
+        )}
+      </TaskListItem>,
+    );
+
+    const descriptors = getAllDescribedBy(screen.getByRole('link'));
+
+    expect(descriptors).toHaveLength(2);
+    expect(descriptors[0]).toHaveTextContent('Completed');
+    expect(descriptors[1]).toHaveTextContent('Test hint');
+  });
+
+  test('provides correct `aria-describedby` render prop when `hint` is not set', () => {
+    render(
+      <TaskListItem id="test" status="Completed">
+        {props => (
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          <a {...props} href="/">
+            Test
+          </a>
+        )}
+      </TaskListItem>,
+    );
+
+    expect(getDescribedBy(screen.getByRole('link'))).toHaveTextContent(
+      'Completed',
+    );
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/Form.tsx
+++ b/src/explore-education-statistics-common/src/components/form/Form.tsx
@@ -55,7 +55,13 @@ export default function Form<TFormValues extends FieldValues>({
   const isMounted = useMountedRef();
 
   const {
-    formState: { errors, submitCount, touchedFields, isSubmitted },
+    formState: {
+      errors,
+      submitCount,
+      touchedFields,
+      isSubmitted,
+      isSubmitting,
+    },
     handleSubmit: submit,
   } = useFormContext<TFormValues>();
 
@@ -105,11 +111,16 @@ export default function Form<TFormValues extends FieldValues>({
   const handleSubmit = useCallback(
     async (event: FormEvent) => {
       event.preventDefault();
+
+      if (isSubmitting) {
+        return;
+      }
+
       toggleSummaryFocus.off();
 
       await submit(async data => onSubmit(data))(event);
     },
-    [submit, toggleSummaryFocus, onSubmit],
+    [isSubmitting, toggleSummaryFocus, submit, onSubmit],
   );
 
   return (

--- a/src/explore-education-statistics-common/src/hooks/__tests__/useButton.test.ts
+++ b/src/explore-education-statistics-common/src/hooks/__tests__/useButton.test.ts
@@ -12,8 +12,6 @@ describe('useButton', () => {
         id: 'id',
         testId: 'test id',
         type: 'submit',
-        underline: false,
-        variant: 'warning',
       }),
     );
     expect(result.current.children).toBe('button text');
@@ -23,8 +21,6 @@ describe('useButton', () => {
     expect(result.current.id).toBe('id');
     expect(result.current['data-testid']).toBe('test id');
     expect(result.current.type).toBe('submit');
-    expect(result.current.underline).toBe(false);
-    expect(result.current.variant).toBe('warning');
   });
 
   test('returns correct props when `disabled = true`', () => {
@@ -58,6 +54,6 @@ describe('useButton', () => {
       }),
     );
     expect(result.current['aria-disabled']).toBe(true);
-    expect(result.current.disabled).toBe(undefined);
+    expect(result.current.disabled).toBe(true);
   });
 });

--- a/src/explore-education-statistics-common/test/render.tsx
+++ b/src/explore-education-statistics-common/test/render.tsx
@@ -8,7 +8,7 @@ import userEvent, { UserEvent } from '@testing-library/user-event';
 import noop from 'lodash/noop';
 import React, { FC, ReactElement, ReactNode } from 'react';
 
-interface CustomRenderResult extends RenderResult {
+export interface CustomRenderResult extends RenderResult {
   user: UserEvent;
 }
 


### PR DESCRIPTION
This PR adds the initial API data set admin pages that are required for the v1.0 workflow. This consists of:

1. A page listing the API data sets relating to the publication

   ![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/9917868/06c12066-0482-4cc7-aa51-a723233e58e0)

3. A modal to create a new API data set:

   ![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/9917868/66f20158-c89f-44ae-a5fd-8038f88f1bf2)

4. A page listing individual API data sets and their draft and / or latest live versions:

   ![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/9917868/3a01ecd0-eeed-45a6-9f2b-41d232ccbacb)

## Related changes

- Added GOV.UK's `TaskList` and `SummaryCard` components for use in the API data set details page.
- Added basic route protection for all release routes. This includes a BAU check on the API data set pages.
- Changed `ButtonGroup` to have configurable horizontal and vertical spacings. This allowed for better positioning of buttons in the draft and live API data set version tables.

## Other changes

- Cleaned up button component's and their disabling functionality. The `disabled` or `aria-disabled` props now work more independently from one another and `aria-disabled` is uses instead of `disabled` to prevent double clicks.
- Added new checks to prevent double submissions when a form is currently submitting.