### PR TITLE
EES-XXXX - enabling Public Data DB connection on Dev for Admin and Publisher

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -112,9 +112,6 @@
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
-    },
-    "publicDataDbExists": {
-      "value": false
     }
   }
 }


### PR DESCRIPTION
This PR will allow Admin and Publisher to start using the Public Data DB connection on Dev.

As far as Admin goes, it'll use this endpoint for populating part of the Release Checklist (to make sure that there are no non-complete Public API Data Set imports) as well as dedicated Public API work like the new tab, and as far as Publisher goes, it'll use this connection to publish Data Sets along with the Releases / amendments as they go live.