### PR TITLE
EES-4954 - continue import of next data set version, using the mappings

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
@@ -57,104 +57,52 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSets.Update(dataSet);
             });
 
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = currentDataSetVersion.Id,
-                TargetDataSetVersionId = nextDataSetVersion.Id,
-                LocationMappingPlan = new LocationMappingPlan
-                {
-                    Levels = new Dictionary<GeographicLevel, LocationLevelMappings>
-                    {
-                        {
-                            GeographicLevel.LocalAuthority, new LocationLevelMappings
-                            {
-                                Mappings = new Dictionary<string, LocationOptionMapping>
-                                {
-                                    {
-                                        "source-location-1-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 1")
-                                            {
-                                                Code = "Source location 1 code"
-                                            },
-                                            Type = MappingType.AutoMapped,
-                                            CandidateKey = "target-location-1-key"
-                                        }
-                                    },
-                                    {
-                                        "source-location-2-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 2")
-                                            {
-                                                Code = "Source location 2 code"
-                                            },
-                                            Type = MappingType.None,
-                                            CandidateKey = null
-                                        }
-                                    }
-                                },
-                                Candidates =
-                                    new Dictionary<string, MappableLocationOption>
-                                    {
-                                        {
-                                            "target-location-1-key",
-                                            new MappableLocationOption("Target location 1")
-                                            {
-                                                Code = "Target location 1 code"
-                                            }
-                                        }
-                                    }
-                            }
-                        },
-                        {
-                            GeographicLevel.Country,
-                            new LocationLevelMappings
-                            {
-                                Mappings = new Dictionary<string, LocationOptionMapping>
-                                {
-                                    {
-                                        "source-location-1-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 1")
-                                            {
-                                                Code = "Source location 1 code"
-                                            },
-                                            Type = MappingType.ManualNone,
-                                            CandidateKey = null
-                                        }
-                                    },
-                                    {
-                                        "source-location-3-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 3")
-                                            {
-                                                Code = "Source location 3 code"
-                                            },
-                                            Type = MappingType.ManualMapped,
-                                            CandidateKey = "target-location-1-key"
-                                        }
-                                    }
-                                },
-                                Candidates = new Dictionary<string, MappableLocationOption>
-                                {
-                                    {
-                                        "target-location-1-key",
-                                        new MappableLocationOption("Target location 1")
-                                        {
-                                            Code = "Target location 1 code"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                FilterMappingPlan = new FilterMappingPlan()
-            };
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .DefaultLocationMappingPlan()
+                    .AddLevel(
+                        level: GeographicLevel.LocalAuthority,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "source-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithAutoMapped("target-location-1-key"))
+                            .AddMapping(
+                                sourceKey: "source-location-2-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping()
+                            )
+                            .AddCandidate(
+                                targetKey: "target-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption()))
+                    .AddLevel(
+                        level: GeographicLevel.Country,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "source-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithManualNone())
+                            .AddMapping(
+                                sourceKey: "source-location-2-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithManualMapped("target-location-1-key")
+                            )
+                            .AddCandidate(
+                                targetKey: "target-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())));
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
@@ -243,104 +191,51 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSets.Update(dataSet);
             });
 
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = currentDataSetVersion.Id,
-                TargetDataSetVersionId = nextDataSetVersion.Id,
-                LocationMappingPlan = new LocationMappingPlan
-                {
-                    Levels = new Dictionary<GeographicLevel, LocationLevelMappings>
-                    {
-                        {
-                            GeographicLevel.LocalAuthority, new LocationLevelMappings
-                            {
-                                Mappings = new Dictionary<string, LocationOptionMapping>
-                                {
-                                    {
-                                        "source-la-location-1-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 1")
-                                            {
-                                                Code = "Source location 1 code"
-                                            },
-                                            Type = MappingType.None,
-                                            CandidateKey = null
-                                        }
-                                    },
-                                    {
-                                        "source-la-location-2-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 2")
-                                            {
-                                                Code = "Source location 2 code"
-                                            },
-                                            Type = MappingType.None,
-                                            CandidateKey = null
-                                        }
-                                    }
-                                },
-                                Candidates =
-                                    new Dictionary<string, MappableLocationOption>
-                                    {
-                                        {
-                                            "target-la-location-1-key",
-                                            new MappableLocationOption("Target location 1")
-                                            {
-                                                Code = "Target location 1 code"
-                                            }
-                                        }
-                                    }
-                            }
-                        },
-                        {
-                            GeographicLevel.Country,
-                            new LocationLevelMappings
-                            {
-                                Mappings = new Dictionary<string, LocationOptionMapping>
-                                {
-                                    {
-                                        "source-country-location-1-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 1")
-                                            {
-                                                Code = "Source location 1 code"
-                                            },
-                                            Type = MappingType.None,
-                                            CandidateKey = null
-                                        }
-                                    },
-                                    {
-                                        "source-country-location-3-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 3")
-                                            {
-                                                Code = "Source location 3 code"
-                                            },
-                                            Type = MappingType.AutoMapped,
-                                            CandidateKey = "target-country-location-3-key"
-                                        }
-                                    }
-                                },
-                                Candidates = new Dictionary<string, MappableLocationOption>
-                                {
-                                    {
-                                        "target-country-location-1-key",
-                                        new MappableLocationOption("Target location 1")
-                                        {
-                                            Code = "Target location 1 code"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                FilterMappingPlan = new FilterMappingPlan()
-            };
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .DefaultLocationMappingPlan()
+                    .AddLevel(
+                        level: GeographicLevel.LocalAuthority,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "source-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping())
+                            .AddMapping(
+                                sourceKey: "source-location-2-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping()
+                            )
+                            .AddCandidate(
+                                targetKey: "target-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption()))
+                    .AddLevel(
+                        level: GeographicLevel.Country,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "source-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping())
+                            .AddMapping(
+                                sourceKey: "source-location-3-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithAutoMapped("target-location-3-key"))
+                            .AddCandidate(
+                                targetKey: "target-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())));
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
@@ -354,14 +249,14 @@ public abstract class DataSetVersionMappingControllerTests(
                 new()
                 {
                     Level = GeographicLevel.LocalAuthority,
-                    SourceKey = "source-la-location-1-key",
+                    SourceKey = "source-location-1-key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "target-la-location-1-key"
+                    CandidateKey = "target-location-1-key"
                 },
                 new()
                 {
                     Level = GeographicLevel.Country,
-                    SourceKey = "source-country-location-3-key",
+                    SourceKey = "source-location-3-key",
                     Type = MappingType.ManualNone
                 }
             ];
@@ -373,6 +268,18 @@ public abstract class DataSetVersionMappingControllerTests(
 
             var viewModel = response.AssertOk<BatchLocationMappingUpdatesResponseViewModel>();
 
+            var originalLocalAuthorityMappingToUpdate = mappings
+                .GetLocationOptionMapping(GeographicLevel.LocalAuthority, "source-location-1-key");
+
+            var originalLocalAuthorityMappingNotUpdated = mappings
+                .GetLocationOptionMapping(GeographicLevel.LocalAuthority, "source-location-2-key");
+
+            var originalCountryMappingNotUpdated = mappings
+                .GetLocationOptionMapping(GeographicLevel.Country, "source-location-1-key");
+
+            var originalCountryMappingToUpdate = mappings
+                .GetLocationOptionMapping(GeographicLevel.Country, "source-location-3-key");
+
             var expectedUpdateResponse = new BatchLocationMappingUpdatesResponseViewModel
             {
                 Updates =
@@ -380,23 +287,19 @@ public abstract class DataSetVersionMappingControllerTests(
                     new LocationMappingUpdateResponseViewModel
                     {
                         Level = GeographicLevel.LocalAuthority,
-                        SourceKey = "source-la-location-1-key",
-                        Mapping = new LocationOptionMapping
+                        SourceKey = "source-location-1-key",
+                        Mapping = originalLocalAuthorityMappingToUpdate with
                         {
-                            Source =
-                                new MappableLocationOption("Source location 1") { Code = "Source location 1 code" },
                             Type = MappingType.ManualMapped,
-                            CandidateKey = "target-la-location-1-key"
+                            CandidateKey = "target-location-1-key"
                         }
                     },
                     new LocationMappingUpdateResponseViewModel
                     {
                         Level = GeographicLevel.Country,
-                        SourceKey = "source-country-location-3-key",
-                        Mapping = new LocationOptionMapping
+                        SourceKey = "source-location-3-key",
+                        Mapping = originalCountryMappingToUpdate with
                         {
-                            Source =
-                                new MappableLocationOption("Source location 3") { Code = "Source location 3 code" },
                             Type = MappingType.ManualNone,
                             CandidateKey = null
                         }
@@ -422,38 +325,19 @@ public abstract class DataSetVersionMappingControllerTests(
                             // We expect this mapping's type ot be set to ManualMapped and
                             // its CandidateKey set.
                             {
-                                "source-la-location-1-key",
-                                new LocationOptionMapping
+                                "source-location-1-key",
+                                originalLocalAuthorityMappingToUpdate with
                                 {
-                                    Source = new MappableLocationOption("Source location 1")
-                                    {
-                                        Code = "Source location 1 code"
-                                    },
                                     Type = MappingType.ManualMapped,
-                                    CandidateKey = "target-la-location-1-key"
+                                    CandidateKey = "target-location-1-key"
                                 }
                             },
-                            {
-                                "source-la-location-2-key",
-                                new LocationOptionMapping
-                                {
-                                    Source = new MappableLocationOption("Source location 2")
-                                    {
-                                        Code = "Source location 2 code"
-                                    },
-                                    Type = MappingType.None,
-                                    CandidateKey = null
-                                }
-                            }
+                            { "source-location-2-key", originalLocalAuthorityMappingNotUpdated }
                         },
-                        Candidates =
-                            new Dictionary<string, MappableLocationOption>
-                            {
-                                {
-                                    "target-la-location-1-key",
-                                    new MappableLocationOption("Target location 1") { Code = "Target location 1 code" }
-                                }
-                            }
+                        Candidates = mappings
+                            .LocationMappingPlan
+                            .Levels[GeographicLevel.LocalAuthority]
+                            .Candidates
                     }
                 },
                 {
@@ -461,46 +345,28 @@ public abstract class DataSetVersionMappingControllerTests(
                     {
                         Mappings = new Dictionary<string, LocationOptionMapping>
                         {
-                            {
-                                "source-country-location-1-key",
-                                new LocationOptionMapping
-                                {
-                                    Source = new MappableLocationOption("Source location 1")
-                                    {
-                                        Code = "Source location 1 code"
-                                    },
-                                    Type = MappingType.None,
-                                    CandidateKey = null
-                                }
-                            },
+                            { "source-location-1-key", originalCountryMappingNotUpdated },
                             {
                                 // We expect this mapping's type to be set to ManualNone and
                                 // its CandidateKey unset.
-                                "source-country-location-3-key",
-                                new LocationOptionMapping
+                                "source-location-3-key",
+                                originalCountryMappingToUpdate with
                                 {
-                                    Source = new MappableLocationOption("Source location 3")
-                                    {
-                                        Code = "Source location 3 code"
-                                    },
                                     Type = MappingType.ManualNone,
                                     CandidateKey = null
                                 }
                             }
                         },
-                        Candidates = new Dictionary<string, MappableLocationOption>
-                        {
-                            {
-                                "target-country-location-1-key",
-                                new MappableLocationOption("Target location 1") { Code = "Target location 1 code" }
-                            }
-                        }
+                        Candidates = mappings
+                            .LocationMappingPlan
+                            .Levels[GeographicLevel.Country]
+                            .Candidates
                     }
                 }
             };
 
             // Test that the updated mappings retrieved from the database reflect the updates
-            // that were requested. 
+            // that were requested.
             updatedMappings.LocationMappingPlan.Levels.AssertDeepEqualTo(
                 expectedFullMappings,
                 ignoreCollectionOrders: true);
@@ -535,85 +401,42 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSets.Update(dataSet);
             });
 
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = currentDataSetVersion.Id,
-                TargetDataSetVersionId = nextDataSetVersion.Id,
-                LocationMappingPlan = new LocationMappingPlan
-                {
-                    Levels = new Dictionary<GeographicLevel, LocationLevelMappings>
-                    {
-                        {
-                            GeographicLevel.LocalAuthority, new LocationLevelMappings
-                            {
-                                Mappings = new Dictionary<string, LocationOptionMapping>
-                                {
-                                    {
-                                        "source-la-location-1-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 1")
-                                            {
-                                                Code = "Source location 1 code"
-                                            },
-                                            Type = MappingType.None,
-                                            CandidateKey = null
-                                        }
-                                    },
-                                    {
-                                        "source-la-location-2-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 2")
-                                            {
-                                                Code = "Source location 2 code"
-                                            },
-                                            Type = MappingType.None,
-                                            CandidateKey = null
-                                        }
-                                    }
-                                },
-                                Candidates =
-                                    new Dictionary<string, MappableLocationOption>
-                                    {
-                                        {
-                                            "target-la-location-1-key",
-                                            new MappableLocationOption("Target location 1")
-                                            {
-                                                Code = "Target location 1 code"
-                                            }
-                                        },
-                                        {
-                                            "target-la-location-2-key",
-                                            new MappableLocationOption("Target location 2")
-                                            {
-                                                Code = "Target location 2 code"
-                                            }
-                                        }
-                                    }
-                            }
-                        },
-                        {
-                            GeographicLevel.Country,
-                            new LocationLevelMappings
-                            {
-                                Mappings = new Dictionary<string, LocationOptionMapping>(),
-                                Candidates = new Dictionary<string, MappableLocationOption>
-                                {
-                                    {
-                                        "target-country-location-1-key",
-                                        new MappableLocationOption("Target location 1")
-                                            {
-                                                Code = "Target location 1 code"
-                                            }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                FilterMappingPlan = new FilterMappingPlan()
-            };
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .DefaultLocationMappingPlan()
+                    .AddLevel(
+                        level: GeographicLevel.LocalAuthority,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "source-la-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping())
+                            .AddMapping(
+                                sourceKey: "source-la-location-2-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping()
+                            )
+                            .AddCandidate(
+                                targetKey: "target-la-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())
+                            .AddCandidate(
+                                targetKey: "target-la-location-2-key",
+                                candidate: DataFixture.DefaultMappableLocationOption()))
+                    .AddLevel(
+                        level: GeographicLevel.Country,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddCandidate(
+                                targetKey: "target-country-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())));
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
@@ -659,6 +482,8 @@ public abstract class DataSetVersionMappingControllerTests(
 
             // The 2 non-existent mappings in the batch update request should have failure messages
             // indicating that the mappings they were attempting to update do not exist.
+            Assert.Equal(2, validationProblem.Errors.Count);
+
             validationProblem.AssertHasError(
                 expectedPath: "updates[1].sourceKey",
                 expectedCode: nameof(ValidationMessages.DataSetVersionMappingSourcePathDoesNotExist));
@@ -666,8 +491,6 @@ public abstract class DataSetVersionMappingControllerTests(
             validationProblem.AssertHasError(
                 expectedPath: "updates[2].sourceKey",
                 expectedCode: nameof(ValidationMessages.DataSetVersionMappingSourcePathDoesNotExist));
-
-            Assert.Equal(2, validationProblem.Errors.Count);
 
             var retrievedMappings = TestApp.GetDbContext<PublicDataDbContext>()
                 .DataSetVersionMappings
@@ -708,73 +531,46 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSets.Update(dataSet);
             });
 
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = currentDataSetVersion.Id,
-                TargetDataSetVersionId = nextDataSetVersion.Id,
-                LocationMappingPlan = new LocationMappingPlan
-                {
-                    Levels = new Dictionary<GeographicLevel, LocationLevelMappings>
-                    {
-                        {
-                            GeographicLevel.LocalAuthority,
-                            new LocationLevelMappings
-                            {
-                                Mappings = new Dictionary<string, LocationOptionMapping>
-                                {
-                                    {
-                                        "source-location-1-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 1")
-                                            {
-                                                Code = "Source location 1 code"
-                                            },
-                                            Type = MappingType.None,
-                                            CandidateKey = null
-                                        }
-                                    },
-                                    {
-                                        "source-location-2-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 2")
-                                            {
-                                                Code = "Source location 2 code"
-                                            },
-                                            Type = MappingType.None,
-                                            CandidateKey = null
-                                        }
-                                    },
-                                    {
-                                        "source-location-3-key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("Source location 3")
-                                            {
-                                                Code = "Source location 3 code"
-                                            },
-                                            Type = MappingType.None,
-                                            CandidateKey = null
-                                        }
-                                    }
-                                },
-                                Candidates = new Dictionary<string, MappableLocationOption>()
-                                {
-                                    {
-                                        "target-la-location-1-key",
-                                        new MappableLocationOption("Target location 1")
-                                        {
-                                            Code = "Target location 1 code"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                FilterMappingPlan = new FilterMappingPlan()
-            };
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .DefaultLocationMappingPlan()
+                    .AddLevel(
+                        level: GeographicLevel.LocalAuthority,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "source-la-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping())
+                            .AddMapping(
+                                sourceKey: "source-la-location-2-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping()
+                            )
+                            .AddMapping(
+                                sourceKey: "source-la-location-3-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping()
+                            )
+                            .AddCandidate(
+                                targetKey: "target-la-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption()))
+                    .AddLevel(
+                        level: GeographicLevel.Country,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddCandidate(
+                                targetKey: "target-country-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())));
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
@@ -796,7 +592,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 // This candidate does not exist as there is no candidate with the key
                 // "target-la-location-2-key" under the "LocalAuthority" level. This tests
                 // the simple case where a candidate simply doesn't exist at all with the
-                // given key. 
+                // given key.
                 new()
                 {
                     Level = GeographicLevel.LocalAuthority,
@@ -914,13 +710,11 @@ public abstract class DataSetVersionMappingControllerTests(
                 client);
 
             var validationProblem = response.AssertValidationProblem();
-
+            Assert.Single(validationProblem.Errors);
             validationProblem.AssertHasError(
                 expectedPath: "updates[0].candidateKey",
                 expectedCode: ValidationMessages.CandidateKeyMustBeSpecifiedWithMappedMappingType.Code,
                 expectedMessage: ValidationMessages.CandidateKeyMustBeSpecifiedWithMappedMappingType.Message);
-
-            Assert.Single(validationProblem.Errors);
         }
 
         [Theory]
@@ -943,13 +737,11 @@ public abstract class DataSetVersionMappingControllerTests(
                 client);
 
             var validationProblem = response.AssertValidationProblem();
-
+            Assert.Single(validationProblem.Errors);
             validationProblem.AssertHasError(
                 expectedPath: "updates[0].candidateKey",
                 expectedCode: ValidationMessages.CandidateKeyMustBeEmptyWithNoneMappingType.Code,
                 expectedMessage: ValidationMessages.CandidateKeyMustBeEmptyWithNoneMappingType.Message);
-
-            Assert.Single(validationProblem.Errors);
         }
 
         [Theory]
@@ -974,13 +766,11 @@ public abstract class DataSetVersionMappingControllerTests(
                 client);
 
             var validationProblem = response.AssertValidationProblem();
-
+            Assert.Single(validationProblem.Errors);
             validationProblem.AssertHasError(
                 expectedPath: "updates[0].type",
                 expectedCode: ValidationMessages.ManualMappingTypeInvalid.Code,
                 expectedMessage: "Type must be one of the following values: ManualMapped, ManualNone");
-
-            Assert.Single(validationProblem.Errors);
         }
 
         private async Task<HttpResponseMessage> ApplyBatchLocationMappingUpdates(
@@ -1029,80 +819,33 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSets.Update(dataSet);
             });
 
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = currentDataSetVersion.Id,
-                TargetDataSetVersionId = nextDataSetVersion.Id,
-                LocationMappingPlan = new LocationMappingPlan(),
-                FilterMappingPlan = new FilterMappingPlan
-                {
-                    Mappings =
-                    {
-                        {
-                            "Filter 1 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 1 label"),
-                                Type = MappingType.AutoMapped,
-                                CandidateKey = "Filter 1 key",
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 1 option 1 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 1 label"),
-                                            Type = MappingType.AutoMapped,
-                                            CandidateKey = "Filter 1 option 1 key"
-                                        }
-                                    },
-                                    {
-                                        "Filter 1 option 2 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 2 label"),
-                                            Type = MappingType.ManualNone
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Filter 2 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 2 label"),
-                                Type = MappingType.AutoNone,
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 2 option 1 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 2 option 1 label"),
-                                            Type = MappingType.AutoNone
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    Candidates =
-                    {
-                        {
-                            "Filter 1 key",
-                            new FilterMappingCandidate("Filter 1 label")
-                            {
-                                Options =
-                                {
-                                    {
-                                        "Filter 1 option 1 key", new MappableFilterOption("Filter 1 option 1 label")
-                                    },
-                                    { "Filter 1 option 3 key", new MappableFilterOption("Filter 1 option 3 label") }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoMapped("filter-1-key")
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithAutoMapped("filter-1-option-1-key"))
+                        .AddOptionMapping("filter-1-option-2-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithManualNone()))
+                    .AddFilterMapping("filter-2-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoMapped("filter-2-key")
+                        .AddOptionMapping("filter-2-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithAutoNone()))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())
+                        .AddOptionCandidate("filter-1-option-3-key", DataFixture
+                            .DefaultMappableFilterOption())));
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
@@ -1190,83 +933,36 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
                 context.DataSets.Update(dataSet);
             });
-
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = currentDataSetVersion.Id,
-                TargetDataSetVersionId = nextDataSetVersion.Id,
-                LocationMappingPlan = new LocationMappingPlan(),
-                FilterMappingPlan = new FilterMappingPlan
-                {
-                    Mappings =
-                    {
-                        {
-                            "Filter 1 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 1 label"),
-                                Type = MappingType.AutoMapped,
-                                CandidateKey = "Filter 1 target key",
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 1 option 1 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 1 label"),
-                                            Type = MappingType.AutoMapped,
-                                            CandidateKey = "Filter 1 option 1 key"
-                                        }
-                                    },
-                                    {
-                                        "Filter 1 option 2 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 2 label"),
-                                            Type = MappingType.ManualNone
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Filter 2 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 2 label"),
-                                Type = MappingType.AutoMapped,
-                                CandidateKey = "Filter 2 key",
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 2 option 1 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 2 option 1 label"),
-                                            Type = MappingType.AutoMapped,
-                                            CandidateKey = "Filter 1 option 1 key"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    Candidates = new Dictionary<string, FilterMappingCandidate>
-                    {
-                        {
-                            "Filter 1 target key",
-                            new FilterMappingCandidate("Filter 1")
-                            {
-                                Options = new Dictionary<string, MappableFilterOption>
-                                {
-                                    {
-                                        "target-filter-option-1-key",
-                                        new MappableFilterOption("Filter 1 option 1 label")
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
+            
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoMapped("filter-1-key")
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithAutoMapped("filter-1-option-1-key"))
+                        .AddOptionMapping("filter-1-option-2-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithManualNone()))
+                    .AddFilterMapping("filter-2-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoMapped("filter-2-key")
+                        .AddOptionMapping("filter-2-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithAutoMapped("filter-2-option-1-key")))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption()))
+                    .AddFilterCandidate("filter-2-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-2-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())));
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
@@ -1279,15 +975,15 @@ public abstract class DataSetVersionMappingControllerTests(
             [
                 new()
                 {
-                    FilterKey = "Filter 1 key",
-                    SourceKey = "Filter 1 option 1 key",
+                    FilterKey = "filter-1-key",
+                    SourceKey = "filter-1-option-1-key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "target-filter-option-1-key"
+                    CandidateKey = "filter-1-option-1-key"
                 },
                 new()
                 {
-                    FilterKey = "Filter 2 key",
-                    SourceKey = "Filter 2 option 1 key",
+                    FilterKey = "filter-2-key",
+                    SourceKey = "filter-2-option-1-key",
                     Type = MappingType.ManualNone
                 }
             ];
@@ -1305,22 +1001,24 @@ public abstract class DataSetVersionMappingControllerTests(
                 [
                     new FilterOptionMappingUpdateResponseViewModel
                     {
-                        FilterKey = "Filter 1 key",
-                        SourceKey = "Filter 1 option 1 key",
-                        Mapping = new FilterOptionMapping
+                        FilterKey = "filter-1-key",
+                        SourceKey = "filter-1-option-1-key",
+                        Mapping = mappings.GetFilterOptionMapping(
+                                filterKey: "filter-1-key", 
+                                filterOptionKey: "filter-1-option-1-key") with
                         {
-                            Source = new MappableFilterOption("Filter 1 option 1 label"),
                             Type = MappingType.ManualMapped,
-                            CandidateKey = "target-filter-option-1-key"
+                            CandidateKey = "filter-1-option-1-key"
                         }
                     },
                     new FilterOptionMappingUpdateResponseViewModel
                     {
-                        FilterKey = "Filter 2 key",
-                        SourceKey = "Filter 2 option 1 key",
-                        Mapping = new FilterOptionMapping
+                        FilterKey = "filter-2-key",
+                        SourceKey = "filter-2-option-1-key",
+                        Mapping = mappings.GetFilterOptionMapping(
+                            filterKey: "filter-2-key", 
+                            filterOptionKey: "filter-2-option-1-key") with
                         {
-                            Source = new MappableFilterOption("Filter 2 option 1 label"),
                             Type = MappingType.ManualNone,
                             CandidateKey = null
                         }
@@ -1339,46 +1037,34 @@ public abstract class DataSetVersionMappingControllerTests(
             var expectedFullMappings = new Dictionary<string, FilterMapping>
             {
                 {
-                    "Filter 1 key", new FilterMapping
+                    "filter-1-key", mappings.GetFilterMapping("filter-1-key") with 
                     {
-                        Source = new MappableFilter("Filter 1 label"),
-                        Type = MappingType.AutoMapped,
-                        CandidateKey = "Filter 1 target key",
-                        OptionMappings =
+                        OptionMappings = new Dictionary<string, FilterOptionMapping>
                         {
                             {
-                                "Filter 1 option 1 key",
-                                new FilterOptionMapping
+                                "filter-1-option-1-key",
+                                mappings.GetFilterOptionMapping("filter-1-key", "filter-1-option-1-key") with
                                 {
-                                    Source = new MappableFilterOption("Filter 1 option 1 label"),
                                     Type = MappingType.ManualMapped,
-                                    CandidateKey = "target-filter-option-1-key"
+                                    CandidateKey = "filter-1-option-1-key"
                                 }
                             },
                             {
-                                "Filter 1 option 2 key",
-                                new FilterOptionMapping
-                                {
-                                    Source = new MappableFilterOption("Filter 1 option 2 label"),
-                                    Type = MappingType.ManualNone
-                                }
+                                "filter-1-option-2-key",
+                                mappings.GetFilterOptionMapping("filter-1-key", "filter-1-option-2-key")
                             }
                         }
                     }
                 },
                 {
-                    "Filter 2 key", new FilterMapping
+                    "filter-2-key", mappings.GetFilterMapping("filter-2-key") with 
                     {
-                        Source = new MappableFilter("Filter 2 label"),
-                        Type = MappingType.AutoMapped,
-                        CandidateKey = "Filter 2 key",
-                        OptionMappings =
+                        OptionMappings = new Dictionary<string, FilterOptionMapping>
                         {
                             {
-                                "Filter 2 option 1 key",
-                                new FilterOptionMapping
+                                "filter-2-option-1-key",
+                                mappings.GetFilterOptionMapping("filter-2-key", "filter-2-option-1-key") with
                                 {
-                                    Source = new MappableFilterOption("Filter 2 option 1 label"),
                                     Type = MappingType.ManualNone,
                                     CandidateKey = null
                                 }
@@ -1389,7 +1075,7 @@ public abstract class DataSetVersionMappingControllerTests(
             };
 
             // Test that the updated mappings retrieved from the database reflect the updates
-            // that were requested. 
+            // that were requested.
             updatedMappings.FilterMappingPlan.Mappings.AssertDeepEqualTo(
                 expectedFullMappings,
                 ignoreCollectionOrders: true);
@@ -1423,71 +1109,30 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
                 context.DataSets.Update(dataSet);
             });
-
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = currentDataSetVersion.Id,
-                TargetDataSetVersionId = nextDataSetVersion.Id,
-                LocationMappingPlan = new LocationMappingPlan(),
-                FilterMappingPlan = new FilterMappingPlan
-                {
-                    Mappings =
-                    {
-                        {
-                            "Filter 1 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 1 label"),
-                                Type = MappingType.AutoMapped,
-                                CandidateKey = "Target filter 1 key",
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 1 option 1 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 1 label"),
-                                            Type = MappingType.AutoMapped,
-                                            CandidateKey = "Filter 1 option 1 key"
-                                        }
-                                    },
-                                    {
-                                        "Filter 1 option 2 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 2 label"),
-                                            Type = MappingType.ManualNone
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    Candidates =
-                    {
-                        {
-                            "Target filter 1 key",
-                            new FilterMappingCandidate("Filter 1")
-                            {
-                                Options =
-                                {
-                                    {
-                                        "Target filter 1 option 1 key",
-                                        new MappableFilterOption("Filter 1 option 1 label")
-                                    },
-                                    {
-                                        "Target filter 1 option 2 key",
-                                        new MappableFilterOption("Filter 1 option 2 label")
-                                    },
-                                    {
-                                        "Target filter 1 option 3 key",
-                                        new MappableFilterOption("Filter 1 option 3 label")
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
+            
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoMapped("filter-1-key")
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithAutoMapped("filter-1-option-1-key"))
+                        .AddOptionMapping("filter-1-option-2-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithManualNone()))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())
+                        .AddOptionCandidate("filter-1-option-2-key", DataFixture
+                            .DefaultMappableFilterOption())
+                        .AddOptionCandidate("filter-1-option-3-key", DataFixture
+                            .DefaultMappableFilterOption())));
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
@@ -1501,18 +1146,18 @@ public abstract class DataSetVersionMappingControllerTests(
                 // This mapping exists.
                 new()
                 {
-                    FilterKey = "Filter 1 key",
-                    SourceKey = "Filter 1 option 1 key",
+                    FilterKey = "filter-1-key",
+                    SourceKey = "filter-1-option-1-key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "Target filter 1 option 1 key"
+                    CandidateKey = "filter-1-option-1-key"
                 },
                 // This mapping does not exist.
                 new()
                 {
-                    FilterKey = "Filter 1 key",
-                    SourceKey = "Filter 1 option 3 key",
+                    FilterKey = "filter-1-key",
+                    SourceKey = "filter-1-option-3-key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "Target filter 1 option 2 key"
+                    CandidateKey = "filter-1-option-2-key"
                 }
             ];
 
@@ -1570,99 +1215,37 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSets.Update(dataSet);
             });
 
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = currentDataSetVersion.Id,
-                TargetDataSetVersionId = nextDataSetVersion.Id,
-                LocationMappingPlan = new LocationMappingPlan(),
-                FilterMappingPlan = new FilterMappingPlan
-                {
-                    Mappings =
-                    {
-                        {
-                            "Filter 1 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 1 label"),
-                                Type = MappingType.AutoMapped,
-                                CandidateKey = "Filter 1 key",
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 1 option 1 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 1 label"),
-                                            Type = MappingType.AutoMapped,
-                                            CandidateKey = "Filter 1 option 1 key"
-                                        }
-                                    },
-                                    {
-                                        "Filter 1 option 2 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 2 label"),
-                                            Type = MappingType.ManualNone
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Filter 2 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 2 label"),
-                                Type = MappingType.AutoMapped,
-                                CandidateKey = "Filter 2 key",
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 2 option 1 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 1 label"),
-                                            Type = MappingType.AutoMapped,
-                                            CandidateKey = "Filter 1 option 1 key"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    Candidates =
-                    {
-                        {
-                            "Filter 1 key",
-                            new FilterMappingCandidate("Filter 1")
-                            {
-                                Options =
-                                {
-                                    {
-                                        "Target filter 1 option 1 key",
-                                        new MappableFilterOption("Filter 1 option 1 label")
-                                    },
-                                    {
-                                        "Target filter 1 option 2 key",
-                                        new MappableFilterOption("Filter 1 option 2 label")
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Filter 2 key",
-                            new FilterMappingCandidate("Filter 2")
-                            {
-                                Options =
-                                {
-                                    {
-                                        "Target filter 2 option 1 key",
-                                        new MappableFilterOption("Filter 2 option 1 label")
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoMapped("filter-1-key")
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithAutoMapped("filter-1-option-1-key"))
+                        .AddOptionMapping("filter-1-option-2-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithManualNone()))
+                    .AddFilterMapping("filter-2-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoMapped("filter-2-key")
+                        .AddOptionMapping("filter-2-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithAutoMapped("filter-2-option-1-key")))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())
+                        .AddOptionCandidate("filter-1-option-2-key", DataFixture
+                            .DefaultMappableFilterOption()))
+                    .AddFilterCandidate("filter-2-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-2-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())));
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
@@ -1676,34 +1259,34 @@ public abstract class DataSetVersionMappingControllerTests(
                 // This candidate exists.
                 new()
                 {
-                    FilterKey = "Filter 1 key",
-                    SourceKey = "Filter 1 option 1 key",
+                    FilterKey = "filter-1-key",
+                    SourceKey = "filter-1-option-1-key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "Target filter 1 option 1 key"
+                    CandidateKey = "filter-1-option-1-key"
                 },
                 // This candidate does not exist as there is no candidate with the key
                 // "Non existent candidate key".  This tests the simple case where a candidate
-                // doesn't exist at all with the given key. 
+                // doesn't exist at all with the given key.
                 new()
                 {
-                    FilterKey = "Filter 1 key",
-                    SourceKey = "Filter 1 option 2 key",
+                    FilterKey = "filter-1-key",
+                    SourceKey = "filter-1-option-2-key",
                     Type = MappingType.ManualMapped,
                     CandidateKey = "Non existent candidate key"
                 },
                 // This candidate does not exist as there is no candidate with the key
-                // "Non existent candidate key" under the filter that "Filter 2 key" is
+                // "Non existent candidate key" under the filter that "filter-2-key" is
                 // mapped to, despite there being a filter option candidate that exists
-                // under a different filter with the key "Target filter 1 option 1 key".
+                // under a different filter with the key "filter-1-option-1-key".
                 // This tests the more complex case whereby only filter option candidates
                 // that exist under the filter that the owning filter is mapped to are
-                // considered valid candidates.  
+                // considered valid candidates.
                 new()
                 {
-                    FilterKey = "Filter 2 key",
-                    SourceKey = "Filter 2 option 1 key",
+                    FilterKey = "filter-2-key",
+                    SourceKey = "filter-2-option-1-key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "Target filter 1 option 1 key"
+                    CandidateKey = "filter-1-option-1-key"
                 }
             ];
 
@@ -1764,62 +1347,26 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
                 context.DataSets.Update(dataSet);
             });
-
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = currentDataSetVersion.Id,
-                TargetDataSetVersionId = nextDataSetVersion.Id,
-                LocationMappingPlan = new LocationMappingPlan(),
-                FilterMappingPlan = new FilterMappingPlan
-                {
-                    Mappings =
-                    {
-                        {
-                            "Filter 1 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 1 label"),
-                                Type = MappingType.ManualNone,
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 1 option 1 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 1 label"),
-                                            Type = MappingType.AutoMapped,
-                                            CandidateKey = "Filter 1 option 1 key"
-                                        }
-                                    },
-                                    {
-                                        "Filter 1 option 2 key",
-                                        new FilterOptionMapping
-                                        {
-                                            Source = new MappableFilterOption("Filter 1 option 2 label"),
-                                            Type = MappingType.ManualNone
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    Candidates =
-                    {
-                        {
-                            "Filter 1 key",
-                            new FilterMappingCandidate("Filter 1")
-                            {
-                                Options =
-                                {
-                                    {
-                                        "Target filter 1 option 1 key",
-                                        new MappableFilterOption("Filter 1 option 1 label")
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
+            
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithManualNone()
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithManualNone())
+                        .AddOptionMapping("filter-1-option-2-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithManualNone()))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())));
 
             await TestApp.AddTestData<PublicDataDbContext>(context =>
             {
@@ -1830,14 +1377,14 @@ public abstract class DataSetVersionMappingControllerTests(
 
             List<FilterOptionMappingUpdateRequest> updates =
             [
-                // This candidate exists, but the filter that owns "Filter 1 option 1 key" has not itself
+                // This candidate exists, but the filter that owns "filter-1-option-1-key" has not itself
                 // been mapped, so it cannot supply any valid candidate filter options.
                 new()
                 {
-                    FilterKey = "Filter 1 key",
-                    SourceKey = "Filter 1 option 1 key",
+                    FilterKey = "filter-1-key",
+                    SourceKey = "filter-1-option-1-key",
                     Type = MappingType.ManualMapped,
-                    CandidateKey = "Target filter 1 option 1 key"
+                    CandidateKey = "filter-1-option-1-key"
                 }
             ];
 
@@ -2014,7 +1561,6 @@ public abstract class DataSetVersionMappingControllerTests(
                 new JsonNetContent(new BatchFilterOptionMappingUpdatesRequest { Updates = updates }));
         }
     }
-
 
     private WebApplicationFactory<TestStartup> BuildApp(ClaimsPrincipal? user = null)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -217,10 +217,12 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
 
                     foreach (var locationOptionMetaViewModel in locationMetaViewModel.Options)
                     {
-                        var locationOptionMeta = Assert.Single(
-                            locationMeta.Options,
+                        var locationOptionMetaLink = Assert.Single(
+                            locationMeta.OptionLinks,
                             o => o.PublicId == locationOptionMetaViewModel.Id);
 
+                        var locationOptionMeta = locationOptionMetaLink.Option;
+                        
                         switch (locationOptionMeta)
                         {
                             case LocationCodedOptionMeta codedMeta:

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -128,14 +128,15 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                         .GenerateList(3))
                     .GenerateList(3);
 
-                var allLocationOptionMetaTypesGeneratorByLevel = new Dictionary<GeographicLevel, Func<LocationOptionMeta>>
-                {
-                    { GeographicLevel.School, () => DataFixture.DefaultLocationSchoolOptionMeta() },
-                    { GeographicLevel.LocalAuthority, () => DataFixture.DefaultLocationLocalAuthorityOptionMeta() },
-                    { GeographicLevel.RscRegion, () => DataFixture.DefaultLocationRscRegionOptionMeta() },
-                    { GeographicLevel.Provider, () => DataFixture.DefaultLocationProviderOptionMeta() },
-                    { GeographicLevel.EnglishDevolvedArea, () => DataFixture.DefaultLocationCodedOptionMeta() },
-                };
+                var allLocationOptionMetaTypesGeneratorByLevel =
+                    new Dictionary<GeographicLevel, Func<LocationOptionMeta>>
+                    {
+                        { GeographicLevel.School, () => DataFixture.DefaultLocationSchoolOptionMeta() },
+                        { GeographicLevel.LocalAuthority, () => DataFixture.DefaultLocationLocalAuthorityOptionMeta() },
+                        { GeographicLevel.RscRegion, () => DataFixture.DefaultLocationRscRegionOptionMeta() },
+                        { GeographicLevel.Provider, () => DataFixture.DefaultLocationProviderOptionMeta() },
+                        { GeographicLevel.EnglishDevolvedArea, () => DataFixture.DefaultLocationCodedOptionMeta() },
+                    };
 
                 var locationMetas = allLocationOptionMetaTypesGeneratorByLevel
                     .Select(locationOptionMetaGenerator => DataFixture
@@ -159,13 +160,13 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                     .WithGeographicLevelMeta()
                     .WithIndicatorMetas(() =>
                         DataFixture
-                        .DefaultIndicatorMeta()
-                        .GenerateList(3)
+                            .DefaultIndicatorMeta()
+                            .GenerateList(3)
                     )
                     .WithTimePeriodMetas(() =>
                         DataFixture
-                        .DefaultTimePeriodMeta()
-                        .GenerateList(3)
+                            .DefaultTimePeriodMeta()
+                            .GenerateList(3)
                     )
                     .WithMetaSummary()
                     .FinishWith(dsv => dataSet.LatestLiveVersion = dsv);
@@ -184,7 +185,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
 
                 foreach (var filterMetaViewModel in content.Filters)
                 {
-                    var filterMeta = Assert.Single(dataSetVersion.FilterMetas, fm => fm.PublicId == filterMetaViewModel.Id);
+                    var filterMeta = Assert.Single(dataSetVersion.FilterMetas,
+                        fm => fm.PublicId == filterMetaViewModel.Id);
                     Assert.Equal(filterMeta.Hint, filterMetaViewModel.Hint);
                     Assert.Equal(filterMeta.Label, filterMetaViewModel.Label);
 
@@ -222,7 +224,7 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                             o => o.PublicId == locationOptionMetaViewModel.Id);
 
                         var locationOptionMeta = locationOptionMetaLink.Option;
-                        
+
                         switch (locationOptionMeta)
                         {
                             case LocationCodedOptionMeta codedMeta:
@@ -233,7 +235,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                                 break;
                             case LocationLocalAuthorityOptionMeta localAuthorityMeta:
                                 var localAuthorityViewModel =
-                                    Assert.IsType<LocationLocalAuthorityOptionMetaViewModel>(locationOptionMetaViewModel);
+                                    Assert.IsType<LocationLocalAuthorityOptionMetaViewModel>(
+                                        locationOptionMetaViewModel);
                                 Assert.Equal(localAuthorityMeta.Label, localAuthorityViewModel.Label);
                                 Assert.Equal(localAuthorityMeta.Code, localAuthorityViewModel.Code);
                                 Assert.Equal(localAuthorityMeta.OldCode, localAuthorityViewModel.OldCode);
@@ -281,13 +284,13 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                     var timePeriodMeta = Assert.Single(
                         dataSetVersion.TimePeriodMetas,
                         tp => tp.Code == timePeriod.Code
-                        && tp.Period == timePeriod.Period);
+                              && tp.Period == timePeriod.Period);
 
                     Assert.Equal(
                         TimePeriodFormatter.FormatLabel(timePeriodMeta.Period, timePeriodMeta.Code),
                         timePeriod.Label);
                 }
-            }                   
+            }
 
             [Theory]
             [InlineData(DataSetVersionStatus.Published)]
@@ -357,7 +360,7 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                 var response = await GetDataSetMeta(dataSet.Id);
 
                 response.AssertForbidden();
-            }           
+            }
 
             [Fact]
             public async Task DataSetDoesNotExist_Returns404()
@@ -392,8 +395,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                         .SetFilterMetas(() =>
                             [
                                 DataFixture
-                            .DefaultFilterMeta()
-                            .WithLabel("filter 1")
+                                    .DefaultFilterMeta()
+                                    .WithLabel("filter 1")
                             ]
                         )
                     )
@@ -402,8 +405,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                         .SetFilterMetas(() =>
                             [
                                 DataFixture
-                            .DefaultFilterMeta()
-                            .WithLabel("filter 2")
+                                    .DefaultFilterMeta()
+                                    .WithLabel("filter 2")
                             ]
                         )
                     )
@@ -412,8 +415,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                         .SetFilterMetas(() =>
                             [
                                 DataFixture
-                            .DefaultFilterMeta()
-                            .WithLabel("filter 3")
+                                    .DefaultFilterMeta()
+                                    .WithLabel("filter 3")
                             ]
                         )
                     )
@@ -422,8 +425,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                         .SetFilterMetas(() =>
                             [
                                 DataFixture
-                            .DefaultFilterMeta()
-                            .WithLabel("filter 4")
+                                    .DefaultFilterMeta()
+                                    .WithLabel("filter 4")
                             ]
                         )
                     )
@@ -462,8 +465,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                         .SetFilterMetas(() =>
                             [
                                 DataFixture
-                            .DefaultFilterMeta()
-                            .WithLabel("filter 1")
+                                    .DefaultFilterMeta()
+                                    .WithLabel("filter 1")
                             ]
                         )
                     )
@@ -472,8 +475,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                         .SetFilterMetas(() =>
                             [
                                 DataFixture
-                            .DefaultFilterMeta()
-                            .WithLabel("filter 2")
+                                    .DefaultFilterMeta()
+                                    .WithLabel("filter 2")
                             ]
                         )
                     )
@@ -482,8 +485,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                         .SetFilterMetas(() =>
                             [
                                 DataFixture
-                            .DefaultFilterMeta()
-                            .WithLabel("filter 3")
+                                    .DefaultFilterMeta()
+                                    .WithLabel("filter 3")
                             ]
                         )
                     )
@@ -492,8 +495,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                         .SetFilterMetas(() =>
                             [
                                 DataFixture
-                            .DefaultFilterMeta()
-                            .WithLabel("filter 4")
+                                    .DefaultFilterMeta()
+                                    .WithLabel("filter 4")
                             ]
                         )
                     )
@@ -525,7 +528,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                     .DefaultDataSet()
                     .WithStatusPublished();
 
-                await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.AddRange(dataSet1, dataSet2));
+                await TestApp.AddTestData<PublicDataDbContext>(context =>
+                    context.DataSets.AddRange(dataSet1, dataSet2));
 
                 DataSetVersion dataSetVersion = DataFixture
                     .DefaultDataSetVersion(
@@ -666,7 +670,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
             [Theory]
             [InlineData(DataSetMetaType.Filters, DataSetMetaType.Locations)]
             [InlineData(DataSetMetaType.Filters, DataSetMetaType.Locations, DataSetMetaType.Indicators)]
-            [InlineData(DataSetMetaType.Filters, DataSetMetaType.Locations, DataSetMetaType.Indicators, DataSetMetaType.TimePeriods)]
+            [InlineData(DataSetMetaType.Filters, DataSetMetaType.Locations, DataSetMetaType.Indicators,
+                DataSetMetaType.TimePeriods)]
             public async Task MultipleTypesSpecified_ReturnsOnlySpecifiedMetaTypes(params DataSetMetaType[] metaTypes)
             {
                 DataSet dataSet = DataFixture
@@ -833,8 +838,10 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
             [InlineData(DataSetMetaType.TimePeriods)]
             [InlineData(DataSetMetaType.Filters, DataSetMetaType.Locations)]
             [InlineData(DataSetMetaType.Filters, DataSetMetaType.Locations, DataSetMetaType.Indicators)]
-            [InlineData(DataSetMetaType.Filters, DataSetMetaType.Locations, DataSetMetaType.Indicators, DataSetMetaType.TimePeriods)]
-            public async Task ArrayQueryParameterSyntax_ReturnsOnlySpecifiedMetaTypes(params DataSetMetaType[] metaTypes)
+            [InlineData(DataSetMetaType.Filters, DataSetMetaType.Locations, DataSetMetaType.Indicators,
+                DataSetMetaType.TimePeriods)]
+            public async Task ArrayQueryParameterSyntax_ReturnsOnlySpecifiedMetaTypes(
+                params DataSetMetaType[] metaTypes)
             {
                 DataSet dataSet = DataFixture
                     .DefaultDataSet()
@@ -859,7 +866,11 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                 });
 
                 var query = metaTypes
-                    .Select((mt, index) => new { mt, index })
+                    .Select((mt, index) => new
+                    {
+                        mt,
+                        index
+                    })
                     .ToDictionary(a => $"types[{a.index}]", a => a.mt.ToString());
 
                 var uri = QueryHelpers.AddQueryString($"{BaseUrl}/{dataSet.Id}/meta", query!);
@@ -975,7 +986,8 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
             [Fact]
             public async Task MixedValidAndInvalidMetaTypes_AllowedValueError()
             {
-                var response = await GetDataSetMeta(Guid.NewGuid(), types: [DataSetMetaType.Filters.ToString(), "invalid"]);
+                var response = await GetDataSetMeta(Guid.NewGuid(),
+                    types: [DataSetMetaType.Filters.ToString(), "invalid"]);
 
                 var validationProblem = response.AssertValidationProblem();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -429,7 +429,7 @@ internal class DataSetService(
 
     private static LocationLevelMetaViewModel MapLocationMeta(LocationMeta locationMeta)
     {
-        var options = locationMeta.Options
+        var options = locationMeta.OptionLinks
             .Select(MapLocationOptionMeta)
             .OrderBy(lom => lom.Label)
             .ToList();
@@ -442,37 +442,39 @@ internal class DataSetService(
         };
     }
 
-    private static LocationOptionMetaViewModel MapLocationOptionMeta(LocationOptionMeta locationOptionMeta)
+    private static LocationOptionMetaViewModel MapLocationOptionMeta(LocationOptionMetaLink locationOptionMetaLink)
     {
+        var locationOptionMeta = locationOptionMetaLink.Option;
+        
         return locationOptionMeta switch
         {
             LocationCodedOptionMeta codedOption => new LocationCodedOptionMetaViewModel
             {
-                Id = codedOption.PublicId,
+                Id = locationOptionMetaLink.PublicId,
                 Label = codedOption.Label,
                 Code = codedOption.Code,
             },
             LocationLocalAuthorityOptionMeta localAuthorityOption => new LocationLocalAuthorityOptionMetaViewModel
             {
-                Id = localAuthorityOption.PublicId,
+                Id = locationOptionMetaLink.PublicId,
                 Label = localAuthorityOption.Label,
                 Code = localAuthorityOption.Code,
                 OldCode = localAuthorityOption.OldCode,
             },
             LocationProviderOptionMeta providerOption => new LocationProviderOptionMetaViewModel
             {
-                Id = providerOption.PublicId,
+                Id = locationOptionMetaLink.PublicId,
                 Label = providerOption.Label,
                 Ukprn = providerOption.Ukprn,
             },
             LocationRscRegionOptionMeta rscRegionOption => new LocationRscRegionOptionMetaViewModel
             {
-                Id = rscRegionOption.PublicId,
+                Id = locationOptionMetaLink.PublicId,
                 Label = rscRegionOption.Label,
             },
             LocationSchoolOptionMeta schoolOption => new LocationSchoolOptionMetaViewModel
             {
-                Id = schoolOption.PublicId,
+                Id = locationOptionMetaLink.PublicId,
                 Label = schoolOption.Label,
                 Urn = schoolOption.Urn,
                 LaEstab = schoolOption.LaEstab,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionMappingGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionMappingGeneratorExtensions.cs
@@ -1,0 +1,87 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+
+public static class DataSetVersionMappingGeneratorExtensions
+{
+    public static Generator<DataSetVersionMapping> DefaultDataSetVersionMapping(this DataFixture fixture)
+        => fixture.Generator<DataSetVersionMapping>().WithDefaults();
+
+    public static Generator<DataSetVersionMapping> WithDefaults(this Generator<DataSetVersionMapping> generator)
+        => generator.ForInstance(s => s.SetDefaults());
+
+    public static Generator<DataSetVersionMapping> WithSourceDataSetVersion(
+        this Generator<DataSetVersionMapping> generator,
+        DataSetVersion dataSetVersion)
+        => generator.ForInstance(s => s.SetSourceDataSetVersion(dataSetVersion));
+
+    public static Generator<DataSetVersionMapping> WithSourceDataSetVersionId(
+        this Generator<DataSetVersionMapping> generator,
+        Guid dataSetVersionId)
+        => generator.ForInstance(s => s.SetSourceDataSetVersionId(dataSetVersionId));
+
+    public static Generator<DataSetVersionMapping> WithTargetDataSetVersion(
+        this Generator<DataSetVersionMapping> generator,
+        DataSetVersion dataSetVersion)
+        => generator.ForInstance(s => s.SetTargetDataSetVersion(dataSetVersion));
+
+    public static Generator<DataSetVersionMapping> WithTargetDataSetVersionId(
+        this Generator<DataSetVersionMapping> generator,
+        Guid dataSetVersionId)
+        => generator.ForInstance(s => s.SetTargetDataSetVersionId(dataSetVersionId));
+
+    public static Generator<DataSetVersionMapping> WithLocationMappingPlan(
+        this Generator<DataSetVersionMapping> generator,
+        LocationMappingPlan locationMappingPlan)
+        => generator.ForInstance(s => s.SetLocationMappingPlan(locationMappingPlan));
+
+    public static Generator<DataSetVersionMapping> WithFilterMappingPlan(
+        this Generator<DataSetVersionMapping> generator,
+        FilterMappingPlan filterMappingPlan)
+        => generator.ForInstance(s => s.SetFilterMappingPlan(filterMappingPlan));
+
+    public static InstanceSetters<DataSetVersionMapping> SetDefaults(
+        this InstanceSetters<DataSetVersionMapping> setters)
+        => setters
+            .SetDefault(mapping => mapping.Id)
+            .SetDefault(mapping => mapping.SourceDataSetVersionId)
+            .SetDefault(mapping => mapping.TargetDataSetVersionId)
+            .SetLocationMappingPlan(new LocationMappingPlan())
+            .SetFilterMappingPlan(new FilterMappingPlan());
+
+    public static InstanceSetters<DataSetVersionMapping> SetSourceDataSetVersion(
+        this InstanceSetters<DataSetVersionMapping> instanceSetter,
+        DataSetVersion dataSetVersion)
+        => instanceSetter
+            .Set(mapping => mapping.SourceDataSetVersion, dataSetVersion)
+            .SetSourceDataSetVersionId(dataSetVersion.Id);
+
+    public static InstanceSetters<DataSetVersionMapping> SetSourceDataSetVersionId(
+        this InstanceSetters<DataSetVersionMapping> instanceSetter,
+        Guid dataSetVersionId)
+        => instanceSetter.Set(mapping => mapping.SourceDataSetVersionId, dataSetVersionId);
+
+    public static InstanceSetters<DataSetVersionMapping> SetTargetDataSetVersion(
+        this InstanceSetters<DataSetVersionMapping> instanceSetter,
+        DataSetVersion dataSetVersion)
+        => instanceSetter
+            .Set(mapping => mapping.TargetDataSetVersion, dataSetVersion)
+            .SetTargetDataSetVersionId(dataSetVersion.Id);
+
+    public static InstanceSetters<DataSetVersionMapping> SetTargetDataSetVersionId(
+        this InstanceSetters<DataSetVersionMapping> instanceSetter,
+        Guid dataSetVersionId)
+        => instanceSetter.Set(mapping => mapping.TargetDataSetVersionId, dataSetVersionId);
+
+    public static InstanceSetters<DataSetVersionMapping> SetLocationMappingPlan(
+        this InstanceSetters<DataSetVersionMapping> instanceSetter,
+        LocationMappingPlan locationMappingPlan)
+        => instanceSetter
+            .Set(mapping => mapping.LocationMappingPlan, locationMappingPlan);
+
+    public static InstanceSetters<DataSetVersionMapping> SetFilterMappingPlan(
+        this InstanceSetters<DataSetVersionMapping> instanceSetter,
+        FilterMappingPlan filterMappingPlan)
+        => instanceSetter
+            .Set(mapping => mapping.FilterMappingPlan, filterMappingPlan);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/FilterMappingPlanGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/FilterMappingPlanGeneratorExtensions.cs
@@ -1,0 +1,364 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+
+public static class FilterMappingPlanGeneratorExtensions
+{
+    /**
+     * FilterMappingPlan
+     */
+    public static Generator<FilterMappingPlan> DefaultFilterMappingPlan(this DataFixture fixture)
+        => fixture.Generator<FilterMappingPlan>();
+
+    public static Generator<FilterMappingPlan> FilterMappingPlanFromFilterMeta(
+        this DataFixture fixture,
+        List<FilterMeta>? sourceFilters = null,
+        List<FilterMeta>? targetFilters = null)
+    {
+        var filterMappingPlanGenerator = fixture.Generator<FilterMappingPlan>();
+    
+        sourceFilters?.ForEach(sourceFilter =>
+        {
+            var filterMappingGenerator = fixture
+                .DefaultFilterMapping()
+                .WithSource(fixture
+                    .DefaultMappableFilter()
+                    .WithLabel(sourceFilter.Label))
+                .WithPublicId(sourceFilter.PublicId);
+           
+            sourceFilter.Options.ForEach(option =>
+            {
+                filterMappingGenerator.AddOptionMapping(
+                    sourceKey: MappingKeyFunctions.FilterOptionKeyGenerator(option),
+                    fixture
+                        .DefaultFilterOptionMapping()
+                        .WithSource(fixture
+                            .DefaultMappableFilterOption()
+                            .WithLabel(option.Label))
+                        .WithPublicId($"{sourceFilter.PublicId} :: {option.Label}"));
+            });
+
+            filterMappingPlanGenerator.AddFilterMapping(
+                columnName: sourceFilter.PublicId,
+                filterMappingGenerator);
+        });
+        
+        targetFilters?.ForEach(targetFilter =>
+        {
+            var filterCandidateGenerator = fixture
+                .DefaultFilterMappingCandidate()
+                .WithLabel(targetFilter.Label);
+            
+            targetFilter.Options.ForEach(option =>
+            {
+                filterCandidateGenerator.AddOptionCandidate(
+                    targetKey: MappingKeyFunctions.FilterOptionKeyGenerator(option),
+                    fixture
+                        .DefaultMappableFilterOption()
+                        .WithLabel(option.Label));
+            });
+
+            filterMappingPlanGenerator.AddFilterCandidate(
+                columnName: targetFilter.PublicId,
+                filterCandidateGenerator);
+        });
+        
+        return filterMappingPlanGenerator;
+    }
+    
+    public static Generator<FilterMappingPlan> AddFilterMapping(
+        this Generator<FilterMappingPlan> generator,
+        string columnName,
+        FilterMapping mapping)
+        => generator.ForInstance(s => s.AddFilterMapping(columnName, mapping));
+    
+    public static Generator<FilterMappingPlan> AddFilterCandidate(
+        this Generator<FilterMappingPlan> generator,
+        string columnName,
+        FilterMappingCandidate candidate)
+        => generator.ForInstance(s => s.AddFilterCandidate(columnName, candidate));
+
+    public static InstanceSetters<FilterMappingPlan> AddFilterMapping(
+        this InstanceSetters<FilterMappingPlan> instanceSetter,
+        string columnName,
+        FilterMapping mapping)
+        => instanceSetter.Set((_, plan) => plan.Mappings.Add(columnName, mapping));
+
+    public static InstanceSetters<FilterMappingPlan> AddFilterCandidate(
+        this InstanceSetters<FilterMappingPlan> instanceSetter,
+        string columnName,
+        FilterMappingCandidate candidate)
+        => instanceSetter.Set((_, plan) => plan.Candidates.Add(columnName, candidate));
+
+    /**
+     * MappableFilter
+     */
+    public static Generator<MappableFilter> DefaultMappableFilter(this DataFixture fixture)
+        => fixture.Generator<MappableFilter>().WithDefaults();
+
+    public static Generator<MappableFilter> WithDefaults(this Generator<MappableFilter> generator)
+        => generator.ForInstance(s => s.SetDefaults());
+
+    public static Generator<MappableFilter> WithLabel(
+        this Generator<MappableFilter> generator,
+        string label)
+        => generator.ForInstance(s => s.SetLabel(label));
+
+    public static InstanceSetters<MappableFilter> SetDefaults(
+        this InstanceSetters<MappableFilter> setters)
+        => setters
+            .SetDefault(option => option.Label);
+
+    public static InstanceSetters<MappableFilter> SetLabel(
+        this InstanceSetters<MappableFilter> instanceSetter,
+        string label)
+        => instanceSetter.Set(option => option.Label, label);
+
+    /**
+     * FilterMapping
+     */
+    public static Generator<FilterMapping> DefaultFilterMapping(this DataFixture fixture)
+        => fixture.Generator<FilterMapping>().WithDefaults();
+
+    public static Generator<FilterMapping> WithDefaults(this Generator<FilterMapping> generator)
+        => generator.ForInstance(s => s.SetDefaults());
+
+    public static Generator<FilterMapping> WithSource(
+        this Generator<FilterMapping> generator,
+        MappableFilter source)
+        => generator.ForInstance(s => s.SetSource(source));
+
+    public static Generator<FilterMapping> WithPublicId(
+        this Generator<FilterMapping> generator,
+        string publicId)
+        => generator.ForInstance(s => s.SetPublicId(publicId));
+
+    public static Generator<FilterMapping> WithType(
+        this Generator<FilterMapping> generator,
+        MappingType type)
+        => generator.ForInstance(s => s.SetType(type));
+
+    public static Generator<FilterMapping> WithNoMapping(
+        this Generator<FilterMapping> generator)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.None)
+            .SetCandidateKey(null));
+
+    public static Generator<FilterMapping> WithAutoMapped(
+        this Generator<FilterMapping> generator,
+        string candidateKey)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.AutoMapped)
+            .SetCandidateKey(candidateKey));
+
+    public static Generator<FilterMapping> WithAutoNone(
+        this Generator<FilterMapping> generator)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.AutoNone)
+            .SetCandidateKey(null));
+
+    public static Generator<FilterMapping> WithManualMapped(
+        this Generator<FilterMapping> generator,
+        string candidateKey)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.ManualMapped)
+            .SetCandidateKey(candidateKey));
+
+    public static Generator<FilterMapping> WithManualNone(
+        this Generator<FilterMapping> generator)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.ManualNone)
+            .SetCandidateKey(null));
+
+    public static Generator<FilterMapping> WithCandidateKey(
+        this Generator<FilterMapping> generator,
+        string candidateKey)
+        => generator.ForInstance(s => s.SetCandidateKey(candidateKey));
+    
+    public static Generator<FilterMapping> AddOptionMapping(
+        this Generator<FilterMapping> generator,
+        string sourceKey,
+        FilterOptionMapping mapping)
+        => generator.ForInstance(s => s.AddOptionMapping(sourceKey, mapping));
+
+    public static InstanceSetters<FilterMapping> SetDefaults(
+        this InstanceSetters<FilterMapping> setters)
+        => setters
+            .SetDefault(mapping => mapping.PublicId)
+            .SetDefault(mapping => mapping.Type)
+            .SetDefault(mapping => mapping.CandidateKey);
+
+    public static InstanceSetters<FilterMapping> SetSource(
+        this InstanceSetters<FilterMapping> setters,
+        MappableFilter source)
+        => setters.Set(mapping => mapping.Source, source);
+
+    public static InstanceSetters<FilterMapping> SetPublicId(
+        this InstanceSetters<FilterMapping> setters,
+        string publicId)
+        => setters.Set(mapping => mapping.PublicId, publicId);
+
+    public static InstanceSetters<FilterMapping> SetType(
+        this InstanceSetters<FilterMapping> setters,
+        MappingType type)
+        => setters.Set(mapping => mapping.Type, type);
+
+    public static InstanceSetters<FilterMapping> SetCandidateKey(
+        this InstanceSetters<FilterMapping> setters,
+        string? candidateKey)
+        => setters.Set(mapping => mapping.CandidateKey, candidateKey);
+
+    public static InstanceSetters<FilterMapping> AddOptionMapping(
+        this InstanceSetters<FilterMapping> instanceSetter,
+        string columnName,
+        FilterOptionMapping mapping)
+        => instanceSetter.Set((_, plan) => plan.OptionMappings.Add(columnName, mapping));
+    
+    /**
+     * FilterMappingCandidate
+     */
+    public static Generator<FilterMappingCandidate> DefaultFilterMappingCandidate(this DataFixture fixture)
+        => fixture.Generator<FilterMappingCandidate>().WithDefaults();
+
+    public static Generator<FilterMappingCandidate> WithDefaults(this Generator<FilterMappingCandidate> generator)
+        => generator.ForInstance(s => s.SetDefaults());
+
+    public static Generator<FilterMappingCandidate> WithLabel(
+        this Generator<FilterMappingCandidate> generator,
+        string label)
+        => generator.ForInstance(s => s.SetLabel(label));
+    
+    public static Generator<FilterMappingCandidate> AddOptionCandidate(
+        this Generator<FilterMappingCandidate> generator,
+        string targetKey,
+        MappableFilterOption candidate)
+        => generator.ForInstance(s => s.AddOptionCandidate(targetKey, candidate));
+
+    public static InstanceSetters<FilterMappingCandidate> SetDefaults(
+        this InstanceSetters<FilterMappingCandidate> setters)
+        => setters
+            .SetDefault(option => option.Label);
+
+    public static InstanceSetters<FilterMappingCandidate> SetLabel(
+        this InstanceSetters<FilterMappingCandidate> instanceSetter,
+        string label)
+        => instanceSetter.Set(option => option.Label, label);
+
+    public static InstanceSetters<FilterMappingCandidate> AddOptionCandidate(
+        this InstanceSetters<FilterMappingCandidate> instanceSetter,
+        string targetKey,
+        MappableFilterOption candidate)
+        => instanceSetter.Set((_, plan) => plan.Options.Add(targetKey, candidate));
+
+    /**
+     * MappableFilterOption
+     */
+    public static Generator<MappableFilterOption> DefaultMappableFilterOption(this DataFixture fixture)
+        => fixture.Generator<MappableFilterOption>().WithDefaults();
+
+    public static Generator<MappableFilterOption> WithDefaults(this Generator<MappableFilterOption> generator)
+        => generator.ForInstance(s => s.SetDefaults());
+
+    public static Generator<MappableFilterOption> WithLabel(
+        this Generator<MappableFilterOption> generator,
+        string label)
+        => generator.ForInstance(s => s.SetLabel(label));
+
+    public static InstanceSetters<MappableFilterOption> SetDefaults(
+        this InstanceSetters<MappableFilterOption> setters)
+        => setters
+            .SetDefault(option => option.Label);
+
+    public static InstanceSetters<MappableFilterOption> SetLabel(
+        this InstanceSetters<MappableFilterOption> instanceSetter,
+        string label)
+        => instanceSetter.Set(option => option.Label, label);
+
+    /**
+     * FilterOptionMapping
+     */
+    public static Generator<FilterOptionMapping> DefaultFilterOptionMapping(this DataFixture fixture)
+        => fixture.Generator<FilterOptionMapping>().WithDefaults();
+
+    public static Generator<FilterOptionMapping> WithDefaults(this Generator<FilterOptionMapping> generator)
+        => generator.ForInstance(s => s.SetDefaults());
+
+    public static Generator<FilterOptionMapping> WithSource(
+        this Generator<FilterOptionMapping> generator,
+        MappableFilterOption source)
+        => generator.ForInstance(s => s.SetSource(source));
+
+    public static Generator<FilterOptionMapping> WithPublicId(
+        this Generator<FilterOptionMapping> generator,
+        string publicId)
+        => generator.ForInstance(s => s.SetPublicId(publicId));
+
+    public static Generator<FilterOptionMapping> WithType(
+        this Generator<FilterOptionMapping> generator,
+        MappingType type)
+        => generator.ForInstance(s => s.SetType(type));
+
+    public static Generator<FilterOptionMapping> WithNoMapping(
+        this Generator<FilterOptionMapping> generator)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.None)
+            .SetCandidateKey(null));
+    
+    public static Generator<FilterOptionMapping> WithAutoMapped(
+        this Generator<FilterOptionMapping> generator,
+        string candidateKey)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.AutoMapped)
+            .SetCandidateKey(candidateKey));
+
+    public static Generator<FilterOptionMapping> WithAutoNone(
+        this Generator<FilterOptionMapping> generator)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.AutoNone)
+            .SetCandidateKey(null));
+
+    public static Generator<FilterOptionMapping> WithManualMapped(
+        this Generator<FilterOptionMapping> generator,
+        string candidateKey)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.ManualMapped)
+            .SetCandidateKey(candidateKey));
+
+    public static Generator<FilterOptionMapping> WithManualNone(
+        this Generator<FilterOptionMapping> generator)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.ManualNone)
+            .SetCandidateKey(null));
+
+    public static Generator<FilterOptionMapping> WithCandidateKey(
+        this Generator<FilterOptionMapping> generator,
+        string candidateKey)
+        => generator.ForInstance(s => s.SetCandidateKey(candidateKey));
+
+    public static InstanceSetters<FilterOptionMapping> SetDefaults(
+        this InstanceSetters<FilterOptionMapping> setters)
+        => setters
+            .SetDefault(mapping => mapping.PublicId)
+            .SetDefault(mapping => mapping.Type)
+            .SetDefault(mapping => mapping.CandidateKey);
+
+    public static InstanceSetters<FilterOptionMapping> SetSource(
+        this InstanceSetters<FilterOptionMapping> setters,
+        MappableFilterOption source)
+        => setters.Set(mapping => mapping.Source, source);
+
+    public static InstanceSetters<FilterOptionMapping> SetPublicId(
+        this InstanceSetters<FilterOptionMapping> setters,
+        string publicId)
+        => setters.Set(mapping => mapping.PublicId, publicId);
+
+    public static InstanceSetters<FilterOptionMapping> SetType(
+        this InstanceSetters<FilterOptionMapping> setters,
+        MappingType type)
+        => setters.Set(mapping => mapping.Type, type);
+
+    public static InstanceSetters<FilterOptionMapping> SetCandidateKey(
+        this InstanceSetters<FilterOptionMapping> setters,
+        string? candidateKey)
+        => setters.Set(mapping => mapping.CandidateKey, candidateKey);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/LocationMappingPlanGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/LocationMappingPlanGeneratorExtensions.cs
@@ -1,0 +1,257 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+
+public static class LocationMappingPlanGeneratorExtensions
+{
+    /**
+     * LocationMappingPlan
+     */
+    public static Generator<LocationMappingPlan> DefaultLocationMappingPlan(this DataFixture fixture)
+        => fixture.Generator<LocationMappingPlan>();
+
+    public static Generator<LocationMappingPlan> LocationMappingPlanFromLocationMeta(
+        this DataFixture fixture,
+        List<LocationMeta>? sourceLocations = null,
+        List<LocationMeta>? targetLocations = null)
+    {
+        var locationMappingPlanGenerator = fixture.Generator<LocationMappingPlan>();
+
+        var levels = (sourceLocations ?? [])
+            .Concat(targetLocations ?? [])
+            .Select(meta => meta.Level)
+            .Distinct()
+            .ToList();
+        
+        levels.ForEach(level =>
+        {
+            var levelGenerator = fixture
+                .DefaultLocationLevelMappings();
+
+            var sourceLocationsForLevel = sourceLocations?
+                .SingleOrDefault(meta => meta.Level == level);
+            
+            sourceLocationsForLevel?.Options.ForEach(option =>
+            {
+                levelGenerator.AddMapping(
+                    sourceKey: MappingKeyFunctions.LocationOptionMetaKeyGenerator(option),
+                    mapping: fixture
+                        .DefaultLocationOptionMapping()
+                        .WithSource(fixture.DefaultMappableLocationOption()
+                            .WithLabel(option.Label)
+                            .WithCodes(option.ToRow())));
+            });
+            
+            var targetLocationsForLevel = targetLocations?
+                .SingleOrDefault(meta => meta.Level == level);
+            
+            targetLocationsForLevel?.Options.ForEach(option =>
+            {
+                levelGenerator.AddCandidate(
+                    targetKey: MappingKeyFunctions.LocationOptionMetaKeyGenerator(option),
+                    candidate: fixture
+                        .DefaultMappableLocationOption()
+                        .WithLabel(option.Label)
+                        .WithCodes(option.ToRow()));
+            });
+                
+            locationMappingPlanGenerator.AddLevel(level, levelGenerator);
+        });
+
+        return locationMappingPlanGenerator;
+    }
+
+    public static Generator<LocationMappingPlan> AddLevel(
+        this Generator<LocationMappingPlan> generator,
+        GeographicLevel level,
+        LocationLevelMappings mappings)
+        => generator.ForInstance(s => s.AddLevel(level, mappings));
+
+    public static InstanceSetters<LocationMappingPlan> AddLevel(
+        this InstanceSetters<LocationMappingPlan> instanceSetter,
+        GeographicLevel level,
+        LocationLevelMappings mappings)
+        => instanceSetter.Set((_, plan) => plan.Levels.Add(level, mappings));
+
+    /**
+     * LocationLevelMappings
+     */
+    public static Generator<LocationLevelMappings> DefaultLocationLevelMappings(this DataFixture fixture)
+        => fixture.Generator<LocationLevelMappings>();
+
+    public static Generator<LocationLevelMappings> AddCandidate(
+        this Generator<LocationLevelMappings> generator,
+        string targetKey,
+        MappableLocationOption candidate)
+        => generator.ForInstance(s => s.AddCandidate(targetKey, candidate));
+
+    public static Generator<LocationLevelMappings> AddMapping(
+        this Generator<LocationLevelMappings> generator,
+        string sourceKey,
+        LocationOptionMapping mapping)
+        => generator.ForInstance(s => s.AddMapping(sourceKey, mapping));
+
+    public static InstanceSetters<LocationLevelMappings> AddCandidate(
+        this InstanceSetters<LocationLevelMappings> instanceSetter,
+        string targetKey,
+        MappableLocationOption candidate)
+        => instanceSetter.Set((_, mappings) => mappings.Candidates.Add(targetKey, candidate));
+
+    public static InstanceSetters<LocationLevelMappings> AddMapping(
+        this InstanceSetters<LocationLevelMappings> instanceSetter,
+        string sourceKey,
+        LocationOptionMapping mapping)
+        => instanceSetter.Set((_, mappings) => mappings.Mappings.Add(sourceKey, mapping));
+
+    /**
+     * MappableLocationOption
+     */
+    public static Generator<MappableLocationOption> DefaultMappableLocationOption(this DataFixture fixture)
+        => fixture.Generator<MappableLocationOption>().WithDefaults();
+
+    public static Generator<MappableLocationOption> WithDefaults(this Generator<MappableLocationOption> generator)
+        => generator.ForInstance(s => s.SetDefaults());
+
+    public static Generator<MappableLocationOption> WithLabel(
+        this Generator<MappableLocationOption> generator,
+        string label)
+        => generator.ForInstance(s => s.SetLabel(label));
+
+    public static Generator<MappableLocationOption> WithCodes(
+        this Generator<MappableLocationOption> generator,
+        string? code,
+        string? oldCode,
+        string? urn,
+        string? laEstab,
+        string? ukprn)
+        => generator.ForInstance(s => s.SetCodes(
+            code: code,
+            oldCode: oldCode,
+            urn: urn,
+            laEstab: laEstab,
+            ukprn: ukprn));
+    
+    public static Generator<MappableLocationOption> WithCodes(
+        this Generator<MappableLocationOption> generator,
+        LocationOptionMetaRow metaRow)
+        => generator.ForInstance(s => s.SetCodes(
+            code: metaRow.Code,
+            oldCode: metaRow.OldCode,
+            urn: metaRow.Urn,
+            laEstab: metaRow.LaEstab,
+            ukprn: metaRow.Ukprn));
+
+    public static InstanceSetters<MappableLocationOption> SetDefaults(
+        this InstanceSetters<MappableLocationOption> setters)
+        => setters
+            .SetDefault(option => option.Label)
+            .SetDefault(option => option.Code);
+
+    public static InstanceSetters<MappableLocationOption> SetLabel(
+        this InstanceSetters<MappableLocationOption> instanceSetter,
+        string label)
+        => instanceSetter.Set(option => option.Label, label);
+
+    public static InstanceSetters<MappableLocationOption> SetCodes(
+        this InstanceSetters<MappableLocationOption> instanceSetter,
+        string? code,
+        string? oldCode,
+        string? urn,
+        string? laEstab,
+        string? ukprn)
+        => instanceSetter
+            .Set(option => option.Code, (_, option) => code ?? option.Code)
+            .Set(option => option.OldCode, (_, option) => oldCode ?? option.OldCode)
+            .Set(option => option.Urn, (_, option) => urn ?? option.Urn)
+            .Set(option => option.LaEstab, (_, option) => laEstab ?? option.LaEstab)
+            .Set(option => option.Ukprn, (_, option) => ukprn ?? option.Ukprn);
+
+    /**
+     * LocationOptionMapping
+     */
+    public static Generator<LocationOptionMapping> DefaultLocationOptionMapping(this DataFixture fixture)
+        => fixture.Generator<LocationOptionMapping>().WithDefaults();
+
+    public static Generator<LocationOptionMapping> WithDefaults(this Generator<LocationOptionMapping> generator)
+        => generator.ForInstance(s => s.SetDefaults());
+
+    public static Generator<LocationOptionMapping> WithSource(
+        this Generator<LocationOptionMapping> generator,
+        MappableLocationOption source)
+        => generator.ForInstance(s => s.SetSource(source));
+
+    public static Generator<LocationOptionMapping> WithPublicId(
+        this Generator<LocationOptionMapping> generator,
+        string publicId)
+        => generator.ForInstance(s => s.SetPublicId(publicId));
+
+    public static Generator<LocationOptionMapping> WithType(
+        this Generator<LocationOptionMapping> generator,
+        MappingType type)
+        => generator.ForInstance(s => s.SetType(type));
+
+    public static Generator<LocationOptionMapping> WithNoMapping(
+        this Generator<LocationOptionMapping> generator)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.None)
+            .SetCandidateKey(null));
+
+    public static Generator<LocationOptionMapping> WithAutoMapped(
+        this Generator<LocationOptionMapping> generator,
+        string candidateKey)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.AutoMapped)
+            .SetCandidateKey(candidateKey));
+
+    public static Generator<LocationOptionMapping> WithAutoNone(
+        this Generator<LocationOptionMapping> generator)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.AutoNone)
+            .SetCandidateKey(null));
+
+    public static Generator<LocationOptionMapping> WithManualMapped(
+        this Generator<LocationOptionMapping> generator,
+        string candidateKey)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.ManualMapped)
+            .SetCandidateKey(candidateKey));
+
+    public static Generator<LocationOptionMapping> WithManualNone(
+        this Generator<LocationOptionMapping> generator)
+        => generator.ForInstance(s => s
+            .SetType(MappingType.ManualNone)
+            .SetCandidateKey(null));
+
+    public static Generator<LocationOptionMapping> WithCandidateKey(
+        this Generator<LocationOptionMapping> generator,
+        string candidateKey)
+        => generator.ForInstance(s => s.SetCandidateKey(candidateKey));
+
+    public static InstanceSetters<LocationOptionMapping> SetDefaults(
+        this InstanceSetters<LocationOptionMapping> setters)
+        => setters
+            .SetDefault(mapping => mapping.PublicId)
+            .SetDefault(mapping => mapping.Type)
+            .SetDefault(mapping => mapping.CandidateKey);
+
+    public static InstanceSetters<LocationOptionMapping> SetSource(
+        this InstanceSetters<LocationOptionMapping> setters,
+        MappableLocationOption source)
+        => setters.Set(mapping => mapping.Source, source);
+
+    public static InstanceSetters<LocationOptionMapping> SetPublicId(
+        this InstanceSetters<LocationOptionMapping> setters,
+        string publicId)
+        => setters.Set(mapping => mapping.PublicId, publicId);
+
+    public static InstanceSetters<LocationOptionMapping> SetType(
+        this InstanceSetters<LocationOptionMapping> setters,
+        MappingType type)
+        => setters.Set(mapping => mapping.Type, type);
+
+    public static InstanceSetters<LocationOptionMapping> SetCandidateKey(
+        this InstanceSetters<LocationOptionMapping> setters,
+        string? candidateKey)
+        => setters.Set(mapping => mapping.CandidateKey, candidateKey);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/LocationMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/LocationMetaGeneratorExtensions.cs
@@ -82,7 +82,7 @@ public static class LocationMetaGeneratorExtensions
     public static InstanceSetters<LocationMeta> SetOptions(
         this InstanceSetters<LocationMeta> setters,
         IEnumerable<LocationOptionMeta> options)
-        => setters.Set(m => m.Options, () => options);
+        => setters.SetOptions(() => options);
 
     public static InstanceSetters<LocationMeta> SetOptions(
         this InstanceSetters<LocationMeta> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/LocationOptionMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/LocationOptionMetaGeneratorExtensions.cs
@@ -9,11 +9,6 @@ public static class LocationOptionMetaGeneratorExtensions
         int id) where TOptionMeta : LocationOptionMeta
         => generator.ForInstance(s => s.SetId(id));
 
-    public static Generator<TOptionMeta> WithPublicId<TOptionMeta>(
-        this Generator<TOptionMeta> generator,
-        string publicId) where TOptionMeta : LocationOptionMeta
-        => generator.ForInstance(s => s.SetPublicId(publicId));
-
     public static Generator<TOptionMeta> WithLabel<TOptionMeta>(
         this Generator<TOptionMeta> generator,
         string label) where TOptionMeta : LocationOptionMeta
@@ -32,18 +27,12 @@ public static class LocationOptionMetaGeneratorExtensions
     public static InstanceSetters<TOptionMeta> SetBaseDefaults<TOptionMeta>(
         this InstanceSetters<TOptionMeta> setters) where TOptionMeta : LocationOptionMeta
         => setters
-            .SetDefault(m => m.PublicId)
             .SetDefault(m => m.Label);
 
     public static InstanceSetters<TOptionMeta> SetId<TOptionMeta>(
         this InstanceSetters<TOptionMeta> setters,
         int id) where TOptionMeta : LocationOptionMeta
         => setters.Set(m => m.Id, id);
-
-    public static InstanceSetters<TOptionMeta> SetPublicId<TOptionMeta>(
-        this InstanceSetters<TOptionMeta> setters,
-        string publicId) where TOptionMeta : LocationOptionMeta
-        => setters.Set(m => m.PublicId, publicId);
 
     public static InstanceSetters<TOptionMeta> SetLabel<TOptionMeta>(
         this InstanceSetters<TOptionMeta> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/LocationOptionMetaLinkGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/LocationOptionMetaLinkGeneratorExtensions.cs
@@ -11,6 +11,11 @@ public static class LocationOptionMetaLinkGeneratorExtensions
         this Generator<LocationOptionMetaLink> generator)
         => generator.ForInstance(s => s.SetDefaults());
 
+    public static Generator<LocationOptionMetaLink> WithPublicId(
+        this Generator<LocationOptionMetaLink> generator,
+        string publicId)
+        => generator.ForInstance(s => s.SetPublicId(publicId));
+
     public static Generator<LocationOptionMetaLink> WithMeta(
         this Generator<LocationOptionMetaLink> generator,
         LocationMeta meta)
@@ -38,7 +43,12 @@ public static class LocationOptionMetaLinkGeneratorExtensions
 
     public static InstanceSetters<LocationOptionMetaLink> SetDefaults(
         this InstanceSetters<LocationOptionMetaLink> setters)
-        => setters;
+        => setters
+            .SetDefault(m => m.PublicId);
+    public static InstanceSetters<LocationOptionMetaLink> SetPublicId(
+        this InstanceSetters<LocationOptionMetaLink> setters,
+        string publicId)
+        => setters.Set(m => m.PublicId, publicId);
 
     public static InstanceSetters<LocationOptionMetaLink> SetMeta(
         this InstanceSetters<LocationOptionMetaLink> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/LocationOptionMetaRowTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/LocationOptionMetaRowTests.cs
@@ -11,25 +11,25 @@ public abstract class LocationOptionMetaRowTests
         {
             HashSet<string> excludedProperties =
             [
-                nameof(LocationOptionMetaRow.Id),
+                $"{nameof(LocationOptionMetaRow.Id)} value",
             ];
 
             var expectedProperties = typeof(LocationOptionMetaRow)
                 .GetProperties()
-                .Select(p => p.Name)
+                .Select(p => $"{p.Name} value")
                 .Except(excludedProperties)
                 .ToHashSet();
 
             var optionRow = new LocationOptionMetaRow
             {
                 Id = 1,
-                Type = nameof(LocationOptionMetaRow.Type),
-                Label = nameof(LocationOptionMetaRow.Label),
-                Code = nameof(LocationOptionMetaRow.Code),
-                OldCode = nameof(LocationOptionMetaRow.OldCode),
-                Urn = nameof(LocationOptionMetaRow.Urn),
-                LaEstab = nameof(LocationOptionMetaRow.LaEstab),
-                Ukprn = nameof(LocationOptionMetaRow.Ukprn),
+                Type = nameof(LocationOptionMetaRow.Type) + " value",
+                Label = nameof(LocationOptionMetaRow.Label) + " value",
+                Code = nameof(LocationOptionMetaRow.Code) + " value",
+                OldCode = nameof(LocationOptionMetaRow.OldCode) + " value",
+                Urn = nameof(LocationOptionMetaRow.Urn) + " value",
+                LaEstab = nameof(LocationOptionMetaRow.LaEstab) + " value",
+                Ukprn = nameof(LocationOptionMetaRow.Ukprn) + " value"
             };
 
             var rowKey = optionRow.GetRowKey();
@@ -37,6 +37,75 @@ public abstract class LocationOptionMetaRowTests
 
             Assert.Equal(expectedProperties, properties);
         }
+    }
+    
+    public class GetRowKeyPrettyTests
+    {
+        [Fact]
+        public void ContainsKeyProperties()
+        {
+            HashSet<string> excludedProperties =
+            [
+                $"{nameof(LocationOptionMetaRow.Id)}:{nameof(LocationOptionMetaRow.Id)} value",
+            ];
+
+            var expectedProperties = typeof(LocationOptionMetaRow)
+                .GetProperties()
+                .Select(p => $"{p.Name}:{p.Name} value")
+                .Except(excludedProperties)
+                .ToHashSet();
+
+            var optionRow = new LocationOptionMetaRow
+            {
+                Id = 1,
+                Type = nameof(LocationOptionMetaRow.Type) + " value",
+                Label = nameof(LocationOptionMetaRow.Label) + " value",
+                Code = nameof(LocationOptionMetaRow.Code) + " value",
+                OldCode = nameof(LocationOptionMetaRow.OldCode) + " value",
+                Urn = nameof(LocationOptionMetaRow.Urn) + " value",
+                LaEstab = nameof(LocationOptionMetaRow.LaEstab) + " value",
+                Ukprn = nameof(LocationOptionMetaRow.Ukprn) + " value"
+            };
+
+            var rowKey = optionRow.GetRowKeyPretty();
+            var properties = rowKey.Split(',').ToHashSet();
+
+            Assert.Equal(expectedProperties, properties);
+        }
+    }
+    
+    [Fact]
+    public void OmitsNullProperties()
+    {
+        HashSet<string> excludedProperties =
+        [
+            $"{nameof(LocationOptionMetaRow.Id)}:{nameof(LocationOptionMetaRow.Id)} value",
+            $"{nameof(LocationOptionMetaRow.OldCode)}:{nameof(LocationOptionMetaRow.OldCode)} value",
+            $"{nameof(LocationOptionMetaRow.Ukprn)}:{nameof(LocationOptionMetaRow.Ukprn)} value",
+        ];
+
+        var expectedProperties = typeof(LocationOptionMetaRow)
+            .GetProperties()
+            .Select(p => $"{p.Name}:{p.Name} value")
+            .Except(excludedProperties)
+            .ToHashSet();
+
+        var optionRow = new LocationOptionMetaRow
+        {
+            Id = 1,
+            Type = nameof(LocationOptionMetaRow.Type) + " value",
+            Label = nameof(LocationOptionMetaRow.Label) + " value",
+            Code = nameof(LocationOptionMetaRow.Code) + " value",
+            OldCode = null,
+            Urn = nameof(LocationOptionMetaRow.Urn) + " value",
+            LaEstab = nameof(LocationOptionMetaRow.LaEstab) + " value",
+            Ukprn = null
+        };
+
+        var rowKey = optionRow.GetRowKeyPretty();
+        var properties = rowKey.Split(',').ToHashSet();
+
+        Assert.Equal(expectedProperties, properties);
     }
 
     public class PropertyTests

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/LocationOptionMetaRowTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/LocationOptionMetaRowTests.cs
@@ -12,7 +12,6 @@ public abstract class LocationOptionMetaRowTests
             HashSet<string> excludedProperties =
             [
                 nameof(LocationOptionMetaRow.Id),
-                nameof(LocationOptionMetaRow.PublicId),
             ];
 
             var expectedProperties = typeof(LocationOptionMetaRow)
@@ -24,7 +23,6 @@ public abstract class LocationOptionMetaRowTests
             var optionRow = new LocationOptionMetaRow
             {
                 Id = 1,
-                PublicId = nameof(LocationOptionMetaRow.PublicId),
                 Type = nameof(LocationOptionMetaRow.Type),
                 Label = nameof(LocationOptionMetaRow.Label),
                 Code = nameof(LocationOptionMetaRow.Code),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/LocationOptionMetaTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/LocationOptionMetaTests.cs
@@ -13,7 +13,6 @@ public abstract class LocationOptionMetaTests
             var option = new LocationCodedOptionMeta
             {
                 Id = 1,
-                PublicId = nameof(LocationCodedOptionMeta.PublicId),
                 Label = nameof(LocationCodedOptionMeta.Label),
                 Code = nameof(LocationCodedOptionMeta.Code),
             };

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionMapping.cs
@@ -232,8 +232,11 @@ public record FilterMappingPlan
 
 public static class MappingKeyFunctions
 {
-    public static Func<LocationOptionMetaRow, string> LocationOptionKeyGenerator =>
-        option => $"{option.Label} :: {option.GetRowKey()}";
+    public static Func<LocationOptionMetaRow, string> LocationOptionMetaRowKeyGenerator =>
+        option => $"{option.Label} :: {option.GetRowKeyPretty()}";
+    
+    public static Func<LocationOptionMeta, string> LocationOptionMetaKeyGenerator =>
+        option => LocationOptionMetaRowKeyGenerator(option.ToRow());
 
     public static Func<FilterMeta, string> FilterKeyGenerator =>
         filter => filter.PublicId;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionMapping.cs
@@ -109,7 +109,7 @@ public abstract record MappableElementWithOptions<TMappableOption>(string Label)
     : MappableElement(Label)
     where TMappableOption : MappableElement
 {
-    public Dictionary<string, TMappableOption> Options { get; set; } = [];
+    public Dictionary<string, TMappableOption> Options { get; init; } = [];
 }
 
 /// <summary>
@@ -121,11 +121,13 @@ public abstract record MappableElementWithOptions<TMappableOption>(string Label)
 public abstract record Mapping<TMappableElement>
     where TMappableElement : MappableElement
 {
+    public TMappableElement Source { get; init; } = null!;
+
+    public string PublicId { get; init; } = string.Empty;
+
     [JsonConverter(typeof(JsonStringEnumConverter))]
     [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
     public MappingType Type { get; set; } = MappingType.None;
-
-    public TMappableElement Source { get; set; } = null!;
 
     public string? CandidateKey { get; set; }
 }
@@ -149,15 +151,15 @@ public abstract record ParentMapping<TMappableElement, TOption, TOptionMapping>
 /// </summary>
 public record MappableLocationOption(string Label) : MappableElement(Label)
 {
-    public string? Code { get; set; }
+    public string? Code { get; init; }
 
-    public string? OldCode { get; set; }
+    public string? OldCode { get; init; }
 
-    public string? Urn { get; set; }
+    public string? Urn { get; init; }
 
-    public string? LaEstab { get; set; }
+    public string? LaEstab { get; init; }
 
-    public string? Ukprn { get; set; }
+    public string? Ukprn { get; init; }
 };
 
 /// <summary>
@@ -172,9 +174,9 @@ public record LocationOptionMapping : Mapping<MappableLocationOption>;
 /// </summary>
 public record LocationLevelMappings
 {
-    public Dictionary<string, LocationOptionMapping> Mappings { get; set; } = [];
+    public Dictionary<string, LocationOptionMapping> Mappings { get; init; } = [];
 
-    public Dictionary<string, MappableLocationOption> Candidates { get; set; } = [];
+    public Dictionary<string, MappableLocationOption> Candidates { get; init; } = [];
 }
 
 /// <summary>
@@ -183,7 +185,7 @@ public record LocationLevelMappings
 /// </summary>
 public class LocationMappingPlan
 {
-    public Dictionary<GeographicLevel, LocationLevelMappings> Levels { get; set; } = [];
+    public Dictionary<GeographicLevel, LocationLevelMappings> Levels { get; init; } = [];
 }
 
 /// <summary>
@@ -223,7 +225,19 @@ public record FilterMapping : ParentMapping<MappableFilter, MappableFilterOption
 /// </summary>
 public record FilterMappingPlan
 {
-    public Dictionary<string, FilterMapping> Mappings { get; set; } = [];
+    public Dictionary<string, FilterMapping> Mappings { get; init; } = [];
 
-    public Dictionary<string, FilterMappingCandidate> Candidates { get; set; } = [];
+    public Dictionary<string, FilterMappingCandidate> Candidates { get; init; } = [];
+}
+
+public static class MappingKeyFunctions
+{
+    public static Func<LocationOptionMetaRow, string> LocationOptionKeyGenerator =>
+        option => $"{option.Label} :: {option.GetRowKey()}";
+
+    public static Func<FilterMeta, string> FilterKeyGenerator =>
+        filter => filter.PublicId;
+
+    public static Func<FilterOptionMeta, string> FilterOptionKeyGenerator =>
+        option => option.Label;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj
@@ -35,4 +35,10 @@
         <Folder Include="Migrations\" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Content Include="Migrations\*.sql">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/LocationOptionMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/LocationOptionMeta.cs
@@ -8,8 +8,6 @@ public abstract class LocationOptionMeta
 {
     public int Id { get; set; }
 
-    public required string PublicId { get; set; }
-
     public required string Label { get; set; }
 
     protected abstract string Type { get; set; }
@@ -32,7 +30,6 @@ public abstract class LocationOptionMeta
     {
         Id = Id,
         Type = Type,
-        PublicId = PublicId,
         Label = Label,
         Code = Code,
         OldCode = OldCode,
@@ -52,10 +49,6 @@ public abstract class LocationOptionMeta
                 .HasValue<LocationProviderOptionMeta>(LocationProviderOptionMeta.TypeValue)
                 .HasValue<LocationRscRegionOptionMeta>(LocationRscRegionOptionMeta.TypeValue)
                 .HasValue<LocationSchoolOptionMeta>(LocationSchoolOptionMeta.TypeValue);
-
-            builder
-                .HasIndex(o => o.PublicId)
-                .IsUnique();
 
             builder
                 .Property(o => o.Type)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/LocationOptionMetaLink.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/LocationOptionMetaLink.cs
@@ -1,7 +1,12 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
 public class LocationOptionMetaLink
 {
+    public required string PublicId { get; set; }
+    
     public required int MetaId { get; set; }
 
     public LocationMeta Meta { get; set; } = null!;
@@ -9,4 +14,12 @@ public class LocationOptionMetaLink
     public required int OptionId { get; set; }
 
     public LocationOptionMeta Option { get; set; } = null!;
+
+    internal class Config : IEntityTypeConfiguration<LocationOptionMetaLink>
+    {
+        public void Configure(EntityTypeBuilder<LocationOptionMetaLink> builder)
+        {
+            builder.HasIndex(o => o.PublicId);
+        }
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/LocationOptionMetaRow.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/LocationOptionMetaRow.cs
@@ -36,4 +36,18 @@ public class LocationOptionMetaRow
         (Urn ?? "null") + ',' +
         (LaEstab ?? "null") + ',' +
         (Ukprn ?? "null");
+
+    public string GetRowKeyPretty()
+    {
+        var rowKey = 
+            $"{nameof(Type)}:{Type}," +
+            $"{nameof(Label)}:{Label}," +
+            (Code is not null ? $"{nameof(Code)}:{Code}," : "") +
+            (OldCode is not null ? $"{nameof(OldCode)}:{OldCode}," : "") +
+            (Urn is not null ? $"{nameof(Urn)}:{Urn}," : "") +
+            (LaEstab is not null ? $"{nameof(LaEstab)}:{LaEstab}," : "") +
+            (Ukprn is not null ? $"{nameof(Ukprn)}:{Ukprn}," : "");
+
+        return rowKey[..^1];
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/LocationOptionMetaRow.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/LocationOptionMetaRow.cs
@@ -13,9 +13,6 @@ public class LocationOptionMetaRow
     public int Id { get; set; }
 
     [Column(CanBeNull = false)]
-    public required string PublicId { get; set; }
-
-    [Column(CanBeNull = false)]
     public required string Type { get; set; }
 
     [Column(CanBeNull = false)]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240710122937_EES4954_MovePublicIdToLocationMetaOptionLinkTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240710122937_EES4954_MovePublicIdToLocationMetaOptionLinkTable.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
 {
     [DbContext(typeof(PublicDataDbContext))]
-    partial class PublicDataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240710122937_EES4954_MovePublicIdToLocationMetaOptionLinkTable")]
+    partial class EES4954_MovePublicIdToLocationMetaOptionLinkTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -25,24 +28,124 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
             modelBuilder.HasSequence<int>("FilterOptionMetaLink_seq");
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Common.Model.JsonBool", b =>
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Common.Model.JsonFragment", b =>
                 {
-                    b.Property<bool>("BoolValue")
-                        .HasColumnType("boolean");
+                    b.Property<string>("JsonString")
+                        .HasColumnType("text");
 
                     b.ToTable((string)null);
 
                     b.ToView(null, (string)null);
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Common.Model.JsonFragment", b =>
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.ChangeSetFilterOptions", b =>
                 {
-                    b.Property<string>("JsonValue")
-                        .HasColumnType("text");
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
 
-                    b.ToTable((string)null);
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("timestamp with time zone");
 
-                    b.ToView(null, (string)null);
+                    b.Property<Guid>("DataSetVersionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset?>("Updated")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DataSetVersionId");
+
+                    b.ToTable("ChangeSetFilterOptions");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.ChangeSetFilters", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("DataSetVersionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset?>("Updated")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DataSetVersionId");
+
+                    b.ToTable("ChangeSetFilters");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.ChangeSetIndicators", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("DataSetVersionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset?>("Updated")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DataSetVersionId");
+
+                    b.ToTable("ChangeSetIndicators");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.ChangeSetLocations", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("DataSetVersionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset?>("Updated")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DataSetVersionId");
+
+                    b.ToTable("ChangeSetLocations");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.ChangeSetTimePeriods", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("DataSetVersionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset?>("Updated")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("DataSetVersionId");
+
+                    b.ToTable("ChangeSetTimePeriods");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", b =>
@@ -273,34 +376,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.ToTable("FilterMetas");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMetaChange", b =>
-                {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-                    b.Property<int?>("CurrentStateId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("DataSetVersionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("PreviousStateId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CurrentStateId");
-
-                    b.HasIndex("DataSetVersionId");
-
-                    b.HasIndex("PreviousStateId");
-
-                    b.ToTable("FilterMetaChanges");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterOptionMeta", b =>
                 {
                     b.Property<int>("Id")
@@ -319,24 +394,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.HasKey("Id");
 
                     b.ToTable("FilterOptionMetas");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterOptionMetaChange", b =>
-                {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-                    b.Property<Guid>("DataSetVersionId")
-                        .HasColumnType("uuid");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("DataSetVersionId");
-
-                    b.ToTable("FilterOptionMetaChanges");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterOptionMetaLink", b =>
@@ -392,35 +449,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.ToTable("GeographicLevelMetas");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.GeographicLevelMetaChange", b =>
-                {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-                    b.Property<int?>("CurrentStateId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("DataSetVersionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("PreviousStateId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CurrentStateId");
-
-                    b.HasIndex("DataSetVersionId")
-                        .IsUnique();
-
-                    b.HasIndex("PreviousStateId");
-
-                    b.ToTable("GeographicLevelMetaChanges");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.IndicatorMeta", b =>
                 {
                     b.Property<int>("Id")
@@ -461,34 +489,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.ToTable("IndicatorMetas");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.IndicatorMetaChange", b =>
-                {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-                    b.Property<int?>("CurrentStateId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("DataSetVersionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("PreviousStateId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CurrentStateId");
-
-                    b.HasIndex("DataSetVersionId");
-
-                    b.HasIndex("PreviousStateId");
-
-                    b.ToTable("IndicatorMetaChanges");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationMeta", b =>
                 {
                     b.Property<int>("Id")
@@ -517,34 +517,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                         .IsUnique();
 
                     b.ToTable("LocationMetas");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationMetaChange", b =>
-                {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-                    b.Property<int?>("CurrentStateId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("DataSetVersionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("PreviousStateId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CurrentStateId");
-
-                    b.HasIndex("DataSetVersionId");
-
-                    b.HasIndex("PreviousStateId");
-
-                    b.ToTable("LocationMetaChanges");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationOptionMeta", b =>
@@ -605,24 +577,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.UseTphMappingStrategy();
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationOptionMetaChange", b =>
-                {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-                    b.Property<Guid>("DataSetVersionId")
-                        .HasColumnType("uuid");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("DataSetVersionId");
-
-                    b.ToTable("LocationOptionMetaChanges");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationOptionMetaLink", b =>
                 {
                     b.Property<int>("MetaId")
@@ -631,44 +585,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.Property<int>("OptionId")
                         .HasColumnType("integer");
 
+                    b.Property<string>("PublicId")
+                        .IsRequired()
+                        .HasColumnType("text");
+
                     b.HasKey("MetaId", "OptionId");
 
                     b.HasIndex("OptionId");
 
                     b.ToTable("LocationOptionMetaLinks");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.PreviewToken", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTimeOffset>("Created")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid>("CreatedByUserId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("DataSetVersionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTimeOffset>("Expiry")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Label")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<DateTimeOffset?>("Updated")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("DataSetVersionId");
-
-                    b.ToTable("PreviewTokens");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.TimePeriodMeta", b =>
@@ -705,34 +630,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.ToTable("TimePeriodMetas");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.TimePeriodMetaChange", b =>
-                {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-                    b.Property<int?>("CurrentStateId")
-                        .HasColumnType("integer");
-
-                    b.Property<Guid>("DataSetVersionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("PreviousStateId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CurrentStateId");
-
-                    b.HasIndex("DataSetVersionId");
-
-                    b.HasIndex("PreviousStateId");
-
-                    b.ToTable("TimePeriodMetaChanges");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationCodedOptionMeta", b =>
                 {
                     b.HasBaseType("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationOptionMeta");
@@ -766,6 +663,513 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.HasBaseType("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationOptionMeta");
 
                     b.HasDiscriminator().HasValue("SCH");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.ChangeSetFilterOptions", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
+                        .WithMany("FilterOptionChanges")
+                        .HasForeignKey("DataSetVersionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.OwnsMany("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Change<GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterOptionChangeState>", "Changes", b1 =>
+                        {
+                            b1.Property<Guid>("ChangeSetFilterOptionsId")
+                                .HasColumnType("uuid");
+
+                            b1.Property<int>("Id")
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
+
+                            b1.Property<Guid>("Identifier")
+                                .HasColumnType("uuid")
+                                .HasAnnotation("Relational:JsonPropertyName", "Id");
+
+                            b1.Property<string>("Type")
+                                .IsRequired()
+                                .HasColumnType("text");
+
+                            b1.HasKey("ChangeSetFilterOptionsId", "Id");
+
+                            b1.ToTable("ChangeSetFilterOptions");
+
+                            b1.ToJson("Changes");
+
+                            b1.WithOwner()
+                                .HasForeignKey("ChangeSetFilterOptionsId");
+
+                            b1.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterOptionChangeState", "CurrentState", b2 =>
+                                {
+                                    b2.Property<Guid>("ChangeSetFilterOptionsId")
+                                        .HasColumnType("uuid");
+
+                                    b2.Property<int>("ChangeId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<string>("FilterId")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Id")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<bool?>("IsAggregate")
+                                        .HasColumnType("boolean");
+
+                                    b2.Property<string>("Label")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.HasKey("ChangeSetFilterOptionsId", "ChangeId");
+
+                                    b2.ToTable("ChangeSetFilterOptions");
+
+                                    b2.WithOwner()
+                                        .HasForeignKey("ChangeSetFilterOptionsId", "ChangeId");
+                                });
+
+                            b1.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterOptionChangeState", "PreviousState", b2 =>
+                                {
+                                    b2.Property<Guid>("ChangeSetFilterOptionsId")
+                                        .HasColumnType("uuid");
+
+                                    b2.Property<int>("ChangeId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<string>("FilterId")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Id")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<bool?>("IsAggregate")
+                                        .HasColumnType("boolean");
+
+                                    b2.Property<string>("Label")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.HasKey("ChangeSetFilterOptionsId", "ChangeId");
+
+                                    b2.ToTable("ChangeSetFilterOptions");
+
+                                    b2.WithOwner()
+                                        .HasForeignKey("ChangeSetFilterOptionsId", "ChangeId");
+                                });
+
+                            b1.Navigation("CurrentState");
+
+                            b1.Navigation("PreviousState");
+                        });
+
+                    b.Navigation("Changes");
+
+                    b.Navigation("DataSetVersion");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.ChangeSetFilters", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
+                        .WithMany("FilterChanges")
+                        .HasForeignKey("DataSetVersionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.OwnsMany("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Change<GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterChangeState>", "Changes", b1 =>
+                        {
+                            b1.Property<Guid>("ChangeSetFiltersId")
+                                .HasColumnType("uuid");
+
+                            b1.Property<int>("Id")
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
+
+                            b1.Property<Guid>("Identifier")
+                                .HasColumnType("uuid")
+                                .HasAnnotation("Relational:JsonPropertyName", "Id");
+
+                            b1.Property<string>("Type")
+                                .IsRequired()
+                                .HasColumnType("text");
+
+                            b1.HasKey("ChangeSetFiltersId", "Id");
+
+                            b1.ToTable("ChangeSetFilters");
+
+                            b1.ToJson("Changes");
+
+                            b1.WithOwner()
+                                .HasForeignKey("ChangeSetFiltersId");
+
+                            b1.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterChangeState", "CurrentState", b2 =>
+                                {
+                                    b2.Property<Guid>("ChangeSetFiltersId")
+                                        .HasColumnType("uuid");
+
+                                    b2.Property<int>("ChangeId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<string>("Hint")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Id")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Label")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.HasKey("ChangeSetFiltersId", "ChangeId");
+
+                                    b2.ToTable("ChangeSetFilters");
+
+                                    b2.WithOwner()
+                                        .HasForeignKey("ChangeSetFiltersId", "ChangeId");
+                                });
+
+                            b1.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterChangeState", "PreviousState", b2 =>
+                                {
+                                    b2.Property<Guid>("ChangeSetFiltersId")
+                                        .HasColumnType("uuid");
+
+                                    b2.Property<int>("ChangeId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<string>("Hint")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Id")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Label")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.HasKey("ChangeSetFiltersId", "ChangeId");
+
+                                    b2.ToTable("ChangeSetFilters");
+
+                                    b2.WithOwner()
+                                        .HasForeignKey("ChangeSetFiltersId", "ChangeId");
+                                });
+
+                            b1.Navigation("CurrentState");
+
+                            b1.Navigation("PreviousState");
+                        });
+
+                    b.Navigation("Changes");
+
+                    b.Navigation("DataSetVersion");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.ChangeSetIndicators", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
+                        .WithMany("IndicatorChanges")
+                        .HasForeignKey("DataSetVersionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.OwnsMany("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Change<GovUk.Education.ExploreEducationStatistics.Public.Data.Model.IndicatorChangeState>", "Changes", b1 =>
+                        {
+                            b1.Property<Guid>("ChangeSetIndicatorsId")
+                                .HasColumnType("uuid");
+
+                            b1.Property<int>("Id")
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
+
+                            b1.Property<Guid>("Identifier")
+                                .HasColumnType("uuid")
+                                .HasAnnotation("Relational:JsonPropertyName", "Id");
+
+                            b1.Property<string>("Type")
+                                .IsRequired()
+                                .HasColumnType("text");
+
+                            b1.HasKey("ChangeSetIndicatorsId", "Id");
+
+                            b1.ToTable("ChangeSetIndicators");
+
+                            b1.ToJson("Changes");
+
+                            b1.WithOwner()
+                                .HasForeignKey("ChangeSetIndicatorsId");
+
+                            b1.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.IndicatorChangeState", "CurrentState", b2 =>
+                                {
+                                    b2.Property<Guid>("ChangeSetIndicatorsId")
+                                        .HasColumnType("uuid");
+
+                                    b2.Property<int>("ChangeId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<byte?>("DecimalPlaces")
+                                        .HasColumnType("smallint");
+
+                                    b2.Property<string>("Id")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Label")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Unit")
+                                        .HasColumnType("text");
+
+                                    b2.HasKey("ChangeSetIndicatorsId", "ChangeId");
+
+                                    b2.ToTable("ChangeSetIndicators");
+
+                                    b2.WithOwner()
+                                        .HasForeignKey("ChangeSetIndicatorsId", "ChangeId");
+                                });
+
+                            b1.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.IndicatorChangeState", "PreviousState", b2 =>
+                                {
+                                    b2.Property<Guid>("ChangeSetIndicatorsId")
+                                        .HasColumnType("uuid");
+
+                                    b2.Property<int>("ChangeId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<byte?>("DecimalPlaces")
+                                        .HasColumnType("smallint");
+
+                                    b2.Property<string>("Id")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Label")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Unit")
+                                        .HasColumnType("text");
+
+                                    b2.HasKey("ChangeSetIndicatorsId", "ChangeId");
+
+                                    b2.ToTable("ChangeSetIndicators");
+
+                                    b2.WithOwner()
+                                        .HasForeignKey("ChangeSetIndicatorsId", "ChangeId");
+                                });
+
+                            b1.Navigation("CurrentState");
+
+                            b1.Navigation("PreviousState");
+                        });
+
+                    b.Navigation("Changes");
+
+                    b.Navigation("DataSetVersion");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.ChangeSetLocations", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
+                        .WithMany("LocationChanges")
+                        .HasForeignKey("DataSetVersionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.OwnsMany("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Change<GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationChangeState>", "Changes", b1 =>
+                        {
+                            b1.Property<Guid>("ChangeSetLocationsId")
+                                .HasColumnType("uuid");
+
+                            b1.Property<int>("Id")
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
+
+                            b1.Property<Guid>("Identifier")
+                                .HasColumnType("uuid")
+                                .HasAnnotation("Relational:JsonPropertyName", "Id");
+
+                            b1.Property<string>("Type")
+                                .IsRequired()
+                                .HasColumnType("text");
+
+                            b1.HasKey("ChangeSetLocationsId", "Id");
+
+                            b1.ToTable("ChangeSetLocations");
+
+                            b1.ToJson("Changes");
+
+                            b1.WithOwner()
+                                .HasForeignKey("ChangeSetLocationsId");
+
+                            b1.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationChangeState", "CurrentState", b2 =>
+                                {
+                                    b2.Property<Guid>("ChangeSetLocationsId")
+                                        .HasColumnType("uuid");
+
+                                    b2.Property<int>("ChangeId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<string>("Code")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Id")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Label")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Level")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.HasKey("ChangeSetLocationsId", "ChangeId");
+
+                                    b2.ToTable("ChangeSetLocations");
+
+                                    b2.WithOwner()
+                                        .HasForeignKey("ChangeSetLocationsId", "ChangeId");
+                                });
+
+                            b1.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationChangeState", "PreviousState", b2 =>
+                                {
+                                    b2.Property<Guid>("ChangeSetLocationsId")
+                                        .HasColumnType("uuid");
+
+                                    b2.Property<int>("ChangeId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<string>("Code")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Id")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<string>("Label")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<int>("Level")
+                                        .HasColumnType("integer");
+
+                                    b2.HasKey("ChangeSetLocationsId", "ChangeId");
+
+                                    b2.ToTable("ChangeSetLocations");
+
+                                    b2.WithOwner()
+                                        .HasForeignKey("ChangeSetLocationsId", "ChangeId");
+                                });
+
+                            b1.Navigation("CurrentState");
+
+                            b1.Navigation("PreviousState");
+                        });
+
+                    b.Navigation("Changes");
+
+                    b.Navigation("DataSetVersion");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.ChangeSetTimePeriods", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
+                        .WithMany("TimePeriodChanges")
+                        .HasForeignKey("DataSetVersionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.OwnsMany("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Change<GovUk.Education.ExploreEducationStatistics.Public.Data.Model.TimePeriodChangeState>", "Changes", b1 =>
+                        {
+                            b1.Property<Guid>("ChangeSetTimePeriodsId")
+                                .HasColumnType("uuid");
+
+                            b1.Property<int>("Id")
+                                .ValueGeneratedOnAdd()
+                                .HasColumnType("integer");
+
+                            b1.Property<Guid>("Identifier")
+                                .HasColumnType("uuid")
+                                .HasAnnotation("Relational:JsonPropertyName", "Id");
+
+                            b1.Property<string>("Type")
+                                .IsRequired()
+                                .HasColumnType("text");
+
+                            b1.HasKey("ChangeSetTimePeriodsId", "Id");
+
+                            b1.ToTable("ChangeSetTimePeriods");
+
+                            b1.ToJson("Changes");
+
+                            b1.WithOwner()
+                                .HasForeignKey("ChangeSetTimePeriodsId");
+
+                            b1.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.TimePeriodChangeState", "CurrentState", b2 =>
+                                {
+                                    b2.Property<Guid>("ChangeSetTimePeriodsId")
+                                        .HasColumnType("uuid");
+
+                                    b2.Property<int>("ChangeId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<string>("Code")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<int>("Year")
+                                        .HasColumnType("integer");
+
+                                    b2.HasKey("ChangeSetTimePeriodsId", "ChangeId");
+
+                                    b2.ToTable("ChangeSetTimePeriods");
+
+                                    b2.WithOwner()
+                                        .HasForeignKey("ChangeSetTimePeriodsId", "ChangeId");
+                                });
+
+                            b1.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.TimePeriodChangeState", "PreviousState", b2 =>
+                                {
+                                    b2.Property<Guid>("ChangeSetTimePeriodsId")
+                                        .HasColumnType("uuid");
+
+                                    b2.Property<int>("ChangeId")
+                                        .HasColumnType("integer");
+
+                                    b2.Property<string>("Code")
+                                        .IsRequired()
+                                        .HasColumnType("text");
+
+                                    b2.Property<int>("Year")
+                                        .HasColumnType("integer");
+
+                                    b2.HasKey("ChangeSetTimePeriodsId", "ChangeId");
+
+                                    b2.ToTable("ChangeSetTimePeriods");
+
+                                    b2.WithOwner()
+                                        .HasForeignKey("ChangeSetTimePeriodsId", "ChangeId");
+                                });
+
+                            b1.Navigation("CurrentState");
+
+                            b1.Navigation("PreviousState");
+                        });
+
+                    b.Navigation("Changes");
+
+                    b.Navigation("DataSetVersion");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", b =>
@@ -934,130 +1338,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.Navigation("DataSetVersion");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMetaChange", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMeta", "CurrentState")
-                        .WithMany()
-                        .HasForeignKey("CurrentStateId");
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
-                        .WithMany("FilterMetaChanges")
-                        .HasForeignKey("DataSetVersionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMeta", "PreviousState")
-                        .WithMany()
-                        .HasForeignKey("PreviousStateId");
-
-                    b.Navigation("CurrentState");
-
-                    b.Navigation("DataSetVersion");
-
-                    b.Navigation("PreviousState");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterOptionMetaChange", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
-                        .WithMany("FilterOptionMetaChanges")
-                        .HasForeignKey("DataSetVersionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterOptionMetaChange+State", "CurrentState", b1 =>
-                        {
-                            b1.Property<long>("FilterOptionMetaChangeId")
-                                .HasColumnType("bigint");
-
-                            b1.Property<int>("MetaId")
-                                .HasColumnType("integer");
-
-                            b1.Property<int>("OptionId")
-                                .HasColumnType("integer");
-
-                            b1.Property<string>("PublicId")
-                                .IsRequired()
-                                .HasColumnType("text");
-
-                            b1.HasKey("FilterOptionMetaChangeId");
-
-                            b1.HasIndex("MetaId");
-
-                            b1.HasIndex("OptionId");
-
-                            b1.ToTable("FilterOptionMetaChanges");
-
-                            b1.WithOwner()
-                                .HasForeignKey("FilterOptionMetaChangeId");
-
-                            b1.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMeta", "Meta")
-                                .WithMany()
-                                .HasForeignKey("MetaId")
-                                .OnDelete(DeleteBehavior.Cascade)
-                                .IsRequired();
-
-                            b1.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterOptionMeta", "Option")
-                                .WithMany()
-                                .HasForeignKey("OptionId")
-                                .OnDelete(DeleteBehavior.Cascade)
-                                .IsRequired();
-
-                            b1.Navigation("Meta");
-
-                            b1.Navigation("Option");
-                        });
-
-                    b.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterOptionMetaChange+State", "PreviousState", b1 =>
-                        {
-                            b1.Property<long>("FilterOptionMetaChangeId")
-                                .HasColumnType("bigint");
-
-                            b1.Property<int>("MetaId")
-                                .HasColumnType("integer");
-
-                            b1.Property<int>("OptionId")
-                                .HasColumnType("integer");
-
-                            b1.Property<string>("PublicId")
-                                .IsRequired()
-                                .HasColumnType("text");
-
-                            b1.HasKey("FilterOptionMetaChangeId");
-
-                            b1.HasIndex("MetaId");
-
-                            b1.HasIndex("OptionId");
-
-                            b1.ToTable("FilterOptionMetaChanges");
-
-                            b1.WithOwner()
-                                .HasForeignKey("FilterOptionMetaChangeId");
-
-                            b1.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMeta", "Meta")
-                                .WithMany()
-                                .HasForeignKey("MetaId")
-                                .OnDelete(DeleteBehavior.Cascade)
-                                .IsRequired();
-
-                            b1.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterOptionMeta", "Option")
-                                .WithMany()
-                                .HasForeignKey("OptionId")
-                                .OnDelete(DeleteBehavior.Cascade)
-                                .IsRequired();
-
-                            b1.Navigation("Meta");
-
-                            b1.Navigation("Option");
-                        });
-
-                    b.Navigation("CurrentState");
-
-                    b.Navigation("DataSetVersion");
-
-                    b.Navigation("PreviousState");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterOptionMetaLink", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMeta", "Meta")
@@ -1088,29 +1368,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.Navigation("DataSetVersion");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.GeographicLevelMetaChange", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.GeographicLevelMeta", "CurrentState")
-                        .WithMany()
-                        .HasForeignKey("CurrentStateId");
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
-                        .WithOne("GeographicLevelMetaChange")
-                        .HasForeignKey("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.GeographicLevelMetaChange", "DataSetVersionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.GeographicLevelMeta", "PreviousState")
-                        .WithMany()
-                        .HasForeignKey("PreviousStateId");
-
-                    b.Navigation("CurrentState");
-
-                    b.Navigation("DataSetVersion");
-
-                    b.Navigation("PreviousState");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.IndicatorMeta", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
@@ -1122,29 +1379,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.Navigation("DataSetVersion");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.IndicatorMetaChange", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.IndicatorMeta", "CurrentState")
-                        .WithMany()
-                        .HasForeignKey("CurrentStateId");
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
-                        .WithMany("IndicatorMetaChanges")
-                        .HasForeignKey("DataSetVersionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.IndicatorMeta", "PreviousState")
-                        .WithMany()
-                        .HasForeignKey("PreviousStateId");
-
-                    b.Navigation("CurrentState");
-
-                    b.Navigation("DataSetVersion");
-
-                    b.Navigation("PreviousState");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationMeta", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
@@ -1154,122 +1388,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                         .IsRequired();
 
                     b.Navigation("DataSetVersion");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationMetaChange", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationMeta", "CurrentState")
-                        .WithMany()
-                        .HasForeignKey("CurrentStateId");
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
-                        .WithMany("LocationMetaChanges")
-                        .HasForeignKey("DataSetVersionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationMeta", "PreviousState")
-                        .WithMany()
-                        .HasForeignKey("PreviousStateId");
-
-                    b.Navigation("CurrentState");
-
-                    b.Navigation("DataSetVersion");
-
-                    b.Navigation("PreviousState");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationOptionMetaChange", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
-                        .WithMany("LocationOptionMetaChanges")
-                        .HasForeignKey("DataSetVersionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationOptionMetaChange+State", "CurrentState", b1 =>
-                        {
-                            b1.Property<long>("LocationOptionMetaChangeId")
-                                .HasColumnType("bigint");
-
-                            b1.Property<int>("MetaId")
-                                .HasColumnType("integer");
-
-                            b1.Property<int>("OptionId")
-                                .HasColumnType("integer");
-
-                            b1.HasKey("LocationOptionMetaChangeId");
-
-                            b1.HasIndex("MetaId");
-
-                            b1.HasIndex("OptionId");
-
-                            b1.ToTable("LocationOptionMetaChanges");
-
-                            b1.WithOwner()
-                                .HasForeignKey("LocationOptionMetaChangeId");
-
-                            b1.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationMeta", "Meta")
-                                .WithMany()
-                                .HasForeignKey("MetaId")
-                                .OnDelete(DeleteBehavior.Cascade)
-                                .IsRequired();
-
-                            b1.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationOptionMeta", "Option")
-                                .WithMany()
-                                .HasForeignKey("OptionId")
-                                .OnDelete(DeleteBehavior.Cascade)
-                                .IsRequired();
-
-                            b1.Navigation("Meta");
-
-                            b1.Navigation("Option");
-                        });
-
-                    b.OwnsOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationOptionMetaChange+State", "PreviousState", b1 =>
-                        {
-                            b1.Property<long>("LocationOptionMetaChangeId")
-                                .HasColumnType("bigint");
-
-                            b1.Property<int>("MetaId")
-                                .HasColumnType("integer");
-
-                            b1.Property<int>("OptionId")
-                                .HasColumnType("integer");
-
-                            b1.HasKey("LocationOptionMetaChangeId");
-
-                            b1.HasIndex("MetaId");
-
-                            b1.HasIndex("OptionId");
-
-                            b1.ToTable("LocationOptionMetaChanges");
-
-                            b1.WithOwner()
-                                .HasForeignKey("LocationOptionMetaChangeId");
-
-                            b1.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationMeta", "Meta")
-                                .WithMany()
-                                .HasForeignKey("MetaId")
-                                .OnDelete(DeleteBehavior.Cascade)
-                                .IsRequired();
-
-                            b1.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationOptionMeta", "Option")
-                                .WithMany()
-                                .HasForeignKey("OptionId")
-                                .OnDelete(DeleteBehavior.Cascade)
-                                .IsRequired();
-
-                            b1.Navigation("Meta");
-
-                            b1.Navigation("Option");
-                        });
-
-                    b.Navigation("CurrentState");
-
-                    b.Navigation("DataSetVersion");
-
-                    b.Navigation("PreviousState");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.LocationOptionMetaLink", b =>
@@ -1291,17 +1409,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.Navigation("Option");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.PreviewToken", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
-                        .WithMany("PreviewTokens")
-                        .HasForeignKey("DataSetVersionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("DataSetVersion");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.TimePeriodMeta", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
@@ -1313,29 +1420,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.Navigation("DataSetVersion");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.TimePeriodMetaChange", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.TimePeriodMeta", "CurrentState")
-                        .WithMany()
-                        .HasForeignKey("CurrentStateId");
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", "DataSetVersion")
-                        .WithMany("TimePeriodMetaChanges")
-                        .HasForeignKey("DataSetVersionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.TimePeriodMeta", "PreviousState")
-                        .WithMany()
-                        .HasForeignKey("PreviousStateId");
-
-                    b.Navigation("CurrentState");
-
-                    b.Navigation("DataSetVersion");
-
-                    b.Navigation("PreviousState");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", b =>
                 {
                     b.Navigation("Versions");
@@ -1343,31 +1427,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSetVersion", b =>
                 {
-                    b.Navigation("FilterMetaChanges");
+                    b.Navigation("FilterChanges");
 
                     b.Navigation("FilterMetas");
 
-                    b.Navigation("FilterOptionMetaChanges");
+                    b.Navigation("FilterOptionChanges");
 
                     b.Navigation("GeographicLevelMeta");
 
-                    b.Navigation("GeographicLevelMetaChange");
-
                     b.Navigation("Imports");
 
-                    b.Navigation("IndicatorMetaChanges");
+                    b.Navigation("IndicatorChanges");
 
                     b.Navigation("IndicatorMetas");
 
-                    b.Navigation("LocationMetaChanges");
+                    b.Navigation("LocationChanges");
 
                     b.Navigation("LocationMetas");
 
-                    b.Navigation("LocationOptionMetaChanges");
-
-                    b.Navigation("PreviewTokens");
-
-                    b.Navigation("TimePeriodMetaChanges");
+                    b.Navigation("TimePeriodChanges");
 
                     b.Navigation("TimePeriodMetas");
                 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240710122937_EES4954_MovePublicIdToLocationMetaOptionLinkTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240710122937_EES4954_MovePublicIdToLocationMetaOptionLinkTable.cs
@@ -1,0 +1,69 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class EES4954_MovePublicIdToLocationMetaOptionLinkTable : Migration
+    {
+        private const string MigrationId = "20240710122937";
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PublicId",
+                table: "LocationOptionMetaLinks",
+                type: "text",
+                nullable: true);
+            
+            migrationBuilder.CreateIndex(
+                name: "IX_LocationOptionMetaLinks_PublicId",
+                table: "LocationOptionMetaLinks",
+                column: "PublicId");
+
+            migrationBuilder.SqlFromFile("Migrations", 
+                $"{MigrationId}_{nameof(EES4954_MovePublicIdToLocationMetaOptionLinkTable)}.sql");
+            
+            migrationBuilder.AlterColumn<Guid>(
+                name: "PublicId",
+                table: "LocationOptionMetaLinks",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+            
+            migrationBuilder.DropIndex(
+                name: "IX_LocationOptionMetas_PublicId",
+                table: "LocationOptionMetas");
+
+            migrationBuilder.DropColumn(
+                name: "PublicId",
+                table: "LocationOptionMetas");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PublicId",
+                table: "LocationOptionMetaLinks");
+
+            migrationBuilder.AddColumn<string>(
+                name: "PublicId",
+                table: "LocationOptionMetas",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LocationOptionMetas_PublicId",
+                table: "LocationOptionMetas",
+                column: "PublicId",
+                unique: true);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240710122937_EES4954_MovePublicIdToLocationMetaOptionLinkTable.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240710122937_EES4954_MovePublicIdToLocationMetaOptionLinkTable.sql
@@ -1,0 +1,6 @@
+﻿UPDATE "LocationOptionMetaLinks"
+SET "PublicId" = (
+  SELECT "PublicId" 
+  FROM "LocationOptionMetas" 
+  WHERE "LocationOptionMetas"."Id" = "LocationOptionMetaLinks"."OptionId"
+);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
@@ -631,9 +631,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.Property<int>("OptionId")
                         .HasColumnType("integer");
 
+                    b.Property<string>("PublicId")
+                        .IsRequired()
+                        .HasColumnType("text");
+
                     b.HasKey("MetaId", "OptionId");
 
                     b.HasIndex("OptionId");
+
+                    b.HasIndex("PublicId");
 
                     b.ToTable("LocationOptionMetaLinks");
                 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Extensions/LocationOptionMetaTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Extensions/LocationOptionMetaTestExtensions.cs
@@ -1,5 +1,6 @@
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Extensions;
 
@@ -8,7 +9,7 @@ public static class LocationOptionMetaTestExtensions
     public static void AssertEqual(this LocationOptionMeta expectedOption, ParquetLocationOption actualOption)
     {
         Assert.Equal(expectedOption.Label, actualOption.Label);
-        Assert.Equal(expectedOption.PublicId, actualOption.PublicId);
+        Assert.Equal(SqidEncoder.Encode(expectedOption.Id), actualOption.PublicId);
 
         switch (expectedOption)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ImportMetadataFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ImportMetadataFunctionTests.cs
@@ -203,7 +203,7 @@ public abstract class ImportMetadataFunctionTests(ProcessorFunctionsIntegrationT
                 CandidateKey = MappingKeyFunctions.LocationOptionMetaRowKeyGenerator(mappedOption2.ToRow())
             };
 
-            var random = new Random();
+            var i = 0;
 
             var mappings = new DataSetVersionMapping
             {
@@ -227,7 +227,7 @@ public abstract class ImportMetadataFunctionTests(ProcessorFunctionsIntegrationT
                                             : option == mappedOption2 ? option2Mapping
                                             : new LocationOptionMapping
                                             {
-                                                Type = random.Next(1) == 0
+                                                Type = i++ % 2 == 0 
                                                     ? MappingType.AutoNone
                                                     : MappingType.ManualNone
                                             })
@@ -420,7 +420,7 @@ public abstract class ImportMetadataFunctionTests(ProcessorFunctionsIntegrationT
                 CandidateKey = MappingKeyFunctions.FilterOptionKeyGenerator(mappedOption2)
             };
 
-            var random = new Random();
+            var i = 0;
 
             var mappings = new DataSetVersionMapping
             {
@@ -444,7 +444,7 @@ public abstract class ImportMetadataFunctionTests(ProcessorFunctionsIntegrationT
                                             : option == mappedOption2 ? option2Mapping
                                             : new FilterOptionMapping
                                             {
-                                                Type = random.Next(1) == 0
+                                                Type = i++ % 2 == 0 
                                                     ? MappingType.AutoNone
                                                     : MappingType.ManualNone
                                             })

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ImportMetadataFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ImportMetadataFunctionTests.cs
@@ -1,5 +1,6 @@
 using Dapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
@@ -9,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Functions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Options;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Extensions;
@@ -184,57 +186,43 @@ public abstract class ImportMetadataFunctionTests(ProcessorFunctionsIntegrationT
             // In this test, we will create mappings for all the original location options.
             // 2 of these mappings will have candidates, and the rest will have no candidates
             // mapped.
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(sourceDataSetVersion.Id)
+                .WithTargetDataSetVersionId(targetDataSetVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .LocationMappingPlanFromLocationMeta(sourceLocations: testData.ExpectedLocations));
+            
+            var random = new Random();
+
+            mappings.LocationMappingPlan.Levels.ForEach(level => 
+                level.Value.Mappings.ForEach(mapping => 
+                    mapping.Value.Type = random.Next(1) == 0 
+                        ? MappingType.AutoNone 
+                        : MappingType.ManualNone));
 
             // Amend a couple of arbitrary mappings to identify some candidates.
-            var mappedOption1 = testData.ExpectedLocations.First().Options.First();
-            var mappedOption2 = testData.ExpectedLocations.Last().Options.Last();
+            var firstLevel = testData.ExpectedLocations.First();
+            var lastLevel = testData.ExpectedLocations.Last();
+            var mappedOption1Key = MappingKeyFunctions.LocationOptionMetaKeyGenerator(firstLevel.Options.First());
+            var mappedOption2Key = MappingKeyFunctions.LocationOptionMetaKeyGenerator(lastLevel.Options.Last());
+            var mappedOption1 = mappings.GetLocationOptionMapping(firstLevel.Level, mappedOption1Key);
+            var mappedOption2 = mappings.GetLocationOptionMapping(lastLevel.Level, mappedOption2Key);
 
-            var option1Mapping = new LocationOptionMapping
+            mappings.LocationMappingPlan.Levels[firstLevel.Level].Mappings[mappedOption1Key] = mappedOption1 with
             {
                 PublicId = "option-1-public-id",
                 Type = MappingType.AutoMapped,
-                CandidateKey = MappingKeyFunctions.LocationOptionMetaRowKeyGenerator(mappedOption1.ToRow())
+                CandidateKey = mappedOption1Key
             };
 
-            var option2Mapping = new LocationOptionMapping
+            mappings.LocationMappingPlan.Levels[lastLevel.Level].Mappings[mappedOption2Key] = mappedOption2 with
             {
                 PublicId = "option-2-public-id",
                 Type = MappingType.ManualMapped,
-                CandidateKey = MappingKeyFunctions.LocationOptionMetaRowKeyGenerator(mappedOption2.ToRow())
+                CandidateKey = mappedOption2Key
             };
-
-            var i = 0;
-
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = sourceDataSetVersion.Id,
-                TargetDataSetVersionId = targetDataSetVersion.Id,
-                FilterMappingPlan = new FilterMappingPlan(),
-                LocationMappingPlan = new LocationMappingPlan
-                {
-                    Levels = testData
-                        .ExpectedLocations
-                        .ToDictionary(
-                            keySelector: level => level.Level,
-                            elementSelector: level => new LocationLevelMappings
-                            {
-                                Mappings = level
-                                    .Options
-                                    .ToDictionary(
-                                        keySelector: MappingKeyFunctions.LocationOptionMetaKeyGenerator,
-                                        elementSelector: option =>
-                                            option == mappedOption1 ? option1Mapping
-                                            : option == mappedOption2 ? option2Mapping
-                                            : new LocationOptionMapping
-                                            {
-                                                Type = i++ % 2 == 0 
-                                                    ? MappingType.AutoNone
-                                                    : MappingType.ManualNone
-                                            })
-                            })
-                }
-            };
-
+            
             await AddTestData<PublicDataDbContext>(context =>
             {
                 context.DataSetVersionMappings.Add(mappings);
@@ -287,10 +275,10 @@ public abstract class ImportMetadataFunctionTests(ProcessorFunctionsIntegrationT
 
             // Public Ids should be SQIDs based on the option's id unless otherwise directed by the
             // mappings.
-            var actualMappedOption1Link = actualLinks.Single(link => link.Option.Label == mappedOption1.Label);
+            var actualMappedOption1Link = actualLinks.Single(link => link.Option.Label == mappedOption1.Source.Label);
             Assert.Equal("option-1-public-id", actualMappedOption1Link.PublicId);
 
-            var actualMappedOption2Link = actualLinks.Single(link => link.Option.Label == mappedOption2.Label);
+            var actualMappedOption2Link = actualLinks.Single(link => link.Option.Label == mappedOption2.Source.Label);
             Assert.Equal("option-2-public-id", actualMappedOption2Link.PublicId);
 
             var otherLinks = actualLocations

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessCompletionOfNextDataSetVersionImportFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessCompletionOfNextDataSetVersionImportFunctionTests.cs
@@ -45,6 +45,7 @@ public abstract class ProcessCompletionOfNextDataSetVersionImportFunctionTests(
 
             string[] expectedActivitySequence =
             [
+                ActivityNames.ImportMetadata,
                 ActivityNames.ImportData,
                 ActivityNames.WriteDataFiles,
                 ActivityNames.CompleteNextDataSetVersionImportProcessing
@@ -75,7 +76,7 @@ public abstract class ProcessCompletionOfNextDataSetVersionImportFunctionTests(
             mockOrchestrationContext
                 .InSequence(activitySequence)
                 .Setup(context =>
-                    context.CallActivityAsync(ActivityNames.ImportData,
+                    context.CallActivityAsync(ActivityNames.ImportMetadata,
                         mockOrchestrationContext.Object.InstanceId,
                         null))
                 .Throws<Exception>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
@@ -267,8 +267,9 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                                 {
                                     CandidateKey = null,
                                     Type = MappingType.None,
-                                    Source = new MappableLocationOption(option.Label)
+                                    Source = new MappableLocationOption
                                     {
+                                        Label = option.Label,
                                         Code = option.ToRow().Code,
                                         OldCode = option.ToRow().OldCode,
                                         Urn = option.ToRow().Urn,
@@ -278,7 +279,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                                 })
                     });
 
-            // There should be 5 levels of mappings when combining all the source and target levels. 
+            // There should be 5 levels of mappings when combining all the source and target levels.
             Assert.Equal(ProcessorTestData
                     .AbsenceSchool
                     .ExpectedGeographicLevels
@@ -332,8 +333,9 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                                 .options
                                 .ToDictionary(
                                     keySelector: MappingKeyFunctions.LocationOptionMetaKeyGenerator,
-                                    elementSelector: option => new MappableLocationOption(option.Label)
+                                    elementSelector: option => new MappableLocationOption
                                     {
+                                        Label = option.Label,
                                         Code = option.ToRow().Code,
                                         OldCode = option.ToRow().OldCode,
                                         Urn = option.ToRow().Urn,
@@ -385,7 +387,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                         {
                             CandidateKey = null,
                             Type = MappingType.None,
-                            Source = new MappableFilter(filter.Label),
+                            Source = new MappableFilter { Label = filter.Label },
                             OptionMappings = filter
                                 .Options
                                 .ToDictionary(
@@ -395,7 +397,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                                         {
                                             CandidateKey = null,
                                             Type = MappingType.None,
-                                            Source = new MappableFilterOption(option.Label)
+                                            Source = new MappableFilterOption { Label = option.Label }
                                         })
                         });
 
@@ -423,14 +425,15 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                 .ToDictionary(
                     keySelector: MappingKeyFunctions.FilterKeyGenerator,
                     elementSelector: filter =>
-                        new FilterMappingCandidate(filter.Label)
+                        new FilterMappingCandidate
                         {
+                            Label = filter.Label,
                             Options = filter
                                 .Options
                                 .ToDictionary(
                                     keySelector: MappingKeyFunctions.FilterOptionKeyGenerator,
                                     elementSelector: optionMeta =>
-                                        new MappableFilterOption(optionMeta.Label))
+                                        new MappableFilterOption { Label = optionMeta.Label })
                         });
 
             mappings.FilterMappingPlan.Candidates.AssertDeepEqualTo(
@@ -500,72 +503,53 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             //
             // In addition to this, the source has a "RSC Region" level that the target does not have, and the target
             // has a "Country" level that the source does not have.
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = originalVersion.Id,
-                TargetDataSetVersionId = nextVersion.Id,
-                FilterMappingPlan = new FilterMappingPlan(),
-                LocationMappingPlan = new LocationMappingPlan
-                {
-                    Levels =
-                    {
-                        {
-                            GeographicLevel.LocalAuthority, new LocationLevelMappings
-                            {
-                                Mappings =
-                                {
-                                    {
-                                        "LA location 1 key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("LA location 1 label")
-                                        }
-                                    },
-                                    {
-                                        "LA location 2 key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("LA location 2 label")
-                                        }
-                                    }
-                                },
-                                Candidates =
-                                {
-                                    { "LA location 1 key", new MappableLocationOption("LA location 1 label") },
-                                    { "LA location 3 key", new MappableLocationOption("LA location 3 label") },
-                                }
-                            }
-                        },
-                        {
-                            GeographicLevel.RscRegion,
-                            new LocationLevelMappings
-                            {
-                                Mappings =
-                                {
-                                    {
-                                        "RSC location 1 key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("RSC location 1 label")
-                                        }
-                                    }
-                                },
-                                Candidates = []
-                            }
-                        },
-                        {
-                            GeographicLevel.Country, new LocationLevelMappings
-                            {
-                                Mappings = [],
-                                Candidates =
-                                {
-                                    { "Country location 1 key", new MappableLocationOption("Country location 1 label") }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .DefaultLocationMappingPlan()
+                    .AddLevel(
+                        level: GeographicLevel.LocalAuthority,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "la-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping())
+                            .AddMapping(
+                                sourceKey: "la-location-2-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping()
+                            )
+                            .AddCandidate(
+                                targetKey: "la-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())
+                            .AddCandidate(
+                                targetKey: "la-location-3-key",
+                                candidate: DataFixture.DefaultMappableLocationOption()))
+                    .AddLevel(
+                        level: GeographicLevel.RscRegion,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "rsc-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithManualNone()))
+                    .AddLevel(
+                        level: GeographicLevel.Country,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddCandidate(
+                                targetKey: "country-location-1-key",
+                                candidate: DataFixture
+                                    .DefaultMappableLocationOption())));
 
             await AddTestData<PublicDataDbContext>(context =>
                 context.DataSetVersionMappings.Add(mappings));
@@ -576,67 +560,56 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             Assert.False(updatedMappings.LocationMappingsComplete);
 
+            var laMapping1 = mappings
+                .GetLocationOptionMapping(GeographicLevel.LocalAuthority, "la-location-1-key");
+
+            var laMapping2 = mappings
+                .GetLocationOptionMapping(GeographicLevel.LocalAuthority, "la-location-2-key");
+
+            var rscMapping1 = mappings
+                .GetLocationOptionMapping(GeographicLevel.RscRegion, "rsc-location-1-key");
+
             Dictionary<GeographicLevel, LocationLevelMappings> expectedLevelMappings = new()
             {
                 {
-                    GeographicLevel.LocalAuthority, new LocationLevelMappings
+                    GeographicLevel.LocalAuthority, mappings.GetLocationLevelMappings(GeographicLevel.LocalAuthority) with
                     {
-                        Mappings =
+                        Mappings = new Dictionary<string, LocationOptionMapping>
                         {
                             {
-                                "LA location 1 key",
-                                new LocationOptionMapping
+                                "la-location-1-key", laMapping1 with
                                 {
-                                    Source = new MappableLocationOption("LA location 1 label"),
                                     Type = MappingType.AutoMapped,
-                                    CandidateKey = "LA location 1 key"
+                                    CandidateKey = "la-location-1-key"
                                 }
                             },
                             {
-                                "LA location 2 key",
-                                new LocationOptionMapping
+                                "la-location-2-key", laMapping2 with
                                 {
-                                    Source = new MappableLocationOption("LA location 2 label"),
                                     Type = MappingType.AutoNone,
                                     CandidateKey = null
                                 }
                             }
-                        },
-                        Candidates =
-                        {
-                            { "LA location 1 key", new MappableLocationOption("LA location 1 label") },
-                            { "LA location 3 key", new MappableLocationOption("LA location 3 label") },
                         }
                     }
                 },
                 {
-                    GeographicLevel.RscRegion,
-                    new LocationLevelMappings
+                    GeographicLevel.RscRegion, mappings.GetLocationLevelMappings(GeographicLevel.RscRegion) with
                     {
-                        Mappings =
+                        Mappings = new Dictionary<string, LocationOptionMapping>
                         {
                             {
-                                "RSC location 1 key",
-                                new LocationOptionMapping
+                                "rsc-location-1-key", rscMapping1 with
                                 {
-                                    Source = new MappableLocationOption("RSC location 1 label"),
                                     Type = MappingType.AutoNone,
                                     CandidateKey = null
                                 }
                             }
-                        },
-                        Candidates = []
+                        }
                     }
                 },
                 {
-                    GeographicLevel.Country, new LocationLevelMappings
-                    {
-                        Mappings = [],
-                        Candidates =
-                            {
-                                { "Country location 1 key", new MappableLocationOption("Country location 1 label") }
-                            }
-                    }
+                    GeographicLevel.Country, mappings.GetLocationLevelMappings(GeographicLevel.Country)
                 }
             };
 
@@ -653,38 +626,25 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // Create a mapping plan based on 2 data set versions with perfectly overlapping
             // locations and levels.
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = originalVersion.Id,
-                TargetDataSetVersionId = nextVersion.Id,
-                FilterMappingPlan = new FilterMappingPlan(),
-                LocationMappingPlan = new LocationMappingPlan
-                {
-                    Levels =
-                    {
-                        {
-                            GeographicLevel.LocalAuthority,
-                            new LocationLevelMappings
-                            {
-                                Mappings =
-                                {
-                                    {
-                                        "LA location 1 key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("LA location 1 label")
-                                        }
-                                    }
-                                },
-                                Candidates =
-                                {
-                                    { "LA location 1 key", new MappableLocationOption("LA location 1 label") }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .DefaultLocationMappingPlan()
+                    .AddLevel(
+                        level: GeographicLevel.LocalAuthority,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping())
+                            .AddCandidate(
+                                targetKey: "location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())));
 
             await AddTestData<PublicDataDbContext>(context =>
                 context.DataSetVersionMappings.Add(mappings));
@@ -695,25 +655,24 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             Assert.True(updatedMappings.LocationMappingsComplete);
 
+            var originalLocationMapping = mappings
+                .GetLocationOptionMapping(GeographicLevel.LocalAuthority, "location-1-key");
+
             Dictionary<GeographicLevel, LocationLevelMappings> expectedLevelMappings = new()
             {
                 {
-                    GeographicLevel.LocalAuthority,
-                    new LocationLevelMappings
+                    GeographicLevel.LocalAuthority, mappings.GetLocationLevelMappings(GeographicLevel.LocalAuthority) with
                     {
-                        Mappings =
+                        Mappings = new Dictionary<string, LocationOptionMapping>
                         {
                             {
-                                "LA location 1 key",
-                                new LocationOptionMapping
+                                "location-1-key", originalLocationMapping with
                                 {
-                                    Source = new MappableLocationOption("LA location 1 label"),
                                     Type = MappingType.AutoMapped,
-                                    CandidateKey = "LA location 1 key"
+                                    CandidateKey = "location-1-key"
                                 }
                             }
-                        },
-                        Candidates = { { "LA location 1 key", new MappableLocationOption("LA location 1 label") } }
+                        }
                     }
                 }
             };
@@ -733,49 +692,36 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             // the target version, leaving some candidates and new levels unused but
             // essentially the mapping is complete unless the user manually intervenes
             // at this point.
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = originalVersion.Id,
-                TargetDataSetVersionId = nextVersion.Id,
-                FilterMappingPlan = new FilterMappingPlan(),
-                LocationMappingPlan = new LocationMappingPlan
-                {
-                    Levels =
-                    {
-                        {
-                            GeographicLevel.LocalAuthority,
-                            new LocationLevelMappings
-                            {
-                                Mappings =
-                                {
-                                    {
-                                        "LA location 1 key",
-                                        new LocationOptionMapping
-                                        {
-                                            Source = new MappableLocationOption("LA location 1 label")
-                                        }
-                                    }
-                                },
-                                Candidates =
-                                {
-                                    { "LA location 1 key", new MappableLocationOption("LA location 1 label") },
-                                    { "LA location 2 key", new MappableLocationOption("LA location 2 label") }
-                                }
-                            }
-                        },
-                        {
-                            GeographicLevel.RscRegion, new LocationLevelMappings
-                            {
-                                Mappings = [],
-                                Candidates =
-                                    {
-                                        { "RSC location 1 key", new MappableLocationOption("RSC location 1 label") }
-                                    }
-                            }
-                        }
-                    }
-                }
-            };
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .DefaultLocationMappingPlan()
+                    .AddLevel(
+                        level: GeographicLevel.LocalAuthority,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "la-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping())
+                            .AddCandidate(
+                                targetKey: "la-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())
+                            .AddCandidate(
+                                targetKey: "la-location-3-key",
+                                candidate: DataFixture.DefaultMappableLocationOption()))
+                    .AddLevel(
+                        level: GeographicLevel.RscRegion,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddCandidate(
+                                targetKey: "rsc-location-1-key",
+                                candidate: DataFixture
+                                    .DefaultMappableLocationOption())));
 
             await AddTestData<PublicDataDbContext>(context =>
                 context.DataSetVersionMappings.Add(mappings));
@@ -786,37 +732,28 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             Assert.True(updatedMappings.LocationMappingsComplete);
 
+            var originalLaMapping = mappings
+                .GetLocationOptionMapping(GeographicLevel.LocalAuthority, "la-location-1-key");
+
             Dictionary<GeographicLevel, LocationLevelMappings> expectedLevelMappings = new()
             {
                 {
-                    GeographicLevel.LocalAuthority,
-                    new LocationLevelMappings
+                    GeographicLevel.LocalAuthority, mappings.GetLocationLevelMappings(GeographicLevel.LocalAuthority) with
                     {
-                        Mappings =
+                        Mappings = new Dictionary<string, LocationOptionMapping>
                         {
                             {
-                                "LA location 1 key",
-                                new LocationOptionMapping
+                                "la-location-1-key", originalLaMapping with
                                 {
-                                    Source = new MappableLocationOption("LA location 1 label"),
                                     Type = MappingType.AutoMapped,
-                                    CandidateKey = "LA location 1 key"
+                                    CandidateKey = "la-location-1-key"
                                 }
                             }
-                        },
-                        Candidates =
-                        {
-                            { "LA location 1 key", new MappableLocationOption("LA location 1 label") },
-                            { "LA location 2 key", new MappableLocationOption("LA location 2 label") }
                         }
                     }
                 },
                 {
-                    GeographicLevel.RscRegion, new LocationLevelMappings
-                    {
-                        Mappings = [],
-                        Candidates = { { "RSC location 1 key", new MappableLocationOption("RSC location 1 label") } }
-                    }
+                    GeographicLevel.RscRegion, mappings.GetLocationLevelMappings(GeographicLevel.RscRegion)
                 }
             };
 
@@ -838,75 +775,35 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // Create a mapping plan based on 2 data set versions with partially overlapping filters.
             // Both have "Filter 1" and both have "Filter 1 option 1", but then each also contains Filter 1
-            // options that the other do not, and each also contains filters that the other does not. 
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = originalVersion.Id,
-                TargetDataSetVersionId = nextVersion.Id,
-                FilterMappingPlan = new FilterMappingPlan
-                {
-                    Mappings =
-                    {
-                        {
-                            "Filter 1 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 1 label"),
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 1 option 1 key",
-                                        new FilterOptionMapping
-                                            {
-                                                Source = new MappableFilterOption("Filter 1 option 1 label")
-                                            }
-                                    },
-                                    {
-                                        "Filter 1 option 2 key",
-                                        new FilterOptionMapping
-                                            {
-                                                Source = new MappableFilterOption("Filter 1 option 2 label")
-                                            }
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Filter 2 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 2 label"),
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 2 option 1 key",
-                                        new FilterOptionMapping
-                                            {
-                                                Source = new MappableFilterOption("Filter 2 option 1 label")
-                                            }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    Candidates =
-                    {
-                        {
-                            "Filter 1 key",
-                            new FilterMappingCandidate("Filter 1 label")
-                            {
-                                Options =
-                                {
-                                    {
-                                        "Filter 1 option 1 key", new MappableFilterOption("Filter 1 option 1 label")
-                                    },
-                                    { "Filter 1 option 3 key", new MappableFilterOption("Filter 1 option 3 label") }
-                                }
-                            }
-                        }
-                    }
-                },
-                LocationMappingPlan = new LocationMappingPlan()
-            };
-
+            // options that the other do not, and each also contains filters that the other does not.
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithNoMapping()
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping())
+                        .AddOptionMapping("filter-1-option-2-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping()))
+                    .AddFilterMapping("filter-2-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithNoMapping()
+                        .AddOptionMapping("filter-2-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping()))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())
+                        .AddOptionCandidate("filter-1-option-3-key", DataFixture
+                            .DefaultMappableFilterOption())));
+            
             await AddTestData<PublicDataDbContext>(context =>
                 context.DataSetVersionMappings.Add(mappings));
 
@@ -914,52 +811,53 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             var updatedMappings = GetDataSetVersionMapping(nextVersion);
 
-            Assert.False(updatedMappings.FilterMappingsComplete);
-
             Dictionary<string, FilterMapping> expectedFilterMappings = new()
             {
                 {
-                    "Filter 1 key", new FilterMapping
+                    "filter-1-key", mappings.GetFilterMapping("filter-1-key") with 
                     {
-                        Source = new MappableFilter("Filter 1 label"),
+                        // The code managed to establish an automapping for this filter.
                         Type = MappingType.AutoMapped,
-                        CandidateKey = "Filter 1 key",
-                        OptionMappings =
+                        CandidateKey = "filter-1-key",
+                        OptionMappings = new Dictionary<string, FilterOptionMapping>
                         {
                             {
-                                "Filter 1 option 1 key",
-                                new FilterOptionMapping
+                                "filter-1-option-1-key",
+                                mappings.GetFilterOptionMapping("filter-1-key", "filter-1-option-1-key") with
                                 {
-                                    Source = new MappableFilterOption("Filter 1 option 1 label"),
+                                    // The code managed to establish an automapping for this filter option.
                                     Type = MappingType.AutoMapped,
-                                    CandidateKey = "Filter 1 option 1 key"
+                                    CandidateKey = "filter-1-option-1-key"
                                 }
                             },
                             {
-                                "Filter 1 option 2 key",
-                                new FilterOptionMapping
+                                "filter-1-option-2-key",
+                                mappings.GetFilterOptionMapping("filter-1-key", "filter-1-option-2-key") with
                                 {
-                                    Source = new MappableFilterOption("Filter 1 option 2 label"),
+                                    // The code managed to establish that no obvious automapping candidate exists for
+                                    // this filter option.
                                     Type = MappingType.AutoNone,
                                     CandidateKey = null
                                 }
                             }
                         }
                     }
-                },
+                }, 
                 {
-                    "Filter 2 key", new FilterMapping
+                    "filter-2-key", mappings.GetFilterMapping("filter-2-key") with 
                     {
-                        Source = new MappableFilter("Filter 2 label"),
+                        // The code managed to establish that no obvious automapping candidate exists for
+                        // this filter.
                         Type = MappingType.AutoNone,
                         CandidateKey = null,
-                        OptionMappings =
+                        OptionMappings = new Dictionary<string, FilterOptionMapping>
                         {
                             {
-                                "Filter 2 option 1 key",
-                                new FilterOptionMapping
+                                "filter-2-option-1-key",
+                                mappings.GetFilterOptionMapping("filter-2-key", "filter-2-option-1-key") with
                                 {
-                                    Source = new MappableFilterOption("Filter 2 option 1 label"),
+                                    // The code managed to establish that no obvious automapping candidate exists for
+                                    // this filter option.
                                     Type = MappingType.AutoNone,
                                     CandidateKey = null
                                 }
@@ -972,6 +870,8 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             updatedMappings.FilterMappingPlan.Mappings.AssertDeepEqualTo(
                 expectedFilterMappings,
                 ignoreCollectionOrders: true);
+
+            Assert.False(updatedMappings.FilterMappingsComplete);
         }
 
         [Fact]
@@ -982,86 +882,38 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // Create a mapping plan based on 2 data set versions with exactly the same filters
             // and filter options.
-
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = originalVersion.Id,
-                TargetDataSetVersionId = nextVersion.Id,
-                FilterMappingPlan = new FilterMappingPlan
-                {
-                    Mappings =
-                    {
-                        {
-                            "Filter 1 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 1 label"),
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 1 option 1 key",
-                                        new FilterOptionMapping
-                                            {
-                                                Source = new MappableFilterOption("Filter 1 option 1 label")
-                                            }
-                                    },
-                                    {
-                                        "Filter 1 option 2 key",
-                                        new FilterOptionMapping
-                                            {
-                                                Source = new MappableFilterOption("Filter 1 option 2 label")
-                                            }
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Filter 2 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 2 label"),
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 2 option 1 key",
-                                        new FilterOptionMapping
-                                            {
-                                                Source = new MappableFilterOption("Filter 2 option 1 label")
-                                            }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    Candidates =
-                    {
-                        {
-                            "Filter 1 key",
-                            new FilterMappingCandidate("Filter 1 label")
-                            {
-                                Options =
-                                {
-                                    {
-                                        "Filter 1 option 1 key", new MappableFilterOption("Filter 1 option 1 label")
-                                    },
-                                    { "Filter 1 option 2 key", new MappableFilterOption("Filter 1 option 2 label") }
-                                }
-                            }
-                        },
-                        {
-                            "Filter 2 key",
-                            new FilterMappingCandidate("Filter 2 label")
-                            {
-                                Options =
-                                {
-                                    {
-                                        "Filter 2 option 1 key", new MappableFilterOption("Filter 2 option 1 label")
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                LocationMappingPlan = new LocationMappingPlan()
-            };
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithNoMapping()
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping())
+                        .AddOptionMapping("filter-1-option-2-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping()))
+                    .AddFilterMapping("filter-2-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithNoMapping()
+                        .AddOptionMapping("filter-2-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping()))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())
+                        .AddOptionCandidate("filter-1-option-2-key", DataFixture
+                            .DefaultMappableFilterOption()))
+                    .AddFilterCandidate("filter-2-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-2-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())));
+            
             await AddTestData<PublicDataDbContext>(context =>
                 context.DataSetVersionMappings.Add(mappings));
 
@@ -1069,54 +921,52 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             var updatedMappings = GetDataSetVersionMapping(nextVersion);
 
-            Assert.True(updatedMappings.FilterMappingsComplete);
-
             Dictionary<string, FilterMapping> expectedFilterMappings = new()
             {
                 {
-                    "Filter 1 key", new FilterMapping
+                    "filter-1-key", mappings.GetFilterMapping("filter-1-key") with
                     {
-                        Source = new MappableFilter("Filter 1 label"),
+                        // The code managed to establish an automapping for this filter.
                         Type = MappingType.AutoMapped,
-                        CandidateKey = "Filter 1 key",
-                        OptionMappings =
+                        CandidateKey = "filter-1-key",
+                        OptionMappings = new Dictionary<string, FilterOptionMapping>
                         {
                             {
-                                "Filter 1 option 1 key",
-                                new FilterOptionMapping
+                                "filter-1-option-1-key",
+                                mappings.GetFilterOptionMapping("filter-1-key", "filter-1-option-1-key") with
                                 {
-                                    Source = new MappableFilterOption("Filter 1 option 1 label"),
+                                    // The code managed to establish an automapping for this filter option.
                                     Type = MappingType.AutoMapped,
-                                    CandidateKey = "Filter 1 option 1 key"
+                                    CandidateKey = "filter-1-option-1-key"
                                 }
                             },
                             {
-                                "Filter 1 option 2 key",
-                                new FilterOptionMapping
+                                "filter-1-option-2-key",
+                                mappings.GetFilterOptionMapping("filter-1-key", "filter-1-option-2-key") with
                                 {
-                                    Source = new MappableFilterOption("Filter 1 option 2 label"),
+                                    // The code managed to establish an automapping for this filter option.
                                     Type = MappingType.AutoMapped,
-                                    CandidateKey = "Filter 1 option 2 key"
+                                    CandidateKey = "filter-1-option-2-key"
                                 }
                             }
                         }
                     }
                 },
                 {
-                    "Filter 2 key", new FilterMapping
+                    "filter-2-key", mappings.GetFilterMapping("filter-2-key") with
                     {
-                        Source = new MappableFilter("Filter 2 label"),
+                        // The code managed to establish an automapping for this filter.
                         Type = MappingType.AutoMapped,
-                        CandidateKey = "Filter 2 key",
-                        OptionMappings =
+                        CandidateKey = "filter-2-key",
+                        OptionMappings = new Dictionary<string, FilterOptionMapping>
                         {
                             {
-                                "Filter 2 option 1 key",
-                                new FilterOptionMapping
+                                "filter-2-option-1-key",
+                                mappings.GetFilterOptionMapping("filter-2-key", "filter-2-option-1-key") with
                                 {
-                                    Source = new MappableFilterOption("Filter 2 option 1 label"),
+                                    // The code managed to establish an automapping for this filter option.
                                     Type = MappingType.AutoMapped,
-                                    CandidateKey = "Filter 2 option 1 key"
+                                    CandidateKey = "filter-2-option-1-key"
                                 }
                             }
                         }
@@ -1125,6 +975,8 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             };
 
             updatedMappings.FilterMappingPlan.Mappings.AssertDeepEqualTo(expectedFilterMappings);
+
+            Assert.True(updatedMappings.FilterMappingsComplete);
         }
 
         [Fact]
@@ -1138,62 +990,28 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             // Each source filter and filter option can be auto-mapped exactly to one in
             // the target version, leaving some candidates unused but essentially the mapping
             // is complete unless the user manually intervenes at this point.
-            var mappings = new DataSetVersionMapping
-            {
-                SourceDataSetVersionId = originalVersion.Id,
-                TargetDataSetVersionId = nextVersion.Id,
-                FilterMappingPlan = new FilterMappingPlan
-                {
-                    Mappings =
-                    {
-                        {
-                            "Filter 1 key", new FilterMapping
-                            {
-                                Source = new MappableFilter("Filter 1 label"),
-                                OptionMappings =
-                                {
-                                    {
-                                        "Filter 1 option 1 key",
-                                        new FilterOptionMapping
-                                            {
-                                                Source = new MappableFilterOption("Filter 1 option 1 label")
-                                            }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    Candidates =
-                    {
-                        {
-                            "Filter 1 key",
-                            new FilterMappingCandidate("Filter 1 label")
-                            {
-                                Options =
-                                {
-                                    {
-                                        "Filter 1 option 1 key", new MappableFilterOption("Filter 1 option 1 label")
-                                    },
-                                    { "Filter 1 option 2 key", new MappableFilterOption("Filter 1 option 2 label") }
-                                }
-                            }
-                        },
-                        {
-                            "Filter 2 key",
-                            new FilterMappingCandidate("Filter 2 label")
-                            {
-                                Options =
-                                {
-                                    {
-                                        "Filter 2 option 1 key", new MappableFilterOption("Filter 2 option 1 label")
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                LocationMappingPlan = new LocationMappingPlan()
-            };
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithNoMapping()
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping()))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())
+                        .AddOptionCandidate("filter-1-option-2-key", DataFixture
+                            .DefaultMappableFilterOption()))
+                    .AddFilterCandidate("filter-2-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-2-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())));
 
             await AddTestData<PublicDataDbContext>(context =>
                 context.DataSetVersionMappings.Add(mappings));
@@ -1202,25 +1020,21 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             var updatedMappings = GetDataSetVersionMapping(nextVersion);
 
-            Assert.True(updatedMappings.FilterMappingsComplete);
-
             Dictionary<string, FilterMapping> expectedFilterMappings = new()
             {
                 {
-                    "Filter 1 key", new FilterMapping
+                    "filter-1-key", mappings.GetFilterMapping("filter-1-key") with
                     {
-                        Source = new MappableFilter("Filter 1 label"),
                         Type = MappingType.AutoMapped,
-                        CandidateKey = "Filter 1 key",
-                        OptionMappings =
+                        CandidateKey = "filter-1-key",
+                        OptionMappings = new Dictionary<string, FilterOptionMapping>
                         {
                             {
-                                "Filter 1 option 1 key",
-                                new FilterOptionMapping
+                                "filter-1-option-1-key",
+                                mappings.GetFilterOptionMapping("filter-1-key", "filter-1-option-1-key") with
                                 {
-                                    Source = new MappableFilterOption("Filter 1 option 1 label"),
                                     Type = MappingType.AutoMapped,
-                                    CandidateKey = "Filter 1 option 1 key"
+                                    CandidateKey = "filter-1-option-1-key"
                                 }
                             }
                         }
@@ -1231,6 +1045,8 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             updatedMappings.FilterMappingPlan.Mappings.AssertDeepEqualTo(
                 expectedFilterMappings,
                 ignoreCollectionOrders: true);
+
+            Assert.True(updatedMappings.FilterMappingsComplete);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
@@ -262,7 +262,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                         Mappings = levelMeta
                             .Options
                             .ToDictionary(
-                                keySelector: option => $"{option.Label} :: {option.ToRow().GetRowKey()}",
+                                keySelector: MappingKeyFunctions.LocationOptionMetaKeyGenerator,
                                 elementSelector: option => new LocationOptionMapping
                                 {
                                     CandidateKey = null,
@@ -331,7 +331,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                             Candidates = levelMeta
                                 .options
                                 .ToDictionary(
-                                    keySelector: option => $"{option.Label} :: {option.ToRow().GetRowKey()}",
+                                    keySelector: MappingKeyFunctions.LocationOptionMetaKeyGenerator,
                                     elementSelector: option => new MappableLocationOption(option.Label)
                                     {
                                         Code = option.ToRow().Code,
@@ -379,7 +379,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             var expectedFilterMappings = initialFilterMeta
                 .ToDictionary(
-                    keySelector: filter => filter.PublicId,
+                    keySelector: MappingKeyFunctions.FilterKeyGenerator,
                     elementSelector: filter =>
                         new FilterMapping
                         {
@@ -389,7 +389,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                             OptionMappings = filter
                                 .Options
                                 .ToDictionary(
-                                    keySelector: option => option.Label,
+                                    keySelector: MappingKeyFunctions.FilterOptionKeyGenerator,
                                     elementSelector: option =>
                                         new FilterOptionMapping
                                         {
@@ -421,14 +421,14 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                 .AbsenceSchool
                 .ExpectedFilters
                 .ToDictionary(
-                    keySelector: filterAndOptions => filterAndOptions.PublicId,
-                    elementSelector: filterAndOptions =>
-                        new FilterMappingCandidate(filterAndOptions.Label)
+                    keySelector: MappingKeyFunctions.FilterKeyGenerator,
+                    elementSelector: filter =>
+                        new FilterMappingCandidate(filter.Label)
                         {
-                            Options = filterAndOptions
+                            Options = filter
                                 .Options
                                 .ToDictionary(
-                                    keySelector: optionMeta => optionMeta.Label,
+                                    keySelector: MappingKeyFunctions.FilterOptionKeyGenerator,
                                     elementSelector: optionMeta =>
                                         new MappableFilterOption(optionMeta.Label))
                         });

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
@@ -1276,11 +1276,8 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             importStage: DataSetVersionImportStage.Completing,
             status: DataSetVersionStatus.Published);
 
-        var dataSet = await GetDbContext<PublicDataDbContext>().DataSets.SingleAsync(dataSet =>
-            dataSet.Id == initialDataSetVersion.DataSet.Id);
-
         var (nextDataSetVersion, instanceId) = await CreateDataSetVersionAndImport(
-            dataSet: dataSet,
+            dataSetId: initialDataSetVersion.DataSetId,
             importStage: importStage,
             versionMajor: 1,
             versionMinor: 1);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorFunctionsIntegrationTest.cs
@@ -66,17 +66,23 @@ public abstract class ProcessorFunctionsIntegrationTest(
 
         await AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
 
-        return await CreateDataSetVersionAndImport(dataSet, importStage, status, releaseFileId);
+        return await CreateDataSetVersionAndImport(dataSet.Id, importStage, status, releaseFileId);
     }
 
     protected async Task<(DataSetVersion dataSetVersion, Guid instanceId)> CreateDataSetVersionAndImport(
-        DataSet dataSet,
+        Guid dataSetId,
         DataSetVersionImportStage importStage,
         DataSetVersionStatus? status = null,
         Guid? releaseFileId = null,
         int versionMajor = 1,
         int versionMinor = 0)
     {
+        await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
+
+        var dataSet = await publicDataDbContext
+            .DataSets
+            .SingleAsync(ds => ds.Id == dataSetId);
+        
         DataSetVersionImport dataSetVersionImport = DataFixture
             .DefaultDataSetVersionImport()
             .WithStage(importStage);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorTestData.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorTestData.cs
@@ -3,7 +3,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests;
 
@@ -80,7 +79,6 @@ public record ProcessorTestData
                     new LocationLocalAuthorityOptionMeta
                     {
                         Id = 1,
-                        PublicId = SqidEncoder.Encode(1),
                         OldCode = "302",
                         Code = "E09000003",
                         Label = "Barnet",
@@ -88,7 +86,6 @@ public record ProcessorTestData
                     new LocationLocalAuthorityOptionMeta
                     {
                         Id = 2,
-                        PublicId = SqidEncoder.Encode(2),
                         OldCode = "314",
                         Code = "E09000021 / E09000027",
                         Label = "Kingston upon Thames / Richmond upon Thames",
@@ -96,7 +93,6 @@ public record ProcessorTestData
                     new LocationLocalAuthorityOptionMeta
                     {
                         Id = 3,
-                        PublicId = SqidEncoder.Encode(3),
                         OldCode = "370",
                         Code = "E08000016",
                         Label = "Barnsley",
@@ -104,7 +100,6 @@ public record ProcessorTestData
                     new LocationLocalAuthorityOptionMeta
                     {
                         Id = 4,
-                        PublicId = SqidEncoder.Encode(4),
                         OldCode = "373",
                         Code = "E08000019",
                         Label = "Sheffield",
@@ -120,7 +115,6 @@ public record ProcessorTestData
                     new LocationCodedOptionMeta
                     {
                         Id = 5,
-                        PublicId = SqidEncoder.Encode(5),
                         Code = "E92000001",
                         Label = "England",
                     },
@@ -135,14 +129,12 @@ public record ProcessorTestData
                     new LocationCodedOptionMeta
                     {
                         Id = 6,
-                        PublicId = SqidEncoder.Encode(6),
                         Code = "E12000003",
                         Label = "Yorkshire and The Humber",
                     },
                     new LocationCodedOptionMeta
                     {
                         Id = 7,
-                        PublicId = SqidEncoder.Encode(7),
                         Code = "E13000002",
                         Label = "Outer London",
                     },
@@ -157,7 +149,6 @@ public record ProcessorTestData
                     new LocationSchoolOptionMeta
                     {
                         Id = 8,
-                        PublicId = SqidEncoder.Encode(8),
                         Urn = "101269",
                         LaEstab = "3022014",
                         Label = "Colindale Primary School",
@@ -165,7 +156,6 @@ public record ProcessorTestData
                     new LocationSchoolOptionMeta
                     {
                         Id = 9,
-                        PublicId = SqidEncoder.Encode(9),
                         Urn = "102579",
                         LaEstab = "3142032",
                         Label = "King Athelstan Primary School",
@@ -173,7 +163,6 @@ public record ProcessorTestData
                     new LocationSchoolOptionMeta
                     {
                         Id = 10,
-                        PublicId = SqidEncoder.Encode(10),
                         Urn = "106653",
                         LaEstab = "3704027",
                         Label = "Penistone Grammar School",
@@ -181,7 +170,6 @@ public record ProcessorTestData
                     new LocationSchoolOptionMeta
                     {
                         Id = 11,
-                        PublicId = SqidEncoder.Encode(11),
                         Urn = "135507",
                         LaEstab = "3026906",
                         Label = "Wren Academy Finchley",
@@ -189,7 +177,6 @@ public record ProcessorTestData
                     new LocationSchoolOptionMeta
                     {
                         Id = 12,
-                        PublicId = SqidEncoder.Encode(12),
                         Urn = "140821",
                         LaEstab = "3734008",
                         Label = "Newfield Secondary School",
@@ -197,7 +184,6 @@ public record ProcessorTestData
                     new LocationSchoolOptionMeta
                     {
                         Id = 13,
-                        PublicId = SqidEncoder.Encode(13),
                         Urn = "141862",
                         LaEstab = "3144001",
                         Label = "The Kingston Academy",
@@ -205,7 +191,6 @@ public record ProcessorTestData
                     new LocationSchoolOptionMeta
                     {
                         Id = 14,
-                        PublicId = SqidEncoder.Encode(14),
                         Urn = "141973",
                         LaEstab = "3702039",
                         Label = "Hoyland Springwood Primary School",
@@ -213,7 +198,6 @@ public record ProcessorTestData
                     new LocationSchoolOptionMeta
                     {
                         Id = 15,
-                        PublicId = SqidEncoder.Encode(15),
                         Urn = "145374",
                         LaEstab = "3732341",
                         Label = "Greenhill Primary School",

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessCompletionOfNextDataSetVersionFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessCompletionOfNextDataSetVersionFunction.cs
@@ -28,6 +28,7 @@ public class ProcessCompletionOfNextDataSetVersionFunction(
 
         try
         {
+            await context.CallActivity(ActivityNames.ImportMetadata, logger, context.InstanceId);
             await context.CallActivity(ActivityNames.ImportData, logger, context.InstanceId);
             await context.CallActivity(ActivityNames.WriteDataFiles, logger, context.InstanceId);
             await context.CallActivity(ActivityNames.CompleteNextDataSetVersionImportProcessing, logger,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/LocationMetaRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/LocationMetaRepository.cs
@@ -119,7 +119,6 @@ public class LocationMetaRepository(
                     foreach (var option in newOptions)
                     {
                         option.Id = startIndex++;
-                        option.PublicId = SqidEncoder.Encode(option.Id);
                     }
 
                     await optionTable.BulkCopyAsync(
@@ -137,6 +136,7 @@ public class LocationMetaRepository(
                     .Where(hasBatchRowKey)
                     .Select((option, index) => new LocationOptionMetaLink
                     {
+                        PublicId = SqidEncoder.Encode(option.Id),
                         MetaId = meta.Id,
                         OptionId = option.Id
                     })
@@ -226,32 +226,27 @@ public class LocationMetaRepository(
         {
             GeographicLevel.LocalAuthority => new LocationLocalAuthorityOptionMeta
             {
-                PublicId = string.Empty,
                 Label = label,
                 Code = row[LocalAuthorityCsvColumns.NewCode],
                 OldCode = row[LocalAuthorityCsvColumns.OldCode]
             },
             GeographicLevel.School => new LocationSchoolOptionMeta
             {
-                PublicId = string.Empty,
                 Label = label,
                 Urn = row[SchoolCsvColumns.Urn],
                 LaEstab = row[SchoolCsvColumns.LaEstab]
             },
             GeographicLevel.Provider => new LocationProviderOptionMeta
             {
-                PublicId = string.Empty,
                 Label = label,
                 Ukprn = row[ProviderCsvColumns.Ukprn]
             },
             GeographicLevel.RscRegion => new LocationRscRegionOptionMeta
             {
-                PublicId = string.Empty,
                 Label = label
             },
             _ => new LocationCodedOptionMeta
             {
-                PublicId = string.Empty,
                 Label = label,
                 Code = row[cols.Codes.First()]
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/LocationMetaRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/LocationMetaRepository.cs
@@ -170,7 +170,7 @@ public class LocationMetaRepository(
         return publicIdMappings
                    .GetPublicIdForCandidate(
                        level: level,
-                       MappingKeyFunctions.LocationOptionKeyGenerator(option))
+                       candidateKey: MappingKeyFunctions.LocationOptionMetaRowKeyGenerator(option))
                ?? SqidEncoder.Encode(option.Id);
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/LocationMetaRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/LocationMetaRepository.cs
@@ -54,9 +54,10 @@ public class LocationMetaRepository(
         CancellationToken cancellationToken = default)
     {
         var metas = GetLocationMetas(dataSetVersion, allowedColumns);
-
         publicDataDbContext.LocationMetas.AddRange(metas);
         await publicDataDbContext.SaveChangesAsync(cancellationToken);
+
+        var publicIdMappings = await CreatePublicIdMappings(dataSetVersion, cancellationToken);
 
         foreach (var meta in metas)
         {
@@ -136,7 +137,7 @@ public class LocationMetaRepository(
                     .Where(hasBatchRowKey)
                     .Select((option, index) => new LocationOptionMetaLink
                     {
-                        PublicId = SqidEncoder.Encode(option.Id),
+                        PublicId = CreatePublicIdForLocationOptionMetaLink(publicIdMappings, meta, option),
                         MetaId = meta.Id,
                         OptionId = option.Id
                     })
@@ -159,6 +160,18 @@ public class LocationMetaRepository(
                 );
             }
         }
+    }
+
+    private static string CreatePublicIdForLocationOptionMetaLink(
+        PublicIdMappings publicIdMappings,
+        GeographicLevel level,
+        LocationOptionMetaRow option)
+    {
+        return publicIdMappings
+                   .GetPublicIdForCandidate(
+                       level: level,
+                       MappingKeyFunctions.LocationOptionKeyGenerator(option))
+               ?? SqidEncoder.Encode(option.Id);
     }
 
     private async Task<List<LocationOptionMetaRow>> GetLocationOptionMetas(
@@ -241,15 +254,59 @@ public class LocationMetaRepository(
                 Label = label,
                 Ukprn = row[ProviderCsvColumns.Ukprn]
             },
-            GeographicLevel.RscRegion => new LocationRscRegionOptionMeta
-            {
-                Label = label
-            },
+            GeographicLevel.RscRegion => new LocationRscRegionOptionMeta { Label = label },
             _ => new LocationCodedOptionMeta
             {
                 Label = label,
                 Code = row[cols.Codes.First()]
             }
         };
+    }
+
+    private async Task<PublicIdMappings> CreatePublicIdMappings(
+        DataSetVersion dataSetVersion,
+        CancellationToken cancellationToken)
+    {
+        var mappings = await EntityFrameworkQueryableExtensions
+            .SingleOrDefaultAsync(publicDataDbContext
+                    .DataSetVersionMappings,
+                mapping => mapping.TargetDataSetVersionId == dataSetVersion.Id,
+                cancellationToken);
+
+        if (mappings is null)
+        {
+            return new PublicIdMappings();
+        }
+
+        var mappingsByLevel = mappings
+            .LocationMappingPlan
+            .Levels
+            .ToDictionary(
+                keySelector: level => level.Key,
+                elementSelector: level => level
+                    .Value
+                    .Mappings
+                    .Values
+                    .Where(mapping => mapping.Type is MappingType.AutoMapped or MappingType.ManualMapped)
+                    .ToDictionary(
+                        keySelector: mapping => mapping.CandidateKey!,
+                        elementSelector: mapping => mapping.PublicId));
+
+        return new PublicIdMappings { Levels = mappingsByLevel };
+    }
+
+    private record PublicIdMappings
+    {
+        public Dictionary<GeographicLevel, Dictionary<string, string>> Levels { get; init; } = [];
+
+        public string? GetPublicIdForCandidate(GeographicLevel level, string candidateKey)
+        {
+            if (!Levels.TryGetValue(level, out var mappingLevel))
+            {
+                return null;
+            }
+
+            return mappingLevel.GetValueOrDefault(candidateKey);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/LocationsDuckDbRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/LocationsDuckDbRepository.cs
@@ -54,7 +54,7 @@ public class LocationsDuckDbRepository(PublicDataDbContext publicDataDbContext) 
                 insertRow.AppendValue(id++);
                 insertRow.AppendValue(option.Label);
                 insertRow.AppendValue(location.Level.GetEnumValue());
-                insertRow.AppendValue(option.PublicId);
+                insertRow.AppendValue(link.PublicId);
 
                 switch (option)
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
@@ -24,15 +24,6 @@ internal class DataSetVersionMappingService(
         MappingType.AutoNone
     ];
 
-    private static Func<LocationOptionMetaRow, string> LocationOptionKeyGenerator =>
-        option => $"{option.Label} :: {option.GetRowKey()}";
-
-    private static Func<FilterMeta, string> FilterKeyGenerator =>
-        filter => filter.PublicId;
-
-    private static Func<FilterOptionMeta, string> FilterOptionKeyGenerator =>
-        option => option.Label;
-
     public async Task<Either<ActionResult, Unit>> CreateMappings(
         Guid nextDataSetVersionId,
         CancellationToken cancellationToken = default)
@@ -317,14 +308,14 @@ internal class DataSetVersionMappingService(
                             .Options
                             .Select(option => option.ToRow())
                             .ToDictionary(
-                                keySelector: MappingKeyFunctions.LocationOptionKeyGenerator,
+                                keySelector: MappingKeyFunctions.LocationOptionMetaRowKeyGenerator,
                                 elementSelector: option => new LocationOptionMapping
                                 {
                                     Source = CreateLocationOptionFromMetaRow(option)
                                 }),
                         Candidates = candidatesForLevel
                             .ToDictionary(
-                                keySelector: MappingKeyFunctions.LocationOptionKeyGenerator,
+                                keySelector: MappingKeyFunctions.LocationOptionMetaRowKeyGenerator,
                                 elementSelector: CreateLocationOptionFromMetaRow)
                     };
                 });
@@ -346,7 +337,7 @@ internal class DataSetVersionMappingService(
                     Candidates = meta
                         .optionsMeta
                         .ToDictionary(
-                            keySelector: MappingKeyFunctions.LocationOptionKeyGenerator,
+                            keySelector: MappingKeyFunctions.LocationOptionMetaRowKeyGenerator,
                             elementSelector: CreateLocationOptionFromMetaRow)
                 });
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
@@ -317,14 +317,14 @@ internal class DataSetVersionMappingService(
                             .Options
                             .Select(option => option.ToRow())
                             .ToDictionary(
-                                keySelector: LocationOptionKeyGenerator,
+                                keySelector: MappingKeyFunctions.LocationOptionKeyGenerator,
                                 elementSelector: option => new LocationOptionMapping
                                 {
                                     Source = CreateLocationOptionFromMetaRow(option)
                                 }),
                         Candidates = candidatesForLevel
                             .ToDictionary(
-                                keySelector: LocationOptionKeyGenerator,
+                                keySelector: MappingKeyFunctions.LocationOptionKeyGenerator,
                                 elementSelector: CreateLocationOptionFromMetaRow)
                     };
                 });
@@ -346,7 +346,7 @@ internal class DataSetVersionMappingService(
                     Candidates = meta
                         .optionsMeta
                         .ToDictionary(
-                            keySelector: LocationOptionKeyGenerator,
+                            keySelector: MappingKeyFunctions.LocationOptionKeyGenerator,
                             elementSelector: CreateLocationOptionFromMetaRow)
                 });
 
@@ -366,7 +366,7 @@ internal class DataSetVersionMappingService(
     {
         var filterMappings = sourceFilterMeta
             .ToDictionary(
-                keySelector: FilterKeyGenerator,
+                keySelector: MappingKeyFunctions.FilterKeyGenerator,
                 elementSelector: filter =>
                     new FilterMapping
                     {
@@ -374,7 +374,7 @@ internal class DataSetVersionMappingService(
                         OptionMappings = filter
                             .Options
                             .ToDictionary(
-                                keySelector: FilterOptionKeyGenerator,
+                                keySelector: MappingKeyFunctions.FilterOptionKeyGenerator,
                                 elementSelector: option =>
                                     new FilterOptionMapping { Source = CreateFilterOptionFromMetaRow(option) })
                     });
@@ -384,13 +384,13 @@ internal class DataSetVersionMappingService(
                 filterMeta: meta.Key,
                 optionsMeta: meta.Value))
             .ToDictionary(
-                keySelector: meta => FilterKeyGenerator(meta.filterMeta),
+                keySelector: meta => MappingKeyFunctions.FilterKeyGenerator(meta.filterMeta),
                 elementSelector: meta =>
                     new FilterMappingCandidate(meta.filterMeta.Label)
                     {
                         Options = meta.optionsMeta
                             .ToDictionary(
-                                keySelector: FilterOptionKeyGenerator,
+                                keySelector: MappingKeyFunctions.FilterOptionKeyGenerator,
                                 elementSelector: CreateFilterOptionFromMetaRow)
                     });
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
@@ -361,7 +361,7 @@ internal class DataSetVersionMappingService(
                 elementSelector: filter =>
                     new FilterMapping
                     {
-                        Source = new MappableFilter(filter.Label),
+                        Source = new MappableFilter { Label = filter.Label },
                         OptionMappings = filter
                             .Options
                             .ToDictionary(
@@ -377,8 +377,9 @@ internal class DataSetVersionMappingService(
             .ToDictionary(
                 keySelector: meta => MappingKeyFunctions.FilterKeyGenerator(meta.filterMeta),
                 elementSelector: meta =>
-                    new FilterMappingCandidate(meta.filterMeta.Label)
+                    new FilterMappingCandidate
                     {
+                        Label = meta.filterMeta.Label,
                         Options = meta.optionsMeta
                             .ToDictionary(
                                 keySelector: MappingKeyFunctions.FilterOptionKeyGenerator,
@@ -396,8 +397,9 @@ internal class DataSetVersionMappingService(
 
     private static MappableLocationOption CreateLocationOptionFromMetaRow(LocationOptionMetaRow option)
     {
-        return new MappableLocationOption(option.Label)
+        return new MappableLocationOption
         {
+            Label = option.Label,
             Code = option.Code,
             OldCode = option.OldCode,
             Ukprn = option.Ukprn,
@@ -408,7 +410,7 @@ internal class DataSetVersionMappingService(
 
     private static MappableFilterOption CreateFilterOptionFromMetaRow(FilterOptionMeta option)
     {
-        return new MappableFilterOption(option.Label);
+        return new MappableFilterOption { Label = option.Label };
     }
 
     private async Task<List<LocationMeta>> GetLocationMeta(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
@@ -620,7 +620,6 @@ public class SeedDataCommand : ICommand
                         foreach (var option in newOptions)
                         {
                             option.Id = startIndex++;
-                            option.PublicId = SqidEncoder.Encode(option.Id);
                         }
 
                         await optionTable.BulkCopyAsync(
@@ -639,6 +638,7 @@ public class SeedDataCommand : ICommand
                         .Where(hasBatchRowKey)
                         .Select((option, index) => new LocationOptionMetaLink
                         {
+                            PublicId = SqidEncoder.Encode(option.Id),
                             MetaId = meta.Id,
                             OptionId = option.Id
                         })
@@ -676,32 +676,27 @@ public class SeedDataCommand : ICommand
             {
                 GeographicLevel.LocalAuthority => new LocationLocalAuthorityOptionMeta
                 {
-                    PublicId = string.Empty,
                     Label = label,
                     Code = row[LocalAuthorityCsvColumns.NewCode],
                     OldCode = row[LocalAuthorityCsvColumns.OldCode]
                 },
                 GeographicLevel.School => new LocationSchoolOptionMeta
                 {
-                    PublicId = string.Empty,
                     Label = label,
                     Urn = row[SchoolCsvColumns.Urn],
                     LaEstab = row[SchoolCsvColumns.LaEstab]
                 },
                 GeographicLevel.Provider => new LocationProviderOptionMeta
                 {
-                    PublicId = string.Empty,
                     Label = label,
                     Ukprn = row[ProviderCsvColumns.Ukprn]
                 },
                 GeographicLevel.RscRegion => new LocationRscRegionOptionMeta
                 {
-                    PublicId = string.Empty,
                     Label = label
                 },
                 _ => new LocationCodedOptionMeta
                 {
-                    PublicId = string.Empty,
                     Label = label,
                     Code = row[cols.Codes.First()]
                 }
@@ -962,7 +957,7 @@ public class SeedDataCommand : ICommand
                     insertRow.AppendValue(id++);
                     insertRow.AppendValue(option.Label);
                     insertRow.AppendValue(location.Level.GetEnumValue());
-                    insertRow.AppendValue(option.PublicId);
+                    insertRow.AppendValue(link.PublicId);
 
                     switch (option)
                     {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
@@ -11,9 +11,7 @@ import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
-import tableBuilderService, {
-  ReleaseTableDataQuery,
-} from '@common/services/tableBuilderService';
+import tableBuilderService from '@common/services/tableBuilderService';
 import React from 'react';
 
 interface Model {


### PR DESCRIPTION
This PR:
- uses the auto mappings and manual mappings established previously to allow reuse of PublicIds from the previous data set version to use again for location options and filter options in the next data set version that have been mapped to.
- moves PublicId back onto LocationOptionMetaLink from LocationOptionMeta (which was its previous home a while back) in order to achieve the reuse of PublicIds without needing to create duplicate LocationOptionMeta rows with different Public Ids.

## Reusing PublicIds for backwards-compatibility with existing data set version queries

This PR allows existing queries built for, say, a `V1.0` data set version to be compatible with `V1.1`, by adopting PublicIds from elements in `V1.0` for their counterparts in `V1.1`.  Thus a user's query that was built using PublicId "abcd" to reference "Bath" in `V1.0` will be compatible with `V1.1`'s "Bath" also, by virtue of `V1.1`'s "Bath" adopting "abcd" as *its* PublicId too (so long as the mappings say that V1.0's "Bath" is mapped to V1.1's "Bath"!).

### Moving PublicId back onto LocationOptionMetaLink

In order to support this PublicId reuse strategy for Location Options, it was necessary to move PublicId back onto the LocationOptionMetaLink table, where it used to exist a while back.

The following scenario highlights why this is necessary, based on the previous model:

> So currently, users of the Public API will be using Public Ids to identify things like LocationOptions and FilterOptions in their data set queries.  So a given Data Set might contain information relating to a LocationOption called "City of Bath", which has a Public Id of "abcd".
>
> People putting together queries against that Data Set will use the Public Id of "abcd" if they're filtering results based on using the "City of Bath" LocationOption.
>
> If another Data Set comes along which also contains information related to a LocationOption of "City of Bath", we can reuse the existing LocationOption in the database (assuming all its Location codes match the one currently in the database), and thus we don't end up with an explosion of LocationOptions in the db.  As a result, people building queries against this other Data Set will also use the Public Id of "abcd" to reference it.
>
> All this works well so far!
>
> If another Data Set comes along and in its V1.0 version it contains a "Bath" LocationOption with a Public Id  of "efgh", people building queries against that Data Set will be using the Public Id of "efgh" to reference it.
If a user then creates a V1.1 data set version for that same Data Set that no longer contains a "Bath" LocationOption, but now contains a "City of Bath" LocationOption, the user will map "Bath" to "City of Bath" during the mapping phase.
When we come to complete the import of this next version, we will use the mappings the user carried out to identify that "Bath" has now become "City of Bath", and here is where it gets tricky with the current model.
>
> In order to allow queries that the user wrote against the V1.0 version to continue working correctly, we need to allow them to continue using the Public Id of "efgh" to reference the now "City of Bath" LocationOption.
> 
> This means we have to be able to either:
> 1. Support a single LocationOption of "City of Bath" with 2 or more Public Ids (in our case so far, "abcd" and "efgh".  In order to support this, I would suggest we move PublicId to the link tables that link data set versions to their meta, rather than on the meta tables themselves.  This would mean in this scenario moving PublicId from LocationOptionMeta to LocationOptionMetaLink.
> 2. Support multiple LocationOptions of "City of Bath", each with a different PublicId.  So in the scenario above, we'd have 2 "City of Bath" LocationOptionMeta entries in the db with the same Label, the same Location Codes, but different PublicIds ("abcd" and "efgh" respectively).


This PR opted to implement option 1 as the preferred option, thus reducing duplication of LocationOptionMeta entries in the database and preventing ambiguity when the importer next comes along to reuse which "City of Bath" to reuse for the next data set that uses it for a location option.

As it went, FilterOptionMetaLinks already had the PublicId on it so it wasn't necessary to make any changes to the filter model.

## Adding PublicIds to the mappings for optimised mapping application

During the applying of mappings when importing the next data set version's metadata, for each new piece of meta that's going into the tables we need to see if they should be adopting a predecessor's PublicId, or generating a new one because they haven't been mapped.

To do this, we generate the "mapping key" (or "candidate key") for that new piece of meta, and see if any mappings that were made in the previous step are referencing that mapping key via their "CandidateKey" field.  If they are, we need to find the original piece of meta's PublicId and adopt it.  This could have been achieved by reading the previous data set version's meta from the database and attempting to match pieces of old meta to their counterparts in the new version, and then finding the original one's Public Id from there, but I felt that it would be a lot more efficient just to store the PublicId in the mapping JSON itself so that it's immediately available in the code when it's needed, without any additional db lookups or object comparisons being necessary.

## Using GetRowKeyPretty() over GetRowKey() for generating mapping keys

Whilst showing the mapping JSON to Amy, I became aware that the mapping keys we were currently using for Location Options were quite mysterious-looking and prone to breaking in a tricky-to-debug way if for any reason someone were to choose to reorder the various codes being output in `GetRowKey()`.

I therefore created `GetRowKeyPretty()` to include the names of the various Code fields alongside their respective values, so that we can more easily see at a glance what all the various codes mean.  To improve space-saving and efficiency of looking up the key, only the non-null Code fields are included in the generated key.