### PR TITLE
EES-5231 Add IsSuperseded to Data catalogue view models

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
@@ -82,6 +82,7 @@ public abstract class DataSetFilesControllerCachingTests : CacheServiceTestFixtu
                         Indicators = ["Indicator 1"],
                     },
                     LatestData = true,
+                    IsSuperseded = false,
                     Published = DateTime.UtcNow,
                 }
             ],

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -1740,6 +1740,9 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                     () => Assert.Equal(theme.Title, viewModel.Theme.Title),
                     () => Assert.Equal(releaseVersion.Id == publication.LatestPublishedReleaseVersionId,
                         viewModel.LatestData),
+                    () => Assert.Equal(publication.SupersededBy != null
+                                       && publication.SupersededBy.LatestPublishedReleaseVersionId != null,
+                            viewModel.IsSuperseded),
                     () => Assert.Equal(releaseFile.ReleaseVersion.Published!.Value, viewModel.Published),
                     () => Assert.Equal(releaseFile.File.PublicApiDataSetId, viewModel.Api?.Id),
                     () => Assert.Equal(
@@ -1850,7 +1853,6 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
         }
     }
 
-
     public class GetDataSetFileTests(TestApplicationFactory testApp) : DataSetFilesControllerTests(testApp)
     {
         public override async Task InitializeAsync()
@@ -1925,6 +1927,7 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
             Assert.Equal(releaseFile.ReleaseVersion.Slug, viewModel.Release.Slug);
             Assert.Equal(releaseFile.ReleaseVersion.Type, viewModel.Release.Type);
             Assert.True(viewModel.Release.IsLatestPublishedRelease);
+            Assert.False(viewModel.Release.IsSuperseded);
             Assert.Equal(releaseFile.ReleaseVersion.Published, viewModel.Release.Published);
 
             Assert.Equal(publication.Id, viewModel.Release.Publication.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -130,6 +130,8 @@ public class DataSetFileService : IDataSetFileService
                 },
                 LatestData = result.Value.ReleaseVersionId ==
                              result.Value.ReleaseVersion.Publication.LatestPublishedReleaseVersionId,
+                IsSuperseded = result.Value.ReleaseVersion.Publication.SupersededBy != null
+                    && result.Value.ReleaseVersion.Publication.SupersededBy.LatestPublishedReleaseVersionId != null,
                 Published = result.Value.ReleaseVersion.Published!.Value,
                 LastUpdated = result.Value.Published!.Value,
                 Api = BuildDataSetFileApiViewModel(result.Value.File),
@@ -178,6 +180,7 @@ public class DataSetFileService : IDataSetFileService
     {
         var releaseFile = await _contentDbContext.ReleaseFiles
             .Include(rf => rf.ReleaseVersion.Publication.Topic.Theme)
+            .Include(rf => rf.ReleaseVersion.Publication.SupersededBy)
             .Include(rf => rf.File)
             .Where(rf =>
                 rf.File.DataSetFileId == dataSetId
@@ -215,6 +218,8 @@ public class DataSetFileService : IDataSetFileService
                 IsLatestPublishedRelease =
                     releaseFile.ReleaseVersion.Publication.LatestPublishedReleaseVersionId ==
                     releaseFile.ReleaseVersionId,
+                IsSuperseded = releaseFile.ReleaseVersion.Publication.SupersededBy != null
+                    && releaseFile.ReleaseVersion.Publication.SupersededBy.LatestPublishedReleaseVersionId != null,
                 Published = releaseFile.ReleaseVersion.Published!.Value,
                 LastUpdated = releaseFile.Published!.Value,
                 Publication = new DataSetFilePublicationViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileSummaryViewModel.cs
@@ -26,6 +26,8 @@ public record DataSetFileSummaryViewModel
 
     public required bool LatestData { get; init; }
 
+    public required bool IsSuperseded { get; init; }
+
     public required DateTime Published { get; init; }
 
     public DateTime LastUpdated { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileViewModel.cs
@@ -47,6 +47,8 @@ public record DataSetFileReleaseViewModel
 
     public required bool IsLatestPublishedRelease { get; init; }
 
+    public required bool IsSuperseded { get; init; }
+
     public required DateTime Published { get; init; }
 
     public DateTime LastUpdated { get; init; }

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePageNew.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePageNew.tsx
@@ -498,12 +498,14 @@ export default function DataCataloguePageNew({ showTypeFilter }: Props) {
                                 <Tag>{releaseTypes[selectedRelease.type]}</Tag>
                                 <Tag
                                   colour={
-                                    selectedRelease.latestRelease
+                                    selectedRelease.latestRelease &&
+                                    !selectedPublication.isSuperseded
                                       ? undefined
                                       : 'orange'
                                   }
                                 >
-                                  {selectedRelease.latestRelease
+                                  {selectedRelease.latestRelease &&
+                                  !selectedPublication.isSuperseded
                                     ? 'This is the latest data'
                                     : 'This is not the latest data'}
                                 </Tag>

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -142,7 +142,7 @@ export default function DataSetFilePage({
       ) : (
         <>
           <div className={styles.info} data-testid="data-set-file-info">
-            {release.isLatestPublishedRelease ? (
+            {release.isLatestPublishedRelease && !release.isSuperseded ? (
               <Tag className="govuk-!-margin-right-5">Latest data</Tag>
             ) : (
               <Tag className="govuk-!-margin-right-5" colour="orange">

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__data__/testDataSets.ts
@@ -81,6 +81,7 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
       indicators: ['Indicator 1', 'Indicator 2'],
     },
     latestData: true,
+    isSuperseded: false,
     publication: {
       id: 'publication-1',
       title: 'Publication 1',
@@ -114,6 +115,7 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
       indicators: ['Indicator 1', 'Indicator 2'],
     },
     latestData: true,
+    isSuperseded: false,
     publication: {
       id: 'publication-1',
       title: 'Publication 1',
@@ -147,6 +149,7 @@ export const testDataSetFileSummaries: DataSetFileSummary[] = [
       indicators: ['Indicator 1', 'Indicator 2'],
     },
     latestData: true,
+    isSuperseded: false,
     publication: {
       id: 'publication-2',
       title: 'Publication 2',
@@ -188,6 +191,7 @@ export const testDataSetFile: DataSetFile = {
   release: {
     id: 'release-id',
     isLatestPublishedRelease: true,
+    isSuperseded: false,
     publication: {
       id: 'publication-id',
       slug: 'publication-slug',

--- a/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
+++ b/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
@@ -42,6 +42,7 @@ export interface DataSetFile {
   release: {
     id: string;
     isLatestPublishedRelease: boolean;
+    isSuperseded: boolean;
     publication: {
       id: string;
       slug: string;
@@ -79,6 +80,7 @@ export interface DataSetFileSummary {
     title: string;
   };
   latestData: boolean;
+  isSuperseded: boolean;
   published: Date;
   lastUpdated: string;
   api?: DataSetFileApi;


### PR DESCRIPTION
This PR adds `IsSuperseded` to `DataSetFileSummaryViewModel` and `DataSetFileViewModel`. We're doing this so that on the new Data catalogue and Data set details pages we can label data sets from superseded publications as `Not the latest data`.