### PR TITLE
EES-5267 Added UI test with retry mechanism that checks title in data…

### DIFF
--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -378,6 +378,14 @@ Cancel the release amendment
     user clicks button    Confirm
     user waits until modal is not visible    Confirm you want to cancel this amended release
 
+    user waits until h3 is visible    Published releases (1 of 1)    %{WAIT_SMALL}
+    user checks page contains element    testid:publication-published-releases
+    user checks table body has x rows    1    testid:publication-published-releases
+    table cell should contain    testid:publication-published-releases    1    1    Release period
+    table cell should contain    testid:publication-published-releases    1    2    Status
+    table cell should contain    testid:publication-published-releases    2    1    Financial year 3000-01
+    table cell should contain    testid:publication-published-releases    2    2    Published
+
 Revisit the Release after the cancellation to double check it remains unaffected
     ${ROW}=    user gets table row    ${RELEASE_NAME}    testid:publication-published-releases
     user clicks element    xpath://*[text()="View"]    ${ROW}

--- a/tests/robot-tests/tests/libs/charts.robot
+++ b/tests/robot-tests/tests/libs/charts.robot
@@ -45,12 +45,12 @@ user waits until element does not contain chart tooltip
 
 user checks chart title contains
     [Arguments]    ${locator}    ${text}
-    ${element}=    get child element    ${locator}    testid:chart-title
+    ${element}=    get child element with retry    ${locator}    testid:chart-title
     user waits until element contains    ${element}    ${text}
 
 user checks chart subtitle contains
     [Arguments]    ${locator}    ${text}
-    ${element}=    get child element    ${locator}    testid:chart-subtitle
+    ${element}=    get child element with retry    ${locator}    testid:chart-subtitle
     user waits until element contains    ${element}    ${text}
 
 user checks chart height

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -4,14 +4,15 @@ import json
 import os
 import re
 from typing import Union
-from urllib.parse import urlparse
 
+import time
 import pytz
 import utilities_init
 import visual
 from robot.libraries.BuiltIn import BuiltIn
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
+from selenium.common.exceptions import NoSuchElementException
 from SeleniumLibrary.utils import is_noney
 from tests.libs.logger import get_logger
 from tests.libs.selenium_elements import element_finder, sl, waiting
@@ -379,3 +380,13 @@ def remove_auth_from_url(publicUrl: str):
     modified_url_without_auth = urlunparse((parsed_url.scheme, netloc, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment))
     return modified_url_without_auth
 
+def get_child_element_with_retry(parent_locator: object, child_locator: str, max_retries=3, retry_delay=2):
+    retry_count = 0
+    while retry_count < max_retries:
+        try:
+            return get_child_element(parent_locator, child_locator)
+        except NoSuchElementException:
+            retry_count += 1
+            logger.warn(f"Child element not found, after ({max_retries}) retries")
+            time.sleep(retry_delay)
+    raise AssertionError(f"Failed to find child element after {max_retries} retries.")


### PR DESCRIPTION
 This PR focusses on addressing following issues in `publish-amend_and_cancel.robot` test suite -                                                               

- Added UI tests that checks that cancellation of release amendment is published to avoid intermittent failures in pipeline
- Added retry mechanism so that it overcomes page loading issue while retrieving the 'chart title' details in Dates block accordion.