### PR TITLE
EES-4914 Add endpoints to create a `PreviewToken` and get a `PreviewToken`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
@@ -1,0 +1,340 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Fixture;
+using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Public.Data;
+
+public abstract class PreviewTokenControllerTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+{
+    private const string BaseUrl = "api/public-data/preview-tokens";
+
+    private static readonly ClaimsPrincipal BauUser = BauUser();
+
+    private static readonly User CreatedByBauUser = new()
+    {
+        Id = BauUser.GetUserId(),
+        Email = "bau.user@test.com"
+    };
+
+    public class CreatePreviewTokenTests(TestApplicationFactory testApp) : PreviewTokenControllerTests(testApp)
+    {
+        public static TheoryData<DataSetVersionStatus> NonDraftDataSetVersionStatuses = new(
+            EnumUtil.GetEnums<DataSetVersionStatus>().Except([DataSetVersionStatus.Draft])
+        );
+
+        [Fact]
+        public async Task Success()
+        {
+            DataSet dataSet = DataFixture.DefaultDataSet();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion dataSetVersion = DataFixture
+                .DefaultDataSetVersion()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            await TestApp.AddTestData<ContentDbContext>(context => context.Users.Add(CreatedByBauUser));
+
+            var label = new string('A', count: 100);
+            var response = await CreatePreviewToken(dataSetVersion.Id, label);
+
+            var (viewModel, createdEntityId) =
+                response.AssertCreated<PreviewTokenViewModel>(
+                    expectedLocationPrefix: "http://localhost/api/public-data/preview-tokens/");
+            Assert.True(Guid.TryParse(createdEntityId, out var previewTokenId));
+
+            Assert.Multiple(
+                () => Assert.Equal(previewTokenId, viewModel.Id),
+                () => Assert.Equal(label, viewModel.Label),
+                () => Assert.Equal(PreviewTokenStatus.Active, viewModel.Status),
+                () => Assert.Equal(CreatedByBauUser.Email, viewModel.CreatedByEmail),
+                () => viewModel.Created.AssertUtcNow(),
+                () => Assert.Equal(DateTimeOffset.UtcNow.AddDays(1),
+                    viewModel.Expiry,
+                    precision: TimeSpan.FromSeconds(2)),
+                () => Assert.Null(viewModel.Updated)
+            );
+
+            await using var publicDataDbContext = TestApp.GetDbContext<PublicDataDbContext>();
+
+            var actualPreviewToken = Assert.Single(await publicDataDbContext.PreviewTokens.ToListAsync());
+
+            Assert.Multiple(
+                () => Assert.Equal(previewTokenId, actualPreviewToken.Id),
+                () => Assert.Equal(label, actualPreviewToken.Label),
+                () => Assert.Equal(dataSetVersion.Id, actualPreviewToken.DataSetVersionId),
+                () => Assert.Equal(CreatedByBauUser.Id, actualPreviewToken.CreatedByUserId),
+                () => viewModel.Created.AssertUtcNow(),
+                () => Assert.Equal(DateTimeOffset.UtcNow.AddDays(1),
+                    viewModel.Expiry,
+                    precision: TimeSpan.FromSeconds(2)),
+                () => Assert.Null(actualPreviewToken.Updated)
+            );
+        }
+
+        [Theory]
+        [MemberData(nameof(NonDraftDataSetVersionStatuses))]
+        public async Task DataSetVersionIsNotDraft_ReturnsValidationProblem(DataSetVersionStatus status)
+        {
+            DataSet dataSet = DataFixture.DefaultDataSet();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion dataSetVersion = DataFixture
+                .DefaultDataSetVersion()
+                .WithDataSet(dataSet)
+                .WithStatus(status)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var response = await CreatePreviewToken(dataSetVersion.Id, "Label");
+
+            var validationProblem = response.AssertValidationProblem();
+
+            validationProblem.AssertHasError(
+                expectedCode: ValidationMessages.DataSetVersionStatusNotDraft.Code,
+                expectedMessage: ValidationMessages.DataSetVersionStatusNotDraft.Message,
+                expectedPath: nameof(PreviewTokenCreateRequest.DataSetVersionId).ToLowerFirst());
+        }
+
+        [Fact]
+        public async Task DataSetVersionIdIsEmpty_ReturnsValidationProblem()
+        {
+            var response = await CreatePreviewToken(dataSetVersionId: Guid.Empty, "Label");
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+            validationProblem.AssertHasNotEmptyError(nameof(PreviewTokenCreateRequest.DataSetVersionId).ToLowerFirst());
+        }
+
+        [Fact]
+        public async Task LabelIsEmpty_ReturnsValidationProblem()
+        {
+            var response = await CreatePreviewToken(Guid.NewGuid(), label: string.Empty);
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+            validationProblem.AssertHasNotEmptyError(nameof(PreviewTokenCreateRequest.Label).ToLowerFirst());
+        }
+
+        [Fact]
+        public async Task LabelAboveMaximumLength_ReturnsValidationProblem()
+        {
+            var response = await CreatePreviewToken(Guid.NewGuid(), label: new string('A', count: 101));
+
+            var validationProblem = response.AssertValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+            validationProblem.AssertHasMaximumLengthError(nameof(PreviewTokenCreateRequest.Label).ToLowerFirst(),
+                maxLength: 100);
+        }
+
+        [Fact]
+        public async Task NoDataSetVersion_ReturnsNotFound()
+        {
+            var response = await CreatePreviewToken(dataSetVersionId: Guid.NewGuid(), "Label");
+            response.AssertNotFound();
+        }
+
+        [Fact]
+        public async Task NotBauUser_ReturnsForbidden()
+        {
+            DataSet dataSet = DataFixture.DefaultDataSet();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion dataSetVersion = DataFixture
+                .DefaultDataSetVersion()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var client = BuildApp(AuthenticatedUser()).CreateClient();
+
+            var response = await CreatePreviewToken(dataSetVersion.Id, "Label", client);
+
+            response.AssertForbidden();
+        }
+
+        private async Task<HttpResponseMessage> CreatePreviewToken(
+            Guid dataSetVersionId,
+            string label,
+            HttpClient? client = null)
+        {
+            client ??= BuildApp().CreateClient();
+
+            var request = new PreviewTokenCreateRequest
+            {
+                DataSetVersionId = dataSetVersionId,
+                Label = label
+            };
+
+            return await client.PostAsJsonAsync(BaseUrl, request);
+        }
+    }
+
+    public class GetPreviewTokenTests(TestApplicationFactory testApp) : PreviewTokenControllerTests(testApp)
+    {
+        [Fact]
+        public async Task Success()
+        {
+            DataSet dataSet = DataFixture.DefaultDataSet();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion dataSetVersion = DataFixture
+                .DefaultDataSetVersion()
+                .WithDataSet(dataSet)
+                .WithPreviewTokens(() => DataFixture.DefaultPreviewToken()
+                    .WithCreatedByUserId(CreatedByBauUser.Id)
+                    .Generate(2))
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            await TestApp.AddTestData<ContentDbContext>(context => context.Users.Add(CreatedByBauUser));
+
+            var previewToken = dataSetVersion.PreviewTokens[0];
+
+            var response = await GetPreviewToken(previewToken.Id);
+
+            var expectedResult = new PreviewTokenViewModel
+            {
+                Id = previewToken.Id,
+                Label = previewToken.Label,
+                Status = PreviewTokenStatus.Active,
+                Created = previewToken.Created,
+                CreatedByEmail = CreatedByBauUser.Email,
+                Expiry = previewToken.Expiry,
+                Updated = previewToken.Updated
+            };
+
+            response.AssertOk(expectedResult);
+        }
+
+        [Fact]
+        public async Task ExpiryInPast_StatusIsExpired()
+        {
+            DataSet dataSet = DataFixture.DefaultDataSet();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion dataSetVersion = DataFixture
+                .DefaultDataSetVersion()
+                .WithDataSet(dataSet)
+                .WithPreviewTokens(() => DataFixture.DefaultPreviewToken()
+                    .WithExpiry(DateTimeOffset.UtcNow.AddSeconds(-1))
+                    .WithCreatedByUserId(CreatedByBauUser.Id)
+                    .Generate(1))
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            await TestApp.AddTestData<ContentDbContext>(context => context.Users.Add(CreatedByBauUser));
+
+            var previewToken = dataSetVersion.PreviewTokens[0];
+
+            var response = await GetPreviewToken(previewToken.Id);
+
+            var viewModel = response.AssertOk<PreviewTokenViewModel>();
+            Assert.Equal(PreviewTokenStatus.Expired, viewModel.Status);
+        }
+
+        [Fact]
+        public async Task NoPreviewToken_ReturnsNotFound()
+        {
+            var response = await GetPreviewToken(previewTokenId: Guid.NewGuid());
+            response.AssertNotFound();
+        }
+
+        [Fact]
+        public async Task NotBauUser_ReturnsForbidden()
+        {
+            DataSet dataSet = DataFixture.DefaultDataSet();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion dataSetVersion = DataFixture
+                .DefaultDataSetVersion()
+                .WithDataSet(dataSet)
+                .WithPreviewTokens(() => DataFixture.DefaultPreviewToken()
+                    .Generate(1))
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var client = BuildApp(AuthenticatedUser()).CreateClient();
+
+            var response = await GetPreviewToken(dataSetVersion.PreviewTokens[0].Id, client);
+
+            response.AssertForbidden();
+        }
+
+        private async Task<HttpResponseMessage> GetPreviewToken(
+            Guid previewTokenId,
+            HttpClient? client = null)
+        {
+            client ??= BuildApp().CreateClient();
+
+            var uri = new Uri($"{BaseUrl}/{previewTokenId}", UriKind.Relative);
+
+            return await client.GetAsync(uri);
+        }
+    }
+
+    private WebApplicationFactory<TestStartup> BuildApp(ClaimsPrincipal? user = null)
+    {
+        return TestApp.SetUser(user ?? BauUser);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/PreviewTokenController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/PreviewTokenController.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Public.Data;
+
+[Authorize]
+[ApiController]
+[Route("api/public-data/preview-tokens")]
+public class PreviewTokenController(IPreviewTokenService previewTokenService) : ControllerBase
+{
+    [HttpPost]
+    public async Task<ActionResult<PreviewTokenViewModel>> CreatePreviewToken(
+        [FromBody] PreviewTokenCreateRequest request,
+        CancellationToken cancellationToken)
+    {
+        return await previewTokenService
+            .CreatePreviewToken(request.DataSetVersionId, request.Label, cancellationToken)
+            .HandleFailuresOr(previewToken =>
+                CreatedAtAction(nameof(GetPreviewToken), new { previewTokenId = previewToken.Id }, previewToken));
+    }
+
+    [HttpGet("{previewTokenId:guid}")]
+    public async Task<ActionResult<PreviewTokenViewModel>> GetPreviewToken(
+        Guid previewTokenId,
+        CancellationToken cancellationToken)
+    {
+        return await previewTokenService
+            .GetPreviewToken(previewTokenId, cancellationToken)
+            .HandleFailuresOrOk();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/PreviewTokenCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/PreviewTokenCreateRequest.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System;
+using FluentValidation;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
+
+public record PreviewTokenCreateRequest
+{
+    public required Guid DataSetVersionId { get; init; }
+
+    public required string Label { get; init; }
+
+    public class Validator : AbstractValidator<PreviewTokenCreateRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.DataSetVersionId)
+                .NotEmpty();
+
+            RuleFor(request => request.Label)
+                .NotEmpty()
+                .MaximumLength(100);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPreviewTokenService.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
+
+public interface IPreviewTokenService
+{
+    Task<Either<ActionResult, PreviewTokenViewModel>> CreatePreviewToken(
+        Guid dataSetVersionId,
+        string label,
+        CancellationToken cancellationToken = default);
+
+    Task<Either<ActionResult, PreviewTokenViewModel>> GetPreviewToken(
+        Guid previewTokenId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PreviewTokenService.cs
@@ -1,0 +1,104 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationMessages;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
+
+public class PreviewTokenService(
+    ContentDbContext contentDbContext,
+    PublicDataDbContext publicDataDbContext,
+    IUserService userService
+) : IPreviewTokenService
+{
+    public async Task<Either<ActionResult, PreviewTokenViewModel>> CreatePreviewToken(
+        Guid dataSetVersionId,
+        string label,
+        CancellationToken cancellationToken = default)
+    {
+        return await userService.CheckIsBauUser()
+            .OnSuccess(async () => await CheckDataSetVersionExists(dataSetVersionId, cancellationToken))
+            .OnSuccessDo(ValidateDraftDataSetVersion)
+            .OnSuccess(async () =>
+            {
+                var previewToken = publicDataDbContext.PreviewTokens.Add(new PreviewToken
+                {
+                    DataSetVersionId = dataSetVersionId,
+                    Label = label,
+                    Expiry = DateTimeOffset.UtcNow.AddDays(1),
+                    CreatedByUserId = userService.GetUserId()
+                });
+                await publicDataDbContext.SaveChangesAsync(cancellationToken);
+                return await MapPreviewToken(previewToken.Entity);
+            });
+    }
+
+    public async Task<Either<ActionResult, PreviewTokenViewModel>> GetPreviewToken(
+        Guid previewTokenId,
+        CancellationToken cancellationToken = default)
+    {
+        return await userService.CheckIsBauUser()
+            .OnSuccess(async () => await publicDataDbContext.PreviewTokens
+                .AsNoTracking()
+                .SingleOrNotFoundAsync(pt => pt.Id == previewTokenId, cancellationToken: cancellationToken))
+            .OnSuccess(MapPreviewToken);
+    }
+
+    private async Task<Either<ActionResult, DataSetVersion>> CheckDataSetVersionExists(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken)
+    {
+        return await publicDataDbContext.DataSetVersions
+            .AsNoTracking()
+            .SingleOrNotFoundAsync(dsv => dsv.Id == dataSetVersionId, cancellationToken);
+    }
+
+    private static Either<ActionResult, Unit> ValidateDraftDataSetVersion(DataSetVersion dataSetVersion)
+    {
+        return dataSetVersion.Status != DataSetVersionStatus.Draft
+            ? ValidationUtils.ValidationResult(new ErrorViewModel
+            {
+                Code = ValidationMessages.DataSetVersionStatusNotDraft.Code,
+                Message = ValidationMessages.DataSetVersionStatusNotDraft.Message,
+                Path = nameof(PreviewTokenCreateRequest.DataSetVersionId).ToLowerFirst(),
+                Detail = new InvalidErrorDetail<Guid>(dataSetVersion.Id)
+            })
+            : Unit.Instance;
+    }
+
+    private async Task<PreviewTokenViewModel> MapPreviewToken(PreviewToken previewToken)
+    {
+        var createdByEmail = await contentDbContext.Users
+            .Where(u => u.Id == previewToken.CreatedByUserId)
+            .Select(u => u.Email)
+            .SingleAsync();
+
+        return new PreviewTokenViewModel
+        {
+            Id = previewToken.Id,
+            Label = previewToken.Label,
+            Status = previewToken.Status,
+            CreatedByEmail = createdByEmail,
+            Created = previewToken.Created,
+            Expiry = previewToken.Expiry,
+            Updated = previewToken.Updated
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -460,6 +460,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                 services.AddTransient<IDataSetService, DataSetService>();
                 services.AddTransient<IDataSetVersionService, DataSetVersionService>();
                 services.AddTransient<IDataSetVersionMappingService, DataSetVersionMappingService>();
+                services.AddTransient<IPreviewTokenService, PreviewTokenService>();
             }
             else
             {
@@ -473,6 +474,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
 
                 services.AddTransient<IDataSetVersionService, NoOpDataSetVersionService>();
                 services.AddTransient<IDataSetVersionMappingService, NoOpDataSetVersionMappingService>();
+                services.AddTransient<IPreviewTokenService, NoOpPreviewTokenService>();
             }
 
             services.AddTransient<INotificationClient>(s =>
@@ -814,6 +816,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
 
         public Task<Either<ActionResult, BatchFilterOptionMappingUpdatesResponseViewModel>> ApplyBatchFilterOptionMappingUpdates(Guid nextDataSetVersionId,
             BatchFilterOptionMappingUpdatesRequest request,
+            CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+    }
+
+    internal class NoOpPreviewTokenService : IPreviewTokenService
+    {
+        public Task<Either<ActionResult, PreviewTokenViewModel>> CreatePreviewToken(
+            Guid dataSetVersionId,
+            string label,
+            CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task<Either<ActionResult, PreviewTokenViewModel>> GetPreviewToken(
+            Guid previewTokenId,
             CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -11,6 +11,11 @@ public static class ValidationMessages
         Message: "The file cannot be deleted as it is linked to an API data set."
     );
 
+    public static readonly LocalizableMessage DataSetVersionStatusNotDraft = new(
+        Code: nameof(DataSetVersionStatusNotDraft),
+        Message: "The data set version is not in draft status."
+    );
+
     public static readonly LocalizableMessage DataSetVersionMappingSourcePathDoesNotExist = new(
         Code: nameof(DataSetVersionMappingSourcePathDoesNotExist),
         Message: "The source mapping does not exist."
@@ -35,7 +40,7 @@ public static class ValidationMessages
         Code: nameof(CandidateKeyMustBeEmptyWithNoneMappingType),
         Message: $"Value must be empty if type is {nameof(MappingType.ManualNone)}"
     );
-    
+
     public static readonly LocalizableMessage OwningFilterNotMapped = new(
         Code: nameof(OwningFilterNotMapped),
         Message: "The filter that owns this filter option has not been mapped."

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/PreviewTokenViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/PreviewTokenViewModel.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
+
+public record PreviewTokenViewModel
+{
+    public Guid Id { get; set; } = UuidUtils.UuidV7();
+
+    public required string Label { get; set; }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public required PreviewTokenStatus Status { get; set; }
+
+    public required string CreatedByEmail { get; set; }
+
+    public required DateTimeOffset Created { get; set; }
+
+    public required DateTimeOffset Expiry { get; set; }
+
+    public required DateTimeOffset? Updated { get; set; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/HttpResponseMessageTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/HttpResponseMessageTestExtensions.cs
@@ -39,6 +39,24 @@ public static class HttpResponseMessageTestExtensions
         return message.AssertBodyEqualTo(expectedBody, useSystemJson);
     }
 
+    public static (T body, string createdEntityId) AssertCreated<T>(
+        this HttpResponseMessage message,
+        string expectedLocationPrefix,
+        bool useSystemJson = false)
+    {
+        Assert.Equal(Created, message.StatusCode);
+        Assert.NotNull(message.Headers.Location);
+
+        var locationHeader = message.Headers.Location.ToString();
+        Assert.StartsWith(expectedLocationPrefix, locationHeader);
+        var createdEntityId = locationHeader[expectedLocationPrefix.Length..];
+
+        var body = Deserialize<T>(message, useSystemJson);
+        var bodyAsType = Assert.IsType<T>(body);
+
+        return (bodyAsType, createdEntityId);
+    }
+
     public static T AssertCreated<T>(
         this HttpResponseMessage message,
         T expectedBody,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
@@ -175,6 +175,11 @@ public static class DataSetVersionGeneratorExtensions
         IEnumerable<ChangeSetTimePeriods> timePeriodChanges)
         => generator.ForInstance(s => s.SetTimePeriodChanges(timePeriodChanges));
 
+    public static Generator<DataSetVersion> WithPreviewTokens(
+        this Generator<DataSetVersion> generator,
+        Func<IEnumerable<PreviewToken>> previewTokens)
+        => generator.ForInstance(s => s.SetPreviewTokens(previewTokens));
+
     public static InstanceSetters<DataSetVersion> SetDefaults(this InstanceSetters<DataSetVersion> setters)
         => setters
             .SetDefault(dsv => dsv.Id)
@@ -481,5 +486,21 @@ public static class DataSetVersionGeneratorExtensions
                     }
                 )
                 .ToList()
+        );
+
+    public static InstanceSetters<DataSetVersion> SetPreviewTokens(
+        this InstanceSetters<DataSetVersion> instanceSetter,
+        Func<IEnumerable<PreviewToken>> previewTokens)
+        => instanceSetter.Set(
+            (_, dsv) =>
+            {
+                dsv.PreviewTokens = previewTokens().ToList();
+
+                foreach (var previewToken in dsv.PreviewTokens)
+                {
+                    previewToken.DataSetVersion = dsv;
+                    previewToken.DataSetVersionId = dsv.Id;
+                }
+            }
         );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/PreviewTokenGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/PreviewTokenGeneratorExtensions.cs
@@ -1,0 +1,72 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+
+public static class PreviewTokenGeneratorExtensions
+{
+    public static Generator<PreviewToken> DefaultPreviewToken(this DataFixture fixture)
+        => fixture.Generator<PreviewToken>().WithDefaults();
+
+    public static Generator<PreviewToken> WithDefaults(this Generator<PreviewToken> generator)
+        => generator.ForInstance(s => s.SetDefaults());
+
+    public static Generator<PreviewToken> WithDataSetVersion(
+        this Generator<PreviewToken> generator,
+        DataSetVersion dataSetVersion)
+        => generator.ForInstance(s => s.SetDataSetVersion(dataSetVersion));
+
+    public static Generator<PreviewToken> WithDataSetVersionId(
+        this Generator<PreviewToken> generator,
+        Guid dataSetVersionId)
+        => generator.ForInstance(s => s.SetDataSetVersionId(dataSetVersionId));
+
+    public static Generator<PreviewToken> WithCreatedByUserId(
+        this Generator<PreviewToken> generator,
+        Guid createdByUserId)
+        => generator.ForInstance(s => s.SetCreatedByUserId(createdByUserId));
+
+    public static Generator<PreviewToken> WithExpiry(
+        this Generator<PreviewToken> generator,
+        DateTimeOffset expiry)
+        => generator.ForInstance(s => s.SetExpiry(expiry));
+
+    public static Generator<PreviewToken> WithLabel(
+        this Generator<PreviewToken> generator,
+        string label)
+        => generator.ForInstance(s => s.SetLabel(label));
+
+    public static InstanceSetters<PreviewToken> SetDefaults(this InstanceSetters<PreviewToken> setters)
+        => setters
+            .SetDefault(pt => pt.Id)
+            .SetDefault(pt => pt.Label)
+            .SetDefault(pt => pt.DataSetVersionId)
+            .SetDefault(pt => pt.CreatedByUserId)
+            .Set(pt => pt.Expiry, DateTimeOffset.UtcNow.AddDays(1));
+
+    public static InstanceSetters<PreviewToken> SetDataSetVersion(
+        this InstanceSetters<PreviewToken> instanceSetter,
+        DataSetVersion dataSetVersion)
+        => instanceSetter
+            .Set(pt => pt.DataSetVersion, dataSetVersion)
+            .Set(pt => pt.DataSetVersionId, dataSetVersion.Id);
+
+    public static InstanceSetters<PreviewToken> SetDataSetVersionId(
+        this InstanceSetters<PreviewToken> instanceSetter,
+        Guid dataSetVersionId)
+        => instanceSetter.Set(pt => pt.DataSetVersionId, dataSetVersionId);
+
+    public static InstanceSetters<PreviewToken> SetCreatedByUserId(
+        this InstanceSetters<PreviewToken> instanceSetter,
+        Guid createdByUserId)
+        => instanceSetter.Set(pt => pt.CreatedByUserId, createdByUserId);
+
+    public static InstanceSetters<PreviewToken> SetExpiry(
+        this InstanceSetters<PreviewToken> instanceSetter,
+        DateTimeOffset expiry)
+        => instanceSetter.Set(pt => pt.Expiry, expiry);
+
+    public static InstanceSetters<PreviewToken> SetLabel(
+        this InstanceSetters<PreviewToken> instanceSetter,
+        string label)
+        => instanceSetter.Set(pt => pt.Label, label);
+}


### PR DESCRIPTION
This PR adds two new secured Admin endpoints to create a `PreviewToken` and get a `PreviewToken`.

### Create a `PreviewToken`

Creating a new token is a `POST` request which accepts:

- `dataSetVersionId (Guid, required)`: Id of the `DataSetVersion` which the token is being created for and will be owned by.
- `label (string, required, max length 100 characters)` -  Label of the token. 

Example request:

```http
POST https://localhost:5021/api/public-data/preview-tokens
Content-Type: application/json

{
  "dataSetVersionId": "00000000-0000-0000-0000-000000000000",
  "label": "Label"
}
```

If successful it responds with a 201 Created Response including a `Location` header containing a URL to the `PreviewToken` entity.

Example response:

```http
HTTP/1.1 201 Created
Content-Type: application/json; charset=utf-8
Location: https://localhost:5021/api/public-data/preview-tokens/00000000-0000-0000-0000-000000000000

{
  "id": "00000000-0000-0000-0000-000000000000",
  "label": "Label",
  "status": "Active",
  "createdByEmail": "first.last@education.gov.uk",
  "created": "2024-01-01T00:00:00.0000000+00:00",
  "expiry": "2024-01-02T00:00:00.0000000+00:00"
}
```

### Get a `PreviewToken`

This endpoint might not be strictly necessary but has been added to respond with the `PreviewToken` if the URL returned in the 201 Created response is followed.

Getting a token is a `GET` request which accepts the `PreviewToken` id appended as a path parameter.

Example request:

```http
GET https://localhost:5021/api/public-data/preview-tokens/00000000-0000-0000-0000-000000000000
```

Example response:

```http
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8

{
  "id": "00000000-0000-0000-0000-000000000000",
  "label": "Label",
  "status": "Active",
  "createdByEmail": "first.last@education.gov.uk",
  "created": "2024-01-01T00:00:00.0000000+00:00",
  "expiry": "2024-01-02T00:00:00.0000000+00:00"
}
```