### PR TITLE
Improve Methodology Sitemap Item query

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/MethodologyControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/MethodologyControllerTests.cs
@@ -62,7 +62,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         {
             var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
 
-            methodologyService.Setup(mock => mock.ListSitemapItems())
+            methodologyService.Setup(mock => mock.ListSitemapItems(default))
                 .ReturnsAsync(new List<MethodologySitemapItemViewModel>()
                 {
                     new()
@@ -74,7 +74,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
 
             var controller = new MethodologyController(methodologyService.Object);
 
-            var response = await controller.ListSitemapItems();
+            var response = await controller.ListSitemapItems(default);
             var sitemapItems = response.AssertOkResult();
 
             Assert.Equal("test-methodology", sitemapItems.Single().Slug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/MethodologyControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/MethodologyControllerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
@@ -62,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         {
             var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
 
-            methodologyService.Setup(mock => mock.ListSitemapItems(default))
+            methodologyService.Setup(mock => mock.ListSitemapItems(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<MethodologySitemapItemViewModel>()
                 {
                     new()
@@ -74,7 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
 
             var controller = new MethodologyController(methodologyService.Object);
 
-            var response = await controller.ListSitemapItems(default);
+            var response = await controller.ListSitemapItems();
             var sitemapItems = response.AssertOkResult();
 
             Assert.Equal("test-methodology", sitemapItems.Single().Slug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/PublicationControllerTests.cs
@@ -108,7 +108,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         {
             var publicationService = new Mock<IPublicationService>(Strict);
 
-            publicationService.Setup(mock => mock.ListSitemapItems(default))
+            publicationService.Setup(mock => mock.ListSitemapItems())
                 .ReturnsAsync(new List<PublicationSitemapItemViewModel>()
                 {
                     new()
@@ -128,7 +128,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
 
             var controller = BuildPublicationController(publicationService: publicationService.Object);
 
-            var response = await controller.ListSitemapItems(default);
+            var response = await controller.ListSitemapItems();
             var sitemapItems = response.AssertOkResult();
 
             var item = Assert.Single(sitemapItems);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/PublicationControllerTests.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
@@ -109,7 +108,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         {
             var publicationService = new Mock<IPublicationService>(Strict);
 
-            publicationService.Setup(mock => mock.ListSitemapItems())
+            publicationService.Setup(mock => mock.ListSitemapItems(default))
                 .ReturnsAsync(new List<PublicationSitemapItemViewModel>()
                 {
                     new()
@@ -129,7 +128,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
 
             var controller = BuildPublicationController(publicationService: publicationService.Object);
 
-            var response = await controller.ListSitemapItems();
+            var response = await controller.ListSitemapItems(default);
             var sitemapItems = response.AssertOkResult();
 
             var item = Assert.Single(sitemapItems);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
@@ -61,7 +61,7 @@ public class DataSetFilesController : ControllerBase
 
     [HttpGet("data-set-files/sitemap-items")]
     public async Task<ActionResult<List<DataSetSitemapItemViewModel>>> ListSitemapItems(
-        CancellationToken cancellationToken) =>
+        CancellationToken cancellationToken = default) =>
         await _dataSetFileService.ListSitemapItems(cancellationToken)
             .HandleFailuresOrOk();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
@@ -60,9 +60,8 @@ public class DataSetFilesController : ControllerBase
     }
 
     [HttpGet("data-set-files/sitemap-items")]
-    public async Task<ActionResult<List<DataSetSitemapItemViewModel>>> ListSitemapItems()
-    {
-        return await _dataSetFileService.ListSitemapItems()
+    public async Task<ActionResult<List<DataSetSitemapItemViewModel>>> ListSitemapItems(
+        CancellationToken cancellationToken) =>
+        await _dataSetFileService.ListSitemapItems(cancellationToken)
             .HandleFailuresOrOk();
-    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/MethodologyController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/MethodologyController.cs
@@ -30,7 +30,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
 
         [HttpGet("methodologies/sitemap-items")]
         public async Task<ActionResult<List<MethodologySitemapItemViewModel>>> ListSitemapItems(
-            CancellationToken cancellationToken) =>
+            CancellationToken cancellationToken = default) =>
             await _methodologyService.ListSitemapItems(cancellationToken)
                 .HandleFailuresOrOk();
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/MethodologyController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/MethodologyController.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Net.Mime;
+using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
@@ -28,10 +29,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         }
 
         [HttpGet("methodologies/sitemap-items")]
-        public async Task<ActionResult<List<MethodologySitemapItemViewModel>>> ListSitemapItems()
-        {
-            return await _methodologyService.ListSitemapItems()
+        public async Task<ActionResult<List<MethodologySitemapItemViewModel>>> ListSitemapItems(
+            CancellationToken cancellationToken) =>
+            await _methodologyService.ListSitemapItems(cancellationToken)
                 .HandleFailuresOrOk();
-        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PublicationController.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Mime;
+using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -105,10 +106,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         }
 
         [HttpGet("publications/sitemap-items")]
-        public async Task<ActionResult<List<PublicationSitemapItemViewModel>>> ListSitemapItems()
-        {
-            return await _publicationService.ListSitemapItems()
+        public async Task<ActionResult<List<PublicationSitemapItemViewModel>>> ListSitemapItems(
+            CancellationToken cancellationToken) =>
+            await _publicationService.ListSitemapItems(cancellationToken)
                 .HandleFailuresOrOk();
-        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PublicationController.cs
@@ -107,7 +107,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
 
         [HttpGet("publications/sitemap-items")]
         public async Task<ActionResult<List<PublicationSitemapItemViewModel>>> ListSitemapItems(
-            CancellationToken cancellationToken) =>
+            CancellationToken cancellationToken = default) =>
             await _publicationService.ListSitemapItems(cancellationToken)
                 .HandleFailuresOrOk();
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
@@ -741,7 +741,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = SetupMethodologyService(contentDbContext);
-                var result = (await service.ListSitemapItems(default)).AssertRight();
+                var result = (await service.ListSitemapItems()).AssertRight();
 
                 var item = Assert.Single(result);
                 Assert.Equal(methodology.OwningPublicationSlug, item.Slug);
@@ -798,7 +798,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = SetupMethodologyService(contentDbContext);
-                var result = (await service.ListSitemapItems(default)).AssertRight();
+                var result = (await service.ListSitemapItems()).AssertRight();
 
                 var item = Assert.Single(result);
                 Assert.Equal("alternative-title", item.Slug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
@@ -740,8 +740,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                contentDbContext.Attach(methodology.Versions[0]);
-                
                 var service = SetupMethodologyService(contentDbContext);
                 var result = (await service.ListSitemapItems()).AssertRight();
 
@@ -799,8 +797,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                contentDbContext.Attach(methodology.Versions[0]);
-                
                 var service = SetupMethodologyService(contentDbContext);
                 var result = (await service.ListSitemapItems()).AssertRight();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
@@ -741,7 +741,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = SetupMethodologyService(contentDbContext);
-                var result = (await service.ListSitemapItems()).AssertRight();
+                var result = (await service.ListSitemapItems(default)).AssertRight();
 
                 var item = Assert.Single(result);
                 Assert.Equal(methodology.OwningPublicationSlug, item.Slug);
@@ -798,7 +798,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = SetupMethodologyService(contentDbContext);
-                var result = (await service.ListSitemapItems()).AssertRight();
+                var result = (await service.ListSitemapItems(default)).AssertRight();
 
                 var item = Assert.Single(result);
                 Assert.Equal("alternative-title", item.Slug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -2103,7 +2103,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 {
                     var service = SetupPublicationService(contentDbContext);
 
-                    var result = (await service.ListSitemapItems(default)).AssertRight();
+                    var result = (await service.ListSitemapItems()).AssertRight();
 
                     var item = Assert.Single(result);
                     Assert.Equal(publication.Slug, item.Slug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -2103,7 +2103,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 {
                     var service = SetupPublicationService(contentDbContext);
 
-                    var result = (await service.ListSitemapItems()).AssertRight();
+                    var result = (await service.ListSitemapItems(default)).AssertRight();
 
                     var item = Assert.Single(result);
                     Assert.Equal(publication.Slug, item.Slug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -1,4 +1,12 @@
 #nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
 using CsvHelper;
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -18,14 +26,6 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interface
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Utils;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Threading;
-using System.Threading.Tasks;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.SortDirection;
 using static GovUk.Education.ExploreEducationStatistics.Content.Requests.DataSetsListRequestSortBy;
 using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
@@ -140,7 +140,8 @@ public class DataSetFileService : IDataSetFileService
             };
     }
 
-    public async Task<Either<ActionResult, List<DataSetSitemapItemViewModel>>> ListSitemapItems()
+    public async Task<Either<ActionResult, List<DataSetSitemapItemViewModel>>> ListSitemapItems(
+        CancellationToken cancellationToken)
     {
         var latestReleaseVersions = _contentDbContext.ReleaseVersions
             .LatestReleaseVersions(publishedOnly: true);
@@ -157,7 +158,7 @@ public class DataSetFileService : IDataSetFileService
                 Id = rf.File.DataSetFileId!.Value.ToString(),
                 LastModified = rf.Published
             })
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
     }
 
     private static async Task<List<DataSetFileSummaryViewModel>> ChangeSummaryHtmlToText(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -141,7 +141,7 @@ public class DataSetFileService : IDataSetFileService
     }
 
     public async Task<Either<ActionResult, List<DataSetSitemapItemViewModel>>> ListSitemapItems(
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         var latestReleaseVersions = _contentDbContext.ReleaseVersions
             .LatestReleaseVersions(publishedOnly: true);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
@@ -29,5 +29,5 @@ public interface IDataSetFileService
     Task<Either<ActionResult, DataSetFileViewModel>> GetDataSetFile(
         Guid dataSetId);
 
-    Task<Either<ActionResult, List<DataSetSitemapItemViewModel>>> ListSitemapItems();
+    Task<Either<ActionResult, List<DataSetSitemapItemViewModel>>> ListSitemapItems(CancellationToken cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
@@ -29,5 +29,6 @@ public interface IDataSetFileService
     Task<Either<ActionResult, DataSetFileViewModel>> GetDataSetFile(
         Guid dataSetId);
 
-    Task<Either<ActionResult, List<DataSetSitemapItemViewModel>>> ListSitemapItems(CancellationToken cancellationToken);
+    Task<Either<ActionResult, List<DataSetSitemapItemViewModel>>> ListSitemapItems(
+        CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IMethodologyService.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
@@ -13,5 +14,6 @@ public interface IMethodologyService
 
     Task<Either<ActionResult, List<AllMethodologiesThemeViewModel>>> GetSummariesTree();
 
-    Task<Either<ActionResult, List<MethodologySitemapItemViewModel>>> ListSitemapItems();
+    Task<Either<ActionResult, List<MethodologySitemapItemViewModel>>> ListSitemapItems(
+        CancellationToken cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IMethodologyService.cs
@@ -15,5 +15,5 @@ public interface IMethodologyService
     Task<Either<ActionResult, List<AllMethodologiesThemeViewModel>>> GetSummariesTree();
 
     Task<Either<ActionResult, List<MethodologySitemapItemViewModel>>> ListSitemapItems(
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IPublicationService.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
@@ -29,5 +30,6 @@ public interface IPublicationService
         int pageSize = 10,
         IEnumerable<Guid>? publicationIds = null);
 
-    Task<Either<ActionResult, List<PublicationSitemapItemViewModel>>> ListSitemapItems();
+    Task<Either<ActionResult, List<PublicationSitemapItemViewModel>>> ListSitemapItems(
+        CancellationToken cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IPublicationService.cs
@@ -31,5 +31,5 @@ public interface IPublicationService
         IEnumerable<Guid>? publicationIds = null);
 
     Task<Either<ActionResult, List<PublicationSitemapItemViewModel>>> ListSitemapItems(
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
@@ -136,7 +136,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
         }
 
         public async Task<Either<ActionResult, List<MethodologySitemapItemViewModel>>> ListSitemapItems(
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default)
         {
             return await _contentDbContext.Methodologies
                 .Include(m => m.LatestPublishedVersion)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -134,7 +135,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             return _mapper.Map<List<MethodologyVersionSummaryViewModel>>(latestPublishedMethodologies);
         }
 
-        public async Task<Either<ActionResult, List<MethodologySitemapItemViewModel>>> ListSitemapItems()
+        public async Task<Either<ActionResult, List<MethodologySitemapItemViewModel>>> ListSitemapItems(
+            CancellationToken cancellationToken)
         {
             return await _contentDbContext.Methodologies
                 .Include(m => m.LatestPublishedVersion)
@@ -148,7 +150,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                         Slug = mv.Slug,
                         LastModified = mv.Published
                     })
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
@@ -138,6 +138,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
         {
             return await _contentDbContext.Methodologies
                 .Include(m => m.LatestPublishedVersion)
+                .ThenInclude(mv => mv!.Methodology)
                 .Where(m => m.LatestPublishedVersion != null)
                 .Select(m => m.LatestPublishedVersion)
                 .OfType<MethodologyVersion>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -343,7 +343,7 @@ public class PublicationService : IPublicationService
     }
 
     public async Task<Either<ActionResult, List<PublicationSitemapItemViewModel>>> ListSitemapItems(
-        CancellationToken cancellationToken) =>
+        CancellationToken cancellationToken = default) =>
         await
             _contentDbContext.Publications
                 .Where(p => p.LatestPublishedReleaseVersionId.HasValue &&

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -341,7 +342,8 @@ public class PublicationService : IPublicationService
             .AnyAsync(rf => rf.ReleaseVersionId == releaseVersionId && rf.File.Type == FileType.Data);
     }
 
-    public async Task<Either<ActionResult, List<PublicationSitemapItemViewModel>>> ListSitemapItems() =>
+    public async Task<Either<ActionResult, List<PublicationSitemapItemViewModel>>> ListSitemapItems(
+        CancellationToken cancellationToken) =>
         await
             _contentDbContext.Publications
                 .Where(p => p.LatestPublishedReleaseVersionId.HasValue &&
@@ -353,7 +355,7 @@ public class PublicationService : IPublicationService
                     LastModified = p.Updated,
                     Releases = ListUniqueReleaseVersionSitemapItems(p)
                 })
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
 
     private static List<ReleaseSitemapItemViewModel> ListUniqueReleaseVersionSitemapItems(Publication publication) =>
         publication.ReleaseVersions


### PR DESCRIPTION
The Dev environment is encountering Null Argument Exceptions when trying to fetch the dynamic sitemap. 

For some bizarre reason this works when running locally, but our query should be properly loading the Methodology of the MethodologyVersion through a `.ThenInclude`. 

This PR also adds cancellation tokens to all ListSitemapItems routes. 
