### PR TITLE
EES-5337: Increase dev/prod statistics DB size to 600GB/1.5TB respectively

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -108,7 +108,7 @@
       "value": 2147483648
     },
     "maxStatsDbSizeBytes": {
-      "value": 375809638400
+      "value": 644245094400
     },
     "dataFactoryConcurrency": {
       "value": 10

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -93,7 +93,7 @@
       "value": 4294967296
     },
     "maxStatsDbSizeBytes": {
-      "value": 1020054732800
+      "value": 1610612736000
     },
     "publicDataDbExists": {
       "value": false


### PR DESCRIPTION
Preventative measure to accommodate growing statistics database to ensure we don't encounter issues inserting/updating data.

`dev` PR: https://github.com/dfe-analytical-services/explore-education-statistics/pull/5041