### PR TITLE
EES-4993 Move `PublicApiDataSet*` columns from `Files` to `ReleaseFiles`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetCandidatesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetCandidatesControllerTests.cs
@@ -179,16 +179,15 @@ public abstract class DataSetCandidatesControllerTests(TestApplicationFactory te
 
             DataImport dataImport = DataFixture
                 .DefaultDataImport()
-                .WithFile(DataFixture.DefaultFile(FileType.Data)
-                    .WithPublicApiDataSetId(Guid.NewGuid())
-                );
+                .WithFile(DataFixture.DefaultFile(FileType.Data));
 
             var releaseVersion = release.Versions.Single();
 
             ReleaseFile releaseFile = DataFixture
                 .DefaultReleaseFile()
                 .WithFile(dataImport.File)
-                .WithReleaseVersion(releaseVersion);
+                .WithReleaseVersion(releaseVersion)
+                .WithPublicApiDataSetId(Guid.NewGuid());
 
             await TestApp.AddTestData<ContentDbContext>(context =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
@@ -314,6 +314,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         )
                     ],
                     Published = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    PublicApiDataSetId = Guid.NewGuid(),
+                    PublicApiDataSetVersion = "1.0.0",
                 },
                 new()
                 {
@@ -1157,7 +1159,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             Assert.Equal(originalReleaseRole.DeletedById, amendedReleaseRole.DeletedById);
         }
 
-        private static void AssertAmendedReleaseFileCorrect(ReleaseFile originalFile, ReleaseFile amendmentDataFile,
+        private static void AssertAmendedReleaseFileCorrect(
+            ReleaseFile originalFile,
+            ReleaseFile amendmentDataFile,
             ReleaseVersion amendment)
         {
             // Assert it's a new link table entry between the Release amendment and the data file reference
@@ -1169,6 +1173,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             Assert.Equal(originalFile.Published!.Value, amendmentDataFile.Published!.Value, TimeSpan.FromMinutes(1));
             originalFile.FilterSequence.AssertDeepEqualTo(amendmentDataFile.FilterSequence);
             originalFile.IndicatorSequence.AssertDeepEqualTo(amendmentDataFile.IndicatorSequence);
+
+            Assert.Equal(originalFile.PublicApiDataSetId, amendmentDataFile.PublicApiDataSetId);
+            Assert.Equal(originalFile.PublicApiDataSetVersion, amendmentDataFile.PublicApiDataSetVersion);
 
             // And assert that the file referenced is the SAME file reference as linked from the original Release's
             // link table entry

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauMigrationController.cs
@@ -1,0 +1,58 @@
+#nullable enable
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+[Route("api/bau")]
+[ApiController]
+[Authorize(Roles = GlobalRoles.RoleNames.BauUser)]
+public class BauMigrationController(
+    ContentDbContext contentDbContext,
+    PublicDataDbContext publicDataDbContext)
+    : ControllerBase
+{
+    [HttpPost("migrate-ees-4993")]
+    public async Task<ActionResult> MigrateEes4993(CancellationToken cancellationToken)
+    {
+        var unpublishedDataSetVersions = await publicDataDbContext
+            .DataSetVersions
+            .Where(dsv => dsv.Status == DataSetVersionStatus.Draft
+                          || dsv.Status == DataSetVersionStatus.Failed
+                          || dsv.Status == DataSetVersionStatus.Processing
+                          || dsv.Status == DataSetVersionStatus.Cancelled)
+            .ToListAsync(cancellationToken);
+
+        foreach (var draftVersion in unpublishedDataSetVersions)
+        {
+            // Update any published release files to no longer incorrectly reference draft data set versions.
+            //
+            // This should only apply to draft data set versions for amendments that were created prior
+            // to the `EES4993_AddPublicApiDataSetIdVersionToReleaseFile` migration.
+
+            // The DB migration moves the `PublicApiDataSetId` and `PublicApiDataSetVersion` columns
+            // from `Files` to `ReleaseFiles`, but can set these incorrectly for published release files.
+            // We need this additional endpoint migration to fix any incorrect column values.
+            await contentDbContext.ReleaseFiles
+                .Where(rf => rf.ReleaseVersion.Published != null)
+                .Where(rf => rf.PublicApiDataSetId == draftVersion.DataSetId)
+                .Where(rf => rf.PublicApiDataSetVersion == draftVersion.Version)
+                .ExecuteUpdateAsync(
+                    s => s
+                        .SetProperty(rf => rf.PublicApiDataSetId, _ => null)
+                        .SetProperty(rf => rf.PublicApiDataSetVersion, _ => null),
+                    cancellationToken
+                );
+        }
+
+        return Ok();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240617005412_EES4993_AddPublicApiDataSetIdVersionToReleaseFile.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240617005412_EES4993_AddPublicApiDataSetIdVersionToReleaseFile.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240617005412_EES4993_AddPublicApiDataSetIdVersionToReleaseFile")]
+    partial class EES4993_AddPublicApiDataSetIdVersionToReleaseFile
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240617005412_EES4993_AddPublicApiDataSetIdVersionToReleaseFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240617005412_EES4993_AddPublicApiDataSetIdVersionToReleaseFile.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES4993_AddPublicApiDataSetIdVersionToReleaseFile : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "PublicApiDataSetId",
+                table: "ReleaseFiles",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PublicApiDataSetVersion",
+                table: "ReleaseFiles",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReleaseFiles_ReleaseVersionId_FileId",
+                table: "ReleaseFiles",
+                columns: new[] { "ReleaseVersionId", "FileId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReleaseFiles_ReleaseVersionId_PublicApiDataSetId_PublicApiDataSetVersion",
+                table: "ReleaseFiles",
+                columns: new[] { "ReleaseVersionId", "PublicApiDataSetId", "PublicApiDataSetVersion" },
+                unique: true,
+                filter: "[PublicApiDataSetId] IS NOT NULL AND [PublicApiDataSetVersion] IS NOT NULL");
+
+            // This can incorrectly set these columns if an amendment is created and any
+            // of its ReleaseFiles are promoted to a draft API data set. This needs to
+            // be rectified by an additional endpoint migration.
+            migrationBuilder.Sql(
+                """
+                UPDATE ReleaseFiles
+                SET ReleaseFiles.PublicApiDataSetId = Files.PublicApiDataSetId,
+                    ReleaseFiles.PublicApiDataSetVersion = Files.PublicApiDataSetVersion
+                FROM dbo.ReleaseFiles
+                INNER JOIN dbo.Files ON Files.Id = ReleaseFiles.FileId
+                """);
+
+            migrationBuilder.DropIndex(
+                name: "IX_ReleaseFiles_ReleaseVersionId",
+                table: "ReleaseFiles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Files_PublicApiDataSetId_PublicApiDataSetVersion",
+                table: "Files");
+
+            migrationBuilder.DropColumn(
+                name: "PublicApiDataSetId",
+                table: "Files");
+
+            migrationBuilder.DropColumn(
+                name: "PublicApiDataSetVersion",
+                table: "Files");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "PublicApiDataSetId",
+                table: "Files",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PublicApiDataSetVersion",
+                table: "Files",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Files_PublicApiDataSetId_PublicApiDataSetVersion",
+                table: "Files",
+                columns: new[] { "PublicApiDataSetId", "PublicApiDataSetVersion" },
+                unique: true,
+                filter: "[PublicApiDataSetId] IS NOT NULL AND [PublicApiDataSetVersion] IS NOT NULL");
+
+            migrationBuilder.Sql(
+                """
+                UPDATE Files
+                SET Files.PublicApiDataSetId = ReleaseFiles.PublicApiDataSetId,
+                    Files.PublicApiDataSetVersion = ReleaseFiles.PublicApiDataSetVersion
+                FROM dbo.ReleaseFiles
+                INNER JOIN dbo.Files ON Files.Id = ReleaseFiles.FileId
+                WHERE ReleaseFiles.PublicApiDataSetId IS NOT NULL
+                    AND ReleaseFiles.PublicApiDataSetVersion IS NOT NULL
+                """);
+
+            migrationBuilder.DropIndex(
+                name: "IX_ReleaseFiles_ReleaseVersionId_FileId",
+                table: "ReleaseFiles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ReleaseFiles_ReleaseVersionId_PublicApiDataSetId_PublicApiDataSetVersion",
+                table: "ReleaseFiles");
+
+            migrationBuilder.DropColumn(
+                name: "PublicApiDataSetId",
+                table: "ReleaseFiles");
+
+            migrationBuilder.DropColumn(
+                name: "PublicApiDataSetVersion",
+                table: "ReleaseFiles");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReleaseFiles_ReleaseVersionId",
+                table: "ReleaseFiles",
+                column: "ReleaseVersionId");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetCandidateService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetCandidateService.cs
@@ -48,7 +48,7 @@ internal class DataSetCandidateService(
             .AsNoTracking()
             .Where(rf => rf.ReleaseVersionId == releaseVersionId)
             .Where(rf => rf.File.Type == FileType.Data)
-            .Where(rf => rf.File.PublicApiDataSetId == null)
+            .Where(rf => rf.PublicApiDataSetId == null)
             .Where(rf => rf.File.ReplacedById == null)
             .Where(rf => rf.File.ReplacingId == null)
             .Join(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseAmendmentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseAmendmentService.cs
@@ -624,6 +624,8 @@ public class ReleaseAmendmentService : IReleaseAmendmentService
                 FilterSequence = originalFile.FilterSequence,
                 IndicatorSequence = originalFile.IndicatorSequence,
                 Published = originalFile.Published,
+                PublicApiDataSetId = originalFile.PublicApiDataSetId,
+                PublicApiDataSetVersion = originalFile.PublicApiDataSetVersion,
             })
             .ToList();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
@@ -49,23 +49,6 @@ public static class FileGeneratorExtensions
         Guid replacedById)
         => generator.ForInstance(s => s.SetReplacedById(replacedById));
 
-    public static Generator<File> WithPublicApiDataSetId(
-        this Generator<File> generator,
-        Guid publicDataSetId)
-        => generator.ForInstance(s => s.SetPublicApiDataSetId(publicDataSetId));
-
-    public static Generator<File> WithPublicApiDataSetVersion(
-        this Generator<File> generator,
-        int major,
-        int minor,
-        int patch = 0)
-        => generator.ForInstance(s => s.SetPublicApiDataSetVersion(major, minor, patch));
-
-    public static Generator<File> WithPublicApiDataSetVersion(
-        this Generator<File> generator,
-        SemVersion version)
-        => generator.ForInstance(s => s.SetPublicApiDataSetVersion(version));
-
     public static Generator<File> WithRootPath(
         this Generator<File> generator,
         Guid rootPath)
@@ -170,25 +153,6 @@ public static class FileGeneratorExtensions
         this InstanceSetters<File> setters,
         Guid replacedById)
         => setters.Set(f => f.ReplacedById, replacedById);
-
-    public static InstanceSetters<File> SetPublicApiDataSetId(
-        this InstanceSetters<File> setters,
-        Guid publicDataSetId)
-        => setters.Set(f => f.PublicApiDataSetId, publicDataSetId);
-
-    public static InstanceSetters<File> SetPublicApiDataSetVersion(
-        this InstanceSetters<File> setters,
-        int major,
-        int minor,
-        int patch = 0)
-        => setters.Set(
-            f => f.PublicApiDataSetVersion,
-            new SemVersion(major: major, minor: minor, patch: patch));
-
-    public static InstanceSetters<File> SetPublicApiDataSetVersion(
-        this InstanceSetters<File> setters,
-        SemVersion version)
-        => setters.Set(f => f.PublicApiDataSetVersion, version);
 
     public static InstanceSetters<File> SetReplacing(
         this InstanceSetters<File> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseFileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseFileGeneratorExtensions.cs
@@ -2,6 +2,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using System;
 using System.Collections.Generic;
+using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 
@@ -89,6 +90,23 @@ public static class ReleaseFileGeneratorExtensions
         List<IndicatorGroupSequenceEntry> sequence)
         => generator.ForInstance(s => s.SetIndicatorSequence(sequence));
 
+    public static Generator<ReleaseFile> WithPublicApiDataSetId(
+        this Generator<ReleaseFile> generator,
+        Guid publicApiDataSetId)
+        => generator.ForInstance(s => s.SetPublicApiDataSetId(publicApiDataSetId));
+
+    public static Generator<ReleaseFile> WithPublicApiDataSetVersion(
+        this Generator<ReleaseFile> generator,
+        SemVersion version)
+        => generator.ForInstance(s => s.SetPublicApiDataSetVersion(version));
+
+    public static Generator<ReleaseFile> WithPublicApiDataSetVersion(
+        this Generator<ReleaseFile> generator,
+        int major,
+        int minor,
+        int patch = 0)
+        => generator.ForInstance(s => s.SetPublicApiDataSetVersion(major, minor, patch));
+
     public static InstanceSetters<ReleaseFile> SetFile(
         this InstanceSetters<ReleaseFile> setters,
         File file)
@@ -141,4 +159,23 @@ public static class ReleaseFileGeneratorExtensions
         this InstanceSetters<ReleaseFile> setters,
         List<IndicatorGroupSequenceEntry> sequence)
         => setters.Set(rf => rf.IndicatorSequence, sequence);
+
+    public static InstanceSetters<ReleaseFile> SetPublicApiDataSetId(
+        this InstanceSetters<ReleaseFile> setters,
+        Guid publicApiDataSetId)
+        => setters.Set(rf => rf.PublicApiDataSetId, publicApiDataSetId);
+
+    public static InstanceSetters<ReleaseFile> SetPublicApiDataSetVersion(
+        this InstanceSetters<ReleaseFile> setters,
+        int major,
+        int minor,
+        int patch = 0)
+        => setters.Set(
+            rf => rf.PublicApiDataSetVersion,
+            new SemVersion(major: major, minor: minor, patch: patch));
+
+    public static InstanceSetters<ReleaseFile> SetPublicApiDataSetVersion(
+        this InstanceSetters<ReleaseFile> setters,
+        SemVersion version)
+        => setters.Set(rf => rf.PublicApiDataSetVersion, version);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -409,6 +409,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                         v => v.HasValue
                             ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
                             : null);
+                entity.Property(f => f.PublicApiDataSetVersion)
+                    .HasMaxLength(20)
+                    .HasConversion(
+                        v => v.ToString(),
+                        v => SemVersion.Parse(v, SemVersionStyles.Strict, 20)
+                    );
+
+                entity.HasIndex(rf => new
+                {
+                    rf.ReleaseVersionId,
+                    rf.FileId,
+                })
+                .IsUnique();
+
+                entity.HasIndex(rf => new
+                {
+                    rf.ReleaseVersionId,
+                    rf.PublicApiDataSetId,
+                    rf.PublicApiDataSetVersion
+                })
+                .IsUnique();
             });
         }
 
@@ -440,19 +461,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     .HasConversion( // You might want to use EF8 JSON support instead of this
                         v => JsonConvert.SerializeObject(v),
                         v => JsonConvert.DeserializeObject<DataSetFileMeta>(v));
-
-                entity.Property(f => f.PublicApiDataSetVersion)
-                    .HasMaxLength(20)
-                    .HasConversion(
-                        v => v.ToString(),
-                        v => SemVersion.Parse(v, SemVersionStyles.Strict, 20)
-                    );
-
-                entity.HasIndex(f => new
-                    {
-                        PublicDataSetId = f.PublicApiDataSetId, PublicDataSetVersion = f.PublicApiDataSetVersion
-                    })
-                    .IsUnique();
             });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -25,10 +25,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public DataSetFileMeta? DataSetFileMeta { get; set; }
 
-        public Guid? PublicApiDataSetId { get; set; }
-
-        public SemVersion? PublicApiDataSetVersion { get; set; }
-
         public Guid? ReplacedById { get; set; }
 
         public File? ReplacedBy { get; set; }
@@ -48,9 +44,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public User? CreatedBy { get; set; }
 
         public Guid? CreatedById { get; set; }
-
-        public string? PublicApiVersionString => PublicApiDataSetVersion is not null
-                ? $"{PublicApiDataSetVersion.Major}.{PublicApiDataSetVersion.Minor}"
-                : null;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
@@ -21,6 +22,14 @@ public class ReleaseFile
     public string? Summary { get; set; }
 
     public int Order { get; set; }
+
+    public Guid? PublicApiDataSetId { get; set; }
+
+    public SemVersion? PublicApiDataSetVersion { get; set; }
+
+    public string? PublicApiVersionString => PublicApiDataSetVersion is not null
+        ? $"{PublicApiDataSetVersion.Major}.{PublicApiDataSetVersion.Minor}"
+        : null;
 
     public List<FilterSequenceEntry>? FilterSequence { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -132,7 +132,7 @@ public class DataSetFileService : IDataSetFileService
                              result.Value.ReleaseVersion.Publication.LatestPublishedReleaseVersionId,
                 Published = result.Value.ReleaseVersion.Published!.Value,
                 LastUpdated = result.Value.Published!.Value,
-                Api = BuildDataSetFileApiViewModel(result.Value.File),
+                Api = BuildDataSetFileApiViewModel(result.Value),
                 Meta = BuildDataSetFileMetaViewModel(
                     result.Value.File.DataSetFileMeta,
                     result.Value.FilterSequence,
@@ -239,7 +239,7 @@ public class DataSetFileService : IDataSetFileService
                 SubjectId = releaseFile.File.SubjectId!.Value,
             },
             Footnotes = FootnotesViewModelBuilder.BuildFootnotes(footnotes),
-            Api = BuildDataSetFileApiViewModel(releaseFile.File)
+            Api = BuildDataSetFileApiViewModel(releaseFile)
         };
     }
 
@@ -352,17 +352,17 @@ public class DataSetFileService : IDataSetFileService
         return indicators.Select(i => i.Label).ToList();
     }
 
-    private static DataSetFileApiViewModel? BuildDataSetFileApiViewModel(File file)
+    private static DataSetFileApiViewModel? BuildDataSetFileApiViewModel(ReleaseFile releaseFile)
     {
-        if (file.PublicApiDataSetId is null || file.PublicApiVersionString is null)
+        if (releaseFile.PublicApiDataSetId is null || releaseFile.PublicApiVersionString is null)
         {
             return null;
         }
 
         return new DataSetFileApiViewModel
         {
-            Id = file.PublicApiDataSetId.Value,
-            Version = file.PublicApiVersionString,
+            Id = releaseFile.PublicApiDataSetId.Value,
+            Version = releaseFile.PublicApiVersionString,
         };
     }
 }
@@ -463,7 +463,7 @@ internal static class ReleaseFileQueryableExtensions
         return dataSetType switch
         {
             DataSetType.All => query,
-            DataSetType.Api => query.Where(rf => rf.File.PublicApiDataSetId.HasValue),
+            DataSetType.Api => query.Where(rf => rf.PublicApiDataSetId.HasValue),
             _ => throw new ArgumentOutOfRangeException(nameof(dataSetType)),
         };
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/DeleteDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/DeleteDataSetVersionFunctionTests.cs
@@ -11,8 +11,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests.
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using LinqToDB;
 using Microsoft.AspNetCore.Mvc;
-using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
-
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Functions;
 
 public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegrationTestFixture fixture)
@@ -69,8 +67,8 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
                 context.DataSets.Update(dataSet);
             });
 
-            releaseFile.File.PublicApiDataSetId = dataSet.Id;
-            releaseFile.File.PublicApiDataSetVersion = dataSetVersion.FullSemanticVersion();
+            releaseFile.PublicApiDataSetId = dataSet.Id;
+            releaseFile.PublicApiDataSetVersion = dataSetVersion.FullSemanticVersion();
 
             await AddTestData<ContentDbContext>(context => context.Files.Update(releaseFile.File));
 
@@ -98,11 +96,11 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
             Assert.False(await publicDataDbContext.FilterMetas
                     .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
             Assert.False(await publicDataDbContext.FilterOptionMetaLinks
-                    .AnyAsync(foml => dataSetVersion.FilterMetas.Contains(foml.Meta)));
+                    .AnyAsync(ml => dataSetVersion.FilterMetas.Contains(ml.Meta)));
             Assert.False(await publicDataDbContext.LocationMetas
                     .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
             Assert.False(await publicDataDbContext.LocationOptionMetaLinks
-                    .AnyAsync(loml => dataSetVersion.LocationMetas.Contains(loml.Meta)));
+                    .AnyAsync(ml => dataSetVersion.LocationMetas.Contains(ml.Meta)));
             Assert.False(await publicDataDbContext.IndicatorMetas
                     .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
             Assert.False(await publicDataDbContext.GeographicLevelMetas
@@ -111,12 +109,15 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
                     .AnyAsync(fm => fm.DataSetVersionId == dataSetVersion.Id));
 
             // Assert that the Data Set Version Import has been deleted
-            Assert.Null(await publicDataDbContext.DataSetVersionImports.SingleOrDefaultAsync(dsvi => dsvi.Id == dataSetVersion.Imports.Single().Id));
+            Assert.Null(await publicDataDbContext.DataSetVersionImports
+                .SingleOrDefaultAsync(v => v.Id == dataSetVersion.Imports.Single().Id));
 
-            // Assert that the Release File has been unassociated with the Public API DataSet
-            var file = await contentDataDbContext.Files.SingleAsync(f => f.Id == releaseFile.FileId);
-            Assert.Null(file.PublicApiDataSetId);
-            Assert.Null(file.PublicApiDataSetVersion);
+            // Assert that the ReleaseFile has been unassociated with the Public API DataSet
+            var updatedReleaseFile = await contentDataDbContext.ReleaseFiles
+                .SingleAsync(rf => rf.Id == releaseFile.Id);
+
+            Assert.Null(updatedReleaseFile.PublicApiDataSetId);
+            Assert.Null(updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         [Theory]
@@ -126,15 +127,11 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
         [InlineData(DataSetVersionStatus.Cancelled)]
         public async Task Success_SubsequentDataSetVersion(DataSetVersionStatus dataSetVersionStatus)
         {
-            File liveFile = DataFixture.DefaultFile(FileType.Data);
-            File draftFile = DataFixture.DefaultFile(FileType.Data);
-
             var releaseFiles = DataFixture.DefaultReleaseFile()
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion()
                     .WithPublication(DataFixture
                         .DefaultPublication()))
-                .ForIndex(0, rf => rf.SetFile(liveFile))
-                .ForIndex(1, rf => rf.SetFile(draftFile))
+                .WithFile(() => DataFixture.DefaultFile(FileType.Data))
                 .GenerateList(2);
 
             var liveReleaseFile = releaseFiles[0];
@@ -181,20 +178,28 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
                 context.DataSets.Update(dataSet);
             });
 
-            liveFile.PublicApiDataSetId = dataSet.Id;
-            liveFile.PublicApiDataSetVersion = liveDataSetVersion.FullSemanticVersion();
-            draftFile.PublicApiDataSetId = dataSet.Id;
-            draftFile.PublicApiDataSetVersion = draftDataSetVersion.FullSemanticVersion();
+            liveReleaseFile.PublicApiDataSetId = dataSet.Id;
+            liveReleaseFile.PublicApiDataSetVersion = liveDataSetVersion.FullSemanticVersion();
+            draftReleaseFile.PublicApiDataSetId = dataSet.Id;
+            draftReleaseFile.PublicApiDataSetVersion = draftDataSetVersion.FullSemanticVersion();
 
-            await AddTestData<ContentDbContext>(context => context.Files.UpdateRange(liveFile, draftFile));
+            await AddTestData<ContentDbContext>(context =>
+                context.ReleaseFiles.UpdateRange(liveReleaseFile, draftReleaseFile));
 
             var liveDataSetVersionDirectory = _dataSetVersionPathResolver.DirectoryPath(liveDataSetVersion);
             var draftDataSetVersionDirectory = _dataSetVersionPathResolver.DirectoryPath(draftDataSetVersion);
 
             Directory.CreateDirectory(liveDataSetVersionDirectory);
             Directory.CreateDirectory(draftDataSetVersionDirectory);
-            System.IO.File.WriteAllText(Path.Combine(liveDataSetVersionDirectory, "version1.txt"), "dummy file text");
-            System.IO.File.WriteAllText(Path.Combine(draftDataSetVersionDirectory, "version2.txt"), "dummy file text");
+
+            await System.IO.File.WriteAllTextAsync(
+                Path.Combine(liveDataSetVersionDirectory, "version1.txt"),
+                "dummy file text"
+            );
+            await System.IO.File.WriteAllTextAsync(
+                Path.Combine(draftDataSetVersionDirectory, "version2.txt"),
+                "dummy file text"
+            );
 
             await DeleteDataSetVersion(draftDataSetVersion.Id);
 
@@ -205,7 +210,9 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
             Assert.False(Directory.Exists(draftDataSetVersionDirectory));
 
             // Assert that the LIVE Data Set Version directory has been untouched
-            var liveDataSetVersionFileName = Assert.Single(Directory.GetFileSystemEntries(liveDataSetVersionDirectory));
+            var liveDataSetVersionFileName = Assert.Single(
+                Directory.GetFileSystemEntries(liveDataSetVersionDirectory)
+            );
             Assert.Contains("version1.txt", liveDataSetVersionFileName);
 
             // Assert that the Data Set has NOT been deleted
@@ -220,7 +227,8 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
             Assert.Equal(liveDataSetVersion.Id, updatedDataSet.LatestLiveVersionId);
 
             // Assert that the DRAFT Data Set Version has been deleted
-            Assert.Null(await publicDataDbContext.DataSetVersions.SingleOrDefaultAsync(dsv => dsv.Id == draftDataSetVersion.Id));
+            Assert.Null(await publicDataDbContext.DataSetVersions
+                .SingleOrDefaultAsync(dsv => dsv.Id == draftDataSetVersion.Id));
 
             // Assert that the LIVE Data Set Version has NOT been deleted
             Assert.Single(await publicDataDbContext.DataSetVersions
@@ -234,7 +242,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
                     .CountAsync());
             Assert.Equal(0,
                 await publicDataDbContext.FilterOptionMetaLinks
-                    .Where(foml => draftDataSetVersion.FilterMetas.Contains(foml.Meta))
+                    .Where(ml => draftDataSetVersion.FilterMetas.Contains(ml.Meta))
                     .CountAsync());
             Assert.Equal(0,
                 await publicDataDbContext.LocationMetas
@@ -242,7 +250,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
                     .CountAsync());
             Assert.Equal(0,
                 await publicDataDbContext.LocationOptionMetaLinks
-                    .Where(loml => draftDataSetVersion.LocationMetas.Contains(loml.Meta))
+                    .Where(ml => draftDataSetVersion.LocationMetas.Contains(ml.Meta))
                     .CountAsync());
             Assert.Equal(0,
                 await publicDataDbContext.IndicatorMetas
@@ -262,13 +270,13 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
                 .Where(fm => fm.DataSetVersionId == liveDataSetVersion.Id)
                 .ToListAsync());
             Assert.NotEmpty(await publicDataDbContext.FilterOptionMetaLinks
-                .Where(foml => liveDataSetVersion.FilterMetas.Contains(foml.Meta))
+                .Where(ml => liveDataSetVersion.FilterMetas.Contains(ml.Meta))
                 .ToListAsync());
             Assert.NotEmpty(await publicDataDbContext.LocationMetas
                 .Where(fm => fm.DataSetVersionId == liveDataSetVersion.Id)
                 .ToListAsync());
             Assert.NotEmpty(await publicDataDbContext.LocationOptionMetaLinks
-                .Where(loml => liveDataSetVersion.LocationMetas.Contains(loml.Meta))
+                .Where(ml => liveDataSetVersion.LocationMetas.Contains(ml.Meta))
                 .ToListAsync());
             Assert.NotEmpty(await publicDataDbContext.IndicatorMetas
                 .Where(fm => fm.DataSetVersionId == liveDataSetVersion.Id)
@@ -281,22 +289,27 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
                 .ToListAsync());
 
             // Assert that the DRAFT Data Set Version Import has been deleted
-            Assert.Null(await publicDataDbContext.DataSetVersionImports.SingleOrDefaultAsync(dsvi => dsvi.Id == draftDataSetVersion.Imports.Single().Id));
+            Assert.Null(await publicDataDbContext.DataSetVersionImports
+                .SingleOrDefaultAsync(i => i .Id == draftDataSetVersion.Imports.Single().Id));
 
             // Assert that the LIVE Data Set Version Import has NOT been deleted
             Assert.Single(await publicDataDbContext.DataSetVersionImports
-                .Where(dsvi => dsvi.Id == liveDataSetVersion.Imports.Single().Id)
+                .Where(i => i.Id == liveDataSetVersion.Imports.Single().Id)
                 .ToListAsync());
 
-            // Assert that the Release File has been unassociated with the DRAFT Public API Data Set Version 
-            var updatedDraftFile = await contentDataDbContext.Files.SingleAsync(f => f.Id == draftFile.Id);
-            Assert.Null(updatedDraftFile.PublicApiDataSetId);
-            Assert.Null(updatedDraftFile.PublicApiDataSetVersion);
+            // Assert that the ReleaseFile has been unassociated with the DRAFT Public API Data Set Version
+            var updatedDraftReleaseFile = await contentDataDbContext.ReleaseFiles
+                .SingleAsync(f => f.Id == draftReleaseFile.Id);
 
-            // Assert that the Release File is still associated with the LIVE Public API Data Set Version 
-            var updatedLiveFile = await contentDataDbContext.Files.SingleAsync(f => f.Id == liveFile.Id);
-            Assert.Equal(dataSet.Id, updatedLiveFile.PublicApiDataSetId);
-            Assert.Equal(liveDataSetVersion.FullSemanticVersion(), updatedLiveFile.PublicApiDataSetVersion);
+            Assert.Null(updatedDraftReleaseFile.PublicApiDataSetId);
+            Assert.Null(updatedDraftReleaseFile.PublicApiDataSetVersion);
+
+            // Assert that the ReleaseFile is still associated with the LIVE Public API Data Set Version
+            var updatedLiveReleaseFile = await contentDataDbContext.ReleaseFiles
+                .SingleAsync(f => f.Id == liveReleaseFile.Id);
+
+            Assert.Equal(dataSet.Id, updatedLiveReleaseFile.PublicApiDataSetId);
+            Assert.Equal(liveDataSetVersion.FullSemanticVersion(), updatedLiveReleaseFile.PublicApiDataSetVersion);
         }
 
         [Theory]
@@ -331,36 +344,6 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
             validationProblem.AssertHasError(
                 expectedPath: "dataSetVersionId",
                 expectedCode: ValidationMessages.DataSetVersionCanNotBeDeleted.Code);
-        }
-
-        [Fact]
-        public async Task ReleaseFileDoesNotExist_Returns500()
-        {
-            DataSet dataSet = DataFixture
-                .DefaultDataSet()
-                .WithStatusDraft();
-
-            await AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
-
-            DataSetVersion dataSetVersion = DataFixture
-                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
-                .WithVersionNumber(1, 0, 0)
-                .WithStatusDraft()
-                .WithDataSet(dataSet)
-                .WithImports(() => DataFixture
-                    .DefaultDataSetVersionImport()
-                    .Generate(1))
-                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
-
-            await AddTestData<PublicDataDbContext>(context =>
-            {
-                context.DataSetVersions.Add(dataSetVersion);
-                context.DataSets.Update(dataSet);
-            });
-
-            var response = await DeleteDataSetVersion(dataSetVersion.Id);
-
-            response.AssertInternalServerError();
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetService.cs
@@ -187,8 +187,8 @@ public class DataSetService(
         DataSetVersion dataSetVersion,
         CancellationToken cancellationToken)
     {
-        releaseFile.File.PublicApiDataSetId = dataSetVersion.DataSetId;
-        releaseFile.File.PublicApiDataSetVersion = dataSetVersion.FullSemanticVersion();
+        releaseFile.PublicApiDataSetId = dataSetVersion.DataSetId;
+        releaseFile.PublicApiDataSetVersion = dataSetVersion.FullSemanticVersion();
         await contentDbContext.SaveChangesAsync(cancellationToken);
     }
 


### PR DESCRIPTION
This PR moves the `PublicApiDataSetId` and `PublicApiDataSetVersion` columns from the content DB's `Files` table to `ReleaseFiles`.

This fixes an issue where creating a draft API data set for a `ReleaseFile` in an amendment can immediately show in the Data Catalogue as an API data set. This was due to the `PublicApiDataSet*` columns previously being on the `Files` table, meaning any changes would be shared between all `ReleaseFiles` sharing the same `File`.

:warning: **Note** - To implement this, we also require an endpoint migration to unset the `PublicApiDataSet*` columns for any amendment `ReleaseFiles` that have already been created with this issue.