### PR TITLE
EES-5197 Use temp directory rather than assembly directory for Public API data set version files

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/DataSetVersionPathResolverTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/DataSetVersionPathResolverTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -93,7 +92,8 @@ public abstract class DataSetVersionPathResolverTests
 
             Assert.Equal(
                 Path.Combine(
-                    Assembly.GetExecutingAssembly().GetDirectoryPath(),
+                    Path.GetTempPath(),
+                    "ExploreEducationStatistics",
                     "data",
                     "data-files",
                     randomTestInstanceDir.ToString()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
@@ -46,10 +45,12 @@ public class DataSetVersionPathResolver : IDataSetVersionPathResolver
 
         if (_environment.IsIntegrationTest())
         {
+            var randomTestInstanceDir = Guid.NewGuid().ToString();
             return Path.Combine(
-                Assembly.GetExecutingAssembly().GetDirectoryPath(),
+                Path.GetTempPath(),
+                "ExploreEducationStatistics",
                 PathUtils.OsPath(_options.Value.BasePath),
-                Guid.NewGuid().ToString()
+                randomTestInstanceDir
             );
         }
 


### PR DESCRIPTION
This PR changes the `DataSetVersionPathResolver` which is used to resolve the path of all Public API data set version files so that 
when running in an integration test environment the path of the current operating system user's 'temp' directory is used as the base file path. The directory `ExploreEducationStatistics` is also appended to that temp path.

Previously the base path was made up of the location of the executing assembly which can already be long depending on the location of the project source code but is made even longer by the `GovUk.Education.ExploreEducationStatistics...` namespace. In integration tests we also append a random test instance directory to the path which adds an additional 36 characters (plus separator) to the length.

An example Windows file path being created by tests before this change was

```C:\Users\ben\dev\explore-education-statistics\src\GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests\bin\Debug\net8.0\data\public-api-data\3ea6b3e4-f96a-4583-99d2-72c4108197c2\9c252d31-700d-524c-0a10-9cd59b6c8065\v1.0\location_options.parquet```
**(262 characters)**

With this change the equivalent file path becomes
```C:\Users\ben\AppData\Local\Temp\ExploreEducationStatistics\data\data-files\3ea6b3e4-f96a-4583-99d2-72c4108197c2\9c252d31-700d-524c-0a10-9cd59b6c8065\v1.0\location_options.parquet```
**(178 characters)**

This change is being made to shorten file paths due to hitting an exception when executing DuckDb commands to query or export data.

Example of an error being hit exporting data:

```
DuckDB.NET.Data.DuckDBException : IO Error: Cannot open file "C:\Users\ben\dev\explore-education-statistics\src\GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests\bin\Debug\net8.0\data\public-api-data\160dc4f6-dd38-46fc-9697-70057b9f73ff\9c252d31-700d-524c-0a10-9cd59b6c8065\v1.0\filter_options.parquet": The system cannot find the path specified.
```

Example of an error being hit querying data:

```
DuckDB.NET.Data.DuckDBException : IO Error: No files found that match the pattern "C:\Users\JackMacDonald\Source\explore-education-statistics\src\GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests\bin\Debug\net8.0\data\public-api-data\5f87dc85-1118-4611-9fac-f01a54b8d95a\9c252d31-700d-524c-0a10-9cd59b6c8065\v1.0\data.csv.gz"
```

When this was investigated I found that the files in the error always exceeded a path length of 256 characters. This appears to be a bug with DuckDb opening or creating files in Windows exceeding 256 characters in length presumably due to hitting a maximum path length limitation.