### PR TITLE
EES-4373 create new api data set version

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -171,6 +171,9 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     expect(summary.getByTestId('Filters')).toHaveTextContent(
       'Test draft filter',
     );
+    expect(
+      screen.getByRole('button', { name: 'Remove draft version' }),
+    ).toBeInTheDocument();
 
     expect(
       screen.queryByRole('heading', { name: 'Latest live version details' }),
@@ -216,6 +219,9 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     );
 
     expect(
+      screen.queryByRole('button', { name: 'Remove draft version' }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByRole('heading', { name: 'Draft version details' }),
     ).not.toBeInTheDocument();
   });
@@ -255,6 +261,9 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     expect(draftSummary.getByTestId('Filters')).toHaveTextContent(
       'Test draft filter',
     );
+    expect(
+      draftSummary.getByRole('button', { name: 'Remove draft version' }),
+    ).toBeInTheDocument();
 
     // Latest live version
 
@@ -283,6 +292,83 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       'href',
       'http://localhost/data-catalogue/data-set/live-file-id',
     );
+  });
+
+  test('does not render the Remove draft version button when cannot update the release', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      draftVersion: testDraftVersion,
+      latestLiveVersion: testLiveVersion,
+    });
+
+    renderPage({ release: { ...testRelease, approvalStatus: 'Approved' } });
+
+    expect(
+      await screen.findByText('Draft version details'),
+    ).toBeInTheDocument();
+
+    const draftSummary = within(screen.getByTestId('draft-version-summary'));
+    expect(
+      draftSummary.queryByRole('button', { name: 'Remove draft version' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders the create new version button when release can be updated and there is no draft version', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      latestLiveVersion: testLiveVersion,
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('Latest live version details'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Create a new version of this data set',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('does not render the create new version button when cannot update the release', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      latestLiveVersion: testLiveVersion,
+    });
+
+    renderPage({ release: { ...testRelease, approvalStatus: 'Approved' } });
+
+    expect(
+      await screen.findByText('Latest live version details'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Create a new version of this data set',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not render the create new version button when there is a draft version', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      draftVersion: testDraftVersion,
+      latestLiveVersion: testLiveVersion,
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('Latest live version details'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Create a new version of this data set',
+      }),
+    ).not.toBeInTheDocument();
   });
 
   function renderPage(options?: { release?: Release; dataSetId?: string }) {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateForm.tsx
@@ -15,12 +15,14 @@ export interface ApiDataSetCreateFormValues {
 
 export interface ApiDataSetCreateFormProps {
   dataSetCandidates: ApiDataSetCandidate[];
+  submitText?: string;
   onCancel: () => void;
   onSubmit: (values: ApiDataSetCreateFormValues) => void;
 }
 
 export default function ApiDataSetCreateForm({
   dataSetCandidates,
+  submitText = 'Confirm new API data set',
   onCancel,
   onSubmit,
 }: ApiDataSetCreateFormProps) {
@@ -49,7 +51,7 @@ export default function ApiDataSetCreateForm({
 
             <ButtonGroup>
               <Button type="submit" ariaDisabled={formState.isSubmitting}>
-                Confirm new API data set
+                {submitText}
               </Button>
               <ButtonText
                 ariaDisabled={formState.isSubmitting}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateModal.tsx
@@ -4,104 +4,81 @@ import ApiDataSetCreateForm, {
 } from '@admin/pages/release/data/components/ApiDataSetCreateForm';
 import apiDataSetCandidateQueries from '@admin/queries/apiDataSetCandidateQueries';
 import {
-  releaseApiDataSetDetailsRoute,
   releaseDataRoute,
-  ReleaseDataSetRouteParams,
   ReleaseRouteParams,
 } from '@admin/routes/releaseRoutes';
-import apiDataSetService from '@admin/services/apiDataSetService';
 import Button from '@common/components/Button';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 import Modal from '@common/components/Modal';
 import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import { useQuery } from '@tanstack/react-query';
-import React from 'react';
-import { generatePath, useHistory } from 'react-router-dom';
+import React, { ReactNode } from 'react';
+import { generatePath } from 'react-router-dom';
 
 interface Props {
+  buttonText?: ReactNode | string;
   publicationId: string;
   releaseId: string;
+  submitText?: string;
+  title?: string;
+  onSubmit: (values: ApiDataSetCreateFormValues) => void;
 }
 
 export default function ApiDataSetCreateModal({
+  buttonText = 'Create API data set',
   publicationId,
   releaseId,
+  submitText,
+  title = 'Create a new API data set',
+  onSubmit,
 }: Props) {
-  const history = useHistory();
   const [isOpen, toggleOpen] = useToggle(false);
 
-  const {
-    data: dataSetCandidates = [],
-    isLoading,
-    refetch,
-  } = useQuery(apiDataSetCandidateQueries.list(releaseId));
-
-  const handleTriggerClick = async () => {
-    toggleOpen.on();
-    await refetch();
-  };
-
-  const handleSubmit = async ({
-    releaseFileId,
-  }: ApiDataSetCreateFormValues) => {
-    const dataSet = await apiDataSetService.createDataSet({
-      releaseFileId,
-    });
-
-    history.push(
-      generatePath<ReleaseDataSetRouteParams>(
-        releaseApiDataSetDetailsRoute.path,
-        {
-          publicationId,
-          releaseId,
-          dataSetId: dataSet.id,
-        },
-      ),
-    );
-  };
-
-  if (isLoading) {
-    return null;
-  }
+  const { data: dataSetCandidates = [], isLoading } = useQuery({
+    ...apiDataSetCandidateQueries.list(releaseId),
+    enabled: isOpen,
+  });
 
   return (
     <Modal
       open={isOpen}
-      title="Create a new API data set"
-      triggerButton={
-        <Button onClick={handleTriggerClick}>Create API data set</Button>
-      }
+      title={title}
+      triggerButton={<Button onClick={toggleOpen.on}>{buttonText}</Button>}
     >
-      <p>
-        Select a data set to become an API data set. This will be made available
-        for third-party applications to consume via the public API.
-      </p>
+      <LoadingSpinner loading={isLoading}>
+        <p>
+          Select a data set to become an API data set. This will be made
+          available for third-party applications to consume via the public API.
+        </p>
 
-      {dataSetCandidates.length > 0 ? (
-        <ApiDataSetCreateForm
-          dataSetCandidates={dataSetCandidates}
-          onCancel={toggleOpen.off}
-          onSubmit={handleSubmit}
-        />
-      ) : (
-        <>
-          <WarningMessage>
-            No API data sets can be created as there are no candidate data files
-            available. New candidate data files can be uploaded in the{' '}
-            <Link
-              to={generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
-                publicationId,
-                releaseId,
-              })}
-            >
-              Data and files
-            </Link>{' '}
-            section.
-          </WarningMessage>
+        {dataSetCandidates.length > 0 ? (
+          <ApiDataSetCreateForm
+            dataSetCandidates={dataSetCandidates}
+            submitText={submitText}
+            onCancel={toggleOpen.off}
+            onSubmit={onSubmit}
+          />
+        ) : (
+          <>
+            <WarningMessage>
+              No API data sets can be created as there are no candidate data
+              files available. New candidate data files can be uploaded in the{' '}
+              <Link
+                to={generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
+                  publicationId,
+                  releaseId,
+                })}
+              >
+                Data and files
+              </Link>{' '}
+              section.
+            </WarningMessage>
 
-          <Button onClick={toggleOpen.off}>Close</Button>
-        </>
-      )}
+            <Button onClick={toggleOpen.off}>Close</Button>
+          </>
+        )}
+      </LoadingSpinner>
     </Modal>
   );
 }

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DeleteDraftVersionButton.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DeleteDraftVersionButton.tsx
@@ -21,7 +21,7 @@ export default function DeleteDraftVersionButton({
   children,
   dataSet,
   dataSetVersion,
-  modalTitle = 'Remove draft version',
+  modalTitle = 'Remove this draft API data set version',
   onDeleted,
 }: DeleteDraftVersionButtonProps) {
   const queryClient = useQueryClient();
@@ -41,15 +41,21 @@ export default function DeleteDraftVersionButton({
 
   return (
     <ModalConfirm
+      confirmText="Remove this API data set version"
+      submitButtonVariant="warning"
       title={modalTitle}
       triggerButton={<ButtonText variant="warning">{children}</ButtonText>}
       hiddenConfirmingText="Removing draft version"
       onConfirm={handleConfirm}
     >
-      <p data-testid="confirm-text">
-        Confirm that you want to delete the draft version{' '}
-        <strong>{dataSetVersion.version}</strong> for API data set: <br />
+      <p>Are you sure you want to remove the selected API data set version?</p>
+      <p>
         <strong>{dataSet.title}</strong>
+      </p>
+      <p>
+        Please note this doesn't affect the current live API data set in any
+        way. You can reassign a data set version at any time prior to this
+        release being published.
       </p>
     </ModalConfirm>
   );

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DraftApiDataSetsTable.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DraftApiDataSetsTable.module.scss
@@ -19,11 +19,12 @@
   }
 }
 
-.rowHighlight {
-  border-left: 5px solid govuk-colour('red');
-}
+.table tbody {
+  tr {
+    border-left: 5px solid transparent;
+  }
 
-.versionTag {
-  text-align: center;
-  width: 100%;
+  .rowHighlight {
+    border-left-color: govuk-colour('red');
+  }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/LiveApiDataSetsTable.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/LiveApiDataSetsTable.module.scss
@@ -7,3 +7,9 @@
     vertical-align: middle;
   }
 }
+
+.table tbody {
+  tr {
+    border-left: 5px solid transparent;
+  }
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseApiDataSetsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseApiDataSetsSection.tsx
@@ -8,13 +8,20 @@ import LiveApiDataSetsTable, {
   LiveApiDataSetSummary,
 } from '@admin/pages/release/data/components/LiveApiDataSetsTable';
 import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
+import apiDataSetService from '@admin/services/apiDataSetService';
+import {
+  releaseApiDataSetDetailsRoute,
+  ReleaseDataSetRouteParams,
+} from '@admin/routes/releaseRoutes';
 import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import { useQuery } from '@tanstack/react-query';
 import React from 'react';
+import { generatePath, useHistory } from 'react-router-dom';
 
 export default function ReleaseApiDataSetsSection() {
+  const history = useHistory();
   const { release } = useReleaseContext();
   const { user } = useAuthContext();
 
@@ -74,6 +81,21 @@ export default function ReleaseApiDataSetsSection() {
               <ApiDataSetCreateModal
                 publicationId={release.publicationId}
                 releaseId={release.id}
+                onSubmit={async ({ releaseFileId }) => {
+                  const dataSet = await apiDataSetService.createDataSet({
+                    releaseFileId,
+                  });
+                  history.push(
+                    generatePath<ReleaseDataSetRouteParams>(
+                      releaseApiDataSetDetailsRoute.path,
+                      {
+                        publicationId: release.publicationId,
+                        releaseId: release.id,
+                        dataSetId: dataSet.id,
+                      },
+                    ),
+                  );
+                }}
               />
             ) : (
               <WarningMessage>
@@ -91,6 +113,7 @@ export default function ReleaseApiDataSetsSection() {
                 <h3>Draft API data sets</h3>
 
                 <DraftApiDataSetsTable
+                  canUpdateRelease={canUpdateRelease}
                   dataSets={draftDataSets}
                   publicationId={release.publicationId}
                   releaseId={release.id}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateModal.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateModal.test.tsx
@@ -6,6 +6,7 @@ import _apiDataSetService from '@admin/services/apiDataSetService';
 import baseRender from '@common-test/render';
 import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory, History } from 'history';
+import noop from 'lodash/noop';
 import { ReactElement } from 'react';
 import { Router } from 'react-router-dom';
 
@@ -34,6 +35,7 @@ describe('ApiDataSetCreateModal', () => {
       <ApiDataSetCreateModal
         publicationId="publication-id"
         releaseId="release-id"
+        onSubmit={noop}
       />,
     );
 
@@ -57,6 +59,7 @@ describe('ApiDataSetCreateModal', () => {
       <ApiDataSetCreateModal
         publicationId="publication-id"
         releaseId="release-id"
+        onSubmit={noop}
       />,
     );
 
@@ -85,7 +88,7 @@ describe('ApiDataSetCreateModal', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('submitting the form calls correct service and redirects to next page', async () => {
+  test('submitting the form calls onSubmit', async () => {
     apiDataSetCandidateService.listCandidates.mockResolvedValue(testCandidates);
     apiDataSetService.createDataSet.mockResolvedValue({
       id: 'data-set-id',
@@ -95,11 +98,13 @@ describe('ApiDataSetCreateModal', () => {
     });
 
     const history = createMemoryHistory();
+    const handleSubmit = jest.fn();
 
     const { user } = render(
       <ApiDataSetCreateModal
         publicationId="publication-id"
         releaseId="release-id"
+        onSubmit={handleSubmit}
       />,
       { history },
     );
@@ -115,24 +120,18 @@ describe('ApiDataSetCreateModal', () => {
       testCandidates[0].releaseFileId,
     );
 
-    expect(apiDataSetService.createDataSet).not.toHaveBeenCalled();
+    expect(handleSubmit).not.toHaveBeenCalled();
 
     await user.click(
       screen.getByRole('button', { name: 'Confirm new API data set' }),
     );
 
     await waitFor(() => {
-      expect(apiDataSetService.createDataSet).toHaveBeenCalledTimes(1);
-      expect(apiDataSetService.createDataSet).toHaveBeenCalledWith<
-        Parameters<typeof apiDataSetService.createDataSet>
-      >({
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+      expect(handleSubmit).toHaveBeenCalledWith({
         releaseFileId: testCandidates[0].releaseFileId,
       });
     });
-
-    expect(history.location.pathname).toBe(
-      '/publication/publication-id/release/release-id/api-data-sets/data-set-id',
-    );
   });
 
   function render(

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DeleteDraftVersionButton.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DeleteDraftVersionButton.test.tsx
@@ -26,38 +26,43 @@ describe('DeleteDraftVersionButton', () => {
         dataSet={testDataSet}
         dataSetVersion={testDataSetVersion}
       >
-        Delete draft version
+        Remove draft version
       </DeleteDraftVersionButton>,
     );
 
     expect(
-      screen.getByRole('button', { name: 'Delete draft version' }),
+      screen.getByRole('button', { name: 'Remove draft version' }),
     ).toBeInTheDocument();
   });
 
-  test('clicking the `Confirm` button opens a confirmation modal', async () => {
+  test('clicking the `Remove` button opens a confirmation modal', async () => {
     const { user } = render(
       <DeleteDraftVersionButton
         dataSet={testDataSet}
         dataSetVersion={testDataSetVersion}
       >
-        Delete draft version
+        Remove draft version
       </DeleteDraftVersionButton>,
     );
 
     await user.click(
-      screen.getByRole('button', { name: 'Delete draft version' }),
+      screen.getByRole('button', { name: 'Remove draft version' }),
     );
 
     const modal = within(screen.getByRole('dialog'));
 
     expect(
-      modal.getByRole('heading', { name: 'Remove draft version' }),
+      modal.getByRole('heading', {
+        name: 'Remove this draft API data set version',
+      }),
     ).toBeInTheDocument();
 
-    expect(modal.getByTestId('confirm-text')).toHaveTextContent(
-      'Confirm that you want to delete the draft version 1.0 for API data set: Data set title',
-    );
+    expect(
+      modal.getByText(
+        'Are you sure you want to remove the selected API data set version?',
+      ),
+    ).toBeInTheDocument();
+    expect(modal.getByText('Data set title')).toBeInTheDocument();
   });
 
   test('confirming the deletion calls the correct service', async () => {
@@ -66,19 +71,21 @@ describe('DeleteDraftVersionButton', () => {
         dataSet={testDataSet}
         dataSetVersion={testDataSetVersion}
       >
-        Delete draft version
+        Remove draft version
       </DeleteDraftVersionButton>,
     );
 
     await user.click(
-      screen.getByRole('button', { name: 'Delete draft version' }),
+      screen.getByRole('button', { name: 'Remove draft version' }),
     );
 
     const modal = within(screen.getByRole('dialog'));
 
     expect(apiDataSetVersionService.deleteVersion).not.toHaveBeenCalled();
 
-    await user.click(modal.getByRole('button', { name: 'Confirm' }));
+    await user.click(
+      modal.getByRole('button', { name: 'Remove this API data set version' }),
+    );
 
     expect(apiDataSetVersionService.deleteVersion).toHaveBeenCalledWith(
       testDataSetVersion.id,
@@ -91,20 +98,24 @@ describe('DeleteDraftVersionButton', () => {
         dataSet={testDataSet}
         dataSetVersion={testDataSetVersion}
       >
-        Delete draft version
+        Remove draft version
       </DeleteDraftVersionButton>,
     );
 
     await user.click(
-      screen.getByRole('button', { name: 'Delete draft version' }),
+      screen.getByRole('button', { name: 'Remove draft version' }),
     );
 
     const modal = within(screen.getByRole('dialog'));
 
-    await user.click(modal.getByRole('button', { name: 'Confirm' }));
+    await user.click(
+      modal.getByRole('button', { name: 'Remove this API data set version' }),
+    );
 
     await waitFor(() => {
-      expect(screen.queryByText('Confirm')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Remove this API data set version'),
+      ).not.toBeInTheDocument();
     });
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DraftApiDataSetsTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DraftApiDataSetsTable.test.tsx
@@ -99,6 +99,7 @@ describe('DraftApiDataSetsTable', () => {
   test('renders draft data set rows correctly', () => {
     render(
       <DraftApiDataSetsTable
+        canUpdateRelease
         dataSets={testDataSets}
         publicationId="publication-1"
         releaseId="release-1"
@@ -128,7 +129,7 @@ describe('DraftApiDataSetsTable', () => {
     ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-1`);
     expect(
       within(row1Cells[4]).getByRole('button', {
-        name: 'Delete draft for Data set 1 title',
+        name: 'Remove draft for Data set 1 title',
       }),
     ).toBeInTheDocument();
 
@@ -149,7 +150,7 @@ describe('DraftApiDataSetsTable', () => {
 
     expect(
       within(row2Cells[4]).getByRole('button', {
-        name: 'Delete draft for Data set 2 title',
+        name: 'Remove draft for Data set 2 title',
       }),
     ).toBeInTheDocument();
 
@@ -169,7 +170,7 @@ describe('DraftApiDataSetsTable', () => {
     ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-3`);
     expect(
       within(row3Cells[4]).queryByRole('button', {
-        name: /Delete draft/,
+        name: /Remove draft/,
       }),
     ).not.toBeInTheDocument();
 
@@ -190,7 +191,7 @@ describe('DraftApiDataSetsTable', () => {
 
     expect(
       within(row4Cells[4]).getByRole('button', {
-        name: 'Delete draft for Data set 4 title',
+        name: 'Remove draft for Data set 4 title',
       }),
     ).toBeInTheDocument();
 
@@ -211,7 +212,7 @@ describe('DraftApiDataSetsTable', () => {
 
     expect(
       within(row5Cells[4]).getByRole('button', {
-        name: 'Delete draft for Data set 5 title',
+        name: 'Remove draft for Data set 5 title',
       }),
     ).toBeInTheDocument();
 
@@ -232,14 +233,117 @@ describe('DraftApiDataSetsTable', () => {
 
     expect(
       within(row6Cells[4]).getByRole('button', {
-        name: 'Delete draft for Data set 6 title',
+        name: 'Remove draft for Data set 6 title',
       }),
     ).toBeInTheDocument();
+  });
+
+  test('renders draft data set rows correctly when cannot update the release', () => {
+    render(
+      <DraftApiDataSetsTable
+        canUpdateRelease={false}
+        dataSets={testDataSets}
+        publicationId="publication-1"
+        releaseId="release-1"
+      />,
+    );
+
+    const baseDataSetUrl =
+      '/publication/publication-1/release/release-1/api-data-sets';
+
+    const rows = within(screen.getByRole('table')).getAllByRole('row');
+
+    expect(rows).toHaveLength(7);
+
+    // Row 1
+
+    const row1Cells = within(rows[1]).getAllByRole('cell');
+    expect(
+      within(row1Cells[4]).getByRole('link', {
+        name: 'View details for Data set 1 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-1`);
+    expect(
+      within(row1Cells[4]).queryByRole('button', {
+        name: /Remove draft/,
+      }),
+    ).not.toBeInTheDocument();
+
+    // Row 2
+
+    const row2Cells = within(rows[2]).getAllByRole('cell');
+    expect(
+      within(row2Cells[4]).getByRole('link', {
+        name: 'View details for Data set 2 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-2`);
+    expect(
+      within(row2Cells[4]).queryByRole('button', {
+        name: /Remove draft/,
+      }),
+    ).not.toBeInTheDocument();
+
+    // Row 3
+
+    const row3Cells = within(rows[3]).getAllByRole('cell');
+    expect(
+      within(row3Cells[4]).getByRole('link', {
+        name: 'View details for Data set 3 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-3`);
+    expect(
+      within(row3Cells[4]).queryByRole('button', {
+        name: /Remove draft/,
+      }),
+    ).not.toBeInTheDocument();
+
+    // Row 4
+
+    const row4Cells = within(rows[4]).getAllByRole('cell');
+    expect(
+      within(row4Cells[4]).getByRole('link', {
+        name: 'View details for Data set 4 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-4`);
+    expect(
+      within(row4Cells[4]).queryByRole('button', {
+        name: /Remove draft/,
+      }),
+    ).not.toBeInTheDocument();
+
+    // Row 5
+
+    const row5Cells = within(rows[5]).getAllByRole('cell');
+    expect(
+      within(row5Cells[4]).getByRole('link', {
+        name: 'View details for Data set 5 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-5`);
+    expect(
+      within(row5Cells[4]).queryByRole('button', {
+        name: /Remove draft/,
+      }),
+    ).not.toBeInTheDocument();
+
+    // Row 6
+
+    const row6Cells = within(rows[6]).getAllByRole('cell');
+    expect(
+      within(row6Cells[4]).getByRole('link', {
+        name: 'View details for Data set 6 title',
+      }),
+    ).toHaveAttribute('href', `${baseDataSetUrl}/data-set-6`);
+    expect(
+      within(row5Cells[4]).queryByRole('button', {
+        name: /Remove draft/,
+      }),
+    ).not.toBeInTheDocument();
   });
 
   test('renders message when no data sets', () => {
     render(
       <DraftApiDataSetsTable
+        canUpdateRelease
         dataSets={[]}
         publicationId="publication-1"
         releaseId="release-1"

--- a/src/explore-education-statistics-admin/src/services/apiDataSetVersionService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetVersionService.ts
@@ -1,6 +1,13 @@
 import client from '@admin/services/utils/service';
+import { ApiDataSet } from '@admin/services/apiDataSetService';
 
 const apiDataSetVersionService = {
+  createVersion(data: {
+    dataSetId: string;
+    releaseFileId: string;
+  }): Promise<ApiDataSet> {
+    return client.post('/public-data/data-set-versions', data);
+  },
   deleteVersion(versionId: string): Promise<void> {
     return client.delete(`/public-data/data-set-versions/${versionId}`);
   },

--- a/src/explore-education-statistics-common/src/components/ModalConfirm.tsx
+++ b/src/explore-education-statistics-common/src/components/ModalConfirm.tsx
@@ -15,6 +15,7 @@ interface Props {
   hiddenConfirmingText?: string;
   open?: boolean;
   showCancel?: boolean;
+  submitButtonVariant?: 'secondary' | 'warning';
   title: string;
   triggerButton?: ReactNode;
   underlayClass?: string;
@@ -32,6 +33,7 @@ export default function ModalConfirm({
   hiddenConfirmingText = 'Confirming',
   open: initialOpen = false,
   showCancel = true,
+  submitButtonVariant = 'secondary',
   title,
   triggerButton,
   underlayClass,
@@ -107,16 +109,16 @@ export default function ModalConfirm({
 
       <ButtonGroup className="govuk-!-margin-top-6">
         {showCancel && (
-          <Button
-            disabled={isConfirming}
-            variant="secondary"
-            onClick={handleCancel}
-          >
+          <Button disabled={isConfirming} onClick={handleCancel}>
             {cancelText}
           </Button>
         )}
 
-        <Button disabled={isCancelling} onClick={handleConfirm}>
+        <Button
+          disabled={isCancelling}
+          variant={submitButtonVariant}
+          onClick={handleConfirm}
+        >
           {confirmText}
         </Button>
 


### PR DESCRIPTION
- Hooks up the UI to create new API data set versions
- Adds the create new API data set version button to the API data set details page
- Changes the 'delete' modal to 'remove' as per the Figma
- If you're viewing a published release I've removed the option to edit / remove drafts for API data sets that have been created on a later release 
- Some tidying up of alignment in the live and draft tables.