### PR TITLE
EES-5167 Upload new redirects and use an object instead of an array

### DIFF
--- a/src/explore-education-statistics-frontend/redirects.js
+++ b/src/explore-education-statistics-frontend/redirects.js
@@ -1,763 +1,1048 @@
-const seoRedirects = [
-  {
-    from: '/nbsp;andnbsp;https://www.gov.uk/government/collections/abortion-statistics-for-england-and-wales',
-    to: '/',
-  },
-  { from: '/!nd-statistics/permanent-and-', to: '/' },
-  {
-    from: '/api/methodologies/%7BmethodologyId%7D/images/7763f949-eff9-4571-93b4-08db2bd4eec9',
-    to: '/',
-  },
-  {
-    from: '/api/methodologies/%7BmethodologyId%7D/images/9348e5bc-c09d-43b4-de90-08d90ae3d820',
-    to: '/',
-  },
-  {
-    from: '/api/methodologies/%7BmethodologyId%7D/images/a095bcaa-7c7c-4a99-de75-08d90ae3d820',
-    to: '/',
-  },
-  {
-    from: '/api/methodologies/%7BmethodologyId%7D/images/cd50d521-0d75-498e-143b-08dac7b96540',
-    to: '/',
-  },
-  {
-    from: '/api/methodologies/%7BmethodologyId%7D/images/d8ecf739-f299-413f-126f-08dacbba9031',
-    to: '/',
-  },
-  {
-    from: '/api/methodologies/%7BmethodologyId%7D/images/ef57d23a-f281-4b6b-a55e-08da6007d7ab',
-    to: '/',
-  },
-  {
-    from: '/api/methodologies/%7BmethodologyId%7D/images/fcfa509c-8572-4b61-ca3a-08dbcefb484c',
-    to: '/',
-  },
-  {
-    from: '/api/methodologies/%7BmethodologyId%7D/images/feeffb4e-f022-469a-6e23-08dacc6823fb',
-    to: '/',
-  },
-  {
-    from: '/api/releases/%7BreleaseId%7D/images/0eb3fc80-77ad-4d66-8090-a6c2509d50c5',
-    to: '/',
-  },
-  {
-    from: '/api/releases/%7BreleaseId%7D/images/26f6ac12-25d0-4831-5293-08db35b5456a',
-    to: '/',
-  },
-  {
-    from: '/api/releases/%7BreleaseId%7D/images/fdb52a67-704d-44f3-9721-752000ff9ab9',
-    to: '/',
-  },
-  { from: '/data', to: '/' },
-  { from: '/data-', to: '/' },
-  { from: '/data-table', to: '/' },
-  { from: '/data-tablesnbsp;-nbsp;springnbsp;2022', to: '/' },
-  { from: '/data-tables/fast-track/%5BdataBlockId%5D', to: '/' },
-  { from: '/data-tables/fast-track/%5BdataBlockParentId%5D', to: '/' },
-  { from: '/data-tables/permalink/%5Bpermalink%5D', to: '/data-tables' },
-  {
-    from: '/data-tables/permalink/09fca49f-7bd8-475f-dd03-08db8e99978c.',
-    to: '/data-tables',
-  },
-  { from: '/data-tables/permalink/167d18fb-', to: '/data-tables' },
-  {
-    from: '/data-tables/permalink/203a8889-429b-469f-abe1-',
-    to: '/data-tables',
-  },
-  {
-    from: '/data-tables/permalink/2e97cf7e-3fe6-4e97-8525-',
-    to: '/data-tables',
-  },
-  {
-    from: '/data-tables/permalink/36526263-f93b-4bb1-9d1f-',
-    to: '/data-tables',
-  },
-  {
-    from: '/data-tables/permalink/47223cca-6ffb-42da-be50-',
-    to: '/data-tables',
-  },
-  {
-    from: '/data-tables/permalink/55ca2487-7a4d-43c4-487d-08db8e99c26c.',
-    to: '/data-tables',
-  },
-  {
-    from: '/data-tables/permalink/59fc4e59-160c-4755-c612-08',
-    to: '/data-tables',
-  },
-  {
-    from: '/data-tables/permalink/5ab5dbf2-393b-4a43-b7a1-',
-    to: '/data-tables',
-  },
-  {
-    from: '/data-tables/permalink/67961e79-5204-410e-b521-',
-    to: '/data-tables',
-  },
-  {
-    from: '/data-tables/permalink/85ba124e-1489-4648-bfde-',
-    to: '/data-tables',
-  },
-  {
-    from: '/data-tables/permalink/85ba124e-1489-4648-bfde-3eff6fdf76a2;',
-    to: '/data-tables',
-  },
-  { from: '/data-tables/permalink/8f50fce8-', to: '/data-tables' },
-  { from: '/data-tables/permalink/970e9bb8-d185-', to: '/data-tables' },
-  {
-    from: '/data-tables/permalink/9795440a-015e-47eb-86e2-',
-    to: '/data-tables',
-  },
-  { from: '/data-tables/permalink/9e420c30-', to: '/data-tables' },
-  {
-    from: '/data-tables/permalink/c0319f82-e1e3-4adf-9db1-',
-    to: '/data-tables',
-  },
-  { from: '/data-tables/permalink/c4cb6884-', to: '/data-tables' },
-  { from: '/data-tables/permalink/e0980465-', to: '/data-tables' },
-  { from: '/data-tables/permalink/e8942369-b2a3-', to: '/data-tables' },
-  { from: '/datatables/apprenticeships-and-traineeships', to: '/data-tables' },
-  { from: '/datatables/permalink/48f9a035-9123-477e-', to: '/data-tables' },
-  { from: '/datatables/permalink/b169759c-', to: '/data-tables' },
-  { from: '/find-st%3C/body%3E%3C/html%3E', to: '/find-statistics' },
-  { from: '/find-sta', to: '/find-statistics' },
-  { from: '/find-stati', to: '/find-statistics' },
-  { from: '/find-statis-', to: '/find-statistics' },
-  { from: '/find-statistic', to: '/find-statistics' },
-  { from: '/find-statistics/[publication]', to: '/find-statistics' },
-  { from: '/find-statistics/[publication]/[release]', to: '/find-statistics' },
-  { from: '/find-statistics/%3ca%20href=', to: '/find-statistics' },
-  { from: '/find-statistics/16-18-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/16-18-destination-measure',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/a-', to: '/find-statistics' },
-  { from: '/find-statistics/a-level', to: '/find-statistics' },
-  { from: '/find-statistics/a-level-and-other-16-to-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/a-level-and-other-16-to-18-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/a-level-and-other-16-to-18-results/2019-20&nbsp%e2%80%93',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/a-level-and-other-level-3-results-in-england-academic-year-2019-to-2020',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/admission-', to: '/find-statistics' },
-  { from: '/find-statistics/apprenticeships-', to: '/find-statistics' },
-  { from: '/find-statistics/apprenticeships-and', to: '/find-statistics' },
-  {
-    from: '/find-statistics/apprenticeships-and-traineeships/2020-21&nbsp;-&nbsp;apprenticeship&nbsp;starts&nbsp;down&nbsp;0.3%&nbsp;in&nbsp;21-22&nbsp;vs&nbsp;19-20',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/apprenticeships-and-traineeshipsThe',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/at-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/attainment-8-score-averages-by-previous-attainment/2019-to-2020-revised',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/attendance-', to: '/find-statistics' },
-  { from: '/find-statistics/attendance-in-', to: '/find-statistics' },
-  { from: '/find-statistics/attendance-in-edu', to: '/find-statistics' },
-  { from: '/find-statistics/attendance-in-educa-', to: '/find-statistics' },
-  { from: '/find-statistics/attendance-in-education', to: '/find-statistics' },
-  { from: '/find-statistics/attendance-in-education-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/attendance-in-education-and-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/attendance-in-education-and-earl',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/attendance-in-education-and-early-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/attendance-in-education-and-early-years',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/attendance-in-education-and-early-years-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/attendance-in-education-and-early-years-settings-during-the-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-covid-19-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-covid-19-outbreak&nbsp;2',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-covid-19-outbreak/2020-week-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-covid-19-outbreak/2021-week-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-covid-19-outbreak/2022-week-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/attendance-in-education-andearly-years-settings-during-the-coronavirus-covid-19-outbreak',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/attendance-ineducation-', to: '/find-statistics' },
-  { from: '/find-statistics/characteristics-of-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/characteristics-of-children-in-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/characteristics-of-children-in-n',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/characteristics-of-children-in-need/2022&nbsp',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/characteristics-of-children-in-need&nbsp',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/characteristics-of-children-inneed/2020',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/childcare', to: '/find-statistics' },
-  { from: '/find-statistics/childcare-and-', to: '/find-statistics' },
-  { from: '/find-statistics/childcare-and-early-', to: '/find-statistics' },
-
-  { from: '/find-statistics/children', to: '/find-statistics' },
-  { from: '/find-statistics/children-', to: '/find-statistics' },
-
-  { from: '/find-statistics/children-loo', to: '/find-statistics' },
-  { from: '/find-statistics/children-looked', to: '/find-statistics' },
-  { from: '/find-statistics/children-looked-after-in', to: '/find-statistics' },
-  {
-    from: '/find-statistics/children-looked-after-in-england',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/children-looked-after-in-england-includ',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/children-looked-after-in-england-including',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/children-looked-after-in-england-including-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/children-looked-after-in-england-including-adopti',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/children-looked-after-in-england-including-adoptions/2020&nbsp;-&nbsp;dataDownloads-1',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/children-looked-after-in-england-including-adoptions/2020developmentofattachmentsbetweenolder',
-    to: '/find-statistics',
-  },
-  {
-    from: '/Find-Statistics/Children-Looked-after-in-England-Including-Adoptions/2021',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/children-looked-after-in-england-including-adoptions/2021&nbsp;/l&nbsp;dataDownloads-1',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/children-looked-after-in-england-including-adoptions/2022.',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/children-s-social-work', to: '/find-statistics' },
-  {
-    from: '/find-statistics/children-s-social-work-workforce-attrition-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/children-s-social-work-workforce/2022&nbsp',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/delivery-of-air-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/early-years-foundation-stage-',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/education-', to: '/find-statistics' },
-  { from: '/find-statistics/education-and-training-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/education-and-training-statistics-for-the-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/education-and-training-statistics-for-the-uk/2022;',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/education-health-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/education-health-and-care',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/education-health-and-care-plan',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/education-health-and-care-plans&nbsp;(opens&nbsp;in&nbsp;external&nbsp;window)',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/education-health-and-care-plans/www.gov.uk/courts-tribunals/first-tier-tribunal-specialeducational-needs-and-disability',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/education-provision-children-under-5/2020&nbsp;(universal&nbsp;three&nbsp;and&nbsp;four-year&nbsp;old&nbsp;offer&nbsp;and&nbsp;disadvantaged&nbsp;two&nbsp;year&nbsp;old&nbsp;offer)&nbsp;and&nbsp;https://www.gov.uk/government/statistics/childcare-and-early-years-survey-of-parents-2019',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/elective-home-education/2022-',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/free-school-meals-', to: '/find-statistics' },
-  { from: '/find-statistics/further-', to: '/find-statistics' },
-  { from: '/find-statistics/further-education-and-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/further-education-outcome-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/further-education-outcome-based-success-mesures',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/graduate-', to: '/find-statistics' },
-  { from: '/find-statistics/graduate-labour-', to: '/find-statistics' },
-  { from: '/find-statistics/graduate-outcomes-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/he.modelling@education.gov.uk',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/higher-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/higher-level-learners-in-england/2018-19.',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/initial-', to: '/find-statistics' },
-  { from: '/find-statistics/initial-teacher-train-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/initial-teacher-training-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/initial-teacher-training-census/2022-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/initial-teacher-training-performance-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/initial-teacher-training-performance-profiles/2019-20.',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/initial-teacher-trainingcensus/2020-21',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/key-stage-', to: '/find-statistics' },
-  { from: '/find-statistics/key-stage-1-and-phonics-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/key-stage-1-and-phonics-screening-check-',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/key-stage-2-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/key-stage-2-attainment-national-headlines/2021',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/key-stage-2-attainment-national-headlines/2021-22&nbspAccessed&nbsp31st&nbspJuly&nbsp2022',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/key-stage-2-attainment/2021-',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/key-stage-4', to: '/find-statistics' },
-  { from: '/find-statistics/key-stage-4-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/key-stage-4-destination-measures/2018-',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/key-stage-4-performance-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/key-stage-4-performance-revised/2020-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/key-stage-4-performance-revised/2021%e2%80%9322',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/la-and-school-expenditure/2019-2',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/la-and-school-expenditure/2020-21;',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/laptops-and-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/level-2-and-3-attainment-by-youn',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/level-2-and-3-attainment-by-young-people-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/level-2-and-3-attainment-by-young-people-aged-19/2020-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/looked-after-children-aged-16-to-17-in-independent-or-semi-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/multiplication-tables-check-',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/national-tutoring-', to: '/find-statistics' },
-  { from: '/find-statistics/neet-statistics-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/outcomes-for-children-in-need-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/outcomes-for-children-in-need-including-c',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/outcomes-for-children-in-needincluding-children-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/outcomes-for-children-in-needincluding-children-looked-after-by-local-authorities-in-england',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/parental', to: '/find-statistics' },
-  { from: '/find-statistics/participation', to: '/find-statistics' },
-  {
-    from: '/find-statistics/participation-in-education-and-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/participation-in-education-training-and-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/participation-measures-in-higher-',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/permanent-', to: '/find-statistics' },
-  { from: '/find-statistics/permanent-and', to: '/find-statistics' },
-  { from: '/find-statistics/permanent-and-fixed', to: '/find-statistics' },
-  { from: '/find-statistics/permanent-and-fixed-', to: '/find-statistics' },
-  { from: '/find-statistics/permanent-and-fixed-p', to: '/find-statistics' },
-  {
-    from: '/find-statistics/permanent-and-fixed-period-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/permanent-and-fixed-period-exclu',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/permanent-and-fixed-period-exclusions-in-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/permanent-and-fixed-period-exclusions-in-eng',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/permanent-and-fixed-period-exclusions-in-eng-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/permanent-and-fixed-period-exclusions-in-england/2018-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/permanent-and-fixed-period-exclusions-in-england/2018-19yougov.uk',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/permanent-and-fixed-period-exclusions-in-englandFigures',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/permanent-and-fixed-period-exclusions-inengland/2018-19',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/permanent-and-fixed-periodexclusions-in-england',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/permanent-and-fixed-term-exclusions-in-england',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/permanentand-fixed-period-exclusions-in-england',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/postgraduate-initial-teacher-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/progression-to-%3ca&nbsphref==',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/progression-to-higher-ed', to: '/find-statistics' },
-  { from: '/find-statistics/pupil', to: '/find-statistics' },
-  { from: '/find-statistics/pupil-absence-', to: '/find-statistics' },
-  { from: '/find-statistics/pupil-absence-in-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/pupil-absence-in-schools-in-engl',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/pupil-absence-in-schools-in-england-autumn-and-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/pupil-absence-in-schools-in-england-autumn-term/data',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/pupil-absence-in-schools-in-england)',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/pupil-absence-inschools-in-england-',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/pupil-attendance', to: '/find-statistics' },
-  { from: '/find-statistics/pupil-attendance-in-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/pupil-attendance-in-schools/2023-7week-29',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/school-funding-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/school-funding-statistics/2021-',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/school-placements-', to: '/find-statistics' },
-  { from: '/find-statistics/school-pup', to: '/find-statistics' },
-  { from: '/find-statistics/school-pupils-', to: '/find-statistics' },
-  { from: '/find-statistics/school-pupils-and-', to: '/find-statistics' },
-  { from: '/find-statistics/school-pupils-and-thei', to: '/find-statistics' },
-  { from: '/find-statistics/school-pupils-and-their-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/school-pupils-and-their-ch',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-pupils-and-their-cha',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-pupils-and-their-characteristics;',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-pupils-and-their-characteristics/2019-20.',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-pupils-and-their-characteristicsa',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-pupils-and-their-characteristicshttps:/explore-education-statistics.service.gov.uk/find-statistics/school-pupils-and-their-characteristics',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-pupils-and-their-characteristicsm',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-pupils-and-theircharacteristics',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-pupils-andtheir-characteristics',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-pupilsand-their-characteristics',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-workforce-in-englan%3c/p%3e&nbsp;%3cp%3e&nbsp;for&nbsp;more&nbsp;detailed&nbsp;information&nbsp;about&nbsp;the&nbsp;cookies&nbsp;we&nbsp;use,&nbsp;please&nbsp;see&nbsp;our&nbsp;%3ca&nbsp;href=',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-workforce-in-england,',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-workforce-in-englandhttps:/explore-education-statistics.service.gov.uk/find-statistics/school-workforce-in-england',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/school-workforce-inengland',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/schoolworkforce-in-england',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/serious-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/serious-incident-notifications&nbsp',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/skills-bootcamps-', to: '/find-statistics' },
-  { from: '/find-statistics/special-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/special-educational-needs-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/special-educational-needs-in-england/2021-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/special-educational-needs-in-england/2021-2',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/special-educational-needs-in-england/221-22',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/special-educationalneeds-in-england',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/student-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/student-loan-forecasts-for',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/student-loan-forecasts-for-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/the-link-between-absence-and-attainment-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/the-link-between-absence-and-attainment-at-ks2-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/uk-revenue-from-education-related-exports-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/uk-revenue-from-education-related-exports-and-',
-    to: '/find-statistics',
-  },
-  { from: '/find-statistics/widen-', to: '/find-statistics' },
-  { from: '/find-statistics/widening', to: '/find-statistics' },
-  { from: '/find-statistics/widening-', to: '/find-statistics' },
-  {
-    from: '/find-statistics/widening-participation-in-higher-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/find-statistics/www.gov.uk/courts-tribunals/first-tier-tribunal-specialeducational-needs-and-disability',
-    to: '/find-statistics',
-  },
-  {
-    from: '/findstatistics/apprenticeships-and-traineeships/2021-22',
-    to: '/find-statistics',
-  },
-  {
-    from: '/findstatistics/apprenticeships-in-england-by-industry-characteristics',
-    to: '/find-statistics',
-  },
-  { from: '/findstatistics/attendance-in-', to: '/find-statistics' },
-  {
-    from: '/findstatistics/attendance-in-education-and-early-years-',
-    to: '/find-statistics',
-  },
-  {
-    from: '/findstatistics/children-s-social-work-workforce',
-    to: '/find-statistics',
-  },
-  {
-    from: '/findstatistics/education-and-training-statistics-for-the-uk/2020',
-    to: '/find-statistics',
-  },
-  { from: '/findstatistics/leo-graduate-and', to: '/find-statistics' },
-  {
-    from: '/findstatistics/special-educational-needs-in-england',
-    to: '/find-statistics',
-  },
-  { from: '/methodol', to: '/methodology' },
-  { from: '/methodology/16-18-destination-', to: '/methodology' },
-  { from: '/methodology/attendance-in-', to: '/methodology' },
-  {
-    from: '/methodology/attendance-ineducation-and-early-years-settings-during-the-coronavirus-covid-19-outbreakmethodology',
-    to: '/methodology',
-  },
-  { from: '/methodology/children-looked-after-', to: '/methodology' },
-  {
-    from: '/methodology/permanent-and-fixed-period-exclusions-in-england',
-    to: '/methodology',
-  },
-  { from: '/methodology/secondary-and-primary-school-', to: '/methodology' },
-  {
-    from: '/methodology/student-loan-forecasts-for-england-',
-    to: '/methodology',
-  },
-  { from: '/methodology/widening-', to: '/methodology' },
-  {
-    from: '/methodology/widening-participation-in-higher-',
-    to: '/methodology',
-  },
-  { from: '/service', to: '/' },
-  {
-    from: '/statistics/pupil-absence-in-schools-in-england',
-    to: '/find-statistics',
-  },
-];
+const seoRedirects = {
+  '/%20and%20%0ahttps%3a/www.gov.uk/government/collections/abortion-statistics-for-england-and-wales':
+    '/',
+  '/%21nd-statistics/permanent-and-': '/',
+  '/api/methodologies/%7bmethodologyid%7d/images/7763f949-eff9-4571-93b4-08db2bd4eec9':
+    '/',
+  '/api/methodologies/%7bmethodologyid%7d/images/9348e5bc-c09d-43b4-de90-08d90ae3d820':
+    '/',
+  '/api/methodologies/%7bmethodologyid%7d/images/a095bcaa-7c7c-4a99-de75-08d90ae3d820':
+    '/',
+  '/api/methodologies/%7bmethodologyid%7d/images/cd50d521-0d75-498e-143b-08dac7b96540':
+    '/',
+  '/api/methodologies/%7bmethodologyid%7d/images/d8ecf739-f299-413f-126f-08dacbba9031':
+    '/',
+  '/api/methodologies/%7bmethodologyid%7d/images/ef57d23a-f281-4b6b-a55e-08da6007d7ab':
+    '/',
+  '/api/methodologies/%7bmethodologyid%7d/images/fcfa509c-8572-4b61-ca3a-08dbcefb484c':
+    '/',
+  '/api/methodologies/%7bmethodologyid%7d/images/feeffb4e-f022-469a-6e23-08dacc6823fb':
+    '/',
+  '/api/releases/%7breleaseid%7d/images/0eb3fc80-77ad-4d66-8090-a6c2509d50c5':
+    '/',
+  '/api/releases/%7breleaseid%7d/images/26f6ac12-25d0-4831-5293-08db35b5456a':
+    '/',
+  '/api/releases/%7breleaseid%7d/images/fdb52a67-704d-44f3-9721-752000ff9ab9':
+    '/',
+  '/data': '/',
+  '/data-': '/',
+  '/data-table': '/',
+  '/data-tables%20-%20spring%20%0a2022': '/',
+  '/data-tables/fast-track/%5bdatablockid%5d': '/',
+  '/data-tables/fast-track/%5bdatablockparentid%5d': '/',
+  '/data-tables/fast-track/0164bb4a-6777-4d8f-a1a0-34ce69f75153':
+    '/data-tables',
+  '/data-tables/fast-track/02b8c449-017b-4cd3-8db9-f96fba507c1c':
+    '/data-tables',
+  '/data-tables/fast-track/02f116d1-72e5-4024-be0c-f3920918c7c0':
+    '/data-tables',
+  '/data-tables/fast-track/03f531e7-d182-416a-9ceb-dce13c9896f4':
+    '/data-tables',
+  '/data-tables/fast-track/043db729-7788-4155-a191-ac44aafbd810':
+    '/data-tables',
+  '/data-tables/fast-track/04a0798b-a8a1-411e-819f-329a056b1693':
+    '/data-tables',
+  '/data-tables/fast-track/04e92348-e4ae-4b3b-8e41-77c80b3ce875':
+    '/data-tables',
+  '/data-tables/fast-track/05d00ec0-c666-4615-a41f-a0526c474af3':
+    '/data-tables',
+  '/data-tables/fast-track/064c8fdc-f45f-4cad-c109-08daa787e284':
+    '/data-tables',
+  '/data-tables/fast-track/089eb3b5-d646-473e-bfd7-4d14a681b491':
+    '/data-tables',
+  '/data-tables/fast-track/0ae5c9ca-2068-44a1-b271-dbb9a7cff76e':
+    '/data-tables',
+  '/data-tables/fast-track/0bb752c7-678f-4c1a-968b-9df1dc40310a':
+    '/data-tables',
+  '/data-tables/fast-track/0f6dcc5d-eaa1-4815-c0b4-08daa787e284':
+    '/data-tables',
+  '/data-tables/fast-track/0fb43712-f795-4141-359e-08daa20fa891':
+    '/data-tables',
+  '/data-tables/fast-track/1031cbca-36e4-4773-e008-08dbe03b87c8/data-tables/fast-track/1031cbca-36e4-4773-e008-08dbe03b87c8':
+    '/data-tables',
+  '/data-tables/fast-track/10afd5a5-6fb8-4823-a373-cb4f6f566df4':
+    '/data-tables',
+  '/data-tables/fast-track/121310d5-6398-4b9f-7758-08dab100bfc2':
+    '/data-tables',
+  '/data-tables/fast-track/1237e676-3142-41bf-35a8-08daa20fa891':
+    '/data-tables',
+  '/data-tables/fast-track/12e52f19-45bf-41e3-d76f-08db513a05d2':
+    '/data-tables',
+  '/data-tables/fast-track/12f1cb60-31bd-4cb0-f7f1-08da8c214b78':
+    '/data-tables',
+  '/data-tables/fast-track/13217d2f-c1e9-4743-42d2-08da3eebca15':
+    '/data-tables',
+  '/data-tables/fast-track/13bd481b-e92b-428b-8969-f6aedced3ce3':
+    '/data-tables',
+  '/data-tables/fast-track/142bc228-0ca7-47c5-358d-08daa20fa891':
+    '/data-tables',
+  '/data-tables/fast-track/14a38393-361d-445c-80d9-7222fab822cf':
+    '/data-tables',
+  '/data-tables/fast-track/14ca58d9-6747-405c-5f81-08db3a70d65c':
+    '/data-tables',
+  '/data-tables/fast-track/15192eda-4efb-47a0-ac7d-765029c1989a':
+    '/data-tables',
+  '/data-tables/fast-track/1624d963-b636-4952-8264-6595225a344a':
+    '/data-tables',
+  '/data-tables/fast-track/165dedb9-d2e4-4377-957b-db92a041a6f5':
+    '/data-tables',
+  '/data-tables/fast-track/1773b6af-9d37-4274-a26b-27b30a88a098':
+    '/data-tables',
+  '/data-tables/fast-track/18ad21e0-efd6-480b-8d72-cbd55ec57811':
+    '/data-tables',
+  '/data-tables/fast-track/19abadb2-8a3f-4394-b017-25fc34686ddc':
+    '/data-tables',
+  '/data-tables/fast-track/1a9aa06b-02ae-4791-8c59-08d884b70554':
+    '/data-tables',
+  '/data-tables/fast-track/1baac6fd-656d-49b1-9b06-2f6b1c7f235d':
+    '/data-tables',
+  '/data-tables/fast-track/1c15f472-6e49-42e4-9b1d-6812050d6e8b':
+    '/data-tables',
+  '/data-tables/fast-track/1c334d03-b7b5-4413-b7a8-c51d123ff3c3':
+    '/data-tables',
+  '/data-tables/fast-track/1c4f7d08-7455-4236-776e-08dab100bfc2':
+    '/data-tables',
+  '/data-tables/fast-track/1c50c543-e9cf-49cd-965e-a55fd8bb6e5b':
+    '/data-tables',
+  '/data-tables/fast-track/1cf335a1-1591-4941-a5e5-b7d78cf694d5':
+    '/data-tables',
+  '/data-tables/fast-track/1d5beeb2-9ef9-4262-b70d-6ef635c04ee8':
+    '/data-tables',
+  '/data-tables/fast-track/1e235c86-4dcd-4777-9afa-ba5f0cfb3b17':
+    '/data-tables',
+  '/data-tables/fast-track/1e7c1415-2200-421e-ad74-67510e97096d':
+    '/data-tables',
+  '/data-tables/fast-track/1ecc6995-3bd1-437e-88dd-08f3824c114f':
+    '/data-tables',
+  '/data-tables/fast-track/1ef9174c-bbfd-4f1b-b0c4-1266a089863b':
+    '/data-tables',
+  '/data-tables/fast-track/2111b824-eb8c-4a5b-8479-e8e26f5ec987':
+    '/data-tables',
+  '/data-tables/fast-track/217b0881-4784-4a0f-b55d-f0ba95d1bc06':
+    '/data-tables',
+  '/data-tables/fast-track/228441a3-c132-47f2-8002-921db4696bfc':
+    '/data-tables',
+  '/data-tables/fast-track/22922154-4afb-48fe-835e-71ceac3bab3b':
+    '/data-tables',
+  '/data-tables/fast-track/22f54370-e54d-4dbd-a932-c9f16fb63e54':
+    '/data-tables',
+  '/data-tables/fast-track/22f9e886-6e9b-43ec-86bc-08da7eccd8d3':
+    '/data-tables',
+  '/data-tables/fast-track/2300c602-baef-48de-a1aa-97025213bf54':
+    '/data-tables',
+  '/data-tables/fast-track/234cab35-71ee-4acb-a88d-db86f20868e4':
+    '/data-tables',
+  '/data-tables/fast-track/25336f4d-a1a2-4f13-89b7-3388efc9d6a8':
+    '/data-tables',
+  '/data-tables/fast-track/258cee77-825e-432f-af12-246e30dcd8cf':
+    '/data-tables',
+  '/data-tables/fast-track/26ec1527-61b9-4d39-def5-08dacc6b24db':
+    '/data-tables',
+  '/data-tables/fast-track/27ef17ce-5f53-48dc-a769-efbe2eb0f5db':
+    '/data-tables',
+  '/data-tables/fast-track/284556f5-36e6-4ce0-8562-9acc7c3137e3':
+    '/data-tables',
+  '/data-tables/fast-track/28f77e89-3c0c-46bb-8288-ed7ec1a490a5':
+    '/data-tables',
+  '/data-tables/fast-track/2a395d39-8f77-46ae-aed3-d2c694c84381':
+    '/data-tables',
+  '/data-tables/fast-track/2c16da26-d63d-4d9e-8add-409ac19317a8':
+    '/data-tables',
+  '/data-tables/fast-track/2c4ad26b-fd81-4580-bc4e-27ba6ca6ef6a':
+    '/data-tables',
+  '/data-tables/fast-track/2cdefe2c-6027-4f58-9a39-9eba029fc168':
+    '/data-tables',
+  '/data-tables/fast-track/2d2e4f14-a48a-4859-bef1-ac45b9a1b83e':
+    '/data-tables',
+  '/data-tables/fast-track/2ed7b34f-8ad6-4516-31fc-08d90ed7dffe':
+    '/data-tables',
+  '/data-tables/fast-track/32d01225-09b9-4629-bc4a-a90fd62c3e20':
+    '/data-tables',
+  '/data-tables/fast-track/32f9af5e-1cae-4a40-b384-08da9bbbb7c1':
+    '/data-tables',
+  '/data-tables/fast-track/3303ab40-23f1-4089-9f19-b6a19f399197':
+    '/data-tables',
+  '/data-tables/fast-track/336e9909-3c43-4413-b06a-1642c7968ae3':
+    '/data-tables',
+  '/data-tables/fast-track/34401325-bf6a-48c1-ac5e-73963b3466b1':
+    '/data-tables',
+  '/data-tables/fast-track/34494aa3-e6c1-48a1-acdb-82d5da0021d7':
+    '/data-tables',
+  '/data-tables/fast-track/35a09351-7129-43b9-8fb0-83a052453471':
+    '/data-tables',
+  '/data-tables/fast-track/35cfe914-9590-40cb-c105-08daa787e284':
+    '/data-tables',
+  '/data-tables/fast-track/361ea940-2a1b-42c9-a87f-01f85cfcdc19':
+    '/data-tables',
+  '/data-tables/fast-track/3683eb72-2ec5-403b-878f-0c9814265fd3':
+    '/data-tables',
+  '/data-tables/fast-track/37176a2a-e4d6-436b-a0c1-5': '/data-tables',
+  '/data-tables/fast-track/386dc2c6-d953-473a-8947-1f081c3094b6':
+    '/data-tables',
+  '/data-tables/fast-track/389db54b-ab55-4f38-8345-f3967fc0d131':
+    '/data-tables',
+  '/data-tables/fast-track/38f63f82-e005-48ec-bf9a-97b03f57a48c':
+    '/data-tables',
+  '/data-tables/fast-track/3aa9d070-0c6a-4b38-a749-f758bbe74b9e':
+    '/data-tables',
+  '/data-tables/fast-track/3c928d23-70c0-4203-a1ad-9f4c8d185d2f':
+    '/data-tables',
+  '/data-tables/fast-track/3e0a5bf2-b2a3-4c18-88c9-6d8039b3007e':
+    '/data-tables',
+  '/data-tables/fast-track/3e94ab36-bceb-4a5f-9c6d-64a6f714dcf0':
+    '/data-tables',
+  '/data-tables/fast-track/3f7f9488-e896-4622-9472-4b01fefba33a':
+    '/data-tables',
+  '/data-tables/fast-track/3f8f4e21-c0f2-4378-b3c3-114cf81465cd':
+    '/data-tables',
+  '/data-tables/fast-track/3f93fe61-36f5-4844-ba9e-6aad692d91dd':
+    '/data-tables',
+  '/data-tables/fast-track/403a75f6-222f-435a-8947-f12d37b77ee5':
+    '/data-tables',
+  '/data-tables/fast-track/40aea90b-3d2c-420c-a013-5d02393dd102':
+    '/data-tables',
+  '/data-tables/fast-track/423c4ef5-c2ec-4f07-8e75-0a81630d3757':
+    '/data-tables',
+  '/data-tables/fast-track/42f62bef-bfe3-4a1e-a27b-3ac8e2928b45':
+    '/data-tables',
+  '/data-tables/fast-track/43401fa9-3cee-4ebe-b7de-34ad4eb525eb':
+    '/data-tables',
+  '/data-tables/fast-track/44433f05-d1e1-4ced-86be-08da7eccd8d3':
+    '/data-tables',
+  '/data-tables/fast-track/45a93b5d-861d-4cf1-b2cb-e2c738a8c99f':
+    '/data-tables',
+  '/data-tables/fast-track/46a36a97-a5e0-4324-a575-31d229942124':
+    '/data-tables',
+  '/data-tables/fast-track/46bfea21-74cb-473b-961a-1480bda0e904':
+    '/data-tables',
+  '/data-tables/fast-track/4760154a-9a9c-439a-d44f-08dabceba8ca':
+    '/data-tables',
+  '/data-tables/fast-track/4891da30-91d7-44b5-75ef-08db786e904b':
+    '/data-tables',
+  '/data-tables/fast-track/48a27133-7247-4b7d-5f7c-08db3a70d65c':
+    '/data-tables',
+  '/data-tables/fast-track/490b6032-3d52-4be7-9223-04da13b956dd':
+    '/data-tables',
+  '/data-tables/fast-track/4a716316-3b92-4c19-3593-08daa20fa891':
+    '/data-tables',
+  '/data-tables/fast-track/4b48701a-9025-475a-c0c5-08daa787e284':
+    '/data-tables',
+  '/data-tables/fast-track/4c98c839-dc1e-4421-b2ea-25e7f4208af8':
+    '/data-tables',
+  '/data-tables/fast-track/4ccb033a-d706-4eac-bee3-9695e512d76e':
+    '/data-tables',
+  '/data-tables/fast-track/4ea0eaa3-36ca-43d2-42e4-08da3eebca15':
+    '/data-tables',
+  '/data-tables/fast-track/4ef5a904-ecd6-4da1-820e-ff218f0ef17c':
+    '/data-tables',
+  '/data-tables/fast-track/4f0fb5cb-b591-45fb-3552-08daa20fa891':
+    '/data-tables',
+  '/data-tables/fast-track/4f4da0c4-6b09-48a8-a731-126d3de01e20':
+    '/data-tables',
+  '/data-tables/fast-track/4fa4f6f7-57fb-4220-b0b4-32008be6c43b':
+    '/data-tables',
+  '/data-tables/fast-track/4fede41b-deb6-4781-b018-e799723ff1a4':
+    '/data-tables',
+  '/data-tables/fast-track/50208d7d-3c3c-4609-b98d-67435406676b':
+    '/data-tables',
+  '/data-tables/fast-track/50747948-ee8c-495c-8d54-6318c1d37d27':
+    '/data-tables',
+  '/data-tables/fast-track/508bfccc-4a82-4fdf-a3c9-79dd3086c658':
+    '/data-tables',
+  '/data-tables/fast-track/51051d54-1b04-4797-8d92-c71893dab2aa':
+    '/data-tables',
+  '/data-tables/fast-track/52da011b-c5a0-483b-89f4-000b6bd38ea7':
+    '/data-tables',
+  '/data-tables/fast-track/5384d9eb-749b-4457-92d4-063699f79f69':
+    '/data-tables',
+  '/data-tables/fast-track/53c9de7d-536f-45c8-8e31-1fcd7f1bb9f2':
+    '/data-tables',
+  '/data-tables/fast-track/54d83471-6d8c-4c83-adee-08d8fff8a85b':
+    '/data-tables',
+  '/data-tables/fast-track/5593f530-5816-4342-bdea-80c738d583b1':
+    '/data-tables',
+  '/data-tables/fast-track/569c3a6b-8328-4e96-8865-00fd965687b1':
+    '/data-tables',
+  '/data-tables/fast-track/5832704e-405b-41d3-8697-08da7eccd8d3':
+    '/data-tables',
+  '/data-tables/fast-track/583c1413-605d-488a-9870-42df33a5f83a':
+    '/data-tables',
+  '/data-tables/fast-track/5942c462-dd79-4cca-a038-be465e8d535e':
+    '/data-tables',
+  '/data-tables/fast-track/5bf308dd-22b5-4ae2-89a4-000c6073b24b':
+    '/data-tables',
+  '/data-tables/fast-track/5c994200-1736-42ed-acc6-12dbcf89466d':
+    '/data-tables',
+  '/data-tables/fast-track/5cb00347-4735-45fd-b23b-451942c1278c':
+    '/data-tables',
+  '/data-tables/fast-track/5f78743f-cdf3-4725-abad-ff4ed7a3a552':
+    '/data-tables',
+  '/data-tables/fast-track/5f9b466e-8dec-4f68-c15e-08daa787e284':
+    '/data-tables',
+  '/data-tables/fast-track/6012c61b-e007-4c35-8959-78eda64429ad':
+    '/data-tables',
+  '/data-tables/fast-track/61424f5b-e434-47bd-8401-33cbd44f3bba':
+    '/data-tables',
+  '/data-tables/fast-track/62452bd5-31df-': '/data-tables',
+  '/data-tables/fast-track/62452bd5-31df-449a-931e-516e8fe7705b':
+    '/data-tables',
+  '/data-tables/fast-track/6356f6c1-2cb9-4ffb-a8aa-08da8f1f9388':
+    '/data-tables',
+  '/data-tables/fast-track/63fdd805-85d9-422b-a54c-c94591b17319':
+    '/data-tables',
+  '/data-tables/fast-track/646bd6fb-7f44-4224-ba29-2f49b076be80':
+    '/data-tables',
+  '/data-tables/fast-track/6657ce22-abac-4508-5b6a-08d98e357d76':
+    '/data-tables',
+  '/data-tables/fast-track/66b09df2-dfcd-4055-849d-9e68a37cfd21':
+    '/data-tables',
+  '/data-tables/fast-track/6858cd82-d149-49bd-bf41-27d659d5c428':
+    '/data-tables',
+  '/data-tables/fast-track/6989b06f-c55d-40a4-8ea6-4eb90b8e5eaf':
+    '/data-tables',
+  '/data-tables/fast-track/69e72292-508e-4558-a15d-fd5bf85af7b4':
+    '/data-tables',
+  '/data-tables/fast-track/6a846ce2-0f94-47d1-a9c3-6d11ffecd170':
+    '/data-tables',
+  '/data-tables/fast-track/6b4bc912-b742-4109-a78b-6093cba746e8':
+    '/data-tables',
+  '/data-tables/fast-track/6be2d494-6a00-48db-defa-08dacc6b24db':
+    '/data-tables',
+  '/data-tables/fast-track/717daf19-e125-413f-bba3-482dc9fab22b':
+    '/data-tables',
+  '/data-tables/fast-track/719569fe-cb80-43f3-8bf7-eb23345d0f49':
+    '/data-tables',
+  '/data-tables/fast-track/71c6ed96-25d2-4985-f248-08db998c77c8':
+    '/data-tables',
+  '/data-tables/fast-track/7427255d-9f04-4869-afba-dc8c57ef6c51':
+    '/data-tables',
+  '/data-tables/fast-track/74fca436-5e3b-4d7e-8ccc-83a78086caee':
+    '/data-tables',
+  '/data-tables/fast-track/7578e83c-3a69-4bac-928a-74194081aed9':
+    '/data-tables',
+  '/data-tables/fast-track/764a0fa2-5722-4a3d-b006-e5b044cc520a':
+    '/data-tables',
+  '/data-tables/fast-track/775cc77f-420e-4ecc-8304-8dc472a57c78':
+    '/data-tables',
+  '/data-tables/fast-track/776af074-bc69-4482-b84f-a12ea30f1c2c':
+    '/data-tables',
+  '/data-tables/fast-track/77bf7a68-beff-4a39-ab32-16376aedf127':
+    '/data-tables',
+  '/data-tables/fast-track/7b87da46-9624-4edf-96e4-3b8a322f5598':
+    '/data-tables',
+  '/data-tables/fast-track/7ce027d2-7cbb-46da-': '/data-tables',
+  '/data-tables/fast-track/7e7a2ca3-309b-44f1-b4ea-55f39e3bb239':
+    '/data-tables',
+  '/data-tables/fast-track/7eea0c3c-b1f7-4703-35bd-08daa20fa891':
+    '/data-tables',
+  '/data-tables/fast-track/7f0de236-f5a1-433d-ad3b-1a75cd7e09cb':
+    '/data-tables',
+  '/data-tables/fast-track/809209ed-4edf-4c2e-7761-08dab100bfc2':
+    '/data-tables',
+  '/data-tables/fast-track/80c23194-68b9-4c2e-b7bd-a164f6163c06':
+    '/data-tables',
+  '/data-tables/fast-track/814bd896-1d3b-475e-b21d-d0c5faf6ee8f':
+    '/data-tables',
+  '/data-tables/fast-track/81ab3729-6cfb-4738-a502-10d2859604b2':
+    '/data-tables',
+  '/data-tables/fast-track/81d1c4f7-e9da-48d9-9729-6a9e34f9f578':
+    '/data-tables',
+  '/data-tables/fast-track/8288f4d3-2e4e-4135-a74f-638a1d849714':
+    '/data-tables',
+  '/data-tables/fast-track/8321bebd-a884-42e0-86d4-408e82ed5f48':
+    '/data-tables',
+  '/data-tables/fast-track/83c1c8fd-ce0c-42a0-c46a-08d9bbe39aeb':
+    '/data-tables',
+  '/data-tables/fast-track/8413bd02-26f0-': '/data-tables',
+  '/data-tables/fast-track/84a9b3f5-ca6f-446b-bcf9-f208b79b6a0e':
+    '/data-tables',
+  '/data-tables/fast-track/84b992d0-9abf-427c-a3b2-393a673795be':
+    '/data-tables',
+  '/data-tables/fast-track/84e08b66-a434-4a3c-903d-83537af066cb':
+    '/data-tables',
+  '/data-tables/fast-track/8560a280-ceb8-40e9-8c24-a760035a008e':
+    '/data-tables',
+  '/data-tables/fast-track/85b4b7ac-f715-4eab-acb8-c872c8ae5281':
+    '/data-tables',
+  '/data-tables/fast-track/8706180c-2bdb-481e-20da-': '/data-tables',
+  '/data-tables/fast-track/8706180c-2bdb-481e-20da-08d99c9bf8eb':
+    '/data-tables',
+  '/data-tables/fast-track/8836e106-600d-4126-b324-c07a9ea970ce':
+    '/data-tables',
+  '/data-tables/fast-track/896ddead-213c-43aa-a080-aaa185af2cd9':
+    '/data-tables',
+  '/data-tables/fast-track/89e05fef-0b22-4d68-9260-9e23039e0dc7':
+    '/data-tables',
+  '/data-tables/fast-track/89f774e6-088e-4345-b3ce-3a62b4e7e32b':
+    '/data-tables',
+  '/data-tables/fast-track/8a41e161-2b53-44a7-a9c6-08da8befc70c':
+    '/data-tables',
+  '/data-tables/fast-track/8a804f47-9581-40cf-8f18-0479b35f2dab':
+    '/data-tables',
+  '/data-tables/fast-track/8b83d7ec-1ba4-44dc-b21c-adb5fa5a4bc8':
+    '/data-tables',
+  '/data-tables/fast-track/8ba8c85a-f067-48b2-81ed-2efa4040f3f9':
+    '/data-tables',
+  '/data-tables/fast-track/8c5674ec-4e2c-448f-80f0-a4dca6be5df8':
+    '/data-tables',
+  '/data-tables/fast-track/8c693d87-28d7-4ff1-9374-a5896c326662':
+    '/data-tables',
+  '/data-tables/fast-track/8c6ae42d-b89e-4e88-bd26-519da67832e1':
+    '/data-tables',
+  '/data-tables/fast-track/8d979f9b-ba2a-42a8-a9f9-a6d43413b89d':
+    '/data-tables',
+  '/data-tables/fast-track/8e066026-ce43-40b1-a534-f32df5dd5adb':
+    '/data-tables',
+  '/data-tables/fast-track/8fa4f92b-980a-46dc-982b-2b35b89b11f9':
+    '/data-tables',
+  '/data-tables/fast-track/90691076-386a-4ba9-9524-08d9986262b5':
+    '/data-tables',
+  '/data-tables/fast-track/908beb34-e6c3-4dd9-88af-00c13d597b04':
+    '/data-tables',
+  '/data-tables/fast-track/9125b59f-95be-4600-85ea-6d583b7566e1':
+    '/data-tables',
+  '/data-tables/fast-track/91805ad0-1ba2-4cdf-bb44-83aad652fe69':
+    '/data-tables',
+  '/data-tables/fast-track/91a730e7-e3d5-46d6-aae5-2eb481c9fb0f':
+    '/data-tables',
+  '/data-tables/fast-track/91e9e185-2da3-47fa-93a9-773249a3c7d6':
+    '/data-tables',
+  '/data-tables/fast-track/9201b32b-cc91-4365-3574-08daa20fa891':
+    '/data-tables',
+  '/data-tables/fast-track/92031aef-7efe-4c70-9204-da82ac02124d':
+    '/data-tables',
+  '/data-tables/fast-track/92d88d1f-1d56-43e2-912d-c13f17916a52':
+    '/data-tables',
+  '/data-tables/fast-track/94385483-4d6a-4d6d-c05f-08db465931c0':
+    '/data-tables',
+  '/data-tables/fast-track/948a5007-b090-4e43-8e9d-8c0b7cfa0fef':
+    '/data-tables',
+  '/data-tables/fast-track/952dc5bd-d0a0-4f22-bf5b-7a597bfc6f68':
+    '/data-tables',
+  '/data-tables/fast-track/97a699fd-1d72-473e-d48c-08dabceba8ca':
+    '/data-tables',
+  '/data-tables/fast-track/9a2cb3b7-6908-415a-8604-ae9eee5265a9':
+    '/data-tables',
+  '/data-tables/fast-track/9a360800-506b-4550-f597-08d8e93777ac':
+    '/data-tables',
+  '/data-tables/fast-track/9af514a7-00d2-4090-80d9-7e5af1677970':
+    '/data-tables',
+  '/data-tables/fast-track/9b1e4a4e-02b1-4795-8c74-b65acfd4d20f':
+    '/data-tables',
+  '/data-tables/fast-track/9b25fded-9844-477d-8694-08da7eccd8d3':
+    '/data-tables',
+  '/data-tables/fast-track/9b4a435d-7a43-4f74-3bed-08db5b843ba5':
+    '/data-tables',
+  '/data-tables/fast-track/9cee6f89-d584-43e1-f595-08d8e93777ac':
+    '/data-tables',
+  '/data-tables/fast-track/9dffde6f-0a27-49ee-a2a5-5fbeae8d9f3a':
+    '/data-tables',
+  '/data-tables/fast-track/9f2d0cdf-84dc-4c08-aa5f-29dcdfc6fe54':
+    '/data-tables',
+  '/data-tables/fast-track/a001d78f-6edf-45e0-af48-f130003c2040':
+    '/data-tables',
+  '/data-tables/fast-track/a011ef71-e150-4c87-8d5d-035b86dd7cd1':
+    '/data-tables',
+  '/data-tables/fast-track/a03ee004-1fd7-44bc-c145-08daa787e284':
+    '/data-tables',
+  '/data-tables/fast-track/a0f9ca30-f651-4876-ad2b-878ce32919cc':
+    '/data-tables',
+  '/data-tables/fast-track/a1413c9c-1b78-48c4-afed-91eb47b66c1b':
+    '/data-tables',
+  '/data-tables/fast-track/a2698ca3-0950-496b-8096-0b4125e3f65f':
+    '/data-tables',
+  '/data-tables/fast-track/a397dea6-5c24-4700-9a02-2ea7957593ef':
+    '/data-tables',
+  '/data-tables/fast-track/a4042cfc-53d4-4349-9a1f-e153999374ac':
+    '/data-tables',
+  '/data-tables/fast-track/a494ffaa-a1cd-428d-9084-ee918506fae8':
+    '/data-tables',
+  '/data-tables/fast-track/a55bef42-f8af-4ca6-9093-3b743d13f2b8':
+    '/data-tables',
+  '/data-tables/fast-track/a6b4d538-b919-490e-c217-08dba88b1a38':
+    '/data-tables',
+  '/data-tables/fast-track/a89db6b7-815e-44cd-a32c-8ce718a9fd39':
+    '/data-tables',
+  '/data-tables/fast-track/ab4809de-fe59-4dc4-a30b-b3b064db9216':
+    '/data-tables',
+  '/data-tables/fast-track/aca1d4a5-88eb-4a96-a8e3-08da8f1f9388':
+    '/data-tables',
+  '/data-tables/fast-track/acbd1b5c-b775-447b-993e-b7ef479a7139':
+    '/data-tables',
+  '/data-tables/fast-track/acff0bb0-4d7a-4971-84da-79a0cd9fe36b':
+    '/data-tables',
+  '/data-tables/fast-track/ae12ebc0-73b6-4a40-d771-08db513a05d2':
+    '/data-tables',
+  '/data-tables/fast-track/afa0571f-a9af-413e-ae52-8e9467c5e30f':
+    '/data-tables',
+  '/data-tables/fast-track/b048b06b-23a4-467f-986b-b471ff54da05':
+    '/data-tables',
+  '/data-tables/fast-track/b071bf10-58a5-41bf-bc4b-08da8695004d':
+    '/data-tables',
+  '/data-tables/fast-track/b0af25f4-84c8-4bb4-b498-de8b3abb5312':
+    '/data-tables',
+  '/data-tables/fast-track/b2b15e44-f8a9-41ff-a8af-b2baa28d60bc':
+    '/data-tables',
+  '/data-tables/fast-track/b2bd9f8c-768e-4d9f-bce0-e9e39a564e22':
+    '/data-tables',
+  '/data-tables/fast-track/b2d0cfe2-e605-4fc6-3beb-08db5b843ba5':
+    '/data-tables',
+  '/data-tables/fast-track/b31d8b95-f7bc-4e11-c064-08db465931c0':
+    '/data-tables',
+  '/data-tables/fast-track/b343e11c-f175-45fa-8541-45c370599f5f':
+    '/data-tables',
+  '/data-tables/fast-track/b4793cfd-5991-4cd0-870d-e41cfb5a65af':
+    '/data-tables',
+  '/data-tables/fast-track/b5d1a528-8b18-44da-aeb6-b47bd3481b18':
+    '/data-tables',
+  '/data-tables/fast-track/b6dc17c3-7d42-4155-9f69-f884ec61bd75':
+    '/data-tables',
+  '/data-tables/fast-track/b82a3833-8d45-4332-aeb2-a51be6c15146':
+    '/data-tables',
+  '/data-tables/fast-track/b84ee31e-4ba5-4cea-5692-08d9924a81c2':
+    '/data-tables',
+  '/data-tables/fast-track/b88bae97-d789-40b5-81aa-508713e7ccc8':
+    '/data-tables',
+  '/data-tables/fast-track/b91ccb4d-7d8b-4ced-969f-a050aecbc77f':
+    '/data-tables',
+  '/data-tables/fast-track/b97bf61a-89cf-4818-b32c-3f83482ad63d':
+    '/data-tables',
+  '/data-tables/fast-track/bba7bc5f-fd01-43c9-35a4-08daa20fa891':
+    '/data-tables',
+  '/data-tables/fast-track/bbbdd826-8df9-45b1-a3d0-b54e18fbd46f':
+    '/data-tables',
+  '/data-tables/fast-track/bbcaf878-50f3-4755-a987-36b0e9a752cd':
+    '/data-tables',
+  '/data-tables/fast-track/bbf9ee63-096a-472a-a50f-0b3039805ebe':
+    '/data-tables',
+  '/data-tables/fast-track/bd25d934-c0b5-4de2-81df-75eec0e9bbbb':
+    '/data-tables',
+  '/data-tables/fast-track/bf12cd2d-83d7-4ed8-a439-00f1ca0ccf06':
+    '/data-tables',
+  '/data-tables/fast-track/bf1beb50-1dd5-4426-b9fa-9db0df20ea7e':
+    '/data-tables',
+  '/data-tables/fast-track/bfa15bab-a5e0-4dee-86ea-4bc2aa1bf3b3':
+    '/data-tables',
+  '/data-tables/fast-track/bfc4c50e-734f-42c3-a4e2-7090e3c11641':
+    '/data-tables',
+  '/data-tables/fast-track/c0057c9f-ca9a-4360-8ae4-10a03d4d7f29':
+    '/data-tables',
+  '/data-tables/fast-track/c0a53e6e-2c9a-4417-bcf6-1e357dede040':
+    '/data-tables',
+  '/data-tables/fast-track/c15f4679-2b6a-4bdb-86b9-08da7eccd8d3':
+    '/data-tables',
+  '/data-tables/fast-track/c18ea9c7-b699-4b46-adfc-9718206e1dd4':
+    '/data-tables',
+  '/data-tables/fast-track/c298fa6e-b23f-49da-9a42-46f313c47983':
+    '/data-tables',
+  '/data-tables/fast-track/c2dbb675-1aea-4c79-9938-7406e44e9bea':
+    '/data-tables',
+  '/data-tables/fast-track/c2e09977-1a41-4554-8fcc-ab1a147f50f6':
+    '/data-tables',
+  '/data-tables/fast-track/c34c7ebc-30e8-4a77-b9a1-bbcf40c624ec':
+    '/data-tables',
+  '/data-tables/fast-track/c3ed3a98-edc1-47e1-917d-98fc0eabbb77':
+    '/data-tables',
+  '/data-tables/fast-track/c4061205-6cd7-4ec2-b2e7-9e5a9cb31b17':
+    '/data-tables',
+  '/data-tables/fast-track/c4bf6323-e7a8-4267-94fd-71084d159296':
+    '/data-tables',
+  '/data-tables/fast-track/c69292a7-d49e-4b43-8fc8-bdd0e46f4e04':
+    '/data-tables',
+  '/data-tables/fast-track/c6ae8b83-29b3-4d68-bac6-8690ea94917d':
+    '/data-tables',
+  '/data-tables/fast-track/c7997707-e733-4591-b993-3faa4ac3668f':
+    '/data-tables',
+  '/data-tables/fast-track/c7ead7a2-5660-4192-7732-08dab100bfc2':
+    '/data-tables',
+  '/data-tables/fast-track/c82b1eab-10d8-4475-872c-207ff32688e3':
+    '/data-tables',
+  '/data-tables/fast-track/c88edc91-fde0-4f08-8f82-bdb3dce8555c':
+    '/data-tables',
+  '/data-tables/fast-track/c991e329-49ec-480a-bfe4-2383cd6f5170':
+    '/data-tables',
+  '/data-tables/fast-track/c99814ff-dbaa-49ac-8a4c-40a0d2d829c1':
+    '/data-tables',
+  '/data-tables/fast-track/c9da44a5-527e-4f75-9812-12fe0490403e':
+    '/data-tables',
+  '/data-tables/fast-track/ca08e074-2ce1-4448-ba3b-08a1db9a57a3':
+    '/data-tables',
+  '/data-tables/fast-track/caca8a1b-9658-4fc2-bfbc-7e5e957a4d2b':
+    '/data-tables',
+  '/data-tables/fast-track/cbb62019-fb9f-48f1-c06a-08db465931c0':
+    '/data-tables',
+  '/data-tables/fast-track/cc345cf1-82b4-4155-b2ba-ffae201f226e':
+    '/data-tables',
+  '/data-tables/fast-track/ccb3ab9a-89a8-49e9-ae93-cfd5634685b2':
+    '/data-tables',
+  '/data-tables/fast-track/ccf319fc-08f4-4720-bd0f-b873127346c7':
+    '/data-tables',
+  '/data-tables/fast-track/cd305910-93d7-419d-9404-0ba98bb43de1':
+    '/data-tables',
+  '/data-tables/fast-track/cd386772-c34a-43e9-a1e6-bef4686d4346':
+    '/data-tables',
+  '/data-tables/fast-track/ce0359d5-a5d0-4e75-aaa1-34e75b017d23':
+    '/data-tables',
+  '/data-tables/fast-track/ce103d9b-f827-43dd-a8ea-f8b71028732f':
+    '/data-tables',
+  '/data-tables/fast-track/cf653512-96c0-4420-b570-b680a32f4e90':
+    '/data-tables',
+  '/data-tables/fast-track/cf753eaf-c214-410d-a832-5dac9980453b':
+    '/data-tables',
+  '/data-tables/fast-track/cf964186-58f0-47ac-bb30-1515940251ce':
+    '/data-tables',
+  '/data-tables/fast-track/d0df05d5-3038-': '/data-tables',
+  '/data-tables/fast-track/d40df679-2092-4d7f-89f7-91e4da6134ae':
+    '/data-tables',
+  '/data-tables/fast-track/d55b6ea8-6ae4-49e8-8749-216e706f5f17':
+    '/data-tables',
+  '/data-tables/fast-track/d596f5e0-3aff-4638-a553-af0515d9e755':
+    '/data-tables',
+  '/data-tables/fast-track/d5aa5ea1-8111-42af-b63e-c1158f00c96c':
+    '/data-tables',
+  '/data-tables/fast-track/d662e080-a7ee-4310-b798-8788c516e8dc':
+    '/data-tables',
+  '/data-tables/fast-track/d77da3cd-db3b-4b87-f58c-08d8e93777ac':
+    '/data-tables',
+  '/data-tables/fast-track/d7ee63f3-f398-4003-9062-250161008878':
+    '/data-tables',
+  '/data-tables/fast-track/da9e690a-16dc-4211-8114-04c3abfd5c4d':
+    '/data-tables',
+  '/data-tables/fast-track/dcdc0385-ef22-477f-8ff4-0f478c04f75d':
+    '/data-tables',
+  '/data-tables/fast-track/dd6a66de-2636-453f-9dca-8ad9f1497c32':
+    '/data-tables',
+  '/data-tables/fast-track/de51d27f-dbf3-42aa-9d1a-6c099919de96':
+    '/data-tables',
+  '/data-tables/fast-track/df2f55d9-3076-4f3c-87a7-d33258f7868a':
+    '/data-tables',
+  '/data-tables/fast-track/e0418641-27c9-4b5a-8804-ac070a8fad2c':
+    '/data-tables',
+  '/data-tables/fast-track/e07a81a3-8a6d-4185-b7ee-03bfe245340c':
+    '/data-tables',
+  '/data-tables/fast-track/e1b81c76-d59e-4ba2-8d0d-e756d48063bd':
+    '/data-tables',
+  '/data-tables/fast-track/e45f43af-b7da-46dd-3575-08daa20fa891':
+    '/data-tables',
+  '/data-tables/fast-track/e4def50d-5224-45bf-baac-473b88f1a0fb':
+    '/data-tables',
+  '/data-tables/fast-track/e50aa2ec-4725-4087-a184-e612db99de03':
+    '/data-tables',
+  '/data-tables/fast-track/e71dd1d5-86d3-': '/data-tables',
+  '/data-tables/fast-track/e79cf591-5f85-45b1-7755-08dab100bfc2':
+    '/data-tables',
+  '/data-tables/fast-track/e8b0b479-d39e-42ef-b4d2-877bbe678c39':
+    '/data-tables',
+  '/data-tables/fast-track/e912c09e-cda2-4829-af3b-bc5027f4f528':
+    '/data-tables',
+  '/data-tables/fast-track/ea1384a0-03d0-42b5-9b6d-3e81ead18f95':
+    '/data-tables',
+  '/data-tables/fast-track/ea917bb0-97d5-4cb5-bd11-9f5d80a5cd17':
+    '/data-tables',
+  '/data-tables/fast-track/eb1178b4-d357-4a6d-d716-08db513a05d2':
+    '/data-tables',
+  '/data-tables/fast-track/ebcd4c02-fdb7-4b8d-9fff-c80cf62bed40':
+    '/data-tables',
+  '/data-tables/fast-track/ec5f9b52-75e0-4029-16e3-08da47b0392d':
+    '/data-tables',
+  '/data-tables/fast-track/ed3120a8-e235-40df-9ce3-3adc103db4aa':
+    '/data-tables',
+  '/data-tables/fast-track/edf5dc3e-cd41-4a9e-3554-08daa20fa891':
+    '/data-tables',
+  '/data-tables/fast-track/ee086150-1e90-4e3e-b4d3-cc11d87a6fc7':
+    '/data-tables',
+  '/data-tables/fast-track/eeb158cd-46c2-40c0-8ca3-1e0ab067f59d':
+    '/data-tables',
+  '/data-tables/fast-track/eee26b50-6367-4e73-86c0-08da7eccd8d3':
+    '/data-tables',
+  '/data-tables/fast-track/ef95998d-f96a-4c4f-9d2a-e00ef17684e7':
+    '/data-tables',
+  '/data-tables/fast-track/f0423305-94d6-4552-86ba-08da7eccd8d3':
+    '/data-tables',
+  '/data-tables/fast-track/f05583c6-4ee5-4c26-bb98-515cc90885c3':
+    '/data-tables',
+  '/data-tables/fast-track/f171d6ff-6e7d-4bb0-b90e-cca1eb1f8767':
+    '/data-tables',
+  '/data-tables/fast-track/f1c0e0bd-af8e-4644-9b25-5490fabd8acc':
+    '/data-tables',
+  '/data-tables/fast-track/f2ed11d3-7320-46c9-b2a4-938fa0a0c2af':
+    '/data-tables',
+  '/data-tables/fast-track/f360a303-3d24-4516-f7f3-08da8c214b78':
+    '/data-tables',
+  '/data-tables/fast-track/f43f768d-df1b-4f48-1d7e-08db8eaeaf03':
+    '/data-tables',
+  '/data-tables/fast-track/f4d42479-': '/data-tables',
+  '/data-tables/fast-track/f4e2ad47-fc89-4020-a3fd-8536a7e7667d':
+    '/data-tables',
+  '/data-tables/fast-track/f5c96542-0736-493b-90f4-917b53717579':
+    '/data-tables',
+  '/data-tables/fast-track/f5e19431-a6c5-443a-bf3d-9b497aa41bc4':
+    '/data-tables',
+  '/data-tables/fast-track/f61793f8-e54e-477a-a6ae-0a856bac4be5':
+    '/data-tables',
+  '/data-tables/fast-track/f6272eee-e3a0-44ac-82bf-f8c7f517e778':
+    '/data-tables',
+  '/data-tables/fast-track/f85ae336-f947-4fd2-829c-94a3c4f613d7':
+    '/data-tables',
+  '/data-tables/fast-track/f88c7e10-7af0-4987-b4ae-cb02a6e82119':
+    '/data-tables',
+  '/data-tables/fast-track/f8d4dcd7-f5a0-4625-9369-bd40bd43c7eb':
+    '/data-tables',
+  '/data-tables/fast-track/f9ae0266-dbeb-4fb6-a0cd-ca0bc0d67ac3':
+    '/data-tables',
+  '/data-tables/fast-track/fbd1ee4f-f072-48c4-abe5-ac15f1c1dd57':
+    '/data-tables',
+  '/data-tables/fast-track/fc23c1d7-6cee-4d9d-8acb-f47879a6f7db':
+    '/data-tables',
+  '/data-tables/fast-track/fd88636c-c6fc-4802-98f6-260e6670cd58':
+    '/data-tables',
+  '/data-tables/fast-track/fd94f5a9-7eac-4017-9d20-a90fe89a627c':
+    '/data-tables',
+  '/data-tables/fast-track/fef5a785-caa5-4de9-a8d8-08da8f1f9388':
+    '/data-tables',
+  '/data-tables/fast-track/ff7bbf92-c452-4805-bd1d-282aec2c9772':
+    '/data-tables',
+  '/data-tables/permalink/%5bpermalink%5d': '/data-tables',
+  '/data-tables/permalink/09fca49f-7bd8-475f-dd03-08db8e99978c.':
+    '/data-tables',
+  '/data-tables/permalink/167d18fb-': '/data-tables',
+  '/data-tables/permalink/203a8889-429b-469f-abe1-': '/data-tables',
+  '/data-tables/permalink/2e97cf7e-3fe6-4e97-8525-': '/data-tables',
+  '/data-tables/permalink/36526263-f93b-4bb1-9d1f-': '/data-tables',
+  '/data-tables/permalink/47223cca-6ffb-42da-be50-': '/data-tables',
+  '/data-tables/permalink/55ca2487-7a4d-43c4-487d-08db8e99c26c.':
+    '/data-tables',
+  '/data-tables/permalink/59fc4e59-160c-4755-c612-08': '/data-tables',
+  '/data-tables/permalink/5ab5dbf2-393b-4a43-b7a1-': '/data-tables',
+  '/data-tables/permalink/67961e79-5204-410e-b521-': '/data-tables',
+  '/data-tables/permalink/85ba124e-1489-4648-bfde-': '/data-tables',
+  '/data-tables/permalink/85ba124e-1489-4648-bfde-3eff6fdf76a2%3b':
+    '/data-tables',
+  '/data-tables/permalink/8f50fce8-': '/data-tables',
+  '/data-tables/permalink/970e9bb8-d185-': '/data-tables',
+  '/data-tables/permalink/9795440a-015e-47eb-86e2-': '/data-tables',
+  '/data-tables/permalink/9e420c30-': '/data-tables',
+  '/data-tables/permalink/c0319f82-e1e3-4adf-9db1-': '/data-tables',
+  '/data-tables/permalink/c4cb6884-': '/data-tables',
+  '/data-tables/permalink/e0980465-': '/data-tables',
+  '/data-tables/permalink/e8942369-b2a3-': '/data-tables',
+  '/datatables/apprenticeships-and-traineeships': '/data-tables',
+  '/datatables/permalink/48f9a035-9123-477e-': '/data-tables',
+  '/datatables/permalink/b169759c-': '/data-tables',
+  '/find-st%3c/body%3e%3c/html%3e': '/find-statistics',
+  '/find-sta': '/find-statistics',
+  '/find-stati': '/find-statistics',
+  '/find-statis-': '/find-statistics',
+  '/find-statistic': '/find-statistics',
+  '/find-statistics/%5bpublication%5d': '/find-statistics',
+  '/find-statistics/%5bpublication%5d/%5brelease%5d': '/find-statistics',
+  '/find-statistics/%3ca%20href%3d': '/find-statistics',
+  '/find-statistics/16-18-': '/find-statistics',
+  '/find-statistics/16-18-destination-measure': '/find-statistics',
+  '/find-statistics/a-': '/find-statistics',
+  '/find-statistics/a-level': '/find-statistics',
+  '/find-statistics/a-level-and-other-16-to-': '/find-statistics',
+  '/find-statistics/a-level-and-other-16-to-18-': '/find-statistics',
+  '/find-statistics/a-level-and-other-16-to-18-results/2019-20%20%e2%80%93':
+    '/find-statistics',
+  '/find-statistics/a-level-and-other-level-3-results-in-england-academic-year-2019-to-2020':
+    '/find-statistics',
+  '/find-statistics/admission-': '/find-statistics',
+  '/find-statistics/apprenticeships-': '/find-statistics',
+  '/find-statistics/apprenticeships-and': '/find-statistics',
+  '/find-statistics/apprenticeships-and-traineeships/2020-21%20%0a-%20apprenticeship%20starts%20down%200.3%25%20in%2021-22%20vs%2019-20':
+    '/find-statistics',
+  '/find-statistics/apprenticeships-and-traineeshipsthe': '/find-statistics',
+  '/find-statistics/at-': '/find-statistics',
+  '/find-statistics/attainment-8-score-averages-by-previous-attainment/2019-to-2020-revised':
+    '/find-statistics',
+  '/find-statistics/attendance-': '/find-statistics',
+  '/find-statistics/attendance-in-': '/find-statistics',
+  '/find-statistics/attendance-in-edu': '/find-statistics',
+  '/find-statistics/attendance-in-educa-': '/find-statistics',
+  '/find-statistics/attendance-in-education': '/find-statistics',
+  '/find-statistics/attendance-in-education-': '/find-statistics',
+  '/find-statistics/attendance-in-education-and-': '/find-statistics',
+  '/find-statistics/attendance-in-education-and-earl': '/find-statistics',
+  '/find-statistics/attendance-in-education-and-early-': '/find-statistics',
+  '/find-statistics/attendance-in-education-and-early-years':
+    '/find-statistics',
+  '/find-statistics/attendance-in-education-and-early-years-':
+    '/find-statistics',
+  '/find-statistics/attendance-in-education-and-early-years-settings-during-the-':
+    '/find-statistics',
+  '/find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-':
+    '/find-statistics',
+  '/find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-covid-19-':
+    '/find-statistics',
+  '/find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-covid-19-outbreak%20%0a2':
+    '/find-statistics',
+  '/find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-covid-19-outbreak/2020-week-':
+    '/find-statistics',
+  '/find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-covid-19-outbreak/2021-week-':
+    '/find-statistics',
+  '/find-statistics/attendance-in-education-and-early-years-settings-during-the-coronavirus-covid-19-outbreak/2022-week-':
+    '/find-statistics',
+  '/find-statistics/attendance-in-education-andearly-years-settings-during-the-coronavirus-covid-19-outbreak':
+    '/find-statistics',
+  '/find-statistics/attendance-ineducation-': '/find-statistics',
+  '/find-statistics/characteristics-of-': '/find-statistics',
+  '/find-statistics/characteristics-of-children-in-': '/find-statistics',
+  '/find-statistics/characteristics-of-children-in-n': '/find-statistics',
+  '/find-statistics/characteristics-of-children-in-need/2022%26nbsp':
+    '/find-statistics',
+  '/find-statistics/characteristics-of-children-in-need%26nbsp':
+    '/find-statistics',
+  '/find-statistics/characteristics-of-children-inneed/2020':
+    '/find-statistics',
+  '/find-statistics/childcare': '/find-statistics',
+  '/find-statistics/childcare-and-': '/find-statistics',
+  '/find-statistics/childcare-and-early-': '/find-statistics',
+  '/find-statistics/children': '/find-statistics',
+  '/find-statistics/children-': '/find-statistics',
+  '/find-statistics/children-loo': '/find-statistics',
+  '/find-statistics/children-looked': '/find-statistics',
+  '/find-statistics/children-looked-after-in': '/find-statistics',
+  '/find-statistics/children-looked-after-in-england': '/find-statistics',
+  '/find-statistics/children-looked-after-in-england-includ':
+    '/find-statistics',
+  '/find-statistics/children-looked-after-in-england-including':
+    '/find-statistics',
+  '/find-statistics/children-looked-after-in-england-including-':
+    '/find-statistics',
+  '/find-statistics/children-looked-after-in-england-including-adopti':
+    '/find-statistics',
+  '/find-statistics/children-looked-after-in-england-including-adoptions/2020%20%0a-%20datadownloads-1':
+    '/find-statistics',
+  '/find-statistics/children-looked-after-in-england-including-adoptions/2020developmentofattachmentsbetweenolder':
+    '/find-statistics',
+  '/find-statistics/children-looked-after-in-england-including-adoptions/2021%22%20%0a/l%20%22datadownloads-1':
+    '/find-statistics',
+  '/find-statistics/children-s-social-work': '/find-statistics',
+  '/find-statistics/children-s-social-work-workforce-attrition-':
+    '/find-statistics',
+  '/find-statistics/children-s-social-work-workforce/2022%26nbsp':
+    '/find-statistics',
+  '/find-statistics/delivery-of-air-': '/find-statistics',
+  '/find-statistics/early-years-foundation-stage-': '/find-statistics',
+  '/find-statistics/education-': '/find-statistics',
+  '/find-statistics/education-and-training-': '/find-statistics',
+  '/find-statistics/education-and-training-statistics-for-the-':
+    '/find-statistics',
+  '/find-statistics/education-and-training-statistics-for-the-uk/2022%3b':
+    '/find-statistics',
+  '/find-statistics/education-health-': '/find-statistics',
+  '/find-statistics/education-health-and-care': '/find-statistics',
+  '/find-statistics/education-health-and-care-plan': '/find-statistics',
+  '/find-statistics/education-health-and-care-plans%20%0a%28opens%20in%20external%20window%29':
+    '/find-statistics',
+  '/find-statistics/education-health-and-care-plans/www.gov.uk/courts-tribunals/first-tier-tribunal-specialeducational-needs-and-disability':
+    '/find-statistics',
+  '/find-statistics/education-provision-children-under-5/2020%20%0a%28universal%20three%20and%20four-year%20old%20offer%20and%20disadvantaged%20two%20year%20old%20%0aoffer%29%20and%20%0ahttps%3a/www.gov.uk/government/statistics/childcare-and-early-years-survey-of-parents-2019':
+    '/find-statistics',
+  '/find-statistics/elective-home-education/2022-': '/find-statistics',
+  '/find-statistics/free-school-meals-': '/find-statistics',
+  '/find-statistics/further-': '/find-statistics',
+  '/find-statistics/further-education-and-': '/find-statistics',
+  '/find-statistics/further-education-outcome-': '/find-statistics',
+  '/find-statistics/further-education-outcome-based-success-mesures':
+    '/find-statistics',
+  '/find-statistics/graduate-': '/find-statistics',
+  '/find-statistics/graduate-labour-': '/find-statistics',
+  '/find-statistics/graduate-outcomes-': '/find-statistics',
+  '/find-statistics/he.modelling%40education.gov.uk': '/find-statistics',
+  '/find-statistics/higher-': '/find-statistics',
+  '/find-statistics/higher-level-learners-in-england/2018-19.':
+    '/find-statistics',
+  '/find-statistics/higher-level-learners-in-england%23datadownloads-1':
+    '/find-statistics',
+  '/find-statistics/initial-': '/find-statistics',
+  '/find-statistics/initial-teacher-train-': '/find-statistics',
+  '/find-statistics/initial-teacher-training-': '/find-statistics',
+  '/find-statistics/initial-teacher-training-census/2022-': '/find-statistics',
+  '/find-statistics/initial-teacher-training-performance-': '/find-statistics',
+  '/find-statistics/initial-teacher-training-performance-profiles/2019-20.':
+    '/find-statistics',
+  '/find-statistics/initial-teacher-trainingcensus/2020-21': '/find-statistics',
+  '/find-statistics/key-stage-': '/find-statistics',
+  '/find-statistics/key-stage-1-and-phonics-': '/find-statistics',
+  '/find-statistics/key-stage-1-and-phonics-screening-check-':
+    '/find-statistics',
+  '/find-statistics/key-stage-2-': '/find-statistics',
+  '/find-statistics/key-stage-2-attainment-national-headlines/2021':
+    '/find-statistics',
+  '/find-statistics/key-stage-2-attainment-national-headlines/2021-22%20%0aaccessed%2031st%20july%202022':
+    '/find-statistics',
+  '/find-statistics/key-stage-2-attainment/2021-': '/find-statistics',
+  '/find-statistics/key-stage-4': '/find-statistics',
+  '/find-statistics/key-stage-4-': '/find-statistics',
+  '/find-statistics/key-stage-4-destination-measures/2018-': '/find-statistics',
+  '/find-statistics/key-stage-4-performance': '/find-statistics',
+  '/find-statistics/key-stage-4-performance-': '/find-statistics',
+  '/find-statistics/key-stage-4-performance-revised/2020-': '/find-statistics',
+  '/find-statistics/key-stage-4-performance-revised/2021%e2%80%9322':
+    '/find-statistics',
+  '/find-statistics/la-and-school-expenditure/2019-2': '/find-statistics',
+  '/find-statistics/la-and-school-expenditure/2020-21%3b': '/find-statistics',
+  '/find-statistics/laptops-and-': '/find-statistics',
+  '/find-statistics/level-2-and-3-attainment-by-youn': '/find-statistics',
+  '/find-statistics/level-2-and-3-attainment-by-young-people-':
+    '/find-statistics',
+  '/find-statistics/level-2-and-3-attainment-by-young-people-aged-19/2020-':
+    '/find-statistics',
+  '/find-statistics/looked-after-children-aged-16-to-17-in-independent-or-semi-':
+    '/find-statistics',
+  '/find-statistics/multiplication-tables-check-': '/find-statistics',
+  '/find-statistics/national-tutoring-': '/find-statistics',
+  '/find-statistics/neet-statistics-': '/find-statistics',
+  '/find-statistics/outcomes-for-children-in-need-': '/find-statistics',
+  '/find-statistics/outcomes-for-children-in-need-including-c':
+    '/find-statistics',
+  '/find-statistics/outcomes-for-children-in-needincluding-children-':
+    '/find-statistics',
+  '/find-statistics/outcomes-for-children-in-needincluding-children-looked-after-by-local-authorities-in-england':
+    '/find-statistics',
+  '/find-statistics/parental': '/find-statistics',
+  '/find-statistics/participation': '/find-statistics',
+  '/find-statistics/participation-in-education-and-': '/find-statistics',
+  '/find-statistics/participation-in-education-training-and-':
+    '/find-statistics',
+  '/find-statistics/participation-measures-in-higher-': '/find-statistics',
+  '/find-statistics/permanent-': '/find-statistics',
+  '/find-statistics/permanent-and': '/find-statistics',
+  '/find-statistics/permanent-and-fixed': '/find-statistics',
+  '/find-statistics/permanent-and-fixed-': '/find-statistics',
+  '/find-statistics/permanent-and-fixed-p': '/find-statistics',
+  '/find-statistics/permanent-and-fixed-period-': '/find-statistics',
+  '/find-statistics/permanent-and-fixed-period-exclu': '/find-statistics',
+  '/find-statistics/permanent-and-fixed-period-exclusions-in-':
+    '/find-statistics',
+  '/find-statistics/permanent-and-fixed-period-exclusions-in-eng':
+    '/find-statistics',
+  '/find-statistics/permanent-and-fixed-period-exclusions-in-eng-':
+    '/find-statistics',
+  '/find-statistics/permanent-and-fixed-period-exclusions-in-england/2018-':
+    '/find-statistics',
+  '/find-statistics/permanent-and-fixed-period-exclusions-in-england/2018-19yougov.uk':
+    '/find-statistics',
+  '/find-statistics/permanent-and-fixed-period-exclusions-in-englandfigures':
+    '/find-statistics',
+  '/find-statistics/permanent-and-fixed-period-exclusions-inengland/2018-19':
+    '/find-statistics',
+  '/find-statistics/permanent-and-fixed-periodexclusions-in-england':
+    '/find-statistics',
+  '/find-statistics/permanent-and-fixed-term-exclusions-in-england':
+    '/find-statistics',
+  '/find-statistics/permanentand-fixed-period-exclusions-in-england':
+    '/find-statistics',
+  '/find-statistics/postgraduate-initial-teacher-': '/find-statistics',
+  '/find-statistics/progression-to-%3ca%20%0ahref%3d': '/find-statistics',
+  '/find-statistics/progression-to-higher-ed': '/find-statistics',
+  '/find-statistics/pupil': '/find-statistics',
+  '/find-statistics/pupil-absence-': '/find-statistics',
+  '/find-statistics/pupil-absence-in-': '/find-statistics',
+  '/find-statistics/pupil-absence-in-schools-in-engl': '/find-statistics',
+  '/find-statistics/pupil-absence-in-schools-in-england-autumn-and-':
+    '/find-statistics',
+  '/find-statistics/pupil-absence-in-schools-in-england-autumn-term/data':
+    '/find-statistics',
+  '/find-statistics/pupil-absence-in-schools-in-england%29': '/find-statistics',
+  '/find-statistics/pupil-absence-inschools-in-england-': '/find-statistics',
+  '/find-statistics/pupil-attendance': '/find-statistics',
+  '/find-statistics/pupil-attendance-in-': '/find-statistics',
+  '/find-statistics/pupil-attendance-in-schools/2023-7week-29':
+    '/find-statistics',
+  '/find-statistics/school-funding-': '/find-statistics',
+  '/find-statistics/school-funding-statistics/2021-': '/find-statistics',
+  '/find-statistics/school-placements-': '/find-statistics',
+  '/find-statistics/school-pup': '/find-statistics',
+  '/find-statistics/school-pupils-': '/find-statistics',
+  '/find-statistics/school-pupils-and-': '/find-statistics',
+  '/find-statistics/school-pupils-and-thei': '/find-statistics',
+  '/find-statistics/school-pupils-and-their-': '/find-statistics',
+  '/find-statistics/school-pupils-and-their-ch': '/find-statistics',
+  '/find-statistics/school-pupils-and-their-cha': '/find-statistics',
+  '/find-statistics/school-pupils-and-their-characteristics%3b':
+    '/find-statistics',
+  '/find-statistics/school-pupils-and-their-characteristics%22':
+    '/find-statistics',
+  '/find-statistics/school-pupils-and-their-characteristics/2019-20.':
+    '/find-statistics',
+  '/find-statistics/school-pupils-and-their-characteristicsa':
+    '/find-statistics',
+  '/find-statistics/school-pupils-and-their-characteristicshttps%3a/explore-education-statistics.service.gov.uk/find-statistics/school-pupils-and-their-characteristics':
+    '/find-statistics',
+  '/find-statistics/school-pupils-and-their-characteristicsm':
+    '/find-statistics',
+  '/find-statistics/school-pupils-and-theircharacteristics': '/find-statistics',
+  '/find-statistics/school-pupils-andtheir-characteristics': '/find-statistics',
+  '/find-statistics/school-pupilsand-their-characteristics': '/find-statistics',
+  '/find-statistics/school-workforce-in-englan%3c/p%3e%20%0a%3cp%3e%20for%20more%20detailed%20information%20about%20the%20cookies%20we%20use%2c%20please%20see%20our%20%0a%3ca%20href%3d':
+    '/find-statistics',
+  '/find-statistics/school-workforce-in-england%2c': '/find-statistics',
+  '/find-statistics/school-workforce-in-england%23data': '/find-statistics',
+  '/find-statistics/school-workforce-in-england%23datablock-f47ed575-f6eb-4bd0-926a-02830e272452-charts':
+    '/find-statistics',
+  '/find-statistics/school-workforce-in-englandhttps%3a/explore-education-statistics.service.gov.uk/find-statistics/school-workforce-in-england':
+    '/find-statistics',
+  '/find-statistics/school-workforce-inengland': '/find-statistics',
+  '/find-statistics/schoolworkforce-in-england': '/find-statistics',
+  '/find-statistics/serious-': '/find-statistics',
+  '/find-statistics/serious-incident-notifications%26nbsp': '/find-statistics',
+  '/find-statistics/skills-bootcamps-': '/find-statistics',
+  '/find-statistics/special-': '/find-statistics',
+  '/find-statistics/special-educational-needs-': '/find-statistics',
+  '/find-statistics/special-educational-needs-in-england/2021-':
+    '/find-statistics',
+  '/find-statistics/special-educational-needs-in-england/2021-2':
+    '/find-statistics',
+  '/find-statistics/special-educational-needs-in-england/221-22':
+    '/find-statistics',
+  '/find-statistics/special-educationalneeds-in-england': '/find-statistics',
+  '/find-statistics/student-': '/find-statistics',
+  '/find-statistics/student-loan-forecasts-for': '/find-statistics',
+  '/find-statistics/student-loan-forecasts-for-': '/find-statistics',
+  '/find-statistics/the-link-between-absence-and-attainment-':
+    '/find-statistics',
+  '/find-statistics/the-link-between-absence-and-attainment-at-ks2-':
+    '/find-statistics',
+  '/find-statistics/uk-revenue-from-education-related-exports-':
+    '/find-statistics',
+  '/find-statistics/uk-revenue-from-education-related-exports-and-':
+    '/find-statistics',
+  '/find-statistics/widen-': '/find-statistics',
+  '/find-statistics/widening': '/find-statistics',
+  '/find-statistics/widening-': '/find-statistics',
+  '/find-statistics/widening-participation-in-higher-': '/find-statistics',
+  '/find-statistics/www.gov.uk/courts-tribunals/first-tier-tribunal-specialeducational-needs-and-disability':
+    '/find-statistics',
+  '/findstatistics/apprenticeships-and-traineeships/2021-22':
+    '/find-statistics',
+  '/findstatistics/apprenticeships-in-england-by-industry-characteristics':
+    '/find-statistics',
+  '/findstatistics/attendance-in-': '/find-statistics',
+  '/findstatistics/attendance-in-education-and-early-years-':
+    '/find-statistics',
+  '/findstatistics/children-s-social-work-workforce': '/find-statistics',
+  '/findstatistics/education-and-training-statistics-for-the-uk/2020':
+    '/find-statistics',
+  '/findstatistics/leo-graduate-and': '/find-statistics',
+  '/findstatistics/special-educational-needs-in-england': '/find-statistics',
+  '/methodol': '/methodology',
+  '/methodology/16-18-destination-': '/methodology',
+  '/methodology/attendance-in-': '/methodology',
+  '/methodology/attendance-ineducation-and-early-years-settings-during-the-coronavirus-covid-19-outbreakmethodology':
+    '/methodology',
+  '/methodology/children-looked-after-': '/methodology',
+  '/methodology/permanent-and-fixed-period-exclusions-in-england':
+    '/methodology',
+  '/methodology/secondary-and-primary-school-': '/methodology',
+  '/methodology/student-loan-forecasts-for-england-': '/methodology',
+  '/methodology/widening-': '/methodology',
+  '/methodology/widening-participation-in-higher-': '/methodology',
+  '/service': '/',
+  '/statistics/pupil-absence-in-schools-in-england': '/find-statistics',
+  '/subscriptions': '/',
+};
 
 module.exports = seoRedirects;

--- a/src/explore-education-statistics-frontend/server.js
+++ b/src/explore-education-statistics-frontend/server.js
@@ -83,7 +83,7 @@ async function startServer() {
    * @returns An absolute URL if redirection is required; undefined otherwise.
    */
   function getRedirectUrl(request) {
-    let redirectPath = request.path;
+    let redirectPath = request.path.toLowerCase();
 
     // Redirect URLs with trailing slash to equivalent without slash with 301
     redirectPath = replaceLastOccurrence(redirectPath, '/', '');
@@ -94,12 +94,7 @@ async function startServer() {
 
     // Search wrongly indexed pages from Google Search Console for matches
     // Redirect away if found to (eventually) clear routes from index
-    const seoRedirect = seoRedirects.find(
-      seoRedirectPath => seoRedirectPath.from === request.url,
-    );
-    if (seoRedirect) {
-      redirectPath = seoRedirect.to;
-    }
+    redirectPath = seoRedirects[redirectPath] ?? redirectPath;
 
     const redirectionRequired =
       request.hostname.startsWith('www') || redirectPath !== request.path;

--- a/tests/playwright-tests/tests/public/redirects.spec.ts
+++ b/tests/playwright-tests/tests/public/redirects.spec.ts
@@ -50,10 +50,10 @@ test.describe('Redirect behaviour', () => {
 
   // Not ideal, I'd rather it.each like Jest has. But from the docs:
   // https://playwright.dev/docs/test-parameterize
-  for (const redirect of seoRedirects) {
-    test.skip(`Redirects from ${redirect.from}`, async ({ page }) => {
-      await page.goto(`${PUBLIC_URL}${redirect.from}`);
-      await expect(page).toHaveURL(`${PUBLIC_URL}${redirect.to}`);
+  for (const redirect of Object.keys(seoRedirects)) {
+    test.skip(`Redirects from ${redirect}`, async ({ page }) => {
+      await page.goto(`${PUBLIC_URL}${redirect}`);
+      await expect(page).toHaveURL(`${PUBLIC_URL}${seoRedirects[redirect]}`);
     });
   }
 });


### PR DESCRIPTION
We have a new set of redirects to upload from Michael - we need to add the fast track data table urls to the list of redirects, as well as a few others which have crept in over time. 

We are also converting the redirects from an array to an object so we can iterate through them slightly faster. 

As usual, I've isolated any redirects that aren't already up on the live site and ran them through the Postman tools to ensure they do actually 404. There were two in there which actually were genuine links to live publications so naturally I've omitted those. 