### PR TITLE
EES-5208 automatically open external links in new tabs

### DIFF
--- a/src/explore-education-statistics-admin/src/hooks/useCKEditorConfig.ts
+++ b/src/explore-education-statistics-admin/src/hooks/useCKEditorConfig.ts
@@ -134,15 +134,6 @@ const useCKEditorConfig = ({
               url?.match(/\/data-tables\/fast-track\/[a-zA-Z-0-9-]/),
             attributes: { 'data-featured-table': '' },
           },
-          openInNewTab: {
-            mode: 'manual',
-            label: 'Open in a new tab',
-            defaultValue: false,
-            attributes: {
-              target: '_blank',
-              rel: 'noopener noreferrer',
-            },
-          },
         },
         defaultProtocol: 'https://',
       },

--- a/src/explore-education-statistics-common/src/components/ContentHtml.tsx
+++ b/src/explore-education-statistics-common/src/components/ContentHtml.tsx
@@ -42,31 +42,17 @@ export default function ContentHtml({
   const cleanHtml = useMemo(() => {
     const opts: SanitizeHtmlOptions = {
       ...sanitizeOptions,
-      transformTags: {
-        ...sanitizeOptions?.transformTags,
-        ...(formatLinks && {
-          a: (tagName, attribs) => {
-            return {
-              tagName,
-              attribs: {
-                ...attribs,
-                href: formatContentLink(attribs.href),
-              },
-            };
-          },
-        }),
-      },
+      transformTags: sanitizeOptions?.transformTags,
     };
 
     return sanitizeHtml(html, opts);
-  }, [formatLinks, html, sanitizeOptions]);
+  }, [html, sanitizeOptions]);
 
   const parsedContent = parseHtmlString(cleanHtml, {
     replace: (node: DOMNode) => {
       if (!(node instanceof Element)) {
         return undefined;
       }
-
       if (
         getGlossaryEntry &&
         node.name === 'a' &&
@@ -92,6 +78,21 @@ export default function ContentHtml({
         return isMounted && typeof text === 'string'
           ? transformFeaturedTableLinks(node.attribs.href, text)
           : undefined;
+      }
+
+      if (formatLinks && node.name === 'a') {
+        const url = formatContentLink(node.attribs.href);
+        const text = domToReact(node.children);
+
+        return !node.attribs.href.includes(
+          'explore-education-statistics.service.gov.uk',
+        ) && typeof node.attribs['data-featured-table'] === 'undefined' ? (
+          <a href={url} target="_blank" rel="noopener noreferrer">
+            {text} (opens in a new tab)
+          </a>
+        ) : (
+          <a href={url}>{text}</a>
+        );
       }
 
       if (node.name === 'figure' && node.attribs.class === 'table') {


### PR DESCRIPTION
- removes the option to set if links open in new tabs or not in CK Editor
- external links now automatically open in a new tab and have the text `(opens in a new tab)` added to them
- internal links open in the same tab