### PR TITLE
EES-4915 Add endpoint to revoke a `PreviewToken`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
@@ -646,9 +646,9 @@ public abstract class PreviewTokenControllerTests(TestApplicationFactory testApp
         {
             client ??= BuildApp().CreateClient();
 
-            var uri = new Uri($"{BaseUrl}/{previewTokenId}", UriKind.Relative);
+            var uri = new Uri($"{BaseUrl}/{previewTokenId}/revoke", UriKind.Relative);
 
-            return await client.DeleteAsync(uri);
+            return await client.PostAsync(uri, content: null);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
@@ -527,6 +527,131 @@ public abstract class PreviewTokenControllerTests(TestApplicationFactory testApp
         }
     }
 
+    public class RevokePreviewTokenTests(TestApplicationFactory testApp) : PreviewTokenControllerTests(testApp)
+    {
+        [Fact]
+        public async Task Success()
+        {
+            DataSet dataSet = DataFixture.DefaultDataSet();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion dataSetVersion = DataFixture
+                .DefaultDataSetVersion()
+                .WithDataSet(dataSet)
+                .WithPreviewTokens(() => DataFixture.DefaultPreviewToken()
+                    .Generate(1))
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var response = await RevokePreviewToken(dataSetVersion.PreviewTokens[0].Id);
+
+            response.AssertNoContent();
+
+            await using var publicDataDbContext = TestApp.GetDbContext<PublicDataDbContext>();
+
+            var actualPreviewToken = await publicDataDbContext.PreviewTokens
+                .SingleAsync(pt => pt.Id == dataSetVersion.PreviewTokens[0].Id);
+
+            Assert.Multiple(
+                () => Assert.Equal(PreviewTokenStatus.Expired, actualPreviewToken.Status),
+                () => actualPreviewToken.Expiry.AssertUtcNow(),
+                () => actualPreviewToken.Updated.AssertUtcNow()
+            );
+        }
+
+        [Fact]
+        public async Task PreviewTokenIsExpired_ReturnsValidationProblem()
+        {
+            DataSet dataSet = DataFixture.DefaultDataSet();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion dataSetVersion = DataFixture
+                .DefaultDataSetVersion()
+                .WithDataSet(dataSet)
+                .WithPreviewTokens(() => DataFixture.DefaultPreviewToken()
+                    .WithExpiry(DateTimeOffset.UtcNow.AddSeconds(-1))
+                    .Generate(1))
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var response = await RevokePreviewToken(dataSetVersion.PreviewTokens[0].Id);
+
+            var validationProblem = response.AssertValidationProblem();
+
+            validationProblem.AssertHasError(
+                expectedPath: "previewTokenId",
+                expectedCode: ValidationMessages.PreviewTokenExpired.Code,
+                expectedMessage: ValidationMessages.PreviewTokenExpired.Message);
+
+            await using var publicDataDbContext = TestApp.GetDbContext<PublicDataDbContext>();
+
+            var actualPreviewToken = await publicDataDbContext.PreviewTokens
+                .SingleAsync(pt => pt.Id == dataSetVersion.PreviewTokens[0].Id);
+
+            Assert.Multiple(
+                () => Assert.Equal(PreviewTokenStatus.Expired, actualPreviewToken.Status),
+                () => Assert.Null(actualPreviewToken.Updated)
+            );
+        }
+
+        [Fact]
+        public async Task NoPreviewToken_ReturnsNotFound()
+        {
+            var response = await RevokePreviewToken(previewTokenId: Guid.NewGuid());
+            response.AssertNotFound();
+        }
+
+        [Fact]
+        public async Task NotBauUser_ReturnsForbidden()
+        {
+            DataSet dataSet = DataFixture.DefaultDataSet();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion dataSetVersion = DataFixture
+                .DefaultDataSetVersion()
+                .WithDataSet(dataSet)
+                .WithPreviewTokens(() => DataFixture.DefaultPreviewToken()
+                    .Generate(1))
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var client = BuildApp(AuthenticatedUser()).CreateClient();
+
+            var response = await RevokePreviewToken(dataSetVersion.PreviewTokens[0].Id, client);
+
+            response.AssertForbidden();
+        }
+
+        private async Task<HttpResponseMessage> RevokePreviewToken(
+            Guid previewTokenId,
+            HttpClient? client = null)
+        {
+            client ??= BuildApp().CreateClient();
+
+            var uri = new Uri($"{BaseUrl}/{previewTokenId}", UriKind.Relative);
+
+            return await client.DeleteAsync(uri);
+        }
+    }
+
     private WebApplicationFactory<TestStartup> BuildApp(ClaimsPrincipal? user = null)
     {
         return TestApp.SetUser(user ?? BauUser);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/PreviewTokenController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/PreviewTokenController.cs
@@ -47,4 +47,14 @@ public class PreviewTokenController(IPreviewTokenService previewTokenService) : 
             .ListPreviewTokens(dataSetVersionId, cancellationToken)
             .HandleFailuresOrOk();
     }
+
+    [HttpDelete("{previewTokenId:guid}")]
+    public async Task<ActionResult> RevokePreviewToken(
+        Guid previewTokenId,
+        CancellationToken cancellationToken)
+    {
+        return await previewTokenService
+            .RevokePreviewToken(previewTokenId, cancellationToken)
+            .HandleFailuresOrNoContent(convertNotFoundToNoContent: false);
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/PreviewTokenController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/PreviewTokenController.cs
@@ -49,12 +49,12 @@ public class PreviewTokenController(IPreviewTokenService previewTokenService) : 
     }
 
     [HttpPost("{previewTokenId:guid}/revoke")]
-    public async Task<ActionResult> RevokePreviewToken(
+    public async Task<ActionResult<PreviewTokenViewModel>> RevokePreviewToken(
         Guid previewTokenId,
         CancellationToken cancellationToken)
     {
         return await previewTokenService
             .RevokePreviewToken(previewTokenId, cancellationToken)
-            .HandleFailuresOrNoContent(convertNotFoundToNoContent: false);
+            .HandleFailuresOrOk();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/PreviewTokenController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/PreviewTokenController.cs
@@ -48,7 +48,7 @@ public class PreviewTokenController(IPreviewTokenService previewTokenService) : 
             .HandleFailuresOrOk();
     }
 
-    [HttpDelete("{previewTokenId:guid}")]
+    [HttpPost("{previewTokenId:guid}/revoke")]
     public async Task<ActionResult> RevokePreviewToken(
         Guid previewTokenId,
         CancellationToken cancellationToken)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPreviewTokenService.cs
@@ -24,7 +24,7 @@ public interface IPreviewTokenService
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default);
 
-    Task<Either<ActionResult, Unit>> RevokePreviewToken(
+    Task<Either<ActionResult, PreviewTokenViewModel>> RevokePreviewToken(
         Guid previewTokenId,
         CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPreviewTokenService.cs
@@ -23,4 +23,8 @@ public interface IPreviewTokenService
     Task<Either<ActionResult, IReadOnlyList<PreviewTokenViewModel>>> ListPreviewTokens(
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default);
+
+    Task<Either<ActionResult, Unit>> RevokePreviewToken(
+        Guid previewTokenId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PreviewTokenService.cs
@@ -71,7 +71,7 @@ public class PreviewTokenService(
             .OnSuccess(async () => await DoList(dataSetVersionId, cancellationToken));
     }
 
-    public async Task<Either<ActionResult, Unit>> RevokePreviewToken(
+    public async Task<Either<ActionResult, PreviewTokenViewModel>> RevokePreviewToken(
         Guid previewTokenId,
         CancellationToken cancellationToken = default)
     {
@@ -79,10 +79,11 @@ public class PreviewTokenService(
             .OnSuccess(async () => await publicDataDbContext.PreviewTokens
                 .SingleOrNotFoundAsync(pt => pt.Id == previewTokenId, cancellationToken: cancellationToken))
             .OnSuccessDo(ValidatePreviewToken)
-            .OnSuccessVoid(async previewToken =>
+            .OnSuccess(async previewToken =>
             {
                 previewToken.Expiry = DateTimeOffset.UtcNow;
                 await publicDataDbContext.SaveChangesAsync(cancellationToken);
+                return await MapPreviewToken(previewToken);
             });
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -841,5 +841,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             Guid dataSetVersionId,
             CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
+
+        public Task<Either<ActionResult, Unit>> RevokePreviewToken(
+            Guid previewTokenId,
+            CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -842,7 +842,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
 
-        public Task<Either<ActionResult, Unit>> RevokePreviewToken(
+        public Task<Either<ActionResult, PreviewTokenViewModel>> RevokePreviewToken(
             Guid previewTokenId,
             CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -114,6 +114,7 @@ public static class ValidationMessages
             Message = string.Format(DatasetNamesCsvReaderException.Message, exception),
         };
     }
+
     public static readonly LocalizableMessage DatasetNamesCsvIncorrectHeaders = new(
         Code: nameof(DatasetNamesCsvIncorrectHeaders),
         Message: "dataset_names.csv has incorrect headers. It should have 'file_name' and 'dataset_name' only."
@@ -277,7 +278,7 @@ public static class ValidationMessages
             Message = string.Format(FileSizeMustNotBeZero.Message, filename),
         };
     }
-    
+
     public static readonly LocalizableMessage DataSetTitleCannotBeEmpty = new(
         Code: nameof(DataSetTitleCannotBeEmpty),
         Message: "Data set title cannot be empty"
@@ -296,5 +297,9 @@ public static class ValidationMessages
             Message = string.Format(DataSetTitleShouldNotContainSpecialCharacters.Message, filename),
         };
     }
-    
+
+    public static readonly LocalizableMessage PreviewTokenExpired = new(
+        Code: nameof(PreviewTokenExpired),
+        Message: "The preview token is expired."
+    );
 }


### PR DESCRIPTION
This PR adds a new secured Admin endpoint to revoke a `PreviewToken`.

## Revoke a `PreviewToken`
Revoking a token is a `POST` request which accepts the `PreviewToken` id appended as a path parameter.

Example request:

```http
POST https://localhost:5021/api/public-data/preview-tokens/00000000-0000-0000-0000-000000000000/revoke
```

### Possible responses

If the request is valid the preview token is revoked by updating the `Expiry` to the current date, and a 200 OK response is returned with body containing the updated preview token resource. 

Example response:

```http
HTTP/1.1 200 OK

{
  "id": "00000000-0000-0000-0000-000000000000",
  "label": "Label",
  "status": "Expired",
  "createdByEmail": "ees-test.bau1@education.gov.uk",
  "created": "2024-07-19T12:42:30.762579+00:00",
  "expiry": "2024-07-19T12:42:39.7281552+00:00",
  "updated": "2024-07-19T12:42:39.7282109+00:00"
}
```

If the preview token is not found a 404 Not Found response is returned.

If the preview token is expired a 400 Bad Request is returned with body containing the error code and message:

```json
  "errors": [
    {
      "message": "The preview token is expired.",
      "path": "previewTokenId",
      "code": "PreviewTokenExpired",
      "detail": {
        "value": "00000000-0000-0000-0000-000000000000"
      }
    }
  ]
```

If the request is not authorised because of an invalid token or the user is not a BAU user a 401 Unauthorized response is returned.