### PR TITLE
EES-5210 hide browser search clear button

### DIFF
--- a/src/explore-education-statistics-common/src/styles/_form.scss
+++ b/src/explore-education-statistics-common/src/styles/_form.scss
@@ -6,3 +6,9 @@
 .govuk-textarea[disabled] {
   cursor: not-allowed;
 }
+
+// Hide the clear button on search inputs as they
+// are not keyboard accessible, see EES-5210.
+[type='search']::-webkit-search-cancel-button {
+  appearance: none;
+}


### PR DESCRIPTION
DAC reported that the clear button on search inputs is not keyboard accessible. This is added to the shadow DOM by browsers so we can't change it to improve its accessibility. There's been an [open bug report in Chromium](https://issues.chromium.org/issues/40730642) for 4 years so I doubt it's getting fixed any time soon.

Rather than change the input type to `text` I've hidden the clear button with `appearance: none` which seems to be a common strategy ([the W3C does this on its main search page](https://www.w3.org/help/search/)).