### PR TITLE
EES-5194 Add Processor bulk delete endpoint for multiple API data set versions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
@@ -253,7 +253,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             HtmlImageUtil.GetReleaseImages(contentBlock.Body))
                         .Distinct();
 
-                    var imageFiles = await _releaseFileRepository.GetByFileType(releaseVersionId, FileType.Image);
+                    var imageFiles = await _releaseFileRepository.GetByFileType(releaseVersionId, types: FileType.Image);
 
                     var unusedImages = imageFiles
                         .Where(file => !contentImageIds.Contains(file.File.Id))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
@@ -148,7 +148,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, Unit>> DeleteAll(Guid releaseVersionId,
             bool forceDelete = false)
         {
-            var releaseFiles = await _releaseFileRepository.GetByFileType(releaseVersionId, FileType.Data);
+            var releaseFiles = await _releaseFileRepository.GetByFileType(releaseVersionId, types: FileType.Data);
 
             return await Delete(releaseVersionId,
                 releaseFiles.Select(releaseFile => releaseFile.File.Id),
@@ -175,7 +175,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(_userService.CheckCanViewReleaseVersion)
                 .OnSuccess(async () =>
                 {
-                    var files = await _releaseFileRepository.GetByFileType(releaseVersionId, FileType.Data);
+                    var files = await _releaseFileRepository.GetByFileType(releaseVersionId, types: FileType.Data);
 
                     // Exclude files that are replacements in progress
                     var filesExcludingReplacements = files

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
@@ -140,7 +140,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<Either<ActionResult, Unit>> DeleteAll(Guid releaseVersionId, bool forceDelete = false)
         {
-            var releaseFiles = await _releaseFileRepository.GetByFileType(releaseVersionId, DeletableFileTypes);
+            var releaseFiles = await _releaseFileRepository.GetByFileType(releaseVersionId, types: DeletableFileTypes);
 
             return await Delete(releaseVersionId,
                 releaseFiles.Select(releaseFile => releaseFile.File.Id),
@@ -155,7 +155,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(_userService.CheckCanViewReleaseVersion)
                 .OnSuccess(async _ =>
                 {
-                    var releaseFiles = await _releaseFileRepository.GetByFileType(releaseVersionId, types);
+                    var releaseFiles = await _releaseFileRepository.GetByFileType(releaseVersionId, types: types);
 
                     return releaseFiles
                         .Select(releaseFile => releaseFile.ToFileInfo())
@@ -320,7 +320,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(_userService.CheckCanViewReleaseVersion)
                 .OnSuccess(async _ =>
                 {
-                    var releaseFiles = await _releaseFileRepository.GetByFileType(releaseVersionId, Ancillary);
+                    var releaseFiles = await _releaseFileRepository.GetByFileType(releaseVersionId, types: Ancillary);
 
                     var filesWithMetadata = await releaseFiles
                         .SelectAsync(async releaseFile => await ToAncillaryFileInfo(releaseFile));

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IReleaseFileRepository.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
@@ -30,6 +31,7 @@ public interface IReleaseFileRepository
         Guid fileId);
 
     Task<List<ReleaseFile>> GetByFileType(Guid releaseVersionId,
+        CancellationToken cancellationToken = default,
         params FileType[] types);
 
     Task<bool> FileIsLinkedToOtherReleases(Guid releaseVersionId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseFileRepository.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -97,6 +98,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
         }
 
         public async Task<List<ReleaseFile>> GetByFileType(Guid releaseVersionId,
+            CancellationToken cancellationToken = default,
             params FileType[] types)
         {
             return await _contentDbContext.ReleaseFiles
@@ -104,7 +106,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                 .Where(releaseFile =>
                     releaseFile.ReleaseVersionId == releaseVersionId
                     && types.Contains(releaseFile.File.Type))
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
         }
 
         public async Task<bool> FileIsLinkedToOtherReleases(Guid releaseVersionId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseService.cs
@@ -139,7 +139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
 
         private async Task<List<FileInfo>> GetDownloadFiles(ReleaseVersion releaseVersion)
         {
-            var files = await _releaseFileRepository.GetByFileType(releaseVersion.Id, FileType.Ancillary,
+            var files = await _releaseFileRepository.GetByFileType(releaseVersion.Id, types: FileType.Ancillary,
                 FileType.Data);
             return files
                 .Select(rf => rf.ToPublicFileInfo())

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseService.cs
@@ -139,8 +139,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
 
         private async Task<List<FileInfo>> GetDownloadFiles(ReleaseVersion releaseVersion)
         {
-            var files = await _releaseFileRepository.GetByFileType(releaseVersion.Id, types: FileType.Ancillary,
-                FileType.Data);
+            var files = await _releaseFileRepository.GetByFileType(
+                releaseVersion.Id, 
+                types: [FileType.Ancillary, FileType.Data]);
             return files
                 .Select(rf => rf.ToPublicFileInfo())
                 .OrderBy(file => file.Name)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
@@ -1,5 +1,4 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests.Validators;
 
@@ -42,7 +41,7 @@ public static class ValidationMessages
 
     public static readonly LocalizableMessage DataSetVersionCanNotBeDeleted = new(
         Code: nameof(DataSetVersionCanNotBeDeleted),
-        Message: $"The data set version is not in a '{DataSetVersionStatus.Draft}' status, so cannot be deleted."
+        Message: $"The data set version is not in a draft status, or is currently being processed, so cannot be deleted."
     );
 
     public static readonly LocalizableMessage DataSetNotFound = new(
@@ -62,6 +61,6 @@ public static class ValidationMessages
 
     public static readonly LocalizableMessage MultipleDataSetVersionsCanNotBeDeleted = new(
         Code: nameof(MultipleDataSetVersionsCanNotBeDeleted),
-        Message: $"One or more data set versions are not in a '{DataSetVersionStatus.Draft}' status, so cannot be deleted."
+        Message: $"One or more data set versions are not in a draft status, or are currently being processed, so cannot be deleted."
 );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
@@ -59,4 +59,9 @@ public static class ValidationMessages
         Code: nameof(DataSetNoLiveVersion),
         Message: "The data set must have a live version."
     );
+
+    public static readonly LocalizableMessage MultipleDataSetVersionsCanNotBeDeleted = new(
+        Code: nameof(MultipleDataSetVersionsCanNotBeDeleted),
+        Message: $"One or more data set versions are not in a '{DataSetVersionStatus.Draft}' status, so cannot be deleted."
+);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/BulkDeleteDataSetVersionsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/BulkDeleteDataSetVersionsFunctionTests.cs
@@ -1,0 +1,269 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
+using LinqToDB;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Functions;
+
+public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsIntegrationTestFixture fixture)
+    : ProcessorFunctionsIntegrationTest(fixture)
+{
+    public class BulkDeleteDataSetVersionsTests : BulkDeleteDataSetVersionsFunctionTests
+    {
+        private readonly IDataSetVersionPathResolver _dataSetVersionPathResolver;
+
+        public BulkDeleteDataSetVersionsTests(ProcessorFunctionsIntegrationTestFixture fixture) : base(fixture)
+        {
+            _dataSetVersionPathResolver = GetRequiredService<IDataSetVersionPathResolver>();
+        }
+
+        [Theory]
+        [InlineData(DataSetVersionStatus.Failed)]
+        [InlineData(DataSetVersionStatus.Mapping)]
+        [InlineData(DataSetVersionStatus.Draft)]
+        [InlineData(DataSetVersionStatus.Cancelled)]
+        public async Task Success(DataSetVersionStatus dataSetVersionStatus)
+        {
+            ReleaseVersion releaseVersion = DataFixture.DefaultReleaseVersion()
+                .WithPublication(DataFixture.DefaultPublication());
+
+            var files = DataFixture.DefaultFile()
+                .GenerateList(3);
+
+            var releaseFiles = DataFixture.DefaultReleaseFile()
+                .WithReleaseVersion(releaseVersion)
+                .ForIndex(0, rf => rf.SetFile(files[0]))
+                .ForIndex(1, rf => rf.SetFile(files[1]))
+                .ForIndex(2, rf => rf.SetFile(files[2]))
+                .GenerateList();
+
+            await AddTestData<ContentDbContext>(context =>
+            {
+                context.ReleaseFiles.AddRange(releaseFiles);
+            });
+
+            var dataSets = DataFixture
+                .DefaultDataSet()
+                .WithStatusDraft()
+                .WithPublicationId(releaseVersion.PublicationId)
+                .GenerateList(3);
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSets.AddRange(dataSets));
+
+            var dataSetVersions = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(1, 0, 0)
+                .WithStatus(dataSetVersionStatus)
+                .WithImports(() => DataFixture
+                    .DefaultDataSetVersionImport()
+                    .Generate(1))
+                .ForIndex(0, dsv => dsv
+                    .SetReleaseFileId(releaseFiles[0].Id)
+                    .SetDataSet(dataSets[0]))
+                .ForIndex(1, dsv => dsv
+                    .SetReleaseFileId(releaseFiles[1].Id)
+                    .SetDataSet(dataSets[1]))
+                .ForIndex(2, dsv => dsv
+                    .SetReleaseFileId(releaseFiles[2].Id)
+                    .SetDataSet(dataSets[2]))
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv)
+                .GenerateList();
+
+            await AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.AddRange(dataSetVersions);
+                context.DataSets.UpdateRange(dataSets);
+            });
+
+            foreach (var (file, index) in files.WithIndex())
+            {
+                file.PublicApiDataSetId = dataSets[index].Id;
+                file.PublicApiDataSetVersion = dataSetVersions[index].FullSemanticVersion();
+            }
+
+            await AddTestData<ContentDbContext>(context => context.Files.UpdateRange(files));
+
+            foreach (var dataSetVersion in dataSetVersions)
+            {
+                var dataSetVersionDirectory = _dataSetVersionPathResolver.DirectoryPath(dataSetVersion);
+
+                Directory.CreateDirectory(dataSetVersionDirectory);
+                await System.IO.File.Create(Path.Combine(dataSetVersionDirectory, "version1.txt")).DisposeAsync();
+            }
+
+            var response = await BulkDeleteDataSetVersions(releaseVersion.Id);
+
+            response.AssertNoContent();
+
+            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
+            await using var contentDataDbContext = GetDbContext<ContentDbContext>();
+
+            // Assert that the base directory containing all parquet data file entries has been emptied
+            var dataSetVersionBaseDirectoryEntries = Directory.GetFileSystemEntries(_dataSetVersionPathResolver.BasePath());
+            Assert.Empty(dataSetVersionBaseDirectoryEntries);
+
+            for (var i = 0; i < 3; i++)
+            {
+                var dataSet = dataSets[i];
+                var dataSetVersion = dataSetVersions[i];
+                var releaseFile = releaseFiles[i];
+
+                // Assert that the Data Set has been deleted
+                Assert.Null(await publicDataDbContext.DataSets.SingleOrDefaultAsync(ds => ds.Id == dataSet.Id));
+
+                // Assert that the Data Set Version has been deleted
+                Assert.Null(await publicDataDbContext.DataSetVersions.SingleOrDefaultAsync(dsv => dsv.Id == dataSetVersion.Id));
+
+                // Assert that the Data Set Version metadata is deleted
+                Assert.False(await publicDataDbContext.FilterMetas
+                        .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
+                Assert.False(await publicDataDbContext.FilterOptionMetaLinks
+                        .AnyAsync(foml => dataSetVersion.FilterMetas.Contains(foml.Meta)));
+                Assert.False(await publicDataDbContext.LocationMetas
+                        .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
+                Assert.False(await publicDataDbContext.LocationOptionMetaLinks
+                        .AnyAsync(loml => dataSetVersion.LocationMetas.Contains(loml.Meta)));
+                Assert.False(await publicDataDbContext.IndicatorMetas
+                        .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
+                Assert.False(await publicDataDbContext.GeographicLevelMetas
+                        .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
+                Assert.False(await publicDataDbContext.TimePeriodMetas
+                        .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
+
+                // Assert that the Data Set Version Import has been deleted
+                Assert.Null(await publicDataDbContext.DataSetVersionImports.SingleOrDefaultAsync(dsvi => dsvi.Id == dataSetVersion.Imports.Single().Id));
+
+                // Assert that the Release File has been unassociated with the Public API DataSet
+                var file = await contentDataDbContext.Files.SingleAsync(f => f.Id == releaseFile.FileId);
+                Assert.Null(file.PublicApiDataSetId);
+                Assert.Null(file.PublicApiDataSetVersion);
+            }
+        }
+
+        [Theory]
+        [InlineData(DataSetVersionStatus.Processing)]
+        [InlineData(DataSetVersionStatus.Published)]
+        [InlineData(DataSetVersionStatus.Deprecated)]
+        [InlineData(DataSetVersionStatus.Withdrawn)]
+        public async Task VersionCanNotBeDeleted_FirstVersion_Returns400(DataSetVersionStatus dataSetVersionStatus)
+        {
+            ReleaseVersion releaseVersion = DataFixture.DefaultReleaseVersion()
+               .WithPublication(DataFixture.DefaultPublication());
+
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithReleaseVersion(releaseVersion)
+                .WithFile(DataFixture.DefaultFile());
+
+            await AddTestData<ContentDbContext>(context =>
+            {
+                context.ReleaseFiles.Add(releaseFile);
+            });
+
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithPublicationId(releaseVersion.Id)
+                .WithStatusDraft();
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion dataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(1, 0, 0)
+                .WithStatus(dataSetVersionStatus)
+                .WithReleaseFileId(releaseFile.Id)
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            await AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var response = await BulkDeleteDataSetVersions(releaseVersion.Id);
+
+            var validationProblem = response.AssertBadRequestWithValidationProblem();
+
+            validationProblem.AssertHasError(
+                expectedPath: "releaseVersionId",
+                expectedCode: ValidationMessages.MultipleDataSetVersionsCanNotBeDeleted.Code);
+        }
+
+        [Theory]
+        [InlineData(DataSetVersionStatus.Processing)]
+        [InlineData(DataSetVersionStatus.Published)]
+        [InlineData(DataSetVersionStatus.Deprecated)]
+        [InlineData(DataSetVersionStatus.Withdrawn)]
+        public async Task VersionCanNotBeDeleted_SubsequentVersion_Returns400(DataSetVersionStatus dataSetVersionStatus)
+        {
+            ReleaseVersion releaseVersion = DataFixture.DefaultReleaseVersion()
+               .WithPublication(DataFixture.DefaultPublication());
+
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithReleaseVersion(releaseVersion)
+                .WithFile(DataFixture.DefaultFile());
+
+            await AddTestData<ContentDbContext>(context =>
+            {
+                context.ReleaseFiles.Add(releaseFile);
+            });
+
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithPublicationId(releaseVersion.Id)
+                .WithStatusPublished();
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion liveDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithReleaseFileId(releaseFile.Id)
+                .WithDataSet(dataSet)
+                .WithVersionNumber(1, 0, 0)
+                .WithStatus(dataSetVersionStatus)
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            DataSetVersion draftDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithReleaseFileId(releaseFile.Id)
+                .WithDataSet(dataSet)
+                .WithVersionNumber(2, 0, 0)
+                .WithStatusDraft()
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.AddRange(liveDataSetVersion, draftDataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var response = await BulkDeleteDataSetVersions(releaseVersion.Id);
+
+            var validationProblem = response.AssertBadRequestWithValidationProblem();
+
+            validationProblem.AssertHasError(
+                expectedPath: "releaseVersionId",
+                expectedCode: ValidationMessages.MultipleDataSetVersionsCanNotBeDeleted.Code);
+        }
+
+        private async Task<IActionResult> BulkDeleteDataSetVersions(Guid releaseVersionId)
+        {
+            var function = GetRequiredService<BulkDeleteDataSetVersionsFunction>();
+
+            return await function.BulkDeleteDataSetVersions(
+                null!,
+                releaseVersionId,
+                CancellationToken.None);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/BulkDeleteDataSetVersionsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/BulkDeleteDataSetVersionsFunctionTests.cs
@@ -12,6 +12,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests.
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using LinqToDB;
 using Microsoft.AspNetCore.Mvc;
+using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Functions;
 
@@ -34,33 +35,47 @@ public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsI
         [InlineData(DataSetVersionStatus.Cancelled)]
         public async Task Success(DataSetVersionStatus dataSetVersionStatus)
         {
-            ReleaseVersion releaseVersion = DataFixture.DefaultReleaseVersion()
+            ReleaseVersion targetReleaseVersion = DataFixture.DefaultReleaseVersion()
                 .WithPublication(DataFixture.DefaultPublication());
 
-            var files = DataFixture.DefaultFile()
+            ReleaseVersion otherReleaseVersion = DataFixture.DefaultReleaseVersion()
+                .WithPublication(DataFixture.DefaultPublication());
+
+            var targetFiles = DataFixture.DefaultFile()
                 .GenerateList(3);
 
-            var releaseFiles = DataFixture.DefaultReleaseFile()
-                .WithReleaseVersion(releaseVersion)
-                .ForIndex(0, rf => rf.SetFile(files[0]))
-                .ForIndex(1, rf => rf.SetFile(files[1]))
-                .ForIndex(2, rf => rf.SetFile(files[2]))
+            File otherFile = DataFixture.DefaultFile();
+
+            var targetReleaseFiles = DataFixture.DefaultReleaseFile()
+                .WithReleaseVersion(targetReleaseVersion)
+                .ForIndex(0, rf => rf.SetFile(targetFiles[0]))
+                .ForIndex(1, rf => rf.SetFile(targetFiles[1]))
+                .ForIndex(2, rf => rf.SetFile(targetFiles[2]))
                 .GenerateList();
+
+            ReleaseFile otherReleaseFile = DataFixture.DefaultReleaseFile()
+                .WithReleaseVersion(otherReleaseVersion)
+                .WithFile(otherFile);
 
             await AddTestData<ContentDbContext>(context =>
             {
-                context.ReleaseFiles.AddRange(releaseFiles);
+                context.ReleaseFiles.AddRange([..targetReleaseFiles, otherReleaseFile]);
             });
 
-            var dataSets = DataFixture
+            var targetDataSets = DataFixture
                 .DefaultDataSet()
                 .WithStatusDraft()
-                .WithPublicationId(releaseVersion.PublicationId)
+                .WithPublicationId(targetReleaseVersion.PublicationId)
                 .GenerateList(3);
 
-            await AddTestData<PublicDataDbContext>(context => context.DataSets.AddRange(dataSets));
+            DataSet otherDataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusDraft()
+                .WithPublicationId(otherReleaseVersion.PublicationId);
 
-            var dataSetVersions = DataFixture
+            await AddTestData<PublicDataDbContext>(context => context.DataSets.AddRange([..targetDataSets, otherDataSet]));
+
+            var targetDataSetVersions = DataFixture
                 .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
                 .WithVersionNumber(1, 0, 0)
                 .WithStatus(dataSetVersionStatus)
@@ -68,86 +83,147 @@ public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsI
                     .DefaultDataSetVersionImport()
                     .Generate(1))
                 .ForIndex(0, dsv => dsv
-                    .SetReleaseFileId(releaseFiles[0].Id)
-                    .SetDataSet(dataSets[0]))
+                    .SetReleaseFileId(targetReleaseFiles[0].Id)
+                    .SetDataSet(targetDataSets[0]))
                 .ForIndex(1, dsv => dsv
-                    .SetReleaseFileId(releaseFiles[1].Id)
-                    .SetDataSet(dataSets[1]))
+                    .SetReleaseFileId(targetReleaseFiles[1].Id)
+                    .SetDataSet(targetDataSets[1]))
                 .ForIndex(2, dsv => dsv
-                    .SetReleaseFileId(releaseFiles[2].Id)
-                    .SetDataSet(dataSets[2]))
+                    .SetReleaseFileId(targetReleaseFiles[2].Id)
+                    .SetDataSet(targetDataSets[2]))
                 .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv)
                 .GenerateList();
 
+            DataSetVersion otherDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(1, 0, 0)
+                .WithStatusDraft()
+                .WithDataSet(otherDataSet)
+                .WithImports(() => DataFixture
+                    .DefaultDataSetVersionImport()
+                    .Generate(1))
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
             await AddTestData<PublicDataDbContext>(context =>
             {
-                context.DataSetVersions.AddRange(dataSetVersions);
-                context.DataSets.UpdateRange(dataSets);
+                context.DataSetVersions.AddRange([..targetDataSetVersions, otherDataSetVersion]);
+                context.DataSets.UpdateRange([..targetDataSets, otherDataSet]);
             });
 
-            foreach (var (file, index) in files.WithIndex())
+            foreach (var (targetFile, index) in targetFiles.WithIndex())
             {
-                file.PublicApiDataSetId = dataSets[index].Id;
-                file.PublicApiDataSetVersion = dataSetVersions[index].FullSemanticVersion();
+                targetFile.PublicApiDataSetId = targetDataSets[index].Id;
+                targetFile.PublicApiDataSetVersion = targetDataSetVersions[index].FullSemanticVersion();
             }
 
-            await AddTestData<ContentDbContext>(context => context.Files.UpdateRange(files));
+            otherFile.PublicApiDataSetId = otherDataSet.Id;
+            otherFile.PublicApiDataSetVersion = otherDataSetVersion.FullSemanticVersion();
 
-            foreach (var dataSetVersion in dataSetVersions)
+            await AddTestData<ContentDbContext>(context => context.Files.UpdateRange([..targetFiles, otherFile]));
+
+            foreach (var targetDataSetVersion in targetDataSetVersions)
             {
-                var dataSetVersionDirectory = _dataSetVersionPathResolver.DirectoryPath(dataSetVersion);
-
-                Directory.CreateDirectory(dataSetVersionDirectory);
-                await System.IO.File.Create(Path.Combine(dataSetVersionDirectory, "version1.txt")).DisposeAsync();
+                var targetDataSetVersionDirectory = _dataSetVersionPathResolver.DirectoryPath(targetDataSetVersion);
+                Directory.CreateDirectory(targetDataSetVersionDirectory);
+                await System.IO.File.Create(Path.Combine(targetDataSetVersionDirectory, "version1.txt")).DisposeAsync();
             }
 
-            var response = await BulkDeleteDataSetVersions(releaseVersion.Id);
+            var otherDataSetVersionDirectory = _dataSetVersionPathResolver.DirectoryPath(otherDataSetVersion);
+            Directory.CreateDirectory(otherDataSetVersionDirectory);
+            await System.IO.File.Create(Path.Combine(otherDataSetVersionDirectory, "version1.txt")).DisposeAsync();
+
+            var response = await BulkDeleteDataSetVersions(targetReleaseVersion.Id);
 
             response.AssertNoContent();
 
             await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
             await using var contentDataDbContext = GetDbContext<ContentDbContext>();
 
-            // Assert that the base directory containing all parquet data file entries has been emptied
-            var dataSetVersionBaseDirectoryEntries = Directory.GetFileSystemEntries(_dataSetVersionPathResolver.BasePath());
-            Assert.Empty(dataSetVersionBaseDirectoryEntries);
-
+            // Assertions for the TARGET data sets linked to the TARGET release version being deleted
             for (var i = 0; i < 3; i++)
             {
-                var dataSet = dataSets[i];
-                var dataSetVersion = dataSetVersions[i];
-                var releaseFile = releaseFiles[i];
+                var targetDataSet = targetDataSets[i];
+                var targetDataSetVersion = targetDataSetVersions[i];
+                var targetReleaseFile = targetReleaseFiles[i];
 
-                // Assert that the Data Set has been deleted
-                Assert.Null(await publicDataDbContext.DataSets.SingleOrDefaultAsync(ds => ds.Id == dataSet.Id));
+                // Assert that the TARGET parquet data set folder, linked to the release version being deleted, is now removed
+                var targetDataSetDirectory = Directory.GetParent(_dataSetVersionPathResolver.DirectoryPath(targetDataSetVersion));
+                Assert.False(Directory.Exists(targetDataSetDirectory!.FullName));
 
-                // Assert that the Data Set Version has been deleted
-                Assert.Null(await publicDataDbContext.DataSetVersions.SingleOrDefaultAsync(dsv => dsv.Id == dataSetVersion.Id));
+                // Assert that the TARGET Data Set has been deleted
+                Assert.Null(await publicDataDbContext.DataSets.SingleOrDefaultAsync(ds => ds.Id == targetDataSet.Id));
 
-                // Assert that the Data Set Version metadata is deleted
+                // Assert that the TARGET Data Set Version has been deleted
+                Assert.Null(await publicDataDbContext.DataSetVersions.SingleOrDefaultAsync(dsv => dsv.Id == targetDataSetVersion.Id));
+
+                // Assert that the TARGET Data Set Version metadata is deleted
                 Assert.False(await publicDataDbContext.FilterMetas
-                        .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
+                        .AnyAsync(fm => fm.DataSetVersionId == targetDataSetVersion.Id));
                 Assert.False(await publicDataDbContext.FilterOptionMetaLinks
-                        .AnyAsync(foml => dataSetVersion.FilterMetas.Contains(foml.Meta)));
+                        .AnyAsync(foml => targetDataSetVersion.FilterMetas.Contains(foml.Meta)));
                 Assert.False(await publicDataDbContext.LocationMetas
-                        .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
+                        .AnyAsync(fm => fm.DataSetVersionId == targetDataSetVersion.Id));
                 Assert.False(await publicDataDbContext.LocationOptionMetaLinks
-                        .AnyAsync(loml => dataSetVersion.LocationMetas.Contains(loml.Meta)));
+                        .AnyAsync(loml => targetDataSetVersion.LocationMetas.Contains(loml.Meta)));
                 Assert.False(await publicDataDbContext.IndicatorMetas
-                        .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
+                        .AnyAsync(fm => fm.DataSetVersionId == targetDataSetVersion.Id));
                 Assert.False(await publicDataDbContext.GeographicLevelMetas
-                        .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
+                        .AnyAsync(fm => fm.DataSetVersionId == targetDataSetVersion.Id));
                 Assert.False(await publicDataDbContext.TimePeriodMetas
-                        .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
+                        .AnyAsync(fm => fm.DataSetVersionId == targetDataSetVersion.Id));
 
-                // Assert that the Data Set Version Import has been deleted
-                Assert.Null(await publicDataDbContext.DataSetVersionImports.SingleOrDefaultAsync(dsvi => dsvi.Id == dataSetVersion.Imports.Single().Id));
+                // Assert that the TARGET Data Set Version Import has been deleted
+                Assert.Null(await publicDataDbContext.DataSetVersionImports.SingleOrDefaultAsync(dsvi => dsvi.Id == targetDataSetVersion.Imports.Single().Id));
 
-                // Assert that the Release File has been unassociated with the Public API DataSet
-                var file = await contentDataDbContext.Files.SingleAsync(f => f.Id == releaseFile.FileId);
-                Assert.Null(file.PublicApiDataSetId);
-                Assert.Null(file.PublicApiDataSetVersion);
+                // Assert that the TARGET Release File has been unassociated with its Public API DataSet
+                var targetFile = await contentDataDbContext.Files.SingleAsync(f => f.Id == targetReleaseFile.FileId);
+                Assert.Null(targetFile.PublicApiDataSetId);
+                Assert.Null(targetFile.PublicApiDataSetVersion);
             }
+
+            // Below are the Assertions for the OTHER data set linked to the NON-TARGET release version. NOTHING should be deleted
+
+            // Assert that the OTHER data set folder, and its contents, linked to the NON-TARGET release version remains
+            // as it was
+            var otherDataSetFolder = Directory.GetParent(_dataSetVersionPathResolver.DirectoryPath(otherDataSetVersion));
+            Assert.True(Directory.Exists(otherDataSetFolder!.FullName));
+
+            var otherDataSetFolderEntries = Directory.GetFileSystemEntries(otherDataSetFolder!.FullName);
+            var otherDataSetVersionFolder = Assert.Single(otherDataSetFolderEntries,
+                entry => new DirectoryInfo(entry).Name == $"v{otherDataSetVersion.Version}");
+
+            var otherDataSetVersionFolderEntries = Directory.GetFileSystemEntries(otherDataSetVersionFolder);
+            Assert.Single(otherDataSetVersionFolderEntries, entry => new FileInfo(entry).Name == "version1.txt");
+
+            // Assert that the OTHER Data Set has NOT been deleted
+            Assert.NotNull(await publicDataDbContext.DataSets.SingleAsync(ds => ds.Id == otherDataSet.Id));
+
+            // Assert that the OTHER Data Set Version has NOT been deleted
+            Assert.NotNull(await publicDataDbContext.DataSetVersions.SingleAsync(dsv => dsv.Id == otherDataSetVersion.Id));
+
+            // Assert that the OTHER Data Set Version metadata is NOT deleted
+            Assert.True(await publicDataDbContext.FilterMetas
+                    .AnyAsync(fm => fm.DataSetVersionId == otherDataSetVersion.Id));
+            Assert.True(await publicDataDbContext.FilterOptionMetaLinks
+                    .AnyAsync(foml => otherDataSetVersion.FilterMetas.Contains(foml.Meta)));
+            Assert.True(await publicDataDbContext.LocationMetas
+                    .AnyAsync(fm => fm.DataSetVersionId == otherDataSetVersion.Id));
+            Assert.True(await publicDataDbContext.LocationOptionMetaLinks
+                    .AnyAsync(loml => otherDataSetVersion.LocationMetas.Contains(loml.Meta)));
+            Assert.True(await publicDataDbContext.IndicatorMetas
+                    .AnyAsync(fm => fm.DataSetVersionId == otherDataSetVersion.Id));
+            Assert.True(await publicDataDbContext.GeographicLevelMetas
+                    .AnyAsync(fm => fm.DataSetVersionId == otherDataSetVersion.Id));
+            Assert.True(await publicDataDbContext.TimePeriodMetas
+                    .AnyAsync(fm => fm.DataSetVersionId == otherDataSetVersion.Id));
+
+            // Assert that the OTHER Data Set Version Import has NOT been deleted
+            Assert.NotNull(await publicDataDbContext.DataSetVersionImports.SingleAsync(dsvi => dsvi.Id == otherDataSetVersion.Imports.Single().Id));
+
+            // Assert that the OTHER Release File is still associated with its Public API DataSet
+            var otherFilePostDelete = await contentDataDbContext.Files.SingleAsync(f => f.Id == otherReleaseFile.FileId);
+            Assert.Equal(otherDataSet.Id, otherFilePostDelete.PublicApiDataSetId);
+            Assert.Equal(otherDataSetVersion.FullSemanticVersion(), otherFilePostDelete.PublicApiDataSetVersion);
         }
 
         [Theory]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/DeleteDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/DeleteDataSetVersionFunctionTests.cs
@@ -70,7 +70,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
             releaseFile.PublicApiDataSetId = dataSet.Id;
             releaseFile.PublicApiDataSetVersion = dataSetVersion.FullSemanticVersion();
 
-            await AddTestData<ContentDbContext>(context => context.Files.Update(releaseFile.File));
+            await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Update(releaseFile));
 
             var dataSetVersionDirectory = _dataSetVersionPathResolver.DirectoryPath(dataSetVersion);
 
@@ -297,14 +297,14 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
                 .Where(i => i.Id == liveDataSetVersion.Imports.Single().Id)
                 .ToListAsync());
 
-            // Assert that the ReleaseFile has been unassociated with the DRAFT Public API Data Set Version
+            // Assert that the DRAFT ReleaseFile has been unassociated with the DRAFT Public API Data Set Version
             var updatedDraftReleaseFile = await contentDataDbContext.ReleaseFiles
                 .SingleAsync(f => f.Id == draftReleaseFile.Id);
 
             Assert.Null(updatedDraftReleaseFile.PublicApiDataSetId);
             Assert.Null(updatedDraftReleaseFile.PublicApiDataSetVersion);
 
-            // Assert that the ReleaseFile is still associated with the LIVE Public API Data Set Version
+            // Assert that the LIVE ReleaseFile is still associated with the LIVE Public API Data Set Version
             var updatedLiveReleaseFile = await contentDataDbContext.ReleaseFiles
                 .SingleAsync(f => f.Id == liveReleaseFile.Id);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
@@ -185,6 +185,7 @@ public class ProcessorFunctionsIntegrationTestFixture : FunctionsIntegrationTest
             typeof(ImportMetadataFunction),
             typeof(HandleProcessingFailureFunction),
             typeof(HealthCheckFunctions),
+            typeof(BulkDeleteDataSetVersionsFunction),
         ];
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/BulkDeleteDataSetVersionsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/BulkDeleteDataSetVersionsFunction.cs
@@ -1,0 +1,35 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Services.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
+
+public class BulkDeleteDataSetVersionsFunction(
+    IDataSetVersionService dataSetVersionService,
+    ILogger<BulkDeleteDataSetVersionsFunction> logger)
+{
+    [Function(nameof(BulkDeleteDataSetVersions))]
+    public async Task<IActionResult> BulkDeleteDataSetVersions(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete",
+            Route = $"{nameof(BulkDeleteDataSetVersions)}/{{releaseVersionId}}")]
+        HttpRequest httpRequest,
+        Guid releaseVersionId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await dataSetVersionService.BulkDeleteVersions(
+                    releaseVersionId,
+                    cancellationToken: cancellationToken)
+                .HandleFailuresOrNoContent(convertNotFoundToNoContent: false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(exception: ex, "Exception occured while executing '{FunctionName}'", nameof(BulkDeleteDataSetVersionsFunction));
+            return new StatusCodeResult(StatusCodes.Status500InternalServerError);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/ProcessorHostBuilder.cs
@@ -6,6 +6,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Functions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Options;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Repository;
@@ -70,6 +72,7 @@ public static class ProcessorHostBuilder
                     .AddFluentValidation()
                     .AddScoped<IDataSetVersionPathResolver, DataSetVersionPathResolver>()
                     .AddScoped<IDataSetService, DataSetService>()
+                    .AddScoped<IReleaseFileRepository, ReleaseFileRepository>()
                     .AddScoped<IDataSetVersionService, DataSetVersionService>()
                     .AddScoped<IDataSetMetaService, DataSetMetaService>()
                     .AddScoped<IDataDuckDbRepository, DataDuckDbRepository>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -100,10 +100,14 @@ internal class DataSetVersionService(
         IReadOnlyList<ReleaseFile> releaseFiles,
         CancellationToken cancellationToken)
     {
+        var releaseFileIds = releaseFiles
+            .Select(rf => rf.Id)
+            .ToList();
+
         return await publicDataDbContext.DataSetVersions
             .AsNoTracking()
             .Include(dsv => dsv.DataSet)
-            .Where(dsv => releaseFiles.Any(rf => rf.Id == dsv.ReleaseFileId))
+            .Where(dsv => releaseFileIds.Contains(dsv.ReleaseFileId))
             .ToListAsync(cancellationToken);
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -59,7 +59,7 @@ internal class DataSetVersionService(
 
     public async Task<Either<ActionResult, Unit>> BulkDeleteVersions(Guid releaseVersionId, CancellationToken cancellationToken = default)
     {
-        return await contentDbContext.RequireTransaction(() =>
+        return await publicDataDbContext.RequireTransaction(() =>
             GetReleaseFiles(releaseVersionId, cancellationToken)
                 .OnSuccessCombineWith(async releaseFiles => await GetDataSetVersions(releaseFiles, cancellationToken))
                 .OnSuccess(releaseFilesAndDataSetVersions =>
@@ -191,14 +191,6 @@ internal class DataSetVersionService(
         CancellationToken cancellationToken)
     {
         return await releaseFileRepository.GetByFileType(releaseVersionId, cancellationToken, FileType.Data);
-    }
-
-    private async Task<Either<ActionResult, ReleaseFile>> GetReleaseFile(DataSetVersion dataSetVersion,
-    CancellationToken cancellationToken)
-    {
-        return await contentDbContext.ReleaseFiles
-            .Include(rf => rf.File)
-            .SingleOrNotFoundAsync(rf => rf.Id == dataSetVersion.ReleaseFileId, cancellationToken);
     }
 
     private async Task UnlinkReleaseFilesFromApiDataSets(IReadOnlyList<ReleaseFile> releaseFiles, CancellationToken cancellationToken)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/Interfaces/IDataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/Interfaces/IDataSetVersionService.cs
@@ -17,6 +17,10 @@ public interface IDataSetVersionService
         Guid instanceId,
         CancellationToken cancellationToken = default);
 
+    Task<Either<ActionResult, Unit>> BulkDeleteVersions(
+        Guid releaseVersionId,
+        CancellationToken cancellationToken = default);
+
     Task<Either<ActionResult, Unit>> DeleteVersion(
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default);


### PR DESCRIPTION
We need to add an endpoint to the Processor to delete multiple data set versions in bulk. 

We will be using this endpoint within the deletion plan for an entire release version.

The deletion is blocked if ANY data set versions linked to the target release version are not in a state which can be deleted.

Similar to the existing Processor endpoint which is used to delete SINGLE data set versions, this endpoint is wrapped in a transaction such that all changes will be rolled back if any single deletion step fails. It will attempt to delete the following:
- The `DataSets` linked to the release version
- The `DataSetVersions`, and any related metadata, linked to the release version
- The `DataSetVersionImports` for all the `DataSetVersions` being deleted
- The parquet files (used by DuckDB) associated with ALL of the imports for each `DataSet` being deleted 
- The `Files` linked to the release version will be unlinked from the deleted `DataSets` and `DataSetVersions`