### PR TITLE
EES-5171 - Fixing Prod-only UI tests

### DIFF
--- a/tests/robot-tests/tests/general_public/prod_only/methodologies_page.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/methodologies_page.robot
@@ -16,6 +16,7 @@ Navigate to /methodology page
 
 Validate accordion sections exist
     user checks url contains    methodology
+    user scrolls down    200
     user waits until page contains accordion section    Children's social care
     user waits until page contains accordion section    COVID-19
     user waits until page contains accordion section    Destination of pupils and students
@@ -37,7 +38,7 @@ Validate page contents
 
     user checks page contains link with text and url
     ...    Pupil absence statistics: methodology
-    ...    /methodology/pupil-absence-in-schools-in-england
+    ...    /methodology/pupil-absence-statistics-methodology
 
 Validate Related information section links exist
     user checks page contains link with text and url


### PR DESCRIPTION
![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/93383553/b0729261-e7bf-4a13-a729-e1b6035becc4)
Couple of UI tests were failing in 'Prod-only' tests in` Methodology_page.robot.`because the slug got updated on the live website.

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/93383553/15a3ff82-bc51-4896-9386-616cfa6ca7ce)

