### PR TITLE
EES-5159 data set page fixes

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -30,7 +30,6 @@ import { logEvent } from '@frontend/services/googleAnalyticsService';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { GetServerSideProps } from 'next';
-import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import omit from 'lodash/omit';
 
@@ -69,7 +68,6 @@ export default function DataSetFilePage({
   const [activeSection, setActiveSection] =
     useState<PageSectionId>('dataSetDetails');
   const [fullScreenPreview, toggleFullScreenPreview] = useToggle(false);
-  const router = useRouter();
 
   const handleDownload = async () => {
     await downloadService.downloadFiles(release.id, [file.id]);
@@ -105,18 +103,6 @@ export default function DataSetFilePage({
         pageSections[pageSectionId]
       ) {
         setActiveSection(pageSectionId);
-        if (router.isReady) {
-          router.push(
-            {
-              pathname: `/data-catalogue/data-set/${dataSetFile.id}`,
-              hash: pageSectionId,
-            },
-            undefined,
-            {
-              shallow: true,
-            },
-          );
-        }
       }
     });
   }, 10);

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFilePreview.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFilePreview.tsx
@@ -27,7 +27,7 @@ export default function DataSetFilePreview({
       <div className={styles.container} tabIndex={0}>
         <table id={tableId}>
           <caption className="govuk-!-font-weight-regular govuk-!-margin-bottom-3">
-            Table showing first 5 rows, from underlying data
+            {`Table showing first ${rows.length} rows, from underlying data`}
           </caption>
           <thead>
             <tr>

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileVariables.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileVariables.tsx
@@ -14,11 +14,12 @@ interface Props {
 }
 
 export default function DataSetFileVariables({ variables }: Props) {
-  const [showAll, toggleShowAll] = useToggle(false);
+  const totalVariables = variables.length;
+  const expandable = totalVariables > defaultVisible;
+  const [showAll, toggleShowAll] = useToggle(!expandable);
   const displayVariables = showAll
     ? variables
     : variables.slice(0, defaultVisible);
-  const totalVariables = variables.length;
 
   return (
     <DataSetFilePageSection heading={pageSections[sectionId]} id={sectionId}>
@@ -44,16 +45,17 @@ export default function DataSetFileVariables({ variables }: Props) {
           ))}
         </tbody>
       </table>
-
-      <ButtonText
-        ariaControls={tableId}
-        ariaExpanded={!showAll}
-        onClick={toggleShowAll}
-      >
-        {showAll
-          ? `Show only ${defaultVisible} variables`
-          : `Show all ${totalVariables} variables`}
-      </ButtonText>
+      {expandable && (
+        <ButtonText
+          ariaControls={tableId}
+          ariaExpanded={!showAll}
+          onClick={toggleShowAll}
+        >
+          {showAll
+            ? `Show only ${defaultVisible} variables`
+            : `Show all ${totalVariables} variables`}
+        </ButtonText>
+      )}
     </DataSetFilePageSection>
   );
 }

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileVariables.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileVariables.test.tsx
@@ -83,4 +83,39 @@ describe('DataSetFileVariables', () => {
     expect(row6Cells[0]).toHaveTextContent('indicator_4');
     expect(row6Cells[1]).toHaveTextContent('Indicator 4 label');
   });
+
+  test('does not render the show all button when there are fewer than 5 variables', () => {
+    render(
+      <DataSetFileVariables
+        variables={[testDataSetVariables[0], testDataSetVariables[1]]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Variables in this data set' }),
+    ).toBeInTheDocument();
+
+    const rows = within(
+      screen.getByRole('table', {
+        name: 'Table showing all 2 variables',
+      }),
+    ).getAllByRole('row');
+    expect(rows).toHaveLength(3);
+
+    const headerCells = within(rows[0]).getAllByRole('columnheader');
+    expect(headerCells[0]).toHaveTextContent('Variable name');
+    expect(headerCells[1]).toHaveTextContent('Variable description');
+
+    const row1Cells = within(rows[1]).getAllByRole('cell');
+    expect(row1Cells[0]).toHaveTextContent('filter_1');
+    expect(row1Cells[1]).toHaveTextContent('Filter 1 label');
+
+    const row2Cells = within(rows[2]).getAllByRole('cell');
+    expect(row2Cells[0]).toHaveTextContent('filter_2');
+    expect(row2Cells[1]).toHaveTextContent('Filter 2 label');
+
+    expect(
+      screen.queryByRole('button', { name: 'Show all 6 variables' }),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Fixes the following issues on the data sets page:
- weird scrolling behaviour caused by the hash change. It seems that there are known issues with Next router and updating the hash which cause reloading (even when `shallow` is true) and jerky scroll behaviour. We can't use `window.history.pushState` to update the hash as that causes a problem with the back button (see https://github.com/dfe-analytical-services/explore-education-statistics/pull/4895). I've ended up just removing updating the hash as you scroll, the navigation items are still highlighted to show where you are which was the original requirement I think.
- fix the variables list when there are fewer than 5
- makes sure the total number of csv rows is correct