### PR TITLE
EES-4974 fix going back to data set page from table tool

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -28,6 +28,7 @@ import { logEvent } from '@frontend/services/googleAnalyticsService';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { GetServerSideProps } from 'next';
+import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 
 // TODO EES-4856
@@ -77,6 +78,7 @@ export default function DataSetFilePage({
     useState<PageSectionId>('dataSetDetails');
   const [fullScreenPreview, toggleFullScreenPreview] = useToggle(false);
   const [showAllPreview, toggleShowAllPreview] = useToggle(false);
+  const router = useRouter();
 
   const handleDownload = async () => {
     await downloadService.downloadFiles(release.id, [file.id]);
@@ -113,7 +115,16 @@ export default function DataSetFilePage({
       ) {
         setActiveSection(pageSectionId);
 
-        window.history.pushState({}, '', `#${pageSectionId}`);
+        router.push(
+          {
+            pathname: `/data-catalogue/data-set/${dataSetFile.id}`,
+            hash: pageSectionId,
+          },
+          undefined,
+          {
+            shallow: true,
+          },
+        );
       }
     });
   }, 10);


### PR DESCRIPTION
Fixes an issue where following a link to the table tool from the data set page and then clicking the browser back button did not work. This seems to be a bug in Next.js when you've changed the hash using `window.history`  (see https://github.com/vercel/next.js/issues/56112 for more info), changing it to use Next Router to update the hash appears to fix it.