### PR TITLE
Permit uppercase characters in URL path without redirecting

### DIFF
--- a/src/explore-education-statistics-frontend/server.js
+++ b/src/explore-education-statistics-frontend/server.js
@@ -97,7 +97,8 @@ async function startServer() {
     redirectPath = seoRedirects[redirectPath] ?? redirectPath;
 
     const redirectionRequired =
-      request.hostname.startsWith('www') || redirectPath !== request.path;
+      request.hostname.startsWith('www') ||
+      redirectPath !== request.path.toLowerCase();
 
     if (redirectionRequired) {
       // Restore any search parameters on original request


### PR DESCRIPTION
The new subscription-verification page contains the verification token as part of its route. This token is case sensitive.

I've recently refactored the code that implements SEO redirects, and because the redirectService is lowercasing any Content API redirects it finds, I chose to be consistent in the SEO redirects.

This, understandably, is a pretty fatal but entirely predictable change for the subscription-verification page 🤦

(If we care about the lowercasing, we could be more explicit about the path itself and still lowercase any parts of the path that aren't the token itself, but I actually don't think it's necessary).