### PR TITLE
EES-5183 Use UTC for ReleaseFiles.Published

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -402,6 +402,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     .HasConversion(
                         v => JsonConvert.SerializeObject(v),
                         v => JsonConvert.DeserializeObject<List<IndicatorGroupSequenceEntry>>(v));
+                entity.Property(rf => rf.Published)
+                    .HasConversion(v => v,
+                        v => v.HasValue
+                            ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
+                            : null);
             });
         }
 


### PR DESCRIPTION
This fixes an issue where the Last updated date for data set files weren't being adjusted from UTC to GMT. This was because we weren't saving the date into the DB as UTC - which meant no `Z` at the end of the date:

```
		"published": "2024-05-23T23:30:03.3859034Z",
		"lastUpdated": "2024-05-23T23:30:03.3859034",
```

This meant the frontend wouldn't treat the date as UTC and so wouldn't adjust it to local time.