### PR TITLE
EES-5160 - Only run www tests against prod and local

### DIFF
--- a/tests/robot-tests/tests/general_public/prod_only/redirects.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/redirects.robot
@@ -40,3 +40,31 @@ Verify that routes without an absolute path still permit trailing slashes
     user navigates to public frontend    %{PUBLIC_URL}
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
+
+Verify that routes with www are redirected without them
+    user navigates to public frontend with www    %{PUBLIC_URL}/
+    user waits until page contains    Explore education statistics
+    user checks url equals    %{PUBLIC_URL}/
+
+    user navigates to public frontend    %{PUBLIC_URL_WITH}/data-catalogue/
+    user waits until page contains    Browse our open data
+    user checks url equals    %{PUBLIC_URL}/data-catalogue
+
+Verify that routes with /1000 are redirected without them
+    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/1000
+    user waits until page contains    Browse our open data
+    user checks url equals    %{PUBLIC_URL}/data-catalogue
+
+Verify that routes with search parameters retain them
+    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue?foo=bar&baz=zod
+    user waits until page contains    Browse our open data
+    user checks url equals    %{PUBLIC_URL}/data-catalogue?foo=bar&baz=zod
+
+Verify that multiple rules work together
+    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/1000?foo=bar&baz=zod
+    user waits until page contains    Browse our open data
+    user checks url equals    %{PUBLIC_URL}/data-catalogue?foo=bar&baz=zod
+
+    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/1000/?foo=bar
+    user waits until page contains    Browse our open data
+    user checks url equals    %{PUBLIC_URL}/data-catalogue?foo=bar

--- a/tests/robot-tests/tests/general_public/redirects.robot
+++ b/tests/robot-tests/tests/general_public/redirects.robot
@@ -43,15 +43,6 @@ Verify that routes without an absolute path still permit trailing slashes
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
 
-Verify that routes with www are redirected without them
-    user navigates to public frontend with www    %{PUBLIC_URL}/
-    user waits until page contains    Explore education statistics
-    user checks url equals    %{PUBLIC_URL}/
-
-    user navigates to public frontend    %{PUBLIC_URL_WITH}/data-catalogue/
-    user waits until page contains    Browse our open data
-    user checks url equals    %{PUBLIC_URL}/data-catalogue
-
 Verify that routes with /1000 are redirected without them
     user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/1000
     user waits until page contains    Browse our open data

--- a/tests/robot-tests/tests/general_public/redirects_www.robot
+++ b/tests/robot-tests/tests/general_public/redirects_www.robot
@@ -1,0 +1,19 @@
+*** Settings ***
+Resource            ../libs/public-common.robot
+
+Suite Setup         user opens the browser
+Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
+
+Force Tags          GeneralPublic    Local
+
+
+*** Test Cases ***
+Verify that routes with www are redirected without them
+    user navigates to public frontend with www    %{PUBLIC_URL}/
+    user waits until page contains    Explore education statistics
+    user checks url equals    %{PUBLIC_URL}/
+
+    user navigates to public frontend    %{PUBLIC_URL_WITH}/data-catalogue/
+    user waits until page contains    Browse our open data
+    user checks url equals    %{PUBLIC_URL}/data-catalogue


### PR DESCRIPTION
The dev, test, and pre-production environments aren't set up with the required certificates to host `www....` urls. 
There is a test to assert that hostnames included www are redirected - this test should run only against local and production. 

Also, some tests recently added to redirects.robot should also have been added to the prod_only version of redirects.robot, but weren't. So this PR also adds them in. 