### PR TITLE
EES-4956 - amending wording of release checklist errors and only show…

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/bau/BoundaryDataUploadPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BoundaryDataUploadPage.tsx
@@ -50,7 +50,9 @@ export default function BoundaryDataUploadPage() {
     return Yup.object({
       boundaryLevel: Yup.string().required('Select a boundary level type'),
       boundaryLevelLabel: Yup.string().required('Enter a boundary level name'),
-      boundaryDataFile: Yup.file().required('Select a boundary file').maxSize(134217728, 'Boundary file must be under 128mb in size'),
+      boundaryDataFile: Yup.file()
+        .required('Select a boundary file')
+        .maxSize(134217728, 'Boundary file must be under 128mb in size'),
       boundaryLevelPublishedDate: Yup.date().required(
         'Enter a boundary file publication date',
       ),

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
@@ -24,6 +24,7 @@ import InsetText from '@common/components/InsetText';
 import React, { useMemo } from 'react';
 import { generatePath } from 'react-router';
 import { publicationMethodologiesRoute } from '@admin/routes/publicationRoutes';
+import { useAuthContext } from '@admin/contexts/AuthContext';
 import { formId } from './ReleaseStatusForm';
 
 interface ChecklistMessage {
@@ -37,6 +38,8 @@ interface Props {
 }
 
 const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
+  const { user } = useAuthContext();
+
   const releaseRouteParams = useMemo<ReleaseRouteParams>(
     () => ({
       releaseId: release.id,
@@ -50,6 +53,13 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
       releaseDataRoute.path,
       releaseRouteParams,
     )}#${releaseDataPageTabIds.dataUploads}`;
+
+    const apiDataSetsTabRoute = user?.permissions.isBauUser
+      ? `${generatePath<ReleaseRouteParams>(
+          releaseDataRoute.path,
+          releaseRouteParams,
+        )}#${releaseDataPageTabIds.apiDataSets}`
+      : undefined;
 
     return checklist.errors.map(error => {
       switch (error.code) {
@@ -126,25 +136,25 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
           };
         case 'PublicApiDataSetImportsMustBeCompleted':
           return {
-            message: 'All Public API data set imports must be completed',
-            link: dataUploadsTabRoute,
+            message: 'All public API data set processing must be completed',
+            link: apiDataSetsTabRoute,
           };
         case 'PublicApiDataSetCancellationsMustBeResolved':
           return {
             message:
-              'All cancelled Public API data set imports must be removed or completed',
-            link: dataUploadsTabRoute,
+              'All cancelled public API data sets must be removed or completed',
+            link: apiDataSetsTabRoute,
           };
         case 'PublicApiDataSetFailuresMustBeResolved':
           return {
             message:
-              'All failed Public API data set imports must be retried or removed',
-            link: dataUploadsTabRoute,
+              'All failed public API data sets must be retried or removed',
+            link: apiDataSetsTabRoute,
           };
         case 'PublicApiDataSetMappingsMustBeCompleted':
           return {
-            message: 'All Public API data set mappings must be completed',
-            link: dataUploadsTabRoute,
+            message: 'All public API data set mappings must be completed',
+            link: apiDataSetsTabRoute,
           };
         default:
           // Show error code, even if there is no mapping,
@@ -154,7 +164,7 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
           };
       }
     });
-  }, [checklist.errors, releaseRouteParams]);
+  }, [checklist.errors, releaseRouteParams, user?.permissions.isBauUser]);
 
   const warnings = useMemo<ChecklistMessage[]>(() => {
     return checklist.warnings.map(warning => {

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
@@ -3,34 +3,47 @@ import { testRelease } from '@admin/pages/release/__data__/testRelease';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
+import { AuthContextTestProvider, User } from '@admin/contexts/AuthContext';
+import { GlobalPermissions } from '@admin/services/authService';
 
 describe('ReleaseStatusChecklist', () => {
   test('renders correctly with errors', () => {
+    const bauUser: User = {
+      id: 'user-id',
+      name: 'BAU',
+      permissions: {
+        isBauUser: true,
+      } as GlobalPermissions,
+    };
+
     render(
-      <MemoryRouter>
-        <ReleaseStatusChecklist
-          checklist={{
-            valid: false,
-            warnings: [],
-            errors: [
-              { code: 'DataFileImportsMustBeCompleted' },
-              { code: 'DataFileReplacementsMustBeCompleted' },
-              { code: 'PublicDataGuidanceRequired' },
-              { code: 'ReleaseNoteRequired' },
-              { code: 'SummarySectionContainsEmptyHtmlBlock' },
-              { code: 'EmptyContentSectionExists' },
-              { code: 'GenericSectionsContainEmptyHtmlBlock' },
-              { code: 'RelatedDashboardsSectionContainsEmptyHtmlBlock' },
-              { code: 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock' },
-              { code: 'PublicApiDataSetImportsMustBeCompleted' },
-              { code: 'PublicApiDataSetCancellationsMustBeResolved' },
-              { code: 'PublicApiDataSetFailuresMustBeResolved' },
-              { code: 'PublicApiDataSetMappingsMustBeCompleted' },
-            ],
-          }}
-          release={testRelease}
-        />
-      </MemoryRouter>,
+      <AuthContextTestProvider user={bauUser}>
+        <MemoryRouter>
+          <ReleaseStatusChecklist
+            checklist={{
+              valid: false,
+              warnings: [],
+              errors: [
+                { code: 'DataFileImportsMustBeCompleted' },
+                { code: 'DataFileReplacementsMustBeCompleted' },
+                { code: 'PublicDataGuidanceRequired' },
+                { code: 'ReleaseNoteRequired' },
+                { code: 'SummarySectionContainsEmptyHtmlBlock' },
+                { code: 'EmptyContentSectionExists' },
+                { code: 'GenericSectionsContainEmptyHtmlBlock' },
+                { code: 'RelatedDashboardsSectionContainsEmptyHtmlBlock' },
+                { code: 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock' },
+                { code: 'PublicApiDataSetImportsMustBeCompleted' },
+                { code: 'PublicApiDataSetCancellationsMustBeResolved' },
+                { code: 'PublicApiDataSetFailuresMustBeResolved' },
+                { code: 'PublicApiDataSetMappingsMustBeCompleted' },
+              ],
+            }}
+            release={testRelease}
+          />
+        </MemoryRouter>
+        ,
+      </AuthContextTestProvider>,
     );
 
     expect(
@@ -126,39 +139,123 @@ describe('ReleaseStatusChecklist', () => {
 
     expect(
       screen.getByRole('link', {
-        name: 'All Public API data set imports must be completed',
+        name: 'All public API data set processing must be completed',
       }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-1/data#data-uploads',
+      '/publication/publication-1/release/release-1/data#api-data-sets',
     );
 
     expect(
       screen.getByRole('link', {
-        name: 'All cancelled Public API data set imports must be removed or completed',
+        name: 'All cancelled public API data sets must be removed or completed',
       }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-1/data#data-uploads',
+      '/publication/publication-1/release/release-1/data#api-data-sets',
     );
 
     expect(
       screen.getByRole('link', {
-        name: 'All failed Public API data set imports must be retried or removed',
+        name: 'All failed public API data sets must be retried or removed',
       }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-1/data#data-uploads',
+      '/publication/publication-1/release/release-1/data#api-data-sets',
     );
 
     expect(
       screen.getByRole('link', {
-        name: 'All Public API data set mappings must be completed',
+        name: 'All public API data set mappings must be completed',
       }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-1/data#data-uploads',
+      '/publication/publication-1/release/release-1/data#api-data-sets',
     );
+  });
+
+  test('does not render api data set links for non-BAU users', () => {
+    const nonBauUser: User = {
+      id: 'user-id',
+      name: 'BAU',
+      permissions: {
+        isBauUser: false,
+      } as GlobalPermissions,
+    };
+
+    render(
+      <AuthContextTestProvider user={nonBauUser}>
+        <MemoryRouter>
+          <ReleaseStatusChecklist
+            checklist={{
+              valid: false,
+              warnings: [],
+              errors: [
+                { code: 'DataFileImportsMustBeCompleted' },
+                { code: 'DataFileReplacementsMustBeCompleted' },
+                { code: 'PublicDataGuidanceRequired' },
+                { code: 'ReleaseNoteRequired' },
+                { code: 'SummarySectionContainsEmptyHtmlBlock' },
+                { code: 'EmptyContentSectionExists' },
+                { code: 'GenericSectionsContainEmptyHtmlBlock' },
+                { code: 'RelatedDashboardsSectionContainsEmptyHtmlBlock' },
+                { code: 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock' },
+                { code: 'PublicApiDataSetImportsMustBeCompleted' },
+                { code: 'PublicApiDataSetCancellationsMustBeResolved' },
+                { code: 'PublicApiDataSetFailuresMustBeResolved' },
+                { code: 'PublicApiDataSetMappingsMustBeCompleted' },
+              ],
+            }}
+            release={testRelease}
+          />
+        </MemoryRouter>
+        ,
+      </AuthContextTestProvider>,
+    );
+
+    expect(
+      screen.getByText('All public API data set processing must be completed'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('link', {
+        name: 'All public API data set processing must be completed',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        'All cancelled public API data sets must be removed or completed',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('link', {
+        name: 'All cancelled public API data sets must be removed or completed',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        'All failed public API data sets must be retried or removed',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('link', {
+        name: 'All failed public API data sets must be retried or removed',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText('All public API data set mappings must be completed'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('link', {
+        name: 'All public API data set mappings must be completed',
+      }),
+    ).not.toBeInTheDocument();
   });
 
   test('renders correctly with warnings', () => {


### PR DESCRIPTION
This PR:
- does no work for EES-4956 because I'd already done it as part of EES-4909!

Instead, this PR:
- amends some wording on the Release Checklist Error messages
- corrects the links associated with API data set checklist errors to go to the API data sets tab
- restricts providing the link to only BAU users in the Release Checklist errors pertaining to public API data set issues

## BAU user view

![image](https://github.com/user-attachments/assets/c5f139ee-bd11-4a1b-a016-4f9c820d93bf)

## Non-BAU user view

![image](https://github.com/user-attachments/assets/0b8fc36b-7365-4bb0-acbd-ae6b7a8851c5)
