### PR TITLE
EES-5164 Ensure isolation of files created between tests

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
@@ -4,7 +4,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,12 +14,23 @@ using Testcontainers.PostgreSql;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests;
 
 public abstract class ProcessorFunctionsIntegrationTest
-    : FunctionsIntegrationTest<ProcessorFunctionsIntegrationTestFixture>
+    : FunctionsIntegrationTest<ProcessorFunctionsIntegrationTestFixture>, IDisposable
 {
     protected ProcessorFunctionsIntegrationTest(FunctionsIntegrationTestFixture fixture) : base(fixture)
     {
         ResetDbContext<ContentDbContext>();
         ClearTestData<PublicDataDbContext>();
+    }
+
+    public void Dispose()
+    {
+        var dataSetVersionPathResolver = GetRequiredService<IDataSetVersionPathResolver>();
+
+        var testInstanceDataFilesDirectory = dataSetVersionPathResolver.BasePath();
+        if (Directory.Exists(testInstanceDataFilesDirectory))
+        {
+            Directory.Delete(testInstanceDataFilesDirectory, recursive: true);
+        }
     }
 }
 
@@ -74,8 +84,6 @@ public class ProcessorFunctionsIntegrationTestFixture : FunctionsIntegrationTest
 
                 using var context = serviceScope.ServiceProvider.GetRequiredService<PublicDataDbContext>();
                 context.Database.Migrate();
-
-                services.ReplaceService<IDataSetVersionPathResolver>(new TestDataSetVersionPathResolver());
             });
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/TestDataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/TestDataSetVersionPathResolver.cs
@@ -7,13 +7,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests;
 
 public class TestDataSetVersionPathResolver : IDataSetVersionPathResolver
 {
-    private string BasePath { get; set; } = Path.Combine(
+    private readonly string _basePath = Path.Combine(
         Assembly.GetExecutingAssembly().GetDirectoryPath(),
         "Resources",
         "ParquetFiles"
     );
 
+    public string BasePath() => _basePath;
+
     public string Directory { get; set; } = string.Empty;
 
-    public string DirectoryPath(DataSetVersion dataSetVersion) => Path.Combine(BasePath, Directory);
+    public string DirectoryPath(DataSetVersion dataSetVersion) => Path.Combine(_basePath, Directory);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
@@ -14,7 +14,6 @@ public class DataSetVersionPathResolver : IDataSetVersionPathResolver
 {
     private readonly IOptions<ParquetFilesOptions> _options;
     private readonly IWebHostEnvironment _environment;
-
     private readonly string _basePath;
 
     public DataSetVersionPathResolver(IOptions<ParquetFilesOptions> options, IWebHostEnvironment environment)
@@ -33,6 +32,8 @@ public class DataSetVersionPathResolver : IDataSetVersionPathResolver
         _basePath = GetBasePath();
     }
 
+    public string BasePath() => _basePath;
+
     public string DirectoryPath(DataSetVersion dataSetVersion)
         => Path.Combine(_basePath, dataSetVersion.DataSetId.ToString(), $"v{dataSetVersion.Version}");
 
@@ -47,7 +48,8 @@ public class DataSetVersionPathResolver : IDataSetVersionPathResolver
         {
             return Path.Combine(
                 Assembly.GetExecutingAssembly().GetDirectoryPath(),
-                PathUtils.OsPath(_options.Value.BasePath)
+                PathUtils.OsPath(_options.Value.BasePath),
+                Guid.NewGuid().ToString()
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/Interfaces/IDataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/Interfaces/IDataSetVersionPathResolver.cs
@@ -5,6 +5,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interf
 
 public interface IDataSetVersionPathResolver
 {
+    string BasePath();
+
     string DirectoryPath(DataSetVersion dataSetVersion);
 
     string CsvDataPath(DataSetVersion dataSetVersion)


### PR DESCRIPTION
This PR changes the `DataSetVersionPathResolver` to append a unique directory to the base path for tests running in an integration test environment to ensure isolation of files created between tests.

An `IDisposable.Dispose` is added to the base `ProcessorFunctionsIntegrationTest` class which deletes this directory after every test.

It also corrects the `ProcessorFunctionsIntegrationTestFixture.ConfigureTestHostBuilder` method to not swap out the default `DataSetVersionPathResolver` with an instance of `TestDataSetVersionPathResolver`. This is because `TestDataSetVersionPathResolver` is only intended to be used where we need to fix the directory path to be a specific directory, e.g. `Resources/ParquetFiles/AbsenceSchool` where files in that directory have been source controlled to provide pre-existing data for use by the tests.