### PR TITLE
EES-5003 - Minor fixes

### DIFF
--- a/src/explore-education-statistics-frontend/.env
+++ b/src/explore-education-statistics-frontend/.env
@@ -5,5 +5,5 @@ PUBLIC_API_DOCS_URL=TODO-GUIDANCE-URL
 NOTIFICATION_API_BASE_URL=http://localhost:7073/api
 GA_TRACKING_ID=
 PUBLIC_URL=http://localhost:3000/
-PROD_PUBLIC_URL=https://explore-education-statistics.service.gov.uk/
+PROD_PUBLIC_URL=https://explore-education-statistics.service.gov.uk
 APP_ENV=Local

--- a/src/explore-education-statistics-frontend/.env
+++ b/src/explore-education-statistics-frontend/.env
@@ -5,4 +5,5 @@ PUBLIC_API_DOCS_URL=TODO-GUIDANCE-URL
 NOTIFICATION_API_BASE_URL=http://localhost:7073/api
 GA_TRACKING_ID=
 PUBLIC_URL=http://localhost:3000/
+PROD_PUBLIC_URL=https://explore-education-statistics.service.gov.uk/
 APP_ENV=Local

--- a/src/explore-education-statistics-frontend/.env.production
+++ b/src/explore-education-statistics-frontend/.env.production
@@ -1,1 +1,0 @@
-PUBLIC_URL=https://explore-education-statistics.service.gov.uk/

--- a/src/explore-education-statistics-frontend/next-sitemap.config.js
+++ b/src/explore-education-statistics-frontend/next-sitemap.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: process.env.PUBLIC_URL,
+  siteUrl: process.env.PROD_PUBLIC_URL,
   sitemapSize: 5000,
   exclude: ['/server-sitemap.xml'],
   generateRobotsTxt: true,
@@ -16,7 +16,7 @@ module.exports = {
         ],
       },
     ],
-    additionalSitemaps: [`${process.env.PUBLIC_URL}server-sitemap.xml`],
+    additionalSitemaps: [`${process.env.PROD_PUBLIC_URL}server-sitemap.xml`],
   },
   transform: async (config, path) => {
     if (path === '/') {

--- a/src/explore-education-statistics-frontend/next-sitemap.config.js
+++ b/src/explore-education-statistics-frontend/next-sitemap.config.js
@@ -16,7 +16,7 @@ module.exports = {
         ],
       },
     ],
-    additionalSitemaps: [`${process.env.PROD_PUBLIC_URL}server-sitemap.xml`],
+    additionalSitemaps: [`${process.env.PROD_PUBLIC_URL}/server-sitemap.xml`],
   },
   transform: async (config, path) => {
     if (path === '/') {

--- a/src/explore-education-statistics-frontend/src/services/sitemapService.ts
+++ b/src/explore-education-statistics-frontend/src/services/sitemapService.ts
@@ -33,7 +33,7 @@ function buildMethodologyRoutes(
   methodologies: MethodologySitemapItem[],
 ): ISitemapField[] {
   return methodologies.map(methodology => ({
-    loc: `${process.env.PUBLIC_URL}methodology/${methodology.slug}`,
+    loc: `${process.env.PROD_PUBLIC_URL}/methodology/${methodology.slug}`,
     lastmod: methodology.lastModified,
   }));
 }
@@ -47,28 +47,28 @@ function buildPublicationRoutes(
     fields.push(
       ...[
         {
-          loc: `${process.env.PUBLIC_URL}data-catalogue/${publication.slug}`,
+          loc: `${process.env.PROD_PUBLIC_URL}/data-catalogue/${publication.slug}`,
           lastmod: publication.lastModified,
         },
         // TODO: Check if data-tables should be included in the sitemap
         // Add <noindex, nofollow> to the data-tables page if not
         // Add to robots.txt if not
         // {
-        //   loc: `${process.env.PUBLIC_URL}data-tables/${publication.slug}`,
+        //   loc: `${process.env.PROD_PUBLIC_URL}/data-tables/${publication.slug}`,
         //   lastmod: publication.lastModified,
         // },
         {
-          loc: `${process.env.PUBLIC_URL}find-statistics/${publication.slug}`,
+          loc: `${process.env.PROD_PUBLIC_URL}/find-statistics/${publication.slug}`,
           lastmod: publication.lastModified,
           priority: 0.7,
         },
         {
-          loc: `${process.env.PUBLIC_URL}find-statistics/${publication.slug}/data-guidance`,
+          loc: `${process.env.PROD_PUBLIC_URL}/find-statistics/${publication.slug}/data-guidance`,
           lastmod: publication.lastModified,
           priority: 0.4,
         },
         {
-          loc: `${process.env.PUBLIC_URL}find-statistics/${publication.slug}/prerelease-access-list`,
+          loc: `${process.env.PROD_PUBLIC_URL}/find-statistics/${publication.slug}/prerelease-access-list`,
           lastmod: publication.lastModified,
           priority: 0.2,
         },
@@ -78,28 +78,28 @@ function buildPublicationRoutes(
     fields.push(
       ...[
         {
-          loc: `${process.env.PUBLIC_URL}data-catalogue/${publication.slug}`,
+          loc: `${process.env.PROD_PUBLIC_URL}/data-catalogue/${publication.slug}`,
           lastmod: publication.lastModified,
         },
         // TODO: Check if data-tables should be included in the sitemap
         // Add <noindex, nofollow> to the data-tables page if not
         // Add to robots.txt if not
         // {
-        //   loc: `${process.env.PUBLIC_URL}data-tables/${publication.slug}`,
+        //   loc: `${process.env.PROD_PUBLIC_URL}/data-tables/${publication.slug}`,
         //   lastmod: publication.lastModified,
         // },
         {
-          loc: `${process.env.PUBLIC_URL}find-statistics/${publication.slug}`,
+          loc: `${process.env.PROD_PUBLIC_URL}/find-statistics/${publication.slug}`,
           lastmod: publication.lastModified,
           priority: 0.7,
         },
         {
-          loc: `${process.env.PUBLIC_URL}find-statistics/${publication.slug}/data-guidance`,
+          loc: `${process.env.PROD_PUBLIC_URL}/find-statistics/${publication.slug}/data-guidance`,
           lastmod: publication.lastModified,
           priority: 0.4,
         },
         {
-          loc: `${process.env.PUBLIC_URL}find-statistics/${publication.slug}/prerelease-access-list`,
+          loc: `${process.env.PROD_PUBLIC_URL}/find-statistics/${publication.slug}/prerelease-access-list`,
           lastmod: publication.lastModified,
           priority: 0.2,
         },
@@ -110,28 +110,28 @@ function buildPublicationRoutes(
       fields.push(
         ...[
           {
-            loc: `${process.env.PUBLIC_URL}find-statistics/${publication.slug}/${release.slug}`,
+            loc: `${process.env.PROD_PUBLIC_URL}/find-statistics/${publication.slug}/${release.slug}`,
             lastmod: release.lastModified,
           },
           {
-            loc: `${process.env.PUBLIC_URL}find-statistics/${publication.slug}/${release.slug}/data-guidance`,
+            loc: `${process.env.PROD_PUBLIC_URL}/find-statistics/${publication.slug}/${release.slug}/data-guidance`,
             lastmod: release.lastModified,
             priority: 0.4,
           },
           {
-            loc: `${process.env.PUBLIC_URL}find-statistics/${publication.slug}/${release.slug}/prerelease-access-list`,
+            loc: `${process.env.PROD_PUBLIC_URL}/find-statistics/${publication.slug}/${release.slug}/prerelease-access-list`,
             lastmod: release.lastModified,
             priority: 0.2,
           },
           {
-            loc: `${process.env.PUBLIC_URL}data-catalogue/${publication.slug}/${release.slug}`,
+            loc: `${process.env.PROD_PUBLIC_URL}/data-catalogue/${publication.slug}/${release.slug}`,
             lastmod: release.lastModified,
           },
           // TODO: Check if data-tables should be included in the sitemap
           // Add <noindex, nofollow> to the data-tables page if not
           // Add to robots.txt if not
           // {
-          //   loc: `${process.env.PUBLIC_URL}data-tables/${publication.slug}/${release.slug}`,
+          //   loc: `${process.env.PROD_PUBLIC_URL}/data-tables/${publication.slug}/${release.slug}`,
           //   lastmod: release.lastModified,
           // },
         ],
@@ -147,7 +147,7 @@ function buildPublicationRoutes(
 //   dataSets: DataSetSitemapItem[],
 // ): ISitemapField[] {
 //   return dataSets.map(dataSet => ({
-//     loc: `${process.env.PUBLIC_URL}data-catalogue/data-set/${dataSet.id}`,
+//     loc: `${process.env.PROD_PUBLIC_URL}/data-catalogue/data-set/${dataSet.id}`,
 //     lastmod: dataSet.lastModified,
 //   }));
 // }

--- a/tests/playwright-tests/tests/public/seoMetadataFiles.spec.ts
+++ b/tests/playwright-tests/tests/public/seoMetadataFiles.spec.ts
@@ -3,7 +3,10 @@ import environment from '@util/env';
 
 const { PUBLIC_URL, PROD_PUBLIC_URL } = environment;
 
-test.describe('SEO Metadata Files', () => {
+// Playwright finds two elements with getByText('...sitemal.xml') because the html span they're displayed
+// in contains the xml <loc> tag, which playwright then treats as another html element.
+// TODO: Either resolve this, or re-create these tests in robot if the team prefers
+test.describe.skip('SEO Metadata Files', () => {
   test('An xml sitemap index file can be found at the expected route', async ({
     page,
   }) => {

--- a/tests/robot-tests/.env.example
+++ b/tests/robot-tests/.env.example
@@ -1,4 +1,5 @@
 PUBLIC_URL=http://localhost:3000  # URL of the public frontend
+PUBLIC_URL_WITH_WWW=http://www.localhost:3000  # URL of the public frontend with www
 DATA_API_URL=http://localhost:5000/api  # URL for the Data API
 CONTENT_API_URL=http://localhost:5010/api  # URL for the Content API
 PUBLIC_AUTH_USER= # the basic auth user for the public frontend (leave empty if none)

--- a/tests/robot-tests/.env.example
+++ b/tests/robot-tests/.env.example
@@ -1,5 +1,4 @@
 PUBLIC_URL=http://localhost:3000  # URL of the public frontend
-PUBLIC_URL_WITH_WWW=http://www.localhost:3000  # URL of the public frontend with www
 DATA_API_URL=http://localhost:5000/api  # URL for the Data API
 CONTENT_API_URL=http://localhost:5010/api  # URL for the Content API
 PUBLIC_AUTH_USER= # the basic auth user for the public frontend (leave empty if none)

--- a/tests/robot-tests/tests/general_public/prod_only/redirects.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/redirects.robot
@@ -46,7 +46,7 @@ Verify that routes with www are redirected without them
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
 
-    user navigates to public frontend    %{PUBLIC_URL_WITH_WWW}/data-catalogue/
+    user navigates to public frontend with www    %{PUBLIC_URL}/data-catalogue/
     user waits until page contains    Browse our open data
     user checks url equals    %{PUBLIC_URL}/data-catalogue
 

--- a/tests/robot-tests/tests/general_public/prod_only/redirects.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/redirects.robot
@@ -46,7 +46,7 @@ Verify that routes with www are redirected without them
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
 
-    user navigates to public frontend    %{PUBLIC_URL_WITH}/data-catalogue/
+    user navigates to public frontend    %{PUBLIC_URL_WITH_WWW}/data-catalogue/
     user waits until page contains    Browse our open data
     user checks url equals    %{PUBLIC_URL}/data-catalogue
 

--- a/tests/robot-tests/tests/general_public/redirects_www.robot
+++ b/tests/robot-tests/tests/general_public/redirects_www.robot
@@ -14,6 +14,6 @@ Verify that routes with www are redirected without them
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
 
-    user navigates to public frontend    %{PUBLIC_URL_WITH_WWW}/data-catalogue/
+    user navigates to public frontend with www    %{PUBLIC_URL}/data-catalogue/
     user waits until page contains    Browse our open data
     user checks url equals    %{PUBLIC_URL}/data-catalogue

--- a/tests/robot-tests/tests/general_public/redirects_www.robot
+++ b/tests/robot-tests/tests/general_public/redirects_www.robot
@@ -14,6 +14,6 @@ Verify that routes with www are redirected without them
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
 
-    user navigates to public frontend    %{PUBLIC_URL_WITH}/data-catalogue/
+    user navigates to public frontend    %{PUBLIC_URL_WITH_WWW}/data-catalogue/
     user waits until page contains    Browse our open data
     user checks url equals    %{PUBLIC_URL}/data-catalogue


### PR DESCRIPTION
Quick intermediary PR which fixes a few niggles ahead of the next deploy to master -

- The `PUBLIC_URL_WITH_WWW` environment variable was incorrectly named, and has been corrected (this will require renaming the similarly incorrectly named pipeline variable).
- To combat the issue of the robots/sitemap files being constructed at build time, which only occurs once and does not have access to environment variables configured for each environment, we introduced `.env.production` so that the build would have access to the correct `PUBLIC_URL` both when running locally and on the pipeline. This however has consequences for the redirect tests, because the redirects are now going to the production url when testing locally. There's a few ways we could resolve this and keep `.env.production`, but this is all just getting too messy and hacky at this stage. I think the simplest thing is to revert `.env.production` and introduce a `PROD_PUBLIC_URL` value to the normal `.env` which only the sitemap config file uses. 
- The SEO metadata playwright tests have been flaky when running locally because the sitemap file produces xml which is confusing playwright's html locators. It finds an xml `<loc>` within an html `span`, so `getByText('foo')` finds two elements, as if both the loc and the span have the same innertext. I spent 15 minutes trying to resolve this but stopped after that since we've decided not to support Playwright tests. For now I've skipped the suite.