### PR TITLE
EES-5248 Added 15 seconds wait for methodology re-directs & Added pag…

### DIFF
--- a/tests/robot-tests/.env.example
+++ b/tests/robot-tests/.env.example
@@ -15,7 +15,7 @@ NO_INVITE_USER_PASSWORD= # No Invite user password
 PENDING_INVITE_USER_EMAIL= # Pending Invite user email
 PENDING_INVITE_USER_PASSWORD= # Pending Invite user password
 RELEASE_COMPLETE_WAIT=120  # Time to wait for a release to publish (in seconds)
-WAIT_CACHE_EXPIRY=2  # Time to wait for the environment's various caches to expire (in seconds. Local = 2, Dev = 10)
+WAIT_CACHE_EXPIRY=2  # Time to wait for the environment's various caches to expire (in seconds. Local = 2, Dev = 15)
 WAIT_MEDIUM=120  # Variable used throughout tests (in seconds)
 WAIT_SMALL=45 # Variable used throughout tests (in seconds)
 WAIT_LONG=180  # Variable used throughout tests (in seconds)

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_methodology_publication_update.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_methodology_publication_update.robot
@@ -136,6 +136,7 @@ Update methodology details
 Navigate to sign-off page and approve the methodology immediately
     user clicks link    Sign off
     User clicks button    Edit status
+    user waits until page finishes loading
     user clicks radio    Approved for publication
     user enters text into element    id:methodologyStatusForm-latestInternalReleaseNote    Internal note
     user clicks radio    Immediately


### PR DESCRIPTION
This PR addresses failing UI tests of following test suites in `admin_and_public_2` suite - 

1. `Publish_methodology_publication_update.robot.`
2. `publish_amend_and_cancel.robot `

**Reason for failure** - In Pipeline, after approving and publishing the release/schedule release/ amended schedule release/ amended methodology   - its taking more than 10 seconds to get published




