### PR TITLE
EES-5201 Refactor functions in preparation for creating next data set versions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetsControllerTests.cs
@@ -15,7 +15,6 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -233,10 +232,10 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
                 .GenerateList();
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
-        {
-            context.DataSetVersions.AddRange(dataSetVersions);
-            context.DataSets.UpdateRange(dataSets);
-        });
+            {
+                context.DataSetVersions.AddRange(dataSetVersions);
+                context.DataSets.UpdateRange(dataSets);
+            });
 
             var response = await ListPublicationDataSets(publication.Id);
 
@@ -477,8 +476,8 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
                 .DefaultPublication()
                 .WithReleases(
                     DataFixture
-                    .DefaultRelease(publishedVersions: 1, draftVersion: true)
-                    .Generate(1)
+                        .DefaultRelease(publishedVersions: 1, draftVersion: true)
+                        .Generate(1)
                 );
 
             var liveReleaseVersion = publication.ReleaseVersions.Single(rv => rv.Published is not null);
@@ -596,8 +595,8 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
                 .DefaultPublication()
                 .WithReleases(
                     DataFixture
-                    .DefaultRelease(publishedVersions: 1, draftVersion: true)
-                    .Generate(1)
+                        .DefaultRelease(publishedVersions: 1, draftVersion: true)
+                        .Generate(1)
                 );
 
             File file = DataFixture.DefaultFile();
@@ -915,10 +914,6 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
 
     public class CreateDataSetTests(TestApplicationFactory testApp) : DataSetsControllerTests(testApp)
     {
-        public static IEnumerable<object[]> AllDataSetVersionStatuses =>
-            EnumUtil.GetEnums<DataSetVersionStatus>()
-            .Select(e => new object[] { e });
-
         [Fact]
         public async Task Success()
         {
@@ -926,8 +921,8 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
                 .DefaultPublication()
                 .WithReleases(
                     DataFixture
-                    .DefaultRelease(publishedVersions: 0, draftVersion: true)
-                    .Generate(1)
+                        .DefaultRelease(publishedVersions: 0, draftVersion: true)
+                        .Generate(1)
                 );
 
             var draftReleaseVersion = publication.ReleaseVersions.Single();
@@ -949,7 +944,7 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
             var processorClient = new Mock<IProcessorClient>(MockBehavior.Strict);
 
             processorClient
-                .Setup(c => c.CreateInitialDataSetVersion(
+                .Setup(c => c.CreateDataSet(
                     releaseFile.Id,
                     It.IsAny<CancellationToken>()))
                 .Returns(async () =>
@@ -974,7 +969,7 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
                         context.DataSets.Update(dataSet);
                     });
 
-                    return new CreateInitialDataSetVersionResponseViewModel
+                    return new CreateDataSetResponseViewModel
                     {
                         DataSetId = dataSet!.Id,
                         DataSetVersionId = dataSetVersion!.Id,
@@ -1026,7 +1021,8 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
             var releaseFileId = Guid.NewGuid();
             var processorClient = new Mock<IProcessorClient>(MockBehavior.Strict);
 
-            ErrorViewModel[] processorErrors = [
+            ErrorViewModel[] processorErrors =
+            [
                 new ErrorViewModel
                 {
                     Code = "TestError1",
@@ -1042,7 +1038,7 @@ public class DataSetsControllerTests(TestApplicationFactory testApp) : Integrati
             ];
 
             processorClient
-                .Setup(c => c.CreateInitialDataSetVersion(releaseFileId, It.IsAny<CancellationToken>()))
+                .Setup(c => c.CreateDataSet(releaseFileId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ValidationUtils.ValidationResult(processorErrors));
 
             var client = BuildApp(processorClient.Object).CreateClient();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Public.Data/ProcessorClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Public.Data/ProcessorClientTests.cs
@@ -36,14 +36,14 @@ public class ProcessorClientTests
             Mock.Of<IWebHostEnvironment>());
     }
 
-    public class CreateInitialDataSetVersionTests : ProcessorClientTests
+    public class CreateDataSetTests : ProcessorClientTests
     {
-        private static readonly Uri Uri = new(BaseUri, "api/CreateInitialDataSetVersion");
+        private static readonly Uri Uri = new(BaseUri, "api/CreateDataSet");
 
         [Fact]
         public async Task HttpClientSuccess()
         {
-            var responseBody = new CreateInitialDataSetVersionResponseViewModel
+            var responseBody = new CreateDataSetResponseViewModel
             {
                 DataSetId = Guid.NewGuid(),
                 DataSetVersionId = Guid.NewGuid(),
@@ -53,7 +53,7 @@ public class ProcessorClientTests
             _mockHttp.Expect(HttpMethod.Post, Uri.AbsoluteUri)
                 .Respond(HttpStatusCode.Accepted, "application/json", JsonConvert.SerializeObject(responseBody));
 
-            var response = await _processorClient.CreateInitialDataSetVersion(releaseFileId: Guid.NewGuid());
+            var response = await _processorClient.CreateDataSet(releaseFileId: Guid.NewGuid());
 
             _mockHttp.VerifyNoOutstandingExpectation();
 
@@ -79,7 +79,7 @@ public class ProcessorClientTests
                         }
                     }));
 
-            var response = await _processorClient.CreateInitialDataSetVersion(releaseFileId: Guid.NewGuid());
+            var response = await _processorClient.CreateDataSet(releaseFileId: Guid.NewGuid());
 
             _mockHttp.VerifyNoOutstandingExpectation();
 
@@ -93,7 +93,7 @@ public class ProcessorClientTests
             _mockHttp.Expect(HttpMethod.Post, Uri.AbsoluteUri)
                 .Respond(HttpStatusCode.NotFound);
 
-            var response = await _processorClient.CreateInitialDataSetVersion(releaseFileId: Guid.NewGuid());
+            var response = await _processorClient.CreateDataSet(releaseFileId: Guid.NewGuid());
 
             _mockHttp.VerifyNoOutstandingExpectation();
 
@@ -118,7 +118,7 @@ public class ProcessorClientTests
 
             await Assert.ThrowsAsync<HttpRequestException>(async () =>
             {
-                await _processorClient.CreateInitialDataSetVersion(releaseFileId: Guid.NewGuid());
+                await _processorClient.CreateDataSet(releaseFileId: Guid.NewGuid());
             });
 
             _mockHttp.VerifyNoOutstandingExpectation();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IProcessorClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IProcessorClient.cs
@@ -10,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.P
 
 public interface IProcessorClient
 {
-    Task<Either<ActionResult, CreateInitialDataSetVersionResponseViewModel>> CreateInitialDataSetVersion(
+    Task<Either<ActionResult, CreateDataSetResponseViewModel>> CreateDataSet(
         Guid releaseFileId,
         CancellationToken cancellationToken = default);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
@@ -80,7 +80,7 @@ internal class DataSetService(
         CancellationToken cancellationToken = default)
     {
         return await userService.CheckIsBauUser()
-            .OnSuccess(async _ => await processorClient.CreateInitialDataSetVersion(
+            .OnSuccess(async _ => await processorClient.CreateDataSet(
                 releaseFileId: releaseFileId,
                 cancellationToken: cancellationToken))
             .OnSuccess(async processorResponse => await QueryDataSet(processorResponse.DataSetId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
@@ -24,23 +24,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
 
 internal class ProcessorClient(
     ILogger<ProcessorClient> logger,
-    HttpClient httpClient, 
+    HttpClient httpClient,
     IOptions<PublicDataProcessorOptions> options,
     IWebHostEnvironment environment) : IProcessorClient
 {
-    public async Task<Either<ActionResult, CreateInitialDataSetVersionResponseViewModel>> CreateInitialDataSetVersion(
-        Guid releaseFileId, 
+    public async Task<Either<ActionResult, CreateDataSetResponseViewModel>> CreateDataSet(
+        Guid releaseFileId,
         CancellationToken cancellationToken = default)
     {
         await AddBearerToken(cancellationToken);
 
-        var request = new InitialDataSetVersionCreateRequest
+        var request = new DataSetCreateRequest
         {
             ReleaseFileId = releaseFileId,
         };
 
         var response = await httpClient
-            .PostAsJsonAsync("api/CreateInitialDataSetVersion", request, cancellationToken: cancellationToken);
+            .PostAsJsonAsync("api/CreateDataSet", request, cancellationToken: cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -56,24 +56,24 @@ internal class ProcessorClient(
                 default:
                     var message = await response.Content.ReadAsStringAsync(cancellationToken);
                     logger.LogError($"""
-                         Failed to create data set version with status code: {response.StatusCode}. Message:
-                         {message}
-                         """);
+                                     Failed to create data set with status code: {response.StatusCode}. Message:
+                                     {message}
+                                     """);
                     response.EnsureSuccessStatusCode();
                     break;
             }
         }
 
-        var content = await response.Content.ReadFromJsonAsync<CreateInitialDataSetVersionResponseViewModel>(
-                cancellationToken: cancellationToken
-            );
+        var content = await response.Content.ReadFromJsonAsync<CreateDataSetResponseViewModel>(
+            cancellationToken: cancellationToken
+        );
 
         return content
             ?? throw new Exception("Could not deserialize the response from the Public Data Processor.");
     }
 
     public async Task<Either<ActionResult, Unit>> DeleteDataSetVersion(
-        Guid dataSetVersionId, 
+        Guid dataSetVersionId,
         CancellationToken cancellationToken = default)
     {
         var response = await httpClient
@@ -126,9 +126,10 @@ internal class ProcessorClient(
         {
             var accessTokenProvider = new DefaultAzureCredential();
             var tokenResponse = await accessTokenProvider.GetTokenAsync(
-                new TokenRequestContext([$"api://{options.Value.AppRegistrationClientId}/.default"]), 
+                new TokenRequestContext([$"api://{options.Value.AppRegistrationClientId}/.default"]),
                 cancellationToken);
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokenResponse.Token);
+            httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", tokenResponse.Token);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/DataSetCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/DataSetCreateRequest.cs
@@ -2,11 +2,11 @@ using FluentValidation;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
 
-public record InitialDataSetVersionCreateRequest
+public record DataSetCreateRequest
 {
     public required Guid ReleaseFileId { get; init; }
 
-    public class Validator : AbstractValidator<InitialDataSetVersionCreateRequest>
+    public class Validator : AbstractValidator<DataSetCreateRequest>
     {
         public Validator()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CopyCsvFilesFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CopyCsvFilesFunctionTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -10,7 +9,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -50,21 +48,14 @@ public abstract class CopyCsvFilesFunctionTests(ProcessorFunctionsIntegrationTes
                 context.ReleaseFiles.AddRange(releaseDataFile, releaseMetaFile);
             });
 
-            var (dataSetVersion, instanceId) = await CreateDataSetVersion(releaseDataFile.Id, Stage.PreviousStage());
+            var (dataSetVersion, instanceId) = await CreateDataSet(Stage.PreviousStage(),
+                releaseFileId: releaseDataFile.Id);
 
             var blobStorageService = GetRequiredService<IPrivateBlobStorageService>();
 
-            var testDataDirectoryPath = Path.Combine(
-                Assembly.GetExecutingAssembly().GetDirectoryPath(),
-                "Resources",
-                "DataFiles",
-                "AbsenceSchool"
-            );
+            var testData = ProcessorTestData.AbsenceSchool;
 
-            var sourceDataFileContent = await File.ReadAllTextAsync(Path.Combine(
-                testDataDirectoryPath,
-                "data.csv"
-            ));
+            var sourceDataFileContent = await File.ReadAllTextAsync(testData.CsvDataFilePath);
 
             await using (var contentStream = sourceDataFileContent.ToStream())
             {
@@ -75,10 +66,7 @@ public abstract class CopyCsvFilesFunctionTests(ProcessorFunctionsIntegrationTes
                     ContentTypes.Csv);
             }
 
-            var sourceMetadataFileContent = await File.ReadAllTextAsync(Path.Combine(
-                testDataDirectoryPath,
-                DataSetFilenames.CsvMetadataFile
-            ));
+            var sourceMetadataFileContent = await File.ReadAllTextAsync(testData.CsvMetadataFilePath);
 
             await using (var contentStream = sourceMetadataFileContent.ToStream())
             {
@@ -90,7 +78,6 @@ public abstract class CopyCsvFilesFunctionTests(ProcessorFunctionsIntegrationTes
             }
 
             var function = GetRequiredService<CopyCsvFilesFunction>();
-
             await function.CopyCsvFiles(instanceId, CancellationToken.None);
 
             await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
@@ -99,8 +86,8 @@ public abstract class CopyCsvFilesFunctionTests(ProcessorFunctionsIntegrationTes
                 .Include(dataSetVersionImport => dataSetVersionImport.DataSetVersion)
                 .SingleAsync(i => i.InstanceId == instanceId);
 
-            Assert.Equal(DataSetVersionStatus.Processing, savedImport.DataSetVersion.Status);
             Assert.Equal(Stage, savedImport.Stage);
+            Assert.Equal(DataSetVersionStatus.Processing, savedImport.DataSetVersion.Status);
 
             var dataSetVersionPathResolver = GetRequiredService<IDataSetVersionPathResolver>();
 
@@ -124,35 +111,6 @@ public abstract class CopyCsvFilesFunctionTests(ProcessorFunctionsIntegrationTes
         {
             var bytes = await File.ReadAllBytesAsync(path);
             return await CompressionUtils.DecompressToString(bytes, ContentEncodings.Gzip);
-        }
-
-        private async Task<(DataSetVersion dataSetVersion, Guid instanceId)> CreateDataSetVersion(
-            Guid releaseFileId,
-            DataSetVersionImportStage importStage)
-        {
-            DataSet dataSet = DataFixture.DefaultDataSet();
-
-            await AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
-
-            DataSetVersionImport dataSetVersionImport = DataFixture
-                .DefaultDataSetVersionImport()
-                .WithStage(importStage);
-
-            DataSetVersion dataSetVersion = DataFixture
-                .DefaultDataSetVersion()
-                .WithDataSet(dataSet)
-                .WithReleaseFileId(releaseFileId)
-                .WithStatus(DataSetVersionStatus.Processing)
-                .WithImports(() => [dataSetVersionImport])
-                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
-
-            await AddTestData<PublicDataDbContext>(context =>
-            {
-                context.DataSetVersions.Add(dataSetVersion);
-                context.DataSets.Update(dataSet);
-            });
-
-            return (dataSetVersion, dataSetVersionImport.InstanceId);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateDataSetFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateDataSetFunctionTests.cs
@@ -22,13 +22,13 @@ using FileType = GovUk.Education.ExploreEducationStatistics.Common.Model.FileTyp
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Functions;
 
-public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunctionsIntegrationTestFixture fixture)
+public abstract class CreateDataSetFunctionTests(ProcessorFunctionsIntegrationTestFixture fixture)
     : ProcessorFunctionsIntegrationTest(fixture)
 {
     private readonly DataFixture _fixture = new();
 
-    public class CreateInitialDataSetVersionTests(ProcessorFunctionsIntegrationTestFixture fixture)
-        : CreateInitialDataSetVersionFunctionTests(fixture)
+    public class CreateDataSetTests(ProcessorFunctionsIntegrationTestFixture fixture)
+        : CreateDataSetFunctionTests(fixture)
     {
         private const string DurableTaskClientName = "TestClient";
 
@@ -71,13 +71,13 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
                         startOrchestrationOptions = options;
                     });
 
-            var result = await CreateInitialDataSetVersion(
+            var result = await CreateDataSet(
                 releaseFileId: releaseFile.Id,
                 durableTaskClientMock.Object);
 
             VerifyAllMocks(durableTaskClientMock);
 
-            var responseViewModel = result.AssertOkObjectResult<CreateInitialDataSetVersionResponseViewModel>();
+            var responseViewModel = result.AssertOkObjectResult<CreateDataSetResponseViewModel>();
 
             await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
 
@@ -136,7 +136,7 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
         {
             var durableTaskClientMock = new Mock<DurableTaskClient>(DurableTaskClientName);
 
-            var result = await CreateInitialDataSetVersion(
+            var result = await CreateDataSet(
                 releaseFileId: Guid.Empty,
                 durableTaskClientMock.Object);
 
@@ -145,7 +145,7 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasNotEmptyError(
-                nameof(InitialDataSetVersionCreateRequest.ReleaseFileId).ToLowerFirst());
+                nameof(DataSetCreateRequest.ReleaseFileId).ToLowerFirst());
         }
 
         [Fact]
@@ -153,7 +153,7 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
         {
             var durableTaskClientMock = new Mock<DurableTaskClient>(DurableTaskClientName);
 
-            var result = await CreateInitialDataSetVersion(
+            var result = await CreateDataSet(
                 releaseFileId: Guid.NewGuid(),
                 durableTaskClientMock.Object);
 
@@ -162,7 +162,7 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(InitialDataSetVersionCreateRequest.ReleaseFileId).ToLowerFirst(),
+                expectedPath: nameof(DataSetCreateRequest.ReleaseFileId).ToLowerFirst(),
                 expectedCode: ValidationMessages.FileNotFound.Code);
         }
 
@@ -193,7 +193,7 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
 
             var durableTaskClientMock = new Mock<DurableTaskClient>(DurableTaskClientName);
 
-            var result = await CreateInitialDataSetVersion(
+            var result = await CreateDataSet(
                 releaseFileId: releaseFile.Id,
                 durableTaskClientMock.Object);
 
@@ -202,7 +202,7 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(InitialDataSetVersionCreateRequest.ReleaseFileId).ToLowerFirst(),
+                expectedPath: nameof(DataSetCreateRequest.ReleaseFileId).ToLowerFirst(),
                 expectedCode: ValidationMessages.FileHasApiDataSetVersion.Code);
         }
 
@@ -226,7 +226,7 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
 
             var durableTaskClientMock = new Mock<DurableTaskClient>(DurableTaskClientName);
 
-            var result = await CreateInitialDataSetVersion(
+            var result = await CreateDataSet(
                 releaseFileId: releaseFile.Id,
                 durableTaskClientMock.Object);
 
@@ -235,7 +235,7 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(InitialDataSetVersionCreateRequest.ReleaseFileId).ToLowerFirst(),
+                expectedPath: nameof(DataSetCreateRequest.ReleaseFileId).ToLowerFirst(),
                 expectedCode: ValidationMessages.FileReleaseVersionNotDraft.Code
             );
         }
@@ -255,7 +255,7 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
 
             var durableTaskClientMock = new Mock<DurableTaskClient>(DurableTaskClientName);
 
-            var result = await CreateInitialDataSetVersion(
+            var result = await CreateDataSet(
                 releaseFileId: releaseFile.Id,
                 durableTaskClientMock.Object);
 
@@ -264,7 +264,7 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(InitialDataSetVersionCreateRequest.ReleaseFileId).ToLowerFirst(),
+                expectedPath: nameof(DataSetCreateRequest.ReleaseFileId).ToLowerFirst(),
                 expectedCode: ValidationMessages.FileTypeNotData.Code
             );
         }
@@ -283,7 +283,7 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
 
             var durableTaskClientMock = new Mock<DurableTaskClient>(DurableTaskClientName);
 
-            var result = await CreateInitialDataSetVersion(
+            var result = await CreateDataSet(
                 releaseFileId: releaseFile.Id,
                 durableTaskClientMock.Object);
 
@@ -292,17 +292,17 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(InitialDataSetVersionCreateRequest.ReleaseFileId).ToLowerFirst(),
+                expectedPath: nameof(DataSetCreateRequest.ReleaseFileId).ToLowerFirst(),
                 expectedCode: ValidationMessages.NoMetadataFile.Code
             );
         }
 
-        private async Task<IActionResult> CreateInitialDataSetVersion(
+        private async Task<IActionResult> CreateDataSet(
             Guid releaseFileId,
             DurableTaskClient durableTaskClient)
         {
-            var function = GetRequiredService<CreateInitialDataSetVersionFunction>();
-            return await function.CreateInitialDataSetVersion(new InitialDataSetVersionCreateRequest
+            var function = GetRequiredService<CreateDataSetFunction>();
+            return await function.CreateDataSet(new DataSetCreateRequest
                 {
                     ReleaseFileId = releaseFileId
                 },

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateInitialDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateInitialDataSetVersionFunctionTests.cs
@@ -120,13 +120,15 @@ public abstract class CreateInitialDataSetVersionFunctionTests(ProcessorFunction
             Assert.NotNull(processInitialDataSetVersionContext);
             Assert.NotNull(startOrchestrationOptions);
             Assert.Equal(new ProcessInitialDataSetVersionContext
-            {
-                DataSetVersionId = dataSetVersion.Id
-            }, processInitialDataSetVersionContext);
+                {
+                    DataSetVersionId = dataSetVersion.Id
+                },
+                processInitialDataSetVersionContext);
             Assert.Equal(new StartOrchestrationOptions
-            {
-                InstanceId = dataSetVersionImport.InstanceId.ToString()
-            }, startOrchestrationOptions);
+                {
+                    InstanceId = dataSetVersionImport.InstanceId.ToString()
+                },
+                startOrchestrationOptions);
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/HandleProcessingFailureFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/HandleProcessingFailureFunctionTests.cs
@@ -1,0 +1,38 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Functions;
+
+public abstract class HandleProcessingFailureFunctionTests(ProcessorFunctionsIntegrationTestFixture fixture)
+    : ProcessorFunctionsIntegrationTest(fixture)
+{
+    public class HandleProcessingFailureTests(ProcessorFunctionsIntegrationTestFixture fixture)
+        : HandleProcessingFailureFunctionTests(fixture)
+    {
+        [Fact]
+        public async Task Success()
+        {
+            // The stage which the failure occured in - This should not be altered by the handler
+            const DataSetVersionImportStage failedStage = DataSetVersionImportStage.CopyingCsvFiles;
+
+            var (_, instanceId) = await CreateDataSet(failedStage);
+
+            var function = GetRequiredService<HandleProcessingFailureFunction>();
+            await function.HandleProcessingFailure(instanceId, CancellationToken.None);
+
+            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
+
+            var savedImport = await publicDataDbContext.DataSetVersionImports
+                .Include(i => i.DataSetVersion)
+                .SingleAsync(i => i.InstanceId == instanceId);
+
+            Assert.Equal(failedStage, savedImport.Stage);
+            savedImport.Completed.AssertUtcNow();
+
+            Assert.Equal(DataSetVersionStatus.Failed, savedImport.DataSetVersion.Status);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ImportMetadataFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ImportMetadataFunctionTests.cs
@@ -1,0 +1,43 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Functions;
+
+public abstract class ImportMetadataFunctionTests(ProcessorFunctionsIntegrationTestFixture fixture)
+    : ProcessorFunctionsIntegrationTest(fixture)
+{
+    public class ImportMetadataTests(ProcessorFunctionsIntegrationTestFixture fixture)
+        : ImportMetadataFunctionTests(fixture)
+    {
+        private const DataSetVersionImportStage Stage = DataSetVersionImportStage.ImportingMetadata;
+
+        [Fact]
+        public async Task Success()
+        {
+            var (dataSetVersion, instanceId) = await CreateDataSet(Stage.PreviousStage());
+
+            SetupCsvDataFilesForDataSetVersion(ProcessorTestData.AbsenceSchool, dataSetVersion);
+
+            var function = GetRequiredService<ImportMetadataFunction>();
+            await function.ImportMetadata(instanceId, CancellationToken.None);
+
+            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
+
+            var savedImport = await publicDataDbContext.DataSetVersionImports
+                .Include(dataSetVersionImport => dataSetVersionImport.DataSetVersion)
+                .SingleAsync(i => i.InstanceId == instanceId);
+
+            Assert.Equal(Stage, savedImport.Stage);
+            Assert.Equal(DataSetVersionStatus.Processing, savedImport.DataSetVersion.Status);
+
+            AssertDataSetVersionDirectoryContainsOnlyFiles(dataSetVersion,
+            [
+                DataSetFilenames.CsvDataFile,
+                DataSetFilenames.CsvMetadataFile,
+                DataSetFilenames.DuckDbDatabaseFile
+            ]);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessInitialDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessInitialDataSetVersionFunctionTests.cs
@@ -93,7 +93,7 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
                 .InSequence(activitySequence)
                 .Setup(context =>
                     context.CallActivityAsync(ActivityNames.HandleProcessingFailure,
-                        null,
+                        mockOrchestrationContext.Object.InstanceId,
                         null))
                 .Returns(Task.CompletedTask);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessInitialDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessInitialDataSetVersionFunctionTests.cs
@@ -1,11 +1,7 @@
-using System.Reflection;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Extensions;
@@ -24,13 +20,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests
 public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctionsIntegrationTestFixture fixture)
     : ProcessorFunctionsIntegrationTest(fixture)
 {
-    private readonly string _testDataDirectoryPath = Path.Combine(
-        Assembly.GetExecutingAssembly().GetDirectoryPath(),
-        "Resources",
-        "DataFiles",
-        "AbsenceSchool"
-    );
-
     private readonly string[] _allDataSetVersionFiles =
     [
         DataSetFilenames.CsvDataFile,
@@ -55,7 +44,7 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
 
             // Expect an entity lock to be acquired for calling the ImportMetadata activity
             var mockEntityFeature = new Mock<TaskOrchestrationEntityFeature>(MockBehavior.Strict);
-            mockEntityFeature.SetupLockForActivity(nameof(ProcessInitialDataSetVersionFunction.ImportMetadata));
+            mockEntityFeature.SetupLockForActivity(ActivityNames.ImportMetadata);
             mockOrchestrationContext.SetupGet(context => context.Entities)
                 .Returns(mockEntityFeature.Object);
 
@@ -63,11 +52,11 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
 
             string[] expectedActivitySequence =
             [
-                nameof(CopyCsvFilesFunction.CopyCsvFiles),
-                nameof(ProcessInitialDataSetVersionFunction.ImportMetadata),
-                nameof(ProcessInitialDataSetVersionFunction.ImportData),
-                nameof(ProcessInitialDataSetVersionFunction.WriteDataFiles),
-                nameof(ProcessInitialDataSetVersionFunction.CompleteProcessing)
+                ActivityNames.CopyCsvFiles,
+                ActivityNames.ImportMetadata,
+                ActivityNames.ImportData,
+                ActivityNames.WriteDataFiles,
+                ActivityNames.CompleteProcessing,
             ];
 
             foreach (var activityName in expectedActivitySequence)
@@ -95,7 +84,7 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
             mockOrchestrationContext
                 .InSequence(activitySequence)
                 .Setup(context =>
-                    context.CallActivityAsync(nameof(CopyCsvFilesFunction.CopyCsvFiles),
+                    context.CallActivityAsync(ActivityNames.CopyCsvFiles,
                         mockOrchestrationContext.Object.InstanceId,
                         null))
                 .Throws<Exception>();
@@ -103,7 +92,7 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
             mockOrchestrationContext
                 .InSequence(activitySequence)
                 .Setup(context =>
-                    context.CallActivityAsync(nameof(ProcessInitialDataSetVersionFunction.HandleProcessingFailure),
+                    context.CallActivityAsync(ActivityNames.HandleProcessingFailure,
                         null,
                         null))
                 .Returns(Task.CompletedTask);
@@ -147,40 +136,6 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
         }
     }
 
-    public class ImportMetadataTests(ProcessorFunctionsIntegrationTestFixture fixture)
-        : ProcessInitialDataSetVersionFunctionTests(fixture)
-    {
-        private const DataSetVersionImportStage Stage = DataSetVersionImportStage.ImportingMetadata;
-
-        [Fact]
-        public async Task Success()
-        {
-            var (dataSetVersion, instanceId) = await CreateDataSetVersion(Stage.PreviousStage());
-
-            // Prepare the data set version directory with data and metadata CSV files
-            SetupCsvDataFiles(dataSetVersion);
-
-            var function = GetRequiredService<ProcessInitialDataSetVersionFunction>();
-            await function.ImportMetadata(instanceId, CancellationToken.None);
-
-            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
-
-            var savedImport = await publicDataDbContext.DataSetVersionImports
-                .Include(dataSetVersionImport => dataSetVersionImport.DataSetVersion)
-                .SingleAsync(i => i.InstanceId == instanceId);
-
-            Assert.Equal(DataSetVersionStatus.Processing, savedImport.DataSetVersion.Status);
-            Assert.Equal(Stage, savedImport.Stage);
-
-            AssertDataSetVersionDirectoryContainsOnlyFiles(dataSetVersion,
-            [
-                DataSetFilenames.CsvDataFile,
-                DataSetFilenames.CsvMetadataFile,
-                DataSetFilenames.DuckDbDatabaseFile
-            ]);
-        }
-    }
-
     public class ImportDataTests(ProcessorFunctionsIntegrationTestFixture fixture)
         : ProcessInitialDataSetVersionFunctionTests(fixture)
     {
@@ -189,17 +144,16 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
         [Fact]
         public async Task Success()
         {
-            var (dataSetVersion, instanceId) = await CreateDataSetVersion(Stage.PreviousStage());
+            var (dataSetVersion, instanceId) = await CreateDataSet(Stage.PreviousStage());
 
-            // Prepare the data set version directory with data and metadata CSV files
-            SetupCsvDataFiles(dataSetVersion);
-
-            var function = GetRequiredService<ProcessInitialDataSetVersionFunction>();
+            SetupCsvDataFilesForDataSetVersion(ProcessorTestData.AbsenceSchool, dataSetVersion);
 
             // Prepare the metadata before calling the ImportData function
-            await function.ImportMetadata(instanceId, CancellationToken.None);
+            var importMetadataFunction = GetRequiredService<ImportMetadataFunction>();
+            await importMetadataFunction.ImportMetadata(instanceId, CancellationToken.None);
 
-            await function.ImportData(instanceId, CancellationToken.None);
+            var processInitialDataSetVersionFunction = GetRequiredService<ProcessInitialDataSetVersionFunction>();
+            await processInitialDataSetVersionFunction.ImportData(instanceId, CancellationToken.None);
 
             await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
 
@@ -207,8 +161,8 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
                 .Include(dataSetVersionImport => dataSetVersionImport.DataSetVersion)
                 .SingleAsync(i => i.InstanceId == instanceId);
 
-            Assert.Equal(DataSetVersionStatus.Processing, savedImport.DataSetVersion.Status);
             Assert.Equal(Stage, savedImport.Stage);
+            Assert.Equal(DataSetVersionStatus.Processing, savedImport.DataSetVersion.Status);
 
             AssertDataSetVersionDirectoryContainsOnlyFiles(dataSetVersion,
             [
@@ -227,18 +181,19 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
         [Fact]
         public async Task Success()
         {
-            var (dataSetVersion, instanceId) = await CreateDataSetVersion(Stage.PreviousStage());
+            var (dataSetVersion, instanceId) = await CreateDataSet(Stage.PreviousStage());
 
-            // Prepare the data set version directory with data and metadata CSV files
-            SetupCsvDataFiles(dataSetVersion);
-
-            var function = GetRequiredService<ProcessInitialDataSetVersionFunction>();
+            SetupCsvDataFilesForDataSetVersion(ProcessorTestData.AbsenceSchool, dataSetVersion);
 
             // Prepare the metadata and data before calling the WriteDataFiles function
-            await function.ImportMetadata(instanceId, CancellationToken.None);
-            await function.ImportData(instanceId, CancellationToken.None);
+            var importMetadataFunction = GetRequiredService<ImportMetadataFunction>();
+            await importMetadataFunction.ImportMetadata(instanceId, CancellationToken.None);
 
-            await function.WriteDataFiles(instanceId, CancellationToken.None);
+            var importDataFunction = GetRequiredService<ProcessInitialDataSetVersionFunction>();
+            await importDataFunction.ImportData(instanceId, CancellationToken.None);
+
+            var processInitialDataSetVersionFunction = GetRequiredService<ProcessInitialDataSetVersionFunction>();
+            await processInitialDataSetVersionFunction.WriteDataFiles(instanceId, CancellationToken.None);
 
             await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
 
@@ -246,36 +201,10 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
                 .Include(dataSetVersionImport => dataSetVersionImport.DataSetVersion)
                 .SingleAsync(i => i.InstanceId == instanceId);
 
-            Assert.Equal(DataSetVersionStatus.Processing, savedImport.DataSetVersion.Status);
             Assert.Equal(Stage, savedImport.Stage);
+            Assert.Equal(DataSetVersionStatus.Processing, savedImport.DataSetVersion.Status);
 
             AssertDataSetVersionDirectoryContainsOnlyFiles(dataSetVersion, _allDataSetVersionFiles);
-        }
-    }
-
-    public class HandleProcessingFailureTests(ProcessorFunctionsIntegrationTestFixture fixture)
-        : ProcessInitialDataSetVersionFunctionTests(fixture)
-    {
-        [Fact]
-        public async Task Success()
-        {
-            // The stage which the failure occured in - This should not be altered by the handler
-            const DataSetVersionImportStage failedStage = DataSetVersionImportStage.CopyingCsvFiles;
-
-            var (_, instanceId) = await CreateDataSetVersion(failedStage);
-
-            var function = GetRequiredService<ProcessInitialDataSetVersionFunction>();
-            await function.HandleProcessingFailure(instanceId, CancellationToken.None);
-
-            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
-
-            var savedImport = await publicDataDbContext.DataSetVersionImports
-                .Include(i => i.DataSetVersion)
-                .SingleAsync(i => i.InstanceId == instanceId);
-
-            Assert.Equal(DataSetVersionStatus.Failed, savedImport.DataSetVersion.Status);
-            Assert.Equal(failedStage, savedImport.Stage);
-            savedImport.Completed.AssertUtcNow();
         }
     }
 
@@ -287,7 +216,7 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
         [Fact]
         public async Task Success()
         {
-            var (dataSetVersion, instanceId) = await CreateDataSetVersion(Stage.PreviousStage());
+            var (dataSetVersion, instanceId) = await CreateDataSet(Stage.PreviousStage());
 
             var dataSetVersionPathResolver = GetRequiredService<IDataSetVersionPathResolver>();
             Directory.CreateDirectory(dataSetVersionPathResolver.DirectoryPath(dataSetVersion));
@@ -300,15 +229,16 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
                 .Include(i => i.DataSetVersion)
                 .SingleAsync(i => i.InstanceId == instanceId);
 
-            Assert.Equal(DataSetVersionStatus.Draft, savedImport.DataSetVersion.Status);
             Assert.Equal(Stage, savedImport.Stage);
             savedImport.Completed.AssertUtcNow();
+
+            Assert.Equal(DataSetVersionStatus.Draft, savedImport.DataSetVersion.Status);
         }
 
         [Fact]
         public async Task DuckDbFileIsDeleted()
         {
-            var (dataSetVersion, instanceId) = await CreateDataSetVersion(Stage.PreviousStage());
+            var (dataSetVersion, instanceId) = await CreateDataSet(Stage.PreviousStage());
 
             // Create empty data set version files for all file paths
             var dataSetVersionPathResolver = GetRequiredService<IDataSetVersionPathResolver>();
@@ -333,56 +263,5 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(ProcessorFunctio
             var function = GetRequiredService<ProcessInitialDataSetVersionFunction>();
             await function.CompleteProcessing(instanceId, CancellationToken.None);
         }
-    }
-
-    private async Task<(DataSetVersion dataSetVersion, Guid instanceId)> CreateDataSetVersion(
-        DataSetVersionImportStage importStage)
-    {
-        DataSet dataSet = DataFixture.DefaultDataSet();
-
-        await AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
-
-        DataSetVersionImport dataSetVersionImport = DataFixture
-            .DefaultDataSetVersionImport()
-            .WithStage(importStage);
-
-        DataSetVersion dataSetVersion = DataFixture
-            .DefaultDataSetVersion()
-            .WithDataSet(dataSet)
-            .WithStatus(DataSetVersionStatus.Processing)
-            .WithImports(() => [dataSetVersionImport])
-            .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
-
-        await AddTestData<PublicDataDbContext>(context =>
-        {
-            context.DataSetVersions.Add(dataSetVersion);
-            context.DataSets.Update(dataSet);
-        });
-
-        return (dataSetVersion, dataSetVersionImport.InstanceId);
-    }
-
-    private void SetupCsvDataFiles(DataSetVersion dataSetVersion)
-    {
-        var dataSetVersionPathResolver = GetRequiredService<IDataSetVersionPathResolver>();
-        Directory.CreateDirectory(dataSetVersionPathResolver.DirectoryPath(dataSetVersion));
-        File.Copy(Path.Combine(_testDataDirectoryPath, DataSetFilenames.CsvDataFile),
-            dataSetVersionPathResolver.CsvDataPath(dataSetVersion));
-        File.Copy(Path.Combine(_testDataDirectoryPath, DataSetFilenames.CsvMetadataFile),
-            dataSetVersionPathResolver.CsvMetadataPath(dataSetVersion));
-    }
-
-    private void AssertDataSetVersionDirectoryContainsOnlyFiles(
-        DataSetVersion dataSetVersion,
-        params string[] expectedFiles)
-    {
-        var dataSetVersionPathResolver = GetRequiredService<IDataSetVersionPathResolver>();
-        var actualFiles = Directory.GetFiles(dataSetVersionPathResolver.DirectoryPath(dataSetVersion))
-            .Select(Path.GetFileName)
-            .ToArray();
-
-        // Assert that the directory contains the expected files and no others
-        Assert.Equal(expectedFiles.Length, actualFiles.Length);
-        Assert.True(ComparerUtils.SequencesAreEqualIgnoringOrder(expectedFiles, actualFiles));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
@@ -153,7 +153,7 @@ public class ProcessorFunctionsIntegrationTestFixture : FunctionsIntegrationTest
     {
         return
         [
-            typeof(CreateInitialDataSetVersionFunction),
+            typeof(CreateDataSetFunction),
             typeof(ProcessInitialDataSetVersionFunction),
             typeof(DeleteDataSetVersionFunction),
             typeof(CopyCsvFilesFunction),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
@@ -1,7 +1,9 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Tests;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -31,6 +33,66 @@ public abstract class ProcessorFunctionsIntegrationTest
         {
             Directory.Delete(testInstanceDataFilesDirectory, recursive: true);
         }
+    }
+
+    protected void SetupCsvDataFilesForDataSetVersion(ProcessorTestData processorTestData, DataSetVersion dataSetVersion)
+    {
+        var dataSetVersionPathResolver = GetRequiredService<IDataSetVersionPathResolver>();
+
+        var dataSetVersionDir = dataSetVersionPathResolver.DirectoryPath(dataSetVersion);
+        if (!Directory.Exists(dataSetVersionDir))
+        {
+            Directory.CreateDirectory(dataSetVersionDir);
+        }
+
+        // Prepare the data set version directory with data and metadata CSV files
+        File.Copy(sourceFileName: processorTestData.CsvDataGzipFilePath,
+            destFileName: dataSetVersionPathResolver.CsvDataPath(dataSetVersion));
+        File.Copy(sourceFileName: processorTestData.CsvMetadataFilePath,
+            destFileName: dataSetVersionPathResolver.CsvMetadataPath(dataSetVersion));
+    }
+
+    protected async Task<(DataSetVersion dataSetVersion, Guid instanceId)> CreateDataSet(
+        DataSetVersionImportStage importStage,
+        DataSetVersionStatus? status = null,
+        Guid? releaseFileId = null)
+    {
+        DataSet dataSet = DataFixture.DefaultDataSet();
+
+        await AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+        DataSetVersionImport dataSetVersionImport = DataFixture
+            .DefaultDataSetVersionImport()
+            .WithStage(importStage);
+
+        DataSetVersion dataSetVersion = DataFixture
+            .DefaultDataSetVersion()
+            .WithDataSet(dataSet)
+            .WithReleaseFileId(releaseFileId ?? Guid.NewGuid())
+            .WithStatus(status ?? DataSetVersionStatus.Processing)
+            .WithImports(() => [dataSetVersionImport])
+            .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+        await AddTestData<PublicDataDbContext>(context =>
+        {
+            context.DataSetVersions.Add(dataSetVersion);
+            context.DataSets.Update(dataSet);
+        });
+
+        return (dataSetVersion, dataSetVersionImport.InstanceId);
+    }
+
+    protected void AssertDataSetVersionDirectoryContainsOnlyFiles(
+        DataSetVersion dataSetVersion,
+        params string[] expectedFiles)
+    {
+        var dataSetVersionPathResolver = GetRequiredService<IDataSetVersionPathResolver>();
+        var actualFiles = Directory.GetFiles(dataSetVersionPathResolver.DirectoryPath(dataSetVersion))
+            .Select(Path.GetFileName)
+            .ToArray();
+
+        // Assert that the directory contains the expected files and no others
+        Assert.Equal(expectedFiles.Order(), actualFiles.Order());
     }
 }
 
@@ -91,11 +153,13 @@ public class ProcessorFunctionsIntegrationTestFixture : FunctionsIntegrationTest
     {
         return
         [
-            typeof(CopyCsvFilesFunction),
             typeof(CreateInitialDataSetVersionFunction),
             typeof(ProcessInitialDataSetVersionFunction),
-            typeof(HealthCheckFunctions),
             typeof(DeleteDataSetVersionFunction),
+            typeof(CopyCsvFilesFunction),
+            typeof(ImportMetadataFunction),
+            typeof(HandleProcessingFailureFunction),
+            typeof(HealthCheckFunctions),
         ];
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorTestData.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorTestData.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests;
+
+public record ProcessorTestData(string Name)
+{
+    private static string DataFilesDirectoryPath => Path.Combine(
+        Assembly.GetExecutingAssembly().GetDirectoryPath(),
+        "Resources",
+        "DataFiles"
+    );
+
+    private string DirectoryPath => Path.Combine(DataFilesDirectoryPath, Name);
+
+    public string CsvDataFilePath => Path.Combine(DirectoryPath, "data.csv");
+    public string CsvDataGzipFilePath => Path.Combine(DirectoryPath, "data.csv.gz");
+    public string CsvMetadataFilePath => Path.Combine(DirectoryPath, "metadata.csv");
+
+    public static ProcessorTestData AbsenceSchool => new(nameof(AbsenceSchool));
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels/CreateDataSetResponseViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels/CreateDataSetResponseViewModel.cs
@@ -1,6 +1,6 @@
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels;
 
-public record CreateInitialDataSetVersionResponseViewModel
+public record CreateDataSetResponseViewModel
 {
     public required Guid DataSetId { get; init; }
     public required Guid DataSetVersionId { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ActivityNames.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ActivityNames.cs
@@ -1,0 +1,12 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
+
+internal static class ActivityNames
+{
+    public const string CopyCsvFiles = nameof(CopyCsvFilesFunction.CopyCsvFiles);
+    public const string ImportMetadata = nameof(ImportMetadataFunction.ImportMetadata);
+    public const string HandleProcessingFailure = nameof(HandleProcessingFailureFunction.HandleProcessingFailure);
+
+    public const string ImportData = nameof(ProcessInitialDataSetVersionFunction.ImportData);
+    public const string WriteDataFiles = nameof(ProcessInitialDataSetVersionFunction.WriteDataFiles);
+    public const string CompleteProcessing = nameof(ProcessInitialDataSetVersionFunction.CompleteProcessing);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CopyCsvFilesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CopyCsvFilesFunction.cs
@@ -20,7 +20,7 @@ public class CopyCsvFilesFunction(
     IDataSetVersionPathResolver dataSetVersionPathResolver,
     IPrivateBlobStorageService privateBlobStorageService) : BaseProcessDataSetVersionFunction(publicDataDbContext)
 {
-    [Function(nameof(CopyCsvFiles))]
+    [Function(ActivityNames.CopyCsvFiles)]
     public async Task CopyCsvFiles(
         [ActivityTrigger] Guid instanceId,
         CancellationToken cancellationToken)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateDataSetFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateDataSetFunction.cs
@@ -14,15 +14,15 @@ using FromBodyAttribute = Microsoft.Azure.Functions.Worker.Http.FromBodyAttribut
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
 
-public class CreateInitialDataSetVersionFunction(
-    ILogger<CreateInitialDataSetVersionFunction> logger,
+public class CreateDataSetFunction(
+    ILogger<CreateDataSetFunction> logger,
     IDataSetService dataSetService,
-    IValidator<InitialDataSetVersionCreateRequest> requestValidator)
+    IValidator<DataSetCreateRequest> requestValidator)
 {
-    [Function(nameof(CreateInitialDataSetVersion))]
-    public async Task<IActionResult> CreateInitialDataSetVersion(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = nameof(CreateInitialDataSetVersion))] [FromBody]
-        InitialDataSetVersionCreateRequest request,
+    [Function(nameof(CreateDataSet))]
+    public async Task<IActionResult> CreateDataSet(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = nameof(CreateDataSet))] [FromBody]
+        DataSetCreateRequest request,
         [DurableClient] DurableTaskClient client,
         CancellationToken cancellationToken)
     {
@@ -30,7 +30,7 @@ public class CreateInitialDataSetVersionFunction(
         var instanceId = Guid.NewGuid();
 
         return await requestValidator.Validate(request, cancellationToken)
-            .OnSuccess(() => dataSetService.CreateDataSetVersion(
+            .OnSuccess(() => dataSetService.CreateDataSet(
                 request,
                 instanceId,
                 cancellationToken: cancellationToken
@@ -43,10 +43,10 @@ public class CreateInitialDataSetVersionFunction(
                     instanceId: instanceId,
                     cancellationToken);
 
-                return new CreateInitialDataSetVersionResponseViewModel
+                return new CreateDataSetResponseViewModel
                 {
                     DataSetId = tuple.dataSetId,
-                    DataSetVersionId = tuple.dataSetVersionId, 
+                    DataSetVersionId = tuple.dataSetVersionId,
                     InstanceId = instanceId
                 };
             })

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/HandleProcesssingFailureFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/HandleProcesssingFailureFunction.cs
@@ -1,0 +1,24 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
+
+public class HandleProcessingFailureFunction(
+    PublicDataDbContext publicDataDbContext) : BaseProcessDataSetVersionFunction(publicDataDbContext)
+{
+    private readonly PublicDataDbContext _publicDataDbContext = publicDataDbContext;
+
+    [Function(ActivityNames.HandleProcessingFailure)]
+    public async Task HandleProcessingFailure(
+        [ActivityTrigger] Guid instanceId,
+        CancellationToken cancellationToken)
+    {
+        var dataSetVersionImport = await GetDataSetVersionImport(instanceId, cancellationToken);
+        var dataSetVersion = dataSetVersionImport.DataSetVersion;
+
+        dataSetVersion.Status = DataSetVersionStatus.Failed;
+        dataSetVersionImport.Completed = DateTimeOffset.UtcNow;
+        await _publicDataDbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ImportMetadataFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ImportMetadataFunction.cs
@@ -1,0 +1,21 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Services.Interfaces;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
+
+public class ImportMetadataFunction(
+    PublicDataDbContext publicDataDbContext,
+    IDataSetMetaService dataSetMetaService) : BaseProcessDataSetVersionFunction(publicDataDbContext)
+{
+    [Function(ActivityNames.ImportMetadata)]
+    public async Task ImportMetadata(
+        [ActivityTrigger] Guid instanceId,
+        CancellationToken cancellationToken)
+    {
+        var dataSetVersionImport = await GetDataSetVersionImport(instanceId, cancellationToken);
+        await UpdateImportStage(dataSetVersionImport, DataSetVersionImportStage.ImportingMetadata, cancellationToken);
+        await dataSetMetaService.CreateDataSetVersionMeta(dataSetVersionImport.DataSetVersionId, cancellationToken);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessInitialDataSetVersionFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessInitialDataSetVersionFunction.cs
@@ -46,7 +46,7 @@ public class ProcessInitialDataSetVersionFunction(
                 context.InstanceId,
                 input.DataSetVersionId);
 
-            await context.CallActivity(ActivityNames.HandleProcessingFailure, logger);
+            await context.CallActivity(ActivityNames.HandleProcessingFailure, logger, context.InstanceId);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/ProcessorHostBuilder.cs
@@ -83,8 +83,8 @@ public static class ProcessorHostBuilder
                     .AddScoped<ITimePeriodMetaRepository, TimePeriodMetaRepository>()
                     .AddScoped<IParquetService, ParquetService>()
                     .AddScoped<IPrivateBlobStorageService, PrivateBlobStorageService>()
-                    .AddScoped<IValidator<InitialDataSetVersionCreateRequest>,
-                        InitialDataSetVersionCreateRequest.Validator>()
+                    .AddScoped<IValidator<DataSetCreateRequest>,
+                        DataSetCreateRequest.Validator>()
                     .Configure<DataFilesOptions>(
                         hostBuilderContext.Configuration.GetSection(DataFilesOptions.Section));
             });

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetService.cs
@@ -22,8 +22,8 @@ public class DataSetService(
     PublicDataDbContext publicDataDbContext
 ) : IDataSetService
 {
-    public async Task<Either<ActionResult, (Guid dataSetId, Guid dataSetVersionId)>> CreateDataSetVersion(
-        InitialDataSetVersionCreateRequest request,
+    public async Task<Either<ActionResult, (Guid dataSetId, Guid dataSetVersionId)>> CreateDataSet(
+        DataSetCreateRequest request,
         Guid instanceId,
         CancellationToken cancellationToken = default)
     {
@@ -65,9 +65,9 @@ public class DataSetService(
 
         return releaseFile is null
             ? ValidationUtils.ValidationResult(CreateReleaseFileIdError(
-                    message: ValidationMessages.FileNotFound,
-                    releaseFileId: releaseFileId
-                ))
+                message: ValidationMessages.FileNotFound,
+                releaseFileId: releaseFileId
+            ))
             : releaseFile;
     }
 
@@ -200,7 +200,7 @@ public class DataSetService(
         {
             Code = message.Code,
             Message = message.Message,
-            Path = nameof(InitialDataSetVersionCreateRequest.ReleaseFileId).ToLowerFirst(),
+            Path = nameof(DataSetCreateRequest.ReleaseFileId).ToLowerFirst(),
             Detail = new InvalidErrorDetail<Guid>(releaseFileId)
         };
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/Interfaces/IDataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/Interfaces/IDataSetService.cs
@@ -6,8 +6,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Servi
 
 public interface IDataSetService
 {
-    Task<Either<ActionResult, (Guid dataSetId, Guid dataSetVersionId)>> CreateDataSetVersion(
-        InitialDataSetVersionCreateRequest request,
+    Task<Either<ActionResult, (Guid dataSetId, Guid dataSetVersionId)>> CreateDataSet(
+        DataSetCreateRequest request,
         Guid instanceId,
         CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
Some of the functions developed as part of EES-4903 for processing the initial data set version will be reusable by functions developed for other activity sequences responsible for creating subsequent data set versions.

The function `CopyCsvFilesTests` was already written with this in mind, but other functions like `ImportMetadata` and probably `HandleProcessingFailure` will end up being used by multiple orchestrators for processing the initial data set version and creating/processing subsequent versions.

This task is to refactor these functions to make them available to multiple different orchestrator functions.

Doing this early will make it easier to work on EES-5152 (writing function tests) and EES-4953 (creating the next data set version) in parallel.

### Other changes

- Rename `DataSetService.CreateDataSetVersion` to `DataSetService.CreateDataSet` after new `DataSetVersionService` was introduced by #4902.
- Rename `CreateInitialDataSetVersionFunction/ CreateInitialDataSetVersion` to `CreateDataSetFunction / CreateDataSet` along with similar renames to request and response types.
- Pass `instanceId` as input to `HandleProcessingFailure`. While not strictly necessary since `instanceId` will be set automatically, this is done to be consistent with the other activity functions.