### PR TITLE
EES-5170 handle geojson param casing

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
@@ -262,7 +262,7 @@ export default function MapBlock({
               decimalPlaces={
                 selectedDataSetConfig.dataSet.indicator.decimalPlaces
               }
-              heading={selectedFeature?.properties.name}
+              heading={selectedFeature?.properties.Name}
               title={selectedDataSetConfig.config.label}
               unit={selectedDataSetConfig.dataSet.indicator.unit}
               value={selectedDataSet?.value}

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapGeoJSON.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapGeoJSON.tsx
@@ -142,7 +142,7 @@ export default function MapGeoJSON({
 
             return (
               `<div class="${styles.tooltip}" style="${tooltipStyle}">` +
-              `<p><strong data-testid="chartTooltip-label">${feature.properties.name}</strong></p>` +
+              `<p><strong data-testid="chartTooltip-label">${feature.properties.Name}</strong></p>` +
               `<p class="${styles.tooltipContent}" data-testid="chartTooltip-contents">${content}</p>` +
               `</div>`
             );

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
@@ -147,10 +147,10 @@ export const testMapTableData: TableDataResponse = {
           geoJson: {
             type: 'Feature',
             properties: {
-              code: 'E08000035',
-              lat: 53.8227005,
-              long: -1.50735998,
-              name: 'Leeds',
+              Code: 'E08000035',
+              LAT: 53.8227005,
+              LONG: -1.50735998,
+              Name: 'Leeds',
             },
             geometry: {
               type: 'Polygon',
@@ -235,10 +235,10 @@ export const testMapTableData: TableDataResponse = {
           geoJson: {
             type: 'Feature',
             properties: {
-              code: 'E08000003',
-              lat: 53.4701004,
-              long: -2.23358989,
-              name: 'Manchester',
+              Code: 'E08000003',
+              LAT: 53.4701004,
+              LONG: -2.23358989,
+              Name: 'Manchester',
             },
             geometry: {
               type: 'Polygon',
@@ -294,10 +294,10 @@ export const testMapTableData: TableDataResponse = {
           geoJson: {
             type: 'Feature',
             properties: {
-              code: 'E08000019',
-              lat: 53.40359879,
-              long: -1.54253995,
-              name: 'Sheffield',
+              Code: 'E08000019',
+              LAT: 53.40359879,
+              LONG: -1.54253995,
+              Name: 'Sheffield',
             },
             geometry: {
               type: 'Polygon',
@@ -421,20 +421,20 @@ export const testGeoJsonFeature: GeoJsonFeature = {
   type: 'Feature',
   geometry: { type: 'Polygon', coordinates: [] },
   properties: {
-    code: '',
-    name: '',
-    lat: 1,
-    long: 2,
+    Code: '',
+    Name: '',
+    LAT: 1,
+    LONG: 2,
   },
 };
 
 export const testGeoJsonFeature1: GeoJsonFeature = {
   type: 'Feature',
   properties: {
-    code: 'location-1',
-    lat: 53.8227005,
-    long: -1.50735998,
-    name: 'Location 1',
+    Code: 'location-1',
+    LAT: 53.8227005,
+    LONG: -1.50735998,
+    Name: 'Location 1',
   },
   geometry: {
     type: 'Polygon',
@@ -515,10 +515,10 @@ export const testGeoJsonFeature1: GeoJsonFeature = {
 export const testGeoJsonFeature2: GeoJsonFeature = {
   type: 'Feature',
   properties: {
-    code: 'location-2',
-    lat: 53.4701004,
-    long: -2.23358989,
-    name: 'Location 2',
+    Code: 'location-2',
+    LAT: 53.4701004,
+    LONG: -2.23358989,
+    Name: 'Location 2',
   },
   geometry: {
     type: 'Polygon',
@@ -570,10 +570,10 @@ export const testGeoJsonFeature2: GeoJsonFeature = {
 export const testGeoJsonFeature3: GeoJsonFeature = {
   type: 'Feature',
   properties: {
-    code: 'location-3',
-    lat: 53.40359879,
-    long: -1.54253995,
-    name: 'Location 3',
+    Code: 'location-3',
+    LAT: 53.40359879,
+    LONG: -1.54253995,
+    Name: 'Location 3',
   },
   geometry: {
     type: 'Polygon',

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/createMapDataSetCategories.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/createMapDataSetCategories.ts
@@ -25,21 +25,11 @@ export default function createMapDataSetCategories(
     includeNonNumericData: true,
   })
     .map(category => {
-      const geo = meta.locations.find(
-        location => location.id === category.filter.id,
-      )?.geoJson;
-
       return {
         ...category,
-        geoJson: {
-          ...geo,
-          properties: {
-            code: geo?.properties.Code,
-            name: geo?.properties.Name,
-            lat: geo?.properties.LAT,
-            long: geo?.properties.LONG,
-          },
-        },
+        geoJson: meta.locations.find(
+          location => location.id === category.filter.id,
+        )?.geoJson,
       };
     })
     .filter(category => !!category?.geoJson) as MapDataSetCategory[];

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -40,11 +40,11 @@ export interface BoundaryLevel {
 }
 
 export interface GeoJsonFeatureProperties {
-  // these are what is required
-  code: string;
-  name: string;
-  long: number;
-  lat: number;
+  // these are what is required - Note the casing here.
+  Code: string;
+  Name: string;
+  LONG: number;
+  LAT: number;
 
   // the following are just named here for easier finding in code completion and not required
   objectid?: number;


### PR DESCRIPTION
Updates the `GeoJsonFeatureProperties` type to expect the same casing of parameter names as is returned by the back end and updates the test data to fix failing unit tests.

It would be preferable if the back end returned the parameters in camelCase but there are some issues here that mean it's not necessarily as simple to do so as we'd like.