### PR TITLE
EES-5213 change form validation mode and fix publication form issues

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableEmbedForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableEmbedForm.test.tsx
@@ -1,11 +1,6 @@
 import EditableEmbedForm from '@admin/components/editable/EditableEmbedForm';
-import {
-  render as baseRender,
-  RenderResult,
-  screen,
-  waitFor,
-} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import baseRender from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
 import noop from 'lodash/noop';
 import React, { ReactNode } from 'react';
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
@@ -41,10 +36,12 @@ describe('EditableEmbedForm', () => {
   });
 
   test('shows a validation error when no title is set', async () => {
-    render(<EditableEmbedForm onCancel={noop} onSubmit={noop} />);
+    const { user } = render(
+      <EditableEmbedForm onCancel={noop} onSubmit={noop} />,
+    );
 
-    await userEvent.click(screen.getByLabelText('Title'));
-    await userEvent.tab();
+    await user.click(screen.getByLabelText('Title'));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -57,10 +54,12 @@ describe('EditableEmbedForm', () => {
   });
 
   test('shows a validation error when no url is set', async () => {
-    render(<EditableEmbedForm onCancel={noop} onSubmit={noop} />);
+    const { user } = render(
+      <EditableEmbedForm onCancel={noop} onSubmit={noop} />,
+    );
 
-    await userEvent.click(screen.getByLabelText('URL'));
-    await userEvent.tab();
+    await user.click(screen.getByLabelText('URL'));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -73,11 +72,12 @@ describe('EditableEmbedForm', () => {
   });
 
   test('shows a validation error when the url is invalid', async () => {
-    render(<EditableEmbedForm onCancel={noop} onSubmit={noop} />);
+    const { user } = render(
+      <EditableEmbedForm onCancel={noop} onSubmit={noop} />,
+    );
 
-    await userEvent.type(screen.getByLabelText('URL'), 'Not a url');
-    await userEvent.tab();
-
+    await user.type(screen.getByLabelText('URL'), 'Not a url');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => {
       expect(screen.getByText('There is a problem')).toBeInTheDocument();
       expect(
@@ -89,10 +89,12 @@ describe('EditableEmbedForm', () => {
   });
 
   test('shows a validation error when the url is not from an allowed domain', async () => {
-    render(<EditableEmbedForm onCancel={noop} onSubmit={noop} />);
+    const { user } = render(
+      <EditableEmbedForm onCancel={noop} onSubmit={noop} />,
+    );
 
-    await userEvent.type(screen.getByLabelText('URL'), 'http://test.com');
-    await userEvent.tab();
+    await user.type(screen.getByLabelText('URL'), 'http://test.com');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(
@@ -105,14 +107,16 @@ describe('EditableEmbedForm', () => {
 
   test('calls `onSubmit` with the form values when submitted successfully', async () => {
     const handleSubmit = jest.fn();
-    render(<EditableEmbedForm onCancel={noop} onSubmit={handleSubmit} />);
+    const { user } = render(
+      <EditableEmbedForm onCancel={noop} onSubmit={handleSubmit} />,
+    );
 
-    await userEvent.type(screen.getByLabelText('Title'), 'Dashboard title');
-    await userEvent.type(
+    await user.type(screen.getByLabelText('Title'), 'Dashboard title');
+    await user.type(
       screen.getByLabelText('URL'),
       'https://department-for-education.shinyapps.io/test-dashboard',
     );
-    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledWith({
@@ -122,7 +126,7 @@ describe('EditableEmbedForm', () => {
     });
   });
 
-  function render(child: ReactNode): RenderResult {
+  function render(child: ReactNode) {
     return baseRender(
       <TestConfigContextProvider>{child}</TestConfigContextProvider>,
     );

--- a/src/explore-education-statistics-admin/src/pages/legacy-releases/components/__tests__/ReleaseSeriesLegacyLinkForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/legacy-releases/components/__tests__/ReleaseSeriesLegacyLinkForm.test.tsx
@@ -1,19 +1,20 @@
 import ReleaseSeriesLegacyLinkForm from '@admin/pages/legacy-releases/components/ReleaseSeriesLegacyLinkForm';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import noop from 'lodash/noop';
 
 describe('ReleaseSeriesLegacyLinkForm', () => {
   test('shows validation error for empty `description`', async () => {
-    render(<ReleaseSeriesLegacyLinkForm onSubmit={noop} />);
+    const { user } = render(<ReleaseSeriesLegacyLinkForm onSubmit={noop} />);
 
     expect(screen.queryByText('Enter a description')).not.toBeInTheDocument();
 
-    const description = screen.getByLabelText('Description');
-
-    await userEvent.click(description);
-    await userEvent.tab();
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Save legacy release',
+      }),
+    );
 
     await waitFor(() => {
       expect(
@@ -25,12 +26,15 @@ describe('ReleaseSeriesLegacyLinkForm', () => {
   });
 
   test('shows validation error for empty `url`', async () => {
-    render(<ReleaseSeriesLegacyLinkForm onSubmit={noop} />);
+    const { user } = render(<ReleaseSeriesLegacyLinkForm onSubmit={noop} />);
 
     expect(screen.queryByText('Enter a URL')).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByLabelText('URL'));
-    await userEvent.tab();
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Save legacy release',
+      }),
+    );
 
     await waitFor(() => {
       expect(
@@ -42,12 +46,17 @@ describe('ReleaseSeriesLegacyLinkForm', () => {
   });
 
   test('shows validation error for invalid `url`', async () => {
-    render(<ReleaseSeriesLegacyLinkForm onSubmit={noop} />);
+    const { user } = render(<ReleaseSeriesLegacyLinkForm onSubmit={noop} />);
 
     expect(screen.queryByText('Enter a valid URL')).not.toBeInTheDocument();
 
-    await userEvent.type(screen.getByLabelText('URL'), 'not a url');
-    await userEvent.tab();
+    await user.type(screen.getByLabelText('URL'), 'not a url');
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Save legacy release',
+      }),
+    );
 
     await waitFor(() => {
       expect(
@@ -69,9 +78,11 @@ describe('ReleaseSeriesLegacyLinkForm', () => {
     test('cannot submit with only invalid values', async () => {
       const handleSubmit = jest.fn();
 
-      render(<ReleaseSeriesLegacyLinkForm onSubmit={handleSubmit} />);
+      const { user } = render(
+        <ReleaseSeriesLegacyLinkForm onSubmit={handleSubmit} />,
+      );
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', {
           name: 'Save legacy release',
         }),
@@ -85,14 +96,13 @@ describe('ReleaseSeriesLegacyLinkForm', () => {
     test('cannot submit with some invalid values', async () => {
       const handleSubmit = jest.fn();
 
-      render(<ReleaseSeriesLegacyLinkForm onSubmit={handleSubmit} />);
-
-      await userEvent.type(
-        screen.getByLabelText('Description'),
-        'Test description',
+      const { user } = render(
+        <ReleaseSeriesLegacyLinkForm onSubmit={handleSubmit} />,
       );
 
-      await userEvent.click(
+      await user.type(screen.getByLabelText('Description'), 'Test description');
+
+      await user.click(
         screen.getByRole('button', {
           name: 'Save legacy release',
         }),
@@ -106,15 +116,14 @@ describe('ReleaseSeriesLegacyLinkForm', () => {
     test('can submit with valid values', async () => {
       const handleSubmit = jest.fn();
 
-      render(<ReleaseSeriesLegacyLinkForm onSubmit={handleSubmit} />);
-
-      await userEvent.type(
-        screen.getByLabelText('Description'),
-        'Test description',
+      const { user } = render(
+        <ReleaseSeriesLegacyLinkForm onSubmit={handleSubmit} />,
       );
-      await userEvent.type(screen.getByLabelText('URL'), 'http://test.com');
 
-      await userEvent.click(
+      await user.type(screen.getByLabelText('Description'), 'Test description');
+      await user.type(screen.getByLabelText('URL'), 'http://test.com');
+
+      await user.click(
         screen.getByRole('button', {
           name: 'Save legacy release',
         }),
@@ -148,11 +157,13 @@ describe('ReleaseSeriesLegacyLinkForm', () => {
     test('cannot submit with invalid values', async () => {
       const handleSubmit = jest.fn();
 
-      render(<ReleaseSeriesLegacyLinkForm onSubmit={handleSubmit} />);
+      const { user } = render(
+        <ReleaseSeriesLegacyLinkForm onSubmit={handleSubmit} />,
+      );
 
-      await userEvent.clear(screen.getByLabelText('Description'));
+      await user.clear(screen.getByLabelText('Description'));
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', {
           name: 'Save legacy release',
         }),
@@ -166,7 +177,7 @@ describe('ReleaseSeriesLegacyLinkForm', () => {
     test('can submit with valid initial values', async () => {
       const handleSubmit = jest.fn();
 
-      render(
+      const { user } = render(
         <ReleaseSeriesLegacyLinkForm
           initialValues={{
             description: 'Test description',
@@ -176,7 +187,7 @@ describe('ReleaseSeriesLegacyLinkForm', () => {
         />,
       );
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', {
           name: 'Save legacy release',
         }),
@@ -193,7 +204,7 @@ describe('ReleaseSeriesLegacyLinkForm', () => {
     test('can submit with valid values', async () => {
       const handleSubmit = jest.fn();
 
-      render(
+      const { user } = render(
         <ReleaseSeriesLegacyLinkForm
           initialValues={{
             description: 'Test description',
@@ -203,10 +214,10 @@ describe('ReleaseSeriesLegacyLinkForm', () => {
         />,
       );
 
-      await userEvent.type(screen.getByLabelText('Description'), ' 2');
-      await userEvent.type(screen.getByLabelText('URL'), '/updated');
+      await user.type(screen.getByLabelText('Description'), ' 2');
+      await user.type(screen.getByLabelText('URL'), '/updated');
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', {
           name: 'Save legacy release',
         }),

--- a/src/explore-education-statistics-admin/src/pages/methodology/components/__tests__/MethodologySummaryForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/components/__tests__/MethodologySummaryForm.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import noop from 'lodash/noop';
 import MethodologySummaryForm from '@admin/pages/methodology/components/MethodologySummaryForm';
+import render from '@common-test/render';
 
 describe('MethodologySummaryForm', () => {
   test('renders the form with initial values', () => {
@@ -30,7 +30,7 @@ describe('MethodologySummaryForm', () => {
   });
 
   test('shows validation error when select alternative title type and no title given', async () => {
-    render(
+    const { user } = render(
       <MethodologySummaryForm
         id="id"
         initialValues={{
@@ -44,10 +44,11 @@ describe('MethodologySummaryForm', () => {
       />,
     );
 
-    await userEvent.click(screen.getByLabelText('Set an alternative title'));
-    await userEvent.clear(screen.getByLabelText('Enter methodology title'));
-    await userEvent.tab();
-
+    await user.click(screen.getByLabelText('Set an alternative title'));
+    await user.clear(screen.getByLabelText('Enter methodology title'));
+    await user.click(
+      screen.getByRole('button', { name: 'Update methodology' }),
+    );
     await waitFor(() => {
       expect(
         screen.getByText('Enter a methodology title', {
@@ -59,7 +60,7 @@ describe('MethodologySummaryForm', () => {
 
   test('submits successfully with an alternative title', async () => {
     const handleSubmit = jest.fn();
-    render(
+    const { user } = render(
       <MethodologySummaryForm
         id="id"
         initialValues={{
@@ -73,14 +74,14 @@ describe('MethodologySummaryForm', () => {
       />,
     );
 
-    await userEvent.click(screen.getByLabelText('Set an alternative title'));
-    await userEvent.clear(screen.getByLabelText('Enter methodology title'));
-    await userEvent.type(
+    await user.click(screen.getByLabelText('Set an alternative title'));
+    await user.clear(screen.getByLabelText('Enter methodology title'));
+    await user.type(
       screen.getByLabelText('Enter methodology title'),
       'an alternative title',
     );
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Update methodology' }),
     );
 
@@ -91,7 +92,7 @@ describe('MethodologySummaryForm', () => {
 
   test('submits successfully with the publication title', async () => {
     const handleSubmit = jest.fn();
-    render(
+    const { user } = render(
       <MethodologySummaryForm
         id="id"
         initialValues={{
@@ -105,7 +106,7 @@ describe('MethodologySummaryForm', () => {
       />,
     );
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Update methodology' }),
     );
 
@@ -116,7 +117,7 @@ describe('MethodologySummaryForm', () => {
 
   test('submits successfully when change back to publication title from an alternative title', async () => {
     const handleSubmit = jest.fn();
-    render(
+    const { user } = render(
       <MethodologySummaryForm
         id="id"
         initialValues={{
@@ -130,9 +131,9 @@ describe('MethodologySummaryForm', () => {
       />,
     );
 
-    await userEvent.click(screen.getByLabelText('Use publication title'));
+    await user.click(screen.getByLabelText('Use publication title'));
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Update methodology' }),
     );
 

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/__tests__/MethodologyNotesSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/__tests__/MethodologyNotesSection.test.tsx
@@ -4,9 +4,9 @@ import { EditingContextProvider } from '@admin/contexts/EditingContext';
 import _methodologyNoteService, {
   MethodologyNote,
 } from '@admin/services/methodologyNoteService';
-import { render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
+import render from '@common-test/render';
 
 jest.mock('@admin/services/methodologyNoteService');
 const methodologyNoteService = _methodologyNoteService as jest.Mocked<
@@ -151,7 +151,7 @@ describe('MethodologyNotesSection', () => {
 
   describe('adding a note', () => {
     test('shows validation error if no note given and does not submit', async () => {
-      render(
+      const { user } = render(
         <EditingContextProvider editingMode="edit">
           <MethodologyNotesSection
             methodology={testMethodologyContentWithNotes}
@@ -159,7 +159,7 @@ describe('MethodologyNotesSection', () => {
         </EditingContextProvider>,
       );
 
-      await userEvent.click(screen.getByRole('button', { name: 'Add note' }));
+      await user.click(screen.getByRole('button', { name: 'Add note' }));
 
       await waitFor(() => {
         expect(
@@ -167,8 +167,8 @@ describe('MethodologyNotesSection', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.click(screen.getByLabelText('New methodology note'));
-      await userEvent.tab();
+      await user.click(screen.getByLabelText('New methodology note'));
+      await user.click(screen.getByRole('button', { name: 'Save note' }));
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
         expect(
@@ -178,7 +178,7 @@ describe('MethodologyNotesSection', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.click(screen.getByRole('button', { name: 'Save note' }));
+      await user.click(screen.getByRole('button', { name: 'Save note' }));
       expect(methodologyNoteService.create).not.toHaveBeenCalled();
     });
 
@@ -194,7 +194,7 @@ describe('MethodologyNotesSection', () => {
         ...newNote,
         id: 'note-4',
       });
-      render(
+      const { user } = render(
         <EditingContextProvider editingMode="edit">
           <MethodologyNotesSection
             methodology={testMethodologyContentWithNotes}
@@ -202,7 +202,7 @@ describe('MethodologyNotesSection', () => {
         </EditingContextProvider>,
       );
 
-      await userEvent.click(screen.getByRole('button', { name: 'Add note' }));
+      await user.click(screen.getByRole('button', { name: 'Add note' }));
 
       await waitFor(() => {
         expect(
@@ -210,11 +210,11 @@ describe('MethodologyNotesSection', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('New methodology note'),
         'New note',
       );
-      await userEvent.click(screen.getByRole('button', { name: 'Save note' }));
+      await user.click(screen.getByRole('button', { name: 'Save note' }));
 
       await waitFor(() => {
         expect(methodologyNoteService.create).toHaveBeenCalledWith(
@@ -243,7 +243,7 @@ describe('MethodologyNotesSection', () => {
 
   describe('editing a note', () => {
     test('shows validation error if note or date removed and does not submit', async () => {
-      render(
+      const { user } = render(
         <EditingContextProvider editingMode="edit">
           <MethodologyNotesSection
             methodology={testMethodologyContentWithNotes}
@@ -252,7 +252,7 @@ describe('MethodologyNotesSection', () => {
       );
 
       const notes = screen.getAllByRole('listitem');
-      await userEvent.click(
+      await user.click(
         within(notes[0]).getByRole('button', { name: 'Edit note' }),
       );
 
@@ -262,8 +262,8 @@ describe('MethodologyNotesSection', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.clear(screen.getByLabelText('Edit methodology note'));
-      await userEvent.tab();
+      await user.clear(screen.getByLabelText('Edit methodology note'));
+      await user.click(screen.getByRole('button', { name: 'Update note' }));
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
         expect(
@@ -273,11 +273,11 @@ describe('MethodologyNotesSection', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.clear(screen.getByLabelText('Day'));
-      await userEvent.clear(screen.getByLabelText('Month'));
-      await userEvent.clear(screen.getByLabelText('Year'));
+      await user.clear(screen.getByLabelText('Day'));
+      await user.clear(screen.getByLabelText('Month'));
+      await user.clear(screen.getByLabelText('Year'));
 
-      await userEvent.tab();
+      await user.click(screen.getByRole('button', { name: 'Update note' }));
       await waitFor(() => {
         expect(
           screen.getByRole('link', {
@@ -286,9 +286,7 @@ describe('MethodologyNotesSection', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update note' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update note' }));
 
       expect(methodologyNoteService.edit).not.toHaveBeenCalled();
     });
@@ -302,7 +300,7 @@ describe('MethodologyNotesSection', () => {
         ...updatedNote,
         id: 'note-1',
       });
-      render(
+      const { user } = render(
         <EditingContextProvider editingMode="edit">
           <MethodologyNotesSection
             methodology={testMethodologyContentWithNotes}
@@ -311,7 +309,7 @@ describe('MethodologyNotesSection', () => {
       );
 
       const notes = screen.getAllByRole('listitem');
-      await userEvent.click(
+      await user.click(
         within(notes[0]).getByRole('button', { name: 'Edit note' }),
       );
 
@@ -321,20 +319,18 @@ describe('MethodologyNotesSection', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('Edit methodology note'),
         ' edited',
       );
-      await userEvent.clear(screen.getByLabelText('Day'));
-      await userEvent.type(screen.getByLabelText('Day'), '31');
-      await userEvent.clear(screen.getByLabelText('Month'));
-      await userEvent.type(screen.getByLabelText('Month'), '12');
-      await userEvent.clear(screen.getByLabelText('Year'));
-      await userEvent.type(screen.getByLabelText('Year'), '2022');
+      await user.clear(screen.getByLabelText('Day'));
+      await user.type(screen.getByLabelText('Day'), '31');
+      await user.clear(screen.getByLabelText('Month'));
+      await user.type(screen.getByLabelText('Month'), '12');
+      await user.clear(screen.getByLabelText('Year'));
+      await user.type(screen.getByLabelText('Year'), '2022');
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Update note' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Update note' }));
       await waitFor(() => {
         expect(methodologyNoteService.edit).toHaveBeenCalledWith(
           'note-1',
@@ -352,7 +348,7 @@ describe('MethodologyNotesSection', () => {
 
   describe('removing notes', () => {
     test('shows the confirm modal when clicking the Remove button', async () => {
-      render(
+      const { user } = render(
         <EditingContextProvider editingMode="edit">
           <MethodologyNotesSection
             methodology={testMethodologyContentWithNotes}
@@ -361,7 +357,7 @@ describe('MethodologyNotesSection', () => {
       );
 
       const notes = screen.getAllByRole('listitem');
-      await userEvent.click(
+      await user.click(
         within(notes[0]).getByRole('button', { name: 'Remove note' }),
       );
 
@@ -382,7 +378,7 @@ describe('MethodologyNotesSection', () => {
     });
 
     test('successfully removes a note', async () => {
-      render(
+      const { user } = render(
         <EditingContextProvider editingMode="edit">
           <MethodologyNotesSection
             methodology={testMethodologyContentWithNotes}
@@ -391,11 +387,11 @@ describe('MethodologyNotesSection', () => {
       );
 
       const notes = screen.getAllByRole('listitem');
-      await userEvent.click(
+      await user.click(
         within(notes[0]).getByRole('button', { name: 'Remove note' }),
       );
 
-      await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
       await waitFor(() => {
         expect(methodologyNoteService.delete).toHaveBeenCalledWith(
           'note-1',

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
@@ -2,12 +2,12 @@ import MethodologyStatusForm, {
   MethodologyStatusFormValues,
 } from '@admin/pages/methodology/edit-methodology/status/components/MethodologyStatusForm';
 import { IdTitlePair } from '@admin/services/types/common';
-import { render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import noop from 'lodash/noop';
 import { MethodologyVersion } from '@admin/services/methodologyService';
 import { MethodologyStatusPermissions } from '@admin/services/permissionService';
+import render from '@common-test/render';
 
 describe('MethodologyStatusForm', () => {
   const testUnpublishedReleases: IdTitlePair[] = [
@@ -189,7 +189,7 @@ describe('MethodologyStatusForm', () => {
   });
 
   test('shows validation error if internal note is empty and status is approved', async () => {
-    render(
+    const { user } = render(
       <MethodologyStatusForm
         methodology={
           {
@@ -203,9 +203,9 @@ describe('MethodologyStatusForm', () => {
       />,
     );
 
-    await userEvent.click(screen.getByLabelText('Approved for publication'));
-    await userEvent.click(screen.getByLabelText('Internal note'));
-    await userEvent.tab();
+    await user.click(screen.getByLabelText('Approved for publication'));
+
+    await user.click(screen.getByRole('button', { name: 'Update status' }));
 
     await waitFor(() => {
       expect(
@@ -218,7 +218,7 @@ describe('MethodologyStatusForm', () => {
   });
 
   test('shows validation error if a release is not selected when publish strategy is with release', async () => {
-    render(
+    const { user } = render(
       <MethodologyStatusForm
         methodology={
           {
@@ -232,9 +232,9 @@ describe('MethodologyStatusForm', () => {
       />,
     );
 
-    await userEvent.click(screen.getByLabelText('With a specific release'));
-    await userEvent.click(screen.getByLabelText('Select release'));
-    await userEvent.tab();
+    await user.click(screen.getByLabelText('With a specific release'));
+
+    await user.click(screen.getByRole('button', { name: 'Update status' }));
 
     await waitFor(() => {
       expect(
@@ -246,7 +246,7 @@ describe('MethodologyStatusForm', () => {
   test('fails to submit with invalid values', async () => {
     const handleSubmit = jest.fn();
 
-    render(
+    const { user } = render(
       <MethodologyStatusForm
         methodology={
           {
@@ -261,9 +261,7 @@ describe('MethodologyStatusForm', () => {
       />,
     );
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Update status' }),
-    );
+    await user.click(screen.getByRole('button', { name: 'Update status' }));
 
     await waitFor(() => {
       expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -281,7 +279,7 @@ describe('MethodologyStatusForm', () => {
   test('successfully submits with valid values', async () => {
     const handleSubmit = jest.fn();
 
-    render(
+    const { user } = render(
       <MethodologyStatusForm
         methodology={
           {
@@ -296,18 +294,16 @@ describe('MethodologyStatusForm', () => {
       />,
     );
 
-    await userEvent.type(
+    await user.type(
       screen.getByLabelText('Internal note'),
       'Test release note',
     );
 
-    await userEvent.selectOptions(screen.getByLabelText('Select release'), [
+    await user.selectOptions(screen.getByLabelText('Select release'), [
       'test-release-1',
     ]);
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Update status' }),
-    );
+    await user.click(screen.getByRole('button', { name: 'Update status' }));
 
     const expectedValues: MethodologyStatusFormValues = {
       latestInternalReleaseNote: 'Test release note',

--- a/src/explore-education-statistics-admin/src/pages/methodology/external-methodology/components/__tests__/ExternalMethodologyForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/external-methodology/components/__tests__/ExternalMethodologyForm.test.tsx
@@ -1,22 +1,24 @@
 import ExternalMethodologyForm from '@admin/pages/methodology/external-methodology/components/ExternalMethodologyForm';
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import noop from 'lodash/noop';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
 
 describe('ExternalMethodologyForm', () => {
   test('can submit with valid values', async () => {
     const handleSubmit = jest.fn();
 
-    render(<ExternalMethodologyForm onSubmit={handleSubmit} onCancel={noop} />);
+    const { user } = render(
+      <ExternalMethodologyForm onSubmit={handleSubmit} onCancel={noop} />,
+    );
 
-    await userEvent.type(screen.getByLabelText('Link title'), 'Test title');
+    await user.type(screen.getByLabelText('Link title'), 'Test title');
 
-    await userEvent.type(screen.getByLabelText('URL'), 'hive.co.uk');
+    await user.type(screen.getByLabelText('URL'), 'hive.co.uk');
 
     expect(handleSubmit).not.toHaveBeenCalled();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledWith({
@@ -27,10 +29,11 @@ describe('ExternalMethodologyForm', () => {
   });
 
   test('show validation errors when no external methodology link title', async () => {
-    render(<ExternalMethodologyForm onSubmit={noop} onCancel={noop} />);
+    const { user } = render(
+      <ExternalMethodologyForm onSubmit={noop} onCancel={noop} />,
+    );
 
-    await userEvent.click(screen.getByLabelText('Link title'));
-    await userEvent.tab();
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(
@@ -42,10 +45,12 @@ describe('ExternalMethodologyForm', () => {
   });
 
   test('show validation error when no external methodology URL', async () => {
-    render(<ExternalMethodologyForm onSubmit={noop} onCancel={noop} />);
+    const { user } = render(
+      <ExternalMethodologyForm onSubmit={noop} onCancel={noop} />,
+    );
 
-    await userEvent.clear(screen.getByLabelText('URL'));
-    await userEvent.tab();
+    await user.clear(screen.getByLabelText('URL'));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(
@@ -57,10 +62,12 @@ describe('ExternalMethodologyForm', () => {
   });
 
   test('show validation error when invalid external methodology URL', async () => {
-    render(<ExternalMethodologyForm onSubmit={noop} onCancel={noop} />);
+    const { user } = render(
+      <ExternalMethodologyForm onSubmit={noop} onCancel={noop} />,
+    );
 
-    await userEvent.type(screen.getByLabelText('URL'), 'not a valid url');
-    await userEvent.tab();
+    await user.type(screen.getByLabelText('URL'), 'not a valid url');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationContactPage.test.tsx
@@ -7,17 +7,11 @@ import {
 import _publicationService, {
   PublicationWithPermissions,
 } from '@admin/services/publicationService';
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import noop from 'lodash/noop';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
+import render from '@common-test/render';
 
 jest.mock('@admin/services/publicationService');
 const publicationService = _publicationService as jest.Mocked<
@@ -71,7 +65,7 @@ describe('PublicationContactPage', () => {
   test('clicking the edit button shows the edit form', async () => {
     publicationService.getContact.mockResolvedValue(testContact);
 
-    renderPage(testPublication);
+    const { user } = renderPage(testPublication);
 
     await waitFor(() => {
       expect(
@@ -79,7 +73,7 @@ describe('PublicationContactPage', () => {
       ).toBeInTheDocument();
     });
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
     );
 
@@ -100,7 +94,7 @@ describe('PublicationContactPage', () => {
   test('clicking the cancel button switches back to readOnly view', async () => {
     publicationService.getContact.mockResolvedValue(testContact);
 
-    renderPage(testPublication);
+    const { user } = renderPage(testPublication);
 
     await waitFor(() => {
       expect(
@@ -108,13 +102,13 @@ describe('PublicationContactPage', () => {
       ).toBeInTheDocument();
     });
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
     );
 
     expect(screen.getByLabelText('Team name')).toHaveValue('Team Smith');
 
-    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(screen.getByTestId('Team name')).toHaveTextContent('Team Smith');
 
@@ -135,7 +129,7 @@ describe('PublicationContactPage', () => {
   test('shows validation errors when there are no contact details', async () => {
     publicationService.getContact.mockResolvedValue(testContact);
 
-    renderPage(testPublication);
+    const { user } = renderPage(testPublication);
 
     await waitFor(() => {
       expect(
@@ -143,18 +137,18 @@ describe('PublicationContactPage', () => {
       ).toBeInTheDocument();
     });
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
     );
 
-    await userEvent.clear(screen.getByLabelText('Team name'));
-    await userEvent.clear(screen.getByLabelText('Team email'));
-    await userEvent.clear(screen.getByLabelText('Contact name'));
-    await userEvent.clear(
-      screen.getByLabelText('Contact telephone (optional)'),
-    );
+    await user.clear(screen.getByLabelText('Team name'));
+    await user.clear(screen.getByLabelText('Team email'));
+    await user.clear(screen.getByLabelText('Contact name'));
+    await user.clear(screen.getByLabelText('Contact telephone (optional)'));
 
-    await userEvent.tab();
+    await user.click(
+      screen.getByRole('button', { name: 'Update contact details' }),
+    );
 
     await waitFor(() => {
       expect(
@@ -184,7 +178,7 @@ describe('PublicationContactPage', () => {
     async telNo => {
       publicationService.getContact.mockResolvedValue(testContact);
 
-      renderPage(testPublication);
+      const { user } = renderPage(testPublication);
 
       await waitFor(() => {
         expect(
@@ -192,20 +186,20 @@ describe('PublicationContactPage', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit contact details' }),
       );
 
-      await userEvent.clear(
-        screen.getByLabelText('Contact telephone (optional)'),
-      );
+      await user.clear(screen.getByLabelText('Contact telephone (optional)'));
 
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('Contact telephone (optional)'),
         telNo,
       );
 
-      await userEvent.tab();
+      await user.click(
+        screen.getByRole('button', { name: 'Update contact details' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -230,7 +224,7 @@ describe('PublicationContactPage', () => {
     async telNo => {
       publicationService.getContact.mockResolvedValue(testContact);
 
-      renderPage(testPublication);
+      const { user } = renderPage(testPublication);
 
       await waitFor(() => {
         expect(
@@ -238,20 +232,20 @@ describe('PublicationContactPage', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit contact details' }),
       );
 
-      await userEvent.clear(
-        screen.getByLabelText('Contact telephone (optional)'),
-      );
+      await user.clear(screen.getByLabelText('Contact telephone (optional)'));
 
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('Contact telephone (optional)'),
         telNo,
       );
 
-      await userEvent.tab();
+      await user.click(
+        screen.getByRole('button', { name: 'Update contact details' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -271,7 +265,7 @@ describe('PublicationContactPage', () => {
     async telNo => {
       publicationService.getContact.mockResolvedValue(testContact);
 
-      renderPage(testPublication);
+      const { user } = renderPage(testPublication);
 
       await waitFor(() => {
         expect(
@@ -279,20 +273,20 @@ describe('PublicationContactPage', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit contact details' }),
       );
 
-      await userEvent.clear(
-        screen.getByLabelText('Contact telephone (optional)'),
-      );
+      await user.clear(screen.getByLabelText('Contact telephone (optional)'));
 
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('Contact telephone (optional)'),
         telNo,
       );
 
-      await userEvent.tab();
+      await user.click(
+        screen.getByRole('button', { name: 'Update contact details' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -307,7 +301,7 @@ describe('PublicationContactPage', () => {
   test('show validation error when contact email is not valid', async () => {
     publicationService.getContact.mockResolvedValue(testContact);
 
-    renderPage(testPublication);
+    const { user } = renderPage(testPublication);
 
     await waitFor(() => {
       expect(
@@ -315,18 +309,17 @@ describe('PublicationContactPage', () => {
       ).toBeInTheDocument();
     });
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
     );
 
-    await userEvent.clear(screen.getByLabelText('Team email'));
+    await user.clear(screen.getByLabelText('Team email'));
 
-    await userEvent.type(
-      screen.getByLabelText('Team email'),
-      'not a valid email',
+    await user.type(screen.getByLabelText('Team email'), 'not a valid email');
+
+    await user.click(
+      screen.getByRole('button', { name: 'Update contact details' }),
     );
-
-    await userEvent.tab();
 
     await waitFor(() => {
       expect(
@@ -340,7 +333,7 @@ describe('PublicationContactPage', () => {
   test('shows a confirmation modal on submit', async () => {
     publicationService.getContact.mockResolvedValue(testContact);
 
-    renderPage(testPublication);
+    const { user } = renderPage(testPublication);
 
     await waitFor(() => {
       expect(
@@ -348,13 +341,13 @@ describe('PublicationContactPage', () => {
       ).toBeInTheDocument();
     });
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
     );
 
     expect(publicationService.updatePublication).not.toHaveBeenCalled();
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Update contact details' }),
     );
 
@@ -366,12 +359,12 @@ describe('PublicationContactPage', () => {
     expect(modal.getByRole('heading')).toHaveTextContent(
       'Confirm contact changes',
     );
-    await userEvent.click(modal.getByRole('button', { name: 'Confirm' }));
+    await user.click(modal.getByRole('button', { name: 'Confirm' }));
   });
 
   test('clicking confirm calls the publication service', async () => {
     publicationService.getContact.mockResolvedValue(testContact);
-    renderPage(testPublication);
+    const { user } = renderPage(testPublication);
 
     await waitFor(() => {
       expect(
@@ -379,7 +372,7 @@ describe('PublicationContactPage', () => {
       ).toBeInTheDocument();
     });
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
     );
 
@@ -387,7 +380,7 @@ describe('PublicationContactPage', () => {
       target: { value: 'new team name' },
     });
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Update contact details' }),
     );
 
@@ -395,7 +388,7 @@ describe('PublicationContactPage', () => {
       expect(screen.getByText('Confirm contact changes')).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
     await waitFor(() => {
       expect(publicationService.updateContact).toHaveBeenCalledWith(
@@ -415,7 +408,7 @@ describe('PublicationContactPage', () => {
       teamEmail: testContact.teamEmail,
       teamName: testContact.teamName,
     });
-    renderPage(testPublication);
+    const { user } = renderPage(testPublication);
 
     await waitFor(() => {
       expect(
@@ -423,11 +416,11 @@ describe('PublicationContactPage', () => {
       ).toBeInTheDocument();
     });
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
     );
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Update contact details' }),
     );
 
@@ -435,7 +428,7 @@ describe('PublicationContactPage', () => {
       expect(screen.getByText('Confirm contact changes')).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
     await waitFor(() => {
       expect(publicationService.updateContact).toHaveBeenCalledWith(
@@ -457,7 +450,7 @@ describe('PublicationContactPage', () => {
       teamName: 'updated team name',
     });
 
-    renderPage(testPublication);
+    const { user } = renderPage(testPublication);
 
     await waitFor(() => {
       expect(
@@ -465,11 +458,11 @@ describe('PublicationContactPage', () => {
       ).toBeInTheDocument();
     });
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Edit contact details' }),
     );
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Update contact details' }),
     );
 
@@ -477,7 +470,7 @@ describe('PublicationContactPage', () => {
       expect(screen.getByText('Confirm contact changes')).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
     await waitFor(() => {
       expect(
@@ -501,7 +494,7 @@ describe('PublicationContactPage', () => {
 });
 
 function renderPage(publication: PublicationWithPermissions) {
-  render(
+  return render(
     <MemoryRouter>
       <PublicationContextProvider
         publication={publication}

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationDetailsPage.test.tsx
@@ -7,12 +7,12 @@ import _publicationService, {
 } from '@admin/services/publicationService';
 import _themeService, { Theme } from '@admin/services/themeService';
 import { PublicationSummary } from '@common/services/publicationService';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import noop from 'lodash/noop';
-import userEvent from '@testing-library/user-event';
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
+import render from '@common-test/render';
 
 jest.mock('@admin/services/themeService');
 const themeService = _themeService as jest.Mocked<typeof _themeService>;
@@ -147,7 +147,10 @@ describe('PublicationDetailsPage', () => {
   });
 
   test('shows the superseding publication if the publication is archived', async () => {
-    renderPage({ ...testPublication, supersededById: 'publication-2' });
+    renderPage({
+      ...testPublication,
+      supersededById: 'publication-2',
+    });
 
     await waitFor(() => {
       expect(screen.getByText('Publication details')).toBeInTheDocument();
@@ -160,13 +163,13 @@ describe('PublicationDetailsPage', () => {
 
   describe('details form', () => {
     test('shows the form when the edit button is clicked', async () => {
-      renderPage(testPublication);
+      const { user } = renderPage(testPublication);
 
       await waitFor(() => {
         expect(screen.getByText('Publication details')).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit publication details' }),
       );
 
@@ -225,13 +228,13 @@ describe('PublicationDetailsPage', () => {
     });
 
     test('updates the topics dropdown when change the theme', async () => {
-      renderPage(testPublication);
+      const { user } = renderPage(testPublication);
 
       await waitFor(() => {
         expect(screen.getByText('Publication details')).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit publication details' }),
       );
 
@@ -249,7 +252,7 @@ describe('PublicationDetailsPage', () => {
       expect(topics[1]).toHaveTextContent('Theme 1 Topic 2');
       expect(topics[1]).toHaveValue('theme-1-topic-2');
 
-      await userEvent.selectOptions(screen.getByLabelText('Select theme'), [
+      await user.selectOptions(screen.getByLabelText('Select theme'), [
         'theme-2',
       ]);
 
@@ -265,13 +268,13 @@ describe('PublicationDetailsPage', () => {
     });
 
     test('clicking the cancel button switches back to readOnly view', async () => {
-      renderPage(testPublication);
+      const { user } = renderPage(testPublication);
 
       await waitFor(() => {
         expect(screen.getByText('Publication details')).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit publication details' }),
       );
 
@@ -283,7 +286,7 @@ describe('PublicationDetailsPage', () => {
         'Publication 1',
       );
 
-      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
       expect(screen.getByTestId('Publication title')).toHaveTextContent(
         'Publication 1',
@@ -306,13 +309,13 @@ describe('PublicationDetailsPage', () => {
     });
 
     test('shows validation errors when there is no title', async () => {
-      renderPage(testPublication);
+      const { user } = renderPage(testPublication);
 
       await waitFor(() => {
         expect(screen.getByText('Publication details')).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit publication details' }),
       );
 
@@ -320,8 +323,10 @@ describe('PublicationDetailsPage', () => {
         expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
       });
 
-      await userEvent.clear(screen.getByLabelText('Publication title'));
-      await userEvent.tab();
+      await user.clear(screen.getByLabelText('Publication title'));
+      await user.click(
+        screen.getByRole('button', { name: 'Update publication details' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -333,13 +338,13 @@ describe('PublicationDetailsPage', () => {
     });
 
     test('shows validation errors when there is no summary', async () => {
-      renderPage(testPublication);
+      const { user } = renderPage(testPublication);
 
       await waitFor(() => {
         expect(screen.getByText('Publication details')).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit publication details' }),
       );
 
@@ -349,8 +354,10 @@ describe('PublicationDetailsPage', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.clear(screen.getByLabelText('Publication summary'));
-      await userEvent.tab();
+      await user.clear(screen.getByLabelText('Publication summary'));
+      await user.click(
+        screen.getByRole('button', { name: 'Update publication details' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -362,13 +369,13 @@ describe('PublicationDetailsPage', () => {
     });
 
     test('shows a confirmation modal on submit', async () => {
-      renderPage(testPublication);
+      const { user } = renderPage(testPublication);
 
       await waitFor(() => {
         expect(screen.getByText('Publication details')).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit publication details' }),
       );
 
@@ -378,7 +385,7 @@ describe('PublicationDetailsPage', () => {
 
       expect(publicationService.updatePublication).not.toHaveBeenCalled();
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Update publication details' }),
       );
 
@@ -388,7 +395,7 @@ describe('PublicationDetailsPage', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         within(screen.getByRole('dialog')).getByRole('button', {
           name: 'Confirm',
         }),
@@ -396,7 +403,7 @@ describe('PublicationDetailsPage', () => {
     });
 
     test('confirmation modal renders correctly when title is changed to match the slug', async () => {
-      renderPage({
+      const { user } = renderPage({
         ...testPublication,
         title: 'Publication 1',
         slug: 'publication-1-updated', // to prevent URL change text in modal from displaying
@@ -406,7 +413,7 @@ describe('PublicationDetailsPage', () => {
         expect(screen.getByText('Publication details')).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit publication details' }),
       );
 
@@ -414,15 +421,15 @@ describe('PublicationDetailsPage', () => {
         expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
       });
 
-      await userEvent.clear(screen.getByLabelText('Publication title'));
-      await userEvent.type(
+      await user.clear(screen.getByLabelText('Publication title'));
+      await user.type(
         screen.getByLabelText('Publication title'),
         'Publication 1 updated',
       );
 
       expect(publicationService.updatePublication).not.toHaveBeenCalled();
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Update publication details' }),
       );
 
@@ -442,7 +449,7 @@ describe('PublicationDetailsPage', () => {
     });
 
     test('confirmation modal renders correctly when a publication title remains the same, but the slug is changed to match the title', async () => {
-      renderPage({
+      const { user } = renderPage({
         ...testPublication,
         title: 'Publication 1 updated',
         slug: 'publication-1', // even with no changes by the user, slug will be changed to match title
@@ -452,7 +459,7 @@ describe('PublicationDetailsPage', () => {
         expect(screen.getByText('Publication details')).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit publication details' }),
       );
 
@@ -462,7 +469,7 @@ describe('PublicationDetailsPage', () => {
 
       expect(publicationService.updatePublication).not.toHaveBeenCalled();
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Update publication details' }),
       );
 
@@ -489,7 +496,7 @@ describe('PublicationDetailsPage', () => {
     });
 
     test('confirmation modal renders correctly when title and slug are changed', async () => {
-      renderPage({
+      const { user } = renderPage({
         ...testPublication,
         title: 'Publication 1',
         slug: 'publication-1',
@@ -499,7 +506,7 @@ describe('PublicationDetailsPage', () => {
         expect(screen.getByText('Publication details')).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit publication details' }),
       );
 
@@ -507,15 +514,15 @@ describe('PublicationDetailsPage', () => {
         expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
       });
 
-      await userEvent.clear(screen.getByLabelText('Publication title'));
-      await userEvent.type(
+      await user.clear(screen.getByLabelText('Publication title'));
+      await user.type(
         screen.getByLabelText('Publication title'),
         'Publication 1 updated',
       );
 
       expect(publicationService.updatePublication).not.toHaveBeenCalled();
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Update publication details' }),
       );
 
@@ -542,13 +549,13 @@ describe('PublicationDetailsPage', () => {
     });
 
     test('successfully submits with updated values', async () => {
-      renderPage(testPublication);
+      const { user } = renderPage(testPublication);
 
       await waitFor(() => {
         expect(screen.getByText('Publication details')).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Edit publication details' }),
       );
 
@@ -556,25 +563,22 @@ describe('PublicationDetailsPage', () => {
         expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
       });
 
-      await userEvent.type(
-        screen.getByLabelText('Publication title'),
-        ' updated',
-      );
+      await user.type(screen.getByLabelText('Publication title'), ' updated');
 
-      await userEvent.selectOptions(screen.getByLabelText('Select theme'), [
+      await user.selectOptions(screen.getByLabelText('Select theme'), [
         'theme-2',
       ]);
 
-      await userEvent.selectOptions(screen.getByLabelText('Select topic'), [
+      await user.selectOptions(screen.getByLabelText('Select topic'), [
         'theme-2-topic-2',
       ]);
 
-      await userEvent.selectOptions(
+      await user.selectOptions(
         screen.getByLabelText('Superseding publication'),
         ['publication-2'],
       );
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Update publication details' }),
       );
 
@@ -584,7 +588,7 @@ describe('PublicationDetailsPage', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+      await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
       await waitFor(() => {
         expect(publicationService.updatePublication).toHaveBeenCalledWith<
@@ -601,7 +605,7 @@ describe('PublicationDetailsPage', () => {
 });
 
 function renderPage(publication: PublicationWithPermissions) {
-  render(
+  return render(
     <MemoryRouter>
       <TestConfigContextProvider>
         <PublicationContextProvider

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
@@ -1,7 +1,7 @@
 import PublicationForm from '@admin/pages/publication/components/PublicationForm';
 import _publicationService from '@admin/services/publicationService';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
 import noop from 'lodash/noop';
 import React from 'react';
 
@@ -12,14 +12,15 @@ const publicationService = _publicationService as jest.Mocked<
 
 describe('PublicationForm', () => {
   test('shows validation error when there is no title', async () => {
-    render(<PublicationForm topicId="topic-id" onSubmit={noop} />);
+    const { user } = render(
+      <PublicationForm topicId="topic-id" onSubmit={noop} />,
+    );
 
     await waitFor(() => {
       expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByLabelText('Publication title'));
-    await userEvent.tab();
+    await user.click(screen.getByRole('button', { name: 'Save publication' }));
 
     await waitFor(() => {
       expect(
@@ -31,14 +32,15 @@ describe('PublicationForm', () => {
   });
 
   test('shows validation error when there is no summary', async () => {
-    render(<PublicationForm topicId="topic-id" onSubmit={noop} />);
+    const { user } = render(
+      <PublicationForm topicId="topic-id" onSubmit={noop} />,
+    );
 
     await waitFor(() => {
       expect(screen.getByLabelText('Publication summary')).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByLabelText('Publication summary'));
-    await userEvent.tab();
+    await user.click(screen.getByRole('button', { name: 'Save publication' }));
 
     await waitFor(() => {
       expect(
@@ -50,25 +52,15 @@ describe('PublicationForm', () => {
   });
 
   test('shows validation errors when there are no contact details', async () => {
-    render(<PublicationForm topicId="topic-id" onSubmit={noop} />);
+    const { user } = render(
+      <PublicationForm topicId="topic-id" onSubmit={noop} />,
+    );
 
     await waitFor(() => {
       expect(screen.getByLabelText('Team name')).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByLabelText('Team name'));
-    await userEvent.tab();
-
-    await userEvent.click(screen.getByLabelText('Team email address'));
-    await userEvent.tab();
-
-    await userEvent.click(screen.getByLabelText('Contact name'));
-    await userEvent.tab();
-
-    await userEvent.click(
-      screen.getByLabelText('Contact telephone (optional)'),
-    );
-    await userEvent.tab();
+    await user.click(screen.getByRole('button', { name: 'Save publication' }));
 
     await waitFor(() => {
       expect(
@@ -96,7 +88,9 @@ describe('PublicationForm', () => {
   test.each([' 0abcdefg ', '01234 4567a', '_12345678', '01234 5678 !'])(
     'show validation error when contact tel no "%s" contains non-numeric or non-whitespace characters',
     async telNo => {
-      render(<PublicationForm topicId="topic-id" onSubmit={noop} />);
+      const { user } = render(
+        <PublicationForm topicId="topic-id" onSubmit={noop} />,
+      );
 
       await waitFor(() => {
         expect(
@@ -104,11 +98,13 @@ describe('PublicationForm', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('Contact telephone (optional)'),
         telNo,
       );
-      await userEvent.tab();
+      await user.click(
+        screen.getByRole('button', { name: 'Save publication' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -131,7 +127,9 @@ describe('PublicationForm', () => {
   ])(
     'show validation error when contact tel no "%s" is DfE enquiries number',
     async telNo => {
-      render(<PublicationForm topicId="topic-id" onSubmit={noop} />);
+      const { user } = render(
+        <PublicationForm topicId="topic-id" onSubmit={noop} />,
+      );
 
       await waitFor(() => {
         expect(
@@ -139,11 +137,13 @@ describe('PublicationForm', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('Contact telephone (optional)'),
         telNo,
       );
-      await userEvent.tab();
+      await user.click(
+        screen.getByRole('button', { name: 'Save publication' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -161,7 +161,9 @@ describe('PublicationForm', () => {
   test.each([' 0123456 ', '0', '012', '0123 56'])(
     'show validation error when contact tel no "%s" is less than 8 characters',
     async telNo => {
-      render(<PublicationForm topicId="topic-id" onSubmit={noop} />);
+      const { user } = render(
+        <PublicationForm topicId="topic-id" onSubmit={noop} />,
+      );
 
       await waitFor(() => {
         expect(
@@ -169,11 +171,13 @@ describe('PublicationForm', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.type(
+      await user.type(
         screen.getByLabelText('Contact telephone (optional)'),
         telNo,
       );
-      await userEvent.tab();
+      await user.click(
+        screen.getByRole('button', { name: 'Save publication' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -186,17 +190,19 @@ describe('PublicationForm', () => {
   );
 
   test('show validation error when contact email is not valid', async () => {
-    render(<PublicationForm topicId="topic-id" onSubmit={noop} />);
+    const { user } = render(
+      <PublicationForm topicId="topic-id" onSubmit={noop} />,
+    );
 
     await waitFor(() => {
       expect(screen.getByLabelText('Team email address')).toBeInTheDocument();
     });
 
-    await userEvent.type(
+    await user.type(
       screen.getByLabelText('Team email address'),
       'not a valid email',
     );
-    await userEvent.tab();
+    await user.click(screen.getByRole('button', { name: 'Save publication' }));
 
     await waitFor(() => {
       expect(
@@ -210,7 +216,9 @@ describe('PublicationForm', () => {
   test('cannot submit with invalid values', async () => {
     const handleSubmit = jest.fn();
 
-    render(<PublicationForm topicId="topic-id" onSubmit={handleSubmit} />);
+    const { user } = render(
+      <PublicationForm topicId="topic-id" onSubmit={handleSubmit} />,
+    );
 
     await waitFor(() => {
       expect(
@@ -220,9 +228,7 @@ describe('PublicationForm', () => {
 
     expect(handleSubmit).not.toHaveBeenCalled();
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Save publication' }),
-    );
+    await user.click(screen.getByRole('button', { name: 'Save publication' }));
 
     await waitFor(() => {
       expect(handleSubmit).not.toHaveBeenCalled();
@@ -232,38 +238,35 @@ describe('PublicationForm', () => {
   test('can submit with valid values', async () => {
     const handleSubmit = jest.fn();
 
-    render(<PublicationForm topicId="topic-id" onSubmit={handleSubmit} />);
+    const { user } = render(
+      <PublicationForm topicId="topic-id" onSubmit={handleSubmit} />,
+    );
 
     await waitFor(() => {
       expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
     });
 
-    await userEvent.type(
-      screen.getByLabelText('Publication title'),
-      'Test title',
-    );
+    await user.type(screen.getByLabelText('Publication title'), 'Test title');
 
-    await userEvent.type(
+    await user.type(
       screen.getByLabelText('Publication summary'),
       'Test summary',
     );
 
-    await userEvent.type(screen.getByLabelText('Team name'), 'Test team');
-    await userEvent.type(
+    await user.type(screen.getByLabelText('Team name'), 'Test team');
+    await user.type(
       screen.getByLabelText('Team email address'),
       'team@test.com',
     );
-    await userEvent.type(screen.getByLabelText('Contact name'), 'John Smith');
-    await userEvent.type(
+    await user.type(screen.getByLabelText('Contact name'), 'John Smith');
+    await user.type(
       screen.getByLabelText('Contact telephone (optional)'),
       '0123456789',
     );
 
     expect(handleSubmit).not.toHaveBeenCalled();
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Save publication' }),
-    );
+    await user.click(screen.getByRole('button', { name: 'Save publication' }));
 
     await waitFor(() => {
       expect(publicationService.createPublication).toHaveBeenCalledWith({
@@ -283,34 +286,31 @@ describe('PublicationForm', () => {
   test('can submit without a contact tel no', async () => {
     const handleSubmit = jest.fn();
 
-    render(<PublicationForm topicId="topic-id" onSubmit={handleSubmit} />);
+    const { user } = render(
+      <PublicationForm topicId="topic-id" onSubmit={handleSubmit} />,
+    );
 
     await waitFor(() => {
       expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
     });
 
-    await userEvent.type(
-      screen.getByLabelText('Publication title'),
-      'Test title',
-    );
+    await user.type(screen.getByLabelText('Publication title'), 'Test title');
 
-    await userEvent.type(
+    await user.type(
       screen.getByLabelText('Publication summary'),
       'Test summary',
     );
 
-    await userEvent.type(screen.getByLabelText('Team name'), 'Test team');
-    await userEvent.type(
+    await user.type(screen.getByLabelText('Team name'), 'Test team');
+    await user.type(
       screen.getByLabelText('Team email address'),
       'team@test.com',
     );
-    await userEvent.type(screen.getByLabelText('Contact name'), 'John Smith');
+    await user.type(screen.getByLabelText('Contact name'), 'John Smith');
 
     expect(handleSubmit).not.toHaveBeenCalled();
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Save publication' }),
-    );
+    await user.click(screen.getByRole('button', { name: 'Save publication' }));
 
     await waitFor(() => {
       expect(publicationService.createPublication).toHaveBeenCalledWith({

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -2,14 +2,14 @@ import { testRelease } from '@admin/pages/release/__data__/testRelease';
 import { ReleaseStatusPermissions } from '@admin/services/permissionService';
 import { ReleaseChecklistErrorCode } from '@admin/services/releaseService';
 import { createServerValidationErrorMock } from '@common-test/createAxiosErrorMock';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import { format } from 'date-fns';
 import React from 'react';
 import ReleaseStatusForm, {
   ReleaseStatusFormValues,
 } from '@admin/pages/release/components/ReleaseStatusForm';
 import noop from 'lodash/noop';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
 
 describe('ReleaseStatusForm', () => {
   const testStatusPermissions: ReleaseStatusPermissions = {
@@ -189,10 +189,9 @@ describe('ReleaseStatusForm', () => {
 
   describe('in Draft', () => {
     test('submits successfully without changing values', async () => {
-      const user = userEvent.setup();
       const handleSubmit = jest.fn();
 
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={testRelease}
           statusPermissions={testStatusPermissions}
@@ -220,11 +219,9 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('submits successfully with updated values', async () => {
-      const user = userEvent.setup();
-
       const handleSubmit = jest.fn();
 
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={testRelease}
           statusPermissions={testStatusPermissions}
@@ -271,9 +268,7 @@ describe('ReleaseStatusForm', () => {
 
   describe('in Higher Level Review', () => {
     test('shows error message when internal note is empty', async () => {
-      const user = userEvent.setup();
-
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -286,7 +281,7 @@ describe('ReleaseStatusForm', () => {
       );
 
       await user.click(screen.getByLabelText('Internal note'));
-      await user.tab();
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -298,11 +293,9 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('fails to submit with invalid values', async () => {
-      const user = userEvent.setup();
-
       const handleSubmit = jest.fn();
 
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -328,10 +321,9 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('submits successfully with updated values', async () => {
-      const user = userEvent.setup();
       const handleSubmit = jest.fn();
 
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -506,9 +498,7 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('shows error message when internal note is empty', async () => {
-      const user = userEvent.setup();
-
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -521,7 +511,7 @@ describe('ReleaseStatusForm', () => {
       );
 
       await user.click(screen.getByLabelText('Internal note'));
-      await user.tab();
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -533,9 +523,7 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('shows error message when no publishing method selected', async () => {
-      const user = userEvent.setup();
-
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -548,9 +536,7 @@ describe('ReleaseStatusForm', () => {
       );
 
       // Focus the field above before tabbing through the options
-      await user.click(screen.getByLabelText('Internal note'));
-      await user.tab();
-      await user.tab();
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -562,9 +548,7 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('shows error message when no publish date', async () => {
-      const user = userEvent.setup();
-
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -577,10 +561,7 @@ describe('ReleaseStatusForm', () => {
       );
 
       await user.click(screen.getByLabelText('On a specific date'));
-      await user.tab();
-      await user.tab();
-      await user.tab();
-      await user.tab();
+      await user.click(screen.getByRole('button', { name: 'Update status' }));
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -592,10 +573,9 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('fails to submit with invalid values', async () => {
-      const user = userEvent.setup();
       const handleSubmit = jest.fn();
 
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -631,9 +611,8 @@ describe('ReleaseStatusForm', () => {
             { code: checklistError, message: '' },
           ]);
         });
-        const user = userEvent.setup();
 
-        render(
+        const { user } = render(
           <ReleaseStatusForm
             release={testRelease}
             statusPermissions={testStatusPermissions}
@@ -665,9 +644,8 @@ describe('ReleaseStatusForm', () => {
           { code: 'UnexpectedError', message: '' },
         ]);
       });
-      const user = userEvent.setup();
 
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={testRelease}
           statusPermissions={testStatusPermissions}
@@ -693,10 +671,9 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('submits successfully with updated values and Draft status', async () => {
-      const user = userEvent.setup();
       const handleSubmit = jest.fn();
 
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -741,9 +718,7 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('shows confirmation modal when submitting with valid values and publish date', async () => {
-      const user = userEvent.setup();
-
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -787,8 +762,7 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('does not show confirmation modal when submitting invalid values with valid publish date', async () => {
-      const user = userEvent.setup();
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -824,14 +798,13 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('shows error modal when submitted with publish date that could not be scheduled', async () => {
-      const user = userEvent.setup();
       const handleSubmit = jest.fn().mockImplementation(() => {
         throw createServerValidationErrorMock([
           { code: 'PublishDateCannotBeScheduled', message: '' },
         ]);
       });
 
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -890,10 +863,9 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('submits successfully with updated values and publish date', async () => {
-      const user = userEvent.setup();
       const handleSubmit = jest.fn();
 
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -961,10 +933,9 @@ describe('ReleaseStatusForm', () => {
     });
 
     test('submits successfully with updated values and immediate publish', async () => {
-      const user = userEvent.setup();
       const handleSubmit = jest.fn();
 
-      render(
+      const { user } = render(
         <ReleaseStatusForm
           release={{
             ...testRelease,
@@ -1038,10 +1009,9 @@ describe('ReleaseStatusForm', () => {
       });
 
       test('renders default values for `notifySubscribers` and `updatePublishedDate` options when status is changed to Approved', async () => {
-        const user = userEvent.setup();
         const handleSubmit = jest.fn();
 
-        render(
+        const { user } = render(
           <ReleaseStatusForm
             release={{
               ...testRelease,
@@ -1089,10 +1059,9 @@ describe('ReleaseStatusForm', () => {
       });
 
       test('shows warning message when `updatePublishedDate` is selected', async () => {
-        const user = userEvent.setup();
         const handleSubmit = jest.fn();
 
-        render(
+        const { user } = render(
           <ReleaseStatusForm
             release={{
               ...testRelease,
@@ -1133,10 +1102,9 @@ describe('ReleaseStatusForm', () => {
       });
 
       test('submits successfully with updated values', async () => {
-        const user = userEvent.setup();
         const handleSubmit = jest.fn();
 
-        render(
+        const { user } = render(
           <ReleaseStatusForm
             release={{
               ...testRelease,

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/RelatedPagesSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/RelatedPagesSection.test.tsx
@@ -3,9 +3,9 @@ import { EditingContextProvider } from '@admin/contexts/EditingContext';
 import _releaseContentRelatedInformationService from '@admin/services/releaseContentRelatedInformationService';
 import { generateEditableRelease } from '@admin-test/generators/releaseContentGenerators';
 import { BasicLink } from '@common/services/publicationService';
-import { render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
+import render from '@common-test/render';
 
 jest.mock('@admin/services/releaseContentRelatedInformationService');
 const releaseContentRelatedInformationService =
@@ -60,8 +60,7 @@ describe('RelatedPagesSection', () => {
     });
 
     test('shows the form when click the add button', async () => {
-      const user = userEvent.setup();
-      render(
+      const { user } = render(
         <EditingContextProvider editingMode="edit">
           <RelatedPagesSection release={testRelease} />
         </EditingContextProvider>,
@@ -82,8 +81,7 @@ describe('RelatedPagesSection', () => {
     });
 
     test('shows a validation error when no title is set', async () => {
-      const user = userEvent.setup();
-      render(
+      const { user } = render(
         <EditingContextProvider editingMode="edit">
           <RelatedPagesSection release={testRelease} />
         </EditingContextProvider>,
@@ -94,7 +92,7 @@ describe('RelatedPagesSection', () => {
       );
 
       await user.click(screen.getByLabelText('Title'));
-      await user.tab();
+      await user.click(screen.getByRole('button', { name: 'Create link' }));
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -107,8 +105,7 @@ describe('RelatedPagesSection', () => {
     });
 
     test('shows a validation error when no url is set', async () => {
-      const user = userEvent.setup();
-      render(
+      const { user } = render(
         <EditingContextProvider editingMode="edit">
           <RelatedPagesSection release={testRelease} />
         </EditingContextProvider>,
@@ -119,7 +116,7 @@ describe('RelatedPagesSection', () => {
       );
 
       await user.click(screen.getByLabelText('Link URL'));
-      await user.tab();
+      await user.click(screen.getByRole('button', { name: 'Create link' }));
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -132,8 +129,7 @@ describe('RelatedPagesSection', () => {
     });
 
     test('shows a validation error when the url is invalid', async () => {
-      const user = userEvent.setup();
-      render(
+      const { user } = render(
         <EditingContextProvider editingMode="edit">
           <RelatedPagesSection release={testRelease} />
         </EditingContextProvider>,
@@ -143,8 +139,8 @@ describe('RelatedPagesSection', () => {
         screen.getByRole('button', { name: 'Add related page link' }),
       );
 
-      await userEvent.type(screen.getByLabelText('Link URL'), 'Not a url');
-      await userEvent.tab();
+      await user.type(screen.getByLabelText('Link URL'), 'Not a url');
+      await user.click(screen.getByRole('button', { name: 'Create link' }));
 
       await waitFor(() => {
         expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -164,8 +160,8 @@ describe('RelatedPagesSection', () => {
       releaseContentRelatedInformationService.create.mockResolvedValue(
         newLinks,
       );
-      const user = userEvent.setup();
-      render(
+
+      const { user } = render(
         <EditingContextProvider editingMode="edit">
           <RelatedPagesSection release={testRelease} />
         </EditingContextProvider>,
@@ -206,8 +202,8 @@ describe('RelatedPagesSection', () => {
 
     test('successfully removes a link', async () => {
       releaseContentRelatedInformationService.delete.mockResolvedValue([]);
-      const user = userEvent.setup();
-      render(
+
+      const { user } = render(
         <EditingContextProvider editingMode="edit">
           <RelatedPagesSection release={testRelease} />
         </EditingContextProvider>,

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseNoteForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseNoteForm.test.tsx
@@ -1,6 +1,6 @@
 import ReleaseNoteForm from '@admin/pages/release/content/components/ReleaseNoteForm';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
 import noop from 'lodash/noop';
 import React from 'react';
 
@@ -30,8 +30,7 @@ describe('ReleaseNoteForm', () => {
     });
 
     test('shows a validation error if no reason is given', async () => {
-      const user = userEvent.setup();
-      render(
+      const { user } = render(
         <ReleaseNoteForm
           id="test-id"
           initialValues={{ reason: '' }}
@@ -40,8 +39,7 @@ describe('ReleaseNoteForm', () => {
         />,
       );
 
-      await user.click(screen.getByLabelText('New release note'));
-      await user.tab();
+      await user.click(screen.getByRole('button', { name: 'Save note' }));
 
       expect(await screen.findByText('There is a problem')).toBeInTheDocument();
 
@@ -57,9 +55,8 @@ describe('ReleaseNoteForm', () => {
     });
 
     test('submits successfully', async () => {
-      const user = userEvent.setup();
       const handleSubmit = jest.fn();
-      render(
+      const { user } = render(
         <ReleaseNoteForm
           id="test-id"
           initialValues={{ reason: '' }}
@@ -107,8 +104,7 @@ describe('ReleaseNoteForm', () => {
     });
 
     test('shows a validation error if no reason is given', async () => {
-      const user = userEvent.setup();
-      render(
+      const { user } = render(
         <ReleaseNoteForm
           id="test-id"
           initialValues={{ on: new Date('2024-01-01'), reason: 'Test note' }}
@@ -118,7 +114,7 @@ describe('ReleaseNoteForm', () => {
       );
 
       await user.clear(screen.getByLabelText('Edit release note'));
-      await user.tab();
+      await user.click(screen.getByRole('button', { name: 'Update note' }));
 
       expect(await screen.findByText('There is a problem')).toBeInTheDocument();
 
@@ -134,8 +130,7 @@ describe('ReleaseNoteForm', () => {
     });
 
     test('shows a validation error if no date is given', async () => {
-      const user = userEvent.setup();
-      render(
+      const { user } = render(
         <ReleaseNoteForm
           id="test-id"
           initialValues={{ on: new Date('2024-01-01'), reason: 'Test note' }}
@@ -147,7 +142,7 @@ describe('ReleaseNoteForm', () => {
       await user.clear(screen.getByLabelText('Day'));
       await user.clear(screen.getByLabelText('Month'));
       await user.clear(screen.getByLabelText('Year'));
-      await user.tab();
+      await user.click(screen.getByRole('button', { name: 'Update note' }));
 
       expect(await screen.findByText('There is a problem')).toBeInTheDocument();
 
@@ -163,9 +158,8 @@ describe('ReleaseNoteForm', () => {
     });
 
     test('submits successfully with updated values', async () => {
-      const user = userEvent.setup();
       const handleSubmit = jest.fn();
-      render(
+      const { user } = render(
         <ReleaseNoteForm
           id="test-id"
           initialValues={{ on: new Date('2024-01-01'), reason: 'Test note' }}

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFilePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFilePage.test.tsx
@@ -6,8 +6,8 @@ import {
 import _releaseDataFileService, {
   DataFile,
 } from '@admin/services/releaseDataFileService';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory, MemoryHistory } from 'history';
 import React from 'react';
 import { generatePath, Route, Router } from 'react-router-dom';
@@ -41,7 +41,10 @@ describe('ReleaseDataFilePage', () => {
   test('renders form with initial values', async () => {
     releaseDataFileService.getDataFile.mockResolvedValue(testFile);
 
-    await renderPage();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Edit data file details')).toBeInTheDocument();
+    });
 
     expect(screen.getByLabelText('Title')).toHaveValue('Test data file');
   });
@@ -51,7 +54,10 @@ describe('ReleaseDataFilePage', () => {
       new Error('Could not find data file'),
     );
 
-    await renderPage();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Edit data file details')).toBeInTheDocument();
+    });
 
     expect(
       screen.getByText('Could not load data file details'),
@@ -62,10 +68,13 @@ describe('ReleaseDataFilePage', () => {
   test('shows validation message if `title` field is empty', async () => {
     releaseDataFileService.getDataFile.mockResolvedValue(testFile);
 
-    await renderPage();
+    const { user } = renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Edit data file details')).toBeInTheDocument();
+    });
 
-    await userEvent.clear(screen.getByLabelText('Title'));
-    await userEvent.tab();
+    await user.clear(screen.getByLabelText('Title'));
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
     await waitFor(() => {
       expect(
@@ -80,9 +89,12 @@ describe('ReleaseDataFilePage', () => {
       title: '',
     });
 
-    await renderPage();
+    const { user } = renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Edit data file details')).toBeInTheDocument();
+    });
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
     await waitFor(() => {
       expect(
@@ -94,14 +106,17 @@ describe('ReleaseDataFilePage', () => {
   test('successfully submitting form sends update request to service', async () => {
     releaseDataFileService.getDataFile.mockResolvedValue(testFile);
 
-    await renderPage();
+    const { user } = renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Edit data file details')).toBeInTheDocument();
+    });
 
     const input = screen.getByLabelText('Title');
 
-    await userEvent.clear(input);
-    await userEvent.type(input, 'Updated test data file');
+    await user.clear(input);
+    await user.type(input, 'Updated test data file');
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
     await waitFor(() => {
       expect(releaseDataFileService.updateFile).toHaveBeenCalledWith<
@@ -117,9 +132,12 @@ describe('ReleaseDataFilePage', () => {
 
     const history = createMemoryHistory();
 
-    await renderPage(history);
+    const { user } = renderPage(history);
+    await waitFor(() => {
+      expect(screen.getByText('Edit data file details')).toBeInTheDocument();
+    });
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
     await waitFor(() => {
       expect(history.location.pathname).toBe(
@@ -129,7 +147,7 @@ describe('ReleaseDataFilePage', () => {
     });
   });
 
-  async function renderPage(history: MemoryHistory = createMemoryHistory()) {
+  function renderPage(history: MemoryHistory = createMemoryHistory()) {
     history.push(
       generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
         publicationId: 'publication-1',
@@ -138,7 +156,7 @@ describe('ReleaseDataFilePage', () => {
       }),
     );
 
-    render(
+    return render(
       <Router history={history}>
         <Route
           path={releaseDataFileRoute.path}
@@ -146,9 +164,5 @@ describe('ReleaseDataFilePage', () => {
         />
       </Router>,
     );
-
-    await waitFor(() => {
-      expect(screen.getByText('Edit data file details')).toBeInTheDocument();
-    });
   }
 });

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/AncillaryFileForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/AncillaryFileForm.test.tsx
@@ -1,17 +1,17 @@
 import AncillaryFileForm, {
   AncillaryFileFormProps,
 } from '@admin/pages/release/data/components/AncillaryFileForm';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
 import noop from 'lodash/noop';
 import React from 'react';
 
 describe('AncillaryFileForm', () => {
   test('shows validation message if `title` field is empty', async () => {
-    render(<AncillaryFileForm onSubmit={noop} />);
+    const { user } = render(<AncillaryFileForm onSubmit={noop} />);
 
-    await userEvent.clear(screen.getByLabelText('Title'));
-    await userEvent.tab();
+    await user.clear(screen.getByLabelText('Title'));
+    await user.click(screen.getByRole('button', { name: 'Add file' }));
 
     await waitFor(() => {
       expect(
@@ -23,7 +23,7 @@ describe('AncillaryFileForm', () => {
   });
 
   test('shows validation message if `title` field is not unique to other files', async () => {
-    render(
+    const { user } = render(
       <AncillaryFileForm
         files={[
           {
@@ -43,9 +43,9 @@ describe('AncillaryFileForm', () => {
       />,
     );
 
-    await userEvent.clear(screen.getByLabelText('Title'));
-    await userEvent.type(screen.getByLabelText('Title'), 'Test title');
-    await userEvent.tab();
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Test title');
+    await user.click(screen.getByRole('button', { name: 'Add file' }));
 
     await waitFor(() => {
       expect(
@@ -57,10 +57,10 @@ describe('AncillaryFileForm', () => {
   });
 
   test('shows validation message if `summary` field is empty', async () => {
-    render(<AncillaryFileForm onSubmit={noop} />);
+    const { user } = render(<AncillaryFileForm onSubmit={noop} />);
 
-    await userEvent.clear(screen.getByLabelText('Summary'));
-    await userEvent.tab();
+    await user.clear(screen.getByLabelText('Summary'));
+    await user.click(screen.getByRole('button', { name: 'Add file' }));
 
     await waitFor(() => {
       expect(
@@ -74,10 +74,10 @@ describe('AncillaryFileForm', () => {
   test('shows validation message if `file` field contains an empty file', async () => {
     const testFile = new File([''], 'test.txt');
 
-    render(<AncillaryFileForm onSubmit={noop} />);
+    const { user } = render(<AncillaryFileForm onSubmit={noop} />);
 
-    await userEvent.upload(screen.getByLabelText('Upload file'), testFile);
-    await userEvent.click(screen.getByRole('button', { name: 'Add file' }));
+    await user.upload(screen.getByLabelText('Upload file'), testFile);
+    await user.click(screen.getByRole('button', { name: 'Add file' }));
 
     await waitFor(() => {
       expect(
@@ -89,9 +89,9 @@ describe('AncillaryFileForm', () => {
   });
 
   test('shows validation messages if submitted form is invalid', async () => {
-    render(<AncillaryFileForm onSubmit={noop} />);
+    const { user } = render(<AncillaryFileForm onSubmit={noop} />);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add file' }));
+    await user.click(screen.getByRole('button', { name: 'Add file' }));
 
     await waitFor(() => {
       expect(
@@ -111,18 +111,18 @@ describe('AncillaryFileForm', () => {
   test('successfully submitting form calls `onSubmit` handler', async () => {
     const handleSubmit = jest.fn();
 
-    render(<AncillaryFileForm onSubmit={handleSubmit} />);
+    const { user } = render(<AncillaryFileForm onSubmit={handleSubmit} />);
 
-    await userEvent.type(screen.getByLabelText('Title'), 'Test title');
-    await userEvent.type(screen.getByLabelText('Summary'), 'Test summary');
+    await user.type(screen.getByLabelText('Title'), 'Test title');
+    await user.type(screen.getByLabelText('Summary'), 'Test summary');
 
     const testFile = new File(['test'], 'test.txt');
 
-    await userEvent.upload(screen.getByLabelText('Upload file'), testFile);
+    await user.upload(screen.getByLabelText('Upload file'), testFile);
 
     expect(handleSubmit).not.toHaveBeenCalled();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add file' }));
+    await user.click(screen.getByRole('button', { name: 'Add file' }));
 
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledWith<

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateForm.test.tsx
@@ -60,7 +60,9 @@ describe('ApiDataSetCreateForm', () => {
     );
 
     await user.click(screen.getByLabelText('Data set'));
-    await user.tab();
+    await user.click(
+      screen.getByRole('button', { name: 'Confirm new API data set' }),
+    );
 
     expect(
       await screen.findByText('Choose a data set', {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileUploadForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileUploadForm.test.tsx
@@ -1,20 +1,18 @@
 import DataFileUploadForm from '@admin/pages/release/data/components/DataFileUploadForm';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import noop from 'lodash/noop';
 
 describe('DataFileUploadForm', () => {
   test('shows validation message when no data file selected', async () => {
-    render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
 
-    await userEvent.click(screen.getByLabelText('Upload data file'));
-    fireEvent.change(screen.getByLabelText('Upload data file'), {
-      target: {
-        value: null,
-      },
-    });
-    await userEvent.tab();
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Upload data files',
+      }),
+    );
 
     await waitFor(() => {
       expect(
@@ -26,14 +24,18 @@ describe('DataFileUploadForm', () => {
   });
 
   test('shows validation message when data file is not empty', async () => {
-    render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
 
     const file = new File([], 'test.csv', {
       type: 'text/csv',
     });
 
-    await userEvent.upload(screen.getByLabelText('Upload data file'), file);
-    await userEvent.tab();
+    await user.upload(screen.getByLabelText('Upload data file'), file);
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Upload data files',
+      }),
+    );
 
     await waitFor(() => {
       expect(
@@ -45,13 +47,13 @@ describe('DataFileUploadForm', () => {
   });
 
   test('shows validation message when no meta data file selected', async () => {
-    render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
 
-    await userEvent.click(screen.getByLabelText('Upload metadata file'));
-    fireEvent.change(screen.getByLabelText('Upload metadata file'), {
-      target: { value: null },
-    });
-    await userEvent.tab();
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Upload data files',
+      }),
+    );
 
     await waitFor(() => {
       expect(
@@ -63,14 +65,18 @@ describe('DataFileUploadForm', () => {
   });
 
   test('shows validation message when metadata file is not empty', async () => {
-    render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
 
     const file = new File([], 'test.csv', {
       type: 'text/csv',
     });
 
-    await userEvent.upload(screen.getByLabelText('Upload metadata file'), file);
-    await userEvent.tab();
+    await user.upload(screen.getByLabelText('Upload metadata file'), file);
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Upload data files',
+      }),
+    );
 
     await waitFor(() => {
       expect(
@@ -82,14 +88,14 @@ describe('DataFileUploadForm', () => {
   });
 
   test('shows validation message when no ZIP file selected', async () => {
-    render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
 
-    await userEvent.click(screen.getByLabelText('ZIP file'));
-    await userEvent.click(screen.getByLabelText('Upload ZIP file'));
-    fireEvent.change(screen.getByLabelText('Upload ZIP file'), {
-      target: { value: null },
-    });
-    await userEvent.tab();
+    await user.click(screen.getByLabelText('ZIP file'));
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Upload data files',
+      }),
+    );
 
     await waitFor(() => {
       expect(
@@ -101,15 +107,19 @@ describe('DataFileUploadForm', () => {
   });
 
   test('shows validation message when ZIP file is empty', async () => {
-    render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
 
     const file = new File([], 'test.zip', {
       type: 'application/zip',
     });
 
-    await userEvent.click(screen.getByLabelText('ZIP file'));
-    await userEvent.upload(screen.getByLabelText('Upload ZIP file'), file);
-    await userEvent.tab();
+    await user.click(screen.getByLabelText('ZIP file'));
+    await user.upload(screen.getByLabelText('Upload ZIP file'), file);
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Upload data files',
+      }),
+    );
 
     await waitFor(() => {
       expect(
@@ -123,9 +133,9 @@ describe('DataFileUploadForm', () => {
   test('cannot submit with invalid values when trying to upload CSV files', async () => {
     const handleSubmit = jest.fn();
 
-    render(<DataFileUploadForm onSubmit={handleSubmit} />);
+    const { user } = render(<DataFileUploadForm onSubmit={handleSubmit} />);
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: 'Upload data files',
       }),
@@ -155,10 +165,10 @@ describe('DataFileUploadForm', () => {
   test('cannot submit with invalid values when trying to upload ZIP file', async () => {
     const handleSubmit = jest.fn();
 
-    render(<DataFileUploadForm onSubmit={handleSubmit} />);
+    const { user } = render(<DataFileUploadForm onSubmit={handleSubmit} />);
 
-    await userEvent.click(screen.getByLabelText('ZIP file'));
-    await userEvent.click(
+    await user.click(screen.getByLabelText('ZIP file'));
+    await user.click(
       screen.getByRole('button', {
         name: 'Upload data files',
       }),

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataGuidanceSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataGuidanceSection.test.tsx
@@ -2,8 +2,8 @@ import ReleaseDataGuidanceSection from '@admin/pages/release/data/components/Rel
 import _releaseDataGuidanceService, {
   ReleaseDataGuidance,
 } from '@admin/services/releaseDataGuidanceService';
-import { render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
+import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 
 jest.mock('@admin/services/releaseDataGuidanceService');
@@ -145,7 +145,7 @@ describe('ReleaseDataGuidanceSection', () => {
         testDataGuidance,
       );
 
-      render(
+      const { user } = render(
         <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
       );
 
@@ -177,7 +177,7 @@ describe('ReleaseDataGuidanceSection', () => {
         '<p>Test data set 1 content</p>',
       );
 
-      await userEvent.click(
+      await user.click(
         dataSet1.getByRole('button', {
           name: 'Variable names and descriptions',
         }),
@@ -199,9 +199,7 @@ describe('ReleaseDataGuidanceSection', () => {
       expect(dataSet1VariableRow2Cells[0]).toHaveTextContent('indicator_1');
       expect(dataSet1VariableRow2Cells[1]).toHaveTextContent('Indicator 1');
 
-      await userEvent.click(
-        dataSet1.getByRole('button', { name: 'Footnotes' }),
-      );
+      await user.click(dataSet1.getByRole('button', { name: 'Footnotes' }));
 
       const dataSet1Footnotes = within(
         dataSet1.getByTestId('Footnotes'),
@@ -227,7 +225,7 @@ describe('ReleaseDataGuidanceSection', () => {
         '<p>Test data set 2 content</p>',
       );
 
-      await userEvent.click(
+      await user.click(
         dataSet2.getByRole('button', {
           name: 'Variable names and descriptions',
         }),
@@ -249,9 +247,7 @@ describe('ReleaseDataGuidanceSection', () => {
       expect(dataSet2VariableRow2Cells[0]).toHaveTextContent('indicator_2');
       expect(dataSet2VariableRow2Cells[1]).toHaveTextContent('Indicator 2');
 
-      await userEvent.click(
-        dataSet2.getByRole('button', { name: 'Footnotes' }),
-      );
+      await user.click(dataSet2.getByRole('button', { name: 'Footnotes' }));
 
       const dataSet2Footnotes = within(
         dataSet2.getByTestId('Footnotes'),
@@ -266,7 +262,7 @@ describe('ReleaseDataGuidanceSection', () => {
         testDataGuidance,
       );
 
-      render(
+      const { user } = render(
         <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
       );
 
@@ -276,7 +272,7 @@ describe('ReleaseDataGuidanceSection', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', { name: 'Preview guidance' }),
       );
 
@@ -322,7 +318,7 @@ describe('ReleaseDataGuidanceSection', () => {
       `,
       );
 
-      await userEvent.click(
+      await user.click(
         dataSet1.getByRole('button', {
           name: 'Variable names and descriptions',
         }),
@@ -344,9 +340,7 @@ describe('ReleaseDataGuidanceSection', () => {
       expect(dataSet1VariableRow2Cells[0]).toHaveTextContent('indicator_1');
       expect(dataSet1VariableRow2Cells[1]).toHaveTextContent('Indicator 1');
 
-      await userEvent.click(
-        dataSet1.getByRole('button', { name: 'Footnotes' }),
-      );
+      await user.click(dataSet1.getByRole('button', { name: 'Footnotes' }));
 
       const dataSet1Footnotes = within(
         dataSet1.getByTestId('Footnotes'),
@@ -382,7 +376,7 @@ describe('ReleaseDataGuidanceSection', () => {
       `,
       );
 
-      await userEvent.click(
+      await user.click(
         dataSet2.getByRole('button', {
           name: 'Variable names and descriptions',
         }),
@@ -404,9 +398,7 @@ describe('ReleaseDataGuidanceSection', () => {
       expect(dataSet2VariableRow2Cells[0]).toHaveTextContent('indicator_2');
       expect(dataSet2VariableRow2Cells[1]).toHaveTextContent('Indicator 2');
 
-      await userEvent.click(
-        dataSet2.getByRole('button', { name: 'Footnotes' }),
-      );
+      await user.click(dataSet2.getByRole('button', { name: 'Footnotes' }));
 
       const dataSet2Footnotes = within(
         dataSet2.getByTestId('Footnotes'),
@@ -421,7 +413,7 @@ describe('ReleaseDataGuidanceSection', () => {
         testDataGuidance,
       );
 
-      render(
+      const { user } = render(
         <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
       );
 
@@ -439,8 +431,8 @@ describe('ReleaseDataGuidanceSection', () => {
         screen.queryByRole('link', { name: 'Enter main guidance content' }),
       ).not.toBeInTheDocument();
 
-      await userEvent.clear(mainGuidanceContent);
-      await userEvent.tab();
+      await user.clear(mainGuidanceContent);
+      await user.click(screen.getByRole('button', { name: 'Save guidance' }));
 
       await waitFor(() => {
         expect(
@@ -459,7 +451,7 @@ describe('ReleaseDataGuidanceSection', () => {
         testDataGuidance,
       );
 
-      render(
+      const { user } = render(
         <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
       );
 
@@ -480,8 +472,8 @@ describe('ReleaseDataGuidanceSection', () => {
         }),
       ).not.toBeInTheDocument();
 
-      await userEvent.clear(fileGuidanceContent);
-      await userEvent.tab();
+      await user.clear(fileGuidanceContent);
+      await user.click(screen.getByRole('button', { name: 'Save guidance' }));
 
       await waitFor(() => {
         expect(
@@ -502,7 +494,7 @@ describe('ReleaseDataGuidanceSection', () => {
         testDataGuidance,
       );
 
-      render(
+      const { user } = render(
         <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
       );
 
@@ -512,15 +504,13 @@ describe('ReleaseDataGuidanceSection', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.clear(screen.getByLabelText('Main guidance content'));
+      await user.clear(screen.getByLabelText('Main guidance content'));
 
       expect(
         releaseDataGuidanceService.updateDataGuidance,
       ).not.toHaveBeenCalled();
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Save guidance' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Save guidance' }));
 
       await waitFor(() => {
         expect(
@@ -540,7 +530,7 @@ describe('ReleaseDataGuidanceSection', () => {
         testDataGuidance,
       );
 
-      render(
+      const { user } = render(
         <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
       );
 
@@ -550,7 +540,7 @@ describe('ReleaseDataGuidanceSection', () => {
 
       const dataSets = screen.getAllByTestId('accordionSection');
 
-      await userEvent.clear(
+      await user.clear(
         within(dataSets[0]).getByLabelText('File guidance content'),
       );
 
@@ -558,9 +548,7 @@ describe('ReleaseDataGuidanceSection', () => {
         releaseDataGuidanceService.updateDataGuidance,
       ).not.toHaveBeenCalled();
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Save guidance' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Save guidance' }));
 
       await waitFor(() => {
         expect(
@@ -580,7 +568,7 @@ describe('ReleaseDataGuidanceSection', () => {
         testDataGuidance,
       );
 
-      render(
+      const { user } = render(
         <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
       );
 
@@ -590,8 +578,8 @@ describe('ReleaseDataGuidanceSection', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.clear(screen.getByLabelText('Main guidance content'));
-      await userEvent.type(
+      await user.clear(screen.getByLabelText('Main guidance content'));
+      await user.type(
         screen.getByLabelText('Main guidance content'),
         '<p>Updated main guidance content</p>',
       );
@@ -601,14 +589,14 @@ describe('ReleaseDataGuidanceSection', () => {
       const dataSet1 = within(dataSets[0]);
       const dataSet2 = within(dataSets[1]);
 
-      await userEvent.clear(dataSet1.getByLabelText('File guidance content'));
-      await userEvent.type(
+      await user.clear(dataSet1.getByLabelText('File guidance content'));
+      await user.type(
         dataSet1.getByLabelText('File guidance content'),
         '<p>Updated data set 1 guidance content</p>',
       );
 
-      await userEvent.clear(dataSet2.getByLabelText('File guidance content'));
-      await userEvent.type(
+      await user.clear(dataSet2.getByLabelText('File guidance content'));
+      await user.type(
         dataSet2.getByLabelText('File guidance content'),
         '<p>Updated data set 2 guidance content</p>',
       );
@@ -623,9 +611,7 @@ describe('ReleaseDataGuidanceSection', () => {
         releaseDataGuidanceService.updateDataGuidance,
       ).not.toHaveBeenCalled();
 
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Save guidance' }),
-      );
+      await user.click(screen.getByRole('button', { name: 'Save guidance' }));
 
       await waitFor(() => {
         expect(
@@ -746,7 +732,7 @@ describe('ReleaseDataGuidanceSection', () => {
         testDataGuidance,
       );
 
-      render(
+      const { user } = render(
         <ReleaseDataGuidanceSection
           releaseId="release-1"
           canUpdateRelease={false}
@@ -785,7 +771,7 @@ describe('ReleaseDataGuidanceSection', () => {
               </p>
           `);
 
-      await userEvent.click(
+      await user.click(
         dataSet1.getByRole('button', {
           name: 'Variable names and descriptions',
         }),
@@ -807,9 +793,7 @@ describe('ReleaseDataGuidanceSection', () => {
       expect(dataSet1VariableRow2Cells[0]).toHaveTextContent('indicator_1');
       expect(dataSet1VariableRow2Cells[1]).toHaveTextContent('Indicator 1');
 
-      await userEvent.click(
-        dataSet1.getByRole('button', { name: 'Footnotes' }),
-      );
+      await user.click(dataSet1.getByRole('button', { name: 'Footnotes' }));
 
       const dataSet1Footnotes = within(
         dataSet1.getByTestId('Footnotes'),
@@ -838,7 +822,7 @@ describe('ReleaseDataGuidanceSection', () => {
               </p>
           `);
 
-      await userEvent.click(
+      await user.click(
         dataSet2.getByRole('button', {
           name: 'Variable names and descriptions',
         }),
@@ -860,9 +844,7 @@ describe('ReleaseDataGuidanceSection', () => {
       expect(dataSet2VariableRow2Cells[0]).toHaveTextContent('indicator_2');
       expect(dataSet2VariableRow2Cells[1]).toHaveTextContent('Indicator 2');
 
-      await userEvent.click(
-        dataSet2.getByRole('button', { name: 'Footnotes' }),
-      );
+      await user.click(dataSet2.getByRole('button', { name: 'Footnotes' }));
 
       const dataSet2Footnotes = within(
         dataSet2.getByTestId('Footnotes'),

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -5,13 +5,13 @@ import _releaseDataFileService, {
   UploadDataFilesRequest,
   UploadZipDataFileRequest,
 } from '@admin/services/releaseDataFileService';
-import { render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import _permissionService, {
   DataFilePermissions,
 } from '@admin/services/permissionService';
+import render from '@common-test/render';
 
 jest.mock('@admin/services/releaseDataFileService');
 jest.mock('@admin/services/permissionService');
@@ -327,7 +327,7 @@ describe('ReleaseDataUploadsSection', () => {
         footnoteIds: ['footnote-1'],
       });
 
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -349,7 +349,7 @@ describe('ReleaseDataUploadsSection', () => {
         }),
       ).toBeInTheDocument();
 
-      await userEvent.click(
+      await user.click(
         within(sections[1]).getByRole('button', {
           name: 'Delete files',
         }),
@@ -411,7 +411,7 @@ describe('ReleaseDataUploadsSection', () => {
       });
       releaseDataFileService.deleteDataFiles.mockResolvedValue();
 
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -433,7 +433,7 @@ describe('ReleaseDataUploadsSection', () => {
         }),
       ).toBeInTheDocument();
 
-      await userEvent.click(
+      await user.click(
         within(sections[1]).getByRole('button', {
           name: 'Delete files',
         }),
@@ -445,7 +445,7 @@ describe('ReleaseDataUploadsSection', () => {
         ).toBeInTheDocument();
       });
 
-      await userEvent.click(
+      await user.click(
         within(screen.getByRole('dialog')).getByRole('button', {
           name: 'Confirm',
         }),
@@ -544,7 +544,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('show validation message when no subject title', async () => {
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -554,8 +554,11 @@ describe('ReleaseDataUploadsSection', () => {
         </MemoryRouter>,
       );
 
-      await userEvent.click(screen.getByLabelText('Subject title'));
-      await userEvent.tab();
+      await user.click(
+        screen.getByRole('button', {
+          name: 'Upload data files',
+        }),
+      );
 
       await waitFor(() => {
         expect(
@@ -567,7 +570,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('shows validation message when non-unique subject title', async () => {
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -577,18 +580,15 @@ describe('ReleaseDataUploadsSection', () => {
         </MemoryRouter>,
       );
 
-      await userEvent.type(
-        screen.getByLabelText('Subject title'),
-        'Test data 1',
-      );
+      await user.type(screen.getByLabelText('Subject title'), 'Test data 1');
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', {
           name: 'Upload data files',
         }),
       );
 
-      await userEvent.click(screen.getByLabelText('Subject title'));
+      await user.click(screen.getByLabelText('Subject title'));
 
       await waitFor(() => {
         expect(
@@ -600,7 +600,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('cannot submit with invalid values when trying to upload CSV files', async () => {
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -610,7 +610,7 @@ describe('ReleaseDataUploadsSection', () => {
         </MemoryRouter>,
       );
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', {
           name: 'Upload data files',
         }),
@@ -644,7 +644,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('cannot submit with invalid values when trying to upload ZIP file', async () => {
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -654,8 +654,8 @@ describe('ReleaseDataUploadsSection', () => {
         </MemoryRouter>,
       );
 
-      await userEvent.click(screen.getByLabelText('ZIP file'));
-      await userEvent.click(
+      await user.click(screen.getByLabelText('ZIP file'));
+      await user.click(
         screen.getByRole('button', {
           name: 'Upload data files',
         }),
@@ -696,7 +696,7 @@ describe('ReleaseDataUploadsSection', () => {
       releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
         testQueuedImportStatus,
       );
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -713,20 +713,14 @@ describe('ReleaseDataUploadsSection', () => {
         type: 'text/csv',
       });
 
-      await userEvent.type(
-        screen.getByLabelText('Subject title'),
-        'Test title',
-      );
+      await user.type(screen.getByLabelText('Subject title'), 'Test title');
 
-      await userEvent.upload(
-        screen.getByLabelText('Upload data file'),
-        dataFile,
-      );
-      await userEvent.upload(
+      await user.upload(screen.getByLabelText('Upload data file'), dataFile);
+      await user.upload(
         screen.getByLabelText('Upload metadata file'),
         metadataFile,
       );
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', {
           name: 'Upload data files',
         }),
@@ -802,7 +796,7 @@ describe('ReleaseDataUploadsSection', () => {
         testQueuedImportStatus,
       );
 
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -816,15 +810,12 @@ describe('ReleaseDataUploadsSection', () => {
         type: 'application/zip',
       });
 
-      await userEvent.type(
-        screen.getByLabelText('Subject title'),
-        'Test zip title',
-      );
+      await user.type(screen.getByLabelText('Subject title'), 'Test zip title');
 
-      await userEvent.click(screen.getByLabelText('ZIP file'));
+      await user.click(screen.getByLabelText('ZIP file'));
 
-      await userEvent.upload(screen.getByLabelText('Upload ZIP file'), zipFile);
-      await userEvent.click(
+      await user.upload(screen.getByLabelText('Upload ZIP file'), zipFile);
+      await user.click(
         screen.getByRole('button', {
           name: 'Upload data files',
         }),
@@ -900,7 +891,7 @@ describe('ReleaseDataUploadsSection', () => {
         {} as DataFilePermissions,
       );
 
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -917,20 +908,14 @@ describe('ReleaseDataUploadsSection', () => {
         type: 'text/csv',
       });
 
-      await userEvent.type(
-        screen.getByLabelText('Subject title'),
-        'Test title',
-      );
+      await user.type(screen.getByLabelText('Subject title'), 'Test title');
 
-      await userEvent.upload(
-        screen.getByLabelText('Upload data file'),
-        dataFile,
-      );
-      await userEvent.upload(
+      await user.upload(screen.getByLabelText('Upload data file'), dataFile);
+      await user.upload(
         screen.getByLabelText('Upload metadata file'),
         metadataFile,
       );
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', {
           name: 'Upload data files',
         }),
@@ -973,7 +958,7 @@ describe('ReleaseDataUploadsSection', () => {
         {} as DataFilePermissions,
       );
 
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -987,15 +972,12 @@ describe('ReleaseDataUploadsSection', () => {
         type: 'application/zip',
       });
 
-      await userEvent.type(
-        screen.getByLabelText('Subject title'),
-        'Test title',
-      );
+      await user.type(screen.getByLabelText('Subject title'), 'Test title');
 
-      await userEvent.click(screen.getByLabelText('ZIP file'));
+      await user.click(screen.getByLabelText('ZIP file'));
 
-      await userEvent.upload(screen.getByLabelText('Upload ZIP file'), zipFile);
-      await userEvent.click(
+      await user.upload(screen.getByLabelText('Upload ZIP file'), zipFile);
+      await user.click(
         screen.getByRole('button', {
           name: 'Upload data files',
         }),
@@ -1107,7 +1089,7 @@ describe('ReleaseDataUploadsSection', () => {
         testUploadedDataFile,
       ]);
 
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1123,7 +1105,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section = getAccordionSection(0);
 
-      await userEvent.click(section.getByRole('button', { name: 'Cancel' }));
+      await user.click(section.getByRole('button', { name: 'Cancel' }));
 
       await waitFor(() => {
         expect(
@@ -1155,7 +1137,7 @@ describe('ReleaseDataUploadsSection', () => {
         testUploadedDataFile,
       ]);
 
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1171,7 +1153,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section = getAccordionSection(0);
 
-      await userEvent.click(section.getByRole('button', { name: 'Cancel' }));
+      await user.click(section.getByRole('button', { name: 'Cancel' }));
 
       await waitFor(() => {
         expect(
@@ -1180,7 +1162,7 @@ describe('ReleaseDataUploadsSection', () => {
       });
 
       const modal = within(screen.getByRole('dialog'));
-      await userEvent.click(modal.getByRole('button', { name: 'Confirm' }));
+      await user.click(modal.getByRole('button', { name: 'Confirm' }));
 
       await waitFor(() => {
         expect(releaseDataFileService.cancelImport).toHaveBeenCalledWith(
@@ -1206,7 +1188,7 @@ describe('ReleaseDataUploadsSection', () => {
         testUploadedDataFile,
       ]);
 
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1222,7 +1204,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section = getAccordionSection(0);
 
-      await userEvent.click(section.getByRole('button', { name: 'Cancel' }));
+      await user.click(section.getByRole('button', { name: 'Cancel' }));
 
       await waitFor(() => {
         expect(
@@ -1231,7 +1213,7 @@ describe('ReleaseDataUploadsSection', () => {
       });
 
       const modal = within(screen.getByRole('dialog'));
-      await userEvent.click(modal.getByRole('button', { name: 'Cancel' }));
+      await user.click(modal.getByRole('button', { name: 'Cancel' }));
 
       await waitFor(() => {
         expect(releaseDataFileService.cancelImport).not.toHaveBeenCalled();
@@ -1254,7 +1236,7 @@ describe('ReleaseDataUploadsSection', () => {
       releaseDataFileService.getDataFiles.mockResolvedValue([
         testUploadedDataFile,
       ]);
-      render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1270,7 +1252,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section = getAccordionSection(0);
 
-      await userEvent.click(section.getByRole('button', { name: 'Cancel' }));
+      await user.click(section.getByRole('button', { name: 'Cancel' }));
 
       await waitFor(() => {
         expect(
@@ -1279,7 +1261,7 @@ describe('ReleaseDataUploadsSection', () => {
       });
 
       const modal = within(screen.getByRole('dialog'));
-      await userEvent.click(modal.getByRole('button', { name: 'Confirm' }));
+      await user.click(modal.getByRole('button', { name: 'Confirm' }));
 
       await waitFor(() => {
         expect(releaseDataFileService.cancelImport).toHaveBeenCalledWith(

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseFileUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseFileUploadsSection.test.tsx
@@ -4,7 +4,6 @@ import _releaseAncillaryFileService, {
 } from '@admin/services/releaseAncillaryFileService';
 import render from '@common-test/render';
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 
@@ -124,7 +123,7 @@ describe('ReleaseFileUploadsSection', () => {
     test('clicking delete file button shows modal to confirm deletion', async () => {
       releaseAncillaryFileService.listFiles.mockResolvedValue(testFiles);
 
-      renderPage();
+      const { user } = renderPage();
 
       await waitFor(() => {
         expect(screen.getAllByTestId('accordionSection')).toHaveLength(2);
@@ -139,7 +138,7 @@ describe('ReleaseFileUploadsSection', () => {
         }),
       ).toBeInTheDocument();
 
-      await userEvent.click(
+      await user.click(
         within(sections[1]).getByRole('button', {
           name: 'Delete file',
         }),
@@ -162,7 +161,7 @@ describe('ReleaseFileUploadsSection', () => {
         testFiles[0],
       ]);
 
-      renderPage();
+      const { user } = renderPage();
 
       await waitFor(() => {
         expect(screen.getAllByTestId('accordionSection')).toHaveLength(2);
@@ -172,7 +171,7 @@ describe('ReleaseFileUploadsSection', () => {
 
       const sections = screen.getAllByTestId('accordionSection');
 
-      await userEvent.click(
+      await user.click(
         within(sections[1]).getByRole('button', {
           name: 'Delete file',
         }),
@@ -188,7 +187,7 @@ describe('ReleaseFileUploadsSection', () => {
 
       expect(releaseAncillaryFileService.deleteFile).not.toHaveBeenCalled();
 
-      await userEvent.click(
+      await user.click(
         within(screen.getByRole('dialog')).getByRole('button', {
           name: 'Confirm',
         }),
@@ -224,15 +223,15 @@ describe('ReleaseFileUploadsSection', () => {
     });
 
     test('shows validation message when no `file` selected', async () => {
-      renderPage();
+      const { user } = renderPage();
 
-      await userEvent.click(screen.getByLabelText('Upload file'));
+      await user.click(screen.getByLabelText('Upload file'));
       fireEvent.change(screen.getByLabelText('Upload file'), {
         target: {
           value: null,
         },
       });
-      await userEvent.tab();
+      await user.click(screen.getByRole('button', { name: 'Add file' }));
 
       await waitFor(
         () => {
@@ -250,13 +249,13 @@ describe('ReleaseFileUploadsSection', () => {
     });
 
     test('shows validation message when `file` uploaded is an empty file', async () => {
-      renderPage();
+      const { user } = renderPage();
 
-      await userEvent.upload(
+      await user.upload(
         screen.getByLabelText('Upload file'),
         new File([''], 'test.txt'),
       );
-      await userEvent.click(screen.getByRole('button', { name: 'Add file' }));
+      await user.click(screen.getByRole('button', { name: 'Add file' }));
 
       await waitFor(() => {
         expect(
@@ -268,9 +267,9 @@ describe('ReleaseFileUploadsSection', () => {
     });
 
     test('cannot submit with invalid values', async () => {
-      renderPage();
+      const { user } = renderPage();
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', {
           name: 'Add file',
         }),
@@ -313,15 +312,15 @@ describe('ReleaseFileUploadsSection', () => {
         created: '2021-05-25T00:00:00',
       });
 
-      renderPage();
+      const { user } = renderPage();
 
       const file = new File(['test'], 'test-file.txt');
 
-      await userEvent.type(screen.getByLabelText('Title'), 'Test title');
-      await userEvent.type(screen.getByLabelText('Summary'), 'Test summary');
+      await user.type(screen.getByLabelText('Title'), 'Test title');
+      await user.type(screen.getByLabelText('Summary'), 'Test summary');
 
-      await userEvent.upload(screen.getByLabelText('Upload file'), file);
-      await userEvent.click(
+      await user.upload(screen.getByLabelText('Upload file'), file);
+      await user.click(
         screen.getByRole('button', {
           name: 'Add file',
         }),
@@ -359,15 +358,15 @@ describe('ReleaseFileUploadsSection', () => {
         newTestFile,
       ]);
 
-      renderPage();
+      const { user } = renderPage();
 
       const file = new File(['test'], 'test-file.docx');
 
-      await userEvent.type(screen.getByLabelText('Title'), 'Test file 3');
-      await userEvent.type(screen.getByLabelText('Summary'), 'Test summary 3');
-      await userEvent.upload(screen.getByLabelText('Upload file'), file);
+      await user.type(screen.getByLabelText('Title'), 'Test file 3');
+      await user.type(screen.getByLabelText('Summary'), 'Test summary 3');
+      await user.upload(screen.getByLabelText('Upload file'), file);
 
-      await userEvent.click(
+      await user.click(
         screen.getByRole('button', {
           name: 'Add file',
         }),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockDetailsForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockDetailsForm.test.tsx
@@ -1,8 +1,8 @@
 import DataBlockDetailsForm, {
   DataBlockDetailsFormValues,
 } from '@admin/pages/release/datablocks/components/DataBlockDetailsForm';
-import { render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
+import { screen, waitFor, within } from '@testing-library/react';
 import noop from 'lodash/noop';
 import React from 'react';
 
@@ -33,11 +33,9 @@ describe('DataBlockDetailsForm', () => {
   });
 
   test('shows validation error if name is empty', async () => {
-    const user = userEvent.setup();
-    render(<DataBlockDetailsForm onSubmit={noop} />);
+    const { user } = render(<DataBlockDetailsForm onSubmit={noop} />);
 
-    await user.click(screen.getByLabelText('Name'));
-    await user.tab();
+    await user.click(screen.getByRole('button', { name: 'Save data block' }));
 
     expect(await screen.findByText('There is a problem')).toBeInTheDocument();
 
@@ -47,11 +45,9 @@ describe('DataBlockDetailsForm', () => {
   });
 
   test('shows validation error if table title is empty', async () => {
-    const user = userEvent.setup();
-    render(<DataBlockDetailsForm onSubmit={noop} />);
+    const { user } = render(<DataBlockDetailsForm onSubmit={noop} />);
 
-    await user.click(screen.getByLabelText('Table title'));
-    await user.tab();
+    await user.click(screen.getByRole('button', { name: 'Save data block' }));
 
     expect(await screen.findByText('There is a problem')).toBeInTheDocument();
 
@@ -61,8 +57,7 @@ describe('DataBlockDetailsForm', () => {
   });
 
   test('shows validation error if no name when featured table checkbox is checked', async () => {
-    const user = userEvent.setup();
-    render(<DataBlockDetailsForm onSubmit={noop} />);
+    const { user } = render(<DataBlockDetailsForm onSubmit={noop} />);
 
     await user.click(
       screen.getByLabelText('Set as a featured table for this publication'),
@@ -70,8 +65,7 @@ describe('DataBlockDetailsForm', () => {
 
     expect(screen.getByLabelText('Featured table name')).toBeInTheDocument();
 
-    await user.click(screen.getByLabelText('Featured table name'));
-    await user.tab();
+    await user.click(screen.getByRole('button', { name: 'Save data block' }));
 
     expect(await screen.findByText('There is a problem')).toBeInTheDocument();
 
@@ -81,8 +75,7 @@ describe('DataBlockDetailsForm', () => {
   });
 
   test('shows validation error if featured table name is entirely a whitespace string', async () => {
-    const user = userEvent.setup();
-    render(
+    const { user } = render(
       <DataBlockDetailsForm
         initialValues={{
           name: 'Test name',
@@ -113,9 +106,9 @@ describe('DataBlockDetailsForm', () => {
   });
 
   test('shows validation error if no description when featured table checkbox is checked', async () => {
-    render(<DataBlockDetailsForm onSubmit={noop} />);
+    const { user } = render(<DataBlockDetailsForm onSubmit={noop} />);
 
-    await userEvent.click(
+    await user.click(
       screen.getByLabelText('Set as a featured table for this publication'),
     );
 
@@ -123,8 +116,7 @@ describe('DataBlockDetailsForm', () => {
       screen.getByLabelText('Featured table description'),
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByLabelText('Featured table description'));
-    await userEvent.tab();
+    await user.click(screen.getByRole('button', { name: 'Save data block' }));
 
     await waitFor(() => {
       expect(
@@ -136,8 +128,7 @@ describe('DataBlockDetailsForm', () => {
   });
 
   test('submitting form with invalid values and featured table checked shows error messages', async () => {
-    const user = userEvent.setup();
-    render(<DataBlockDetailsForm onSubmit={noop} />);
+    const { user } = render(<DataBlockDetailsForm onSubmit={noop} />);
 
     await user.click(
       screen.getByLabelText('Set as a featured table for this publication'),
@@ -170,8 +161,7 @@ describe('DataBlockDetailsForm', () => {
   });
 
   test('submitting form with invalid values and featured table unchecked shows error messages', async () => {
-    const user = userEvent.setup();
-    render(<DataBlockDetailsForm onSubmit={noop} />);
+    const { user } = render(<DataBlockDetailsForm onSubmit={noop} />);
 
     await user.click(screen.getByRole('button', { name: 'Save data block' }));
 
@@ -189,8 +179,8 @@ describe('DataBlockDetailsForm', () => {
 
   test('successfully submits form with valid values', async () => {
     const handleSubmit = jest.fn();
-    const user = userEvent.setup();
-    render(<DataBlockDetailsForm onSubmit={handleSubmit} />);
+
+    const { user } = render(<DataBlockDetailsForm onSubmit={handleSubmit} />);
 
     await user.type(screen.getByLabelText('Name'), 'Test name');
     await user.type(screen.getByLabelText('Table title'), 'Test title');
@@ -228,8 +218,8 @@ describe('DataBlockDetailsForm', () => {
 
   test('trim featured table name and description values', async () => {
     const handleSubmit = jest.fn();
-    const user = userEvent.setup();
-    render(<DataBlockDetailsForm onSubmit={handleSubmit} />);
+
+    const { user } = render(<DataBlockDetailsForm onSubmit={handleSubmit} />);
 
     await user.type(screen.getByLabelText('Name'), 'Test name');
     await user.type(screen.getByLabelText('Table title'), 'Test title');

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataGroupingForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataGroupingForm.tsx
@@ -200,6 +200,7 @@ export default function ChartDataGroupingForm({
         numberOfGroupsQuantiles: dataSetConfig.dataGrouping.numberOfGroups,
         copyCustomGroups: undefined,
       }}
+      mode="onBlur"
       validationSchema={validationSchema}
     >
       {({ resetField, setValue, watch }) => {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
@@ -235,6 +235,7 @@ const ChartLegendConfiguration = ({
     <FormProvider
       enableReinitialize
       initialValues={initialValues}
+      mode="onBlur"
       validationSchema={validationSchema}
     >
       {({ formState, watch }) => {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLineConfigurationForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLineConfigurationForm.tsx
@@ -38,12 +38,11 @@ export default function ChartReferenceLineConfigurationForm({
   majorAxisOptions,
   onSave,
 }: Props) {
-  const { formState, setError, watch } =
+  const { formState, setError, watch, trigger } =
     useFormContext<ChartAxisConfigurationFormValues>();
   const values = watch();
   const referenceLine = values.referenceLines?.[index];
   const { axis, type: axisType } = axisDefinition || {};
-
   return (
     <>
       <td className="dfe-vertical-align--bottom">
@@ -68,6 +67,7 @@ export default function ChartReferenceLineConfigurationForm({
                     ]
                   : []),
               ]}
+              onBlur={() => trigger(`referenceLines.${index}.position`)}
             />
             {referenceLine?.position ===
               otherAxisPositionTypes.betweenDataPoints && (
@@ -88,6 +88,9 @@ export default function ChartReferenceLineConfigurationForm({
                   placeholder="Start point"
                   order={FormSelect.unordered}
                   options={majorAxisOptions}
+                  onBlur={() =>
+                    trigger(`referenceLines.${index}.otherAxisStart`)
+                  }
                 />
                 <br />
                 <FormFieldSelect<ChartAxisConfigurationFormValues>
@@ -99,6 +102,7 @@ export default function ChartReferenceLineConfigurationForm({
                   placeholder="End point"
                   order={FormSelect.unordered}
                   options={majorAxisOptions}
+                  onBlur={() => trigger(`referenceLines.${index}.otherAxisEnd`)}
                 />
               </FormFieldset>
             )}
@@ -110,6 +114,7 @@ export default function ChartReferenceLineConfigurationForm({
             label="Position"
             formGroup={false}
             hideLabel
+            onBlur={() => trigger(`referenceLines.${index}.position`)}
           />
         )}
       </td>
@@ -137,6 +142,9 @@ export default function ChartReferenceLineConfigurationForm({
                   value: otherAxisPositionTypes.betweenDataPoints,
                 },
               ]}
+              onBlur={() =>
+                trigger(`referenceLines.${index}.otherAxisPositionType`)
+              }
             />
 
             {referenceLine?.otherAxisPositionType !==
@@ -151,6 +159,9 @@ export default function ChartReferenceLineConfigurationForm({
                       label={`Percent along ${axis === 'x' ? 'Y' : 'X'} axis`}
                       formGroup={false}
                       width={10}
+                      onBlur={() =>
+                        trigger(`referenceLines.${index}.otherAxisPosition`)
+                      }
                     />
                   </div>
                 ) : (
@@ -171,6 +182,9 @@ export default function ChartReferenceLineConfigurationForm({
                       placeholder="Start point"
                       order={FormSelect.unordered}
                       options={majorAxisOptions}
+                      onBlur={() =>
+                        trigger(`referenceLines.${index}.otherAxisStart`)
+                      }
                     />
                     <br />
                     <FormFieldSelect<ChartAxisConfigurationFormValues>
@@ -182,6 +196,9 @@ export default function ChartReferenceLineConfigurationForm({
                       placeholder="End point"
                       order={FormSelect.unordered}
                       options={majorAxisOptions}
+                      onBlur={() =>
+                        trigger(`referenceLines.${index}.otherAxisEnd`)
+                      }
                     />
                   </FormFieldset>
                 )}
@@ -202,6 +219,7 @@ export default function ChartReferenceLineConfigurationForm({
                 : ''
             }`}
             width={10}
+            onBlur={() => trigger(`referenceLines.${index}.otherAxisPosition`)}
           />
         )}
       </td>
@@ -212,6 +230,7 @@ export default function ChartReferenceLineConfigurationForm({
           label="Label"
           formGroup={false}
           hideLabel
+          onBlur={() => trigger(`referenceLines.${index}.label`)}
         />
       </td>
       <td className="dfe-vertical-align--bottom">
@@ -223,6 +242,7 @@ export default function ChartReferenceLineConfigurationForm({
           formGroup={false}
           hideLabel
           width={10}
+          onBlur={() => trigger(`referenceLines.${index}.labelWidth`)}
         />
       </td>
       <td className="dfe-vertical-align--bottom">
@@ -239,6 +259,7 @@ export default function ChartReferenceLineConfigurationForm({
             { label: 'Solid', value: 'solid' },
             { label: 'None', value: 'none' },
           ]}
+          onBlur={() => trigger(`referenceLines.${index}.style`)}
         />
       </td>
       <td className="dfe-vertical-align--bottom">

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.tsx
@@ -1,6 +1,6 @@
 import styles from '@admin/pages/release/datablocks/components/chart/ChartReferenceLinesConfiguration.module.scss';
 import { ChartAxisConfigurationFormValues } from '@admin/pages/release/datablocks/components/chart/ChartAxisConfiguration';
-import ChartReferenceLineForm from '@admin/pages/release/datablocks/components/chart/ChartReferenceLineConfigurationForm';
+import ChartReferenceLineConfigurationForm from '@admin/pages/release/datablocks/components/chart/ChartReferenceLineConfigurationForm';
 import ButtonGroup from '@common/components/ButtonGroup';
 import Button from '@common/components/Button';
 
@@ -145,7 +145,7 @@ export default function ChartReferenceLinesConfiguration({
             {filteredReferenceLines.map((referenceLine, index) => (
               <tr key={`line-${index.toString()}`}>
                 {isEqual(referenceLine, editingLine) ? (
-                  <ChartReferenceLineForm
+                  <ChartReferenceLineConfigurationForm
                     axisDefinition={axisDefinition}
                     axisPositionOptions={majorAxisOptions}
                     chartType={chartType}
@@ -210,7 +210,7 @@ export default function ChartReferenceLinesConfiguration({
             ))}
             {showAddNewLineForm && !editingLine && (
               <tr>
-                <ChartReferenceLineForm
+                <ChartReferenceLineConfigurationForm
                   axisDefinition={axisDefinition}
                   axisPositionOptions={filteredOptions}
                   chartType={chartType}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
@@ -263,7 +263,9 @@ describe('ChartAxisConfiguration', () => {
     await user.click(screen.getByLabelText('Custom'));
     await user.clear(screen.getByLabelText('Every nth value'));
     await user.type(screen.getByLabelText('Every nth value'), 'x');
-    await user.tab();
+    await user.click(
+      screen.getByRole('button', { name: 'Save chart options' }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -275,8 +277,9 @@ describe('ChartAxisConfiguration', () => {
 
     await user.clear(screen.getByLabelText('Every nth value'));
     await user.type(screen.getByLabelText('Every nth value'), '-1');
-    await user.tab();
-
+    await user.click(
+      screen.getByRole('button', { name: 'Save chart options' }),
+    );
     await waitFor(() => {
       expect(screen.getByText('There is a problem')).toBeInTheDocument();
     });
@@ -303,7 +306,9 @@ describe('ChartAxisConfiguration', () => {
     );
 
     await user.type(screen.getByLabelText('Width (pixels)'), '-1');
-    await user.tab();
+    await user.click(
+      screen.getByRole('button', { name: 'Save chart options' }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -331,7 +336,9 @@ describe('ChartAxisConfiguration', () => {
     );
     await user.clear(screen.getByLabelText('Size of axis (pixels)'));
     await user.type(screen.getByLabelText('Size of axis (pixels)'), '-1');
-    await user.tab();
+    await user.click(
+      screen.getByRole('button', { name: 'Save chart options' }),
+    );
 
     expect(await screen.findByText('There is a problem')).toBeInTheDocument();
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartConfiguration.test.tsx
@@ -474,7 +474,9 @@ describe('ChartConfiguration', () => {
       'below',
     ]);
 
-    await user.tab();
+    await user.click(
+      screen.getByRole('button', { name: 'Save chart options' }),
+    );
 
     await waitFor(() => {
       expect(

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/__tests__/PreReleaseUserAccessForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/__tests__/PreReleaseUserAccessForm.test.tsx
@@ -1,10 +1,10 @@
 import _preReleaseUserService, {
   PreReleaseUser,
 } from '@admin/services/preReleaseUserService';
-import { render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import PreReleaseUserAccessForm from '@admin/pages/release/pre-release/components/PreReleaseUserAccessForm';
+import render from '@common-test/render';
 
 const preReleaseUserService = _preReleaseUserService as jest.Mocked<
   typeof _preReleaseUserService
@@ -110,10 +110,11 @@ describe('PreReleaseUserAccessForm', () => {
 
   describe('inviting new users', () => {
     test('shows validation message when there are no email values', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(
@@ -121,8 +122,9 @@ describe('PreReleaseUserAccessForm', () => {
         ).toBeInTheDocument();
       });
 
-      await user.click(screen.getByLabelText('Invite new users by email'));
-      await user.tab();
+      await user.click(
+        screen.getByRole('button', { name: 'Invite new users' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -134,10 +136,11 @@ describe('PreReleaseUserAccessForm', () => {
     });
 
     test('shows validation message when the number of email lines exceeds the upper limit', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(
@@ -148,7 +151,10 @@ describe('PreReleaseUserAccessForm', () => {
       const emailsTextarea = screen.getByLabelText('Invite new users by email');
       // type values up to but not exceeding the limit of lines
       await user.type(emailsTextarea, `test@test.com{enter}`.repeat(50));
-      await user.tab();
+
+      await user.click(
+        screen.getByRole('button', { name: 'Invite new users' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -160,7 +166,10 @@ describe('PreReleaseUserAccessForm', () => {
 
       // now exceed the limit
       await user.type(emailsTextarea, `{enter}test@test.com`);
-      await user.tab();
+
+      await user.click(
+        screen.getByRole('button', { name: 'Invite new users' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -172,10 +181,11 @@ describe('PreReleaseUserAccessForm', () => {
     });
 
     test('shows validation message when emails contains invalid values', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(
@@ -195,7 +205,9 @@ describe('PreReleaseUserAccessForm', () => {
         screen.getByLabelText('Invite new users by email'),
         '{enter}invalid-2',
       );
-      await user.tab();
+      await user.click(
+        screen.getByRole('button', { name: 'Invite new users' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -207,10 +219,11 @@ describe('PreReleaseUserAccessForm', () => {
     });
 
     test('shows validation message when email has more than one @', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(
@@ -222,7 +235,9 @@ describe('PreReleaseUserAccessForm', () => {
         screen.getByLabelText('Invite new users by email'),
         'test@test.com@test',
       );
-      await user.tab();
+      await user.click(
+        screen.getByRole('button', { name: 'Invite new users' }),
+      );
 
       await waitFor(() => {
         expect(
@@ -237,10 +252,11 @@ describe('PreReleaseUserAccessForm', () => {
     });
 
     test('shows validation message when email has invalid domain', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(
@@ -252,8 +268,9 @@ describe('PreReleaseUserAccessForm', () => {
         screen.getByLabelText('Invite new users by email'),
         'test@test.',
       );
-      await user.tab();
-
+      await user.click(
+        screen.getByRole('button', { name: 'Invite new users' }),
+      );
       await waitFor(() => {
         expect(
           screen.getByText("'test@test.' is not a valid email address", {
@@ -264,10 +281,11 @@ describe('PreReleaseUserAccessForm', () => {
     });
 
     test('submitting form with no values shows a validation error', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(
@@ -289,10 +307,11 @@ describe('PreReleaseUserAccessForm', () => {
     });
 
     test('submitting form with invalid values shows a validation error', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(
@@ -327,10 +346,11 @@ describe('PreReleaseUserAccessForm', () => {
     });
 
     test('whitespace is trimmed and blank lines are filtered without causing a validation error', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(
@@ -356,10 +376,11 @@ describe('PreReleaseUserAccessForm', () => {
     });
 
     test('accepts a range of valid values without causing a validation error', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(
@@ -376,7 +397,6 @@ describe('PreReleaseUserAccessForm', () => {
           'test@education.gov.uk{enter}' +
           'test@gov.wales',
       );
-      await user.tab();
 
       await user.click(
         screen.getByRole('button', { name: 'Invite new users' }),
@@ -398,10 +418,11 @@ describe('PreReleaseUserAccessForm', () => {
     });
 
     test('submitting the form opens confirmation modal with invite plan', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(
@@ -491,10 +512,11 @@ describe('PreReleaseUserAccessForm', () => {
     });
 
     test('cancelling the confirmation closes the modal', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(
@@ -539,8 +561,7 @@ describe('PreReleaseUserAccessForm', () => {
     });
 
     test('confirmation modal displays correct notifications warning when release is approved', async () => {
-      const user = userEvent.setup();
-      render(
+      const { user } = render(
         <PreReleaseUserAccessForm releaseId="release-1" isReleaseApproved />,
       );
 
@@ -579,10 +600,11 @@ describe('PreReleaseUserAccessForm', () => {
     });
 
     test('accepting the confirmation modal adds newly invited users to list', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(
@@ -657,10 +679,11 @@ describe('PreReleaseUserAccessForm', () => {
 
   describe('removing user', () => {
     test('clicking Remove button removes user from the list', async () => {
-      const user = userEvent.setup();
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-      render(<PreReleaseUserAccessForm releaseId="release-1" />);
+      const { user } = render(
+        <PreReleaseUserAccessForm releaseId="release-1" />,
+      );
 
       await waitFor(() => {
         expect(

--- a/src/explore-education-statistics-admin/src/pages/themes/components/__tests__/ThemeForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/themes/components/__tests__/ThemeForm.test.tsx
@@ -1,67 +1,47 @@
 import ThemeForm, {
   ThemeFormValues,
 } from '@admin/pages/themes/components/ThemeForm';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
 import noop from 'lodash/noop';
 import React from 'react';
 
 describe('ThemeForm', () => {
-  test('shows validation error when there is no title', async () => {
-    render(<ThemeForm onSubmit={noop} />);
-
-    await userEvent.click(screen.getByLabelText('Title'));
-    await userEvent.tab();
-
-    await waitFor(() => {
-      expect(
-        screen.getByText('Enter a title', {
-          selector: '#themeForm-title-error',
-        }),
-      ).toBeInTheDocument();
-    });
-  });
-
-  test('shows validation error when there is no summary', async () => {
-    render(<ThemeForm onSubmit={noop} />);
-
-    await userEvent.click(screen.getByLabelText('Summary'));
-    await userEvent.tab();
-
-    await waitFor(() => {
-      expect(
-        screen.getByText('Enter a summary', {
-          selector: '#themeForm-summary-error',
-        }),
-      ).toBeInTheDocument();
-    });
-  });
-
   test('cannot submit with invalid values', async () => {
     const handleSubmit = jest.fn();
 
-    render(<ThemeForm onSubmit={handleSubmit} />);
+    const { user } = render(<ThemeForm onSubmit={handleSubmit} />);
 
     expect(handleSubmit).not.toHaveBeenCalled();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save theme' }));
+    await user.click(screen.getByRole('button', { name: 'Save theme' }));
 
-    await waitFor(() => {
-      expect(handleSubmit).not.toHaveBeenCalled();
-    });
+    expect(
+      await screen.findByText('Enter a title', {
+        selector: '#themeForm-title-error',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByText('Enter a summary', {
+        selector: '#themeForm-summary-error',
+      }),
+    ).toBeInTheDocument();
+
+    expect(handleSubmit).not.toHaveBeenCalled();
   });
 
   test('can submit with valid values', async () => {
     const handleSubmit = jest.fn();
 
-    render(<ThemeForm onSubmit={handleSubmit} />);
+    const { user } = render(<ThemeForm onSubmit={handleSubmit} />);
 
-    await userEvent.type(screen.getByLabelText('Title'), 'Test title');
-    await userEvent.type(screen.getByLabelText('Summary'), 'Test summary');
+    await user.type(screen.getByLabelText('Title'), 'Test title');
+    await user.type(screen.getByLabelText('Summary'), 'Test summary');
 
     expect(handleSubmit).not.toHaveBeenCalled();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save theme' }));
+    await user.click(screen.getByRole('button', { name: 'Save theme' }));
 
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledWith({
@@ -92,31 +72,41 @@ describe('ThemeForm', () => {
     test('cannot submit with updated invalid values', async () => {
       const handleSubmit = jest.fn();
 
-      render(<ThemeForm onSubmit={handleSubmit} />);
+      const { user } = render(<ThemeForm onSubmit={handleSubmit} />);
 
       expect(handleSubmit).not.toHaveBeenCalled();
 
-      await userEvent.clear(screen.getByLabelText('Title'));
-      await userEvent.clear(screen.getByLabelText('Summary'));
+      await user.clear(screen.getByLabelText('Title'));
+      await user.clear(screen.getByLabelText('Summary'));
 
-      await userEvent.click(screen.getByRole('button', { name: 'Save theme' }));
+      await user.click(screen.getByRole('button', { name: 'Save theme' }));
 
-      await waitFor(() => {
-        expect(handleSubmit).not.toHaveBeenCalled();
-      });
+      expect(
+        await screen.findByText('Enter a title', {
+          selector: '#themeForm-title-error',
+        }),
+      ).toBeInTheDocument();
+
+      expect(
+        await screen.findByText('Enter a summary', {
+          selector: '#themeForm-summary-error',
+        }),
+      ).toBeInTheDocument();
+
+      expect(handleSubmit).not.toHaveBeenCalled();
     });
 
     test('can submit with updated valid values', async () => {
       const handleSubmit = jest.fn();
 
-      render(<ThemeForm onSubmit={handleSubmit} />);
+      const { user } = render(<ThemeForm onSubmit={handleSubmit} />);
 
-      await userEvent.type(screen.getByLabelText('Title'), 'Updated title');
-      await userEvent.type(screen.getByLabelText('Summary'), 'Updated summary');
+      await user.type(screen.getByLabelText('Title'), 'Updated title');
+      await user.type(screen.getByLabelText('Summary'), 'Updated summary');
 
       expect(handleSubmit).not.toHaveBeenCalled();
 
-      await userEvent.click(screen.getByRole('button', { name: 'Save theme' }));
+      await user.click(screen.getByRole('button', { name: 'Save theme' }));
 
       await waitFor(() => {
         expect(handleSubmit).toHaveBeenCalledWith({

--- a/src/explore-education-statistics-admin/src/pages/themes/topics/components/__tests__/TopicForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/themes/topics/components/__tests__/TopicForm.test.tsx
@@ -1,51 +1,40 @@
 import TopicForm, {
   TopicFormValues,
 } from '@admin/pages/themes/topics/components/TopicForm';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
 import noop from 'lodash/noop';
 import React from 'react';
 
 describe('ThemeForm', () => {
-  test('shows validation error when there is no title', async () => {
-    render(<TopicForm onSubmit={noop} />);
-
-    await userEvent.click(screen.getByLabelText('Title'));
-    await userEvent.tab();
-
-    await waitFor(() => {
-      expect(
-        screen.getByText('Enter a title', {
-          selector: '#topicForm-title-error',
-        }),
-      ).toBeInTheDocument();
-    });
-  });
-
   test('cannot submit with invalid values', async () => {
     const handleSubmit = jest.fn();
 
-    render(<TopicForm onSubmit={handleSubmit} />);
+    const { user } = render(<TopicForm onSubmit={handleSubmit} />);
 
     expect(handleSubmit).not.toHaveBeenCalled();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save topic' }));
+    await user.click(screen.getByRole('button', { name: 'Save topic' }));
 
-    await waitFor(() => {
-      expect(handleSubmit).not.toHaveBeenCalled();
-    });
+    expect(
+      await screen.findByText('Enter a title', {
+        selector: '#topicForm-title-error',
+      }),
+    ).toBeInTheDocument();
+
+    expect(handleSubmit).not.toHaveBeenCalled();
   });
 
   test('can submit with valid values', async () => {
     const handleSubmit = jest.fn();
 
-    render(<TopicForm onSubmit={handleSubmit} />);
+    const { user } = render(<TopicForm onSubmit={handleSubmit} />);
 
-    await userEvent.type(screen.getByLabelText('Title'), 'Test title');
+    await user.type(screen.getByLabelText('Title'), 'Test title');
 
     expect(handleSubmit).not.toHaveBeenCalled();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save topic' }));
+    await user.click(screen.getByRole('button', { name: 'Save topic' }));
 
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledWith({
@@ -73,29 +62,33 @@ describe('ThemeForm', () => {
     test('cannot submit with updated invalid values', async () => {
       const handleSubmit = jest.fn();
 
-      render(<TopicForm onSubmit={handleSubmit} />);
+      const { user } = render(<TopicForm onSubmit={handleSubmit} />);
 
       expect(handleSubmit).not.toHaveBeenCalled();
 
-      await userEvent.clear(screen.getByLabelText('Title'));
+      await user.clear(screen.getByLabelText('Title'));
 
-      await userEvent.click(screen.getByRole('button', { name: 'Save topic' }));
+      await user.click(screen.getByRole('button', { name: 'Save topic' }));
 
-      await waitFor(() => {
-        expect(handleSubmit).not.toHaveBeenCalled();
-      });
+      expect(
+        await screen.findByText('Enter a title', {
+          selector: '#topicForm-title-error',
+        }),
+      ).toBeInTheDocument();
+
+      expect(handleSubmit).not.toHaveBeenCalled();
     });
 
     test('can submit with updated valid values', async () => {
       const handleSubmit = jest.fn();
 
-      render(<TopicForm onSubmit={handleSubmit} />);
+      const { user } = render(<TopicForm onSubmit={handleSubmit} />);
 
-      await userEvent.type(screen.getByLabelText('Title'), 'Updated title');
+      await user.type(screen.getByLabelText('Title'), 'Updated title');
 
       expect(handleSubmit).not.toHaveBeenCalled();
 
-      await userEvent.click(screen.getByRole('button', { name: 'Save topic' }));
+      await user.click(screen.getByRole('button', { name: 'Save topic' }));
 
       await waitFor(() => {
         expect(handleSubmit).toHaveBeenCalledWith({

--- a/src/explore-education-statistics-admin/src/pages/users/__tests__/UserInvitePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/__tests__/UserInvitePage.test.tsx
@@ -13,7 +13,6 @@ import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, Route } from 'react-router';
 import { administrationUserInviteRoute } from '@admin/routes/administrationRoutes';
-import userEvent from '@testing-library/user-event';
 
 jest.mock('@admin/services/publicationService');
 jest.mock('@admin/services/userService');
@@ -25,7 +24,10 @@ const userService = _userService as jest.Mocked<typeof _userService>;
 
 describe('UserInvitePage', () => {
   test('renders correctly', async () => {
-    await renderPage();
+    renderPage();
+    expect(
+      await screen.findByText('Manage access to this service'),
+    ).toBeInTheDocument();
 
     expect(
       screen.getByRole('heading', { name: 'Invite user' }),
@@ -49,11 +51,12 @@ describe('UserInvitePage', () => {
   });
 
   test('shows validation error if user email is empty', async () => {
-    const user = userEvent.setup();
-    await renderPage();
+    const { user } = renderPage();
+    expect(
+      await screen.findByText('Manage access to this service'),
+    ).toBeInTheDocument();
 
-    await user.click(screen.getByLabelText('User email'));
-    await user.tab();
+    await user.click(screen.getByRole('button', { name: 'Send invite' }));
 
     expect(await screen.findByText('There is a problem')).toBeInTheDocument();
     expect(
@@ -68,13 +71,15 @@ describe('UserInvitePage', () => {
   });
 
   test('shows validation error if role is empty', async () => {
-    const user = userEvent.setup();
-    await renderPage();
+    const { user } = renderPage();
+    expect(
+      await screen.findByText('Manage access to this service'),
+    ).toBeInTheDocument();
 
     await user.type(screen.getByLabelText('User email'), 'test@test.com');
 
     await user.selectOptions(screen.getByLabelText('Role'), 'Choose role');
-    await user.tab();
+    await user.click(screen.getByRole('button', { name: 'Send invite' }));
 
     expect(await screen.findByText('There is a problem')).toBeInTheDocument();
     expect(
@@ -90,8 +95,10 @@ describe('UserInvitePage', () => {
 
   describe('adding release roles', () => {
     test('shows validation error if release is empty', async () => {
-      const user = userEvent.setup();
-      await renderPage();
+      const { user } = renderPage();
+      expect(
+        await screen.findByText('Manage access to this service'),
+      ).toBeInTheDocument();
 
       await user.click(
         screen.getByRole('button', { name: 'Add release role' }),
@@ -103,8 +110,10 @@ describe('UserInvitePage', () => {
     });
 
     test('shows validation error if release role is empty', async () => {
-      const user = userEvent.setup();
-      await renderPage();
+      const { user } = renderPage();
+      expect(
+        await screen.findByText('Manage access to this service'),
+      ).toBeInTheDocument();
 
       await user.click(
         screen.getByRole('button', { name: 'Add release role' }),
@@ -116,8 +125,10 @@ describe('UserInvitePage', () => {
     });
 
     test('shows validation error if try to add another role for a release', async () => {
-      const user = userEvent.setup();
-      await renderPage();
+      const { user } = renderPage();
+      expect(
+        await screen.findByText('Manage access to this service'),
+      ).toBeInTheDocument();
 
       await user.selectOptions(screen.getByLabelText('Release'), 'Release 1');
       await user.selectOptions(
@@ -142,8 +153,10 @@ describe('UserInvitePage', () => {
     });
 
     test('successfully adds release roles', async () => {
-      const user = userEvent.setup();
-      await renderPage();
+      const { user } = renderPage();
+      expect(
+        await screen.findByText('Manage access to this service'),
+      ).toBeInTheDocument();
 
       await user.selectOptions(screen.getByLabelText('Release'), 'Release 1');
       await user.selectOptions(
@@ -182,8 +195,10 @@ describe('UserInvitePage', () => {
     });
 
     test('successfully removes release roles', async () => {
-      const user = userEvent.setup();
-      await renderPage();
+      const { user } = renderPage();
+      expect(
+        await screen.findByText('Manage access to this service'),
+      ).toBeInTheDocument();
 
       await user.selectOptions(screen.getByLabelText('Release'), 'Release 1');
       await user.selectOptions(
@@ -216,8 +231,10 @@ describe('UserInvitePage', () => {
 
   describe('adding publication roles', () => {
     test('shows validation error if publication is empty', async () => {
-      const user = userEvent.setup();
-      await renderPage();
+      const { user } = renderPage();
+      expect(
+        await screen.findByText('Manage access to this service'),
+      ).toBeInTheDocument();
 
       await user.click(
         screen.getByRole('button', { name: 'Add publication role' }),
@@ -229,8 +246,10 @@ describe('UserInvitePage', () => {
     });
 
     test('shows validation error if publication role is empty', async () => {
-      const user = userEvent.setup();
-      await renderPage();
+      const { user } = renderPage();
+      expect(
+        await screen.findByText('Manage access to this service'),
+      ).toBeInTheDocument();
 
       await user.click(
         screen.getByRole('button', { name: 'Add publication role' }),
@@ -242,8 +261,10 @@ describe('UserInvitePage', () => {
     });
 
     test('shows validation error if try to add another role for a publication', async () => {
-      const user = userEvent.setup();
-      await renderPage();
+      const { user } = renderPage();
+      expect(
+        await screen.findByText('Manage access to this service'),
+      ).toBeInTheDocument();
 
       await user.selectOptions(
         screen.getByLabelText('Publication'),
@@ -277,8 +298,10 @@ describe('UserInvitePage', () => {
     });
 
     test('successfully adds publication roles', async () => {
-      const user = userEvent.setup();
-      await renderPage();
+      const { user } = renderPage();
+      expect(
+        await screen.findByText('Manage access to this service'),
+      ).toBeInTheDocument();
 
       await user.selectOptions(
         screen.getByLabelText('Publication'),
@@ -328,8 +351,10 @@ describe('UserInvitePage', () => {
     });
 
     test('successfully removes publication roles', async () => {
-      const user = userEvent.setup();
-      await renderPage();
+      const { user } = renderPage();
+      expect(
+        await screen.findByText('Manage access to this service'),
+      ).toBeInTheDocument();
 
       await user.selectOptions(
         screen.getByLabelText('Publication'),
@@ -366,8 +391,10 @@ describe('UserInvitePage', () => {
   });
 
   test('submits successfully without release or publication roles', async () => {
-    const user = userEvent.setup();
-    await renderPage();
+    const { user } = renderPage();
+    expect(
+      await screen.findByText('Manage access to this service'),
+    ).toBeInTheDocument();
 
     await user.type(screen.getByLabelText('User email'), 'test@test.com');
 
@@ -387,8 +414,10 @@ describe('UserInvitePage', () => {
   });
 
   test('submits successfully with release and publication roles', async () => {
-    const user = userEvent.setup();
-    await renderPage();
+    const { user } = renderPage();
+    expect(
+      await screen.findByText('Manage access to this service'),
+    ).toBeInTheDocument();
 
     await user.type(screen.getByLabelText('User email'), 'test@test.com');
 
@@ -429,7 +458,7 @@ describe('UserInvitePage', () => {
     });
   });
 
-  const renderPage = async () => {
+  const renderPage = () => {
     publicationService.getPublicationSummaries.mockResolvedValue(
       testPublicationSummaries,
     );
@@ -437,7 +466,7 @@ describe('UserInvitePage', () => {
     userService.getResourceRoles.mockResolvedValue(testResourceRoles);
     userService.getReleases.mockResolvedValue(testReleases);
 
-    render(
+    return render(
       <MemoryRouter initialEntries={[administrationUserInviteRoute.path]}>
         <TestConfigContextProvider>
           <Route
@@ -447,9 +476,5 @@ describe('UserInvitePage', () => {
         </TestConfigContextProvider>
       </MemoryRouter>,
     );
-
-    expect(
-      await screen.findByText('Manage access to this service'),
-    ).toBeInTheDocument();
   };
 });

--- a/src/explore-education-statistics-common/src/components/form/Form.tsx
+++ b/src/explore-education-statistics-common/src/components/form/Form.tsx
@@ -20,6 +20,7 @@ interface Props<TFormValues extends FieldValues> {
   children: ReactNode;
   id: string;
   initialTouched?: Path<TFormValues>[];
+  noValidate?: boolean;
   submitId?: string;
   showErrorSummary?: boolean;
   visuallyHiddenErrorSummary?: boolean;
@@ -47,6 +48,7 @@ export default function Form<TFormValues extends FieldValues>({
   children,
   id,
   initialTouched,
+  noValidate = true,
   submitId = `${id}-submit`,
   showErrorSummary = true,
   visuallyHiddenErrorSummary = false,
@@ -125,7 +127,7 @@ export default function Form<TFormValues extends FieldValues>({
 
   return (
     <FormIdContextProvider id={id}>
-      <form id={id} onSubmit={handleSubmit}>
+      <form id={id} noValidate={noValidate} onSubmit={handleSubmit}>
         {showErrorSummary && (
           <ErrorSummary
             errors={allErrors}

--- a/src/explore-education-statistics-common/src/components/form/FormProvider.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormProvider.tsx
@@ -32,7 +32,9 @@ interface FormProviderProps<TFormValues extends FieldValues> {
   fallbackErrorMapping?: FieldMessageMapper<TFormValues>;
   fallbackSubmitError?: string;
   initialValues?: UseFormProps<TFormValues>['defaultValues'];
+  mode?: 'onChange' | 'onBlur' | 'onSubmit' | 'onTouched' | 'all';
   resetAfterSubmit?: boolean;
+  reValidateMode?: 'onChange' | 'onBlur' | 'onSubmit';
   validationSchema?: ObjectSchema<TFormValues> & Schema<TFormValues>;
 }
 
@@ -44,12 +46,15 @@ export default function FormProvider<TFormValues extends FieldValues>({
   fallbackServerValidationError = 'The form submission is invalid and could not be processed',
   fallbackSubmitError = 'Something went wrong whilst submitting the form',
   initialValues,
+  mode = 'onSubmit',
   resetAfterSubmit = false,
+  reValidateMode = 'onChange',
   validationSchema,
 }: FormProviderProps<TFormValues>) {
   const form = useForm<TFormValues>({
     defaultValues: initialValues,
-    mode: 'onBlur',
+    mode,
+    reValidateMode,
     resolver: validationSchema ? yupResolver(validationSchema) : undefined,
     shouldFocusError: false,
   });

--- a/src/explore-education-statistics-common/src/components/form/__tests__/Form.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/Form.test.tsx
@@ -4,13 +4,13 @@ import Form from '@common/components/form/Form';
 import SubmitError from '@common/components/form/util/SubmitError';
 import delay from '@common/utils/delay';
 import Yup from '@common/validation/yup';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
 describe('Form', () => {
   test('renders error summary from form errors when form is submitted', async () => {
-    const { container } = render(
+    const { container, user } = render(
       <FormProvider
         initialValues={{
           firstName: '',
@@ -28,7 +28,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('First name is required')).toHaveAttribute(
@@ -45,7 +45,7 @@ describe('Form', () => {
   });
 
   test('does not render errors for fields that do not have errors', async () => {
-    const { container } = render(
+    const { container, user } = render(
       <FormProvider
         initialValues={{
           firstName: '',
@@ -63,7 +63,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.queryByText('First name is required')).toBeInTheDocument();
@@ -76,7 +76,7 @@ describe('Form', () => {
   });
 
   test('renders nested error messages', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           address: {
@@ -96,7 +96,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('Line 1 of address is required')).toHaveAttribute(
@@ -107,7 +107,7 @@ describe('Form', () => {
   });
 
   test('does not render nested error messages for fields that do not have errors', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           address: {
@@ -129,7 +129,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(
@@ -144,7 +144,7 @@ describe('Form', () => {
   test('calls `onSubmit` handler when form is submitted successfully', async () => {
     const handleSubmit = jest.fn();
 
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -160,7 +160,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledTimes(1);
@@ -170,7 +170,7 @@ describe('Form', () => {
   test('prevents multiple `onSubmit` calls until submission completes', async () => {
     const handleSubmit = jest.fn(() => delay(200));
 
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -189,9 +189,9 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     expect(handleSubmit).toHaveBeenCalledTimes(1);
 
@@ -201,7 +201,7 @@ describe('Form', () => {
   });
 
   test('renders submit error with default message when error thrown', async () => {
-    const { container } = render(
+    const { container, user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -222,7 +222,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(
@@ -234,7 +234,7 @@ describe('Form', () => {
   });
 
   test('renders submit error with custom message when `SubmitError` thrown', async () => {
-    const { container } = render(
+    const { container, user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -255,7 +255,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('Custom submit error message')).toHaveAttribute(
@@ -268,7 +268,7 @@ describe('Form', () => {
   });
 
   test('renders submit error with custom field when `SubmitError` thrown', async () => {
-    const { container } = render(
+    const { container, user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -291,7 +291,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('Custom submit error message')).toHaveAttribute(
@@ -304,7 +304,7 @@ describe('Form', () => {
   });
 
   test('renders submit error with default href when `SubmitError` thrown with invalid field', async () => {
-    const { container } = render(
+    const { container, user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -327,7 +327,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('Custom submit error message')).toHaveAttribute(
@@ -344,7 +344,7 @@ describe('Form', () => {
       throw new Error();
     });
 
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -360,7 +360,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(
@@ -371,7 +371,7 @@ describe('Form', () => {
     // Stop the onSubmit from throwing error
     onSubmit.mockImplementation();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(
@@ -381,7 +381,7 @@ describe('Form', () => {
   });
 
   test('removes submit error when form is reset', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -412,7 +412,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(
@@ -420,7 +420,7 @@ describe('Form', () => {
       ).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByText('Reset form'));
+    await user.click(screen.getByText('Reset form'));
 
     await waitFor(() => {
       expect(
@@ -430,7 +430,7 @@ describe('Form', () => {
   });
 
   test('renders mapped server validation errors when form submitted', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -453,7 +453,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('Invalid first name')).toBeInTheDocument();
@@ -467,7 +467,7 @@ describe('Form', () => {
       ]);
     });
 
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -483,7 +483,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('Invalid first name')).toBeInTheDocument();
@@ -492,7 +492,7 @@ describe('Form', () => {
     // Stop the onSubmit from throwing error
     onSubmit.mockImplementation();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.queryByText('Invalid first name')).not.toBeInTheDocument();
@@ -500,7 +500,7 @@ describe('Form', () => {
   });
 
   test('removes mapped server validation errors when form is reset', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -533,13 +533,13 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('Invalid first name')).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByText('Reset form'));
+    await user.click(screen.getByText('Reset form'));
 
     await waitFor(() => {
       expect(screen.queryByText('Invalid first name')).not.toBeInTheDocument();
@@ -547,7 +547,7 @@ describe('Form', () => {
   });
 
   test('removes mapped server validation errors when field values are changed', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -579,16 +579,13 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('Invalid first name')).toBeInTheDocument();
     });
 
-    await userEvent.type(
-      screen.getByLabelText('Firstname'),
-      'Another firstname',
-    );
+    await user.type(screen.getByLabelText('Firstname'), 'Another firstname');
 
     await waitFor(() => {
       expect(screen.queryByText('Invalid first name')).not.toBeInTheDocument();
@@ -596,7 +593,7 @@ describe('Form', () => {
   });
 
   test('does not render unmapped server validation errors when form submitted', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           firstName: 'Firstname',
@@ -624,7 +621,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('The form is submitted')).toBeInTheDocument();
@@ -642,7 +639,7 @@ describe('Form', () => {
   });
 
   test('focuses error summary on submit', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           firstName: '',
@@ -664,7 +661,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -674,7 +671,7 @@ describe('Form', () => {
   });
 
   test('does not re-focus error summary when changing input', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           firstName: '',
@@ -697,7 +694,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -707,13 +704,15 @@ describe('Form', () => {
 
     const input = screen.getByLabelText('First name');
 
-    await userEvent.type(input, 'a first name');
+    await user.type(input, 'a first name');
+    await user.tab();
 
     await waitFor(() => {
       expect(screen.queryByText('There is a problem')).not.toBeInTheDocument();
     });
 
-    await userEvent.clear(input);
+    await user.clear(input);
+    await user.tab();
 
     await waitFor(() => {
       expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -723,7 +722,7 @@ describe('Form', () => {
   });
 
   test('re-focuses error summary on re-submit', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           firstName: '',
@@ -746,7 +745,7 @@ describe('Form', () => {
       </FormProvider>,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('There is a problem')).toBeInTheDocument();
@@ -757,7 +756,7 @@ describe('Form', () => {
     screen.getByLabelText('First name').focus();
     expect(screen.getByTestId('errorSummary')).not.toHaveFocus();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(screen.getByText('There is a problem')).toBeInTheDocument();

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxGroup.test.tsx
@@ -2,9 +2,9 @@ import Yup from '@common/validation/yup';
 import FormFieldCheckboxGroup from '@common/components/form/FormFieldCheckboxGroup';
 import FormProvider from '@common/components/form/FormProvider';
 import Form from '@common/components/form/Form';
+import render from '@common-test/render';
 import { waitFor } from '@testing-library/dom';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
 import React from 'react';
 
 describe('FormFieldCheckboxGroup', () => {
@@ -149,7 +149,7 @@ describe('FormFieldCheckboxGroup', () => {
   });
 
   test('checking option checks it', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           test: [],
@@ -172,13 +172,13 @@ describe('FormFieldCheckboxGroup', () => {
 
     expect(checkbox).not.toBeChecked();
 
-    await userEvent.click(checkbox);
+    await user.click(checkbox);
 
     expect(checkbox).toBeChecked();
   });
 
   test('un-checking option un-checks it', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           test: ['1'],
@@ -201,13 +201,13 @@ describe('FormFieldCheckboxGroup', () => {
 
     expect(checkbox).toBeChecked();
 
-    await userEvent.click(checkbox);
+    await user.click(checkbox);
 
     expect(checkbox).not.toBeChecked();
   });
 
   test('clicking `Select all 3 options` button checks all values', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           test: [],
@@ -235,7 +235,7 @@ describe('FormFieldCheckboxGroup', () => {
     expect(checkbox2).not.toBeChecked();
     expect(checkbox3).not.toBeChecked();
 
-    await userEvent.click(screen.getByText('Select all 3 options'));
+    await user.click(screen.getByText('Select all 3 options'));
 
     expect(checkbox1).toBeChecked();
     expect(checkbox2).toBeChecked();
@@ -243,7 +243,7 @@ describe('FormFieldCheckboxGroup', () => {
   });
 
   test('clicking `Unselect all 3 options` button un-checks all values', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           test: ['1', '2', '3'],
@@ -271,7 +271,7 @@ describe('FormFieldCheckboxGroup', () => {
     expect(checkbox2).toBeChecked();
     expect(checkbox3).toBeChecked();
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Unselect all 3 options' }),
     );
 
@@ -281,7 +281,7 @@ describe('FormFieldCheckboxGroup', () => {
   });
 
   test('checking all options renders the `Unselect all 3 options` button', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           test: [],
@@ -313,9 +313,9 @@ describe('FormFieldCheckboxGroup', () => {
       screen.queryByRole('button', { name: 'Unselect all 3 options' }),
     ).not.toBeInTheDocument();
 
-    await userEvent.click(checkbox1);
-    await userEvent.click(checkbox2);
-    await userEvent.click(checkbox3);
+    await user.click(checkbox1);
+    await user.click(checkbox2);
+    await user.click(checkbox3);
 
     expect(checkbox1).toBeChecked();
     expect(checkbox2).toBeChecked();
@@ -329,7 +329,7 @@ describe('FormFieldCheckboxGroup', () => {
   });
 
   test('un-checking any options renders the `Select all 3 options` button', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           test: ['1', '2', '3'],
@@ -359,7 +359,7 @@ describe('FormFieldCheckboxGroup', () => {
       screen.getByRole('button', { name: 'Unselect all 3 options' }),
     ).toBeInTheDocument();
 
-    await userEvent.click(checkbox);
+    await user.click(checkbox);
 
     expect(checkbox).not.toBeChecked();
     expect(
@@ -371,37 +371,8 @@ describe('FormFieldCheckboxGroup', () => {
   });
 
   describe('error messages', () => {
-    test('does not display validation message when checkboxes are untouched', async () => {
-      render(
-        <FormProvider
-          initialValues={{
-            test: [],
-          }}
-          validationSchema={Yup.object({
-            test: Yup.array().min(1, 'Select at least one option'),
-          })}
-        >
-          <FormFieldCheckboxGroup
-            name="test"
-            id="checkboxes"
-            legend="Test checkboxes"
-            selectAll
-            options={[
-              { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
-              { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
-              { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
-            ]}
-          />
-        </FormProvider>,
-      );
-
-      expect(
-        screen.queryByText('Select at least one option'),
-      ).not.toBeInTheDocument();
-    });
-
     test('displays validation message when form is submitted', async () => {
-      render(
+      const { user } = render(
         <FormProvider
           initialValues={{
             test: [],
@@ -431,7 +402,7 @@ describe('FormFieldCheckboxGroup', () => {
         screen.queryByText('Select at least one option'),
       ).not.toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       await waitFor(() => {
         expect(
@@ -440,8 +411,8 @@ describe('FormFieldCheckboxGroup', () => {
       });
     });
 
-    test('displays validation message when checkboxes have been touched', async () => {
-      render(
+    test('updates validation message when change values after form is submitted', async () => {
+      const { user } = render(
         <FormProvider
           initialValues={{
             test: [],
@@ -450,116 +421,77 @@ describe('FormFieldCheckboxGroup', () => {
             test: Yup.array().min(1, 'Select at least one option'),
           })}
         >
-          <FormFieldCheckboxGroup
-            name="test"
-            id="checkboxes"
-            legend="Test checkboxes"
-            options={[
-              { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
-              { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
-              { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
-            ]}
-          />
+          <Form id="testId" showErrorSummary={false} onSubmit={Promise.resolve}>
+            <FormFieldCheckboxGroup
+              name="test"
+              id="checkboxes"
+              legend="Test checkboxes"
+              selectAll
+              options={[
+                { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+                { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+                { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+              ]}
+            />
+            <button type="submit">Submit</button>
+          </Form>
         </FormProvider>,
       );
 
-      await userEvent.tab();
-      await userEvent.tab();
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       await waitFor(() => {
         expect(
           screen.getByText('Select at least one option'),
         ).toBeInTheDocument();
       });
-    });
 
-    test('displays validation message when no checkboxes are checked', async () => {
-      render(
-        <FormProvider
-          initialValues={{
-            test: ['1'],
-          }}
-          validationSchema={Yup.object({
-            test: Yup.array().min(1, 'Select at least one option'),
-          })}
-        >
-          <FormFieldCheckboxGroup
-            name="test"
-            id="checkboxes"
-            legend="Test checkboxes"
-            selectAll
-            options={[
-              { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
-              { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
-              { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
-            ]}
-          />
-        </FormProvider>,
-      );
-
-      const checkbox = screen.getByLabelText('Checkbox 1');
-
-      expect(checkbox).toBeChecked();
-      expect(
-        screen.queryByText('Select at least one option'),
-      ).not.toBeInTheDocument();
-
-      await userEvent.click(checkbox);
-
-      expect(checkbox).not.toBeChecked();
-
-      await userEvent.tab();
-
-      await waitFor(() => {
-        expect(
-          screen.getByText('Select at least one option'),
-        ).toBeInTheDocument();
-      });
-    });
-
-    test('does not display validation message when `showError` is false', async () => {
-      render(
-        <FormProvider
-          initialValues={{
-            test: ['1'],
-          }}
-          validationSchema={Yup.object({
-            test: Yup.array().min(1, 'Select at least one option'),
-          })}
-        >
-          <FormFieldCheckboxGroup
-            name="test"
-            id="checkboxes"
-            legend="Test checkboxes"
-            selectAll
-            showError={false}
-            options={[
-              { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
-              { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
-              { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
-            ]}
-          />
-        </FormProvider>,
-      );
-
-      const checkbox = screen.getByLabelText('Checkbox 1');
-
-      expect(checkbox).toBeChecked();
-      expect(
-        screen.queryByText('Select at least one option'),
-      ).not.toBeInTheDocument();
-
-      await userEvent.click(checkbox);
-
-      expect(checkbox).not.toBeChecked();
-
-      await userEvent.tab();
+      await user.click(screen.getByLabelText('Checkbox 2'));
 
       await waitFor(() => {
         expect(
           screen.queryByText('Select at least one option'),
         ).not.toBeInTheDocument();
       });
+    });
+
+    test('does not display validation message when `showError` is false', async () => {
+      const { user } = render(
+        <FormProvider
+          initialValues={{
+            test: [],
+          }}
+          validationSchema={Yup.object({
+            test: Yup.array().min(1, 'Select at least one option'),
+          })}
+        >
+          <Form id="testId" showErrorSummary={false} onSubmit={Promise.resolve}>
+            <FormFieldCheckboxGroup
+              name="test"
+              id="checkboxes"
+              legend="Test checkboxes"
+              selectAll
+              showError={false}
+              options={[
+                { id: 'checkbox-1', value: '1', label: 'Checkbox 1' },
+                { id: 'checkbox-2', value: '2', label: 'Checkbox 2' },
+                { id: 'checkbox-3', value: '3', label: 'Checkbox 3' },
+              ]}
+            />
+            <button type="submit">Submit</button>
+          </Form>
+        </FormProvider>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldRadioGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldRadioGroup.test.tsx
@@ -2,9 +2,9 @@ import Form from '@common/components/form/Form';
 import FormProvider from '@common/components/form/FormProvider';
 import FormFieldRadioGroup from '@common/components/form/FormFieldRadioGroup';
 import Yup from '@common/validation/yup';
+import render from '@common-test/render';
 import { waitFor } from '@testing-library/dom';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
 import React from 'react';
 
 describe('FormFieldRadioGroup', () => {
@@ -145,7 +145,7 @@ describe('FormFieldRadioGroup', () => {
   });
 
   test('checking an option checks it', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           test: '',
@@ -168,13 +168,13 @@ describe('FormFieldRadioGroup', () => {
 
     expect(radio.checked).toBe(false);
 
-    await userEvent.click(radio);
+    await user.click(radio);
 
     expect(radio.checked).toBe(true);
   });
 
   test('checking another option un-checks the currently checked option', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           test: '1',
@@ -199,7 +199,7 @@ describe('FormFieldRadioGroup', () => {
     expect(radio1.checked).toBe(true);
     expect(radio2.checked).toBe(false);
 
-    await userEvent.click(radio2);
+    await user.click(radio2);
 
     expect(radio1.checked).toBe(false);
     expect(radio2.checked).toBe(true);
@@ -207,7 +207,7 @@ describe('FormFieldRadioGroup', () => {
 
   describe('error messages', () => {
     test('displays validation message when form is submitted', async () => {
-      render(
+      const { user } = render(
         <FormProvider
           initialValues={{
             test: '',
@@ -237,17 +237,17 @@ describe('FormFieldRadioGroup', () => {
         </FormProvider>,
       );
 
-      expect(screen.queryByText('Select an option')).toBeNull();
+      expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       await waitFor(() => {
         expect(screen.getByText('Select an option')).toBeInTheDocument();
       });
     });
 
-    test('displays validation message when radios have been touched', async () => {
-      render(
+    test('updates validation message when update values after form is submitted', async () => {
+      const { user } = render(
         <FormProvider
           initialValues={{
             test: '',
@@ -256,55 +256,44 @@ describe('FormFieldRadioGroup', () => {
             test: Yup.string().ensure().required('Select an option'),
           })}
         >
-          <FormFieldRadioGroup
-            name="test"
-            id="radios"
-            legend="Test radios"
-            options={[
-              { id: 'radio-1', value: '1', label: 'Radio 1' },
-              { id: 'radio-2', value: '2', label: 'Radio 2' },
-              { id: 'radio-3', value: '3', label: 'Radio 3' },
-            ]}
-          />
+          <Form
+            id="testForm"
+            showErrorSummary={false}
+            onSubmit={Promise.resolve}
+          >
+            <FormFieldRadioGroup
+              name="test"
+              id="radios"
+              legend="Test radios"
+              options={[
+                { id: 'radio-1', value: '1', label: 'Radio 1' },
+                { id: 'radio-2', value: '2', label: 'Radio 2' },
+                { id: 'radio-3', value: '3', label: 'Radio 3' },
+              ]}
+            />
+
+            <button type="submit">Submit</button>
+          </Form>
         </FormProvider>,
       );
 
-      await userEvent.tab();
-      await userEvent.tab();
+      expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       await waitFor(() => {
         expect(screen.getByText('Select an option')).toBeInTheDocument();
       });
-    });
 
-    test('does not display validation message when radios are untouched', async () => {
-      render(
-        <FormProvider
-          initialValues={{
-            test: '',
-          }}
-          validationSchema={Yup.object({
-            test: Yup.string().ensure().required('Select an option'),
-          })}
-        >
-          <FormFieldRadioGroup
-            name="test"
-            id="radios"
-            legend="Test radios"
-            options={[
-              { id: 'radio-1', value: '1', label: 'Radio 1' },
-              { id: 'radio-2', value: '2', label: 'Radio 2' },
-              { id: 'radio-3', value: '3', label: 'Radio 3' },
-            ]}
-          />
-        </FormProvider>,
+      await user.click(screen.getByLabelText('Radio 3'));
+
+      await waitFor(() =>
+        expect(screen.queryByText('Select an option')).not.toBeInTheDocument(),
       );
-
-      expect(screen.queryByText('Select an option')).toBeNull();
     });
 
     test('does not display validation message when `showError` is false', async () => {
-      render(
+      const { user } = render(
         <FormProvider
           initialValues={{
             test: '',
@@ -338,12 +327,12 @@ describe('FormFieldRadioGroup', () => {
       const radio = screen.getByLabelText('Radio 1') as HTMLInputElement;
 
       expect(radio.checked).toBe(false);
-      expect(screen.queryByText('Select an option')).toBeNull();
+      expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       expect(radio.checked).toBe(false);
-      expect(screen.queryByText('Select an option')).toBeNull();
+      expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldRadioSearchGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldRadioSearchGroup.test.tsx
@@ -2,9 +2,9 @@ import FormProvider from '@common/components/form/FormProvider';
 import Form from '@common/components/form/Form';
 import FormFieldRadioSearchGroup from '@common/components/form/FormFieldRadioSearchGroup';
 import Yup from '@common/validation/yup';
+import render from '@common-test/render';
 import { waitFor } from '@testing-library/dom';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
 
 import noop from 'lodash/noop';
 import React from 'react';
@@ -88,7 +88,7 @@ describe('FormFieldRadioSearchGroup', () => {
   });
 
   test('checking an option checks it', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           test: '',
@@ -111,13 +111,13 @@ describe('FormFieldRadioSearchGroup', () => {
 
     expect(radio.checked).toBe(false);
 
-    await userEvent.click(radio);
+    await user.click(radio);
 
     expect(radio.checked).toBe(true);
   });
 
   test('checking another option un-checks the currently checked option', async () => {
-    render(
+    const { user } = render(
       <FormProvider
         initialValues={{
           test: '1',
@@ -144,7 +144,7 @@ describe('FormFieldRadioSearchGroup', () => {
     expect(radio2.checked).toBe(false);
     expect(radio3.checked).toBe(false);
 
-    await userEvent.click(radio2);
+    await user.click(radio2);
 
     expect(radio1.checked).toBe(false);
     expect(radio2.checked).toBe(true);
@@ -153,7 +153,7 @@ describe('FormFieldRadioSearchGroup', () => {
 
   describe('error messages', () => {
     test('displays validation message when form is submitted', async () => {
-      render(
+      const { user } = render(
         <FormProvider
           initialValues={{
             test: '',
@@ -179,17 +179,17 @@ describe('FormFieldRadioSearchGroup', () => {
         </FormProvider>,
       );
 
-      expect(screen.queryByText('Select an option')).toBeNull();
+      expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       await waitFor(() => {
         expect(screen.getByText('Select an option')).toBeInTheDocument();
       });
     });
 
-    test('displays validation message when radios have been touched', async () => {
-      render(
+    test('updates validation message when change values after form is submitted', async () => {
+      const { user } = render(
         <FormProvider
           initialValues={{
             test: '',
@@ -209,47 +209,29 @@ describe('FormFieldRadioSearchGroup', () => {
                 { id: 'radio-3', value: '3', label: 'Radio 3' },
               ]}
             />
+
+            <button type="submit">Submit</button>
           </Form>
         </FormProvider>,
       );
 
-      await userEvent.tab();
-      await userEvent.tab();
-      await userEvent.tab();
+      expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       await waitFor(() => {
         expect(screen.getByText('Select an option')).toBeInTheDocument();
       });
-    });
 
-    test('does not display validation message when radios are untouched', async () => {
-      render(
-        <FormProvider
-          initialValues={{
-            test: '',
-          }}
-          validationSchema={Yup.object({
-            test: Yup.string().required('Select an option'),
-          })}
-        >
-          <FormFieldRadioSearchGroup
-            id="test-group"
-            name="test"
-            legend="Test radios"
-            options={[
-              { id: 'radio-1', value: '1', label: 'Radio 1' },
-              { id: 'radio-2', value: '2', label: 'Radio 2' },
-              { id: 'radio-3', value: '3', label: 'Radio 3' },
-            ]}
-          />
-        </FormProvider>,
-      );
+      await user.click(screen.getByLabelText('Radio 3'));
 
-      expect(screen.queryByText('Select an option')).toBeNull();
+      await waitFor(() => {
+        expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
+      });
     });
 
     test('does not display validation message when `showError` is false', async () => {
-      render(
+      const { user } = render(
         <FormProvider
           initialValues={{
             test: '',
@@ -281,7 +263,7 @@ describe('FormFieldRadioSearchGroup', () => {
       expect(radio.checked).toBe(false);
       expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       expect(radio.checked).toBe(false);
       expect(screen.queryByText('Select an option')).not.toBeInTheDocument();
@@ -290,7 +272,7 @@ describe('FormFieldRadioSearchGroup', () => {
 
   describe('search', () => {
     test('providing a search term filters the radios', async () => {
-      render(
+      const { user } = render(
         <FormProvider
           initialValues={{
             test: '',
@@ -312,7 +294,7 @@ describe('FormFieldRadioSearchGroup', () => {
 
       const searchInput = screen.getByLabelText('Search') as HTMLInputElement;
 
-      await userEvent.type(searchInput, '2');
+      await user.type(searchInput, '2');
 
       await waitFor(() =>
         expect(screen.queryByLabelText('Radio 3')).not.toBeInTheDocument(),
@@ -325,7 +307,7 @@ describe('FormFieldRadioSearchGroup', () => {
     });
 
     test('providing a search term does not remove a radio that has already been checked', async () => {
-      render(
+      const { user } = render(
         <FormProvider
           initialValues={{
             test: '',
@@ -349,10 +331,10 @@ describe('FormFieldRadioSearchGroup', () => {
       const radio1 = screen.getByLabelText('Radio 1') as HTMLInputElement;
       const radio2 = screen.getByLabelText('Radio 2') as HTMLInputElement;
 
-      await userEvent.click(radio1);
+      await user.click(radio1);
       expect(radio1.checked).toBe(true);
 
-      await userEvent.type(searchInput, '2');
+      await user.type(searchInput, '2');
 
       await waitFor(() =>
         expect(screen.queryByLabelText('Radio 3')).not.toBeInTheDocument(),

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/Form.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/Form.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Form does not render errors for fields that do not have errors 1`] = `
-<form id="test-form">
+<form id="test-form"
+      novalidate
+>
   <div class="govuk-error-summary"
        tabindex="-1"
        data-testid="errorSummary"
@@ -29,7 +31,9 @@ exports[`Form does not render errors for fields that do not have errors 1`] = `
 `;
 
 exports[`Form renders error summary from form errors when form is submitted 1`] = `
-<form id="test-form">
+<form id="test-form"
+      novalidate
+>
   <div class="govuk-error-summary"
        tabindex="-1"
        data-testid="errorSummary"
@@ -62,7 +66,9 @@ exports[`Form renders error summary from form errors when form is submitted 1`] 
 `;
 
 exports[`Form renders submit error with custom field when \`SubmitError\` thrown 1`] = `
-<form id="test-form">
+<form id="test-form"
+      novalidate
+>
   <div class="govuk-error-summary"
        tabindex="-1"
        data-testid="errorSummary"
@@ -90,7 +96,9 @@ exports[`Form renders submit error with custom field when \`SubmitError\` thrown
 `;
 
 exports[`Form renders submit error with custom message when \`SubmitError\` thrown 1`] = `
-<form id="test-form">
+<form id="test-form"
+      novalidate
+>
   <div class="govuk-error-summary"
        tabindex="-1"
        data-testid="errorSummary"
@@ -118,7 +126,9 @@ exports[`Form renders submit error with custom message when \`SubmitError\` thro
 `;
 
 exports[`Form renders submit error with default href when \`SubmitError\` thrown with invalid field 1`] = `
-<form id="test-form">
+<form id="test-form"
+      novalidate
+>
   <div class="govuk-error-summary"
        tabindex="-1"
        data-testid="errorSummary"
@@ -146,7 +156,9 @@ exports[`Form renders submit error with default href when \`SubmitError\` thrown
 `;
 
 exports[`Form renders submit error with default message when error thrown 1`] = `
-<form id="test-form">
+<form id="test-form"
+      novalidate
+>
   <div class="govuk-error-summary"
        tabindex="-1"
        data-testid="errorSummary"

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -21,7 +21,7 @@ import { ObjectSchema } from 'yup';
 
 interface FormValues {
   publicationId: string;
-  themeId?: string;
+  themeId?: string | null;
 }
 
 export type PublicationFormSubmitHandler = (values: {
@@ -40,10 +40,7 @@ interface Props extends InjectedWizardProps {
 }
 
 const PublicationForm = ({
-  initialValues = {
-    publicationId: '',
-    themeId: '',
-  },
+  initialValues,
   showSupersededPublications = false,
   stepTitle,
   themes,
@@ -106,11 +103,13 @@ const PublicationForm = ({
   const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
     return Yup.object({
       publicationId: Yup.string().required('Choose a publication'),
-      themeId: Yup.string().test(
-        'theme',
-        'Choose a theme',
-        value => !(!publications.length && !value),
-      ),
+      themeId: Yup.string()
+        .nullable()
+        .test(
+          'theme',
+          'Choose a theme',
+          value => !(!publications.length && !value),
+        ),
     });
   }, [publications.length]);
 
@@ -148,9 +147,11 @@ const PublicationForm = ({
                   name="publicationSearch"
                   onChange={event => {
                     setSearchTerm(event.target.value);
-                    setSelectedThemeId('');
-                    resetField('themeId');
-                    resetField('publicationId');
+                    if (searchTerm !== event.target.value) {
+                      setSelectedThemeId('');
+                      resetField('themeId');
+                      resetField('publicationId');
+                    }
                   }}
                   onKeyPress={event => {
                     if (event.key === 'Enter') {

--- a/tests/robot-tests/tests/general_public/redirects_www.robot
+++ b/tests/robot-tests/tests/general_public/redirects_www.robot
@@ -15,5 +15,5 @@ Verify that routes with www are redirected without them
     user checks url equals    %{PUBLIC_URL}/
 
     user navigates to public frontend with www    %{PUBLIC_URL}/data-catalogue/
-    user waits until page contains    Browse our open data
+    user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue


### PR DESCRIPTION
Following feedback in the DAC report about validation on the publication form in the table tool this PR makes the following changes to all forms:
- changes validation to be triggered when the form is submitted instead of `onBlur` (when a form field loses focus). This complies better with the GDS guidance as well as the DAC feedback.
- once a form has been submitted revalidation happens `onChange` so users get instant feedback that they've resolved the problem.
- set `noValidate` on forms by default so that the build in html form validation isn't triggered as this can cause accessibility issues.

There are some exceptions to this where we have very complex validation for the chart builder that would require a lot of reworking to get to work with only validating on submit, here I've set the form to validate `onBlur` (`ChartDataGroupingForm` and `ChartLegendConfiguration`) or set it on some individual fields (`ChartReferenceLinesConfiguration`)

I've updated all the tests which were checking for error messages appearing `onBlur`, while I was there I've changed these to use the new `user` from the common `render` instead of `userEvent`, so it's a bit noisey, sorry.

Also:
- fixed a validation problem on the publication form where you could end up with the error 'themeId cannot be null'
- fixed the `redirects_www` robot test now the data catalogue page has switched over



