### PR TITLE
EES-5196 Add data set status and summary to admin details page

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/ReleaseApiDataSetDetailsPage.tsx
@@ -8,10 +8,14 @@ import {
   ReleaseDataSetRouteParams,
   ReleaseRouteParams,
 } from '@admin/routes/releaseRoutes';
+import { DataSetStatus } from '@admin/services/apiDataSetService';
 import ButtonText from '@common/components/ButtonText';
+import ContentHtml from '@common/components/ContentHtml';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import SummaryCard from '@common/components/SummaryCard';
-import Tag from '@common/components/Tag';
+import SummaryList from '@common/components/SummaryList';
+import SummaryListItem from '@common/components/SummaryListItem';
+import Tag, { TagProps } from '@common/components/Tag';
 import TaskList from '@common/components/TaskList';
 import TaskListItem from '@common/components/TaskListItem';
 import { useQuery } from '@tanstack/react-query';
@@ -95,6 +99,17 @@ export default function ReleaseApiDataSetDetailsPage() {
     />
   ) : null;
 
+  function getDataSetStatusColour(status: DataSetStatus): TagProps['colour'] {
+    switch (status) {
+      case 'Deprecated':
+        return 'purple';
+      case 'Withdrawn':
+        return 'red';
+      default:
+        return 'blue';
+    }
+  }
+
   return (
     <>
       <Link
@@ -113,6 +128,20 @@ export default function ReleaseApiDataSetDetailsPage() {
           <>
             <span className="govuk-caption-l">API data set details</span>
             <h2>{dataSet.title}</h2>
+
+            <SummaryList
+              className="govuk-!-width-two-thirds govuk-!-margin-bottom-8"
+              testId="data-set-summary"
+            >
+              <SummaryListItem term="Status">
+                <Tag colour={getDataSetStatusColour(dataSet.status)}>
+                  {dataSet.status}
+                </Tag>
+              </SummaryListItem>
+              <SummaryListItem term="Summary">
+                <ContentHtml html={dataSet.summary} />
+              </SummaryListItem>
+            </SummaryList>
 
             {dataSet.draftVersion?.status === 'Mapping' &&
               showDraftVersionTasks && (

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -92,7 +92,23 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     },
   };
 
-  test('renders correctly with processing version only', async () => {
+  test('renders correctly with data set summary', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      draftVersion: testProcessingVersion,
+    });
+
+    renderPage();
+
+    const summary = within(await screen.findByTestId('data-set-summary'));
+
+    expect(summary.getByTestId('Status')).toHaveTextContent('Published');
+    expect(summary.getByTestId('Summary')).toHaveTextContent(
+      'Data set summary',
+    );
+  });
+
+  test('renders correctly with processing draft version only', async () => {
     apiDataSetService.getDataSet.mockResolvedValue({
       ...testDataSet,
       draftVersion: testProcessingVersion,
@@ -123,7 +139,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('renders correctly with draft version only', async () => {
+  test('renders correctly with processed draft version only', async () => {
     apiDataSetService.getDataSet.mockResolvedValue({
       ...testDataSet,
       draftVersion: testDraftVersion,

--- a/src/explore-education-statistics-admin/src/pages/release/api-data-sets/utils/getVersionStatusColour.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/api-data-sets/utils/getVersionStatusColour.ts
@@ -8,7 +8,7 @@ export default function getVersionStatusTagColour(
     case 'Published':
       return 'blue';
     case 'Deprecated':
-      return 'light-blue';
+      return 'purple';
     case 'Withdrawn':
       return 'grey';
     case 'Draft':


### PR DESCRIPTION
This PR adds the data set's status and summary information to the admin's details page:

![image](https://github.com/dfe-analytical-services/explore-education-statistics/assets/9917868/0ac2d4b5-7c60-40f2-ab1b-8f4a0185ab42)