### PR TITLE
EES-5339 Temporarily increase statistics database scale after slow running observed

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -84,7 +84,7 @@
       "value": "GeneralPurpose"
     },
     "capacityStatisticsDb": {
-      "value": 6
+      "value": 10
     },
     "tableBuilderMaxTableCellsAllowed": {
       "value": 1000000


### PR DESCRIPTION
This PR changes the statistics primary and replica databases in the Prod environment from provisioned 6 to 10 vCores.

This is a code change to reflect the same change that's already been made to the databases manually on 10/07/24.