### PR TITLE
EES-5211 remove group role on details element

### DIFF
--- a/src/explore-education-statistics-common/src/components/Details.tsx
+++ b/src/explore-education-statistics-common/src/components/Details.tsx
@@ -95,7 +95,6 @@ const Details = ({
       className={classNames('govuk-details', className)}
       open={open}
       ref={ref}
-      role={onMounted('group')}
       data-testid={testId}
     >
       <summary

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Details.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Details.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`Details renders correctly 1`] = `
 <details id="details-tag-test-details"
          class="govuk-details"
-         role="group"
 >
   <summary class="govuk-details__summary"
            aria-controls="test-details"
@@ -30,7 +29,6 @@ exports[`Details renders correctly with \`open\` prop set to true 1`] = `
 <details id="details-tag-test-details"
          class="govuk-details"
          open
-         role="group"
 >
   <summary class="govuk-details__summary"
            aria-controls="test-details"


### PR DESCRIPTION
Removes the role `group` from `details` elements following advice from DAC that it can cause accessibility issues.