### PR TITLE
EES-5346 add mapping complete flags to data set

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 
-public record DataSetVersionViewModel
+public abstract record DataSetVersionViewModel
 {
     public required Guid Id { get; init; }
 
@@ -33,6 +33,11 @@ public record DataSetVersionViewModel
     public IReadOnlyList<string>? Filters { get; init; }
 
     public IReadOnlyList<string>? Indicators { get; init; }
+}
+
+public record DataSetDraftVersionViewModel : DataSetVersionViewModel
+{
+    public MappingStatusViewModel? MappingStatus { get; init; }
 }
 
 public record DataSetLiveVersionViewModel : DataSetVersionViewModel
@@ -66,4 +71,11 @@ public record DataSetVersionSummaryViewModel
 public record DataSetLiveVersionSummaryViewModel : DataSetVersionSummaryViewModel
 {
     public required DateTimeOffset Published { get; init; }
+}
+
+public record MappingStatusViewModel
+{
+    public required bool LocationsComplete { get; init; }
+    
+    public required bool FiltersComplete { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetViewModels.cs
@@ -20,7 +20,7 @@ public record DataSetViewModel
 
     public Guid? SupersedingDataSetId { get; init; }
 
-    public required DataSetVersionViewModel? DraftVersion { get; init; }
+    public required DataSetDraftVersionViewModel? DraftVersion { get; init; }
 
     public required DataSetLiveVersionViewModel? LatestLiveVersion { get; init; }
 

--- a/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
@@ -56,6 +56,10 @@ export interface ApiDataSetDraftVersion extends ApiDataSetVersion {
   geographicLevels?: string[];
   filters?: string[];
   indicators?: string[];
+  mappingStatus?: {
+    locationsComplete: boolean;
+    filtersComplete: boolean;
+  }
 }
 
 export interface ApiDataSetLiveVersion extends ApiDataSetVersion {

--- a/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
@@ -59,7 +59,7 @@ export interface ApiDataSetDraftVersion extends ApiDataSetVersion {
   mappingStatus?: {
     locationsComplete: boolean;
     filtersComplete: boolean;
-  }
+  };
 }
 
 export interface ApiDataSetLiveVersion extends ApiDataSetVersion {


### PR DESCRIPTION
This PR:
- adds flags to the DataSetDraftVersionViewModel to support the rendering of the "Draft version tasks" section of the Data Set Details page in Admin.

We make sure only to fetch the necessary columns themselves from the db to prevent having to load any expensive JSON from the mapping columns that are in the same table.

![image](https://github.com/user-attachments/assets/d1e3bab0-1c6d-4fd0-b6dc-41fa16dcbc35)
