### PR TITLE
EES-4529 Update GovukNotify to 7.1.0

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
     <PackageReference Include="GeoJSON.Net" Version="1.2.19" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4" PrivateAssets="all" />
-    <PackageReference Include="GovukNotify" Version="7.0.0" />
+    <PackageReference Include="GovukNotify" Version="7.1.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
     <PackageReference Include="JsonKnownTypes" Version="0.6.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/LoggingNotificationClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/LoggingNotificationClient.cs
@@ -18,9 +18,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _logger = logger;
         }
 
-        public EmailNotificationResponse SendEmail(string emailAddress, string templateId, 
+        public EmailNotificationResponse SendEmail(string emailAddress,
+            string templateId,
             Dictionary<string, dynamic> personalisation = null,
-            string clientReference = null, string emailReplyToId = null)
+            string clientReference = null,
+            string emailReplyToId = null,
+            string oneClickUnsubscribeURL = null)
         {
             return new EmailNotificationResponse();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
-    <PackageReference Include="GovukNotify" Version="7.0.0" />
+    <PackageReference Include="GovukNotify" Version="7.1.0" />
     <PackageReference Include="JWT" Version="10.1.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.5.1" />


### PR DESCRIPTION
This PR is part of the work to update all minor backend dependencies.

The change from GovukNotify 7.0.0 to 7.1.0 includes a change to `SendEmail`, which now includes an additional optional string argument, `oneClickSubscribeURL`.

This addition prevents Admin from building due to `LoggingNotificationClient` implementing `INotificationClient`. 