### PR TITLE
EES-5013 Suppress SQL command console logging in Function apps

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Program.cs
@@ -15,6 +15,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Data.Processor.Model.ProcessorQueues;
 
 var host = new HostBuilder()
@@ -25,6 +26,11 @@ var host = new HostBuilder()
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
             .AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: false)
             .AddEnvironmentVariables();
+    })
+    .ConfigureLogging(logging =>
+    {
+        // TODO EES-5013 Why can't this be controlled through application settings?
+        logging.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Warning);
     })
     .ConfigureServices((hostContext, services) =>
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "Logging": {
+    "LogLevel": {
+      "Default": "Error",
+      "GovUk.Education.ExploreEducationStatistics": "Information",
+      "Microsoft": "Warning"
+    }
+  },
   "CoreStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;QueueEndpoint=http://data-storage:10001/devstoreaccount1;TableEndpoint=http://data-storage:10002/devstoreaccount1",
   "AppSettings": {
     "RowsPerBatch": 3000

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/host.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/host.json
@@ -10,11 +10,8 @@
       "enableLiveMetricsFilters": true
     },
     "logLevel": {
-      "default": "Warning",
-      "Microsoft": "Warning",
-      "Function": "Information",
-      "GovUk.Education.ExploreEducationStatistics": "Information",
-      "Azure": "Error"
+      "default": "Error",
+      "Function": "Information"
     }
   },
   "extensions": {

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 var host = new HostBuilder()
     .ConfigureFunctionsWebApplication()
@@ -16,6 +17,11 @@ var host = new HostBuilder()
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
             .AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: false)
             .AddEnvironmentVariables();
+    })
+    .ConfigureLogging(logging =>
+    {
+        // TODO EES-5013 Why can't this be controlled through application settings?
+        logging.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Warning);
     })
     .ConfigureServices((hostContext, services) =>
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "Logging": {
+    "LogLevel": {
+      "Default": "Error",
+      "GovUk.Education.ExploreEducationStatistics": "Information",
+      "Microsoft": "Warning"
+    }
+  },
   "AppSettings": {
     "BaseUrl": "http://localhost:7073/api",
     "TableStorageConnectionString": "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;QueueEndpoint=http://data-storage:10001/devstoreaccount1;TableEndpoint=http://data-storage:10002/devstoreaccount1;",

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/host.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/host.json
@@ -9,11 +9,8 @@
       "enableLiveMetricsFilters": true
     },
     "logLevel": {
-      "default": "Warning",
-      "Microsoft": "Warning",
-      "Function": "Information",
-      "GovUk.Education.ExploreEducationStatistics": "Information",
-      "Azure": "Error"
+      "default": "Error",
+      "Function": "Information"
     }
   },
   "extensions": {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
@@ -51,6 +51,11 @@ public static class PublisherHostBuilderExtensions
                     .AddEnvironmentVariables()
                     .AddConfiguration(hostBuilderContext.Configuration);
             })
+            .ConfigureLogging(logging =>
+            {
+                // TODO EES-5013 Why can't this be controlled through application settings?
+                logging.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Warning);
+            })
             .ConfigureServices((hostContext, services) =>
             {
                 var configuration = hostContext.Configuration;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "Logging": {
+    "LogLevel": {
+      "Default": "Error",
+      "GovUk.Education.ExploreEducationStatistics": "Information",
+      "Microsoft": "Warning"
+    }
+  },
   "CoreStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;",
   "NotificationStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;QueueEndpoint=http://data-storage:10001/devstoreaccount1;",
   "PublicStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;TableEndpoint=http://data-storage:10002/devstoreaccount1;",

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/host.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/host.json
@@ -9,11 +9,8 @@
       "enableLiveMetricsFilters": true
     },
     "logLevel": {
-      "default": "Warning",
-      "Microsoft": "Warning",
-      "Function": "Information",
-      "GovUk.Education.ExploreEducationStatistics": "Information",
-      "Azure": "Error"
+      "default": "Error",
+      "Function": "Information"
     }
   },
   "extensions": {


### PR DESCRIPTION
This PR suppresses the `DbCommand` SQL console logging seen in our Azure Function apps when running locally that started occurring after either the change to use the Isolated Worker Model in #4673 or the .NET 8 update in #4639.

This has been making it difficult to spot exceptions and other log messages because they are surrounded by superfluous SQL command logging.

This PR brings the logging config in sync with the Public Data Processor function app where this fix has already been applied.

Note that this doesn't completely close the issue as we still leave a `TODO` in the code to answer why we can’t we filter `Microsoft.EntityFrameworkCore.Database.Command` using standard logging config in app settings.

We normally control SQL command logging by setting the `Microsoft.EntityFrameworkCore.Database.Command` filter in the logging configuration. E.g. to turn it on:

```
"Microsoft.EntityFrameworkCore.Database.Command": "Debug"
```