### PR TITLE
EES-5162 Add UUID v7 IDs to public API DB models

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Database/UuidV7ValueGenerator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Database/UuidV7ValueGenerator.cs
@@ -1,0 +1,17 @@
+#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Database;
+
+/// <summary>
+/// Generates UUID v7s that are compatible with non-MSSQL databases (e.g. Postgres).
+/// </summary>
+public class UuidV7ValueGenerator : ValueGenerator<Guid>
+{
+    public override Guid Next(EntityEntry entry) => UuidUtils.UuidV7();
+
+    public override bool GeneratesTemporaryValues => false;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -25,6 +25,7 @@
         <PackageReference Include="FluentValidation" Version="11.9.0" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
         <PackageReference Include="InterpolatedSql" Version="2.3.0" />
+        <PackageReference Include="Medo.Uuid7" Version="1.9.1" />
         <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.3" />
         <!-- TODO EES-4202 DataMovement depends on deprecated Microsoft.Azure.Storage.Blob SDK v11 -->

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -134,9 +134,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 
         public static async Task<Either<TFailure, TSuccess>> OnSuccessDo<TFailure, TSuccess>(
             this Task<Either<TFailure, TSuccess>> task,
+            Action successTask)
+        {
+            return await task.OnSuccessDo(_ => successTask());
+        }
+
+        public static async Task<Either<TFailure, TSuccess>> OnSuccessDo<TFailure, TSuccess>(
+            this Task<Either<TFailure, TSuccess>> task,
             Func<Task> successTask)
         {
             return await task.OnSuccessDo(async _ => await successTask());
+        }
+
+        public static async Task<Either<TFailure, TSuccess>> OnSuccessDo<TFailure, TSuccess>(
+            this Task<Either<TFailure, TSuccess>> task,
+            Action<TSuccess> successTask)
+        {
+            var firstResult = await task;
+
+            if (firstResult.IsLeft)
+            {
+                return firstResult.Left;
+            }
+
+            successTask(firstResult.Right);
+            return firstResult.Right;
         }
 
         public static async Task<Either<TFailure, TSuccess>> OnSuccessDo<TFailure, TSuccess>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/UuidUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/UuidUtils.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System;
+using Medo;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public static class UuidUtils
+{
+    /// <summary>
+    /// Generate a UUID v7 compatible with non-MSSQL databases e.g. Postgres.
+    /// </summary>
+    /// <remarks>
+    /// Use <see cref="UuidV7MsSql"/> if you are using an MSSQL database.
+    /// </remarks>
+    public static Guid UuidV7() => Uuid7.NewGuid();
+
+    /// <summary>
+    /// Generate a UUID v7 compatible with MSSQL databases.
+    /// </summary>
+    /// <remarks>
+    /// Use <see cref="UuidV7"/> if you are using non-MSSQL databases.
+    /// </remarks>
+    public static Guid UuidV7MsSql() => Uuid7.NewGuidMsSql();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Change.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Change.cs
@@ -1,8 +1,10 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
 public class Change<TState>
 {
-    public Guid Identifier { get; set; } = Guid.NewGuid();
+    public Guid Identifier { get; set; } = UuidUtils.UuidV7();
 
     public required ChangeType Type { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/ChangeSet.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/ChangeSet.cs
@@ -1,4 +1,5 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -26,6 +27,9 @@ public class ChangeSetFilters : ChangeSet<FilterChangeState>
     {
         public void Configure(EntityTypeBuilder<ChangeSetFilters> builder)
         {
+            builder.Property(cs => cs.Id)
+                .HasValueGenerator<UuidV7ValueGenerator>();
+
             builder.OwnsMany(cs => cs.Changes, cs =>
             {
                 cs.ToJson();
@@ -44,6 +48,9 @@ public class ChangeSetFilterOptions : ChangeSet<FilterOptionChangeState>
     {
         public void Configure(EntityTypeBuilder<ChangeSetFilterOptions> builder)
         {
+            builder.Property(cs => cs.Id)
+                .HasValueGenerator<UuidV7ValueGenerator>();
+
             builder.OwnsMany(cs => cs.Changes, cs =>
             {
                 cs.ToJson();
@@ -62,6 +69,9 @@ public class ChangeSetIndicators : ChangeSet<IndicatorChangeState>
     {
         public void Configure(EntityTypeBuilder<ChangeSetIndicators> builder)
         {
+            builder.Property(cs => cs.Id)
+                .HasValueGenerator<UuidV7ValueGenerator>();
+
             builder.OwnsMany(cs => cs.Changes, cs =>
             {
                 cs.ToJson();
@@ -88,6 +98,9 @@ public class ChangeSetLocations : ChangeSet<LocationChangeState>
     {
         public void Configure(EntityTypeBuilder<ChangeSetLocations> builder)
         {
+            builder.Property(cs => cs.Id)
+                .HasValueGenerator<UuidV7ValueGenerator>();
+
             builder.OwnsMany(cs => cs.Changes, cs =>
             {
                 cs.ToJson();
@@ -109,6 +122,9 @@ public class ChangeSetTimePeriods : ChangeSet<TimePeriodChangeState>
     {
         public void Configure(EntityTypeBuilder<ChangeSetTimePeriods> builder)
         {
+            builder.Property(cs => cs.Id)
+                .HasValueGenerator<UuidV7ValueGenerator>();
+
             builder.OwnsMany(cs => cs.Changes, cs =>
             {
                 cs.ToJson();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSet.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSet.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -42,6 +43,9 @@ public class DataSet : ICreatedUpdatedTimestamps<DateTimeOffset, DateTimeOffset?
     {
         public void Configure(EntityTypeBuilder<DataSet> builder)
         {
+            builder.Property(ds => ds.Id)
+                .HasValueGenerator<UuidV7ValueGenerator>();
+
             builder.Property(ds => ds.Status).HasConversion<string>();
 
             builder

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -1,4 +1,5 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using Microsoft.EntityFrameworkCore;
@@ -77,7 +78,11 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
     {
         public void Configure(EntityTypeBuilder<DataSetVersion> builder)
         {
-            builder.Property(dsv => dsv.Status).HasConversion<string>();
+            builder.Property(dsv => dsv.Id)
+                .HasValueGenerator<UuidV7ValueGenerator>();
+
+            builder.Property(dsv => dsv.Status)
+                .HasConversion<string>();
 
             builder.OwnsOne(v => v.MetaSummary, ms =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionImport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionImport.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -26,6 +27,9 @@ public class DataSetVersionImport : ICreatedUpdatedTimestamps<DateTimeOffset, Da
     {
         public void Configure(EntityTypeBuilder<DataSetVersionImport> builder)
         {
+            builder.Property(i => i.Id)
+                .HasValueGenerator<UuidV7ValueGenerator>();
+
             builder.Property(i => i.Stage)
                 .HasConversion<string>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetService.cs
@@ -1,3 +1,4 @@
+using System.Transactions;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators;
@@ -26,16 +27,30 @@ public class DataSetService(
         Guid instanceId,
         CancellationToken cancellationToken = default)
     {
-        return await GetReleaseFile(request.ReleaseFileId, cancellationToken)
-            .OnSuccess(async releaseFile => await ValidateReleaseFile(releaseFile, cancellationToken)
-                .OnSuccess(async () => await CreateDataSet(releaseFile, cancellationToken))
-                .OnSuccess(async dataSet =>
-                    await CreateDataSetVersion(dataSet, releaseFile, cancellationToken))
-                .OnSuccessDo(async dataSetVersion =>
-                    await CreateDataSetVersionImport(dataSetVersion, instanceId, cancellationToken))
-                .OnSuccessDo(async dataSetVersion =>
-                    await UpdateFilePublicDataSetVersionId(releaseFile, dataSetVersion, cancellationToken))
-                .OnSuccess(dataSetVersion => (dataSetId: dataSetVersion.DataSetId, dataSetVersionId: dataSetVersion.Id)));
+        var strategy = contentDbContext.Database.CreateExecutionStrategy();
+
+        return await strategy.ExecuteAsync(async () =>
+        {
+            using var transactionScope = new TransactionScope(
+                TransactionScopeOption.Required,
+                new TransactionOptions
+                {
+                    IsolationLevel = IsolationLevel.ReadCommitted
+                },
+                TransactionScopeAsyncFlowOption.Enabled);
+
+            return await GetReleaseFile(request.ReleaseFileId, cancellationToken)
+                .OnSuccess(async releaseFile => await ValidateReleaseFile(releaseFile, cancellationToken)
+                    .OnSuccess(async () => await CreateDataSet(releaseFile, cancellationToken))
+                    .OnSuccess(async dataSet =>
+                        await CreateDataSetVersion(dataSet, releaseFile, cancellationToken))
+                    .OnSuccessDo(async dataSetVersion =>
+                        await CreateDataSetVersionImport(dataSetVersion, instanceId, cancellationToken))
+                    .OnSuccessDo(async dataSetVersion =>
+                        await UpdateFilePublicDataSetVersionId(releaseFile, dataSetVersion, cancellationToken))
+                    .OnSuccessDo(transactionScope.Complete)
+                    .OnSuccess(dataSetVersion => (dataSetId: dataSetVersion.DataSetId, dataSetVersionId: dataSetVersion.Id)));
+        });
     }
 
     private async Task<Either<ActionResult, ReleaseFile>> GetReleaseFile(


### PR DESCRIPTION
This PR adds UUID v7s for the various public API DB models instead of the default UUID v4s used by Guids.

UUID v7s are a better format for database performance as they can be sorted and cluster better, leading to better index performance. This was originally part of the database model proposed by Paul.

## Other changes

- Added transaction around `DataSetService.CreateDataSetVersion`, which could previously result in inconsistent state if any of its constituent saves failed to commit their changes.