### PR TITLE
EES-5111 - added Newtonsoft JSON converter

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionMapping.cs
@@ -122,6 +122,7 @@ public abstract record Mapping<TMappableElement>
     where TMappableElement : MappableElement
 {
     [JsonConverter(typeof(JsonStringEnumConverter))]
+    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
     public MappingType Type { get; set; } = MappingType.None;
 
     public TMappableElement Source { get; set; } = null!;


### PR DESCRIPTION
This PR:
- adds a Newtonsoft JSON converter to allow the MappingType enum to be serialised as a string over MVC

We already use System.Text.Json.Serialisation's JsonConverter to handle conversion for the database, as this is what is used by Entity Framework.