### PR TITLE
EES-5214 ensure map legends are visible in high contrast mode

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.module.scss
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.module.scss
@@ -26,6 +26,7 @@
 }
 
 .legendIcon {
+  forced-color-adjust: none;
   height: 20px;
   margin-right: govuk-spacing(1);
   width: 20px;


### PR DESCRIPTION
Uses `forced-color-adjust: none` to prevent the map legend colours from disappearing in high contrast mode.