### PR TITLE
EES-5256 Fix `LocationStep` not awaiting form submission

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationStep.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationStep.tsx
@@ -75,9 +75,9 @@ export default function LocationStep(stepProps: LocationFiltersFormProps) {
   return (
     <LocationFiltersForm
       {...stepProps}
-      onSubmit={values => {
+      onSubmit={async values => {
         setSelectedLocationIds(values.locationIds);
-        onSubmit(values);
+        await onSubmit(values);
       }}
     />
   );


### PR DESCRIPTION
This fixes the `LocationStep` component not awaiting in its `onSubmit` handler for its form. This means that currently, users move straight to the time period step without the meta filtering completing.

This compounds with the backend performance regression (introduced by EF's use of `OPENJSON`) where the meta filtering takes so long that the user is essentially able to complete the rest of their table query before it resolves. In this situation, the query will be persisted to the database with an empty `locationIds` array.