### PR TITLE
EES-5239 Add `PreviewToken` to Public API data model

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -59,6 +59,8 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public List<DataSetVersionImport> Imports { get; set; } = [];
 
+    public List<PreviewToken> PreviewTokens { get; set; } = [];
+
     public DateTimeOffset? Published { get; set; }
 
     public DateTimeOffset? Withdrawn { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Database/PublicDataDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Database/PublicDataDbContext.cs
@@ -69,7 +69,8 @@ public class PublicDataDbContext : DbContext
     public DbSet<ChangeSetIndicators> ChangeSetIndicators { get; init; } = null!;
     public DbSet<ChangeSetLocations> ChangeSetLocations { get; init; } = null!;
     public DbSet<ChangeSetTimePeriods> ChangeSetTimePeriods { get; init; } = null!;
-    
+    public DbSet<PreviewToken> PreviewTokens { get; init; } = null!;
+
     public DbSet<JsonFragment> JsonFragments { get; init; } = null!;
     
     public DbSet<JsonBool> JsonBool { get; init; } = null!;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240711142913_EE5239_AddPreviewTokenTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240711142913_EE5239_AddPreviewTokenTable.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
 {
     [DbContext(typeof(PublicDataDbContext))]
-    partial class PublicDataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240711142913_EE5239_AddPreviewTokenTable")]
+    partial class EE5239_AddPreviewTokenTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240711142913_EE5239_AddPreviewTokenTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240711142913_EE5239_AddPreviewTokenTable.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations;
+
+/// <inheritdoc />
+[ExcludeFromCodeCoverage]
+public partial class EE5239_AddPreviewTokenTable : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "PreviewTokens",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uuid", nullable: false),
+                Label = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                DataSetVersionId = table.Column<Guid>(type: "uuid", nullable: false),
+                CreatedByUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                Expiry = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                Updated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_PreviewTokens", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_PreviewTokens_DataSetVersions_DataSetVersionId",
+                    column: x => x.DataSetVersionId,
+                    principalTable: "DataSetVersions",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_PreviewTokens_DataSetVersionId",
+            table: "PreviewTokens",
+            column: "DataSetVersionId");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "PreviewTokens");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
@@ -25,6 +25,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
 
             modelBuilder.HasSequence<int>("FilterOptionMetaLink_seq");
 
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Common.Model.JsonBool", b =>
+                {
+                    b.Property<bool>("BoolValue")
+                        .HasColumnType("boolean");
+
+                    b.ToTable((string)null);
+
+                    b.ToView(null, (string)null);
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Common.Model.JsonFragment", b =>
+                {
+                    b.Property<string>("JsonValue")
+                        .HasColumnType("text");
+
+                    b.ToTable((string)null);
+
+                    b.ToView(null, (string)null);
+                });
+
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.ChangeSetFilterOptions", b =>
                 {
                     b.Property<Guid>("Id")

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/PreviewToken.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/PreviewToken.cs
@@ -1,0 +1,47 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+
+public class PreviewToken : ICreatedUpdatedTimestamps<DateTimeOffset, DateTimeOffset?>
+{
+    public Guid Id { get; set; } = UuidUtils.UuidV7();
+
+    public required string Label { get; set; }
+
+    public required Guid DataSetVersionId { get; set; }
+
+    public DataSetVersion DataSetVersion { get; set; } = null!;
+
+    public required Guid CreatedByUserId { get; set; }
+
+    public DateTimeOffset Created { get; set; }
+
+    public required DateTimeOffset Expiry { get; set; }
+
+    public DateTimeOffset? Updated { get; set; }
+
+    public PreviewTokenStatus Status =>
+        DateTimeOffset.UtcNow > Expiry ? PreviewTokenStatus.Expired : PreviewTokenStatus.Active;
+
+    internal class Config : IEntityTypeConfiguration<PreviewToken>
+    {
+        public void Configure(EntityTypeBuilder<PreviewToken> builder)
+        {
+            builder.Property(pt => pt.Id)
+                .HasValueGenerator<UuidV7ValueGenerator>();
+
+            builder.Property(pt => pt.Label)
+                .HasMaxLength(100);
+        }
+    }
+}
+
+public enum PreviewTokenStatus
+{
+    Active,
+    Expired
+}


### PR DESCRIPTION
This PR adds and configures the `PreviewToken` entity type to the Public API data model, following the writeup of the model in [EES-5239](https://dfedigital.atlassian.net/browse/EES-5239).

There is a zero-to-many relationship between `DataSetVersions` and `PreviewTokens`. `PreviewTokens` is made up of:

- **Id** (uuid) - The primary key of the table and also the security token, assuming that EES-4913 decides to secure the Public API with unique tokens.
- **Label** (character, max 100) - Label of the PreviewToken.
- **DataSetVersionId** (uuid) - Foreign key of the DataSetVersion which owns the PreviewToken.
- **CreatedByUserId** (uuid) - Id of the user in the Admin’s Identity model who created the PreviewToken. This is going to be used when building the view model to get or list PreviewTokens to look up the user and include their email address.
- **Created** (timestamp with timezone) - The created date of the PreviewToken.
- **Expiry** (timestamp with timezone) - The expiry date of the PreviewToken. This will always be set on creation and be updated if a user chooses to ‘expire’ a PreviewToken ahead of its scheduled expiry date.
- **Updated** (timestamp with timezone, optional) - This field exists for consistency with other entity types in the Public Data model. It’s value would only ever be expected to be null,  or the same value as Expiry if a PreviewToken token is updated to ‘expire’ it early. This might change if for example in future we allow a label to be updated or the validity to be extended.