### PR TITLE
EES-4906 - added restrictions on when to show "Create new version" bu…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -44,7 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
 
             CreateMap<ReleaseVersion, ReleaseViewModel>()
                 .ForMember(
-                    dest => dest.ReleaseSeriesId,
+                    dest => dest.ReleaseId,
                     m => m.MapFrom(rv => rv.ReleaseId))
                 .ForMember(
                     dest => dest.LatestRelease,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -44,6 +44,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
 
             CreateMap<ReleaseVersion, ReleaseViewModel>()
                 .ForMember(
+                    dest => dest.ReleaseSeriesId,
+                    m => m.MapFrom(rv => rv.ReleaseId))
+                .ForMember(
                     dest => dest.LatestRelease,
                     m => m.MapFrom(rv => rv.Publication.LatestPublishedReleaseVersionId == rv.Id))
                 .ForMember(dest => dest.PublicationTitle,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
@@ -187,7 +187,6 @@ internal class DataSetService(
     {
         return await contentDbContext
             .ReleaseFiles
-            .Include(releaseFile => releaseFile.ReleaseVersion)
             .Where(releaseFile => releaseFileIds.Contains(releaseFile.Id))
             .Select(releaseFile => releaseFile.ReleaseVersion.ReleaseId)
             .ToListAsync(cancellationToken);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetViewModels.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -22,6 +23,8 @@ public record DataSetViewModel
     public required DataSetVersionViewModel? DraftVersion { get; init; }
 
     public required DataSetLiveVersionViewModel? LatestLiveVersion { get; init; }
+
+    public required List<Guid> PreviousReleaseIds { get; init; }
 }
 
 public record DataSetSummaryViewModel
@@ -40,4 +43,6 @@ public record DataSetSummaryViewModel
     public required DataSetVersionSummaryViewModel? DraftVersion { get; init; }
 
     public required DataSetLiveVersionSummaryViewModel? LatestLiveVersion { get; init; }
+
+    public required List<Guid> PreviousReleaseIds { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -13,6 +13,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
     {
         public Guid Id { get; set; }
 
+        public Guid ReleaseSeriesId { get; set; }
+        
         public string Title { get; set; } = string.Empty;
 
         public string Slug { get; set; } = string.Empty;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -13,7 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
     {
         public Guid Id { get; set; }
 
-        public Guid ReleaseSeriesId { get; set; }
+        public Guid ReleaseId { get; set; }
         
         public string Title { get; set; } = string.Empty;
 

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationManageReleaseContributorsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationManageReleaseContributorsPage.test.tsx
@@ -27,7 +27,7 @@ const testRelease: Release = {
   amendment: false,
   approvalStatus: 'Draft',
   id: 'release-1',
-  releaseSeriesId: 'release-series-1',
+  releaseId: 'release-series-1',
   latestInternalReleaseNote: 'release1-release-note',
   latestRelease: true,
   live: false,

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationManageReleaseContributorsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationManageReleaseContributorsPage.test.tsx
@@ -27,6 +27,7 @@ const testRelease: Release = {
   amendment: false,
   approvalStatus: 'Draft',
   id: 'release-1',
+  releaseSeriesId: 'release-series-1',
   latestInternalReleaseNote: 'release1-release-note',
   latestRelease: true,
   live: false,

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -157,22 +157,6 @@ const ReleasePageContainer = ({
                 } for ${release.title}`}
               />
             </div>
-
-            {/* EES-2464
-            <div className="govuk-grid-column-one-third">
-              <RelatedInformation heading="Help and guidance">
-                <ul className="govuk-list">
-                  <li>
-                    <Link
-                      to="/documentation/create-new-release"
-                      target="_blank"
-                    >
-                      Creating a new release
-                    </Link>
-                  </li>
-                </ul>
-              </RelatedInformation>
-            </div> */}
           </div>
 
           <Tag>{getReleaseApprovalStatusLabel(release.approvalStatus)}</Tag>

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
@@ -3,6 +3,7 @@ import { Release } from '@admin/services/releaseService';
 // eslint-disable-next-line import/prefer-default-export
 export const testRelease: Release = {
   id: 'release-1',
+  releaseSeriesId: 'release-series-1',
   slug: 'release-1-slug',
   approvalStatus: 'Draft',
   latestRelease: false,

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
@@ -3,7 +3,7 @@ import { Release } from '@admin/services/releaseService';
 // eslint-disable-next-line import/prefer-default-export
 export const testRelease: Release = {
   id: 'release-1',
-  releaseSeriesId: 'release-series-1',
+  releaseId: 'release-series-1',
   slug: 'release-1-slug',
   approvalStatus: 'Draft',
   latestRelease: false,

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -248,7 +248,7 @@ export default function ReleaseApiDataSetDetailsPage() {
             </div>
             {canUpdateRelease &&
               !dataSet.draftVersion &&
-              !dataSet.previousReleaseIds.includes(release.releaseSeriesId) && (
+              !dataSet.previousReleaseIds.includes(release.releaseId) && (
                 <ApiDataSetCreateModal
                   buttonText="Create a new version of this data set"
                   publicationId={release.publicationId}

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -246,22 +246,24 @@ export default function ReleaseApiDataSetDetailsPage() {
                 </div>
               )}
             </div>
-            {canUpdateRelease && !dataSet.draftVersion && (
-              <ApiDataSetCreateModal
-                buttonText="Create a new version of this data set"
-                publicationId={release.publicationId}
-                releaseId={release.id}
-                submitText="Confirm new data set version"
-                title="Create a new API data set version"
-                onSubmit={async ({ releaseFileId }) => {
-                  await apiDataSetVersionService.createVersion({
-                    dataSetId: dataSet.id,
-                    releaseFileId,
-                  });
-                  refetch();
-                }}
-              />
-            )}
+            {canUpdateRelease &&
+              !dataSet.draftVersion &&
+              !dataSet.previousReleaseIds.includes(release.releaseSeriesId) && (
+                <ApiDataSetCreateModal
+                  buttonText="Create a new version of this data set"
+                  publicationId={release.publicationId}
+                  releaseId={release.id}
+                  submitText="Confirm new data set version"
+                  title="Create a new API data set version"
+                  onSubmit={async ({ releaseFileId }) => {
+                    await apiDataSetVersionService.createVersion({
+                      dataSetId: dataSet.id,
+                      releaseFileId,
+                    });
+                    refetch();
+                  }}
+                />
+              )}
           </>
         )}
       </LoadingSpinner>

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -27,6 +27,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     title: 'Data set title',
     summary: 'Data set summary',
     status: 'Published',
+    previousReleaseIds: ['release-id'],
   };
 
   const testLiveVersion: ApiDataSetLiveVersion = {
@@ -359,6 +360,30 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     });
 
     renderPage();
+
+    expect(
+      await screen.findByText('Latest live version details'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Create a new version of this data set',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not render the create new version button when release series includes a previous version of this data set', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      latestLiveVersion: testLiveVersion,
+    });
+
+    renderPage({
+      release: {
+        ...testRelease,
+        releaseSeriesId: testDataSet.previousReleaseIds[0],
+      },
+    });
 
     expect(
       await screen.findByText('Latest live version details'),

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -381,7 +381,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     renderPage({
       release: {
         ...testRelease,
-        releaseSeriesId: testDataSet.previousReleaseIds[0],
+        releaseId: testDataSet.previousReleaseIds[0],
       },
     });
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetLocationsMappingPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetLocationsMappingPage.test.tsx
@@ -67,6 +67,7 @@ describe('ReleaseApiDataSetLocationsMappingPage', () => {
         end: '2023',
       },
     },
+    previousReleaseIds: [],
   };
 
   test('renders the mappings tables correctly', async () => {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/LiveApiDataSetsTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/LiveApiDataSetsTable.tsx
@@ -27,16 +27,16 @@ interface Props {
   canUpdateRelease?: boolean;
   dataSets: LiveApiDataSetSummary[];
   publicationId: string;
+  releaseVersionId: string;
   releaseId: string;
-  releaseSeriesId: string;
 }
 
 export default function LiveApiDataSetsTable({
   canUpdateRelease,
   dataSets,
   publicationId,
+  releaseVersionId,
   releaseId,
-  releaseSeriesId,
 }: Props) {
   const history = useHistory();
 
@@ -76,7 +76,7 @@ export default function LiveApiDataSetsTable({
                     releaseApiDataSetDetailsRoute.path,
                     {
                       publicationId,
-                      releaseId,
+                      releaseId: releaseVersionId,
                       dataSetId: dataSet.id,
                     },
                   )}
@@ -85,7 +85,7 @@ export default function LiveApiDataSetsTable({
                   <VisuallyHidden> for {dataSet.title}</VisuallyHidden>
                 </Link>
                 {canUpdateRelease &&
-                  !dataSet.previousReleaseIds.includes(releaseSeriesId) && (
+                  !dataSet.previousReleaseIds.includes(releaseId) && (
                     <ApiDataSetCreateModal
                       buttonText={
                         <>
@@ -94,7 +94,7 @@ export default function LiveApiDataSetsTable({
                         </>
                       }
                       publicationId={publicationId}
-                      releaseId={releaseId}
+                      releaseId={releaseVersionId}
                       submitText="Confirm new data set version"
                       title="Create a new API data set version"
                       onSubmit={async ({ releaseFileId }) => {
@@ -107,7 +107,7 @@ export default function LiveApiDataSetsTable({
                             releaseApiDataSetDetailsRoute.path,
                             {
                               publicationId,
-                              releaseId,
+                              releaseId: releaseVersionId,
                               dataSetId: dataSet.id,
                             },
                           ),

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/LiveApiDataSetsTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/LiveApiDataSetsTable.tsx
@@ -28,6 +28,7 @@ interface Props {
   dataSets: LiveApiDataSetSummary[];
   publicationId: string;
   releaseId: string;
+  releaseSeriesId: string;
 }
 
 export default function LiveApiDataSetsTable({
@@ -35,6 +36,7 @@ export default function LiveApiDataSetsTable({
   dataSets,
   publicationId,
   releaseId,
+  releaseSeriesId,
 }: Props) {
   const history = useHistory();
 
@@ -82,36 +84,37 @@ export default function LiveApiDataSetsTable({
                   View details
                   <VisuallyHidden> for {dataSet.title}</VisuallyHidden>
                 </Link>
-                {canUpdateRelease && (
-                  <ApiDataSetCreateModal
-                    buttonText={
-                      <>
-                        Create new version
-                        <VisuallyHidden> for {dataSet.title}</VisuallyHidden>
-                      </>
-                    }
-                    publicationId={publicationId}
-                    releaseId={releaseId}
-                    submitText="Confirm new data set version"
-                    title="Create a new API data set version"
-                    onSubmit={async ({ releaseFileId }) => {
-                      await apiDataSetVersionService.createVersion({
-                        dataSetId: dataSet.id,
-                        releaseFileId,
-                      });
-                      history.push(
-                        generatePath<ReleaseDataSetRouteParams>(
-                          releaseApiDataSetDetailsRoute.path,
-                          {
-                            publicationId,
-                            releaseId,
-                            dataSetId: dataSet.id,
-                          },
-                        ),
-                      );
-                    }}
-                  />
-                )}
+                {canUpdateRelease &&
+                  !dataSet.previousReleaseIds.includes(releaseSeriesId) && (
+                    <ApiDataSetCreateModal
+                      buttonText={
+                        <>
+                          Create new version
+                          <VisuallyHidden> for {dataSet.title}</VisuallyHidden>
+                        </>
+                      }
+                      publicationId={publicationId}
+                      releaseId={releaseId}
+                      submitText="Confirm new data set version"
+                      title="Create a new API data set version"
+                      onSubmit={async ({ releaseFileId }) => {
+                        await apiDataSetVersionService.createVersion({
+                          dataSetId: dataSet.id,
+                          releaseFileId,
+                        });
+                        history.push(
+                          generatePath<ReleaseDataSetRouteParams>(
+                            releaseApiDataSetDetailsRoute.path,
+                            {
+                              publicationId,
+                              releaseId,
+                              dataSetId: dataSet.id,
+                            },
+                          ),
+                        );
+                      }}
+                    />
+                  )}
               </ButtonGroup>
             </td>
           </tr>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseApiDataSetsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseApiDataSetsSection.tsx
@@ -129,8 +129,8 @@ export default function ReleaseApiDataSetsSection() {
                   canUpdateRelease={canUpdateRelease}
                   dataSets={liveDataSets}
                   publicationId={release.publicationId}
-                  releaseId={release.id}
-                  releaseSeriesId={release.releaseSeriesId}
+                  releaseVersionId={release.id}
+                  releaseId={release.releaseId}
                 />
               </>
             )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseApiDataSetsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseApiDataSetsSection.tsx
@@ -130,6 +130,7 @@ export default function ReleaseApiDataSetsSection() {
                   dataSets={liveDataSets}
                   publicationId={release.publicationId}
                   releaseId={release.id}
+                  releaseSeriesId={release.releaseSeriesId}
                 />
               </>
             )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateModal.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateModal.test.tsx
@@ -95,6 +95,7 @@ describe('ApiDataSetCreateModal', () => {
       title: 'Test title',
       summary: 'Test summary',
       status: 'Draft',
+      previousReleaseIds: [],
     });
 
     const history = createMemoryHistory();

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DraftApiDataSetsTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DraftApiDataSetsTable.test.tsx
@@ -19,6 +19,7 @@ describe('DraftApiDataSetsTable', () => {
         status: 'Draft',
         type: 'Major',
       },
+      previousReleaseIds: [],
     },
     {
       id: 'data-set-3',
@@ -31,6 +32,7 @@ describe('DraftApiDataSetsTable', () => {
         status: 'Processing',
         type: 'Major',
       },
+      previousReleaseIds: [],
     },
     {
       id: 'data-set-2',
@@ -50,6 +52,7 @@ describe('DraftApiDataSetsTable', () => {
         status: 'Published',
         type: 'Major',
       },
+      previousReleaseIds: [],
     },
     {
       id: 'data-set-1',
@@ -69,6 +72,7 @@ describe('DraftApiDataSetsTable', () => {
         status: 'Published',
         type: 'Major',
       },
+      previousReleaseIds: [],
     },
     {
       id: 'data-set-6',
@@ -81,6 +85,7 @@ describe('DraftApiDataSetsTable', () => {
         status: 'Cancelled',
         type: 'Major',
       },
+      previousReleaseIds: [],
     },
     {
       id: 'data-set-5',
@@ -93,6 +98,7 @@ describe('DraftApiDataSetsTable', () => {
         status: 'Failed',
         type: 'Major',
       },
+      previousReleaseIds: [],
     },
   ];
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/LiveApiDataSetsTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/LiveApiDataSetsTable.test.tsx
@@ -80,13 +80,13 @@ describe('LiveApiDataSetsTable', () => {
         canUpdateRelease
         dataSets={testDataSets}
         publicationId="publication-1"
+        releaseVersionId="release-version-1"
         releaseId="release-1"
-        releaseSeriesId="release-id"
       />,
     );
 
     const baseDataSetUrl =
-      '/publication/publication-1/release/release-1/api-data-sets';
+      '/publication/publication-1/release/release-version-1/api-data-sets';
 
     const rows = within(screen.getByRole('table')).getAllByRole('row');
 
@@ -156,8 +156,8 @@ describe('LiveApiDataSetsTable', () => {
         canUpdateRelease={false}
         dataSets={testDataSets}
         publicationId="publication-1"
-        releaseId="release-1"
-        releaseSeriesId="release-id"
+        releaseVersionId="release-1"
+        releaseId="release-id"
       />,
     );
 
@@ -172,8 +172,8 @@ describe('LiveApiDataSetsTable', () => {
         canUpdateRelease
         dataSets={testDataSets}
         publicationId="publication-1"
-        releaseId="release-1"
-        releaseSeriesId="previous-release-id"
+        releaseVersionId="release-1"
+        releaseId="previous-release-id"
       />,
     );
 
@@ -187,8 +187,8 @@ describe('LiveApiDataSetsTable', () => {
       <LiveApiDataSetsTable
         dataSets={[]}
         publicationId="publication-1"
-        releaseId="release-1"
-        releaseSeriesId="release-id"
+        releaseVersionId="release-1"
+        releaseId="release-id"
       />,
     );
 
@@ -204,8 +204,8 @@ describe('LiveApiDataSetsTable', () => {
         canUpdateRelease
         dataSets={testDataSets}
         publicationId="publication-1"
-        releaseId="release-1"
-        releaseSeriesId="release-id"
+        releaseVersionId="release-1"
+        releaseId="release-id"
       />,
     );
 
@@ -251,8 +251,8 @@ describe('LiveApiDataSetsTable', () => {
         canUpdateRelease
         dataSets={testDataSets}
         publicationId="publication-1"
+        releaseVersionId="release-version-1"
         releaseId="release-1"
-        releaseSeriesId="release-id"
       />,
       { history },
     );
@@ -291,7 +291,7 @@ describe('LiveApiDataSetsTable', () => {
     });
 
     expect(history.location.pathname).toBe(
-      '/publication/publication-1/release/release-1/api-data-sets/data-set-1',
+      '/publication/publication-1/release/release-version-1/api-data-sets/data-set-1',
     );
   });
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/LiveApiDataSetsTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/LiveApiDataSetsTable.test.tsx
@@ -31,6 +31,7 @@ describe('LiveApiDataSetsTable', () => {
         status: 'Published',
         type: 'Major',
       },
+      previousReleaseIds: ['previous-release-id'],
     },
     {
       id: 'data-set-1',
@@ -44,6 +45,7 @@ describe('LiveApiDataSetsTable', () => {
         status: 'Published',
         type: 'Major',
       },
+      previousReleaseIds: ['previous-release-id'],
     },
     {
       id: 'data-set-3',
@@ -57,6 +59,7 @@ describe('LiveApiDataSetsTable', () => {
         status: 'Published',
         type: 'Minor',
       },
+      previousReleaseIds: ['previous-release-id'],
     },
   ];
 
@@ -78,6 +81,7 @@ describe('LiveApiDataSetsTable', () => {
         dataSets={testDataSets}
         publicationId="publication-1"
         releaseId="release-1"
+        releaseSeriesId="release-id"
       />,
     );
 
@@ -153,6 +157,23 @@ describe('LiveApiDataSetsTable', () => {
         dataSets={testDataSets}
         publicationId="publication-1"
         releaseId="release-1"
+        releaseSeriesId="release-id"
+      />,
+    );
+
+    expect(
+      screen.queryAllByRole('button', { name: /Create new version/ }),
+    ).toHaveLength(0);
+  });
+
+  test("does not render 'Create new version' buttons when release series contains previous version of this data set", () => {
+    render(
+      <LiveApiDataSetsTable
+        canUpdateRelease
+        dataSets={testDataSets}
+        publicationId="publication-1"
+        releaseId="release-1"
+        releaseSeriesId="previous-release-id"
       />,
     );
 
@@ -167,6 +188,7 @@ describe('LiveApiDataSetsTable', () => {
         dataSets={[]}
         publicationId="publication-1"
         releaseId="release-1"
+        releaseSeriesId="release-id"
       />,
     );
 
@@ -183,6 +205,7 @@ describe('LiveApiDataSetsTable', () => {
         dataSets={testDataSets}
         publicationId="publication-1"
         releaseId="release-1"
+        releaseSeriesId="release-id"
       />,
     );
 
@@ -218,6 +241,7 @@ describe('LiveApiDataSetsTable', () => {
       title: 'Test title',
       summary: 'Test summary',
       status: 'Draft',
+      previousReleaseIds: [],
     });
 
     const history = createMemoryHistory();
@@ -228,6 +252,7 @@ describe('LiveApiDataSetsTable', () => {
         dataSets={testDataSets}
         publicationId="publication-1"
         releaseId="release-1"
+        releaseSeriesId="release-id"
       />,
       { history },
     );

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseApiDataSetsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseApiDataSetsSection.test.tsx
@@ -50,6 +50,7 @@ describe('ReleaseApiDataSetsSection', () => {
         status: 'Draft',
         type: 'Major',
       },
+      previousReleaseIds: [],
     },
     {
       id: 'data-set-2',
@@ -69,6 +70,7 @@ describe('ReleaseApiDataSetsSection', () => {
         type: 'Major',
         published: '2024-05-01T09:30:00+00:00',
       },
+      previousReleaseIds: [],
     },
     {
       id: 'data-set-3',
@@ -82,6 +84,7 @@ describe('ReleaseApiDataSetsSection', () => {
         type: 'Major',
         published: '2024-05-01T09:30:00+00:00',
       },
+      previousReleaseIds: [],
     },
   ];
 
@@ -234,6 +237,7 @@ describe('ReleaseApiDataSetsSection', () => {
       title: 'Test title',
       summary: 'Test summary',
       status: 'Draft',
+      previousReleaseIds: [],
     });
 
     const history = createMemoryHistory();

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
@@ -37,6 +37,7 @@ const testPublication: Publication = {
 
 const testRelease: Release = {
   id: '123',
+  releaseSeriesId: '456',
   slug: '123',
   approvalStatus: 'Draft',
   updatePublishedDate: false,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
@@ -37,7 +37,7 @@ const testPublication: Publication = {
 
 const testRelease: Release = {
   id: '123',
-  releaseSeriesId: '456',
+  releaseId: '456',
   slug: '123',
   approvalStatus: 'Draft',
   updatePublishedDate: false,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
@@ -108,7 +108,7 @@ const ChartBuilderTabSection = ({
         query: nextQuery,
       });
     },
-    [onTableUpdate, query],
+    [onTableUpdate, query, releaseId],
   );
 
   return (

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -190,6 +190,7 @@ describe('PreReleaseTableToolPage', () => {
 
   const testRelease: Release = {
     id: '123',
+    releaseSeriesId: '456',
     slug: '123',
     approvalStatus: 'Draft',
     updatePublishedDate: false,

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -190,7 +190,7 @@ describe('PreReleaseTableToolPage', () => {
 
   const testRelease: Release = {
     id: '123',
-    releaseSeriesId: '456',
+    releaseId: '456',
     slug: '123',
     approvalStatus: 'Draft',
     updatePublishedDate: false,

--- a/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
@@ -10,6 +10,7 @@ export interface ApiDataSetSummary {
   supersedingDataSetId?: string;
   draftVersion?: ApiDataSetDraftVersionSummary;
   latestLiveVersion?: ApiDataSetLiveVersionSummary;
+  previousReleaseIds: string[];
 }
 
 export interface ApiDataSetVersionSummary {
@@ -36,6 +37,7 @@ export interface ApiDataSet {
   supersedingDataSetId?: string;
   draftVersion?: ApiDataSetDraftVersion;
   latestLiveVersion?: ApiDataSetLiveVersion;
+  previousReleaseIds: string[];
 }
 
 export interface ApiDataSetVersion {

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -21,6 +21,7 @@ export interface ReleasePermissions {
 
 export interface Release {
   id: string;
+  releaseSeriesId: string;
   slug: string;
   approvalStatus: ReleaseApprovalStatus;
   notifySubscribers?: boolean;

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -21,7 +21,7 @@ export interface ReleasePermissions {
 
 export interface Release {
   id: string;
-  releaseSeriesId: string;
+  releaseId: string;
   slug: string;
   approvalStatus: ReleaseApprovalStatus;
   notifySubscribers?: boolean;


### PR DESCRIPTION
This PR:
- fixes a problem whereby the front end was letting you select data set candidates for the next version of an existing data set that would be invalid from the Data Processor's point of view.

## A quick note on terminology in this PR

The front end code still refers to a ReleaseVersion as "Release", and thus the ReleaseVersion's Id is `release.id`.

I actually need to provide ReleaseVersion.ReleaseId so we're able to provide that as a comparison when looking at rendering the "Create new version" buttons for a data set.  Having `release.id` and `release.releaseId` in the front end seemed confusing, so I opted to go for `release.id` and `release.releaseSeriesId` instead in an attempt to be clearer.  Let me know if I succeeded or not!

## The problem scenario

Specifically, the case that it was failing on was attempting to create a next version by using a data set candidate from a release amendment, where a previous version of that amendment contained a previous version of that data set.

For example, we have a "2023 Academic Year" `v0` Release, which contains a `V1.0` version of a data set.

"2023 Academic Year" `v0` gets published.

We then create an amendment of "2023 Academic Year", `v1`, AND upload a new Subject and then attempt to use it as the next `V1.1` version of the same data set that had its `V1.0` version on the `v0` release version.

The Data Processor considers this invalid, because after the amendment "2023 Academic Year" `v1` is published, this would result in the data set's `V1.0` version belonging to a release version that is no longer publicly visible (because the amendment has superseded it).

This PR now will hide the "Create new version" button in both the `Live Data Sets` list view and also on the `API Data Set` page itself when you're looking at it in the context of a release version that already has a version of that same data set in its amendment history.

## The correct user journey

We have a "2023 Academic Year" `v0` Release, which contains a `V1.0` version of a data set.

"2023 Academic Year" `v0` gets published.

The user would then create a "2024 Academic Year" `v0` Release (i.e. a new Release for the next year's statistics), which contains a `V1.1` version of the data set originally created on the 2023 Release.

"2023 Academic Year" `v0` gets published.