### PR TITLE
Update public API ports to avoid collisions with Windows service host

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Properties/launchSettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Properties/launchSettings.json
@@ -22,7 +22,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "docs",
-      "applicationUrl": "https://0.0.0.0:5041;http://0.0.0.0:5040;https://[::1]:5041;http://[::1]:5040",
+      "applicationUrl": "https://0.0.0.0:5051;http://0.0.0.0:5050;https://[::1]:5051;http://[::1]:5050",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/explore-education-statistics-frontend/.env
+++ b/src/explore-education-statistics-frontend/.env
@@ -1,6 +1,6 @@
 CONTENT_API_BASE_URL=http://localhost:5010/api
 DATA_API_BASE_URL=http://localhost:5000/api
-PUBLIC_API_BASE_URL=http://localhost:5040/api/v1.0
+PUBLIC_API_BASE_URL=http://localhost:5050/api/v1.0
 PUBLIC_API_DOCS_URL=TODO-GUIDANCE-URL
 NOTIFICATION_API_BASE_URL=http://localhost:7073/api
 GA_TRACKING_ID=


### PR DESCRIPTION
This PR updates the public API ports yet again to avoid collisions with Windows service host (`svchost`) which runs on TCP 5040 and UDP 5050. 

Note that we had previously tried updating the public API port to 5040 and 5041 in #4889 to avoid collisions with the IDP container.

Whilst the public API would end up sharing 5050 with the service host's UDP 5050, there (hopefully) shouldn't be any problems as they'd be on different protocols.

In the future, we might want to consider changing our port range to avoid these types of collisions some more.