### PR TITLE
EES-5277 Quick fix for methodology page href issue

### DIFF
--- a/src/explore-education-statistics-common/src/components/ContentHtml.tsx
+++ b/src/explore-education-statistics-common/src/components/ContentHtml.tsx
@@ -84,9 +84,8 @@ export default function ContentHtml({
         const url = formatContentLink(node.attribs.href);
         const text = domToReact(node.children);
 
-        return !node.attribs.href.includes(
-          'explore-education-statistics.service.gov.uk',
-        ) && typeof node.attribs['data-featured-table'] === 'undefined' ? (
+        return !url?.includes('explore-education-statistics.service.gov.uk') &&
+          typeof node.attribs['data-featured-table'] === 'undefined' ? (
           <a href={url} target="_blank" rel="noopener noreferrer">
             {text} (opens in a new tab)
           </a>


### PR DESCRIPTION
This PR fixes an issue where in methodology content, the entire methodology fails if it tries to process a link without a `href` attribute.

In the methodology that is failing on Prod, there was no link without a `href` attribute, so I'm suspicious that `sanitizeHtml` is removing the `href` attribute from a link, leading to the methodology not rendering.

I tried to recreate the problem locally but failed. I was not able to replicate the Content/Annexes of the failing methodology locally (it was too long to copy into my local db). And I tried copying a few of the links from the failing methodology into my own local db's methodology Content, and they seemed to render fine.

This PR ensures that methodology pages will always load even if no `href` attribute is found in a link, but it will not fix the issue entirely, as we will now have broken links in methodology content. But I'm creating this PR now to solve the worst of the problem before investigating further.