### PR TITLE
EES-5243 Add CORS policy to allow access to public API from public frontend

### DIFF
--- a/infrastructure/templates/public-api/components/containerApp.bicep
+++ b/infrastructure/templates/public-api/components/containerApp.bicep
@@ -12,11 +12,18 @@ param containerAppImageName string
 
 @minLength(2)
 @maxLength(32)
-@description('Specifies the name of the container app.')
+@description('Specifies the name of the Container App.')
 param containerAppName string
 
 @description('Specifies the container port.')
 param containerAppTargetPort int = 8080
+
+@description('The CORS policy to use for the Container App.')
+param corsPolicy {
+  allowedHeaders: string[]?
+  allowedMethods: string[]?
+  allowedOrigins: string[]?
+}
 
 @description('Number of CPU cores the container can use. Can be with a maximum of two decimals.')
 @allowed([
@@ -88,7 +95,7 @@ param volumeMounts {
 var containerImageName = '${acrLoginServer}/${containerAppImageName}'
 var containerApplicationName = toLower('${resourcePrefix}-ca-${containerAppName}')
 
-resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
+resource containerApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
   name: containerApplicationName
   location: location
   identity: {
@@ -106,6 +113,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
         external: true
         targetPort: containerAppTargetPort
         allowInsecure: false
+        corsPolicy: corsPolicy
         traffic: [
           {
             latestRevision: true
@@ -123,7 +131,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
     template: {
       containers: [
         {
-          name: containerAppName 
+          name: containerAppName
           image: containerImageName
           env: appSettings
           resources: {

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -72,7 +72,8 @@ param updatePsqlFlexibleServer bool = false
 @description('Public URLs of other components in the service.')
 param publicUrls {
   contentApi: string
-}?
+  publicApp: string
+}
 
 @description('Specifies whether or not the Data Processor Function App already exists.')
 param dataProcessorFunctionAppExists bool = false
@@ -261,6 +262,13 @@ module apiContainerAppModule 'components/containerApp.bicep' = if (deployContain
     containerAppImageName: 'ees-public-api/api:${dockerImagesTag}'
     userAssignedManagedIdentityId: apiContainerAppManagedIdentity.id
     managedEnvironmentId: containerAppEnvironmentModule.outputs.containerAppEnvironmentId
+    corsPolicy: {
+      allowedOrigins: [
+        publicUrls.publicApp
+        'http://localhost:3000'
+        'http://127.0.0.1'
+      ]
+    }
     volumeMounts: [
       {
         volumeName: dataFilesFileShareMountName
@@ -291,7 +299,7 @@ module apiContainerAppModule 'components/containerApp.bicep' = if (deployContain
       }
       {
         name: 'ContentApi__Url'
-        value: publicUrls!.contentApi
+        value: publicUrls.contentApi
       }
       {
         name: 'MiniProfiler__Enabled'

--- a/infrastructure/templates/public-api/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-dev.bicepparam
@@ -3,6 +3,11 @@ using '../main.bicep'
 // Environment Params
 param environmentName = 'Development'
 
+param publicUrls = {
+  contentApi: 'https://content.dev.explore-education-statistics.service.gov.uk'
+  publicApp: 'https://dev.explore-education-statistics.service.gov.uk'
+}
+
 // PostgreSQL Database Params
 param postgreSqlSkuName = 'Standard_B1ms'
 param postgreSqlStorageSizeGB = 32

--- a/infrastructure/templates/public-api/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-preprod.bicepparam
@@ -3,6 +3,11 @@ using '../main.bicep'
 // Environment Params
 param environmentName = 'Pre-Production'
 
+param publicUrls = {
+  contentApi: 'https://s101p02-as-ees-content.azurewebsites.net'
+  publicApp: 'https://pre-production.explore-education-statistics.service.gov.uk'
+}
+
 // PostgreSQL Database Params
 param postgreSqlSkuName = 'Standard_B1ms'
 param postgreSqlStorageSizeGB = 32

--- a/infrastructure/templates/public-api/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-prod.bicepparam
@@ -3,6 +3,11 @@ using '../main.bicep'
 // Environment Params
 param environmentName = 'Production'
 
+param publicUrls = {
+  contentApi: 'https://content.explore-education-statistics.service.gov.uk'
+  publicApp: 'https://explore-education-statistics.service.gov.uk'
+}
+
 // PostgreSQL Database Params
 param postgreSqlSkuName = 'Standard_B1ms'
 param postgreSqlStorageSizeGB = 32

--- a/infrastructure/templates/public-api/parameters/main-test.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-test.bicepparam
@@ -3,6 +3,11 @@ using '../main.bicep'
 // Environment Params
 param environmentName = 'Test'
 
+param publicUrls = {
+  contentApi: 'https://content.test.explore-education-statistics.service.gov.uk'
+  publicApp: 'https://test.explore-education-statistics.service.gov.uk'
+}
+
 // PostgreSQL Database Params
 param postgreSqlSkuName = 'Standard_B1ms'
 param postgreSqlStorageSizeGB = 32

--- a/renovate.json
+++ b/renovate.json
@@ -66,6 +66,12 @@
       "matchPackageNames": ["node"],
       "groupName": "Node version",
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["azure-bicep-resource"],
+      "groupName": "Azure Bicep resources",
+      "description": "Prevent unofficial resource versions being suggested",
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
This PR adds a CORS policy for the public API so that clients from the public frontend can access it.

## Other changes

- Disabled Renovate for Bicep resources as this was suggesting incorrect versions that do not have official documentation and consequently have broken intellisense. In the future, we should manually upgrade these resource as required.