### PR TITLE
EES-5176 accessibility improvements for data catalogue and find stats

### DIFF
--- a/src/explore-education-statistics-common/src/components/Modal.tsx
+++ b/src/explore-education-statistics-common/src/components/Modal.tsx
@@ -1,9 +1,12 @@
 import Button from '@common/components/Button';
 import styles from '@common/components/Modal.module.scss';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 import useToggle from '@common/hooks/useToggle';
 import * as Dialog from '@radix-ui/react-dialog';
 import classNames from 'classnames';
 import React, { ReactNode, useEffect, useRef } from 'react';
+
+const defaultCloseText = 'Close';
 
 export interface ModalProps {
   children: ReactNode;
@@ -29,7 +32,7 @@ const Modal = ({
   className,
   closeOnEsc = true,
   closeOnOutsideClick = true,
-  closeText = 'Close',
+  closeText = defaultCloseText,
   description,
   fullScreen = false,
   hideTitle = false,
@@ -100,7 +103,12 @@ const Modal = ({
             {children}
             {showClose && (
               <Dialog.Close asChild>
-                <Button>{closeText}</Button>
+                <Button>
+                  {closeText}
+                  {closeText === defaultCloseText && (
+                    <VisuallyHidden> modal</VisuallyHidden>
+                  )}
+                </Button>
               </Dialog.Close>
             )}
           </Dialog.Content>

--- a/src/explore-education-statistics-common/src/components/__tests__/ContentHtml.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ContentHtml.test.tsx
@@ -43,7 +43,7 @@ describe('ContentHtml', () => {
       modal.getByRole('heading', { name: 'Absence heading' }),
     ).toBeInTheDocument();
     expect(modal.getByText('Absence body')).toBeInTheDocument();
-    const closeButton = modal.getByRole('button', { name: 'Close' });
+    const closeButton = modal.getByRole('button', { name: 'Close modal' });
     expect(closeButton).toBeInTheDocument();
   });
 
@@ -73,7 +73,7 @@ describe('ContentHtml', () => {
     expect(getEntry).toHaveBeenCalled();
 
     const modal = within(screen.getByRole('dialog'));
-    const closeButton = modal.getByRole('button', { name: 'Close' });
+    const closeButton = modal.getByRole('button', { name: 'Close modal' });
     await userEvent.click(closeButton);
 
     await waitFor(() => {

--- a/src/explore-education-statistics-common/src/components/__tests__/Modal.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Modal.test.tsx
@@ -1,11 +1,11 @@
+import render from '@common-test/render';
 import Modal from '@common/components/Modal';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
 describe('Modal', () => {
   test('clicking the trigger button opens the modal', async () => {
-    render(
+    const { user } = render(
       <Modal
         triggerButton={<button type="button">Open</button>}
         title="Test modal"
@@ -19,7 +19,7 @@ describe('Modal', () => {
       screen.queryByRole('heading', { name: 'Test modal' }),
     ).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Open' }));
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(
@@ -28,7 +28,7 @@ describe('Modal', () => {
   });
 
   test('clicking the close button closes the modal', async () => {
-    render(
+    const { user } = render(
       <Modal
         showClose
         triggerButton={<button type="button">Open</button>}
@@ -44,7 +44,7 @@ describe('Modal', () => {
       screen.getByRole('heading', { name: 'Test modal' }),
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Close' }));
+    await user.click(screen.getByRole('button', { name: 'Close modal' }));
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(
@@ -119,7 +119,7 @@ describe('Modal', () => {
   test('when opened the `onOpen` handler is called', async () => {
     const onOpen = jest.fn();
 
-    render(
+    const { user } = render(
       <Modal
         triggerButton={<button type="button">Open</button>}
         title="Test modal"
@@ -132,7 +132,7 @@ describe('Modal', () => {
 
     expect(onOpen).not.toHaveBeenCalled();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Open' }));
 
     await waitFor(() => {
       expect(onOpen).toHaveBeenCalled();
@@ -142,7 +142,7 @@ describe('Modal', () => {
   test('closing the modal calls the `onExit` handler', async () => {
     const onExit = jest.fn();
 
-    render(
+    const { user } = render(
       <Modal
         triggerButton={<button type="button">Open</button>}
         title="Test modal"
@@ -156,7 +156,7 @@ describe('Modal', () => {
 
     expect(onExit).not.toHaveBeenCalled();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Close' }));
+    await user.click(screen.getByRole('button', { name: 'Close modal' }));
 
     await waitFor(() => {
       expect(onExit).toHaveBeenCalled();

--- a/src/explore-education-statistics-frontend/src/components/Breadcrumbs.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Breadcrumbs.tsx
@@ -10,7 +10,6 @@ export interface BreadcrumbsProps {
 
 const Breadcrumbs = ({ breadcrumbs = [] }: BreadcrumbsProps) => {
   const currentBreadcrumbIndex = breadcrumbs.length - 1;
-
   return (
     <nav className="govuk-breadcrumbs" aria-label="Breadcrumb">
       <ol className="govuk-breadcrumbs__list" data-testid="breadcrumbs--list">

--- a/src/explore-education-statistics-frontend/src/components/Page.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Page.tsx
@@ -10,6 +10,7 @@ import PageMeta, { PageMetaProps } from './PageMeta';
 import PageTitle from './PageTitle';
 
 type Props = {
+  includeDefaultMetaTitle?: boolean;
   title: string;
   metaTitle?: string;
   caption?: string;
@@ -23,6 +24,7 @@ type Props = {
 } & BreadcrumbsProps;
 
 const Page = ({
+  includeDefaultMetaTitle,
   title,
   metaTitle,
   caption = '',
@@ -39,6 +41,7 @@ const Page = ({
     <>
       <CookieBanner wide={wide} />
       <PageMeta
+        includeDefaultMetaTitle={includeDefaultMetaTitle}
         title={metaTitle ?? `${title}${caption && `, ${caption}`}`}
         description={description}
         {...pageMeta}

--- a/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import Head from 'next/head';
 
 export interface PageMetaProps {
+  includeDefaultMetaTitle?: boolean;
   title?: string;
   description?: string;
   imgUrl?: string;
 }
 
-const defaultPageTitle = 'Explore education statistics – GOV.UK';
+const defaultPageTitle = 'Explore education statistics - GOV.UK';
 
 const PageMeta = ({
+  includeDefaultMetaTitle = true,
   title = defaultPageTitle,
   description = 'Find, download and explore official Department for Education (DfE) statistics and data in England.',
   imgUrl,
@@ -18,8 +20,8 @@ const PageMeta = ({
     <Head>
       {/* <!-- Primary Meta Tags --> */}
       <title>
-        {title && title !== defaultPageTitle
-          ? `${title} – ${defaultPageTitle}`
+        {title && title !== defaultPageTitle && includeDefaultMetaTitle
+          ? `${title} - ${defaultPageTitle}`
           : title}
       </title>
       <meta name="title" content={title} />

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
@@ -1,4 +1,4 @@
-import publicationService, {
+import {
   PublicationTreeSummary,
   ReleaseSummary,
   Theme,

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataCataloguePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataCataloguePage.test.tsx
@@ -13,7 +13,6 @@ import _dataSetFileService from '@frontend/services/dataSetFileService';
 import { testReleases } from '@frontend/modules/data-catalogue/__data__/testReleases';
 import { testThemes } from '@frontend/modules/data-catalogue/__data__/testThemes';
 import { screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { produce } from 'immer';
 import mockRouter from 'next-router-mock';
@@ -119,7 +118,7 @@ describe('DataCataloguePage', () => {
   ];
 
   test('renders the page correctly with themes and publications', async () => {
-    render(<DataCataloguePage themes={testThemes} />);
+    const { user } = render(<DataCataloguePage themes={testThemes} />);
 
     expect(screen.getByText('Choose a publication')).toBeInTheDocument();
 
@@ -142,7 +141,7 @@ describe('DataCataloguePage', () => {
       }),
     ).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('radio', { name: 'Theme title 1' }));
+    await user.click(screen.getByRole('radio', { name: 'Theme title 1' }));
 
     // Check there is only one radio for the publication
     await waitFor(() => {
@@ -168,7 +167,7 @@ describe('DataCataloguePage', () => {
     publicationService.listReleases.mockResolvedValue(testReleases);
     tableBuilderService.listReleaseSubjects.mockResolvedValue(testSubjects);
 
-    render(<DataCataloguePage themes={testThemes} />);
+    const { user } = render(<DataCataloguePage themes={testThemes} />);
 
     expect(screen.getByTestId('wizardStep-1')).toHaveAttribute(
       'aria-current',
@@ -181,11 +180,9 @@ describe('DataCataloguePage', () => {
 
     expect(step1.getByText('Choose a publication')).toBeInTheDocument();
 
-    await userEvent.click(step1.getByRole('radio', { name: 'Theme title 1' }));
-    await userEvent.click(
-      step1.getByRole('radio', { name: 'Publication title 1' }),
-    );
-    await userEvent.click(step1.getByRole('button', { name: 'Next step' }));
+    await user.click(step1.getByRole('radio', { name: 'Theme title 1' }));
+    await user.click(step1.getByRole('radio', { name: 'Publication title 1' }));
+    await user.click(step1.getByRole('button', { name: 'Next step' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('wizardStep-1')).not.toHaveAttribute(
@@ -218,8 +215,8 @@ describe('DataCataloguePage', () => {
     expect(releaseRadios[1]).toEqual(step2.getByLabelText('Release title 2'));
     expect(releaseRadios[2]).toEqual(step2.getByLabelText('Release title 1'));
 
-    await userEvent.click(releaseRadios[0]);
-    await userEvent.click(step2.getByRole('button', { name: 'Next step' }));
+    await user.click(releaseRadios[0]);
+    await user.click(step2.getByRole('button', { name: 'Next step' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('wizardStep-2')).not.toHaveAttribute(
@@ -251,10 +248,10 @@ describe('DataCataloguePage', () => {
       step3.getByLabelText('Subject 3 (csv, 30 Mb)'),
     );
 
-    await userEvent.click(fileCheckboxes[1]);
-    await userEvent.click(fileCheckboxes[2]);
+    await user.click(fileCheckboxes[1]);
+    await user.click(fileCheckboxes[2]);
 
-    await userEvent.click(
+    await user.click(
       step3.getByRole('button', { name: 'Download selected files' }),
     );
 
@@ -276,16 +273,16 @@ describe('DataCataloguePage', () => {
         slug: 'test-publication-2',
       };
     });
-    render(<DataCataloguePage themes={testThemesSuperseded} />);
+    const { user } = render(
+      <DataCataloguePage themes={testThemesSuperseded} />,
+    );
 
     // Step 1
 
     const step1 = within(screen.getByTestId('wizardStep-1'));
-    await userEvent.click(step1.getByRole('radio', { name: 'Theme title 1' }));
-    await userEvent.click(
-      step1.getByRole('radio', { name: 'Publication title 1' }),
-    );
-    await userEvent.click(step1.getByRole('button', { name: 'Next step' }));
+    await user.click(step1.getByRole('radio', { name: 'Theme title 1' }));
+    await user.click(step1.getByRole('radio', { name: 'Publication title 1' }));
+    await user.click(step1.getByRole('button', { name: 'Next step' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('wizardStep-1')).not.toHaveAttribute(
@@ -318,7 +315,9 @@ describe('DataCataloguePage', () => {
       };
     });
 
-    render(<DataCataloguePage themes={testThemesSuperseded} />);
+    const { user } = render(
+      <DataCataloguePage themes={testThemesSuperseded} />,
+    );
 
     expect(screen.getByTestId('wizardStep-1')).toHaveAttribute(
       'aria-current',
@@ -329,11 +328,9 @@ describe('DataCataloguePage', () => {
 
     const step1 = within(screen.getByTestId('wizardStep-1'));
 
-    await userEvent.click(step1.getByRole('radio', { name: 'Theme title 1' }));
-    await userEvent.click(
-      step1.getByRole('radio', { name: 'Publication title 1' }),
-    );
-    await userEvent.click(step1.getByRole('button', { name: 'Next step' }));
+    await user.click(step1.getByRole('radio', { name: 'Theme title 1' }));
+    await user.click(step1.getByRole('radio', { name: 'Publication title 1' }));
+    await user.click(step1.getByRole('button', { name: 'Next step' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('wizardStep-1')).not.toHaveAttribute(
@@ -586,7 +583,7 @@ describe('DataCataloguePage', () => {
         expect(screen.getByText('30 data sets')).toBeInTheDocument();
       });
 
-      const themesSelect = screen.getByLabelText('Theme');
+      const themesSelect = screen.getByLabelText('Filter by Theme');
       const themes = within(themesSelect).getAllByRole(
         'option',
       ) as HTMLOptionElement[];
@@ -604,10 +601,10 @@ describe('DataCataloguePage', () => {
       expect(themes[2]).toHaveValue('theme-2');
       expect(themes[2].selected).toBe(false);
 
-      const publicationsSelect = screen.getByLabelText('Publication');
+      const publicationsSelect = screen.getByLabelText('Filter by Publication');
       expect(publicationsSelect).toBeDisabled();
 
-      const releasesSelect = screen.getByLabelText('Releases');
+      const releasesSelect = screen.getByLabelText('Filter by Releases');
       const releases = within(releasesSelect).getAllByRole(
         'option',
       ) as HTMLOptionElement[];
@@ -634,25 +631,31 @@ describe('DataCataloguePage', () => {
         });
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('30 data sets')).toBeInTheDocument();
         });
 
-        expect(screen.getByLabelText('Publication')).toBeDisabled();
+        expect(screen.getByLabelText('Filter by Publication')).toBeDisabled();
         expect(
-          within(screen.getByLabelText('Publication')).getAllByRole('option'),
+          within(screen.getByLabelText('Filter by Publication')).getAllByRole(
+            'option',
+          ),
         ).toHaveLength(1);
 
-        userEvent.selectOptions(screen.getByLabelText('Theme'), ['theme-2']);
+        user.selectOptions(screen.getByLabelText('Filter by Theme'), [
+          'theme-2',
+        ]);
 
         await waitFor(() => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
         });
       });
       test('populates and enables the publications dropdown', async () => {
-        const publicationsSelect = screen.getByLabelText('Publication');
+        const publicationsSelect = screen.getByLabelText(
+          'Filter by Publication',
+        );
         expect(publicationsSelect).not.toBeDisabled();
 
         const publications = within(publicationsSelect).getAllByRole(
@@ -719,13 +722,15 @@ describe('DataCataloguePage', () => {
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
         publicationService.listReleases.mockResolvedValue(testReleases);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('30 data sets')).toBeInTheDocument();
         });
 
-        userEvent.selectOptions(screen.getByLabelText('Theme'), ['theme-2']);
+        user.selectOptions(screen.getByLabelText('Filter by Theme'), [
+          'theme-2',
+        ]);
 
         await waitFor(() => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
@@ -734,7 +739,7 @@ describe('DataCataloguePage', () => {
         expect(publicationService.listReleases).not.toHaveBeenCalled();
 
         // Select publication
-        userEvent.selectOptions(screen.getByLabelText('Publication'), [
+        user.selectOptions(screen.getByLabelText('Filter by Publication'), [
           'publication-2',
         ]);
 
@@ -748,7 +753,7 @@ describe('DataCataloguePage', () => {
           'publication-slug-2',
         );
 
-        const releasesSelect = screen.getByLabelText('Releases');
+        const releasesSelect = screen.getByLabelText('Filter by Releases');
         const updatedReleases = within(releasesSelect).getAllByRole(
           'option',
         ) as HTMLOptionElement[];
@@ -863,23 +868,25 @@ describe('DataCataloguePage', () => {
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
         publicationService.listReleases.mockResolvedValue(testReleases);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('30 data sets')).toBeInTheDocument();
         });
 
-        const releasesSelect = screen.getByLabelText('Releases');
+        const releasesSelect = screen.getByLabelText('Filter by Releases');
 
         // Select theme
-        userEvent.selectOptions(screen.getByLabelText('Theme'), ['theme-2']);
+        user.selectOptions(screen.getByLabelText('Filter by Theme'), [
+          'theme-2',
+        ]);
 
         await waitFor(() => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
         });
 
         // Select publication
-        userEvent.selectOptions(screen.getByLabelText('Publication'), [
+        user.selectOptions(screen.getByLabelText('Filter by Publication'), [
           'publication-2',
         ]);
 
@@ -887,7 +894,7 @@ describe('DataCataloguePage', () => {
           expect(screen.getByText('1 data set')).toBeInTheDocument();
         });
 
-        userEvent.selectOptions(releasesSelect, ['release-1']);
+        user.selectOptions(releasesSelect, ['release-1']);
 
         await waitFor(() => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
@@ -924,6 +931,10 @@ describe('DataCataloguePage', () => {
           screen.getByRole('button', { name: 'Reset filters' }),
         ).toBeInTheDocument();
 
+        await waitFor(() =>
+          expect(screen.getByTestId('release-info')).toBeInTheDocument(),
+        );
+
         const releaseInfo = within(screen.getByTestId('release-info'));
 
         expect(
@@ -957,15 +968,15 @@ describe('DataCataloguePage', () => {
         });
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('30 data sets')).toBeInTheDocument();
         });
 
-        const releasesSelect = screen.getByLabelText('Releases');
+        const releasesSelect = screen.getByLabelText('Filter by Releases');
 
-        userEvent.selectOptions(releasesSelect, ['all']);
+        user.selectOptions(releasesSelect, ['all']);
 
         await waitFor(() => {
           expect(releasesSelect).toHaveValue('all');
@@ -978,7 +989,7 @@ describe('DataCataloguePage', () => {
           },
         });
 
-        userEvent.selectOptions(releasesSelect, ['latest']);
+        user.selectOptions(releasesSelect, ['latest']);
 
         await waitFor(() => {
           expect(releasesSelect).toHaveValue('latest');
@@ -1005,17 +1016,14 @@ describe('DataCataloguePage', () => {
         });
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('30 data sets')).toBeInTheDocument();
         });
 
-        await userEvent.type(
-          screen.getByLabelText('Search data sets'),
-          'find me',
-        );
-        await userEvent.click(screen.getByRole('button', { name: 'Search' }));
+        await user.type(screen.getByLabelText('Search data sets'), 'find me');
+        await user.click(screen.getByRole('button', { name: 'Search' }));
 
         await waitFor(() => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
@@ -1067,9 +1075,11 @@ describe('DataCataloguePage', () => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
         });
 
-        expect(screen.getByLabelText('Theme')).toHaveValue('theme-2');
+        expect(screen.getByLabelText('Filter by Theme')).toHaveValue('theme-2');
 
-        const publicationsSelect = screen.getByLabelText('Publication');
+        const publicationsSelect = screen.getByLabelText(
+          'Filter by Publication',
+        );
         expect(publicationsSelect).not.toBeDisabled();
 
         const publications = within(publicationsSelect).getAllByRole(
@@ -1089,7 +1099,9 @@ describe('DataCataloguePage', () => {
         expect(publications[2]).toHaveValue('publication-3');
         expect(publications[2].selected).toBe(false);
 
-        expect(screen.getByLabelText('Releases')).toHaveValue('latest');
+        expect(screen.getByLabelText('Filter by Releases')).toHaveValue(
+          'latest',
+        );
 
         expect(
           screen.getByRole('button', {
@@ -1119,19 +1131,21 @@ describe('DataCataloguePage', () => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
         });
 
-        expect(screen.getByLabelText('Theme')).toHaveValue('theme-2');
-        expect(screen.getByLabelText('Publication')).toHaveValue(
+        expect(screen.getByLabelText('Filter by Theme')).toHaveValue('theme-2');
+        expect(screen.getByLabelText('Filter by Publication')).toHaveValue(
           'publication-2',
         );
 
-        const releasesSelect = screen.getByLabelText('Releases');
+        const releasesSelect = screen.getByLabelText('Filter by Releases');
         const releases = within(releasesSelect).getAllByRole(
           'option',
         ) as HTMLOptionElement[];
         expect(releases).toHaveLength(4);
 
         await waitFor(() => {
-          expect(screen.getByLabelText('Releases')).toHaveValue('release-3');
+          expect(screen.getByLabelText('Filter by Releases')).toHaveValue(
+            'release-3',
+          );
         });
 
         expect(releases[0]).toHaveTextContent('All releases');
@@ -1189,19 +1203,21 @@ describe('DataCataloguePage', () => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
         });
 
-        expect(screen.getByLabelText('Theme')).toHaveValue('theme-2');
-        expect(screen.getByLabelText('Publication')).toHaveValue(
+        expect(screen.getByLabelText('Filter by Theme')).toHaveValue('theme-2');
+        expect(screen.getByLabelText('Filter by Publication')).toHaveValue(
           'publication-2',
         );
 
-        const releasesSelect = screen.getByLabelText('Releases');
+        const releasesSelect = screen.getByLabelText('Filter by Releases');
         const releases = within(releasesSelect).getAllByRole(
           'option',
         ) as HTMLOptionElement[];
         expect(releases).toHaveLength(4);
 
         await waitFor(() => {
-          expect(screen.getByLabelText('Releases')).toHaveValue('release-1');
+          expect(screen.getByLabelText('Filter by Releases')).toHaveValue(
+            'release-1',
+          );
         });
 
         expect(releases[0]).toHaveTextContent('All releases');
@@ -1262,19 +1278,21 @@ describe('DataCataloguePage', () => {
           query: { publicationId: 'publication-2', themeId: 'theme-2' },
         });
 
-        expect(screen.getByLabelText('Theme')).toHaveValue('theme-2');
-        expect(screen.getByLabelText('Publication')).toHaveValue(
+        expect(screen.getByLabelText('Filter by Theme')).toHaveValue('theme-2');
+        expect(screen.getByLabelText('Filter by Publication')).toHaveValue(
           'publication-2',
         );
 
-        const releasesSelect = screen.getByLabelText('Releases');
+        const releasesSelect = screen.getByLabelText('Filter by Releases');
         const releases = within(releasesSelect).getAllByRole(
           'option',
         ) as HTMLOptionElement[];
         expect(releases).toHaveLength(4);
 
         await waitFor(() => {
-          expect(screen.getByLabelText('Releases')).toHaveValue('release-3');
+          expect(screen.getByLabelText('Filter by Releases')).toHaveValue(
+            'release-3',
+          );
         });
 
         expect(releases[0]).toHaveTextContent('All releases');
@@ -1329,9 +1347,13 @@ describe('DataCataloguePage', () => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
         });
 
-        expect(screen.getByLabelText('Theme')).toHaveValue('all');
-        expect(screen.getByLabelText('Publication')).toHaveValue('all');
-        expect(screen.getByLabelText('Releases')).toHaveValue('latest');
+        expect(screen.getByLabelText('Filter by Theme')).toHaveValue('all');
+        expect(screen.getByLabelText('Filter by Publication')).toHaveValue(
+          'all',
+        );
+        expect(screen.getByLabelText('Filter by Releases')).toHaveValue(
+          'latest',
+        );
 
         expect(
           screen.getByRole('button', {
@@ -1359,9 +1381,13 @@ describe('DataCataloguePage', () => {
           expect(screen.getByText('30 data sets')).toBeInTheDocument();
         });
 
-        expect(screen.getByLabelText('Theme')).toHaveValue('all');
-        expect(screen.getByLabelText('Publication')).toHaveValue('all');
-        expect(screen.getByLabelText('Releases')).toHaveValue('latest');
+        expect(screen.getByLabelText('Filter by Theme')).toHaveValue('all');
+        expect(screen.getByLabelText('Filter by Publication')).toHaveValue(
+          'all',
+        );
+        expect(screen.getByLabelText('Filter by Releases')).toHaveValue(
+          'latest',
+        );
 
         expect(
           screen.queryByRole('button', { name: 'Reset filters' }),
@@ -1383,23 +1409,25 @@ describe('DataCataloguePage', () => {
         });
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
         });
 
-        const themesSelect = screen.getByLabelText('Theme');
+        const themesSelect = screen.getByLabelText('Filter by Theme');
         expect(themesSelect).toHaveValue('theme-2');
 
-        const publicationsSelect = screen.getByLabelText('Publication');
+        const publicationsSelect = screen.getByLabelText(
+          'Filter by Publication',
+        );
         expect(publicationsSelect).not.toBeDisabled();
         expect(publicationsSelect).toHaveValue('all');
         expect(within(publicationsSelect).getAllByRole('option')).toHaveLength(
           3,
         );
 
-        userEvent.click(
+        user.click(
           screen.getByRole('button', {
             name: 'Remove filter: Theme Theme title 2',
           }),
@@ -1441,23 +1469,25 @@ describe('DataCataloguePage', () => {
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
         publicationService.listReleases.mockResolvedValue(testReleases);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
         });
 
-        const themesSelect = screen.getByLabelText('Theme');
+        const themesSelect = screen.getByLabelText('Filter by Theme');
         expect(themesSelect).toHaveValue('theme-2');
 
-        const publicationsSelect = screen.getByLabelText('Publication');
+        const publicationsSelect = screen.getByLabelText(
+          'Filter by Publication',
+        );
         expect(publicationsSelect).not.toBeDisabled();
         expect(publicationsSelect).toHaveValue('publication-2');
         expect(within(publicationsSelect).getAllByRole('option')).toHaveLength(
           3,
         );
 
-        const releasesSelect = screen.getByLabelText('Releases');
+        const releasesSelect = screen.getByLabelText('Filter by Releases');
         await waitFor(() => {
           expect(releasesSelect).toHaveValue('release-1');
         });
@@ -1474,7 +1504,7 @@ describe('DataCataloguePage', () => {
           }),
         ).toBeInTheDocument();
 
-        userEvent.click(
+        user.click(
           screen.getByRole('button', {
             name: 'Remove filter: Theme Theme title 2',
           }),
@@ -1534,16 +1564,18 @@ describe('DataCataloguePage', () => {
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
         publicationService.listReleases.mockResolvedValue(testReleases);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
         });
 
-        const publicationsSelect = screen.getByLabelText('Publication');
+        const publicationsSelect = screen.getByLabelText(
+          'Filter by Publication',
+        );
         expect(publicationsSelect).toHaveValue('publication-2');
 
-        const releasesSelect = screen.getByLabelText('Releases');
+        const releasesSelect = screen.getByLabelText('Filter by Releases');
         await waitFor(() => {
           expect(releasesSelect).toHaveValue('release-1');
         });
@@ -1554,15 +1586,15 @@ describe('DataCataloguePage', () => {
           }),
         ).toBeInTheDocument();
 
-        await userEvent.click(
+        await user.click(
           screen.getByRole('button', {
             name: 'Remove filter: Publication Publication title 2',
           }),
         );
 
-        await waitFor(() => {
-          expect(screen.getByText('30 data sets')).toBeInTheDocument();
-        });
+        expect(await screen.getByTestId('total-results')).toHaveTextContent(
+          '30 data sets',
+        );
 
         expect(mockRouter).toMatchObject({
           pathname: '/data-catalogue',
@@ -1600,24 +1632,26 @@ describe('DataCataloguePage', () => {
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
         publicationService.listReleases.mockResolvedValue(testReleases);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
         });
 
-        const releasesSelect = screen.getByLabelText('Releases');
+        const releasesSelect = screen.getByLabelText('Filter by Releases');
         await waitFor(() => {
           expect(releasesSelect).toHaveValue('release-1');
         });
 
-        await userEvent.click(
+        await user.click(
           screen.getByRole('button', {
             name: 'Remove filter: Release Release title 1',
           }),
         );
 
-        expect(await screen.findByText('30 data sets')).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.getByText('30 data sets')).toBeInTheDocument();
+        });
 
         expect(mockRouter).toMatchObject({
           pathname: '/data-catalogue',
@@ -1646,13 +1680,13 @@ describe('DataCataloguePage', () => {
         });
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
         });
 
-        userEvent.click(
+        user.click(
           screen.getByRole('button', {
             name: 'Remove filter: Search find me',
           }),
@@ -1690,7 +1724,7 @@ describe('DataCataloguePage', () => {
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
         publicationService.listReleases.mockResolvedValue(testReleases);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
@@ -1714,7 +1748,7 @@ describe('DataCataloguePage', () => {
           }),
         ).toBeInTheDocument();
 
-        await userEvent.click(
+        await user.click(
           screen.getByRole('button', {
             name: 'Reset filters',
           }),
@@ -1763,13 +1797,13 @@ describe('DataCataloguePage', () => {
         });
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('30 data sets')).toBeInTheDocument();
         });
 
-        userEvent.click(screen.getByLabelText('A to Z'));
+        user.click(screen.getByLabelText('A to Z'));
 
         await waitFor(() => {
           expect(mockRouter).toMatchObject({
@@ -1790,19 +1824,14 @@ describe('DataCataloguePage', () => {
         });
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('30 data sets')).toBeInTheDocument();
         });
 
-        await userEvent.type(
-          screen.getByLabelText('Search data sets'),
-          'Find me',
-        );
-        await await userEvent.click(
-          screen.getByRole('button', { name: 'Search' }),
-        );
+        await user.type(screen.getByLabelText('Search data sets'), 'Find me');
+        await await user.click(screen.getByRole('button', { name: 'Search' }));
 
         await waitFor(() => {
           expect(screen.getByText('2 data sets')).toBeInTheDocument();
@@ -1828,7 +1857,7 @@ describe('DataCataloguePage', () => {
         });
         publicationService.getPublicationTree.mockResolvedValue(testThemes);
 
-        render(<DataCataloguePage newDesign />);
+        const { user } = render(<DataCataloguePage newDesign />);
 
         await waitFor(() => {
           expect(screen.getByText('1 data set')).toBeInTheDocument();
@@ -1839,7 +1868,7 @@ describe('DataCataloguePage', () => {
           query: { orderBy: 'relevance' },
         });
 
-        await userEvent.click(
+        await user.click(
           screen.getByRole('button', {
             name: 'Remove filter: Search Find me',
           }),
@@ -1864,21 +1893,19 @@ describe('DataCataloguePage', () => {
       });
       publicationService.getPublicationTree.mockResolvedValue(testThemes);
 
-      render(<DataCataloguePage newDesign />);
+      const { user } = render(<DataCataloguePage newDesign />);
 
       expect(await screen.findByText('30 data sets')).toBeInTheDocument();
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Filter results' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Filter results' }));
 
       expect(await screen.findByText('Back to results')).toBeInTheDocument();
 
       const modal = within(screen.getByRole('dialog'));
 
-      expect(modal.getByLabelText('Theme')).toBeInTheDocument();
-      expect(modal.getByLabelText('Publication')).toBeInTheDocument();
-      expect(modal.getByLabelText('Releases')).toBeInTheDocument();
+      expect(modal.getByLabelText('Filter by Theme')).toBeInTheDocument();
+      expect(modal.getByLabelText('Filter by Publication')).toBeInTheDocument();
+      expect(modal.getByLabelText('Filter by Releases')).toBeInTheDocument();
       expect(
         modal.getByRole('button', { name: 'Back to results' }),
       ).toBeInTheDocument();

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/Filters.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/Filters.tsx
@@ -5,12 +5,8 @@ import {
 } from '@common/services/publicationService';
 import Button from '@common/components/Button';
 import ButtonText from '@common/components/ButtonText';
-import {
-  FormFieldset,
-  FormGroup,
-  FormRadioGroup,
-  FormSelect,
-} from '@common/components/form';
+import { FormGroup, FormRadioGroup, FormSelect } from '@common/components/form';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 import ThemesModal from '@frontend/modules/find-statistics/components/ThemesModal';
 import {
   DataSetFileFilter,
@@ -60,119 +56,125 @@ export default function Filters({
   const latestValue = latestOnly === 'true' ? 'latest' : 'all';
   return (
     <form className={styles.form} id={formId}>
-      <FormFieldset
-        id={`${formId}-filters`}
-        legend="Filter data sets"
-        legendSize="m"
-        className="govuk-fieldset "
-      >
-        <FormGroup>
-          <FormSelect
-            className="govuk-!-width-full"
-            hint={<ThemesModal themes={themes} />}
-            id={`${formId}-theme`}
-            inlineHint
-            label="Theme"
-            name="themeId"
-            options={[
-              { label: 'All themes', value: 'all' },
-              ...themes.map(theme => ({
-                label: theme.title,
-                value: theme.id,
-              })),
-            ]}
-            value={themeId ?? 'all'}
-            order={[]}
-            onChange={e => {
-              onChange({ filterType: 'themeId', nextValue: e.target.value });
-            }}
-          />
-        </FormGroup>
+      <FormGroup className="govuk-!-margin-bottom-1">
+        <h2 className="govuk-heading-m">Filter data sets</h2>
+        <FormSelect
+          className="govuk-!-width-full"
+          id={`${formId}-theme`}
+          inlineHint
+          label={
+            <>
+              <VisuallyHidden>Filter by </VisuallyHidden>Theme
+            </>
+          }
+          name="themeId"
+          options={[
+            { label: 'All themes', value: 'all' },
+            ...themes.map(theme => ({
+              label: theme.title,
+              value: theme.id,
+            })),
+          ]}
+          value={themeId ?? 'all'}
+          order={[]}
+          onChange={e => {
+            onChange({ filterType: 'themeId', nextValue: e.target.value });
+          }}
+        />
+      </FormGroup>
+      <ThemesModal themes={themes} />
 
-        <FormGroup>
-          <FormSelect
-            className="govuk-!-width-full"
-            disabled={!themeId}
-            id={`${formId}-publication`}
-            label="Publication"
-            name="publicationId"
-            options={[
-              { label: 'All publications', value: 'all' },
-              ...publications.map(publication => ({
-                label: publication.title,
-                value: publication.id,
-              })),
-            ]}
-            value={publicationId ?? 'all'}
-            order={[]}
-            onChange={e => {
-              onChange({
-                filterType: 'publicationId',
-                nextValue: e.target.value,
-              });
-            }}
-          />
-        </FormGroup>
+      <FormGroup className="govuk-!-margin-top-4">
+        <FormSelect
+          className="govuk-!-width-full"
+          disabled={!themeId}
+          id={`${formId}-publication`}
+          label={
+            <>
+              <VisuallyHidden>Filter by </VisuallyHidden>Publication
+            </>
+          }
+          name="publicationId"
+          options={[
+            { label: 'All publications', value: 'all' },
+            ...publications.map(publication => ({
+              label: publication.title,
+              value: publication.id,
+            })),
+          ]}
+          value={publicationId ?? 'all'}
+          order={[]}
+          onChange={e => {
+            onChange({
+              filterType: 'publicationId',
+              nextValue: e.target.value,
+            });
+          }}
+        />
+      </FormGroup>
 
-        <FormGroup>
-          <FormSelect
-            className="govuk-!-width-full"
-            id={`${formId}-release`}
-            label="Releases"
-            name="releaseId"
-            options={[
-              ...(!publicationId
-                ? [{ label: 'Latest releases', value: 'latest' }]
-                : []),
-              { label: 'All releases', value: 'all' },
-              ...(publicationId
-                ? releases.map(release => ({
-                    label: release.title,
-                    value: release.id,
-                  }))
-                : []),
-            ]}
-            value={releaseId ?? latestValue}
-            order={[]}
-            onChange={e => {
-              onChange({ filterType: 'releaseId', nextValue: e.target.value });
-            }}
-          />
-        </FormGroup>
+      <FormGroup>
+        <FormSelect
+          className="govuk-!-width-full"
+          id={`${formId}-release`}
+          label={
+            <>
+              <VisuallyHidden>Filter by </VisuallyHidden>Releases
+            </>
+          }
+          name="releaseId"
+          options={[
+            ...(!publicationId
+              ? [{ label: 'Latest releases', value: 'latest' }]
+              : []),
+            { label: 'All releases', value: 'all' },
+            ...(publicationId
+              ? releases.map(release => ({
+                  label: release.title,
+                  value: release.id,
+                }))
+              : []),
+          ]}
+          value={releaseId ?? latestValue}
+          order={[]}
+          onChange={e => {
+            onChange({ filterType: 'releaseId', nextValue: e.target.value });
+          }}
+        />
+      </FormGroup>
 
-        {showClearFiltersButton && (
-          <ButtonText
-            className={classNames({ 'govuk-!-margin-top-4': !showTypeFilter })}
-            onClick={onClearFilters}
-          >
-            Reset filters
-          </ButtonText>
-        )}
-        {showTypeFilter && (
-          <FormRadioGroup<DataSetType>
-            formGroupClass="dfe-border-top govuk-!-padding-top-4 govuk-!-margin-top-2"
-            id={`${formId}-dataSetType`}
-            legend="Type of data"
-            legendSize="s"
-            name="dataSetType"
-            options={[
-              { label: 'All data', value: 'all' },
-              {
-                label: 'API data sets only',
-                value: 'api',
-              },
-            ]}
-            small
-            value={dataSetType}
-            onChange={e => {
-              onChange({
-                filterType: 'dataSetType',
-                nextValue: e.target.value,
-              });
-            }}
-          />
-        )}
-      </FormFieldset>
+      {showClearFiltersButton && (
+        <ButtonText
+          className={classNames({ 'govuk-!-margin-top-4': !showTypeFilter })}
+          onClick={onClearFilters}
+        >
+          Reset filters
+        </ButtonText>
+      )}
+      {showTypeFilter && (
+        <FormRadioGroup<DataSetType>
+          formGroupClass="dfe-border-top govuk-!-padding-top-4 govuk-!-margin-top-2"
+          id={`${formId}-dataSetType`}
+          legend="Type of data"
+          legendSize="s"
+          name="dataSetType"
+          options={[
+            { label: 'All data', value: 'all' },
+            {
+              label: 'API data sets only',
+              value: 'api',
+            },
+          ]}
+          small
+          value={dataSetType}
+          onChange={e => {
+            onChange({
+              filterType: 'dataSetType',
+              nextValue: e.target.value,
+            });
+          }}
+        />
+      )}
 
       <Button className="dfe-js-hidden" type="submit">
         Submit

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileDetails.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileDetails.test.tsx
@@ -59,6 +59,8 @@ describe('DataSetFileDetails', () => {
     expect(
       modal.getByRole('heading', { name: 'Accredited official statistics' }),
     ).toBeInTheDocument();
-    expect(modal.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+    expect(
+      modal.getByRole('button', { name: 'Close modal' }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/Filters.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/Filters.test.tsx
@@ -10,7 +10,7 @@ describe('Filters', () => {
   test('renders the default filters', () => {
     render(<Filters themes={testThemes} onChange={noop} />);
 
-    const themesSelect = screen.getByLabelText('Theme');
+    const themesSelect = screen.getByLabelText('Filter by Theme');
     const themes = within(themesSelect).getAllByRole(
       'option',
     ) as HTMLOptionElement[];
@@ -28,7 +28,7 @@ describe('Filters', () => {
     expect(themes[2]).toHaveValue('theme-2');
     expect(themes[2].selected).toBe(false);
 
-    const publicationsSelect = screen.getByLabelText('Publication');
+    const publicationsSelect = screen.getByLabelText('Filter by Publication');
     const publications = within(publicationsSelect).getAllByRole(
       'option',
     ) as HTMLOptionElement[];
@@ -38,7 +38,7 @@ describe('Filters', () => {
     expect(publications[0]).toHaveValue('all');
     expect(publications[0].selected).toBe(true);
 
-    const releasesSelect = screen.getByLabelText('Releases');
+    const releasesSelect = screen.getByLabelText('Filter by Releases');
     const releases = within(releasesSelect).getAllByRole(
       'option',
     ) as HTMLOptionElement[];
@@ -84,7 +84,7 @@ describe('Filters', () => {
       />,
     );
 
-    const releasesSelect = screen.getByLabelText('Releases');
+    const releasesSelect = screen.getByLabelText('Filter by Releases');
     const releases = within(releasesSelect).getAllByRole(
       'option',
     ) as HTMLOptionElement[];
@@ -106,13 +106,13 @@ describe('Filters', () => {
   test('disables the publication filter when there is no themeId', () => {
     render(<Filters themes={testThemes} onChange={noop} />);
 
-    expect(screen.getByLabelText('Publication')).toBeDisabled();
+    expect(screen.getByLabelText('Filter by Publication')).toBeDisabled();
   });
 
   test('enables the publication filter when there is a themeId', () => {
     render(<Filters themes={testThemes} themeId="theme-2" onChange={noop} />);
 
-    expect(screen.getByLabelText('Publication')).not.toBeDisabled();
+    expect(screen.getByLabelText('Filter by Publication')).not.toBeDisabled();
   });
 
   test('calls the onChange handler when the theme filter is changed', async () => {
@@ -123,7 +123,9 @@ describe('Filters', () => {
 
     expect(handleChange).not.toHaveBeenCalled();
 
-    await user.selectOptions(screen.getByLabelText('Theme'), ['theme-1']);
+    await user.selectOptions(screen.getByLabelText('Filter by Theme'), [
+      'theme-1',
+    ]);
 
     expect(handleChange).toHaveBeenCalledWith({
       filterType: 'themeId',
@@ -144,7 +146,7 @@ describe('Filters', () => {
 
     expect(handleChange).not.toHaveBeenCalled();
 
-    await user.selectOptions(screen.getByLabelText('Publication'), [
+    await user.selectOptions(screen.getByLabelText('Filter by Publication'), [
       'publication-2',
     ]);
 
@@ -168,7 +170,9 @@ describe('Filters', () => {
 
     expect(handleChange).not.toHaveBeenCalled();
 
-    await user.selectOptions(screen.getByLabelText('Releases'), ['release-1']);
+    await user.selectOptions(screen.getByLabelText('Filter by Releases'), [
+      'release-1',
+    ]);
 
     expect(handleChange).toHaveBeenCalledWith({
       filterType: 'releaseId',
@@ -202,7 +206,7 @@ describe('Filters', () => {
   test('sets the initial value for the theme filter', () => {
     render(<Filters themes={testThemes} themeId="theme-2" onChange={noop} />);
 
-    expect(screen.getByLabelText('Theme')).toHaveValue('theme-2');
+    expect(screen.getByLabelText('Filter by Theme')).toHaveValue('theme-2');
   });
 
   test('sets the initial value for the publication filter', () => {
@@ -216,7 +220,9 @@ describe('Filters', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Publication')).toHaveValue('publication-2');
+    expect(screen.getByLabelText('Filter by Publication')).toHaveValue(
+      'publication-2',
+    );
   });
 
   test('sets the initial value for the release filter', () => {
@@ -231,6 +237,8 @@ describe('Filters', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Releases')).toHaveValue('release-2');
+    expect(screen.getByLabelText('Filter by Releases')).toHaveValue(
+      'release-2',
+    );
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPage.test.tsx
@@ -91,10 +91,6 @@ describe('FindStatisticsPage', () => {
     });
 
     expect(
-      screen.getByRole('heading', { name: '30 results' }),
-    ).toBeInTheDocument();
-
-    expect(
       screen.getByText('Page 1 of 3, showing all publications'),
     ).toBeInTheDocument();
 
@@ -353,9 +349,7 @@ describe('FindStatisticsPage', () => {
       await screen.findByText('There are no matching results.'),
     ).toBeInTheDocument();
 
-    expect(
-      screen.getByRole('heading', { name: '0 results' }),
-    ).toBeInTheDocument();
+    expect(screen.getByText('0 results')).toBeInTheDocument();
 
     expect(screen.getByText('0 pages, filtered by:')).toBeInTheDocument();
 

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/ThemeFilters.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/ThemeFilters.tsx
@@ -27,7 +27,7 @@ const ThemeFilters = ({
   return (
     <form id="themeFilters">
       <FormRadioGroup
-        hint={<ThemesModal themes={themes} />}
+        formGroupClass="govuk-!-margin-bottom-1"
         id="theme"
         legend="Filter by theme"
         name="theme"
@@ -39,6 +39,7 @@ const ThemeFilters = ({
           onChange({ filterType: 'themeId', nextValue: e.target.value });
         }}
       />
+      <ThemesModal themes={themes} />
       <Button className="dfe-js-hidden" type="submit">
         Submit
       </Button>


### PR DESCRIPTION
Fixes the following accessibility issues on the data catalogue (new version) and find statistics pages:

### Screen reader announcements

Currently:
- when filter or search:
  - the page title is updated with the new number of pages and is announced before the number of results, e.g. "Data catalogue (page 1 of 27) – Explore education statistics – GOV.UK" followed by "25 results". The DAC report highlighted this as an issue as a lot is read before the useful information - the number of results, see p.130
  - the page title that's announced is actually wrong, it's the title from before the filter happened
  - the number of results is read twice
- when use the pagination
  - the full page title is announced and has the previous page number in, e.g. if you go to page 2 it'll announce "Data catalogue (page 1 of 27) – Explore education statistics – GOV.UK"

This PR changes it so that:
- when filter or search:
  - the page title is updated to 'Data catalogue search results' (without the 'Explore education statistics – GOV.UK'). 
  - the first time you filter or search this new title will be announced followed by the number of results. Ideally this would just announce the number of results, but Next's route announcer always announces the page title the first time a query param is added to the URL, so the best I could come up with is to shorten the page title and not change it on subsequent filters so it isn't re-announced. 
  - the number of results is now only announced once, this uses the `ScreenReaderMessage` component and `aria-hidden` on the visible number of results heading.
 - when use the pagination:
   - the page title is updated to include the new page number, the 'Explore education statistics – GOV.UK' part is removed and the new title is announced.

### Other improvements

- Themes modal - updated the close button to have hidden text so it reads as 'Close modal' in screen readers. This will apply to all modals that have the default close button text. See DAC report p.86
- Moved the 'What are themes' button to below the dropdown / radio buttons and removed the unnecessary fieldset on the data catalogue version. See DAC report p.128
- Added some hidden text to the data catalogue filter dropdown labels to make it clearer what they do, e.g. 'Filter by Theme' instead of just 'Theme'.
