### PR TITLE
EES-4929 Adding endpoint to unsubscribe users from API data sets

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ApiSubscriptionFunctionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ApiSubscriptionFunctionsTests.cs
@@ -378,6 +378,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var apiSubscriptionManager = GetRequiredService<ApiSubscriptionFunctions>();
 
             return await apiSubscriptionManager.VerifyApiSubscription(
+                request: null!,
                 dataSetId: dataSetId,
                 token: token,
                 cancellationToken: CancellationToken.None);

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ApiSubscriptionFunctionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ApiSubscriptionFunctionsTests.cs
@@ -1,6 +1,5 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Tests.Functions;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Functions;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Requests;
@@ -24,8 +23,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
     : NotifierFunctionsIntegrationTest(fixture)
 {
     private readonly Guid _dataSetId = Guid.NewGuid();
-    private readonly string _dataSetTitle = "data set title";
-    private readonly string _email = "test@test.com";
+    private const string DataSetTitle = "data set title";
+    private const string Email = "test@test.com";
 
     public class RequestPendingApiSubscriptionTests(NotifierFunctionsIntegrationTestFixture fixture)
         : ApiSubscriptionFunctionsTests(fixture)
@@ -36,12 +35,12 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             string verificationLink = null!;
             fixture._notificationClient
                 .Setup(mock => mock.SendEmail(
-                    _email,
+                    Email,
                     GetGovUkNotifyOptions().EmailTemplates.ApiSubscriptionVerificationId,
                     It.Is<Dictionary<string, dynamic>>(values =>
                         AssertEmailTemplateValues(
                             values,
-                            _dataSetTitle,
+                            DataSetTitle,
                             $"{GetAppSettingsOptions().PublicAppUrl}/api-subscriptions/{_dataSetId}/confirm-subscription/",
                             null)
                     ),
@@ -59,28 +58,28 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
             var result = await RequestPendingApiSubscription(
                 dataSetId: _dataSetId,
-                dataSetTitle: _dataSetTitle,
-                email: _email);
+                dataSetTitle: DataSetTitle,
+                email: Email);
 
             var response = result.AssertOkObjectResult<ApiSubscriptionViewModel>();
 
             Assert.Equal(_dataSetId, response.DataSetId);
-            Assert.Equal(_dataSetTitle, response.DataSetTitle);
-            Assert.Equal(_email, response.Email);
+            Assert.Equal(DataSetTitle, response.DataSetTitle);
+            Assert.Equal(Email, response.Email);
             Assert.Equal(ApiSubscriptionStatus.SubscriptionPending, response.Status);
 
             // Assert that the verification link contains a valid token
             var extractedEmail = ExtractEmailFromSubscriptionLinkToken(verificationLink);
-            Assert.Equal(extractedEmail, _email);
+            Assert.Equal(Email, extractedEmail);
 
             var subscription = await GetApiSubscriptionIfExists(
                 dataSetId: _dataSetId,
-                email: _email);
+                email: Email);
 
             Assert.NotNull(subscription);
-            Assert.Equal(_email, subscription.RowKey);
+            Assert.Equal(Email, subscription.RowKey);
             Assert.Equal(_dataSetId.ToString(), subscription.PartitionKey);
-            Assert.Equal(_dataSetTitle, subscription.DataSetTitle);
+            Assert.Equal(DataSetTitle, subscription.DataSetTitle);
             Assert.Equal(ApiSubscriptionStatus.SubscriptionPending, subscription.Status);
             subscription.Expiry.AssertEqual(DateTimeOffset.UtcNow.AddHours(1));
             subscription.Timestamp.AssertUtcNow();
@@ -92,8 +91,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var subscription = new ApiSubscription
             {
                 PartitionKey = _dataSetId.ToString(),
-                RowKey = _email,
-                DataSetTitle = _dataSetTitle,
+                RowKey = Email,
+                DataSetTitle = DataSetTitle,
                 Status = ApiSubscriptionStatus.SubscriptionPending,
                 Expiry = DateTimeOffset.UtcNow.AddHours(1),
             };
@@ -102,8 +101,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
             var result = await RequestPendingApiSubscription(
                 dataSetId: _dataSetId,
-                dataSetTitle: _dataSetTitle,
-                email: _email);
+                dataSetTitle: DataSetTitle,
+                email: Email);
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
@@ -118,8 +117,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var subscription = new ApiSubscription
             {
                 PartitionKey = _dataSetId.ToString(),
-                RowKey = _email,
-                DataSetTitle = _dataSetTitle,
+                RowKey = Email,
+                DataSetTitle = DataSetTitle,
                 Status = ApiSubscriptionStatus.Subscribed
             };
 
@@ -127,8 +126,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
             var result = await RequestPendingApiSubscription(
                 dataSetId: _dataSetId,
-                dataSetTitle: _dataSetTitle,
-                email: _email);
+                dataSetTitle: DataSetTitle,
+                email: Email);
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
@@ -144,7 +143,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         {
             var result = await RequestPendingApiSubscription(
                 dataSetId: _dataSetId,
-                dataSetTitle: _dataSetTitle,
+                dataSetTitle: DataSetTitle,
                 email: email!);
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
@@ -161,8 +160,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         {
             var result = await RequestPendingApiSubscription(
                 dataSetId: _dataSetId,
-                dataSetTitle: _dataSetTitle,
-                email: email!);
+                dataSetTitle: DataSetTitle,
+                email: email);
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
@@ -174,8 +173,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         {
             var result = await RequestPendingApiSubscription(
                 dataSetId: Guid.Empty,
-                dataSetTitle: _dataSetTitle,
-                email: _email);
+                dataSetTitle: DataSetTitle,
+                email: Email);
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
@@ -190,7 +189,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var result = await RequestPendingApiSubscription(
                 dataSetId: _dataSetId,
                 dataSetTitle: dataSetTitle!,
-                email: _email);
+                email: Email);
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
@@ -200,8 +199,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         private async Task<IActionResult> RequestPendingApiSubscription(
             Guid dataSetId,
             string dataSetTitle,
-            string email,
-            FunctionContext? functionContext = null)
+            string email)
         {
             var request = new PendingApiSubscriptionCreateRequest
             {
@@ -214,13 +212,12 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
             return await apiSubscriptionManager.RequestPendingApiSubscription(
                 request: request,
-                context: functionContext ?? new TestFunctionContext(),
                 cancellationToken: CancellationToken.None);
         }
     }
 
     public class VerifyApiSubscriptionTests(NotifierFunctionsIntegrationTestFixture fixture)
-    : ApiSubscriptionFunctionsTests(fixture)
+        : ApiSubscriptionFunctionsTests(fixture)
     {
         [Fact]
         public async Task Success()
@@ -228,8 +225,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var pendingSubscription = new ApiSubscription
             {
                 PartitionKey = _dataSetId.ToString(),
-                RowKey =_email,
-                DataSetTitle = _dataSetTitle,
+                RowKey = Email,
+                DataSetTitle = DataSetTitle,
                 Status = ApiSubscriptionStatus.SubscriptionPending,
                 Expiry = DateTime.UtcNow.AddHours(1),
             };
@@ -239,12 +236,12 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             string unsubscribeLink = null!;
             fixture._notificationClient
                 .Setup(mock => mock.SendEmail(
-                    _email,
+                    Email,
                     GetGovUkNotifyOptions().EmailTemplates.ApiSubscriptionConfirmationId,
                     It.Is<Dictionary<string, dynamic>>(values =>
                         AssertEmailTemplateValues(
                             values,
-                            _dataSetTitle,
+                            DataSetTitle,
                             null,
                             $"{GetAppSettingsOptions().PublicAppUrl}/api-subscriptions/{_dataSetId}/confirm-unsubscription/")
                     ),
@@ -261,7 +258,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                     => unsubscribeLink = values["unsubscribe_link"]);
 
             var tokenService = GetRequiredService<ITokenService>();
-            var subscribeToken = tokenService.GenerateToken(pendingSubscription.RowKey, pendingSubscription.Expiry.Value.UtcDateTime);
+            var subscribeToken = tokenService.GenerateToken(pendingSubscription.RowKey,
+                pendingSubscription.Expiry.Value.UtcDateTime);
 
             var result = await VerifyApiSubscription(
                 dataSetId: _dataSetId,
@@ -270,22 +268,22 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var response = result.AssertOkObjectResult<ApiSubscriptionViewModel>();
 
             Assert.Equal(_dataSetId, response.DataSetId);
-            Assert.Equal(_dataSetTitle, response.DataSetTitle);
-            Assert.Equal(_email, response.Email);
+            Assert.Equal(DataSetTitle, response.DataSetTitle);
+            Assert.Equal(Email, response.Email);
             Assert.Equal(ApiSubscriptionStatus.Subscribed, response.Status);
 
             // Assert that the unsubscribe link contains a valid token
             var extractedEmail = ExtractEmailFromSubscriptionLinkToken(unsubscribeLink);
-            Assert.Equal(extractedEmail, _email);
+            Assert.Equal(Email, extractedEmail);
 
             var verifiedSubscription = await GetApiSubscriptionIfExists(
                 dataSetId: _dataSetId,
-                email: _email);
+                email: Email);
 
             Assert.NotNull(verifiedSubscription);
-            Assert.Equal(_email, verifiedSubscription.RowKey);
+            Assert.Equal(Email, verifiedSubscription.RowKey);
             Assert.Equal(_dataSetId.ToString(), verifiedSubscription.PartitionKey);
-            Assert.Equal(_dataSetTitle, verifiedSubscription.DataSetTitle);
+            Assert.Equal(DataSetTitle, verifiedSubscription.DataSetTitle);
             Assert.Equal(ApiSubscriptionStatus.Subscribed, verifiedSubscription.Status);
             Assert.Null(verifiedSubscription.Expiry);
             verifiedSubscription.Timestamp.AssertUtcNow();
@@ -295,7 +293,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         public async Task PendingSubscriptionDoesNotExist_404()
         {
             var tokenService = GetRequiredService<ITokenService>();
-            var subscribeToken = tokenService.GenerateToken(_email, DateTime.UtcNow);
+            var subscribeToken = tokenService.GenerateToken(Email, DateTime.UtcNow);
 
             var result = await VerifyApiSubscription(
                 dataSetId: _dataSetId,
@@ -310,8 +308,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var verifiedSubscription = new ApiSubscription
             {
                 PartitionKey = _dataSetId.ToString(),
-                RowKey = _email,
-                DataSetTitle = _dataSetTitle,
+                RowKey = Email,
+                DataSetTitle = DataSetTitle,
                 Status = ApiSubscriptionStatus.Subscribed
             };
 
@@ -337,8 +335,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var verifiedSubscription = new ApiSubscription
             {
                 PartitionKey = _dataSetId.ToString(),
-                RowKey = _email,
-                DataSetTitle = _dataSetTitle,
+                RowKey = Email,
+                DataSetTitle = DataSetTitle,
                 Status = ApiSubscriptionStatus.SubscriptionPending,
                 Expiry = DateTimeOffset.UtcNow.AddHours(-1)
             };
@@ -375,19 +373,17 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
         private async Task<IActionResult> VerifyApiSubscription(
             Guid dataSetId,
-            string token,
-            FunctionContext? functionContext = null)
+            string token)
         {
             var apiSubscriptionManager = GetRequiredService<ApiSubscriptionFunctions>();
 
             return await apiSubscriptionManager.VerifyApiSubscription(
-                context: functionContext ?? new TestFunctionContext(),
                 dataSetId: dataSetId,
                 token: token,
                 cancellationToken: CancellationToken.None);
         }
     }
-    
+
     public class ApiUnsubscribeTests(NotifierFunctionsIntegrationTestFixture fixture)
         : ApiSubscriptionFunctionsTests(fixture)
     {
@@ -397,16 +393,17 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var subscription = new ApiSubscription
             {
                 PartitionKey = _dataSetId.ToString(),
-                RowKey = _email,
-                DataSetTitle = _dataSetTitle,
+                RowKey = Email,
+                DataSetTitle = DataSetTitle,
                 Status = ApiSubscriptionStatus.Subscribed,
-                Expiry = null,
+                Expiry = DateTimeOffset.UtcNow.AddYears(1)
             };
 
             await CreateApiSubscription(subscription);
 
             var tokenService = GetRequiredService<ITokenService>();
-            var unsubscribeToken = tokenService.GenerateToken(subscription.RowKey, DateTime.UtcNow.AddYears(1));
+            var unsubscribeToken =
+                tokenService.GenerateToken(subscription.RowKey, subscription.Expiry.Value.UtcDateTime);
 
             var result = await Unsubscribe(
                 dataSetId: _dataSetId,
@@ -416,7 +413,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
             var deletedSubscription = await GetApiSubscriptionIfExists(
                 dataSetId: _dataSetId,
-                email: _email);
+                email: Email);
 
             Assert.Null(deletedSubscription);
         }
@@ -425,7 +422,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         public async Task SubscriptionDoesNotExist_404()
         {
             var tokenService = GetRequiredService<ITokenService>();
-            var unsubscribeToken = tokenService.GenerateToken(_email, DateTime.UtcNow.AddYears(1));
+            var unsubscribeToken = tokenService.GenerateToken(Email, DateTime.UtcNow.AddYears(1));
 
             var result = await Unsubscribe(
                 dataSetId: _dataSetId,
@@ -440,8 +437,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var subscription = new ApiSubscription
             {
                 PartitionKey = _dataSetId.ToString(),
-                RowKey = _email,
-                DataSetTitle = _dataSetTitle,
+                RowKey = Email,
+                DataSetTitle = DataSetTitle,
                 Status = ApiSubscriptionStatus.SubscriptionPending,
                 Expiry = DateTimeOffset.UtcNow,
             };
@@ -449,7 +446,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             await CreateApiSubscription(subscription);
 
             var tokenService = GetRequiredService<ITokenService>();
-            var unsubscribeToken = tokenService.GenerateToken(subscription.RowKey, subscription.Expiry.Value.UtcDateTime);
+            var unsubscribeToken =
+                tokenService.GenerateToken(subscription.RowKey, subscription.Expiry.Value.UtcDateTime);
 
             var result = await Unsubscribe(
                 dataSetId: _dataSetId,
@@ -480,7 +478,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         public async Task UnsubscribeTokenExpired_400()
         {
             var tokenService = GetRequiredService<ITokenService>();
-            var unsubscribeToken = tokenService.GenerateToken(_email, DateTime.UtcNow.AddYears(-1));
+            var unsubscribeToken = tokenService.GenerateToken(Email, DateTime.UtcNow.AddYears(-1));
 
             var result = await Unsubscribe(
                 dataSetId: _dataSetId,
@@ -495,18 +493,18 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
         private async Task<IActionResult> Unsubscribe(
             Guid dataSetId,
-            string token,
-            FunctionContext? functionContext = null)
+            string token)
         {
             var apiSubscriptionManager = GetRequiredService<ApiSubscriptionFunctions>();
 
             return await apiSubscriptionManager.ApiUnsubscribe(
-                context: functionContext ?? new TestFunctionContext(),
+                request: null!,
                 dataSetId: dataSetId,
                 token: token,
                 cancellationToken: CancellationToken.None);
         }
     }
+
     public class RemoveExpiredApiSubscriptionsTests(NotifierFunctionsIntegrationTestFixture fixture)
         : ApiSubscriptionFunctionsTests(fixture)
     {
@@ -515,27 +513,27 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         {
             var pendingAndExpiredSubscription = new ApiSubscription
             {
-                PartitionKey = _email,
+                PartitionKey = Email,
                 RowKey = Guid.NewGuid().ToString(),
-                DataSetTitle = _dataSetTitle,
+                DataSetTitle = DataSetTitle,
                 Status = ApiSubscriptionStatus.SubscriptionPending,
                 Expiry = DateTime.UtcNow.AddHours(-1),
             };
 
             var pendingSubscription = new ApiSubscription
             {
-                PartitionKey = _email,
+                PartitionKey = Email,
                 RowKey = Guid.NewGuid().ToString(),
-                DataSetTitle = _dataSetTitle,
+                DataSetTitle = DataSetTitle,
                 Status = ApiSubscriptionStatus.SubscriptionPending,
                 Expiry = DateTime.UtcNow.AddHours(1),
             };
 
             var subscribedSubscription = new ApiSubscription
             {
-                PartitionKey = _email,
+                PartitionKey = Email,
                 RowKey = Guid.NewGuid().ToString(),
-                DataSetTitle = _dataSetTitle,
+                DataSetTitle = DataSetTitle,
                 Status = ApiSubscriptionStatus.Subscribed,
                 Expiry = null,
             };
@@ -552,15 +550,12 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             Assert.Single(subscriptions, s => s.RowKey == subscribedSubscription.RowKey);
         }
 
-        private async Task RemoveExpiredApiSubscriptions(
-            TimerInfo? timerInfo = null,
-            FunctionContext? functionContext = null)
+        private async Task RemoveExpiredApiSubscriptions(TimerInfo? timerInfo = null)
         {
             var apiSubscriptionManager = GetRequiredService<ApiSubscriptionFunctions>();
 
             await apiSubscriptionManager.RemoveExpiredApiSubscriptions(
                 timerInfo: timerInfo ?? new TimerInfo(),
-                context: functionContext ?? new TestFunctionContext(),
                 cancellationToken: CancellationToken.None);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
@@ -44,7 +44,8 @@ public class ApiSubscriptionFunctions(
 
     [Function("VerifyApiSubscription")]
     public async Task<IActionResult> VerifyApiSubscription(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "patch", Route = "public-api/{dataSetId:guid}/verify-subscription/{token}")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "public-api/{dataSetId:guid}/verify-subscription/{token}")]
+        HttpRequest request,
         Guid dataSetId,
         string token,
         CancellationToken cancellationToken)

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
@@ -45,7 +45,7 @@ public class ApiSubscriptionFunctions(
 
     [Function("VerifyApiSubscription")]
     public async Task<IActionResult> VerifyApiSubscription(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "public-api/{dataSetId:guid}/verify-subscription/{token}")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "patch", Route = "public-api/{dataSetId:guid}/verify-subscription/{token}")]
         FunctionContext context,
         Guid dataSetId,
         string token,
@@ -58,6 +58,29 @@ public class ApiSubscriptionFunctions(
                 token: token,
                 cancellationToken: cancellationToken)
                 .HandleFailuresOr(subscription => new OkObjectResult(subscription));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(exception: ex, "Exception occured while executing '{FunctionName}'", nameof(VerifyApiSubscription));
+            return new StatusCodeResult(StatusCodes.Status500InternalServerError);
+        }
+    }
+
+    [Function("ApiUnsubscribe")]
+    public async Task<IActionResult> ApiUnsubscribe(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "public-api/{dataSetId:guid}/unsubscribe/{token}")]
+        FunctionContext context,
+        Guid dataSetId,
+        string token,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await apiSubscriptionService.Unsubscribe(
+                dataSetId: dataSetId,
+                token: token,
+                cancellationToken: cancellationToken)
+                .HandleFailuresOrNoContent(convertNotFoundToNoContent: false);
         }
         catch (Exception ex)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
@@ -21,9 +21,8 @@ public class ApiSubscriptionFunctions(
 {
     [Function("RequestPendingApiSubscription")]
     public async Task<IActionResult> RequestPendingApiSubscription(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "public-api/request-pending-subscription/")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "public-api/request-pending-subscription")]
         [FromBody] PendingApiSubscriptionCreateRequest request,
-        FunctionContext context,
         CancellationToken cancellationToken)
     {
         try
@@ -46,7 +45,6 @@ public class ApiSubscriptionFunctions(
     [Function("VerifyApiSubscription")]
     public async Task<IActionResult> VerifyApiSubscription(
         [HttpTrigger(AuthorizationLevel.Anonymous, "patch", Route = "public-api/{dataSetId:guid}/verify-subscription/{token}")]
-        FunctionContext context,
         Guid dataSetId,
         string token,
         CancellationToken cancellationToken)
@@ -69,7 +67,7 @@ public class ApiSubscriptionFunctions(
     [Function("ApiUnsubscribe")]
     public async Task<IActionResult> ApiUnsubscribe(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "public-api/{dataSetId:guid}/unsubscribe/{token}")]
-        FunctionContext context,
+        HttpRequest request,
         Guid dataSetId,
         string token,
         CancellationToken cancellationToken)
@@ -84,7 +82,7 @@ public class ApiSubscriptionFunctions(
         }
         catch (Exception ex)
         {
-            logger.LogError(exception: ex, "Exception occured while executing '{FunctionName}'", nameof(VerifyApiSubscription));
+            logger.LogError(exception: ex, "Exception occured while executing '{FunctionName}'", nameof(ApiUnsubscribe));
             return new StatusCodeResult(StatusCodes.Status500InternalServerError);
         }
     }
@@ -92,7 +90,6 @@ public class ApiSubscriptionFunctions(
     [Function("RemoveExpiredApiSubscriptions")]
     public async Task RemoveExpiredApiSubscriptions(
         [TimerTrigger("0 * * * * *")] TimerInfo timerInfo,
-        FunctionContext context,
         CancellationToken cancellationToken)
     {
         await apiSubscriptionService.RemoveExpiredApiSubscriptions(cancellationToken);

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
@@ -101,7 +101,8 @@ internal class ApiSubscriptionService(
                 dataSetId: dataSetId,
                 email: email,
                 cancellationToken: cancellationToken))
-            .OnSuccess(subscription => DeleteSubscription(subscription: subscription, cancellationToken: cancellationToken));
+            .OnSuccess(subscription =>
+                DeleteSubscription(subscription: subscription, cancellationToken: cancellationToken));
     }
 
     public async Task RemoveExpiredApiSubscriptions(CancellationToken cancellationToken = default)
@@ -126,13 +127,10 @@ internal class ApiSubscriptionService(
             cancellationToken: cancellationToken);
 
         return subscription.IsLeft
-            ? (
-                subscription.Left is NotFoundResult
+            ? subscription.Left is NotFoundResult
                 ? Unit.Instance
                 : subscription.Left
-            )
-            : (
-                subscription.Right.Status is ApiSubscriptionStatus.SubscriptionPending
+            : subscription.Right.Status is ApiSubscriptionStatus.SubscriptionPending
                 ? ValidationUtils.ValidationResult(new ErrorViewModel
                 {
                     Code = ValidationMessages.ApiPendingSubscriptionAlreadyExists.Code,
@@ -146,14 +144,13 @@ internal class ApiSubscriptionService(
                     Message = ValidationMessages.ApiVerifiedSubscriptionAlreadyExists.Message,
                     Detail = new ApiSubscriptionErrorDetail(dataSetId, email),
                     Path = nameof(PendingApiSubscriptionCreateRequest.DataSetId).ToLowerFirst()
-                })
-            );
+                });
     }
 
     private async Task<Either<ActionResult, ApiSubscription>> GetSubscription(
-    Guid dataSetId,
-    string email,
-    CancellationToken cancellationToken)
+        Guid dataSetId,
+        string email,
+        CancellationToken cancellationToken)
     {
         var subscription = await apiSubscriptionRepository.GetSubscription(
             dataSetId: dataSetId,
@@ -198,7 +195,8 @@ internal class ApiSubscriptionService(
             : email;
     }
 
-    private async Task<Either<ActionResult, Unit>> VerifySubscription(ApiSubscription subscription, CancellationToken cancellationToken)
+    private async Task<Either<ActionResult, Unit>> VerifySubscription(
+        ApiSubscription subscription, CancellationToken cancellationToken)
     {
         if (subscription.Status is ApiSubscriptionStatus.Subscribed)
         {
@@ -319,7 +317,11 @@ internal class ApiSubscriptionService(
 
         return await apiSubscriptionRepository.QuerySubscriptions(
             filter: filter,
-            select: new List<string>() { nameof(ApiSubscription.PartitionKey), nameof(ApiSubscription.RowKey) },
+            select: new List<string>
+            {
+                nameof(ApiSubscription.PartitionKey),
+                nameof(ApiSubscription.RowKey)
+            },
             cancellationToken: cancellationToken);
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/Interfaces/IApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/Interfaces/IApiSubscriptionService.cs
@@ -20,5 +20,10 @@ public interface IApiSubscriptionService
         string token,
         CancellationToken cancellationToken = default);
 
+    Task<Either<ActionResult, Unit>> Unsubscribe(
+        Guid dataSetId,
+        string token,
+        CancellationToken cancellationToken = default);
+
     Task RemoveExpiredApiSubscriptions(CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Validators/ValidationMessages.cs
@@ -19,6 +19,11 @@ public static class ValidationMessages
         Message: "The unverified subscription has expired. The user must request a new subscription."
     );
 
+    public static readonly LocalizableMessage ApiSubscriptionHasNotBeenVerified = new(
+        Code: nameof(ApiSubscriptionHasNotBeenVerified),
+        Message: "The subscription has not been verified."
+    );
+
     public static readonly LocalizableMessage AuthorizationTokenInvalid = new(
         Code: nameof(AuthorizationTokenInvalid),
         Message: "The authorization token is invalid."


### PR DESCRIPTION
This PR adds an endpoint to the Notifier project to allow users to unsubscribe from API data sets.

The status codes that the endpoint returns are:
- `204` the subscription was successfully deleted in the database (hence, the user is now unsubscribed)
- `400` either the token supplied is invalid, **or** the subscription has not yet been verified (you can't unsubscribe to something you were never subscribed to!)
- `404` the subscription does not exist (applies to both pending and verified subscriptions)