### PR TITLE
EES-5203 Disable Publisher config of `PublicDataDbContext` if the Public API database does not exist

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
@@ -160,7 +160,10 @@ public static class PublisherHostBuilderExtensions
                 if (!hostEnvironment.IsIntegrationTest())
                 {
                     var connectionString = ConnectionUtils.GetPostgreSqlConnectionString("PublicDataDb")!;
-                    services.AddFunctionAppPsqlDbContext<PublicDataDbContext>(connectionString, hostContext);
+                    if (publicDataDbExists)
+                    {
+                        services.AddFunctionAppPsqlDbContext<PublicDataDbContext>(connectionString, hostContext);
+                    }
                 }
 
                 StartupUtils.AddPersistenceHelper<ContentDbContext>(services);


### PR DESCRIPTION
This PR is a hotifx to disable the Publisher config of the `PublicDataDbContext` if the Public API database does not exist which is currently the case in Test/Pre-Prod/Prod.

This matches similar config that we have for the Admin service.