### PR TITLE
Ees 5114 endpoint to retrieve filter mappings

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
@@ -4,8 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Claims;
-using System.Text.Json;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Fixture;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
@@ -706,7 +706,7 @@ public abstract class DataSetVersionMappingControllerTests(
         {
             var client = BuildApp().CreateClient();
 
-            var response = await ApplyBatchMappingUpdates(
+            var response = await ApplyBatchLocationMappingUpdates(
                 Guid.NewGuid(),
                 [
                     new LocationMappingUpdateRequest
@@ -864,174 +864,6 @@ public abstract class DataSetVersionMappingControllerTests(
                 client);
 
             var retrievedMappings = response.AssertOk<FilterMappingPlan>();
-            
-            // Test that the mappings from the Controller are identical to the mappings saved in the database
-            retrievedMappings.AssertDeepEqualTo(
-                mappings.FilterMappingPlan,
-                ignoreCollectionOrders: true);
-        }
-        
-        [Fact]
-        public async Task NotBauUser_Returns403()
-        {
-            var client = BuildApp(user: AuthenticatedUser()).CreateClient();
-
-            var response = await GetFilterMappings(
-                Guid.NewGuid(),
-                client);
-
-            response.AssertForbidden();
-        }
-
-        [Fact]
-        public async Task DataSetVersionMappingDoesNotExist_Returns404()
-        {
-            var client = BuildApp().CreateClient();
-
-            var response = await GetFilterMappings(
-                Guid.NewGuid(),
-                client);
-
-            response.AssertNotFound();
-        }
-
-        private async Task<HttpResponseMessage> GetFilterMappings(
-            Guid nextDataSetVersionId,
-            HttpClient? client = null)
-        {
-            client ??= BuildApp().CreateClient();
-
-            var uri = new Uri($"{BaseUrl}/{nextDataSetVersionId}/mapping/filters", UriKind.Relative);
-
-            return await client.GetAsync(uri);
-        }
-    }
-
-    public class GetFilterMappingsTests(
-        TestApplicationFactory testApp) : DataSetVersionMappingControllerTests(testApp)
-    {
-        [Fact]
-        public async Task Success()
-        {
-            DataSet dataSet = DataFixture
-                .DefaultDataSet()
-                .WithStatusPublished();
-
-            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
-
-            DataSetVersion currentDataSetVersion = DataFixture
-                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
-                .WithVersionNumber(major: 1, minor: 0)
-                .WithStatusPublished()
-                .WithDataSet(dataSet)
-                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
-
-            DataSetVersion nextDataSetVersion = DataFixture
-                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
-                .WithVersionNumber(major: 1, minor: 1)
-                .WithStatusDraft()
-                .WithDataSet(dataSet)
-                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
-
-            await TestApp.AddTestData<PublicDataDbContext>(context =>
-            {
-                context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
-                context.DataSets.Update(dataSet);
-            });
-
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = currentDataSetVersion.Id,
-                TargetDataSetVersionId = nextDataSetVersion.Id,
-                LocationMappingPlan = new LocationMappingPlan(),
-                FilterMappingPlan = new FilterMappingPlan
-                {
-                    Mappings =
-                    {
-                        {
-                            "Filter 1 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 1 label"),
-                                Type = MappingType.AutoMapped,
-                                CandidateKey = "Filter 1 key",
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 1 option 1 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 1 label"),
-                                            Type = MappingType.AutoMapped,
-                                            CandidateKey = "Filter 1 option 1 key"
-                                        }
-                                    },
-                                    {
-                                        "Filter 1 option 2 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 2 label"),
-                                            Type = MappingType.ManualNone
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Filter 2 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 2 label"),
-                                Type = MappingType.AutoNone,
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 2 option 1 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 2 option 1 label"),
-                                            Type = MappingType.AutoNone
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    Candidates =
-                    {
-                        {
-                            "Filter 1 key",
-                            new FilterMappingCandidate("Filter 1 label")
-                            {
-                                Options =
-                                {
-                                    {
-                                        "Filter 1 option 1 key", 
-                                        new MappableFilterOption("Filter 1 option 1 label")
-                                    },
-                                    {
-                                        "Filter 1 option 3 key", 
-                                        new MappableFilterOption("Filter 1 option 3 label")
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            await TestApp.AddTestData<PublicDataDbContext>(context =>
-            {
-                context.DataSetVersionMappings.Add(mappings);
-            });
-
-            var client = BuildApp().CreateClient();
-
-            var response = await GetFilterMappings(
-                nextDataSetVersionId: nextDataSetVersion.Id,
-                client);
-
-            var retrievedMappings = response.AssertOk<FilterMappingPlan>();
-
-            var s = JsonSerializer.Serialize(retrievedMappings);
             
             // Test that the mappings from the Controller are identical to the mappings saved in the database
             retrievedMappings.AssertDeepEqualTo(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionMappingController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionMappingController.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
@@ -44,4 +43,16 @@ public class DataSetVersionMappingController(IDataSetVersionMappingService mappi
                 cancellationToken: cancellationToken)
             .HandleFailuresOrOk();
     }
+    
+    [HttpGet("{nextDataSetVersionId:guid}/mapping/filters")]
+    [Produces("application/json")]
+    public Task<ActionResult<FilterMappingPlan>> GetFilterMappings(
+        [FromRoute] Guid nextDataSetVersionId,
+        CancellationToken cancellationToken)
+    {
+        return mappingService
+            .GetFilterMappings(nextDataSetVersionId, cancellationToken)
+            .HandleFailuresOrOk();
+    }
+
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionMappingController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionMappingController.cs
@@ -19,7 +19,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Publi
 public class DataSetVersionMappingController(IDataSetVersionMappingService mappingService)
     : ControllerBase
 {
-
     [HttpGet("locations")]
     [Produces("application/json")]
     public Task<ActionResult<LocationMappingPlan>> GetLocationMappings(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionMappingController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionMappingController.cs
@@ -31,20 +31,20 @@ public class DataSetVersionMappingController(IDataSetVersionMappingService mappi
 
     [HttpPatch("locations")]
     [Produces("application/json")]
-    public async Task<ActionResult<BatchLocationMappingUpdatesResponseViewModel>> ApplyBatchMappingUpdates(
+    public async Task<ActionResult<BatchLocationMappingUpdatesResponseViewModel>> ApplyBatchLocationMappingUpdates(
         [FromRoute] Guid nextDataSetVersionId,
         [FromBody] BatchLocationMappingUpdatesRequest request,
         CancellationToken cancellationToken)
     {
         return await mappingService
-            .ApplyBatchMappingUpdates(
+            .ApplyBatchLocationMappingUpdates(
                 nextDataSetVersionId: nextDataSetVersionId,
                 request: request,
                 cancellationToken: cancellationToken)
             .HandleFailuresOrOk();
     }
-    
-    [HttpGet("{nextDataSetVersionId:guid}/mapping/filters")]
+
+    [HttpGet("filters")]
     [Produces("application/json")]
     public Task<ActionResult<FilterMappingPlan>> GetFilterMappings(
         [FromRoute] Guid nextDataSetVersionId,
@@ -54,5 +54,4 @@ public class DataSetVersionMappingController(IDataSetVersionMappingService mappi
             .GetFilterMappings(nextDataSetVersionId, cancellationToken)
             .HandleFailuresOrOk();
     }
-
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/BatchMappingUpdateRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/BatchMappingUpdateRequests.cs
@@ -8,6 +8,35 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
 
+public record LocationMappingUpdateRequest : MappingUpdateRequest
+{
+    public GeographicLevel? Level { get; init; }
+
+    public class Validator : MappingUpdateRequestValidator<LocationMappingUpdateRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.Level)
+                .NotNull()
+                .IsInEnum();
+        }
+    }
+}
+
+public record FilterOptionMappingUpdateRequest : MappingUpdateRequest
+{
+    public string? FilterKey { get; init; } = null;
+
+    public class Validator : MappingUpdateRequestValidator<FilterOptionMappingUpdateRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.FilterKey)
+                .NotEmpty();
+        }
+    }
+}
+
 public record BatchLocationMappingUpdatesRequest
 {
     public List<LocationMappingUpdateRequest> Updates { get; init; } = [];
@@ -22,30 +51,40 @@ public record BatchLocationMappingUpdatesRequest
     }
 }
 
-public record LocationMappingUpdateRequest
+public record BatchFilterOptionMappingUpdatesRequest
 {
-    public GeographicLevel? Level { get; init; }
+    public List<FilterOptionMappingUpdateRequest> Updates { get; init; } = [];
 
-    public string SourceKey { get; init; } = string.Empty;
+    public class Validator : AbstractValidator<BatchFilterOptionMappingUpdatesRequest>
+    {
+        public Validator()
+        {
+            RuleForEach(request => request.Updates)
+                .SetValidator(new FilterOptionMappingUpdateRequest.Validator());
+        }
+    }
+}
+
+public abstract record MappingUpdateRequest
+{
+    private static readonly MappingType[] ManualMappingTypes =
+    [
+        MappingType.ManualNone,
+        MappingType.ManualMapped
+    ];
+
+    public string? SourceKey { get; init; }
 
     public string? CandidateKey { get; init; }
 
     public MappingType? Type { get; init; }
 
-    public class Validator : AbstractValidator<LocationMappingUpdateRequest>
+    public abstract class MappingUpdateRequestValidator<TMappingUpdateRequest>
+        : AbstractValidator<TMappingUpdateRequest>
+        where TMappingUpdateRequest : MappingUpdateRequest
     {
-        private static readonly MappingType[] ManualMappingTypes =
-        [
-            MappingType.ManualNone,
-            MappingType.ManualMapped
-        ];
-
-        public Validator()
+        public MappingUpdateRequestValidator()
         {
-            RuleFor(request => request.Level)
-                .NotNull()
-                .IsInEnum();
-
             RuleFor(request => request.SourceKey)
                 .NotEmpty();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionMappingService.cs
@@ -19,4 +19,8 @@ public interface IDataSetVersionMappingService
         Guid nextDataSetVersionId,
         BatchLocationMappingUpdatesRequest request,
         CancellationToken cancellationToken = default);
+    
+    Task<Either<ActionResult, FilterMappingPlan>> GetFilterMappings(
+        Guid nextDataSetVersionId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionMappingService.cs
@@ -15,7 +15,7 @@ public interface IDataSetVersionMappingService
         Guid nextDataSetVersionId,
         CancellationToken cancellationToken = default);
 
-    Task<Either<ActionResult, BatchLocationMappingUpdatesResponseViewModel>> ApplyBatchMappingUpdates(
+    Task<Either<ActionResult, BatchLocationMappingUpdatesResponseViewModel>> ApplyBatchLocationMappingUpdates(
         Guid nextDataSetVersionId,
         BatchLocationMappingUpdatesRequest request,
         CancellationToken cancellationToken = default);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
@@ -38,7 +38,7 @@ public class DataSetVersionMappingService(
             .OnSuccess(mapping => mapping.LocationMappingPlan);
     }
 
-    public async Task<Either<ActionResult, BatchLocationMappingUpdatesResponseViewModel>> ApplyBatchMappingUpdates(
+    public async Task<Either<ActionResult, BatchLocationMappingUpdatesResponseViewModel>> ApplyBatchLocationMappingUpdates(
         Guid nextDataSetVersionId,
         BatchLocationMappingUpdatesRequest request,
         CancellationToken cancellationToken = default)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
@@ -61,6 +61,17 @@ public class DataSetVersionMappingService(
                         .OnFailure<ActionResult>(errors => ValidationUtils.ValidationResult(errors));
                 }));
     }
+    
+    public Task<Either<ActionResult, FilterMappingPlan>> GetFilterMappings(
+        Guid nextDataSetVersionId,
+        CancellationToken cancellationToken = default)
+    {
+        return userService
+            .CheckIsBauUser()
+            .OnSuccess(() => CheckMappingExists(nextDataSetVersionId, cancellationToken))
+            .OnSuccess(mapping => mapping.FilterMappingPlan);
+    }
+
 
     /// <summary>
     /// Given a batch of Location mapping update requests, this method will return a list of either success or failure

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/BatchMappingUpdateViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/BatchMappingUpdateViewModels.cs
@@ -5,16 +5,35 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 
-public record BatchLocationMappingUpdatesResponseViewModel
-{
-    public List<LocationMappingUpdateResponseViewModel> Updates { get; init; } = [];
-}
-
-public record LocationMappingUpdateResponseViewModel
+public record LocationMappingUpdateResponseViewModel : MappingUpdateResponse<LocationOptionMapping, MappableLocationOption>
 {
     public GeographicLevel Level { get; init; }
+}
 
+public record FilterOptionMappingUpdateResponseViewModel : MappingUpdateResponse<FilterOptionMapping, MappableFilterOption>
+{
+    public string FilterKey { get; init; } = string.Empty;
+}
+
+public record BatchLocationMappingUpdatesResponseViewModel : BatchMappingUpdatesResponseViewModel
+    <LocationMappingUpdateResponseViewModel, LocationOptionMapping, MappableLocationOption>;
+
+public record BatchFilterOptionMappingUpdatesResponseViewModel : BatchMappingUpdatesResponseViewModel
+    <FilterOptionMappingUpdateResponseViewModel, FilterOptionMapping, MappableFilterOption>;
+
+public abstract record MappingUpdateResponse<TMapping, TMappableElement>
+    where TMapping : Mapping<TMappableElement>
+    where TMappableElement : MappableElement
+{
     public string SourceKey { get; init; } = string.Empty;
 
-    public LocationOptionMapping Mapping { get; init; } = null!;
+    public TMapping Mapping { get; init; } = null!;
+}
+
+public abstract record BatchMappingUpdatesResponseViewModel<TMappingUpdateResponse, TMapping, TMappableElement>
+    where TMappingUpdateResponse : MappingUpdateResponse<TMapping, TMappableElement>
+    where TMapping : Mapping<TMappableElement>
+    where TMappableElement : MappableElement
+{
+    public List<TMappingUpdateResponse> Updates { get; init; } = [];
 }


### PR DESCRIPTION
This PR:
- adds an endpoint for retrieving the current Filter mappings for a data set version.

The JSON returned looks like:

```json
{
  "Mappings": {
    "Filter 1 key": {
      "OptionMappings": {
        "Filter 1 option 1 key": {
          "Type": "AutoMapped",
          "Source": {
            "Label": "Filter 1 option 1 label"
          },
          "CandidateKey": "Filter 1 option 1 key"
        },
        "Filter 1 option 2 key": {
          "Type": "ManualNone",
          "Source": {
            "Label": "Filter 1 option 2 label"
          },
          "CandidateKey": null
        }
      },
      "Type": "AutoMapped",
      "Source": {
        "Label": "Filter 1 label"
      },
      "CandidateKey": "Filter 1 key"
    },
    "Filter 2 key": {
      "OptionMappings": {
        "Filter 2 option 1 key": {
          "Type": "AutoNone",
          "Source": {
            "Label": "Filter 2 option 1 label"
          },
          "CandidateKey": null
        }
      },
      "Type": "AutoNone",
      "Source": {
        "Label": "Filter 2 label"
      },
      "CandidateKey": null
    }
  },
  "Candidates": {
    "Filter 1 key": {
      "Options": {
        "Filter 1 option 1 key": {
          "Label": "Filter 1 option 1 label"
        },
        "Filter 1 option 3 key": {
          "Label": "Filter 1 option 3 label"
        }
      },
      "Label": "Filter 1 label"
    }
  }
}
```