### PR TITLE
EES-5270 Temporarily disable snapshots for Find stats and Data catalo…

### DIFF
--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -38,8 +38,8 @@ class SnapshotService:
         self.timeout = 10
         self.page_size = 10
         self.snapshots = [
-            "data_catalogue_snapshot.json",
-            "find_statistics_snapshot.json",
+            #"data_catalogue_snapshot.json", # EES-5270
+            #"find_statistics_snapshot.json", # EES-5270
             "methodologies_snapshot.json",
             "table_tool_snapshot.json",
         ]


### PR DESCRIPTION
…gue pages

This PR temporarily stops validating the snapshots for the Find statistics page and the Data catalogue page. These will be enabled again when they're fixed as part of the work for EES-5270.