### PR TITLE
EES-5256 Opt-out of OPENJSON subquery transformation in time periods query and revert #5002

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
@@ -30,7 +30,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -26,20 +26,20 @@
 
   <ItemGroup>
     <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4" PrivateAssets="all" />
     <PackageReference Include="GovukNotify" Version="7.0.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
     <PackageReference Include="JsonKnownTypes" Version="0.6.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.4" />
     <PackageReference Include="Microsoft.Azure.SignalR" Version="1.25.2" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.4" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
@@ -14,7 +14,7 @@
     <ItemGroup>
         <PackageReference Include="AspectInjector" Version="2.8.2" />
         <PackageReference Include="Bogus" Version="35.5.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" PrivateAssets="all" />
         <PackageReference Include="CompareNETObjects" Version="4.83.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />  

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -27,12 +27,12 @@
         <PackageReference Include="InterpolatedSql" Version="2.3.0" />
         <PackageReference Include="Medo.Uuid7" Version="1.9.1" />
         <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.4" />
         <!-- TODO EES-4202 DataMovement depends on deprecated Microsoft.Azure.Storage.Blob SDK v11 -->
         <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="2.0.4" />
         <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
         <PackageReference Include="Namotion.Reflection" Version="3.1.1" />
         <PackageReference Include="NCrontab.Signed" Version="3.3.3" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
@@ -14,7 +14,7 @@
     <ItemGroup>
         <PackageReference Include="AspectInjector" Version="2.8.2" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="MockQueryable.Moq" Version="7.0.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
@@ -16,9 +16,9 @@
         <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
         <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
-        <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.4" />
         <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
         <PackageReference Include="xunit" Version="2.7.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
           <PrivateAssets>all</PrivateAssets>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/GovUk.Education.ExploreEducationStatistics.Content.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/GovUk.Education.ExploreEducationStatistics.Content.Model.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="JsonKnownTypes" Version="0.6.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.csproj
@@ -19,7 +19,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/GovUk.Education.ExploreEducationStatistics.Content.Security.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/GovUk.Education.ExploreEducationStatistics.Content.Security.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
@@ -18,11 +18,11 @@
 
   <ItemGroup>
     <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.4" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Thinktecture.EntityFrameworkCore.SqlServer" Version="8.1.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="xunit" Version="2.7.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Thinktecture.EntityFrameworkCore.BulkOperations" Version="8.1.1" />
   </ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/GovUk.Education.ExploreEducationStatistics.Data.Services.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/GovUk.Education.ExploreEducationStatistics.Data.Services.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
         <PackageReference Include="CsvHelper" Version="31.0.4" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -56,7 +56,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             GetFilterItems
         }
 
-        public async Task<Either<ActionResult, SubjectMetaViewModel>> GetSubjectMeta(Guid releaseVersionId,
+        public async Task<Either<ActionResult, SubjectMetaViewModel>> GetSubjectMeta(
+            Guid releaseVersionId,
             Guid subjectId)
         {
             return await releaseSubjectService.Find(subjectId: subjectId,
@@ -85,7 +86,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 });
         }
 
-        public async Task<Either<ActionResult, SubjectMetaViewModel>> FilterSubjectMeta(Guid? releaseVersionId,
+        public async Task<Either<ActionResult, SubjectMetaViewModel>> FilterSubjectMeta(
+            Guid? releaseVersionId,
             ObservationQueryContext query,
             CancellationToken cancellationToken)
         {
@@ -181,7 +183,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     var observations = statisticsDbContext
                         .Observation
                         .AsNoTracking()
-                        .Where(o => o.SubjectId == query.SubjectId && query.LocationIds.Contains(o.LocationId));
+                        .Where(o =>
+                            o.SubjectId == query.SubjectId &&
+                            EF.Constant(query.LocationIds).Contains(o.LocationId));
 
                     var timePeriods = await GetTimePeriods(observations);
 
@@ -369,11 +373,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             return AssertCollectionsAreSameIgnoringOrder(firstIdList, secondIdList, error);
         }
 
-        private static Either<ActionResult, Unit> AssertCollectionsAreSameIgnoringOrder<T>(IEnumerable<T> first,
+        private static Either<ActionResult, Unit> AssertCollectionsAreSameIgnoringOrder<T>(
+            IEnumerable<T> first,
             IEnumerable<T> second,
             ValidationErrorMessages error) where T : IComparable
         {
-            if(ComparerUtils.SequencesAreEqualIgnoringOrder(first, second))
+            if (ComparerUtils.SequencesAreEqualIgnoringOrder(first, second))
             {
                 return Unit.Instance;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
@@ -29,12 +29,12 @@
         <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0" />
         <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.0.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.4" />
         <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.3.8" />
         <PackageReference Include="MiniProfiler.EntityFrameworkCore" Version="4.3.8" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj
@@ -18,8 +18,8 @@
         <PackageReference Include="DuckDB.NET.Data.Full" Version="0.10.2" />
         <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0" />
         <PackageReference Include="linq2db.EntityFrameworkCore" Version="8.1.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/GovUk.Education.ExploreEducationStatistics.Publisher.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/GovUk.Education.ExploreEducationStatistics.Publisher.Tests.csproj
@@ -22,7 +22,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR opts-out of the `OPENJSON` subquery transformation of the location id's in the time periods metadata query and revert back to using an SQL `IN` clause as was the behaviour prior to updating to Entity Framework Core 8.

Prior to this change the query is translated using an `OPENJSON` subquery

```
SELECT DISTINCT [o].[Year], [o].[TimeIdentifier]
 FROM [Observation] AS [o]
WHERE [o].[SubjectId] = @__8__locals1_query_SubjectId_0
AND [o].[LocationId] IN (
    SELECT [l].[value]
    FROM OPENJSON(@__locationIds_1) WITH ([value] uniqueidentifier '$') AS [l]
)
```

With this change, for multiple location id's the query is translated using `IN`

```
SELECT DISTINCT [o].[Year], [o].[TimeIdentifier]
FROM [Observation] AS [o]
WHERE [o].[SubjectId] = @__8__locals1_query_SubjectId_0
AND [o].[LocationId] IN ('00000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-000000000000')
```

For a single location id the query is now translated as

```
SELECT DISTINCT [o].[Year], [o].[TimeIdentifier]
FROM [Observation] AS [o]
WHERE [o].[SubjectId] = @__query_SubjectId_0
AND [o].[LocationId] = '00000000-0000-0000-0000-000000000000'
```

We will need to test this carefully as performance could be worse given that the constant location values in the SQL statement will result in unique query plans being generated as opposed to the previous parameterised version where the SQL statement remained constant.

### Revert dependency downgrade made by #5002

This PR also reverts the changes made in https://github.com/dfe-analytical-services/explore-education-statistics/pull/5002 which were going to downgrade EF 8.0.4 to 8.0.3 but this has not been deployed to any environment yet and is thought not be the cause of the degradation.

