### PR TITLE
EES-5112 - adding validation to ensure Candidate Keys are valid

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
@@ -66,8 +66,7 @@ public abstract class DataSetVersionMappingControllerTests(
                     Levels = new Dictionary<GeographicLevel, LocationLevelMappings>
                     {
                         {
-                            GeographicLevel.LocalAuthority,
-                            new LocationLevelMappings
+                            GeographicLevel.LocalAuthority, new LocationLevelMappings
                             {
                                 Mappings = new Dictionary<string, LocationOptionMapping>
                                 {
@@ -253,8 +252,7 @@ public abstract class DataSetVersionMappingControllerTests(
                     Levels = new Dictionary<GeographicLevel, LocationLevelMappings>
                     {
                         {
-                            GeographicLevel.LocalAuthority,
-                            new LocationLevelMappings
+                            GeographicLevel.LocalAuthority, new LocationLevelMappings
                             {
                                 Mappings = new Dictionary<string, LocationOptionMapping>
                                 {
@@ -546,8 +544,7 @@ public abstract class DataSetVersionMappingControllerTests(
                     Levels = new Dictionary<GeographicLevel, LocationLevelMappings>
                     {
                         {
-                            GeographicLevel.LocalAuthority,
-                            new LocationLevelMappings
+                            GeographicLevel.LocalAuthority, new LocationLevelMappings
                             {
                                 Mappings = new Dictionary<string, LocationOptionMapping>
                                 {
@@ -576,23 +573,24 @@ public abstract class DataSetVersionMappingControllerTests(
                                         }
                                     }
                                 },
-                                Candidates = new Dictionary<string, MappableLocationOption>
-                                {
+                                Candidates =
+                                    new Dictionary<string, MappableLocationOption>
                                     {
-                                        "target-la-location-1-key",
-                                        new MappableLocationOption("Target location 1")
                                         {
-                                            Code = "Target location 1 code"
-                                        }
-                                    },
-                                    {
-                                        "target-la-location-2-key",
-                                        new MappableLocationOption("Target location 2")
+                                            "target-la-location-1-key",
+                                            new MappableLocationOption("Target location 1")
+                                            {
+                                                Code = "Target location 1 code"
+                                            }
+                                        },
                                         {
-                                            Code = "Target location 2 code"
+                                            "target-la-location-2-key",
+                                            new MappableLocationOption("Target location 2")
+                                            {
+                                                Code = "Target location 2 code"
+                                            }
                                         }
                                     }
-                                }
                             }
                         },
                         {
@@ -605,9 +603,9 @@ public abstract class DataSetVersionMappingControllerTests(
                                     {
                                         "target-country-location-1-key",
                                         new MappableLocationOption("Target location 1")
-                                        {
-                                            Code = "Target location 1 code"
-                                        }
+                                            {
+                                                Code = "Target location 1 code"
+                                            }
                                     }
                                 }
                             }
@@ -682,7 +680,7 @@ public abstract class DataSetVersionMappingControllerTests(
         }
 
         [Fact]
-        public async Task CandidateKeyDoesNotExist_Returns400_AndRollsBackTransaction()
+        public async Task CandidateKeyDoesNotExist_Returns400()
         {
             DataSet dataSet = DataFixture
                 .DefaultDataSet()
@@ -795,7 +793,10 @@ public abstract class DataSetVersionMappingControllerTests(
                     Type = MappingType.ManualMapped,
                     CandidateKey = "target-la-location-1-key"
                 },
-                // This candidate does not exist.
+                // This candidate does not exist as there is no candidate with the key
+                // "target-la-location-2-key" under the "LocalAuthority" level. This tests
+                // the simple case where a candidate simply doesn't exist at all with the
+                // given key. 
                 new()
                 {
                     Level = GeographicLevel.LocalAuthority,
@@ -803,7 +804,12 @@ public abstract class DataSetVersionMappingControllerTests(
                     Type = MappingType.ManualMapped,
                     CandidateKey = "target-la-location-2-key"
                 },
-                // This candidate does not exist.
+                // This candidate does not exist as there is no candidate with the key
+                // "target-la-location-1-key" under the "Country" level, despite it existing
+                // under the "LocalAuthority" level.  This tests the more complex case
+                // whereby a candidate *does* exist with the given key, but it's under a
+                // different level than that of the source location and thus is not a valid
+                // candidate.
                 new()
                 {
                     Level = GeographicLevel.Country,
@@ -1465,12 +1471,17 @@ public abstract class DataSetVersionMappingControllerTests(
                                 Options =
                                 {
                                     {
-                                        "Target filter 1 option 1 key", new MappableFilterOption("Filter 1 option 1 label")
+                                        "Target filter 1 option 1 key",
+                                        new MappableFilterOption("Filter 1 option 1 label")
                                     },
                                     {
-                                        "Target filter 1 option 2 key", new MappableFilterOption("Filter 1 option 2 label")
+                                        "Target filter 1 option 2 key",
+                                        new MappableFilterOption("Filter 1 option 2 label")
                                     },
-                                    { "Target filter 1 option 3 key", new MappableFilterOption("Filter 1 option 3 label") }
+                                    {
+                                        "Target filter 1 option 3 key",
+                                        new MappableFilterOption("Filter 1 option 3 label")
+                                    }
                                 }
                             }
                         }
@@ -1531,7 +1542,7 @@ public abstract class DataSetVersionMappingControllerTests(
         }
 
         [Fact]
-        public async Task CandidateKeyDoesNotExist_Returns400_AndRollsBackTransaction()
+        public async Task CandidateKeyDoesNotExist_Returns400()
         {
             DataSet dataSet = DataFixture
                 .DefaultDataSet()
@@ -1670,7 +1681,9 @@ public abstract class DataSetVersionMappingControllerTests(
                     Type = MappingType.ManualMapped,
                     CandidateKey = "Target filter 1 option 1 key"
                 },
-                // This candidate does not exist.
+                // This candidate does not exist as there is no candidate with the key
+                // "Non existent candidate key".  This tests the simple case where a candidate
+                // doesn't exist at all with the given key. 
                 new()
                 {
                     FilterKey = "Filter 1 key",
@@ -1678,7 +1691,13 @@ public abstract class DataSetVersionMappingControllerTests(
                     Type = MappingType.ManualMapped,
                     CandidateKey = "Non existent candidate key"
                 },
-                // This candidate does not exist.
+                // This candidate does not exist as there is no candidate with the key
+                // "Non existent candidate key" under the filter that "Filter 2 key" is
+                // mapped to, despite there being a filter option candidate that exists
+                // under a different filter with the key "Target filter 1 option 1 key".
+                // This tests the more complex case whereby only filter option candidates
+                // that exist under the filter that the owning filter is mapped to are
+                // considered valid candidates.  
                 new()
                 {
                     FilterKey = "Filter 2 key",
@@ -1718,7 +1737,7 @@ public abstract class DataSetVersionMappingControllerTests(
         }
 
         [Fact]
-        public async Task OwningFilterNotMapped_Returns400_AndRollsBackTransaction()
+        public async Task OwningFilterNotMapped_Returns400()
         {
             DataSet dataSet = DataFixture
                 .DefaultDataSet()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
@@ -96,16 +96,17 @@ public abstract class DataSetVersionMappingControllerTests(
                                         }
                                     }
                                 },
-                                Candidates = new Dictionary<string, MappableLocationOption>
-                                {
+                                Candidates =
+                                    new Dictionary<string, MappableLocationOption>
                                     {
-                                        "target-location-1-key",
-                                        new MappableLocationOption("Target location 1")
                                         {
-                                            Code = "Target location 1 code"
+                                            "target-location-1-key",
+                                            new MappableLocationOption("Target location 1")
+                                            {
+                                                Code = "Target location 1 code"
+                                            }
                                         }
                                     }
-                                }
                             }
                         },
                         {
@@ -174,7 +175,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 mappings.LocationMappingPlan,
                 ignoreCollectionOrders: true);
         }
-        
+
         [Fact]
         public async Task NotBauUser_Returns403()
         {
@@ -258,7 +259,7 @@ public abstract class DataSetVersionMappingControllerTests(
                                 Mappings = new Dictionary<string, LocationOptionMapping>
                                 {
                                     {
-                                        "source-location-1-key",
+                                        "source-la-location-1-key",
                                         new LocationOptionMapping
                                         {
                                             Source = new MappableLocationOption("Source location 1")
@@ -270,7 +271,7 @@ public abstract class DataSetVersionMappingControllerTests(
                                         }
                                     },
                                     {
-                                        "source-location-2-key",
+                                        "source-la-location-2-key",
                                         new LocationOptionMapping
                                         {
                                             Source = new MappableLocationOption("Source location 2")
@@ -281,7 +282,18 @@ public abstract class DataSetVersionMappingControllerTests(
                                             CandidateKey = null
                                         }
                                     }
-                                }
+                                },
+                                Candidates =
+                                    new Dictionary<string, MappableLocationOption>
+                                    {
+                                        {
+                                            "target-la-location-1-key",
+                                            new MappableLocationOption("Target location 1")
+                                            {
+                                                Code = "Target location 1 code"
+                                            }
+                                        }
+                                    }
                             }
                         },
                         {
@@ -291,7 +303,7 @@ public abstract class DataSetVersionMappingControllerTests(
                                 Mappings = new Dictionary<string, LocationOptionMapping>
                                 {
                                     {
-                                        "source-location-1-key",
+                                        "source-country-location-1-key",
                                         new LocationOptionMapping
                                         {
                                             Source = new MappableLocationOption("Source location 1")
@@ -303,7 +315,7 @@ public abstract class DataSetVersionMappingControllerTests(
                                         }
                                     },
                                     {
-                                        "source-location-3-key",
+                                        "source-country-location-3-key",
                                         new LocationOptionMapping
                                         {
                                             Source = new MappableLocationOption("Source location 3")
@@ -311,7 +323,17 @@ public abstract class DataSetVersionMappingControllerTests(
                                                 Code = "Source location 3 code"
                                             },
                                             Type = MappingType.AutoMapped,
-                                            CandidateKey = "target-location-3-key"
+                                            CandidateKey = "target-country-location-3-key"
+                                        }
+                                    }
+                                },
+                                Candidates = new Dictionary<string, MappableLocationOption>
+                                {
+                                    {
+                                        "target-country-location-1-key",
+                                        new MappableLocationOption("Target location 1")
+                                        {
+                                            Code = "Target location 1 code"
                                         }
                                     }
                                 }
@@ -334,14 +356,14 @@ public abstract class DataSetVersionMappingControllerTests(
                 new()
                 {
                     Level = GeographicLevel.LocalAuthority,
-                    SourceKey = "source-location-1-key",
+                    SourceKey = "source-la-location-1-key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "target-location-1-key"
+                    CandidateKey = "target-la-location-1-key"
                 },
                 new()
                 {
                     Level = GeographicLevel.Country,
-                    SourceKey = "source-location-3-key",
+                    SourceKey = "source-country-location-3-key",
                     Type = MappingType.ManualNone
                 }
             ];
@@ -360,19 +382,19 @@ public abstract class DataSetVersionMappingControllerTests(
                     new LocationMappingUpdateResponseViewModel
                     {
                         Level = GeographicLevel.LocalAuthority,
-                        SourceKey = "source-location-1-key",
+                        SourceKey = "source-la-location-1-key",
                         Mapping = new LocationOptionMapping
                         {
                             Source =
                                 new MappableLocationOption("Source location 1") { Code = "Source location 1 code" },
                             Type = MappingType.ManualMapped,
-                            CandidateKey = "target-location-1-key"
+                            CandidateKey = "target-la-location-1-key"
                         }
                     },
                     new LocationMappingUpdateResponseViewModel
                     {
                         Level = GeographicLevel.Country,
-                        SourceKey = "source-location-3-key",
+                        SourceKey = "source-country-location-3-key",
                         Mapping = new LocationOptionMapping
                         {
                             Source =
@@ -402,7 +424,7 @@ public abstract class DataSetVersionMappingControllerTests(
                             // We expect this mapping's type ot be set to ManualMapped and
                             // its CandidateKey set.
                             {
-                                "source-location-1-key",
+                                "source-la-location-1-key",
                                 new LocationOptionMapping
                                 {
                                     Source = new MappableLocationOption("Source location 1")
@@ -410,11 +432,11 @@ public abstract class DataSetVersionMappingControllerTests(
                                         Code = "Source location 1 code"
                                     },
                                     Type = MappingType.ManualMapped,
-                                    CandidateKey = "target-location-1-key"
+                                    CandidateKey = "target-la-location-1-key"
                                 }
                             },
                             {
-                                "source-location-2-key",
+                                "source-la-location-2-key",
                                 new LocationOptionMapping
                                 {
                                     Source = new MappableLocationOption("Source location 2")
@@ -425,7 +447,15 @@ public abstract class DataSetVersionMappingControllerTests(
                                     CandidateKey = null
                                 }
                             }
-                        }
+                        },
+                        Candidates =
+                            new Dictionary<string, MappableLocationOption>
+                            {
+                                {
+                                    "target-la-location-1-key",
+                                    new MappableLocationOption("Target location 1") { Code = "Target location 1 code" }
+                                }
+                            }
                     }
                 },
                 {
@@ -434,7 +464,7 @@ public abstract class DataSetVersionMappingControllerTests(
                         Mappings = new Dictionary<string, LocationOptionMapping>
                         {
                             {
-                                "source-location-1-key",
+                                "source-country-location-1-key",
                                 new LocationOptionMapping
                                 {
                                     Source = new MappableLocationOption("Source location 1")
@@ -448,7 +478,7 @@ public abstract class DataSetVersionMappingControllerTests(
                             {
                                 // We expect this mapping's type to be set to ManualNone and
                                 // its CandidateKey unset.
-                                "source-location-3-key",
+                                "source-country-location-3-key",
                                 new LocationOptionMapping
                                 {
                                     Source = new MappableLocationOption("Source location 3")
@@ -458,6 +488,13 @@ public abstract class DataSetVersionMappingControllerTests(
                                     Type = MappingType.ManualNone,
                                     CandidateKey = null
                                 }
+                            }
+                        },
+                        Candidates = new Dictionary<string, MappableLocationOption>
+                        {
+                            {
+                                "target-country-location-1-key",
+                                new MappableLocationOption("Target location 1") { Code = "Target location 1 code" }
                             }
                         }
                     }
@@ -472,7 +509,180 @@ public abstract class DataSetVersionMappingControllerTests(
         }
 
         [Fact]
-        public async Task UpdateMappingDoesNotExist_Returns400_AndRollsBackTransaction()
+        public async Task SourceKeyDoesNotExist_Returns400_AndRollsBackTransaction()
+        {
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusPublished();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion currentDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 0)
+                .WithStatusPublished()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            DataSetVersion nextDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 1)
+                .WithStatusDraft()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var mappings = new DataSetVersionMapping
+            {
+                SourceDataSetVersionId = currentDataSetVersion.Id,
+                TargetDataSetVersionId = nextDataSetVersion.Id,
+                LocationMappingPlan = new LocationMappingPlan
+                {
+                    Levels = new Dictionary<GeographicLevel, LocationLevelMappings>
+                    {
+                        {
+                            GeographicLevel.LocalAuthority,
+                            new LocationLevelMappings
+                            {
+                                Mappings = new Dictionary<string, LocationOptionMapping>
+                                {
+                                    {
+                                        "source-la-location-1-key",
+                                        new LocationOptionMapping
+                                        {
+                                            Source = new MappableLocationOption("Source location 1")
+                                            {
+                                                Code = "Source location 1 code"
+                                            },
+                                            Type = MappingType.None,
+                                            CandidateKey = null
+                                        }
+                                    },
+                                    {
+                                        "source-la-location-2-key",
+                                        new LocationOptionMapping
+                                        {
+                                            Source = new MappableLocationOption("Source location 2")
+                                            {
+                                                Code = "Source location 2 code"
+                                            },
+                                            Type = MappingType.None,
+                                            CandidateKey = null
+                                        }
+                                    }
+                                },
+                                Candidates = new Dictionary<string, MappableLocationOption>
+                                {
+                                    {
+                                        "target-la-location-1-key",
+                                        new MappableLocationOption("Target location 1")
+                                        {
+                                            Code = "Target location 1 code"
+                                        }
+                                    },
+                                    {
+                                        "target-la-location-2-key",
+                                        new MappableLocationOption("Target location 2")
+                                        {
+                                            Code = "Target location 2 code"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            GeographicLevel.Country,
+                            new LocationLevelMappings
+                            {
+                                Mappings = new Dictionary<string, LocationOptionMapping>(),
+                                Candidates = new Dictionary<string, MappableLocationOption>
+                                {
+                                    {
+                                        "target-country-location-1-key",
+                                        new MappableLocationOption("Target location 1")
+                                        {
+                                            Code = "Target location 1 code"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                FilterMappingPlan = new FilterMappingPlan()
+            };
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersionMappings.Add(mappings);
+            });
+
+            var client = BuildApp().CreateClient();
+
+            List<LocationMappingUpdateRequest> updates =
+            [
+                // This mapping exists.
+                new()
+                {
+                    Level = GeographicLevel.LocalAuthority,
+                    SourceKey = "source-la-location-1-key",
+                    Type = MappingType.ManualMapped,
+                    CandidateKey = "target-la-location-1-key"
+                },
+                // This mapping does not exist.
+                new()
+                {
+                    Level = GeographicLevel.LocalAuthority,
+                    SourceKey = "source-la-location-3-key",
+                    Type = MappingType.ManualMapped,
+                    CandidateKey = "target-la-location-2-key"
+                },
+                // This mapping does not exist.
+                new()
+                {
+                    Level = GeographicLevel.Country,
+                    SourceKey = "source-la-location-2-key",
+                    Type = MappingType.ManualMapped,
+                    CandidateKey = "target-country-location-1-key"
+                }
+            ];
+
+            var response = await ApplyBatchLocationMappingUpdates(
+                nextDataSetVersionId: nextDataSetVersion.Id,
+                updates: updates,
+                client);
+
+            var validationProblem = response.AssertValidationProblem();
+
+            // The 2 non-existent mappings in the batch update request should have failure messages
+            // indicating that the mappings they were attempting to update do not exist.
+            validationProblem.AssertHasError(
+                expectedPath: "updates[1].sourceKey",
+                expectedCode: nameof(ValidationMessages.DataSetVersionMappingSourcePathDoesNotExist));
+
+            validationProblem.AssertHasError(
+                expectedPath: "updates[2].sourceKey",
+                expectedCode: nameof(ValidationMessages.DataSetVersionMappingSourcePathDoesNotExist));
+
+            Assert.Equal(2, validationProblem.Errors.Count);
+
+            var retrievedMappings = TestApp.GetDbContext<PublicDataDbContext>()
+                .DataSetVersionMappings
+                .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
+
+            // Test that the mappings are not updated due to the failures of some of the update requests.
+            retrievedMappings.LocationMappingPlan.Levels.AssertDeepEqualTo(
+                mappings.LocationMappingPlan.Levels,
+                ignoreCollectionOrders: true);
+        }
+
+        [Fact]
+        public async Task CandidateKeyDoesNotExist_Returns400_AndRollsBackTransaction()
         {
             DataSet dataSet = DataFixture
                 .DefaultDataSet()
@@ -525,6 +735,40 @@ public abstract class DataSetVersionMappingControllerTests(
                                             Type = MappingType.None,
                                             CandidateKey = null
                                         }
+                                    },
+                                    {
+                                        "source-location-2-key",
+                                        new LocationOptionMapping
+                                        {
+                                            Source = new MappableLocationOption("Source location 2")
+                                            {
+                                                Code = "Source location 2 code"
+                                            },
+                                            Type = MappingType.None,
+                                            CandidateKey = null
+                                        }
+                                    },
+                                    {
+                                        "source-location-3-key",
+                                        new LocationOptionMapping
+                                        {
+                                            Source = new MappableLocationOption("Source location 3")
+                                            {
+                                                Code = "Source location 3 code"
+                                            },
+                                            Type = MappingType.None,
+                                            CandidateKey = null
+                                        }
+                                    }
+                                },
+                                Candidates = new Dictionary<string, MappableLocationOption>()
+                                {
+                                    {
+                                        "target-la-location-1-key",
+                                        new MappableLocationOption("Target location 1")
+                                        {
+                                            Code = "Target location 1 code"
+                                        }
                                     }
                                 }
                             }
@@ -543,29 +787,29 @@ public abstract class DataSetVersionMappingControllerTests(
 
             List<LocationMappingUpdateRequest> updates =
             [
-                // This mapping exists.
+                // This candidate exists.
                 new()
                 {
                     Level = GeographicLevel.LocalAuthority,
-                    SourceKey = "source-location-1-key",
+                    SourceKey = "source-la-location-1-key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "target-location-1-key"
+                    CandidateKey = "target-la-location-1-key"
                 },
-                // This mapping does not exist.
+                // This candidate does not exist.
                 new()
                 {
                     Level = GeographicLevel.LocalAuthority,
-                    SourceKey = "source-location-2-key",
+                    SourceKey = "source-la-location-2-key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "target-location-2-key"
+                    CandidateKey = "target-la-location-2-key"
                 },
-                // This mapping does not exist.
+                // This candidate does not exist.
                 new()
                 {
-                    Level = GeographicLevel.LocalAuthority,
-                    SourceKey = "source-location-3-key",
+                    Level = GeographicLevel.Country,
+                    SourceKey = "source-la-location-3-key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "target-location-3-key"
+                    CandidateKey = "target-la-location-1-key"
                 }
             ];
 
@@ -578,15 +822,15 @@ public abstract class DataSetVersionMappingControllerTests(
 
             // The 2 non-existent mappings in the batch update request should have failure messages
             // indicating that the mappings they were attempting to update do not exist.
+            validationProblem.AssertHasError(
+                expectedPath: "updates[1].candidateKey",
+                expectedCode: nameof(ValidationMessages.DataSetVersionMappingCandidatePathDoesNotExist));
+
+            validationProblem.AssertHasError(
+                expectedPath: "updates[2].candidateKey",
+                expectedCode: nameof(ValidationMessages.DataSetVersionMappingCandidatePathDoesNotExist));
+
             Assert.Equal(2, validationProblem.Errors.Count);
-
-            validationProblem.AssertHasError(
-                expectedPath: "updates[1].sourceKey",
-                expectedCode: nameof(ValidationMessages.DataSetVersionMappingPathDoesNotExist));
-
-            validationProblem.AssertHasError(
-                expectedPath: "updates[2].sourceKey",
-                expectedCode: nameof(ValidationMessages.DataSetVersionMappingPathDoesNotExist));
 
             var retrievedMappings = TestApp.GetDbContext<PublicDataDbContext>()
                 .DataSetVersionMappings
@@ -664,11 +908,13 @@ public abstract class DataSetVersionMappingControllerTests(
                 client);
 
             var validationProblem = response.AssertValidationProblem();
-            Assert.Single(validationProblem.Errors);
+
             validationProblem.AssertHasError(
                 expectedPath: "updates[0].candidateKey",
                 expectedCode: ValidationMessages.CandidateKeyMustBeSpecifiedWithMappedMappingType.Code,
                 expectedMessage: ValidationMessages.CandidateKeyMustBeSpecifiedWithMappedMappingType.Message);
+
+            Assert.Single(validationProblem.Errors);
         }
 
         [Theory]
@@ -691,11 +937,13 @@ public abstract class DataSetVersionMappingControllerTests(
                 client);
 
             var validationProblem = response.AssertValidationProblem();
-            Assert.Single(validationProblem.Errors);
+
             validationProblem.AssertHasError(
                 expectedPath: "updates[0].candidateKey",
                 expectedCode: ValidationMessages.CandidateKeyMustBeEmptyWithNoneMappingType.Code,
                 expectedMessage: ValidationMessages.CandidateKeyMustBeEmptyWithNoneMappingType.Message);
+
+            Assert.Single(validationProblem.Errors);
         }
 
         [Theory]
@@ -720,11 +968,13 @@ public abstract class DataSetVersionMappingControllerTests(
                 client);
 
             var validationProblem = response.AssertValidationProblem();
-            Assert.Single(validationProblem.Errors);
+
             validationProblem.AssertHasError(
-                expectedPath: "updates[0].type", 
+                expectedPath: "updates[0].type",
                 expectedCode: ValidationMessages.ManualMappingTypeInvalid.Code,
                 expectedMessage: "Type must be one of the following values: ManualMapped, ManualNone");
+
+            Assert.Single(validationProblem.Errors);
         }
 
         private async Task<HttpResponseMessage> ApplyBatchLocationMappingUpdates(
@@ -740,7 +990,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 new JsonNetContent(new BatchLocationMappingUpdatesRequest { Updates = updates }));
         }
     }
-    
+
     public class GetFilterMappingsTests(
         TestApplicationFactory testApp) : DataSetVersionMappingControllerTests(testApp)
     {
@@ -838,13 +1088,9 @@ public abstract class DataSetVersionMappingControllerTests(
                                 Options =
                                 {
                                     {
-                                        "Filter 1 option 1 key", 
-                                        new MappableFilterOption("Filter 1 option 1 label")
+                                        "Filter 1 option 1 key", new MappableFilterOption("Filter 1 option 1 label")
                                     },
-                                    {
-                                        "Filter 1 option 3 key", 
-                                        new MappableFilterOption("Filter 1 option 3 label")
-                                    }
+                                    { "Filter 1 option 3 key", new MappableFilterOption("Filter 1 option 3 label") }
                                 }
                             }
                         }
@@ -864,13 +1110,13 @@ public abstract class DataSetVersionMappingControllerTests(
                 client);
 
             var retrievedMappings = response.AssertOk<FilterMappingPlan>();
-            
+
             // Test that the mappings from the Controller are identical to the mappings saved in the database
             retrievedMappings.AssertDeepEqualTo(
                 mappings.FilterMappingPlan,
                 ignoreCollectionOrders: true);
         }
-        
+
         [Fact]
         public async Task NotBauUser_Returns403()
         {
@@ -916,29 +1162,403 @@ public abstract class DataSetVersionMappingControllerTests(
             DataSet dataSet = DataFixture
                 .DefaultDataSet()
                 .WithStatusPublished();
-        
+
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
-        
+
             DataSetVersion currentDataSetVersion = DataFixture
                 .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
                 .WithVersionNumber(major: 1, minor: 0)
                 .WithStatusPublished()
                 .WithDataSet(dataSet)
                 .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
-        
+
             DataSetVersion nextDataSetVersion = DataFixture
                 .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
                 .WithVersionNumber(major: 1, minor: 1)
                 .WithStatusDraft()
                 .WithDataSet(dataSet)
                 .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
-        
+
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
                 context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
                 context.DataSets.Update(dataSet);
             });
-        
+
+            var mappings = new DataSetVersionMapping
+            {
+                SourceDataSetVersionId = currentDataSetVersion.Id,
+                TargetDataSetVersionId = nextDataSetVersion.Id,
+                LocationMappingPlan = new LocationMappingPlan(),
+                FilterMappingPlan = new FilterMappingPlan
+                {
+                    Mappings =
+                    {
+                        {
+                            "Filter 1 key", new FilterMapping
+                            {
+                                Source = new MappableFilter("Filter 1 label"),
+                                Type = MappingType.AutoMapped,
+                                CandidateKey = "Filter 1 target key",
+                                OptionMappings =
+                                {
+                                    {
+                                        "Filter 1 option 1 key",
+                                        new FilterOptionMapping
+                                        {
+                                            Source = new MappableFilterOption("Filter 1 option 1 label"),
+                                            Type = MappingType.AutoMapped,
+                                            CandidateKey = "Filter 1 option 1 key"
+                                        }
+                                    },
+                                    {
+                                        "Filter 1 option 2 key",
+                                        new FilterOptionMapping
+                                        {
+                                            Source = new MappableFilterOption("Filter 1 option 2 label"),
+                                            Type = MappingType.ManualNone
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Filter 2 key", new FilterMapping
+                            {
+                                Source = new MappableFilter("Filter 2 label"),
+                                Type = MappingType.AutoMapped,
+                                CandidateKey = "Filter 2 key",
+                                OptionMappings =
+                                {
+                                    {
+                                        "Filter 2 option 1 key",
+                                        new FilterOptionMapping
+                                        {
+                                            Source = new MappableFilterOption("Filter 2 option 1 label"),
+                                            Type = MappingType.AutoMapped,
+                                            CandidateKey = "Filter 1 option 1 key"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    Candidates = new Dictionary<string, FilterMappingCandidate>
+                    {
+                        {
+                            "Filter 1 target key",
+                            new FilterMappingCandidate("Filter 1")
+                            {
+                                Options = new Dictionary<string, MappableFilterOption>
+                                {
+                                    {
+                                        "target-filter-option-1-key",
+                                        new MappableFilterOption("Filter 1 option 1 label")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersionMappings.Add(mappings);
+            });
+
+            var client = BuildApp().CreateClient();
+
+            List<FilterOptionMappingUpdateRequest> updates =
+            [
+                new()
+                {
+                    FilterKey = "Filter 1 key",
+                    SourceKey = "Filter 1 option 1 key",
+                    Type = MappingType.ManualMapped,
+                    CandidateKey = "target-filter-option-1-key"
+                },
+                new()
+                {
+                    FilterKey = "Filter 2 key",
+                    SourceKey = "Filter 2 option 1 key",
+                    Type = MappingType.ManualNone
+                }
+            ];
+
+            var response = await ApplyBatchFilterOptionMappingUpdates(
+                nextDataSetVersionId: nextDataSetVersion.Id,
+                updates: updates,
+                client);
+
+            var viewModel = response.AssertOk<BatchFilterOptionMappingUpdatesResponseViewModel>();
+
+            var expectedUpdateResponse = new BatchFilterOptionMappingUpdatesResponseViewModel
+            {
+                Updates =
+                [
+                    new FilterOptionMappingUpdateResponseViewModel
+                    {
+                        FilterKey = "Filter 1 key",
+                        SourceKey = "Filter 1 option 1 key",
+                        Mapping = new FilterOptionMapping
+                        {
+                            Source = new MappableFilterOption("Filter 1 option 1 label"),
+                            Type = MappingType.ManualMapped,
+                            CandidateKey = "target-filter-option-1-key"
+                        }
+                    },
+                    new FilterOptionMappingUpdateResponseViewModel
+                    {
+                        FilterKey = "Filter 2 key",
+                        SourceKey = "Filter 2 option 1 key",
+                        Mapping = new FilterOptionMapping
+                        {
+                            Source = new MappableFilterOption("Filter 2 option 1 label"),
+                            Type = MappingType.ManualNone,
+                            CandidateKey = null
+                        }
+                    },
+                ]
+            };
+
+            // Test that the response from the Controller contains details of all the mappings
+            // that were updated.
+            viewModel.AssertDeepEqualTo(expectedUpdateResponse, ignoreCollectionOrders: true);
+
+            var updatedMappings = TestApp.GetDbContext<PublicDataDbContext>()
+                .DataSetVersionMappings
+                .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
+
+            var expectedFullMappings = new Dictionary<string, FilterMapping>
+            {
+                {
+                    "Filter 1 key", new FilterMapping
+                    {
+                        Source = new MappableFilter("Filter 1 label"),
+                        Type = MappingType.AutoMapped,
+                        CandidateKey = "Filter 1 target key",
+                        OptionMappings =
+                        {
+                            {
+                                "Filter 1 option 1 key",
+                                new FilterOptionMapping
+                                {
+                                    Source = new MappableFilterOption("Filter 1 option 1 label"),
+                                    Type = MappingType.ManualMapped,
+                                    CandidateKey = "target-filter-option-1-key"
+                                }
+                            },
+                            {
+                                "Filter 1 option 2 key",
+                                new FilterOptionMapping
+                                {
+                                    Source = new MappableFilterOption("Filter 1 option 2 label"),
+                                    Type = MappingType.ManualNone
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "Filter 2 key", new FilterMapping
+                    {
+                        Source = new MappableFilter("Filter 2 label"),
+                        Type = MappingType.AutoMapped,
+                        CandidateKey = "Filter 2 key",
+                        OptionMappings =
+                        {
+                            {
+                                "Filter 2 option 1 key",
+                                new FilterOptionMapping
+                                {
+                                    Source = new MappableFilterOption("Filter 2 option 1 label"),
+                                    Type = MappingType.ManualNone,
+                                    CandidateKey = null
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Test that the updated mappings retrieved from the database reflect the updates
+            // that were requested. 
+            updatedMappings.FilterMappingPlan.Mappings.AssertDeepEqualTo(
+                expectedFullMappings,
+                ignoreCollectionOrders: true);
+        }
+
+        [Fact]
+        public async Task SourceKeyDoesNotExist_Returns400_AndRollsBackTransaction()
+        {
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusPublished();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion currentDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 0)
+                .WithStatusPublished()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            DataSetVersion nextDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 1)
+                .WithStatusDraft()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var mappings = new DataSetVersionMapping
+            {
+                SourceDataSetVersionId = currentDataSetVersion.Id,
+                TargetDataSetVersionId = nextDataSetVersion.Id,
+                LocationMappingPlan = new LocationMappingPlan(),
+                FilterMappingPlan = new FilterMappingPlan
+                {
+                    Mappings =
+                    {
+                        {
+                            "Filter 1 key", new FilterMapping
+                            {
+                                Source = new MappableFilter("Filter 1 label"),
+                                Type = MappingType.AutoMapped,
+                                CandidateKey = "Target filter 1 key",
+                                OptionMappings =
+                                {
+                                    {
+                                        "Filter 1 option 1 key",
+                                        new FilterOptionMapping
+                                        {
+                                            Source = new MappableFilterOption("Filter 1 option 1 label"),
+                                            Type = MappingType.AutoMapped,
+                                            CandidateKey = "Filter 1 option 1 key"
+                                        }
+                                    },
+                                    {
+                                        "Filter 1 option 2 key",
+                                        new FilterOptionMapping
+                                        {
+                                            Source = new MappableFilterOption("Filter 1 option 2 label"),
+                                            Type = MappingType.ManualNone
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    Candidates =
+                    {
+                        {
+                            "Target filter 1 key",
+                            new FilterMappingCandidate("Filter 1")
+                            {
+                                Options =
+                                {
+                                    {
+                                        "Target filter 1 option 1 key", new MappableFilterOption("Filter 1 option 1 label")
+                                    },
+                                    {
+                                        "Target filter 1 option 2 key", new MappableFilterOption("Filter 1 option 2 label")
+                                    },
+                                    { "Target filter 1 option 3 key", new MappableFilterOption("Filter 1 option 3 label") }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersionMappings.Add(mappings);
+            });
+
+            var client = BuildApp().CreateClient();
+
+            List<FilterOptionMappingUpdateRequest> updates =
+            [
+                // This mapping exists.
+                new()
+                {
+                    FilterKey = "Filter 1 key",
+                    SourceKey = "Filter 1 option 1 key",
+                    Type = MappingType.ManualMapped,
+                    CandidateKey = "Target filter 1 option 1 key"
+                },
+                // This mapping does not exist.
+                new()
+                {
+                    FilterKey = "Filter 1 key",
+                    SourceKey = "Filter 1 option 3 key",
+                    Type = MappingType.ManualMapped,
+                    CandidateKey = "Target filter 1 option 2 key"
+                }
+            ];
+
+            var response = await ApplyBatchFilterOptionMappingUpdates(
+                nextDataSetVersionId: nextDataSetVersion.Id,
+                updates: updates,
+                client);
+
+            var validationProblem = response.AssertValidationProblem();
+
+            // The non-existent mapping in the batch update request should have failure messages
+            // indicating that the mappings they were attempting to update do not exist.
+            validationProblem.AssertHasError(
+                expectedPath: "updates[1].sourceKey",
+                expectedCode: nameof(ValidationMessages.DataSetVersionMappingSourcePathDoesNotExist));
+
+            Assert.Single(validationProblem.Errors);
+
+            var retrievedMappings = TestApp.GetDbContext<PublicDataDbContext>()
+                .DataSetVersionMappings
+                .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
+
+            // Test that the mappings are not updated due to the failures of some of the update requests.
+            retrievedMappings.FilterMappingPlan.Mappings.AssertDeepEqualTo(
+                mappings.FilterMappingPlan.Mappings,
+                ignoreCollectionOrders: true);
+        }
+
+        [Fact]
+        public async Task CandidateKeyDoesNotExist_Returns400_AndRollsBackTransaction()
+        {
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusPublished();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion currentDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 0)
+                .WithStatusPublished()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            DataSetVersion nextDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 1)
+                .WithStatusDraft()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
             var mappings = new DataSetVersionMapping
             {
                 SourceDataSetVersionId = currentDataSetVersion.Id,
@@ -988,7 +1608,7 @@ public abstract class DataSetVersionMappingControllerTests(
                                         "Filter 2 option 1 key",
                                         new FilterOptionMapping
                                         {
-                                            Source = new MappableFilterOption("Filter 2 option 1 label"),
+                                            Source = new MappableFilterOption("Filter 1 option 1 label"),
                                             Type = MappingType.AutoMapped,
                                             CandidateKey = "Filter 1 option 1 key"
                                         }
@@ -996,166 +1616,136 @@ public abstract class DataSetVersionMappingControllerTests(
                                 }
                             }
                         }
+                    },
+                    Candidates =
+                    {
+                        {
+                            "Filter 1 key",
+                            new FilterMappingCandidate("Filter 1")
+                            {
+                                Options =
+                                {
+                                    {
+                                        "Target filter 1 option 1 key",
+                                        new MappableFilterOption("Filter 1 option 1 label")
+                                    },
+                                    {
+                                        "Target filter 1 option 2 key",
+                                        new MappableFilterOption("Filter 1 option 2 label")
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Filter 2 key",
+                            new FilterMappingCandidate("Filter 2")
+                            {
+                                Options =
+                                {
+                                    {
+                                        "Target filter 2 option 1 key",
+                                        new MappableFilterOption("Filter 2 option 1 label")
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             };
-        
+
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
                 context.DataSetVersionMappings.Add(mappings);
             });
-        
+
             var client = BuildApp().CreateClient();
-        
+
             List<FilterOptionMappingUpdateRequest> updates =
             [
+                // This candidate exists.
                 new()
                 {
                     FilterKey = "Filter 1 key",
                     SourceKey = "Filter 1 option 1 key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "target-filter-option-1-key"
+                    CandidateKey = "Target filter 1 option 1 key"
                 },
+                // This candidate does not exist.
+                new()
+                {
+                    FilterKey = "Filter 1 key",
+                    SourceKey = "Filter 1 option 2 key",
+                    Type = MappingType.ManualMapped,
+                    CandidateKey = "Non existent candidate key"
+                },
+                // This candidate does not exist.
                 new()
                 {
                     FilterKey = "Filter 2 key",
                     SourceKey = "Filter 2 option 1 key",
-                    Type = MappingType.ManualNone
+                    Type = MappingType.ManualMapped,
+                    CandidateKey = "Target filter 1 option 1 key"
                 }
             ];
-        
+
             var response = await ApplyBatchFilterOptionMappingUpdates(
                 nextDataSetVersionId: nextDataSetVersion.Id,
                 updates: updates,
                 client);
-        
-            var viewModel = response.AssertOk<BatchFilterOptionMappingUpdatesResponseViewModel>();
-        
-            var expectedUpdateResponse = new BatchFilterOptionMappingUpdatesResponseViewModel
-            {
-                Updates =
-                [
-                    new FilterOptionMappingUpdateResponseViewModel
-                    {
-                        FilterKey = "Filter 1 key",
-                        SourceKey = "Filter 1 option 1 key",
-                        Mapping = new FilterOptionMapping
-                        {
-                            Source = new MappableFilterOption("Filter 1 option 1 label"),
-                            Type = MappingType.ManualMapped,
-                            CandidateKey = "target-filter-option-1-key"
-                        }
-                    },
-                    new FilterOptionMappingUpdateResponseViewModel
-                    {
-                        FilterKey = "Filter 2 key",
-                        SourceKey = "Filter 2 option 1 key",
-                        Mapping = new FilterOptionMapping
-                        {
-                            Source = new MappableFilterOption("Filter 2 option 1 label"),
-                            Type = MappingType.ManualNone,
-                            CandidateKey = null
-                        }
-                    },
-                ]
-            };
-        
-            // Test that the response from the Controller contains details of all the mappings
-            // that were updated.
-            viewModel.AssertDeepEqualTo(expectedUpdateResponse, ignoreCollectionOrders: true);
-        
-            var updatedMappings = TestApp.GetDbContext<PublicDataDbContext>()
+
+            var validationProblem = response.AssertValidationProblem();
+
+            // The 2 non-existent mappings in the batch update request should have failure messages
+            // indicating that the mappings they were attempting to update do not exist.
+            validationProblem.AssertHasError(
+                expectedPath: "updates[1].candidateKey",
+                expectedCode: nameof(ValidationMessages.DataSetVersionMappingCandidatePathDoesNotExist));
+
+            validationProblem.AssertHasError(
+                expectedPath: "updates[2].candidateKey",
+                expectedCode: nameof(ValidationMessages.DataSetVersionMappingCandidatePathDoesNotExist));
+
+            Assert.Equal(2, validationProblem.Errors.Count);
+
+            var retrievedMappings = TestApp.GetDbContext<PublicDataDbContext>()
                 .DataSetVersionMappings
                 .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
-        
-            var expectedFullMappings = new Dictionary<string, FilterMapping>
-            {
-                {
-                    "Filter 1 key", new FilterMapping
-                    {
-                        Source = new MappableFilter("Filter 1 label"),
-                        Type = MappingType.AutoMapped,
-                        CandidateKey = "Filter 1 key",
-                        OptionMappings =
-                        {
-                            {
-                                "Filter 1 option 1 key",
-                                new FilterOptionMapping
-                                {
-                                    Source = new MappableFilterOption("Filter 1 option 1 label"),
-                                    Type = MappingType.ManualMapped,
-                                    CandidateKey = "target-filter-option-1-key"
-                                }
-                            },
-                            {
-                                "Filter 1 option 2 key",
-                                new FilterOptionMapping
-                                {
-                                    Source = new MappableFilterOption("Filter 1 option 2 label"),
-                                    Type = MappingType.ManualNone
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "Filter 2 key", new FilterMapping
-                    {
-                        Source = new MappableFilter("Filter 2 label"),
-                        Type = MappingType.AutoMapped,
-                        CandidateKey = "Filter 2 key",
-                        OptionMappings =
-                        {
-                            {
-                                "Filter 2 option 1 key",
-                                new FilterOptionMapping
-                                {
-                                    Source = new MappableFilterOption("Filter 2 option 1 label"),
-                                    Type = MappingType.ManualNone,
-                                    CandidateKey = null
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-        
-            // Test that the updated mappings retrieved from the database reflect the updates
-            // that were requested. 
-            updatedMappings.FilterMappingPlan.Mappings.AssertDeepEqualTo(
-                expectedFullMappings,
+
+            // Test that the mappings are not updated due to the failures of some of the update requests.
+            retrievedMappings.FilterMappingPlan.Mappings.AssertDeepEqualTo(
+                mappings.FilterMappingPlan.Mappings,
                 ignoreCollectionOrders: true);
         }
-        
+
         [Fact]
-        public async Task UpdateMappingDoesNotExist_Returns400_AndRollsBackTransaction()
+        public async Task OwningFilterNotMapped_Returns400_AndRollsBackTransaction()
         {
             DataSet dataSet = DataFixture
                 .DefaultDataSet()
                 .WithStatusPublished();
-        
+
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
-        
+
             DataSetVersion currentDataSetVersion = DataFixture
                 .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
                 .WithVersionNumber(major: 1, minor: 0)
                 .WithStatusPublished()
                 .WithDataSet(dataSet)
                 .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
-        
+
             DataSetVersion nextDataSetVersion = DataFixture
                 .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
                 .WithVersionNumber(major: 1, minor: 1)
                 .WithStatusDraft()
                 .WithDataSet(dataSet)
                 .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
-        
+
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
                 context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
                 context.DataSets.Update(dataSet);
             });
-        
+
             var mappings = new DataSetVersionMapping
             {
                 SourceDataSetVersionId = currentDataSetVersion.Id,
@@ -1169,8 +1759,7 @@ public abstract class DataSetVersionMappingControllerTests(
                             "Filter 1 key", new FilterMapping
                             {
                                 Source = new MappableFilter("Filter 1 label"),
-                                Type = MappingType.AutoMapped,
-                                CandidateKey = "Filter 1 key",
+                                Type = MappingType.ManualNone,
                                 OptionMappings =
                                 {
                                     {
@@ -1193,68 +1782,65 @@ public abstract class DataSetVersionMappingControllerTests(
                                 }
                             }
                         }
+                    },
+                    Candidates =
+                    {
+                        {
+                            "Filter 1 key",
+                            new FilterMappingCandidate("Filter 1")
+                            {
+                                Options =
+                                {
+                                    {
+                                        "Target filter 1 option 1 key",
+                                        new MappableFilterOption("Filter 1 option 1 label")
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             };
-        
+
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
                 context.DataSetVersionMappings.Add(mappings);
             });
-        
+
             var client = BuildApp().CreateClient();
-        
+
             List<FilterOptionMappingUpdateRequest> updates =
             [
-                // This mapping exists.
+                // This candidate exists, but the filter that owns "Filter 1 option 1 key" has not itself
+                // been mapped, so it cannot supply any valid candidate filter options.
                 new()
                 {
                     FilterKey = "Filter 1 key",
                     SourceKey = "Filter 1 option 1 key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "target-filter-option-1-key"
-                },
-                // This mapping does not exist.
-                new()
-                {
-                    FilterKey = "Filter 1 key",
-                    SourceKey = "Filter 1 option 3 key",
-                    Type = MappingType.ManualMapped,
-                    CandidateKey = "target-filter-option-1-key"
-                },
-                // This mapping does not exist.
-                new()
-                {
-                    FilterKey = "Filter 2 key",
-                    SourceKey = "Filter 2 option 1 key",
-                    Type = MappingType.ManualMapped,
-                    CandidateKey = "target-filter-option-1-key"
+                    CandidateKey = "Target filter 1 option 1 key"
                 }
             ];
-        
+
             var response = await ApplyBatchFilterOptionMappingUpdates(
                 nextDataSetVersionId: nextDataSetVersion.Id,
                 updates: updates,
                 client);
-        
+
             var validationProblem = response.AssertValidationProblem();
-        
-            // The 2 non-existent mappings in the batch update request should have failure messages
-            // indicating that the mappings they were attempting to update do not exist.
-            Assert.Equal(2, validationProblem.Errors.Count);
-        
+
+            // The mappings in the batch update request should have failure messages
+            // indicating that the owning filter has not been mapped.
             validationProblem.AssertHasError(
-                expectedPath: "updates[1].sourceKey",
-                expectedCode: nameof(ValidationMessages.DataSetVersionMappingPathDoesNotExist));
-        
-            validationProblem.AssertHasError(
-                expectedPath: "updates[2].sourceKey",
-                expectedCode: nameof(ValidationMessages.DataSetVersionMappingPathDoesNotExist));
-        
+                expectedPath: "updates[0].filterKey",
+                expectedCode: nameof(ValidationMessages.OwningFilterNotMapped));
+
+            Assert.Single(validationProblem.Errors);
+
             var retrievedMappings = TestApp.GetDbContext<PublicDataDbContext>()
                 .DataSetVersionMappings
                 .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
-        
+
             // Test that the mappings are not updated due to the failures of some of the update requests.
             retrievedMappings.FilterMappingPlan.Mappings.AssertDeepEqualTo(
                 mappings.FilterMappingPlan.Mappings,
@@ -1327,11 +1913,13 @@ public abstract class DataSetVersionMappingControllerTests(
                 client);
 
             var validationProblem = response.AssertValidationProblem();
-            Assert.Single(validationProblem.Errors);
+
             validationProblem.AssertHasError(
                 expectedPath: "updates[0].candidateKey",
                 expectedCode: ValidationMessages.CandidateKeyMustBeSpecifiedWithMappedMappingType.Code,
                 expectedMessage: ValidationMessages.CandidateKeyMustBeSpecifiedWithMappedMappingType.Message);
+
+            Assert.Single(validationProblem.Errors);
         }
 
         [Theory]
@@ -1354,11 +1942,13 @@ public abstract class DataSetVersionMappingControllerTests(
                 client);
 
             var validationProblem = response.AssertValidationProblem();
-            Assert.Single(validationProblem.Errors);
+
             validationProblem.AssertHasError(
                 expectedPath: "updates[0].candidateKey",
                 expectedCode: ValidationMessages.CandidateKeyMustBeEmptyWithNoneMappingType.Code,
                 expectedMessage: ValidationMessages.CandidateKeyMustBeEmptyWithNoneMappingType.Message);
+
+            Assert.Single(validationProblem.Errors);
         }
 
         [Theory]
@@ -1383,13 +1973,14 @@ public abstract class DataSetVersionMappingControllerTests(
                 client);
 
             var validationProblem = response.AssertValidationProblem();
-            Assert.Single(validationProblem.Errors);
+
             validationProblem.AssertHasError(
-                expectedPath: "updates[0].type", 
+                expectedPath: "updates[0].type",
                 expectedCode: ValidationMessages.ManualMappingTypeInvalid.Code,
                 expectedMessage: "Type must be one of the following values: ManualMapped, ManualNone");
-        }
 
+            Assert.Single(validationProblem.Errors);
+        }
 
         private async Task<HttpResponseMessage> ApplyBatchFilterOptionMappingUpdates(
             Guid nextDataSetVersionId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -13,12 +13,12 @@ public static class ValidationMessages
 
     public static readonly LocalizableMessage DataSetVersionMappingSourcePathDoesNotExist = new(
         Code: nameof(DataSetVersionMappingSourcePathDoesNotExist),
-        Message: "The data set mapping does not exist."
+        Message: "The source mapping does not exist."
     );
 
     public static readonly LocalizableMessage DataSetVersionMappingCandidatePathDoesNotExist = new(
         Code: nameof(DataSetVersionMappingCandidatePathDoesNotExist),
-        Message: "The data set candidate does not exist."
+        Message: "The candidate does not exist."
     );
 
     public static readonly LocalizableMessage ManualMappingTypeInvalid = new(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -11,23 +11,33 @@ public static class ValidationMessages
         Message: "The file cannot be deleted as it is linked to an API data set."
     );
 
-    public static readonly LocalizableMessage DataSetVersionMappingPathDoesNotExist = new(
-        Code: nameof(DataSetVersionMappingPathDoesNotExist),
+    public static readonly LocalizableMessage DataSetVersionMappingSourcePathDoesNotExist = new(
+        Code: nameof(DataSetVersionMappingSourcePathDoesNotExist),
         Message: "The data set mapping does not exist."
     );
-    
+
+    public static readonly LocalizableMessage DataSetVersionMappingCandidatePathDoesNotExist = new(
+        Code: nameof(DataSetVersionMappingCandidatePathDoesNotExist),
+        Message: "The data set candidate does not exist."
+    );
+
     public static readonly LocalizableMessage ManualMappingTypeInvalid = new(
         Code: nameof(ManualMappingTypeInvalid),
         Message: $"Type must be one of the following values: {MappingType.ManualMapped}, {MappingType.ManualNone}"
     );
-    
+
     public static readonly LocalizableMessage CandidateKeyMustBeSpecifiedWithMappedMappingType = new(
         Code: nameof(CandidateKeyMustBeSpecifiedWithMappedMappingType),
         Message: $"Value must be specified if type is {nameof(MappingType.ManualMapped)}"
     );
-    
+
     public static readonly LocalizableMessage CandidateKeyMustBeEmptyWithNoneMappingType = new(
         Code: nameof(CandidateKeyMustBeEmptyWithNoneMappingType),
         Message: $"Value must be empty if type is {nameof(MappingType.ManualNone)}"
+    );
+    
+    public static readonly LocalizableMessage OwningFilterNotMapped = new(
+        Code: nameof(OwningFilterNotMapped),
+        Message: "The filter that owns this filter option has not been mapped."
     );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/JsonDtos.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/JsonDtos.cs
@@ -11,4 +11,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
 /// modelBuilder.Entity&lt;JsonFragment&gt;().HasNoKey().ToView(null);
 /// </code>
 /// </summary>
-public record JsonFragment(string? JsonString);
+public record JsonFragment(string? JsonValue);
+
+/// <summary>
+/// Used as a DTO by <see cref="PostgreSqlRepository" /> to extract boolean results from JSONB queries.
+/// In order to use this in a DbContext, to must be registered as a DTO by adding the following configuration to
+/// the OnModelBuilding() method of the DbContext:
+/// <code>
+/// modelBuilder.Entity&lt;JsonBool&gt;().HasNoKey().ToView(null);
+/// </code>
+/// </summary>
+public record JsonBool(bool BoolValue);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IPostgreSqlRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IPostgreSqlRepository.cs
@@ -11,6 +11,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 public interface IPostgreSqlRepository
 {
     /// <summary>
+    /// Determines if a given key exists within the JSON at the specified JSONB path.
+    /// If the JSONB path does not exist, this method will return false.
+    /// </summary>
+    Task<bool> KeyExistsAtJsonbPath<TDbContext, TRowId>(
+        TDbContext context,
+        JsonbPathRequest<TRowId> request,
+        string keyValue,
+        CancellationToken cancellationToken = default)
+        where TDbContext : DbContext;
+
+    /// <summary>
     /// Retrieve a JSON fragment from a JSONB column in a particular table and row,
     /// given a JSON path to the fragment.
     /// </summary>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/PostgreSqlRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/PostgreSqlRepository.cs
@@ -14,6 +14,38 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services;
 
 public class PostgreSqlRepository : IPostgreSqlRepository
 {
+#pragma warning disable EF1002
+    public async Task<bool> KeyExistsAtJsonbPath<TDbContext, TRowId>(TDbContext context,
+        JsonbPathRequest<TRowId> request,
+        string keyValue,
+        CancellationToken cancellationToken = default)
+        where TDbContext : DbContext
+    {
+        var jsonPathParam = new NpgsqlParameter("jsonPath", request.PathSegments);
+        var keyValueParam = new NpgsqlParameter("keyValue", keyValue);
+        var rowIdParam = new NpgsqlParameter("rowId", request.RowId);
+
+        // We use the COALESCE function below to ensure that we're testing the existence of
+        // the given key against a non-null JSON fragment. Without this, an exception is thrown
+        // whereas we are wanting to return false. 
+        var response = await context
+            .Set<JsonBool>()
+            .FromSqlRaw(
+                sql: $"""
+                      SELECT COALESCE("{request.JsonbColumnName}" #> @jsonPath, '[]'::jsonb)
+                      ? @keyValue "{nameof(JsonBool.BoolValue)}"
+                      FROM "{request.TableName}"
+                      WHERE "{request.IdColumnName}" = @rowId
+                      """,
+                parameters: [jsonPathParam, keyValueParam, rowIdParam])
+            .SingleOrDefaultAsync(cancellationToken);
+
+        return response?.BoolValue is not null
+               && JsonSerializer.Deserialize<bool>(response.BoolValue);
+    }
+#pragma warning restore EF1002
+
+#pragma warning disable EF1002
     public async Task<TResponse?> GetJsonbFromPath<TDbContext, TRowId, TResponse>(
         TDbContext context,
         JsonbPathRequest<TRowId> request,
@@ -28,16 +60,18 @@ public class PostgreSqlRepository : IPostgreSqlRepository
             .Set<JsonFragment>()
             .FromSqlRaw(
                 sql: $"""
-                    SELECT "{request.JsonbColumnName}"#>@jsonPath "{nameof(JsonFragment.JsonString)}" FROM "{request.TableName}"
-                    WHERE "{request.IdColumnName}" = @rowId
-                    """,
+                      SELECT "{request.JsonbColumnName}" #> @jsonPath "{nameof(JsonFragment.JsonValue)}"
+                      FROM "{request.TableName}"
+                      WHERE "{request.IdColumnName}" = @rowId
+                      """,
                 parameters: [jsonPathParam, rowIdParam])
             .SingleOrDefaultAsync(cancellationToken);
 
-        return response?.JsonString is not null
-            ? JsonSerializer.Deserialize<TResponse>(response.JsonString)
+        return response?.JsonValue is not null
+            ? JsonSerializer.Deserialize<TResponse>(response.JsonValue)
             : null;
     }
+#pragma warning restore EF1002
 
 #pragma warning disable EF1002
     public async Task<TValue?> SetJsonbAtPath<TDbContext, TValue, TRowId>(
@@ -70,7 +104,6 @@ public class PostgreSqlRepository : IPostgreSqlRepository
 
         return value;
     }
-
 #pragma warning restore EF1002
 
     public async Task<Either<TFailure, TValue?>> UpdateJsonbAtPath<TDbContext, TValue, TRowId, TFailure>(
@@ -88,6 +121,10 @@ public class PostgreSqlRepository : IPostgreSqlRepository
 
         return await updateValueFn
             .Invoke(json)
-            .OnSuccessDo(updateResult => SetJsonbAtPath(context, request, updateResult, cancellationToken));
+            .OnSuccessDo(updateResult => SetJsonbAtPath(
+                context: context,
+                request: request,
+                value: updateResult,
+                cancellationToken: cancellationToken));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Database/PublicDataDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Database/PublicDataDbContext.cs
@@ -31,8 +31,10 @@ public class PublicDataDbContext : DbContext
 
         modelBuilder.HasSequence<int>(FilterOptionMetaLinkSequence);
 
-        // This JsonFragment is a DTO for extracting JSON fragments from JSONB columns and not an entity.
+        // These Json classes are DTOs for extracting JSON fragments / query results  from JSONB columns.
+        // They are mapped here to inform EF that they are not entities.
         modelBuilder.Entity<JsonFragment>().HasNoKey().ToView(null);
+        modelBuilder.Entity<JsonBool>().HasNoKey().ToView(null);
     }
 
     [SuppressMessage("Security", "EF1002:Risk of vulnerability to SQL injection.")]
@@ -69,4 +71,6 @@ public class PublicDataDbContext : DbContext
     public DbSet<ChangeSetTimePeriods> ChangeSetTimePeriods { get; init; } = null!;
     
     public DbSet<JsonFragment> JsonFragments { get; init; } = null!;
+    
+    public DbSet<JsonBool> JsonBool { get; init; } = null!;
 }


### PR DESCRIPTION
This PR:
- adds in validation for the selected candidate keys for update requests, for both Locations and Filter Options.

## Location candidate validation

This validation is pretty simple.  We only need to take the "Level" supplied in the update request, and see if there is a candidate Location within that same Level with the given CandidateKey.

## Filter option validation

This validation is a little more involved.  In order to validate, we:

1. Take the "FilterKey" from the update request, which identifies the owning filter of the filter option being updated.
2. Find the filter that that owning filter is mapped to.
3. If the owning filter has not yet been mapped, return an error.
4. If the owning filter has been mapped, look for the candidate filter option underneath the filter that the owning filter has been mapped to.

## New "KeyExistsAtJsonbPath" method

This is an optimised method that in this PR we are using to check for the existence of a key within a given chunk of JSON.