### PR TITLE
EES-5269- Fix prod-only UI test failure

### DIFF
--- a/tests/robot-tests/tests/general_public/prod_only/statistics_page.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/statistics_page.robot
@@ -19,15 +19,15 @@ Validate Related information section and links exist
     user checks element contains child element    ${related_information}    xpath://h2[text()="Related information"]
 
     user checks page contains link with text and url
-    ...    Education statistics: data catalogue
+    ...    Data catalogue
     ...    /data-catalogue
     ...    ${related_information}
     user checks page contains link with text and url
-    ...    Education statistics: methodology
+    ...    Methodology
     ...    /methodology
     ...    ${related_information}
     user checks page contains link with text and url
-    ...    Education statistics: glossary
+    ...    Glossary
     ...    /glossary
     ...    ${related_information}
 

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -6,7 +6,6 @@ Library     file_operations.py
 Library     utilities.py
 Library     fail_fast.py
 Library     visual.py
-Library     urlparsing.py
 Resource    ./tables-common.robot
 Resource    ./table_tool.robot
 


### PR DESCRIPTION
Updated UI tests that run against Prod to fix a failure due to change in text of links under 'Related Information' on Find Stats page.
Also removed an unused library in `common.robot` as an error was popping up in console.
