### PR TITLE
EES-5283 Add missing `MetaInsertBatchSize` app setting to Public API Data Processor function app

### DIFF
--- a/infrastructure/templates/public-api/components/functionApp.bicep
+++ b/infrastructure/templates/public-api/components/functionApp.bicep
@@ -27,8 +27,8 @@ param appServicePlanOS string = 'Linux'
 ])
 param functionAppRuntime string = 'dotnet'
 
-@description('Specifies the additional setting to add to the functionapp.')
-param settings object = {}
+@description('Specifies the additional setting to add to the Function App')
+param appSettings object = {}
 
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object
@@ -401,7 +401,7 @@ module functionAppSlotSettings 'appServiceSlotConfig.bicep' = {
       // site is being viewed.
       'SLOT_NAME'
     ]
-    commonSettings: union(settings, {
+    commonSettings: union(appSettings, {
 
       // This tells the Function App where to store its "azure-webjobs-hosts" and "azure-webjobs-secrets" files.
       AzureWebJobsStorage: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=${sharedStorageAccountModule.outputs.connectionStringSecretName})'

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -393,6 +393,9 @@ module dataProcessorFunctionAppModule 'components/functionApp.bicep' = {
       path: '/api/HealthCheck'
       unhealthyMetricName: '${subscription}PublicDataProcessorUnhealthy'
     }
+    appSettings: {
+      AppSettings__MetaInsertBatchSize: 1000
+    }
     azureFileShares: [{
       storageName: dataFilesFileShareModule.outputs.fileShareName
       storageAccountKey: publicApiStorageAccountAccessKey


### PR DESCRIPTION
This PR adds a missing app setting `AppSettings__MetaInsertBatchSize` to the Public API Data Processor function app.

The missing setting is thought to be the cause of data set versions failing to be processed in Azure environments.

Without this setting we are observing high CPU activity in the `ImportMetadata` function, thought to be because `_appSettingsOptions.MetaInsertBatchSize` is resolving to zero in the following block, resulting in the batch iteration to be in an infinite loop.

https://github.com/dfe-analytical-services/explore-education-statistics/blob/c52407b1d8ae62a1e3701c21f72a24e18c5e6ea3/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/FilterMetaRepository.cs#L103-L106

After around 10 minutes (thought to be the function timeout) the exception `Npgsql.NpgsqlOperationInProgressException (0x80004005): The connection is already in state 'Executing'` was occuring in the following block of code:

https://github.com/dfe-analytical-services/explore-education-statistics/blob/c52407b1d8ae62a1e3701c21f72a24e18c5e6ea3/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/FilterMetaRepository.cs#L115-L125

This exception can be reproduced locally by running the function app with `AppSettings__MetaInsertBatchSize` set to zero.