### PR TITLE
EES-4916 Add endpoint to list `PreviewToken`'s

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/PreviewTokenController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/PreviewTokenController.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
@@ -34,6 +35,16 @@ public class PreviewTokenController(IPreviewTokenService previewTokenService) : 
     {
         return await previewTokenService
             .GetPreviewToken(previewTokenId, cancellationToken)
+            .HandleFailuresOrOk();
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<PreviewTokenViewModel>>> ListPreviewTokens(
+        [FromQuery] Guid dataSetVersionId,
+        CancellationToken cancellationToken)
+    {
+        return await previewTokenService
+            .ListPreviewTokens(dataSetVersionId, cancellationToken)
             .HandleFailuresOrOk();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPreviewTokenService.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
@@ -17,5 +18,9 @@ public interface IPreviewTokenService
 
     Task<Either<ActionResult, PreviewTokenViewModel>> GetPreviewToken(
         Guid previewTokenId,
+        CancellationToken cancellationToken = default);
+
+    Task<Either<ActionResult, IReadOnlyList<PreviewTokenViewModel>>> ListPreviewTokens(
+        Guid dataSetVersionId,
         CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -832,5 +832,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             Guid previewTokenId,
             CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
+
+        public Task<Either<ActionResult, IReadOnlyList<PreviewTokenViewModel>>> ListPreviewTokens(
+            Guid dataSetVersionId,
+            CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
This PR adds a new secured Admin endpoint to list the `PreviewToken`'s for a data set version.

## List `PreviewToken`'s
Listing preview tokens is a `GET` request which accepts `dataSetVersionId` appended as a query parameter.

Example request:

```http
GET https://localhost:5021/api/public-data/preview-tokens?dataSetVersionId=00000000-0000-0000-0000-000000000000
```

### Possible responses

If the request is valid a 200 OK response is returned with a body containing the list of preview tokens for the specified data set version in descending expiry date order.

Example response:

```http
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8

[
  {
    "id": "71c09001-0af7-9d71-bd1b-5f01e8d3d131",
    "label": "Token for Cam's testing",
    "status": "Active",
    "createdByEmail": "first.last@education.gov.uk",
    "created": "2024-07-17T11:26:52.68301+00:00",
    "expiry": "2024-07-18T11:26:52.682741+00:00"
  },
  {
    "id": "71c09001-f19a-c477-8596-f3f08fb15058",
    "label": "Token for Ben",
    "status": "Expired",
    "createdByEmail": "first.last@education.gov.uk",
    "created": "2024-07-16T10:01:29.120908+00:00",
    "expiry": "2024-07-17T10:01:29.105472+00:00"
  }
]
```

If the data set version is not found a 404 Not Found response is returned.

If the request is not authorised because of an invalid token or the user is not a BAU user a 401 Unauthorized response is returned.