### PR TITLE
EES-5119 - prevent parallel runs of API infrastructure pipeline

### DIFF
--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -24,6 +24,7 @@ resources:
           - refs/heads/dev
           - refs/heads/test
           - refs/heads/master
+        batch: true
 # This param is helpful for debugging to allow the selection of a particular branch from which to base a deploy from this pipeline.
 # This should be removed in the long term in favour of using the "Resources" selection from the "Run pipeline" dialog.
 #


### PR DESCRIPTION
This small change is an attempt to stop multiple parallel runs of the Public API Infrastructure pipeline from running together and competing for resources.