### PR TITLE
EES-5238 - adding new HTTP trigger and orchestration for completing the next data set version import

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
@@ -83,7 +83,7 @@ public abstract class DataSetVersionsControllerTests(
                         context.DataSets.Update(savedDataSet);
                     });
 
-                    return new CreateDataSetResponseViewModel
+                    return new ProcessDataSetVersionResponseViewModel
                     {
                         DataSetId = dataSet.Id,
                         DataSetVersionId = nextVersion.Id,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetsControllerTests.cs
@@ -967,7 +967,7 @@ public abstract class DataSetsControllerTests(
                         context.DataSets.Update(dataSet);
                     });
 
-                    return new CreateDataSetResponseViewModel
+                    return new ProcessDataSetVersionResponseViewModel
                     {
                         DataSetId = dataSet.Id,
                         DataSetVersionId = dataSetVersion.Id,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Public.Data/ProcessorClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Public.Data/ProcessorClientTests.cs
@@ -43,7 +43,7 @@ public class ProcessorClientTests
         [Fact]
         public async Task HttpClientSuccess()
         {
-            var responseBody = new CreateDataSetResponseViewModel
+            var responseBody = new ProcessDataSetVersionResponseViewModel
             {
                 DataSetId = Guid.NewGuid(),
                 DataSetVersionId = Guid.NewGuid(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IProcessorClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IProcessorClient.cs
@@ -10,11 +10,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.P
 
 public interface IProcessorClient
 {
-    Task<Either<ActionResult, CreateDataSetResponseViewModel>> CreateDataSet(
+    Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateDataSet(
         Guid releaseFileId,
         CancellationToken cancellationToken = default);
 
-    Task<Either<ActionResult, CreateDataSetResponseViewModel>> CreateNextDataSetVersion(
+    Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateNextDataSetVersion(
         Guid dataSetId,
         Guid releaseFileId,
         CancellationToken cancellationToken = default);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
@@ -28,19 +28,19 @@ internal class ProcessorClient(
     IOptions<PublicDataProcessorOptions> options,
     IWebHostEnvironment environment) : IProcessorClient
 {
-    public async Task<Either<ActionResult, CreateDataSetResponseViewModel>> CreateDataSet(
+    public async Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateDataSet(
         Guid releaseFileId,
         CancellationToken cancellationToken = default)
     {
         var request = new DataSetCreateRequest { ReleaseFileId = releaseFileId };
 
-        return await SendPost<DataSetCreateRequest, CreateDataSetResponseViewModel>(
+        return await SendPost<DataSetCreateRequest, ProcessDataSetVersionResponseViewModel>(
             "api/CreateDataSet",
             request,
             cancellationToken: cancellationToken);
     }
 
-    public async Task<Either<ActionResult, CreateDataSetResponseViewModel>> CreateNextDataSetVersion(
+    public async Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateNextDataSetVersion(
         Guid dataSetId,
         Guid releaseFileId,
         CancellationToken cancellationToken = default)
@@ -51,7 +51,7 @@ internal class ProcessorClient(
             DataSetId = dataSetId
         };
 
-        return await SendPost<NextDataSetVersionCreateRequest, CreateDataSetResponseViewModel>(
+        return await SendPost<NextDataSetVersionCreateRequest, ProcessDataSetVersionResponseViewModel>(
             "api/CreateNextDataSetVersion",
             request,
             cancellationToken: cancellationToken);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
@@ -45,13 +45,13 @@ internal class ProcessorClient(
         Guid releaseFileId,
         CancellationToken cancellationToken = default)
     {
-        var request = new NextDataSetVersionCreateRequest
+        var request = new NextDataSetVersionCreateMappingsRequest
         {
             ReleaseFileId = releaseFileId,
             DataSetId = dataSetId
         };
 
-        return await SendPost<NextDataSetVersionCreateRequest, ProcessDataSetVersionResponseViewModel>(
+        return await SendPost<NextDataSetVersionCreateMappingsRequest, ProcessDataSetVersionResponseViewModel>(
             "api/CreateNextDataSetVersion",
             request,
             cancellationToken: cancellationToken);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ActionResultTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ActionResultTestExtensions.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq;
 using System.Net;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -39,16 +40,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
 
             return value;
         }
-        
+
         public static T AssertObjectResult<T>(
             this IActionResult result,
-            HttpStatusCode expectedStatusCode, 
+            HttpStatusCode expectedStatusCode,
             T? expectedValue = null) where T : class
         {
             var objectResult = Assert.IsAssignableFrom<ObjectResult>(result);
-            Assert.Equal((int) expectedStatusCode, objectResult.StatusCode);
+            Assert.Equal((int)expectedStatusCode, objectResult.StatusCode);
             var value = Assert.IsAssignableFrom<T>(objectResult.Value);
-            
+
             if (expectedValue != null)
             {
                 Assert.Equal(expectedValue, value);
@@ -125,7 +126,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             return validationProblem;
         }
 
-        private static void AssertBadRequestWithValidationErrors(this IActionResult result, params Enum[] expectedErrorCodes)
+        public static ValidationProblemViewModel AssertNotFoundWithValidationProblem<TEntity, TId>(
+            this IActionResult result,
+            TId expectedId,
+            string expectedPath)
+        {
+            var notFound = Assert.IsAssignableFrom<NotFoundObjectResult>(result);
+            var validationProblem = Assert.IsAssignableFrom<ValidationProblemViewModel>(notFound.Value);
+
+            validationProblem.AssertHasError(
+                expectedPath: expectedPath,
+                expectedCode: "NotFound",
+                expectedMessage: $"{typeof(TEntity).Name} not found",
+                expectedDetail: new InvalidErrorDetail<TId>(expectedId));
+
+            return validationProblem;
+        }
+
+        private static void AssertBadRequestWithValidationErrors(this IActionResult result,
+            params Enum[] expectedErrorCodes)
         {
             var badRequest = Assert.IsAssignableFrom<BadRequestObjectResult>(result);
             var validationProblem = Assert.IsAssignableFrom<ValidationProblemViewModel>(badRequest.Value);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationProblemViewModelTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ValidationProblemViewModelTestExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Validators.AllowedValueValidator;
 
@@ -391,7 +392,8 @@ public static class ValidationProblemViewModelTestExtensions
         this ValidationProblemViewModel validationProblem,
         string? expectedPath,
         string expectedCode,
-        string? expectedMessage = null)
+        string? expectedMessage = null,
+        object? expectedDetail = null)
     {
         Predicate<ErrorViewModel> predicate = error =>
         {
@@ -399,7 +401,12 @@ public static class ValidationProblemViewModelTestExtensions
             {
                 return false;
             }
-            
+
+            if (expectedDetail is not null && (error.Detail is null || !error.Detail.Equals(expectedDetail)))
+            {
+                return false;
+            }
+
             return error.Path == expectedPath && error.Code == expectedCode;
         };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ValidationUtils.cs
@@ -2,7 +2,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using FluentValidation.Results;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Validators;
@@ -33,9 +36,31 @@ public static class ValidationUtils
 
     public static BadRequestObjectResult ValidationResult(IEnumerable<ErrorViewModel> errors)
     {
-        return new BadRequestObjectResult(new ValidationProblemViewModel
+        return new BadRequestObjectResult(new ValidationProblemViewModel { Errors = errors.ToList() });
+    }
+
+    /// <summary>
+    /// Creates a NotFoundObjectResult with the given error details. Use this method when
+    /// failing to find any of the principal entities being referenced in a request (e.g.
+    /// a DataSetVersion for a given "dataSetVersionId" parameter in a request, but use
+    /// ValidationResult when failing to find any secondary entities (e.g.
+    /// a DataSetVersionMapping record) that *should* exist if the primary entity exists. 
+    /// </summary>
+    public static NotFoundObjectResult NotFoundResult<TEntity, TId>(TId id, string path)
+    {
+        return new NotFoundObjectResult(new ValidationProblemViewModel
         {
-            Errors = errors.ToList()
+            Status = StatusCodes.Status404NotFound,
+            Errors =
+            [
+                new ErrorViewModel
+                {
+                    Code = "NotFound",
+                    Path = path,
+                    Detail = new InvalidErrorDetail<TId>(id),
+                    Message = $"{typeof(TEntity).Name} not found"
+                }
+            ]
         });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionImportStage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionImportStage.cs
@@ -11,6 +11,7 @@ public enum DataSetVersionImportStage
     ImportingMetadata,
     CreatingMappings,
     AutoMapping,
+    ManualMapping,
     ImportingData,
     WritingDataFiles,
     Completing

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/DataSetVersionProcessRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/DataSetVersionProcessRequest.cs
@@ -2,11 +2,11 @@ using FluentValidation;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
 
-public record NextDataSetVersionCompleteImportRequest
+public record DataSetVersionProcessRequest
 {
     public required Guid DataSetVersionId { get; init; }
 
-    public class Validator : AbstractValidator<NextDataSetVersionCompleteImportRequest>
+    public class Validator : AbstractValidator<DataSetVersionProcessRequest>
     {
         public Validator()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/NextDataSetVersionCompleteImportRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/NextDataSetVersionCompleteImportRequest.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
+
+public record NextDataSetVersionCompleteImportRequest
+{
+    public required Guid DataSetVersionId { get; init; }
+
+    public class Validator : AbstractValidator<NextDataSetVersionCompleteImportRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.DataSetVersionId)
+                .NotEmpty();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/NextDataSetVersionCompleteImportRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/NextDataSetVersionCompleteImportRequest.cs
@@ -2,11 +2,11 @@ using FluentValidation;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
 
-public record DataSetVersionProcessRequest
+public record NextDataSetVersionCompleteImportRequest
 {
     public required Guid DataSetVersionId { get; init; }
 
-    public class Validator : AbstractValidator<DataSetVersionProcessRequest>
+    public class Validator : AbstractValidator<NextDataSetVersionCompleteImportRequest>
     {
         public Validator()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/NextDataSetVersionCreateMappingsRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/NextDataSetVersionCreateMappingsRequest.cs
@@ -2,13 +2,13 @@ using FluentValidation;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
 
-public record NextDataSetVersionCreateRequest
+public record NextDataSetVersionCreateMappingsRequest
 {
     public required Guid DataSetId { get; init; }
 
     public required Guid ReleaseFileId { get; init; }
 
-    public class Validator : AbstractValidator<NextDataSetVersionCreateRequest>
+    public class Validator : AbstractValidator<NextDataSetVersionCreateMappingsRequest>
     {
         public Validator()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
@@ -42,7 +42,7 @@ public static class ValidationMessages
     public static readonly LocalizableMessage DataSetVersionCanNotBeDeleted = new(
         Code: nameof(DataSetVersionCanNotBeDeleted),
         Message:
-        $"The data set version is not in a draft status, or is currently being processed, so cannot be deleted."
+        "The data set version is not in a draft status, or is currently being processed, so cannot be deleted."
     );
 
     public static readonly LocalizableMessage DataSetNotFound = new(
@@ -67,8 +67,8 @@ public static class ValidationMessages
 
     public static readonly LocalizableMessage MultipleDataSetVersionsCanNotBeDeleted = new(
         Code: nameof(MultipleDataSetVersionsCanNotBeDeleted),
-        Message:
-        $"One or more data set versions are not in a draft status, or are currently being processed, so cannot be deleted."
+        Message: "One or more data set versions are not in a draft status, " +
+                 "or are currently being processed, so cannot be deleted."
     );
 
     public static readonly LocalizableMessage DataSetVersionNotInMappingStatus = new(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
@@ -41,12 +41,18 @@ public static class ValidationMessages
 
     public static readonly LocalizableMessage DataSetVersionCanNotBeDeleted = new(
         Code: nameof(DataSetVersionCanNotBeDeleted),
-        Message: $"The data set version is not in a draft status, or is currently being processed, so cannot be deleted."
+        Message:
+        $"The data set version is not in a draft status, or is currently being processed, so cannot be deleted."
     );
 
     public static readonly LocalizableMessage DataSetNotFound = new(
         Code: nameof(DataSetNotFound),
         Message: "The data set could not be found."
+    );
+
+    public static readonly LocalizableMessage DataSetVersionNotFound = new(
+        Code: nameof(DataSetVersionNotFound),
+        Message: "The data set version could not be found."
     );
 
     public static readonly LocalizableMessage DataSetMustHaveNoExistingVersions = new(
@@ -61,6 +67,27 @@ public static class ValidationMessages
 
     public static readonly LocalizableMessage MultipleDataSetVersionsCanNotBeDeleted = new(
         Code: nameof(MultipleDataSetVersionsCanNotBeDeleted),
-        Message: $"One or more data set versions are not in a draft status, or are currently being processed, so cannot be deleted."
-);
+        Message:
+        $"One or more data set versions are not in a draft status, or are currently being processed, so cannot be deleted."
+    );
+
+    public static readonly LocalizableMessage DataSetVersionNotInMappingStatus = new(
+        Code: nameof(DataSetVersionNotInMappingStatus),
+        Message: "The data set version must be in the 'Mapping' status."
+    );
+
+    public static readonly LocalizableMessage ImportInManualMappingStateNotFound = new(
+        Code: nameof(ImportInManualMappingStateNotFound),
+        Message: "An import in mapping state could not be found."
+    );
+
+    public static readonly LocalizableMessage DataSetVersionMappingNotFound = new(
+        Code: nameof(DataSetVersionMappingNotFound),
+        Message: "The data set version mapping could not be found."
+    );
+
+    public static readonly LocalizableMessage DataSetVersionMappingsNotComplete = new(
+        Code: nameof(DataSetVersionMappingsNotComplete),
+        Message: "The data set version mappings are not complete."
+    );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/Validators/ValidationMessages.cs
@@ -4,11 +4,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Reque
 
 public static class ValidationMessages
 {
-    public static readonly LocalizableMessage FileNotFound = new(
-        Code: nameof(FileNotFound),
-        Message: "The file could not be found."
-    );
-
     public static readonly LocalizableMessage FileHasApiDataSetVersion = new(
         Code: nameof(FileHasApiDataSetVersion),
         Message: "The file has already been used for an API data set version."
@@ -45,16 +40,6 @@ public static class ValidationMessages
         "The data set version is not in a draft status, or is currently being processed, so cannot be deleted."
     );
 
-    public static readonly LocalizableMessage DataSetNotFound = new(
-        Code: nameof(DataSetNotFound),
-        Message: "The data set could not be found."
-    );
-
-    public static readonly LocalizableMessage DataSetVersionNotFound = new(
-        Code: nameof(DataSetVersionNotFound),
-        Message: "The data set version could not be found."
-    );
-
     public static readonly LocalizableMessage DataSetMustHaveNoExistingVersions = new(
         Code: nameof(DataSetMustHaveNoExistingVersions),
         Message: "The data set must have no existing versions when creating the initial version."
@@ -83,7 +68,7 @@ public static class ValidationMessages
 
     public static readonly LocalizableMessage DataSetVersionMappingNotFound = new(
         Code: nameof(DataSetVersionMappingNotFound),
-        Message: "The data set version mapping could not be found."
+        Message: "A data set version mapping could not be found."
     );
 
     public static readonly LocalizableMessage DataSetVersionMappingsNotComplete = new(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CompleteNextDataSetVersionImportFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CompleteNextDataSetVersionImportFunctionTests.cs
@@ -1,0 +1,354 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests.Validators;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using FileType = GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Functions;
+
+public abstract class CompleteNextDataSetVersionImportFunctionTests(
+    ProcessorFunctionsIntegrationTestFixture fixture)
+    : ProcessorFunctionsIntegrationTest(fixture)
+{
+    public class CompleteNextDataSetVersionImportTests(
+        ProcessorFunctionsIntegrationTestFixture fixture)
+        : CompleteNextDataSetVersionImportFunctionTests(fixture)
+    {
+        [Fact]
+        public async Task Success()
+        {
+            var (_, _, nextVersion) = await AddDataSetAndLatestLiveAndNextVersion();
+
+            var durableTaskClientMock = new Mock<DurableTaskClient>(MockBehavior.Strict, "TestClient");
+
+            ProcessDataSetVersionContext? processNextDataSetVersionContext = null;
+            StartOrchestrationOptions? startOrchestrationOptions = null;
+            durableTaskClientMock.Setup(client =>
+                    client.ScheduleNewOrchestrationInstanceAsync(
+                        nameof(ProcessCompletionOfNextDataSetVersionFunction
+                            .CompleteNextDataSetVersionImportProcessing),
+                        It.IsAny<ProcessDataSetVersionContext>(),
+                        It.IsAny<StartOrchestrationOptions>(),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync((TaskName _, object _, StartOrchestrationOptions? options, CancellationToken _) =>
+                    options?.InstanceId ?? Guid.NewGuid().ToString())
+                .Callback<TaskName, object, StartOrchestrationOptions?, CancellationToken>(
+                    (_, input, options, _) =>
+                    {
+                        processNextDataSetVersionContext =
+                            Assert.IsAssignableFrom<ProcessDataSetVersionContext>(input);
+                        startOrchestrationOptions = options;
+                    });
+
+            var result = await CompleteNextDataSetVersionImport(
+                dataSetVersionId: nextVersion.Id,
+                durableTaskClientMock.Object);
+
+            VerifyAllMocks(durableTaskClientMock);
+
+            var responseViewModel = result.AssertOkObjectResult<ProcessDataSetVersionResponseViewModel>();
+
+            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
+
+            // Assert that the InstanceId of the pre-existing import entry for the next data
+            // set version  is re-used.
+            var dataSetVersionImport = publicDataDbContext
+                .DataSetVersionImports
+                .Single(import => import.DataSetVersionId == nextVersion.Id);
+
+            Assert.Equal(dataSetVersionImport.InstanceId, responseViewModel.InstanceId);
+
+            // Assert the processing orchestrator was scheduled with the correct arguments
+            Assert.NotNull(processNextDataSetVersionContext);
+            Assert.NotNull(startOrchestrationOptions);
+            Assert.Equal(new ProcessDataSetVersionContext { DataSetVersionId = nextVersion.Id },
+                processNextDataSetVersionContext);
+            Assert.Equal(new StartOrchestrationOptions { InstanceId = dataSetVersionImport.InstanceId.ToString() },
+                startOrchestrationOptions);
+        }
+
+        [Fact]
+        public async Task DataSetVersionIdIsEmpty_ReturnsValidationProblem()
+        {
+            var result = await CompleteNextDataSetVersionImport(
+                dataSetVersionId: Guid.Empty);
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+
+            validationProblem.AssertHasNotEmptyError(
+                nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst());
+        }
+
+        [Fact]
+        public async Task DataSetVersionIsNotFound_ReturnsValidationProblem()
+        {
+            var result = await CompleteNextDataSetVersionImport(
+                dataSetVersionId: Guid.NewGuid());
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+
+            validationProblem.AssertHasError(
+                expectedPath: nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                expectedCode: ValidationMessages.DataSetVersionNotFound.Code);
+        }
+
+        [Fact]
+        public async Task DataSetVersionNotInMappingStatus_ReturnsValidationProblem()
+        {
+            var (_, _, nextVersion) = await AddDataSetAndLatestLiveAndNextVersion();
+
+            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
+
+            // Update the next data set version's status to no longer be "Mapping".
+            var nextVersionWithIncorrectStatus = await publicDataDbContext
+                .DataSetVersions
+                .SingleAsync(dsv => dsv.Id == nextVersion.Id);
+
+            nextVersionWithIncorrectStatus.Status = DataSetVersionStatus.Draft;
+
+            await publicDataDbContext.SaveChangesAsync();
+
+            var result = await CompleteNextDataSetVersionImport(
+                dataSetVersionId: nextVersion.Id);
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+
+            validationProblem.AssertHasError(
+                expectedPath: nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                expectedCode: ValidationMessages.DataSetVersionNotInMappingStatus.Code);
+        }
+
+        [Fact]
+        public async Task DataSetVersionMappingNotFound_ReturnsValidationProblem()
+        {
+            var (_, _, nextVersion) = await AddDataSetAndLatestLiveAndNextVersion();
+
+            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
+
+            // Remove the DataSetVersionMapping entry from the database.
+            var mapping = await publicDataDbContext
+                .DataSetVersionMappings
+                .SingleAsync();
+            publicDataDbContext.Remove(mapping);
+            await publicDataDbContext.SaveChangesAsync();
+
+            var result = await CompleteNextDataSetVersionImport(
+                dataSetVersionId: nextVersion.Id);
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+
+            validationProblem.AssertHasError(
+                expectedPath: nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                expectedCode: ValidationMessages.DataSetVersionMappingNotFound.Code);
+        }
+        
+        [Fact]
+        public async Task DataSetVersionMappings_LocationsNotComplete_ReturnsValidationProblem()
+        {
+            var (_, _, nextVersion) = await AddDataSetAndLatestLiveAndNextVersion();
+
+            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
+
+            // Remove the DataSetVersionMapping entry from the database.
+            var mapping = await publicDataDbContext
+                .DataSetVersionMappings
+                .SingleAsync();
+
+            mapping.LocationMappingsComplete = false;
+            
+            await publicDataDbContext.SaveChangesAsync();
+
+            var result = await CompleteNextDataSetVersionImport(
+                dataSetVersionId: nextVersion.Id);
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+
+            validationProblem.AssertHasError(
+                expectedPath: nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                expectedCode: ValidationMessages.DataSetVersionMappingsNotComplete.Code);
+        }
+        
+        [Fact]
+        public async Task DataSetVersionMappings_FilterOptionsNotComplete_ReturnsValidationProblem()
+        {
+            var (_, _, nextVersion) = await AddDataSetAndLatestLiveAndNextVersion();
+
+            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
+
+            // Remove the DataSetVersionMapping entry from the database.
+            var mapping = await publicDataDbContext
+                .DataSetVersionMappings
+                .SingleAsync();
+
+            mapping.FilterMappingsComplete = false;
+            
+            await publicDataDbContext.SaveChangesAsync();
+
+            var result = await CompleteNextDataSetVersionImport(
+                dataSetVersionId: nextVersion.Id);
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+
+            validationProblem.AssertHasError(
+                expectedPath: nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                expectedCode: ValidationMessages.DataSetVersionMappingsNotComplete.Code);
+        }
+
+        [Fact]
+        public async Task DataSetVersionImportInManualMappingStateNotFound_ReturnsValidationProblem()
+        {
+            var (_, _, nextVersion) = await AddDataSetAndLatestLiveAndNextVersion();
+
+            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
+
+            // Update the next data set version's import status to no longer be "ManualMapping".
+            var importWithIncorrectStatus = await publicDataDbContext
+                .DataSetVersionImports
+                .SingleAsync(import => import.DataSetVersionId == nextVersion.Id);
+
+            importWithIncorrectStatus.Stage = DataSetVersionImportStage.AutoMapping;
+
+            await publicDataDbContext.SaveChangesAsync();
+
+            var result = await CompleteNextDataSetVersionImport(
+                dataSetVersionId: nextVersion.Id);
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+
+            validationProblem.AssertHasError(
+                expectedPath: nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                expectedCode: ValidationMessages.ImportInManualMappingStateNotFound.Code);
+        }
+
+        private async Task<(DataSet, DataSetVersion, DataSetVersion)> AddDataSetAndLatestLiveAndNextVersion()
+        {
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusPublished();
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            var liveVersion = await AddLatestLiveDataSetVersion(dataSet);
+            var nextVersion = await AddNextDataSetVersionAndMapping(dataSet.Id);
+            return (dataSet, liveVersion, nextVersion);
+        }
+
+        private async Task<DataSetVersion> AddLatestLiveDataSetVersion(DataSet dataSet)
+        {
+            var (dataFile, _) = await AddDataAndMetadataFiles(dataSet.PublicationId);
+
+            DataSetVersion liveDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(1, 0)
+                .WithStatusPublished()
+                .WithDataSet(dataSet)
+                .WithReleaseFileId(dataFile.Id)
+                .WithImports(() => DataFixture
+                    .DefaultDataSetVersionImport()
+                    .Generate(1))
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            await AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(liveDataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            return liveDataSetVersion;
+        }
+
+        private async Task<DataSetVersion> AddNextDataSetVersionAndMapping(Guid dataSetId)
+        {
+            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
+
+            var dataSet = await publicDataDbContext
+                .DataSets
+                .SingleAsync(ds => ds.Id == dataSetId);
+
+            var (dataFile, _) = await AddDataAndMetadataFiles(dataSet.PublicationId);
+
+            DataSetVersion nextDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(1, 1)
+                .WithStatusMapping()
+                .WithDataSet(dataSet)
+                .WithReleaseFileId(dataFile.Id)
+                .WithImports(() => DataFixture
+                    .DefaultDataSetVersionImport()
+                    .WithStage(DataSetVersionImportStage.ManualMapping)
+                    .Generate(1))
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            var dataSetVersionMapping = new DataSetVersionMapping
+            {
+                SourceDataSetVersionId = dataSet.LatestLiveVersionId!.Value,
+                TargetDataSetVersionId = nextDataSetVersion.Id,
+                FilterMappingPlan = new FilterMappingPlan(),
+                LocationMappingPlan = new LocationMappingPlan(),
+                LocationMappingsComplete = true,
+                FilterMappingsComplete = true
+            };
+
+            await AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(nextDataSetVersion);
+                context.DataSets.Update(dataSet);
+                context.DataSetVersionMappings.Add(dataSetVersionMapping);
+            });
+
+            return nextDataSetVersion;
+        }
+
+        private async Task<(ReleaseFile, ReleaseFile)> AddDataAndMetadataFiles(Guid publicationId)
+        {
+            var subjectId = Guid.NewGuid();
+
+            var (dataFile, metaFile) = DataFixture
+                .DefaultReleaseFile()
+                .WithReleaseVersion(DataFixture
+                    .DefaultReleaseVersion()
+                    .WithPublicationId(publicationId))
+                .WithFiles([
+                    DataFixture
+                        .DefaultFile(FileType.Data)
+                        .WithSubjectId(subjectId),
+                    DataFixture
+                        .DefaultFile(FileType.Metadata)
+                        .WithSubjectId(subjectId)
+                ])
+                .GenerateList()
+                .ToTuple2();
+
+            await AddTestData<ContentDbContext>(context =>
+                context.ReleaseFiles.AddRange(dataFile, metaFile));
+
+            return (dataFile, metaFile);
+        }
+
+        private async Task<IActionResult> CompleteNextDataSetVersionImport(
+            Guid dataSetVersionId,
+            DurableTaskClient? durableTaskClient = null)
+        {
+            var function = GetRequiredService<CompleteNextDataSetVersionImportFunction>();
+            return await function.CompleteNextDataSetVersionImport(
+                new DataSetVersionProcessRequest { DataSetVersionId = dataSetVersionId },
+                durableTaskClient ?? new Mock<DurableTaskClient>(MockBehavior.Strict, "TestClient").Object,
+                CancellationToken.None);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CompleteNextDataSetVersionImportFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CompleteNextDataSetVersionImportFunctionTests.cs
@@ -9,7 +9,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixture
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests.Validators;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.DurableTask;
@@ -18,6 +17,8 @@ using Microsoft.EntityFrameworkCore;
 using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using FileType = GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
+using ValidationMessages =
+    GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests.Validators.ValidationMessages;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Functions;
 
@@ -102,20 +103,20 @@ public abstract class CompleteNextDataSetVersionImportFunctionTests(
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasNotEmptyError(
-                nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst());
+                nameof(NextDataSetVersionCompleteImportRequest.DataSetVersionId).ToLowerFirst());
         }
 
         [Fact]
-        public async Task DataSetVersionIsNotFound_ReturnsValidationProblem()
+        public async Task DataSetVersionIsNotFound_ReturnsNotFound()
         {
+            var dataSetVersionId = Guid.NewGuid();
+
             var result = await CompleteNextDataSetVersionImport(
-                dataSetVersionId: Guid.NewGuid());
+                dataSetVersionId: dataSetVersionId);
 
-            var validationProblem = result.AssertBadRequestWithValidationProblem();
-
-            validationProblem.AssertHasError(
-                expectedPath: nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
-                expectedCode: ValidationMessages.DataSetVersionNotFound.Code);
+            result.AssertNotFoundWithValidationProblem<DataSetVersion, Guid>(
+                expectedId: dataSetVersionId,
+                expectedPath: nameof(NextDataSetVersionCompleteImportRequest.DataSetVersionId).ToLowerFirst());
         }
 
         [Fact]
@@ -140,7 +141,7 @@ public abstract class CompleteNextDataSetVersionImportFunctionTests(
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                expectedPath: nameof(NextDataSetVersionCompleteImportRequest.DataSetVersionId).ToLowerFirst(),
                 expectedCode: ValidationMessages.DataSetVersionNotInMappingStatus.Code);
         }
 
@@ -164,7 +165,7 @@ public abstract class CompleteNextDataSetVersionImportFunctionTests(
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                expectedPath: nameof(NextDataSetVersionCompleteImportRequest.DataSetVersionId).ToLowerFirst(),
                 expectedCode: ValidationMessages.DataSetVersionMappingNotFound.Code);
         }
 
@@ -190,7 +191,7 @@ public abstract class CompleteNextDataSetVersionImportFunctionTests(
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                expectedPath: nameof(NextDataSetVersionCompleteImportRequest.DataSetVersionId).ToLowerFirst(),
                 expectedCode: ValidationMessages.DataSetVersionMappingsNotComplete.Code);
         }
 
@@ -216,7 +217,7 @@ public abstract class CompleteNextDataSetVersionImportFunctionTests(
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                expectedPath: nameof(NextDataSetVersionCompleteImportRequest.DataSetVersionId).ToLowerFirst(),
                 expectedCode: ValidationMessages.DataSetVersionMappingsNotComplete.Code);
         }
 
@@ -242,7 +243,7 @@ public abstract class CompleteNextDataSetVersionImportFunctionTests(
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                expectedPath: nameof(NextDataSetVersionCompleteImportRequest.DataSetVersionId).ToLowerFirst(),
                 expectedCode: ValidationMessages.ImportInManualMappingStateNotFound.Code);
         }
 
@@ -357,7 +358,7 @@ public abstract class CompleteNextDataSetVersionImportFunctionTests(
         {
             var function = GetRequiredService<CompleteNextDataSetVersionImportFunction>();
             return await function.CompleteNextDataSetVersionImport(
-                new DataSetVersionProcessRequest { DataSetVersionId = dataSetVersionId },
+                new NextDataSetVersionCompleteImportRequest { DataSetVersionId = dataSetVersionId },
                 durableTaskClient ?? new Mock<DurableTaskClient>(MockBehavior.Strict, "TestClient").Object,
                 CancellationToken.None);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateDataSetFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateDataSetFunctionTests.cs
@@ -74,7 +74,7 @@ public abstract class CreateDataSetFunctionTests(
 
             VerifyAllMocks(durableTaskClientMock);
 
-            var responseViewModel = result.AssertOkObjectResult<CreateDataSetResponseViewModel>();
+            var responseViewModel = result.AssertOkObjectResult<ProcessDataSetVersionResponseViewModel>();
 
             await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateDataSetFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateDataSetFunctionTests.cs
@@ -136,13 +136,13 @@ public abstract class CreateDataSetFunctionTests(
         [Fact]
         public async Task ReleaseFileIdIsNotFound_ReturnsValidationProblem()
         {
-            var result = await CreateDataSet(releaseFileId: Guid.NewGuid());
+            var releaseFileId = Guid.NewGuid();
 
-            var validationProblem = result.AssertBadRequestWithValidationProblem();
+            var result = await CreateDataSet(releaseFileId: releaseFileId);
 
-            validationProblem.AssertHasError(
-                expectedPath: nameof(DataSetCreateRequest.ReleaseFileId).ToLowerFirst(),
-                expectedCode: ValidationMessages.FileNotFound.Code);
+            result.AssertNotFoundWithValidationProblem<ReleaseFile, Guid>(
+                expectedId: releaseFileId,
+                expectedPath: nameof(DataSetCreateRequest.ReleaseFileId).ToLowerFirst());
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateNextDataSetVersionMappingsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateNextDataSetVersionMappingsFunctionTests.cs
@@ -62,7 +62,7 @@ public abstract class CreateNextDataSetVersionMappingsFunctionTests(
 
             VerifyAllMocks(durableTaskClientMock);
 
-            var responseViewModel = result.AssertOkObjectResult<CreateDataSetResponseViewModel>();
+            var responseViewModel = result.AssertOkObjectResult<ProcessDataSetVersionResponseViewModel>();
 
             await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessCompletionOfNextDataSetVersionImportFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessCompletionOfNextDataSetVersionImportFunctionTests.cs
@@ -124,7 +124,7 @@ public abstract class ProcessCompletionOfNextDataSetVersionImportFunctionTests(
         }
     }
 
-    public class CompleteInitialDataSetVersionProcessingTests(
+    public class CompleteNextDataSetVersionImportProcessingTests(
         ProcessorFunctionsIntegrationTestFixture fixture)
         : ProcessCompletionOfNextDataSetVersionImportFunctionTests(fixture)
     {
@@ -177,8 +177,8 @@ public abstract class ProcessCompletionOfNextDataSetVersionImportFunctionTests(
 
         private async Task CompleteProcessing(Guid instanceId)
         {
-            var function = GetRequiredService<ProcessInitialDataSetVersionFunction>();
-            await function.CompleteInitialDataSetVersionProcessing(instanceId, CancellationToken.None);
+            var function = GetRequiredService<ProcessCompletionOfNextDataSetVersionFunction>();
+            await function.CompleteNextDataSetVersionImportProcessing(instanceId, CancellationToken.None);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessInitialDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessInitialDataSetVersionFunctionTests.cs
@@ -58,7 +58,7 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(
                 ActivityNames.ImportMetadata,
                 ActivityNames.ImportData,
                 ActivityNames.WriteDataFiles,
-                ActivityNames.CompleteInitialDataSetVersionProcessing,
+                ActivityNames.CompleteInitialDataSetVersionMappingProcessing,
             ];
 
             foreach (var activityName in expectedActivitySequence)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessInitialDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessInitialDataSetVersionFunctionTests.cs
@@ -58,7 +58,7 @@ public abstract class ProcessInitialDataSetVersionFunctionTests(
                 ActivityNames.ImportMetadata,
                 ActivityNames.ImportData,
                 ActivityNames.WriteDataFiles,
-                ActivityNames.CompleteInitialDataSetVersionMappingProcessing,
+                ActivityNames.CompleteInitialDataSetVersionProcessing
             ];
 
             foreach (var activityName in expectedActivitySequence)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
@@ -1238,7 +1238,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
         ProcessorFunctionsIntegrationTestFixture fixture)
         : ProcessNextDataSetVersionMappingsFunctionTests(fixture)
     {
-        private const DataSetVersionImportStage Stage = DataSetVersionImportStage.Completing;
+        private const DataSetVersionImportStage Stage = DataSetVersionImportStage.ManualMapping;
 
         [Fact]
         public async Task Success()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
@@ -1257,7 +1257,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                 .SingleAsync(i => i.InstanceId == instanceId);
 
             Assert.Equal(Stage, savedImport.Stage);
-            savedImport.Completed.AssertUtcNow();
+            Assert.Null(savedImport.Completed);
 
             Assert.Equal(DataSetVersionStatus.Mapping, savedImport.DataSetVersion.Status);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Testcontainers.Azurite;
 using Testcontainers.PostgreSql;
 
@@ -173,8 +172,8 @@ public class ProcessorFunctionsIntegrationTestFixture : FunctionsIntegrationTest
                     options =>
                     {
                         options.UseNpgsql(
-                                _postgreSqlContainer.GetConnectionString(),
-                                psqlOptions => psqlOptions.EnableRetryOnFailure());
+                            _postgreSqlContainer.GetConnectionString(),
+                            psqlOptions => psqlOptions.EnableRetryOnFailure());
                     });
 
                 using var serviceScope = services.BuildServiceProvider()
@@ -194,6 +193,7 @@ public class ProcessorFunctionsIntegrationTestFixture : FunctionsIntegrationTest
             typeof(ProcessInitialDataSetVersionFunction),
             typeof(CreateNextDataSetVersionMappingsFunction),
             typeof(ProcessNextDataSetVersionMappingsFunction),
+            typeof(CompleteNextDataSetVersionImportFunction),
             typeof(ProcessCompletionOfNextDataSetVersionFunction),
             typeof(DeleteDataSetVersionFunction),
             typeof(CopyCsvFilesFunction),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
@@ -194,6 +194,7 @@ public class ProcessorFunctionsIntegrationTestFixture : FunctionsIntegrationTest
             typeof(ProcessInitialDataSetVersionFunction),
             typeof(CreateNextDataSetVersionMappingsFunction),
             typeof(ProcessNextDataSetVersionMappingsFunction),
+            typeof(ProcessCompletionOfNextDataSetVersionFunction),
             typeof(DeleteDataSetVersionFunction),
             typeof(CopyCsvFilesFunction),
             typeof(ImportMetadataFunction),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels/ProcessDataSetVersionResponseViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels/ProcessDataSetVersionResponseViewModel.cs
@@ -1,6 +1,6 @@
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels;
 
-public record CreateDataSetResponseViewModel
+public record ProcessDataSetVersionResponseViewModel
 {
     public required Guid DataSetId { get; init; }
     public required Guid DataSetVersionId { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ActivityNames.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ActivityNames.cs
@@ -15,4 +15,7 @@ internal static class ActivityNames
     public const string ApplyAutoMappings = nameof(ProcessNextDataSetVersionMappingsFunction.ApplyAutoMappings);
     public const string CompleteNextDataSetVersionMappingProcessing = 
         nameof(ProcessNextDataSetVersionMappingsFunction.CompleteNextDataSetVersionMappingProcessing);
+    
+    public const string CompleteNextDataSetVersionImportProcessing = 
+        nameof(ProcessCompletionOfNextDataSetVersionFunction.CompleteNextDataSetVersionImportProcessing);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CompleteNextDataSetVersionImportFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CompleteNextDataSetVersionImportFunction.cs
@@ -1,10 +1,13 @@
 using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
@@ -13,46 +16,141 @@ using Microsoft.DurableTask.Client;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using FromBodyAttribute = Microsoft.Azure.Functions.Worker.Http.FromBodyAttribute;
+using ValidationMessages =
+    GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests.Validators.ValidationMessages;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
 
-public class CompleteNextDataSetVersionProcessingFunction(
-    ILogger<CompleteNextDataSetVersionProcessingFunction> logger,
+public class CompleteNextDataSetVersionImportFunction(
+    ILogger<CompleteNextDataSetVersionImportFunction> logger,
     PublicDataDbContext publicDataDbContext,
-    IValidator<NextDataSetVersionCompleteImportRequest> requestValidator)
+    IValidator<DataSetVersionProcessRequest> requestValidator)
 {
     [Function(nameof(CompleteNextDataSetVersionImport))]
     public async Task<IActionResult> CompleteNextDataSetVersionImport(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = nameof(CompleteNextDataSetVersionImport))] [FromBody]
-        NextDataSetVersionCompleteImportRequest request,
+        DataSetVersionProcessRequest request,
         [DurableClient] DurableTaskClient client,
         CancellationToken cancellationToken)
     {
-        var instanceId = Guid.NewGuid();
-
-        return await requestValidator.Validate(request, cancellationToken)
-            .OnSuccess(_ => publicDataDbContext
-                .DataSetVersions
-                .AsNoTracking()
-                .SingleOrNotFoundAsync(
-                    dataSetVersion => dataSetVersion.Id == request.DataSetVersionId, 
-                    cancellationToken))
-            .OnSuccess(async nextDataSetVersion =>
+        return await requestValidator
+            .Validate(request, cancellationToken)
+            .OnSuccess(_ => GetNextDataSetVersionInMappingStatus(request, cancellationToken))
+            .OnSuccessDo(_ => GetCompletedDataSetVersionMapping(request, cancellationToken))
+            .OnSuccessCombineWith(nextDataSetVersion =>
+                GetImportInManualMappingStage(request, nextDataSetVersion))
+            .OnSuccess(async versionAndImport =>
             {
+                var (nextVersion, importToContinue) = versionAndImport;
+
+                var instanceId = importToContinue.InstanceId;
+
                 await ProcessCompletionOfNextDataSetVersionImport(
                     client,
-                    dataSetVersionId: nextDataSetVersion.Id,
+                    dataSetVersionId: nextVersion.Id,
                     instanceId: instanceId,
                     cancellationToken);
 
                 return new ProcessDataSetVersionResponseViewModel
                 {
-                    DataSetId = nextDataSetVersion.DataSetId,
-                    DataSetVersionId = nextDataSetVersion.Id,
+                    DataSetId = nextVersion.DataSetId,
+                    DataSetVersionId = nextVersion.Id,
                     InstanceId = instanceId
                 };
             })
             .HandleFailuresOr(result => new OkObjectResult(result));
+    }
+
+    private static Either<ActionResult, DataSetVersionImport> GetImportInManualMappingStage(
+        DataSetVersionProcessRequest request,
+        DataSetVersion nextDataSetVersion)
+    {
+        var importToContinue = nextDataSetVersion
+            .Imports
+            .SingleOrDefault(import => import.DataSetVersionId == nextDataSetVersion.Id
+                                       && import.Stage == DataSetVersionImportStage.ManualMapping);
+
+        return importToContinue is null
+            ? ValidationUtils.ValidationResult(new ErrorViewModel
+            {
+                Code = ValidationMessages.ImportInManualMappingStateNotFound.Code,
+                Message = ValidationMessages.ImportInManualMappingStateNotFound.Message,
+                Path = nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                Detail = new InvalidErrorDetail<Guid>(request.DataSetVersionId)
+            })
+            : importToContinue;
+    }
+
+    private async Task<Either<ActionResult, DataSetVersion>> GetNextDataSetVersionInMappingStatus(DataSetVersionProcessRequest request,
+        CancellationToken cancellationToken)
+    {
+        var nextVersion = await publicDataDbContext
+            .DataSetVersions
+            .AsNoTracking()
+            .Include(dataSetVersion => dataSetVersion.Imports)
+            .SingleOrDefaultAsync(
+                dataSetVersion => dataSetVersion.Id == request.DataSetVersionId,
+                cancellationToken);
+
+        if (nextVersion is null)
+        {
+            return ValidationUtils.ValidationResult(new ErrorViewModel
+            {
+                Code = ValidationMessages.DataSetVersionNotFound.Code,
+                Message = ValidationMessages.DataSetVersionNotFound.Message,
+                Path = nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                Detail = new InvalidErrorDetail<Guid>(request.DataSetVersionId)
+            });
+        }
+
+        if (nextVersion.Status != DataSetVersionStatus.Mapping)
+        {
+            return ValidationUtils.ValidationResult(new ErrorViewModel
+            {
+                Code = ValidationMessages.DataSetVersionNotInMappingStatus.Code,
+                Message = ValidationMessages.DataSetVersionNotInMappingStatus.Message,
+                Path = nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                Detail = new InvalidErrorDetail<Guid>(request.DataSetVersionId)
+            });
+        }
+        
+        return nextVersion;
+    }
+
+    private async Task<Either<ActionResult, DataSetVersionMapping>> GetCompletedDataSetVersionMapping(
+        DataSetVersionProcessRequest request,
+        CancellationToken cancellationToken)
+    {
+        var mapping = await publicDataDbContext
+            .DataSetVersionMappings
+            .AsNoTracking()
+            .SingleOrDefaultAsync(
+                mapping => mapping.TargetDataSetVersionId == request.DataSetVersionId,
+                cancellationToken);
+
+        if (mapping is null)
+        {
+            return ValidationUtils.ValidationResult(new ErrorViewModel
+            {
+                Code = ValidationMessages.DataSetVersionMappingNotFound.Code,
+                Message = ValidationMessages.DataSetVersionMappingNotFound.Message,
+                Path = nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                Detail = new InvalidErrorDetail<Guid>(request.DataSetVersionId)
+            });
+        }
+
+        if (!mapping.FilterMappingsComplete || !mapping.LocationMappingsComplete)
+        {
+            return ValidationUtils.ValidationResult(new ErrorViewModel
+            {
+                Code = ValidationMessages.DataSetVersionMappingsNotComplete.Code,
+                Message = ValidationMessages.DataSetVersionMappingsNotComplete.Message,
+                Path = nameof(DataSetVersionProcessRequest.DataSetVersionId).ToLowerFirst(),
+                Detail = new InvalidErrorDetail<Guid>(request.DataSetVersionId)
+            });
+        }
+        
+        return mapping;
     }
 
     private async Task ProcessCompletionOfNextDataSetVersionImport(
@@ -61,7 +159,7 @@ public class CompleteNextDataSetVersionProcessingFunction(
         Guid instanceId,
         CancellationToken cancellationToken)
     {
-        const string orchestratorName = 
+        const string orchestratorName =
             nameof(ProcessCompletionOfNextDataSetVersionFunction.CompleteNextDataSetVersionImportProcessing);
 
         var input = new ProcessDataSetVersionContext { DataSetVersionId = dataSetVersionId };

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CompleteNextDataSetVersionImportFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CompleteNextDataSetVersionImportFunction.cs
@@ -143,7 +143,7 @@ public class CompleteNextDataSetVersionImportFunction(
         CancellationToken cancellationToken)
     {
         const string orchestratorName =
-            nameof(ProcessCompletionOfNextDataSetVersionFunction.CompleteNextDataSetVersionImportProcessing);
+            nameof(ProcessCompletionOfNextDataSetVersionFunction.ProcessCompletionOfNextDataSetVersion);
 
         var input = new ProcessDataSetVersionContext { DataSetVersionId = dataSetVersionId };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CompleteNextDataSetVersionProcessingFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CompleteNextDataSetVersionProcessingFunction.cs
@@ -1,0 +1,81 @@
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.Extensions.Logging;
+using FromBodyAttribute = Microsoft.Azure.Functions.Worker.Http.FromBodyAttribute;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
+
+public class CompleteNextDataSetVersionProcessingFunction(
+    ILogger<CompleteNextDataSetVersionProcessingFunction> logger,
+    IDataSetVersionService dataSetVersionService,
+    IValidator<NextDataSetVersionCreateRequest> requestValidator)
+{
+    [Function(nameof(CreateNextDataSetVersion))]
+    public async Task<IActionResult> CreateNextDataSetVersion(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = nameof(CreateNextDataSetVersion))] [FromBody]
+        NextDataSetVersionCreateRequest request,
+        [DurableClient] DurableTaskClient client,
+        CancellationToken cancellationToken)
+    {
+        // Identifier of the scheduled processing orchestration instance
+        var instanceId = Guid.NewGuid();
+
+        return await requestValidator.Validate(request, cancellationToken)
+            .OnSuccess(() => dataSetVersionService.CreateNextVersion(
+                dataSetId: request.DataSetId,
+                releaseFileId: request.ReleaseFileId,
+                instanceId,
+                cancellationToken: cancellationToken
+            ))
+            .OnSuccess(async dataSetVersionId =>
+            {
+                await ProcessNextDataSetVersion(
+                    client,
+                    dataSetVersionId: dataSetVersionId,
+                    instanceId: instanceId,
+                    cancellationToken);
+
+                return new CreateDataSetResponseViewModel
+                {
+                    DataSetId = request.DataSetId,
+                    DataSetVersionId = dataSetVersionId,
+                    InstanceId = instanceId
+                };
+            })
+            .HandleFailuresOr(result => new OkObjectResult(result));
+    }
+
+    private async Task ProcessNextDataSetVersion(
+        DurableTaskClient client,
+        Guid dataSetVersionId,
+        Guid instanceId,
+        CancellationToken cancellationToken)
+    {
+        const string orchestratorName = nameof(ProcessNextDataSetVersionMappingsFunction.ProcessNextDataSetVersion);
+
+        var input = new ProcessDataSetVersionContext { DataSetVersionId = dataSetVersionId };
+
+        var options = new StartOrchestrationOptions { InstanceId = instanceId.ToString() };
+
+        logger.LogInformation(
+            "Scheduling '{OrchestratorName}' (InstanceId={InstanceId}, DataSetVersionId={DataSetVersionId})",
+            orchestratorName,
+            instanceId,
+            dataSetVersionId);
+
+        await client.ScheduleNewOrchestrationInstanceAsync(
+            orchestratorName,
+            input,
+            options,
+            cancellationToken);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateDataSetFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateDataSetFunction.cs
@@ -43,7 +43,7 @@ public class CreateDataSetFunction(
                     instanceId: instanceId,
                     cancellationToken);
 
-                return new CreateDataSetResponseViewModel
+                return new ProcessDataSetVersionResponseViewModel
                 {
                     DataSetId = tuple.dataSetId,
                     DataSetVersionId = tuple.dataSetVersionId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateNextDataSetVersionMappingsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateNextDataSetVersionMappingsFunction.cs
@@ -44,7 +44,7 @@ public class CreateNextDataSetVersionMappingsFunction(
                     instanceId: instanceId,
                     cancellationToken);
 
-                return new CreateDataSetResponseViewModel
+                return new ProcessDataSetVersionResponseViewModel
                 {
                     DataSetId = request.DataSetId,
                     DataSetVersionId = dataSetVersionId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateNextDataSetVersionMappingsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateNextDataSetVersionMappingsFunction.cs
@@ -17,22 +17,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Funct
 public class CreateNextDataSetVersionMappingsFunction(
     ILogger<CreateNextDataSetVersionMappingsFunction> logger,
     IDataSetVersionService dataSetVersionService,
-    IValidator<NextDataSetVersionCreateRequest> requestValidator)
+    IValidator<NextDataSetVersionCreateMappingsRequest> requestValidator)
 {
     [Function(nameof(CreateNextDataSetVersion))]
     public async Task<IActionResult> CreateNextDataSetVersion(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = nameof(CreateNextDataSetVersion))] [FromBody]
-        NextDataSetVersionCreateRequest request,
+        NextDataSetVersionCreateMappingsRequest mappingsRequest,
         [DurableClient] DurableTaskClient client,
         CancellationToken cancellationToken)
     {
         // Identifier of the scheduled processing orchestration instance
         var instanceId = Guid.NewGuid();
 
-        return await requestValidator.Validate(request, cancellationToken)
+        return await requestValidator.Validate(mappingsRequest, cancellationToken)
             .OnSuccess(() => dataSetVersionService.CreateNextVersion(
-                dataSetId: request.DataSetId,
-                releaseFileId: request.ReleaseFileId,
+                dataSetId: mappingsRequest.DataSetId,
+                releaseFileId: mappingsRequest.ReleaseFileId,
                 instanceId,
                 cancellationToken: cancellationToken
             ))
@@ -46,7 +46,7 @@ public class CreateNextDataSetVersionMappingsFunction(
 
                 return new ProcessDataSetVersionResponseViewModel
                 {
-                    DataSetId = request.DataSetId,
+                    DataSetId = mappingsRequest.DataSetId,
                     DataSetVersionId = dataSetVersionId,
                     InstanceId = instanceId
                 };

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessCompletionOfNextDataSetVersionFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessCompletionOfNextDataSetVersionFunction.cs
@@ -1,0 +1,65 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.DurableTask;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
+
+public class ProcessCompletionOfNextDataSetVersionFunction(
+    PublicDataDbContext publicDataDbContext,
+    IDataSetVersionPathResolver dataSetVersionPathResolver) : BaseProcessDataSetVersionFunction(publicDataDbContext)
+{
+    [Function(nameof(ProcessCompletionOfNextDataSetVersion))]
+    public async Task ProcessCompletionOfNextDataSetVersion(
+        [OrchestrationTrigger] TaskOrchestrationContext context,
+        ProcessDataSetVersionContext input)
+    {
+        var logger = context.CreateReplaySafeLogger(nameof(ProcessCompletionOfNextDataSetVersion));
+
+        logger.LogInformation(
+            "Processing completion of import for next data set version (InstanceId={InstanceId}, " +
+            "DataSetVersionId={DataSetVersionId})",
+            context.InstanceId,
+            input.DataSetVersionId);
+
+        try
+        {
+            await context.CallActivity(ActivityNames.ImportData, logger, context.InstanceId);
+            await context.CallActivity(ActivityNames.WriteDataFiles, logger, context.InstanceId);
+            await context.CallActivity(ActivityNames.CompleteNextDataSetVersionImportProcessing, logger,
+                context.InstanceId);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e,
+                "Activity failed with an exception (InstanceId={InstanceId}, DataSetVersionId={DataSetVersionId})",
+                context.InstanceId,
+                input.DataSetVersionId);
+
+            await context.CallActivity(ActivityNames.HandleProcessingFailure, logger, context.InstanceId);
+        }
+    }
+
+    [Function(ActivityNames.CompleteNextDataSetVersionImportProcessing)]
+    public async Task CompleteNextDataSetVersionImportProcessing(
+        [ActivityTrigger] Guid instanceId,
+        CancellationToken cancellationToken)
+    {
+        var dataSetVersionImport = await GetDataSetVersionImport(instanceId, cancellationToken);
+        await UpdateImportStage(dataSetVersionImport, DataSetVersionImportStage.Completing, cancellationToken);
+
+        var dataSetVersion = dataSetVersionImport.DataSetVersion;
+
+        // Delete the DuckDb database file as it is no longer needed
+        File.Delete(dataSetVersionPathResolver.DuckDbPath(dataSetVersion));
+        
+        dataSetVersion.Status = DataSetVersionStatus.Draft;
+
+        dataSetVersionImport.Completed = DateTimeOffset.UtcNow;
+        await publicDataDbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessNextDataSetVersionMappingsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessNextDataSetVersionMappingsFunction.cs
@@ -69,7 +69,7 @@ public class ProcessNextDataSetVersionMappingsFunction(
         CancellationToken cancellationToken)
     {
         var dataSetVersionImport = await GetDataSetVersionImport(instanceId, cancellationToken);
-        await UpdateImportStage(dataSetVersionImport, DataSetVersionImportStage.Completing, cancellationToken);
+        await UpdateImportStage(dataSetVersionImport, DataSetVersionImportStage.ManualMapping, cancellationToken);
 
         var dataSetVersion = dataSetVersionImport.DataSetVersion;
         dataSetVersion.Status = DataSetVersionStatus.Mapping;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessNextDataSetVersionMappingsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessNextDataSetVersionMappingsFunction.cs
@@ -74,7 +74,6 @@ public class ProcessNextDataSetVersionMappingsFunction(
         var dataSetVersion = dataSetVersionImport.DataSetVersion;
         dataSetVersion.Status = DataSetVersionStatus.Mapping;
 
-        dataSetVersionImport.Completed = DateTimeOffset.UtcNow;
         await publicDataDbContext.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetService.cs
@@ -1,9 +1,6 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators;
-using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
-using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
@@ -12,8 +9,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using ValidationMessages =
-    GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests.Validators.ValidationMessages;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Services;
 
@@ -68,13 +63,9 @@ public class DataSetService(
             .FirstOrDefaultAsync(rf => rf.Id == releaseFileId, cancellationToken);
 
         return releaseFile is null
-            ? ValidationUtils.ValidationResult(new ErrorViewModel
-            {
-                Code = ValidationMessages.FileNotFound.Code,
-                Message = ValidationMessages.FileNotFound.Message,
-                Path = nameof(DataSetCreateRequest.ReleaseFileId).ToLowerFirst(),
-                Detail = new InvalidErrorDetail<Guid>(releaseFileId)
-            })
+            ? ValidationUtils.NotFoundResult<ReleaseFile, Guid>(
+                releaseFileId, 
+                nameof(DataSetCreateRequest.ReleaseFileId).ToLowerFirst())
             : releaseFile;
     }
 }


### PR DESCRIPTION
## Overview

This PR:
- adds an HTTP trigger for kicking off the completion of the next data set version import after mapping is complete.
- adds an orchestration that is triggered by the HTTP trigger.  Currently the additional logic to use the mappings to complete the import is not implemented, but will be added into this workflow as part of EES-4954.
- adds validation and tests around the new trigger and orchestration.

## Other miscellaneous changes

### Reusing and renaming CreateDataSetResponseViewModel

All 3 of the HTTP trigger Functions were returning the same response details, so I renamed `CreateDataSetResponseViewModel` to `ProcessDataSetVersionResponseViewModel` and reused across all 3.  This has led to a few little changes in other miscellaneous files.

### New "ManualMapping" import stage

As the import process is effectively "paused" at this stage of processing until the user finishes the manual mapping, I added another stage to reflect this.  Upon triggering this new orchestration, the import will "unpause" and continue to completion.

A new InstanceId will be assigned to the import entity so as not to confuse a new orchestration with an already-run one!

It didn't have to be done this way - we could also have completed the 1st import entity and then created a 2nd import entity to start off the second stage of the import, but to me personally this felt like more of an intuitive way to model it.   