### PR TITLE
EES-5182 redirect data catalogue slug urls

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePageNew.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePageNew.tsx
@@ -157,7 +157,7 @@ export default function DataCataloguePageNew({ showTypeFilter }: Props) {
           ...router.query,
           themeId: publicationThemeId,
         },
-        ...(releaseId && { releaseId }),
+        ...(!latestOnly && releaseId && { releaseId }),
         onFetchReleases: () =>
           queryClient.fetchQuery(
             publicationQueries.listReleases(publicationSlug ?? ''),
@@ -217,9 +217,10 @@ export default function DataCataloguePageNew({ showTypeFilter }: Props) {
   }) => {
     await updateQueryParams({
       ...(filterType === 'all'
-        ? omit(router.query, 'page', ...dataSetFileFilters)
+        ? omit(router.query, 'page', 'latestOnly', ...dataSetFileFilters)
         : omit(router.query, getFiltersToRemove(filterType), 'page')),
       sortBy: searchTerm && sortBy === 'relevance' ? 'newest' : sortBy,
+      ...(filterType === 'releaseId' && { latestOnly: 'false' }),
     });
 
     logEvent({

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/getUpdatedQueryParams.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/getUpdatedQueryParams.ts
@@ -28,7 +28,7 @@ export default async function getUpdatedQueryParams({
     return {
       ...omit(query, [
         'page',
-        ...(filterByReleaseId ? ['latest'] : ['releaseId']),
+        ...(filterByReleaseId ? ['latest', 'latestOnly'] : ['releaseId']),
       ]),
       ...(!filterByReleaseId && {
         latestOnly: nextValue === 'latest' ? 'true' : 'false',

--- a/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
@@ -252,6 +252,7 @@ Remove publication filter
 Remove release filter
     user chooses select option    id:filters-form-theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
     user chooses select option    id:filters-form-publication    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
+    user chooses select option    id:filters-form-release    ${PUPIL_ABSENCE_RELEASE_NAME}
     user clicks button    ${PUPIL_ABSENCE_RELEASE_NAME}
     user checks page contains button    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
     user checks page contains button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
@@ -266,11 +267,11 @@ Clear all filters
     user checks page contains button    pupil
     user checks page contains button    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
 
-    user clicks button    Clear filters
+    user clicks button    Reset filters
 
     user checks page does not contain button    pupil
     user checks page does not contain button    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
-    user checks page does not contain button    Clear filters
+    user checks page does not contain button    Reset filters
 
 Searching
     user clicks element    id:searchForm-search
@@ -298,3 +299,21 @@ Validate zip contains correct files
     sleep    8    # wait for file to download
     ${list}=    create list    data/dates.csv    data-guidance/data-guidance.txt
     zip should contain directories and files    ui-tests-data-catalogue-%{RUN_IDENTIFIER}_2021-22-q1.zip    ${list}
+
+Validate data catalogue page redirect from slug based urls
+    environment variable should be set    PUBLIC_URL
+    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/${PUPIL_ABSENCE_PUBLICATION_SLUG}/2016-17?newDesign=true
+    user waits until h1 is visible    Data catalogue
+
+    user checks page contains button    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
+    user waits until page contains button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
+    user waits until page contains button    ${PUPIL_ABSENCE_RELEASE_NAME}
+
+    user checks element count is x    css:[data-testid="data-set-file-list"] li:first-child    2
+    ${dataSet_1}=    user gets testid element    data-set-file-summary-Absence by characteristic
+    user checks element contains    ${dataSet_1}    Absence by characteristic
+    ${dataSet_2}=    user gets testid element    data-set-file-summary-Absence in PRUs
+    user checks element contains    ${dataSet_2}    Absence in PRUs
+
+
+    


### PR DESCRIPTION
Release pages have links to the data catalogue on using publication and release slugs, e.g. `/data-catalogue/<publication-slug>/<release-slug>`. This PR adds a redirect on the new version of the data catalogue page so that these links will work correctly. The link itself will be updated as part of the tidy up ticket, [EES-4781](https://dfedigital.atlassian.net/browse/EES-4781), but we'll want to keep the redirect so that bookmarked links will still work.

Also:
- fixes a bug where removing a release filter wasn't updating the data sets list to show all releases
- fixes a UI test that broke when I changed 'clear filters' to 'reset filters'