### PR TITLE
Ees 4906 rename release to release version in frontend

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -33,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         [Fact]
         public async Task Create_Release_Returns_Ok()
         {
-            var returnedViewModel = new ReleaseViewModel();
+            var returnedViewModel = new ReleaseVersionViewModel();
 
             var releaseService = new Mock<IReleaseService>(Strict);
 
@@ -202,7 +202,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                     It.Is<Guid>(id => id.Equals(_releaseVersionId)),
                     It.IsAny<ReleaseUpdateRequest>())
                 )
-                .ReturnsAsync(new ReleaseViewModel { Id = _releaseVersionId });
+                .ReturnsAsync(new ReleaseVersionViewModel { Id = _releaseVersionId });
 
             var controller = BuildController(releaseService: releaseService.Object);
 
@@ -388,7 +388,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var releaseService = new Mock<IReleaseService>(Strict);
 
             var request = new ReleaseStatusCreateRequest();
-            var returnedReleaseViewModel = new ReleaseViewModel();
+            var returnedReleaseViewModel = new ReleaseVersionViewModel();
 
             releaseApprovalService
                 .Setup(s => s.CreateReleaseStatus(_releaseVersionId, request))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -49,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpPost("publications/{publicationId:guid}/releases")]
-        public async Task<ActionResult<ReleaseViewModel>> CreateRelease(ReleaseCreateRequest release,
+        public async Task<ActionResult<ReleaseVersionViewModel>> CreateRelease(ReleaseCreateRequest release,
             Guid publicationId)
         {
             release.PublicationId = publicationId;
@@ -147,7 +147,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpGet("releases/{releaseVersionId:guid}")]
-        public async Task<ActionResult<ReleaseViewModel>> GetRelease(Guid releaseVersionId)
+        public async Task<ActionResult<ReleaseVersionViewModel>> GetRelease(Guid releaseVersionId)
         {
             return await _releaseService
                 .GetRelease(releaseVersionId)
@@ -172,7 +172,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpPut("releases/{releaseVersionId:guid}")]
-        public async Task<ActionResult<ReleaseViewModel>> UpdateRelease(ReleaseUpdateRequest request,
+        public async Task<ActionResult<ReleaseVersionViewModel>> UpdateRelease(ReleaseUpdateRequest request,
             Guid releaseVersionId)
         {
             return await _releaseService
@@ -181,7 +181,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpPost("releases/{releaseVersionId:guid}/status")]
-        public async Task<ActionResult<ReleaseViewModel>> CreateReleaseStatus(ReleaseStatusCreateRequest request,
+        public async Task<ActionResult<ReleaseVersionViewModel>> CreateReleaseStatus(ReleaseStatusCreateRequest request,
             Guid releaseVersionId)
         {
             return await _releaseApprovalService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -27,7 +27,6 @@ using MethodologyVersionViewModel = GovUk.Education.ExploreEducationStatistics.A
 using PublicationViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.PublicationViewModel;
 using ReleaseNoteViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent.ReleaseNoteViewModel;
 using ReleaseSummaryViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ReleaseSummaryViewModel;
-using ReleaseViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ReleaseViewModel;
 using ThemeViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ThemeViewModel;
 using TopicViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.TopicViewModel;
 
@@ -42,7 +41,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
         {
             CreateMap<User, UserDetailsViewModel>();
 
-            CreateMap<ReleaseVersion, ReleaseViewModel>()
+            CreateMap<ReleaseVersion, ReleaseVersionViewModel>()
                 .ForMember(
                     dest => dest.ReleaseId,
                     m => m.MapFrom(rv => rv.ReleaseId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -14,7 +14,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IReleaseService
     {
-        Task<Either<ActionResult, ReleaseViewModel>> CreateRelease(ReleaseCreateRequest releaseCreate);
+        Task<Either<ActionResult, ReleaseVersionViewModel>> CreateRelease(ReleaseCreateRequest releaseCreate);
 
         Task<Either<ActionResult, DeleteReleasePlanViewModel>> GetDeleteReleaseVersionPlan(
             Guid releaseVersionId, 
@@ -22,12 +22,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, Unit>> DeleteReleaseVersion(Guid releaseVersionId);
 
-        Task<Either<ActionResult, ReleaseViewModel>> GetRelease(Guid releaseVersionId);
+        Task<Either<ActionResult, ReleaseVersionViewModel>> GetRelease(Guid releaseVersionId);
 
         Task<Either<ActionResult, ReleasePublicationStatusViewModel>>
             GetReleasePublicationStatus(Guid releaseVersionId);
 
-        Task<Either<ActionResult, ReleaseViewModel>> UpdateReleaseVersion(Guid releaseVersionId, ReleaseUpdateRequest request);
+        Task<Either<ActionResult, ReleaseVersionViewModel>> UpdateReleaseVersion(Guid releaseVersionId, ReleaseUpdateRequest request);
 
         Task<Either<ActionResult, Unit>> UpdateReleasePublished(Guid releaseVersionId,
             ReleasePublishedUpdateRequest request);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -101,13 +101,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _cacheService = cacheService;
         }
 
-        public async Task<Either<ActionResult, ReleaseViewModel>> GetRelease(Guid releaseVersionId)
+        public async Task<Either<ActionResult, ReleaseVersionViewModel>> GetRelease(Guid releaseVersionId)
         {
             return await _persistenceHelper
                 .CheckEntityExists<ReleaseVersion>(releaseVersionId, HydrateReleaseVersion)
                 .OnSuccess(_userService.CheckCanViewReleaseVersion)
                 .OnSuccess(releaseVersion => _mapper
-                    .Map<ReleaseViewModel>(releaseVersion) with
+                    .Map<ReleaseVersionViewModel>(releaseVersion) with
                     {
                         PreReleaseUsersOrInvitesAdded = _context
                             .UserReleaseRoles
@@ -120,7 +120,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     });
         }
 
-        public async Task<Either<ActionResult, ReleaseViewModel>> CreateRelease(ReleaseCreateRequest releaseCreate)
+        public async Task<Either<ActionResult, ReleaseVersionViewModel>> CreateRelease(ReleaseCreateRequest releaseCreate)
         {
             return await ReleaseCreateRequestValidator.Validate(releaseCreate)
                 .OnSuccess(async () => await _persistenceHelper.CheckEntityExists<Publication>(releaseCreate.PublicationId))
@@ -270,7 +270,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(_mapper.Map<ReleasePublicationStatusViewModel>);
         }
 
-        public async Task<Either<ActionResult, ReleaseViewModel>> UpdateReleaseVersion(
+        public async Task<Either<ActionResult, ReleaseVersionViewModel>> UpdateReleaseVersion(
             Guid releaseVersionId, ReleaseUpdateRequest request)
         {
             return await ReleaseUpdateRequestValidator.Validate(request)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
-    public record ReleaseViewModel
+    public record ReleaseVersionViewModel
     {
         public Guid Id { get; set; }
 

--- a/src/explore-education-statistics-admin/src/contexts/ReleaseContentHubContext.tsx
+++ b/src/explore-education-statistics-admin/src/contexts/ReleaseContentHubContext.tsx
@@ -18,12 +18,12 @@ const ReleaseContentHubContext = createContext<
 
 interface ReleaseContentHubContextProviderProps {
   children: ReactNode | ((value: HubState<ReleaseContentHub>) => ReactNode);
-  releaseId: string;
+  releaseVersionId: string;
 }
 
 export function ReleaseContentHubContextProvider({
   children,
-  releaseId,
+  releaseVersionId,
 }: ReleaseContentHubContextProviderProps) {
   const hubState = useHubState(releaseContentHub);
 
@@ -37,7 +37,7 @@ export function ReleaseContentHubContextProvider({
       joinStateRef.current = 'joining';
 
       hub
-        .joinReleaseGroup(releaseId)
+        .joinReleaseGroup(releaseVersionId)
         .then(() => {
           joinStateRef.current = 'joined';
         })
@@ -45,17 +45,17 @@ export function ReleaseContentHubContextProvider({
           joinStateRef.current = '';
         });
     }
-  }, [hub, hubState, isMountedRef, releaseId, status]);
+  }, [hub, hubState, isMountedRef, releaseVersionId, status]);
 
   useEffect(() => {
     return () => {
       if (hub.status() === 'Connected' && joinStateRef.current === 'joined') {
-        hub.leaveReleaseGroup(releaseId);
+        hub.leaveReleaseGroup(releaseVersionId);
       }
     };
     // We only want this to run when the component unmounts.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [releaseId]);
+  }, [releaseVersionId]);
 
   if (!hubState) {
     return <LoadingSpinner />;

--- a/src/explore-education-statistics-admin/src/contexts/__tests__/ReleaseContentHubContext.test.tsx
+++ b/src/explore-education-statistics-admin/src/contexts/__tests__/ReleaseContentHubContext.test.tsx
@@ -10,7 +10,7 @@ import React, { FC, ReactNode } from 'react';
 jest.mock('@admin/services/hubs/utils/createConnection');
 
 const wrapper: FC = ({ children }: { children?: ReactNode }) => (
-  <ReleaseContentHubContextProvider releaseId="release-1">
+  <ReleaseContentHubContextProvider releaseVersionId="release-1">
     {children}
   </ReleaseContentHubContextProvider>
 );

--- a/src/explore-education-statistics-admin/src/hooks/useGetChartFile.ts
+++ b/src/explore-education-statistics-admin/src/hooks/useGetChartFile.ts
@@ -1,9 +1,10 @@
 import releaseChartFileService from '@admin/services/releaseChartFileService';
 import { useCallback } from 'react';
 
-export default function useGetChartFile(releaseId: string) {
+export default function useGetChartFile(releaseVersionId: string) {
   return useCallback(
-    (fileId: string) => releaseChartFileService.getChartFile(releaseId, fileId),
-    [releaseId],
+    (fileId: string) =>
+      releaseChartFileService.getChartFile(releaseVersionId, fileId),
+    [releaseVersionId],
   );
 }

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ApprovalsTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ApprovalsTab.tsx
@@ -1,5 +1,5 @@
 import ApprovalsTable from '@admin/pages/admin-dashboard/components/ApprovalsTable';
-import { DashboardReleaseSummary } from '@admin/services/releaseService';
+import { DashboardReleaseVersionSummary } from '@admin/services/releaseService';
 import { MethodologyVersion } from '@admin/services/methodologyService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import React from 'react';
@@ -7,7 +7,7 @@ import React from 'react';
 interface Props {
   isLoading: boolean;
   methodologyApprovals: MethodologyVersion[];
-  releaseApprovals: DashboardReleaseSummary[];
+  releaseApprovals: DashboardReleaseVersionSummary[];
 }
 
 export default function ApprovalsTab({

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ApprovalsTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ApprovalsTable.tsx
@@ -1,6 +1,6 @@
 import Link from '@admin/components/Link';
 import { MethodologyVersion } from '@admin/services/methodologyService';
-import { DashboardReleaseSummary } from '@admin/services/releaseService';
+import { DashboardReleaseVersionSummary } from '@admin/services/releaseService';
 import {
   MethodologyRouteParams,
   methodologyContentRoute,
@@ -18,7 +18,7 @@ import merge from 'lodash/merge';
 
 interface Props {
   methodologyApprovals: MethodologyVersion[];
-  releaseApprovals: DashboardReleaseSummary[];
+  releaseApprovals: DashboardReleaseVersionSummary[];
 }
 
 export default function ApprovalsTable({
@@ -26,10 +26,10 @@ export default function ApprovalsTable({
   releaseApprovals,
 }: Props) {
   const releasesByPublication: Dictionary<{
-    releases: DashboardReleaseSummary[];
+    releases: DashboardReleaseVersionSummary[];
   }> = useMemo(() => {
     return releaseApprovals.reduce<
-      Dictionary<{ releases: DashboardReleaseSummary[] }>
+      Dictionary<{ releases: DashboardReleaseVersionSummary[] }>
     >((acc, release) => {
       if (acc[release.publication.title]) {
         acc[release.publication.title].releases.push(release);
@@ -104,7 +104,7 @@ export default function ApprovalsTable({
 interface PublicationRowProps {
   publication: string;
   methodologies: MethodologyVersion[];
-  releases: DashboardReleaseSummary[];
+  releases: DashboardReleaseVersionSummary[];
 }
 
 function PublicationRow({
@@ -130,7 +130,7 @@ function PublicationRow({
             <Link
               to={generatePath<ReleaseRouteParams>(releaseContentRoute.path, {
                 publicationId: release.publication.id,
-                releaseId: release.id,
+                releaseVersionId: release.id,
               })}
             >
               Review this page

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRow.tsx
@@ -27,7 +27,7 @@ interface Props {
 const DraftReleaseRow = ({ isBauUser, release, onChangeRelease }: Props) => {
   const [deleteReleasePlan, setDeleteReleasePlan] = useState<
     DeleteReleasePlan & {
-      releaseId: string;
+      releaseVersionId: string;
     }
   >();
   return (
@@ -40,7 +40,7 @@ const DraftReleaseRow = ({ isBauUser, release, onChangeRelease }: Props) => {
           }`}
         </Tag>
       </td>
-      {!isBauUser && <DraftReleaseRowIssues releaseId={release.id} />}
+      {!isBauUser && <DraftReleaseRowIssues releaseVersionId={release.id} />}
       <td>
         <Link
           className="govuk-!-margin-right-4 govuk-!-display-inline-block"
@@ -75,7 +75,7 @@ const DraftReleaseRow = ({ isBauUser, release, onChangeRelease }: Props) => {
                 onClick={async () => {
                   setDeleteReleasePlan({
                     ...(await releaseService.getDeleteReleasePlan(release.id)),
-                    releaseId: release.id,
+                    releaseVersionId: release.id,
                   });
                 }}
               >
@@ -85,7 +85,9 @@ const DraftReleaseRow = ({ isBauUser, release, onChangeRelease }: Props) => {
             }
             onConfirm={async () => {
               if (deleteReleasePlan) {
-                await releaseService.deleteRelease(deleteReleasePlan.releaseId);
+                await releaseService.deleteRelease(
+                  deleteReleasePlan.releaseVersionId,
+                );
                 setDeleteReleasePlan(undefined);
                 onChangeRelease();
               }

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRow.tsx
@@ -2,8 +2,8 @@ import Link from '@admin/components/Link';
 import DraftReleaseRowIssues from '@admin/pages/admin-dashboard/components/DraftReleaseRowIssues';
 import { getReleaseApprovalStatusLabel } from '@admin/pages/release/utils/releaseSummaryUtil';
 import releaseService, {
-  ReleaseSummaryWithPermissions,
-  DashboardReleaseSummary,
+  ReleaseVersionSummaryWithPermissions,
+  DashboardReleaseVersionSummary,
   DeleteReleasePlan,
 } from '@admin/services/releaseService';
 import {
@@ -19,7 +19,8 @@ import CancelAmendmentModal from './CancelAmendmentModal';
 
 interface Props {
   isBauUser: boolean;
-  release: DashboardReleaseSummary & ReleaseSummaryWithPermissions;
+  release: DashboardReleaseVersionSummary &
+    ReleaseVersionSummaryWithPermissions;
   onChangeRelease: () => void;
 }
 
@@ -45,7 +46,7 @@ const DraftReleaseRow = ({ isBauUser, release, onChangeRelease }: Props) => {
           className="govuk-!-margin-right-4 govuk-!-display-inline-block"
           to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
             publicationId: release.publication.id,
-            releaseId: release.id,
+            releaseVersionId: release.id,
           })}
         >
           {release.permissions?.canUpdateRelease ? 'Edit' : 'View'}
@@ -57,7 +58,7 @@ const DraftReleaseRow = ({ isBauUser, release, onChangeRelease }: Props) => {
             className="govuk-!-margin-right-4 govuk-!-display-inline-block"
             to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
               publicationId: release.publication.id,
-              releaseId: release.previousVersionId,
+              releaseVersionId: release.previousVersionId,
             })}
           >
             View existing version

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRowIssues.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleaseRowIssues.tsx
@@ -7,12 +7,14 @@ import React from 'react';
 import TagGroup from '@common/components/TagGroup';
 
 interface Props {
-  releaseId: string;
+  releaseVersionId: string;
 }
 
-const DraftReleaseRowIssues = ({ releaseId }: Props) => {
+const DraftReleaseRowIssues = ({ releaseVersionId }: Props) => {
   const { value: checklist, isLoading: isLoadingChecklist } =
-    useAsyncHandledRetry(() => releaseService.getReleaseChecklist(releaseId));
+    useAsyncHandledRetry(() =>
+      releaseService.getReleaseChecklist(releaseVersionId),
+    );
 
   const totalIssues = checklist
     ? checklist.errors.length + checklist.warnings.length

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTab.tsx
@@ -1,12 +1,12 @@
 import DraftReleasesTable from '@admin/pages/admin-dashboard/components/DraftReleasesTable';
-import { DashboardReleaseSummary } from '@admin/services/releaseService';
+import { DashboardReleaseVersionSummary } from '@admin/services/releaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import React from 'react';
 
 interface Props {
   isBauUser: boolean;
   isLoading: boolean;
-  releases: DashboardReleaseSummary[];
+  releases: DashboardReleaseVersionSummary[];
   onChangeRelease: () => void;
 }
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTable.tsx
@@ -4,7 +4,7 @@ import {
   DraftStatusGuidanceModal,
   IssuesGuidanceModal,
 } from '@admin/pages/publication/components/PublicationGuidance';
-import { DashboardReleaseSummary } from '@admin/services/releaseService';
+import { DashboardReleaseVersionSummary } from '@admin/services/releaseService';
 import { Dictionary } from '@common/types';
 import orderBy from 'lodash/orderBy';
 import React, { useMemo } from 'react';
@@ -12,7 +12,7 @@ import React, { useMemo } from 'react';
 interface PublicationRowProps {
   isBauUser: boolean;
   publication: string;
-  releases: DashboardReleaseSummary[];
+  releases: DashboardReleaseVersionSummary[];
   onChangeRelease: () => void;
 }
 
@@ -43,7 +43,7 @@ const PublicationRow = ({
 
 interface DraftReleasesTableProps {
   isBauUser: boolean;
-  releases: DashboardReleaseSummary[];
+  releases: DashboardReleaseVersionSummary[];
   onChangeRelease: () => void;
 }
 
@@ -52,9 +52,9 @@ const DraftReleasesTable = ({
   releases,
   onChangeRelease,
 }: DraftReleasesTableProps) => {
-  const releasesByPublication: Dictionary<DashboardReleaseSummary[]> =
+  const releasesByPublication: Dictionary<DashboardReleaseVersionSummary[]> =
     useMemo(() => {
-      return releases.reduce<Dictionary<DashboardReleaseSummary[]>>(
+      return releases.reduce<Dictionary<DashboardReleaseVersionSummary[]>>(
         (acc, release) => {
           if (acc[release.publication.title]) {
             acc[release.publication.title].push(release);

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTab.tsx
@@ -1,11 +1,11 @@
 import ScheduledReleasesTable from '@admin/pages/admin-dashboard/components/ScheduledReleasesTable';
-import { DashboardReleaseSummary } from '@admin/services/releaseService';
+import { DashboardReleaseVersionSummary } from '@admin/services/releaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import React from 'react';
 
 interface Props {
   isLoading: boolean;
-  releases: DashboardReleaseSummary[];
+  releases: DashboardReleaseVersionSummary[];
 }
 
 const ScheduledReleasesTab = ({ isLoading, releases }: Props) => {

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ScheduledReleasesTable.tsx
@@ -3,14 +3,14 @@ import {
   ScheduledStagesGuidanceModal,
   ScheduledStatusGuidanceModal,
 } from '@admin/pages/publication/components/PublicationGuidance';
-import { DashboardReleaseSummary } from '@admin/services/releaseService';
+import { DashboardReleaseVersionSummary } from '@admin/services/releaseService';
 import { Dictionary } from '@common/types';
 import orderBy from 'lodash/orderBy';
 import React, { useMemo } from 'react';
 
 interface PublicationRowProps {
   publication: string;
-  releases: DashboardReleaseSummary[];
+  releases: DashboardReleaseVersionSummary[];
 }
 
 const PublicationRow = ({ publication, releases }: PublicationRowProps) => {
@@ -33,13 +33,13 @@ const PublicationRow = ({ publication, releases }: PublicationRowProps) => {
 };
 
 interface ScheduledReleasesTableProps {
-  releases: DashboardReleaseSummary[];
+  releases: DashboardReleaseVersionSummary[];
 }
 
 const ScheduledReleasesTable = ({ releases }: ScheduledReleasesTableProps) => {
-  const releasesByPublication: Dictionary<DashboardReleaseSummary[]> =
+  const releasesByPublication: Dictionary<DashboardReleaseVersionSummary[]> =
     useMemo(() => {
-      return releases.reduce<Dictionary<DashboardReleaseSummary[]>>(
+      return releases.reduce<Dictionary<DashboardReleaseVersionSummary[]>>(
         (acc, release) => {
           if (acc[release.publication.title]) {
             acc[release.publication.title].push(release);

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ApprovalsTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ApprovalsTable.test.tsx
@@ -1,6 +1,6 @@
 import ApprovalsTable from '@admin/pages/admin-dashboard/components/ApprovalsTable';
 import { MethodologyVersion } from '@admin/services/methodologyService';
-import { DashboardReleaseSummary } from '@admin/services/releaseService';
+import { DashboardReleaseVersionSummary } from '@admin/services/releaseService';
 import { waitFor, within } from '@testing-library/dom';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
@@ -32,7 +32,7 @@ describe('ApprovalsTable', () => {
     },
   ];
 
-  const testReleases: DashboardReleaseSummary[] = [
+  const testReleases: DashboardReleaseVersionSummary[] = [
     {
       id: 'test-id',
       title: 'Academic year 2016/17',

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/DraftReleasesTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/DraftReleasesTable.test.tsx
@@ -1,6 +1,6 @@
 import DraftReleasesTable from '@admin/pages/admin-dashboard/components/DraftReleasesTable';
 import _releaseService, {
-  DashboardReleaseSummary,
+  DashboardReleaseVersionSummary,
 } from '@admin/services/releaseService';
 import { waitFor, within } from '@testing-library/dom';
 import { render, screen } from '@testing-library/react';
@@ -13,7 +13,7 @@ jest.mock('@admin/services/releaseService');
 const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
 
 describe('DraftReleasesTable', () => {
-  const testReleases: DashboardReleaseSummary[] = [
+  const testReleases: DashboardReleaseVersionSummary[] = [
     {
       id: 'release-1',
       latestRelease: true,

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ScheduledReleasesTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ScheduledReleasesTable.test.tsx
@@ -1,6 +1,6 @@
 import ScheduledReleasesTable from '@admin/pages/admin-dashboard/components/ScheduledReleasesTable';
 import _releaseService, {
-  DashboardReleaseSummary,
+  DashboardReleaseVersionSummary,
 } from '@admin/services/releaseService';
 import { waitFor, within } from '@testing-library/dom';
 import { render, screen } from '@testing-library/react';
@@ -11,7 +11,7 @@ jest.mock('@admin/services/releaseService');
 const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
 
 describe('ScheduledReleasesTable', () => {
-  const testReleases: DashboardReleaseSummary[] = [
+  const testReleases: DashboardReleaseVersionSummary[] = [
     {
       id: 'release-1',
       latestRelease: true,

--- a/src/explore-education-statistics-admin/src/pages/bau/BauImportsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauImportsPage.tsx
@@ -45,7 +45,7 @@ const BauImportsPage = () => {
                   <td>{subject.percentageComplete}%</td>
                   <td>
                     <Link
-                      to={`/publication/${subject.publicationId}/release/${subject.releaseVersionId}/data`}
+                      to={`/publication/${subject.publicationId}/release/${subject.releaseId}/data`}
                     >
                       {subject.publicationTitle} {subject.releaseTitle}
                     </Link>

--- a/src/explore-education-statistics-admin/src/pages/bau/BauImportsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauImportsPage.tsx
@@ -45,7 +45,7 @@ const BauImportsPage = () => {
                   <td>{subject.percentageComplete}%</td>
                   <td>
                     <Link
-                      to={`/publication/${subject.publicationId}/release/${subject.releaseId}/data`}
+                      to={`/publication/${subject.publicationId}/release/${subject.releaseVersionId}/data`}
                     >
                       {subject.publicationTitle} {subject.releaseTitle}
                     </Link>

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationEditReleaseSeriesLegacyLinkPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationEditReleaseSeriesLegacyLinkPage.tsx
@@ -12,8 +12,8 @@ import publicationService, {
 } from '@admin/services/publicationService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import React from 'react';
-import {generatePath, RouteComponentProps, useHistory} from 'react-router';
-import {useQuery} from '@tanstack/react-query';
+import { generatePath, RouteComponentProps, useHistory } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
 
 export const mapToReleaseSeriesItemUpdateRequest = (
   releaseSeries: ReleaseSeriesTableEntry[],
@@ -29,13 +29,13 @@ export const mapToReleaseSeriesItemUpdateRequest = (
 };
 
 export default function PublicationEditReleaseSeriesLegacyLinkPage({
-                                                                     match,
-                                                                   }: RouteComponentProps<PublicationEditReleaseSeriesLegacyLinkRouteParams>) {
-  const {releaseSeriesItemId} = match.params;
-  const {publicationId} = usePublicationContext();
+  match,
+}: RouteComponentProps<PublicationEditReleaseSeriesLegacyLinkRouteParams>) {
+  const { releaseSeriesItemId } = match.params;
+  const { publicationId } = usePublicationContext();
   const history = useHistory();
 
-  const {data: releaseSeries = [], isLoading} = useQuery(
+  const { data: releaseSeries = [], isLoading } = useQuery(
     publicationQueries.getReleaseSeries(publicationId),
   );
 
@@ -75,10 +75,10 @@ export default function PublicationEditReleaseSeriesLegacyLinkPage({
             const updatedReleaseSeries = releaseSeries.map(release => {
               return release.id === releaseSeriesItemId
                 ? {
-                  ...release,
-                  description: values.description,
-                  legacyLinkUrl: values.url,
-                }
+                    ...release,
+                    description: values.description,
+                    legacyLinkUrl: values.url,
+                  }
                 : release;
             });
 

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationEditReleaseSeriesLegacyLinkPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationEditReleaseSeriesLegacyLinkPage.tsx
@@ -20,7 +20,7 @@ export const mapToReleaseSeriesItemUpdateRequest = (
 ): ReleaseSeriesItemUpdateRequest[] => {
   return releaseSeries.map(seriesItem => ({
     id: seriesItem.id,
-    releaseId: seriesItem.releaseId,
+    releaseVersionId: seriesItem.releaseId,
     legacyLinkDescription: seriesItem.isLegacyLink
       ? seriesItem.description
       : undefined,
@@ -54,6 +54,7 @@ export default function PublicationEditReleaseSeriesLegacyLinkPage({
     <LoadingSpinner loading={isLoading}>
       <h2>Edit legacy release</h2>
 
+      {/* TODO rename to releaseVersionId */}
       {!legacyRelease || legacyRelease.releaseId !== undefined ? (
         <>
           <p>Legacy release not found.</p>

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationEditReleaseSeriesLegacyLinkPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationEditReleaseSeriesLegacyLinkPage.tsx
@@ -12,15 +12,15 @@ import publicationService, {
 } from '@admin/services/publicationService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import React from 'react';
-import { generatePath, RouteComponentProps, useHistory } from 'react-router';
-import { useQuery } from '@tanstack/react-query';
+import {generatePath, RouteComponentProps, useHistory} from 'react-router';
+import {useQuery} from '@tanstack/react-query';
 
 export const mapToReleaseSeriesItemUpdateRequest = (
   releaseSeries: ReleaseSeriesTableEntry[],
 ): ReleaseSeriesItemUpdateRequest[] => {
   return releaseSeries.map(seriesItem => ({
     id: seriesItem.id,
-    releaseVersionId: seriesItem.releaseId,
+    releaseId: seriesItem.releaseId,
     legacyLinkDescription: seriesItem.isLegacyLink
       ? seriesItem.description
       : undefined,
@@ -29,13 +29,13 @@ export const mapToReleaseSeriesItemUpdateRequest = (
 };
 
 export default function PublicationEditReleaseSeriesLegacyLinkPage({
-  match,
-}: RouteComponentProps<PublicationEditReleaseSeriesLegacyLinkRouteParams>) {
-  const { releaseSeriesItemId } = match.params;
-  const { publicationId } = usePublicationContext();
+                                                                     match,
+                                                                   }: RouteComponentProps<PublicationEditReleaseSeriesLegacyLinkRouteParams>) {
+  const {releaseSeriesItemId} = match.params;
+  const {publicationId} = usePublicationContext();
   const history = useHistory();
 
-  const { data: releaseSeries = [], isLoading } = useQuery(
+  const {data: releaseSeries = [], isLoading} = useQuery(
     publicationQueries.getReleaseSeries(publicationId),
   );
 
@@ -75,10 +75,10 @@ export default function PublicationEditReleaseSeriesLegacyLinkPage({
             const updatedReleaseSeries = releaseSeries.map(release => {
               return release.id === releaseSeriesItemId
                 ? {
-                    ...release,
-                    description: values.description,
-                    legacyLinkUrl: values.url,
-                  }
+                  ...release,
+                  description: values.description,
+                  legacyLinkUrl: values.url,
+                }
                 : release;
             });
 

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationInviteUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationInviteUsersPage.tsx
@@ -12,7 +12,7 @@ const PublicationInviteUsersPage = ({
 }: RouteComponentProps<PublicationManageTeamRouteParams>) => {
   const { publicationId, publication } = usePublicationContext();
 
-  const { releaseId } = match.params;
+  const { releaseVersionId } = match.params;
 
   const { value: allReleases = { results: [] }, isLoading } =
     useAsyncHandledRetry(() => publicationService.listReleases(publicationId));
@@ -24,7 +24,7 @@ const PublicationInviteUsersPage = ({
       <PublicationInviteNewUsersForm
         publication={publication}
         releases={releases}
-        releaseId={releaseId}
+        releaseVersionId={releaseVersionId}
       />
     </LoadingSpinner>
   );

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationManageReleaseContributorsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationManageReleaseContributorsPage.tsx
@@ -4,14 +4,14 @@ import { PublicationManageTeamRouteParams } from '@admin/routes/publicationRoute
 import releasePermissionService, {
   UserReleaseRole,
 } from '@admin/services/releasePermissionService';
-import releaseService, { Release } from '@admin/services/releaseService';
+import releaseService, { ReleaseVersion } from '@admin/services/releaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
 interface Model {
-  release: Release;
+  release: ReleaseVersion;
   publicationContributors: UserReleaseRole[];
   releaseContributors: UserReleaseRole[];
 }
@@ -21,13 +21,13 @@ const PublicationManageReleaseContributorsPage = ({
 }: RouteComponentProps<PublicationManageTeamRouteParams>) => {
   const { publicationId } = usePublicationContext();
 
-  const { releaseId } = match.params;
+  const { releaseVersionId } = match.params;
 
   const { value, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const [release, publicationContributors, releaseRoles] = await Promise.all([
-      releaseService.getRelease(releaseId),
+      releaseService.getRelease(releaseVersionId),
       releasePermissionService.listPublicationContributors(publicationId),
-      releasePermissionService.listRoles(releaseId),
+      releasePermissionService.listRoles(releaseVersionId),
     ]);
     return {
       release,
@@ -36,7 +36,7 @@ const PublicationManageReleaseContributorsPage = ({
         role => role.role === 'Contributor',
       ),
     };
-  }, [publicationId, releaseId]);
+  }, [publicationId, releaseVersionId]);
 
   const {
     release,
@@ -50,7 +50,7 @@ const PublicationManageReleaseContributorsPage = ({
 
       <PublicationReleaseContributorsForm
         publicationId={publicationId}
-        releaseId={releaseId}
+        releaseId={releaseVersionId}
         publicationContributors={publicationContributors}
         releaseContributors={releaseContributors}
       />

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationManageReleaseContributorsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationManageReleaseContributorsPage.tsx
@@ -50,7 +50,7 @@ const PublicationManageReleaseContributorsPage = ({
 
       <PublicationReleaseContributorsForm
         publicationId={publicationId}
-        releaseId={releaseVersionId}
+        releaseVersionId={releaseVersionId}
         publicationContributors={publicationContributors}
         releaseContributors={releaseContributors}
       />

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationTeamAccessPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationTeamAccessPage.tsx
@@ -7,7 +7,7 @@ import {
 import publicationService, {
   PublicationPermissions,
 } from '@admin/services/publicationService';
-import { ReleaseSummary } from '@admin/services/releaseService';
+import { ReleaseVersionSummary } from '@admin/services/releaseService';
 import { FormSelect } from '@common/components/form';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
@@ -21,7 +21,7 @@ import ButtonLink from '@admin/components/ButtonLink';
 import PublicationReleaseAccess from '@admin/pages/publication/components/PublicationReleaseAccess';
 
 interface Model {
-  releases: ReleaseSummary[];
+  releases: ReleaseVersionSummary[];
   publicationRoles: UserPublicationRole[];
   publicationOwners: UserPublicationRole[];
   publicationApprovers: UserPublicationRole[];
@@ -32,9 +32,11 @@ const PublicationTeamAccessPage = ({
   match,
 }: RouteComponentProps<PublicationTeamRouteParams>) => {
   const history = useHistory();
-  const { releaseId } = match.params;
+  const { releaseVersionId } = match.params;
   const { publicationId, permissions } = usePublicationContext();
-  const [currentReleaseId, setCurrentReleaseId] = useState(releaseId ?? '');
+  const [currentReleaseVersionId, setCurrentReleaseVersionId] = useState(
+    releaseVersionId ?? '',
+  );
 
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const { results: releases } = await publicationService.listReleases(
@@ -42,15 +44,15 @@ const PublicationTeamAccessPage = ({
     );
     const publicationRoles = await publicationService.listRoles(publicationId);
 
-    if (!releaseId && releases.length) {
-      setCurrentReleaseId(releases[0].id);
+    if (!releaseVersionId && releases.length) {
+      setCurrentReleaseVersionId(releases[0].id);
 
       history.replace(
         generatePath<PublicationTeamRouteParams>(
           publicationTeamAccessRoute.path,
           {
             publicationId,
-            releaseId: releases[0].id,
+            releaseVersionId: releases[0].id,
           },
         ),
       );
@@ -74,7 +76,7 @@ const PublicationTeamAccessPage = ({
   }
 
   const currentRelease = model.releases.find(
-    release => release.id === currentReleaseId,
+    release => release.id === currentReleaseVersionId,
   );
 
   return (
@@ -146,13 +148,13 @@ const PublicationTeamAccessPage = ({
       )}
 
       {model.permissions.canUpdateContributorReleaseRole &&
-        currentReleaseId !== '' && (
+        currentReleaseVersionId !== '' && (
           <ButtonLink
             to={generatePath<PublicationTeamRouteParams>(
               publicationInviteUsersPageRoute.path,
               {
                 publicationId,
-                releaseId: currentReleaseId,
+                releaseVersionId: currentReleaseVersionId,
               },
             )}
           >
@@ -180,15 +182,15 @@ const PublicationTeamAccessPage = ({
                     value: release.id,
                   }))}
                   order={[]}
-                  value={currentReleaseId}
+                  value={currentReleaseVersionId}
                   onChange={e => {
-                    setCurrentReleaseId(e.target.value);
+                    setCurrentReleaseVersionId(e.target.value);
                     history.replace(
                       generatePath<PublicationTeamRouteParams>(
                         publicationTeamAccessRoute.path,
                         {
                           publicationId,
-                          releaseId: e.target.value,
+                          releaseVersionId: e.target.value,
                         },
                       ),
                     );

--- a/src/explore-education-statistics-admin/src/pages/publication/__data__/testReleaseSeries.ts
+++ b/src/explore-education-statistics-admin/src/pages/publication/__data__/testReleaseSeries.ts
@@ -6,7 +6,7 @@ export const testReleaseSeries: ReleaseSeriesTableEntry[] = [
     id: 'ees-release-3',
     isLegacyLink: false,
     description: 'EES release 3',
-    releaseId: 'release-id',
+    releaseId: 'release-id', // TODO rename to releaseVersionId
     releaseSlug: '3',
     isLatest: false,
     isPublished: false,

--- a/src/explore-education-statistics-admin/src/pages/publication/__data__/testReleases.ts
+++ b/src/explore-education-statistics-admin/src/pages/publication/__data__/testReleases.ts
@@ -1,8 +1,8 @@
-import { ReleaseSummary } from '@admin/services/releaseService';
+import { ReleaseVersionSummary } from '@admin/services/releaseService';
 import { PaginatedList } from '@common/services/types/pagination';
 
 // eslint-disable-next-line import/prefer-default-export
-export const testReleaseSummaries: ReleaseSummary[] = [
+export const testReleaseSummaries: ReleaseVersionSummary[] = [
   {
     id: 'release-1',
     slug: 'release-1-slug',
@@ -54,17 +54,18 @@ export const testReleaseSummaries: ReleaseSummary[] = [
   },
 ];
 
-export const testPaginatedReleaseSummaries: PaginatedList<ReleaseSummary> = {
-  results: testReleaseSummaries,
-  paging: {
-    page: 1,
-    pageSize: 5,
-    totalPages: 1,
-    totalResults: 3,
-  },
-};
+export const testPaginatedReleaseSummaries: PaginatedList<ReleaseVersionSummary> =
+  {
+    results: testReleaseSummaries,
+    paging: {
+      page: 1,
+      pageSize: 5,
+      totalPages: 1,
+      totalResults: 3,
+    },
+  };
 
-export const testPaginatedReleaseSummariesNoResults: PaginatedList<ReleaseSummary> =
+export const testPaginatedReleaseSummariesNoResults: PaginatedList<ReleaseVersionSummary> =
   {
     results: [],
     paging: { page: 1, pageSize: 1, totalPages: 1, totalResults: 0 },

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationEditReleaseSeriesLegacyLinkPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationEditReleaseSeriesLegacyLinkPage.test.tsx
@@ -32,11 +32,11 @@ describe('PublicationEditReleaseSeriesLegacyLinkPage', () => {
       legacyLinkUrl: 'https://gov.uk/1',
     },
     {
-      id: 'release-1',
+      id: 'release-version-1',
       isLegacyLink: false,
       description: 'Academic Year 2000/01',
 
-      releaseId: 'release-parent-1',
+      releaseId: 'release-1',
       releaseSlug: 'release-slug',
       isLatest: true,
       isPublished: true,
@@ -96,9 +96,9 @@ describe('PublicationEditReleaseSeriesLegacyLinkPage', () => {
             legacyLinkUrl: 'https://gov.uk/1/edit',
           },
           {
-            id: 'release-1',
+            id: 'release-version-1',
 
-            releaseId: 'release-parent-1',
+            releaseVersionId: 'release-1',
           },
           {
             id: 'legacy-release-2',

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationEditReleaseSeriesLegacyLinkPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationEditReleaseSeriesLegacyLinkPage.test.tsx
@@ -98,7 +98,7 @@ describe('PublicationEditReleaseSeriesLegacyLinkPage', () => {
           {
             id: 'release-version-1',
 
-            releaseVersionId: 'release-1',
+            releaseId: 'release-1',
           },
           {
             id: 'legacy-release-2',

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationInviteUsersPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationInviteUsersPage.test.tsx
@@ -66,7 +66,7 @@ function renderPage() {
     publicationInviteUsersPageRoute.path,
     {
       publicationId: testPublication.id,
-      releaseId: testPaginatedReleaseSummaries.results[0].id,
+      releaseVersionId: testPaginatedReleaseSummaries.results[0].id,
     },
   );
 

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationManageReleaseContributorsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationManageReleaseContributorsPage.test.tsx
@@ -5,7 +5,9 @@ import {
   publicationManageReleaseContributorsPageRoute,
   PublicationManageTeamRouteParams,
 } from '@admin/routes/publicationRoutes';
-import _releaseService, { Release } from '@admin/services/releaseService';
+import _releaseService, {
+  ReleaseVersion,
+} from '@admin/services/releaseService';
 import _releasePermissionService, {
   UserReleaseRole,
 } from '@admin/services/releasePermissionService';
@@ -23,11 +25,11 @@ const releasePermissionService = _releasePermissionService as jest.Mocked<
   typeof _releasePermissionService
 >;
 
-const testRelease: Release = {
+const testRelease: ReleaseVersion = {
   amendment: false,
   approvalStatus: 'Draft',
-  id: 'release-1',
-  releaseId: 'release-series-1',
+  id: 'release-version-1',
+  releaseId: 'release-1',
   latestInternalReleaseNote: 'release1-release-note',
   latestRelease: true,
   live: false,
@@ -139,7 +141,7 @@ function renderPage() {
     publicationManageReleaseContributorsPageRoute.path,
     {
       publicationId: testPublication.id,
-      releaseId: testRelease.id,
+      releaseVersionId: testRelease.id,
     },
   );
 

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationPageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationPageContainer.test.tsx
@@ -7,7 +7,7 @@ import {
 } from '@admin/routes/publicationRoutes';
 import { publicationRoute } from '@admin/routes/routes';
 import _publicationService from '@admin/services/publicationService';
-import { ReleaseSummaryWithPermissions } from '@admin/services/releaseService';
+import { ReleaseVersionSummaryWithPermissions } from '@admin/services/releaseService';
 import { PaginatedList } from '@common/services/types/pagination';
 import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
@@ -20,15 +20,16 @@ const publicationService = _publicationService as jest.Mocked<
 >;
 
 describe('PublicationPageContainer', () => {
-  const testEmptyReleases: PaginatedList<ReleaseSummaryWithPermissions> = {
-    paging: {
-      page: 1,
-      pageSize: 5,
-      totalPages: 1,
-      totalResults: 0,
-    },
-    results: [],
-  };
+  const testEmptyReleases: PaginatedList<ReleaseVersionSummaryWithPermissions> =
+    {
+      paging: {
+        page: 1,
+        pageSize: 5,
+        totalPages: 1,
+        totalResults: 0,
+      },
+      results: [],
+    };
 
   test('renders the page with the releases tab', async () => {
     publicationService.getPublication.mockResolvedValue(testPublication);

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationTeamAccessPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationTeamAccessPage.test.tsx
@@ -540,7 +540,7 @@ describe('PublicationTeamAccessPage', () => {
     );
 
     await renderPage({
-      releaseId: 'release-3',
+      releaseVersionId: 'release-3',
     });
 
     await waitFor(() => {
@@ -643,17 +643,17 @@ describe('PublicationTeamAccessPage', () => {
 
 async function renderPage({
   history = createMemoryHistory(),
-  releaseId,
+  releaseVersionId,
   publication,
 }: {
   history?: MemoryHistory;
-  releaseId?: string;
+  releaseVersionId?: string;
   publication?: PublicationWithPermissions;
 }) {
   history.push(
     generatePath<PublicationTeamRouteParams>(publicationTeamAccessRoute.path, {
       publicationId: 'publication-1',
-      releaseVersionId: releaseId,
+      releaseVersionId,
     }),
   );
 

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationTeamAccessPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationTeamAccessPage.test.tsx
@@ -653,7 +653,7 @@ async function renderPage({
   history.push(
     generatePath<PublicationTeamRouteParams>(publicationTeamAccessRoute.path, {
       publicationId: 'publication-1',
-      releaseId,
+      releaseVersionId: releaseId,
     }),
   );
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/DraftReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/DraftReleaseRow.tsx
@@ -3,7 +3,7 @@ import { getReleaseApprovalStatusLabel } from '@admin/pages/release/utils/releas
 import CancelAmendmentModal from '@admin/pages/admin-dashboard/components/CancelAmendmentModal';
 import releaseService, {
   DeleteReleasePlan,
-  ReleaseSummaryWithPermissions,
+  ReleaseVersionSummaryWithPermissions,
 } from '@admin/services/releaseService';
 import {
   ReleaseRouteParams,
@@ -19,7 +19,7 @@ import { generatePath } from 'react-router';
 
 interface Props {
   publicationId: string;
-  release: ReleaseSummaryWithPermissions;
+  release: ReleaseVersionSummaryWithPermissions;
   onAmendmentDelete?: () => void;
 }
 
@@ -62,7 +62,7 @@ const DraftReleaseRow = ({
           className="govuk-!-margin-right-4 govuk-!-display-inline-block"
           to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
             publicationId,
-            releaseId: release.id,
+            releaseVersionId: release.id,
           })}
         >
           {release.permissions?.canUpdateRelease ? 'Edit' : 'View'}
@@ -74,7 +74,7 @@ const DraftReleaseRow = ({
             className="govuk-!-margin-right-4 govuk-!-display-inline-block"
             to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
               publicationId,
-              releaseId: release.previousVersionId,
+              releaseVersionId: release.previousVersionId,
             })}
           >
             View existing version

--- a/src/explore-education-statistics-admin/src/pages/publication/components/DraftReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/DraftReleaseRow.tsx
@@ -33,7 +33,7 @@ const DraftReleaseRow = ({
 
   const [deleteReleasePlan, setDeleteReleasePlan] = useState<
     DeleteReleasePlan & {
-      releaseId: string;
+      releaseVersionId: string;
     }
   >();
 
@@ -91,7 +91,7 @@ const DraftReleaseRow = ({
                 onClick={async () => {
                   setDeleteReleasePlan({
                     ...(await releaseService.getDeleteReleasePlan(release.id)),
-                    releaseId: release.id,
+                    releaseVersionId: release.id,
                   });
                 }}
               >
@@ -101,7 +101,9 @@ const DraftReleaseRow = ({
             }
             onConfirm={async () => {
               if (deleteReleasePlan) {
-                await releaseService.deleteRelease(deleteReleasePlan.releaseId);
+                await releaseService.deleteRelease(
+                  deleteReleasePlan.releaseVersionId,
+                );
                 setDeleteReleasePlan(undefined);
                 onAmendmentDelete?.();
               }

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDraftReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDraftReleases.tsx
@@ -3,13 +3,13 @@ import {
   DraftStatusGuidanceModal,
   IssuesGuidanceModal,
 } from '@admin/pages/publication/components/PublicationGuidance';
-import { ReleaseSummaryWithPermissions } from '@admin/services/releaseService';
+import { ReleaseVersionSummaryWithPermissions } from '@admin/services/releaseService';
 import InsetText from '@common/components/InsetText';
 import React from 'react';
 
 interface Props {
   publicationId: string;
-  releases: ReleaseSummaryWithPermissions[];
+  releases: ReleaseVersionSummaryWithPermissions[];
   onAmendmentDelete?: () => void;
 }
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationInviteNewUsersForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationInviteNewUsersForm.tsx
@@ -21,12 +21,12 @@ import { ObjectSchema } from 'yup';
 
 interface FormValues {
   email: string;
-  releaseIds: string[];
+  releaseVersionIds: string[];
 }
 
 export const errorMappings = [
   mapFieldErrors<FormValues>({
-    target: 'releaseIds',
+    target: 'releaseVersionIds',
     messages: {
       NotAllReleasesBelongToPublication:
         "Some of the releases don't belong to the publication",
@@ -54,7 +54,7 @@ const PublicationInviteNewUsersForm = ({
     await userService.inviteContributor(
       values.email,
       publication.id,
-      values.releaseIds,
+      values.releaseVersionIds,
     );
     history.push(
       generatePath<PublicationTeamRouteParams>(
@@ -69,7 +69,7 @@ const PublicationInviteNewUsersForm = ({
 
   const initialValues: FormValues = {
     email: '',
-    releaseIds: releases.map(r => r.id),
+    releaseVersionIds: releases.map(r => r.id),
   };
 
   const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
@@ -77,7 +77,7 @@ const PublicationInviteNewUsersForm = ({
       email: Yup.string()
         .required('Enter an email address')
         .email('Enter a valid email address'),
-      releaseIds: Yup.array()
+      releaseVersionIds: Yup.array()
         .of(Yup.string().defined())
         .min(1, 'Select at least one release')
         .required('Select at least one release'),
@@ -101,7 +101,7 @@ const PublicationInviteNewUsersForm = ({
                 label="Enter an email address"
               />
               <FormFieldCheckboxGroup<FormValues>
-                name="releaseIds"
+                name="releaseVersionIds"
                 legend="Select which releases you wish the user to have access"
                 legendSize="m"
                 disabled={formState.isSubmitting}

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationInviteNewUsersForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationInviteNewUsersForm.tsx
@@ -3,7 +3,7 @@ import {
   publicationTeamAccessRoute,
 } from '@admin/routes/publicationRoutes';
 import { Publication } from '@admin/services/publicationService';
-import { ReleaseSummary } from '@admin/services/releaseService';
+import { ReleaseVersionSummary } from '@admin/services/releaseService';
 import userService from '@admin/services/userService';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
@@ -39,14 +39,14 @@ export const errorMappings = [
 
 interface Props {
   publication: Publication;
-  releases: ReleaseSummary[];
-  releaseId: string;
+  releases: ReleaseVersionSummary[];
+  releaseVersionId: string;
 }
 
 const PublicationInviteNewUsersForm = ({
   publication,
   releases,
-  releaseId,
+  releaseVersionId,
 }: Props) => {
   const history = useHistory();
 
@@ -61,7 +61,7 @@ const PublicationInviteNewUsersForm = ({
         publicationTeamAccessRoute.path,
         {
           publicationId: publication.id,
-          releaseId,
+          releaseVersionId,
         },
       ),
     );
@@ -126,7 +126,7 @@ const PublicationInviteNewUsersForm = ({
                         publicationTeamAccessRoute.path,
                         {
                           publicationId: publication.id,
-                          releaseId,
+                          releaseVersionId,
                         },
                       ),
                     );

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleases.tsx
@@ -5,7 +5,7 @@ import {
 } from '@admin/routes/releaseRoutes';
 import publicationService from '@admin/services/publicationService';
 import releaseService, {
-  ReleaseSummaryWithPermissions,
+  ReleaseVersionSummaryWithPermissions,
 } from '@admin/services/releaseService';
 import ButtonText from '@common/components/ButtonText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -41,7 +41,7 @@ export default function PublicationPublishedReleases({
   } = useInfiniteQuery(
     ['publicationPublishedReleases', publicationId],
     ({ pageParam = 1 }) => {
-      return publicationService.listReleases<ReleaseSummaryWithPermissions>(
+      return publicationService.listReleases<ReleaseVersionSummaryWithPermissions>(
         publicationId,
         {
           live: true,
@@ -110,7 +110,7 @@ export default function PublicationPublishedReleases({
                 history.push(
                   generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
                     publicationId,
-                    releaseId: amendmentId,
+                    releaseVersionId: amendmentId,
                   }),
                 );
               }}

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleasesTable.tsx
@@ -4,7 +4,7 @@ import {
   ReleaseRouteParams,
   releaseSummaryRoute,
 } from '@admin/routes/releaseRoutes';
-import { ReleaseSummaryWithPermissions } from '@admin/services/releaseService';
+import { ReleaseVersionSummaryWithPermissions } from '@admin/services/releaseService';
 import ButtonText from '@common/components/ButtonText';
 import FormattedDate from '@common/components/FormattedDate';
 import InsetText from '@common/components/InsetText';
@@ -18,7 +18,7 @@ import { PublishedStatusGuidanceModal } from './PublicationGuidance';
 interface PublishedReleasesTableProps {
   focusReleaseId?: string;
   publicationId: string;
-  releases: ReleaseSummaryWithPermissions[];
+  releases: ReleaseVersionSummaryWithPermissions[];
   onAmend: (releaseId: string) => void;
 }
 
@@ -80,7 +80,7 @@ export default function PublicationPublishedReleasesTable({
                       releaseSummaryRoute.path,
                       {
                         publicationId,
-                        releaseId: release.id,
+                        releaseVersionId: release.id,
                       },
                     )}
                   >

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleasesTable.tsx
@@ -19,7 +19,7 @@ interface PublishedReleasesTableProps {
   focusReleaseId?: string;
   publicationId: string;
   releases: ReleaseVersionSummaryWithPermissions[];
-  onAmend: (releaseId: string) => void;
+  onAmend: (releaseVersionId: string) => void;
 }
 
 export default function PublicationPublishedReleasesTable({

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationReleaseAccess.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationReleaseAccess.tsx
@@ -5,7 +5,7 @@ import {
   publicationManageReleaseContributorsPageRoute,
   PublicationTeamRouteParams,
 } from '@admin/routes/publicationRoutes';
-import { ReleaseSummary } from '@admin/services/releaseService';
+import { ReleaseVersionSummary } from '@admin/services/releaseService';
 import releasePermissionService from '@admin/services/releasePermissionService';
 import userService from '@admin/services/userService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -20,7 +20,7 @@ import releasePermissionQueries from '@admin/queries/releasePermissionQueries';
 
 interface Props {
   publicationId: string;
-  release: ReleaseSummary;
+  release: ReleaseVersionSummary;
   hasReleaseTeamManagementPermission: boolean;
 }
 
@@ -118,7 +118,7 @@ const PublicationReleaseAccess = ({
             publicationManageReleaseContributorsPageRoute.path,
             {
               publicationId,
-              releaseId: release.id,
+              releaseVersionId: release.id,
             },
           )}
         >

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationReleaseContributorsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationReleaseContributorsForm.tsx
@@ -44,7 +44,7 @@ const PublicationReleaseContributorsForm = ({
         publicationTeamAccessRoute.path,
         {
           publicationId,
-          releaseId,
+          releaseVersionId: releaseId,
         },
       ),
     );
@@ -63,7 +63,7 @@ const PublicationReleaseContributorsForm = ({
                 publicationTeamAccessRoute.path,
                 {
                   publicationId,
-                  releaseId,
+                  releaseVersionId: releaseId,
                 },
               ),
             );
@@ -112,7 +112,7 @@ const PublicationReleaseContributorsForm = ({
                       publicationTeamAccessRoute.path,
                       {
                         publicationId,
-                        releaseId,
+                        releaseVersionId: releaseId,
                       },
                     ),
                   );

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationReleaseContributorsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationReleaseContributorsForm.tsx
@@ -23,20 +23,20 @@ interface Props {
   publicationContributors: UserReleaseRole[];
   publicationId: string;
   releaseContributors: UserReleaseRole[];
-  releaseId: string;
+  releaseVersionId: string;
 }
 
 const PublicationReleaseContributorsForm = ({
   publicationContributors,
   publicationId,
   releaseContributors,
-  releaseId,
+  releaseVersionId,
 }: Props) => {
   const history = useHistory();
 
   const handleSubmit = async (values: FormValues) => {
     await releasePermissionService.updateReleaseContributors(
-      releaseId,
+      releaseVersionId,
       values.userIds,
     );
     history.push(
@@ -44,7 +44,7 @@ const PublicationReleaseContributorsForm = ({
         publicationTeamAccessRoute.path,
         {
           publicationId,
-          releaseVersionId: releaseId,
+          releaseVersionId,
         },
       ),
     );
@@ -63,7 +63,7 @@ const PublicationReleaseContributorsForm = ({
                 publicationTeamAccessRoute.path,
                 {
                   publicationId,
-                  releaseVersionId: releaseId,
+                  releaseVersionId,
                 },
               ),
             );
@@ -112,7 +112,7 @@ const PublicationReleaseContributorsForm = ({
                       publicationTeamAccessRoute.path,
                       {
                         publicationId,
-                        releaseVersionId: releaseId,
+                        releaseVersionId,
                       },
                     ),
                   );

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationScheduledReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationScheduledReleases.tsx
@@ -4,13 +4,13 @@ import {
   ScheduledStagesGuidanceModal,
   ScheduledStatusGuidanceModal,
 } from '@admin/pages/publication/components/PublicationGuidance';
-import { ReleaseSummaryWithPermissions } from '@admin/services/releaseService';
+import { ReleaseVersionSummaryWithPermissions } from '@admin/services/releaseService';
 import InsetText from '@common/components/InsetText';
 import React from 'react';
 
 interface Props {
   publicationId: string;
-  releases: ReleaseSummaryWithPermissions[];
+  releases: ReleaseVersionSummaryWithPermissions[];
 }
 
 const PublicationScheduledReleases = ({ publicationId, releases }: Props) => {

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationUnpublishedReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationUnpublishedReleases.tsx
@@ -1,7 +1,7 @@
 import PublicationDraftReleases from '@admin/pages/publication/components/PublicationDraftReleases';
 import PublicationScheduledReleases from '@admin/pages/publication/components/PublicationScheduledReleases';
 import publicationService from '@admin/services/publicationService';
-import { ReleaseSummaryWithPermissions } from '@admin/services/releaseService';
+import { ReleaseVersionSummaryWithPermissions } from '@admin/services/releaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import { useQuery } from '@tanstack/react-query';
@@ -22,7 +22,7 @@ export default function PublicationUnpublishedReleases({
     isSuccess,
     refetch,
   } = useQuery(['publicationUnpublishedReleases', publicationId], () =>
-    publicationService.listReleases<ReleaseSummaryWithPermissions>(
+    publicationService.listReleases<ReleaseVersionSummaryWithPermissions>(
       publicationId,
       {
         live: false,

--- a/src/explore-education-statistics-admin/src/pages/publication/components/ScheduledReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/ScheduledReleaseRow.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 const ScheduledReleaseRow = ({ publicationId, release }: Props) => {
   const { currentStatus, currentStatusDetail } = useReleasePublishingStatus({
-    releaseId: release.id,
+    releaseVersionId: release.id,
   });
 
   return (

--- a/src/explore-education-statistics-admin/src/pages/publication/components/ScheduledReleaseRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/ScheduledReleaseRow.tsx
@@ -6,7 +6,7 @@ import {
   ReleaseRouteParams,
   releaseSummaryRoute,
 } from '@admin/routes/releaseRoutes';
-import { ReleaseSummary } from '@admin/services/releaseService';
+import { ReleaseVersionSummary } from '@admin/services/releaseService';
 import FormattedDate from '@common/components/FormattedDate';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import React from 'react';
@@ -14,7 +14,7 @@ import { generatePath } from 'react-router';
 
 interface Props {
   publicationId: string;
-  release: ReleaseSummary;
+  release: ReleaseVersionSummary;
 }
 
 const ScheduledReleaseRow = ({ publicationId, release }: Props) => {
@@ -47,7 +47,7 @@ const ScheduledReleaseRow = ({ publicationId, release }: Props) => {
         <Link
           to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
             publicationId,
-            releaseId: release.id,
+            releaseVersionId: release.id,
           })}
         >
           {release.permissions?.canUpdateRelease ? 'Edit' : 'View'}

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationDraftReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationDraftReleases.test.tsx
@@ -1,6 +1,6 @@
 import PublicationDraftReleases from '@admin/pages/publication/components/PublicationDraftReleases';
 import _releaseService, {
-  ReleaseSummaryWithPermissions,
+  ReleaseVersionSummaryWithPermissions,
 } from '@admin/services/releaseService';
 import {
   render as baseRender,
@@ -19,7 +19,7 @@ const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
 describe('PublicationDraftReleases', () => {
   const testPublicationId = 'publication-1';
 
-  const testRelease1: ReleaseSummaryWithPermissions = {
+  const testRelease1: ReleaseVersionSummaryWithPermissions = {
     amendment: false,
     approvalStatus: 'Draft',
     id: 'release-1',
@@ -43,7 +43,7 @@ describe('PublicationDraftReleases', () => {
     latestRelease: false,
   };
 
-  const testRelease2: ReleaseSummaryWithPermissions = {
+  const testRelease2: ReleaseVersionSummaryWithPermissions = {
     ...testRelease1,
     approvalStatus: 'HigherLevelReview',
     id: 'release-2',
@@ -52,7 +52,7 @@ describe('PublicationDraftReleases', () => {
     title: 'Release 2',
   };
 
-  const testRelease3: ReleaseSummaryWithPermissions = {
+  const testRelease3: ReleaseVersionSummaryWithPermissions = {
     ...testRelease1,
     amendment: true,
     id: 'release-3',

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationInviteNewUsersForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationInviteNewUsersForm.test.tsx
@@ -25,7 +25,7 @@ describe('PublicationInviteNewUsersForm', () => {
       <PublicationInviteNewUsersForm
         publication={publication}
         releases={testReleaseSummaries}
-        releaseId={currentReleaseId}
+        releaseVersionId={currentReleaseId}
       />,
     );
 
@@ -86,7 +86,7 @@ describe('PublicationInviteNewUsersForm', () => {
       <PublicationInviteNewUsersForm
         publication={publication}
         releases={testReleaseSummaries}
-        releaseId={currentReleaseId}
+        releaseVersionId={currentReleaseId}
       />,
     );
 
@@ -115,7 +115,7 @@ describe('PublicationInviteNewUsersForm', () => {
       <PublicationInviteNewUsersForm
         publication={publication}
         releases={testReleaseSummaries}
-        releaseId={currentReleaseId}
+        releaseVersionId={currentReleaseId}
       />,
     );
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationInviteNewUsersForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationInviteNewUsersForm.test.tsx
@@ -151,7 +151,7 @@ describe('PublicationInviteNewUsersForm', () => {
       expect(userService.inviteContributor).toHaveBeenCalledTimes(0);
       expect(
         screen.getByText('Select at least one release', {
-          selector: '#inviteContributorForm-releaseIds-error',
+          selector: '#inviteContributorForm-releaseVersionIds-error',
         }),
       );
     });

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationPublishedReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationPublishedReleases.test.tsx
@@ -1,6 +1,6 @@
 import PublicationPublishedReleases from '@admin/pages/publication/components/PublicationPublishedReleases';
 import _releaseService, {
-  ReleaseSummaryWithPermissions,
+  ReleaseVersionSummaryWithPermissions,
 } from '@admin/services/releaseService';
 import _publicationService from '@admin/services/publicationService';
 import baseRender from '@common-test/render';
@@ -23,7 +23,7 @@ const publicationService = _publicationService as jest.Mocked<
 describe('PublicationPublishedReleases', () => {
   const testPublicationId = 'publication-1';
 
-  const testRelease1: ReleaseSummaryWithPermissions = {
+  const testRelease1: ReleaseVersionSummaryWithPermissions = {
     amendment: false,
     approvalStatus: 'Approved',
     id: 'release-1',
@@ -48,7 +48,7 @@ describe('PublicationPublishedReleases', () => {
     latestRelease: false,
   };
 
-  const testRelease2: ReleaseSummaryWithPermissions = {
+  const testRelease2: ReleaseVersionSummaryWithPermissions = {
     ...testRelease1,
     id: 'release-2',
     published: '2022-01-02T00:00:00',
@@ -58,7 +58,7 @@ describe('PublicationPublishedReleases', () => {
     yearTitle: '2020/21',
   };
 
-  const testRelease3: ReleaseSummaryWithPermissions = {
+  const testRelease3: ReleaseVersionSummaryWithPermissions = {
     ...testRelease1,
     id: 'release-3',
     published: '2022-01-03T00:00:00',
@@ -68,7 +68,7 @@ describe('PublicationPublishedReleases', () => {
     yearTitle: '2019/20',
   };
 
-  const testRelease4: ReleaseSummaryWithPermissions = {
+  const testRelease4: ReleaseVersionSummaryWithPermissions = {
     ...testRelease1,
     id: 'release-4',
     published: '2022-01-04T00:00:00',
@@ -78,7 +78,7 @@ describe('PublicationPublishedReleases', () => {
     yearTitle: '2018/19',
   };
 
-  const testRelease5: ReleaseSummaryWithPermissions = {
+  const testRelease5: ReleaseVersionSummaryWithPermissions = {
     ...testRelease1,
     id: 'release-5',
     published: '2022-01-05T00:00:00',
@@ -88,7 +88,7 @@ describe('PublicationPublishedReleases', () => {
     yearTitle: '2017/18',
   };
 
-  const testRelease6: ReleaseSummaryWithPermissions = {
+  const testRelease6: ReleaseVersionSummaryWithPermissions = {
     ...testRelease1,
     id: 'release-6',
     published: '2022-01-06T00:00:00',
@@ -98,7 +98,7 @@ describe('PublicationPublishedReleases', () => {
     yearTitle: '2016/17',
   };
 
-  const testRelease7: ReleaseSummaryWithPermissions = {
+  const testRelease7: ReleaseVersionSummaryWithPermissions = {
     ...testRelease1,
     id: 'release-7',
     published: '2022-01-07T00:00:00',
@@ -108,7 +108,7 @@ describe('PublicationPublishedReleases', () => {
     yearTitle: '2015/16',
   };
 
-  const testReleases: ReleaseSummaryWithPermissions[] = [
+  const testReleases: ReleaseVersionSummaryWithPermissions[] = [
     testRelease1,
     testRelease2,
     testRelease3,
@@ -118,24 +118,26 @@ describe('PublicationPublishedReleases', () => {
     testRelease7,
   ];
 
-  const testReleasesPage1: PaginatedList<ReleaseSummaryWithPermissions> = {
-    paging: {
-      page: 1,
-      pageSize: 5,
-      totalPages: 2,
-      totalResults: 7,
-    },
-    results: testReleases.slice(0, 5),
-  };
-  const testReleasesPage2: PaginatedList<ReleaseSummaryWithPermissions> = {
-    paging: {
-      page: 2,
-      pageSize: 5,
-      totalPages: 2,
-      totalResults: 7,
-    },
-    results: testReleases.slice(5),
-  };
+  const testReleasesPage1: PaginatedList<ReleaseVersionSummaryWithPermissions> =
+    {
+      paging: {
+        page: 1,
+        pageSize: 5,
+        totalPages: 2,
+        totalResults: 7,
+      },
+      results: testReleases.slice(0, 5),
+    };
+  const testReleasesPage2: PaginatedList<ReleaseVersionSummaryWithPermissions> =
+    {
+      paging: {
+        page: 2,
+        pageSize: 5,
+        totalPages: 2,
+        totalResults: 7,
+      },
+      results: testReleases.slice(5),
+    };
 
   test('renders the published releases table once loaded', async () => {
     publicationService.listReleases.mockResolvedValue(testReleasesPage1);

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationReleaseAccess.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationReleaseAccess.test.tsx
@@ -1,6 +1,6 @@
 import baseRender from '@common-test/render';
 import PublicationReleaseAccess from '@admin/pages/publication/components/PublicationReleaseAccess';
-import { ReleaseSummary } from '@admin/services/releaseService';
+import { ReleaseVersionSummary } from '@admin/services/releaseService';
 import _userService from '@admin/services/userService';
 import _releasePermissionService, {
   UserReleaseInvite,
@@ -22,7 +22,7 @@ const userService = _userService as jest.Mocked<typeof _userService>;
 describe('PublicationReleaseAccess', () => {
   const testPublicationId = 'publication-1';
 
-  const testRelease: ReleaseSummary = {
+  const testRelease: ReleaseVersionSummary = {
     id: 'release1-id',
     slug: 'release-1-slug',
     timePeriodCoverage: {

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationReleaseContributorsForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationReleaseContributorsForm.test.tsx
@@ -53,7 +53,7 @@ describe('PublicationReleaseContributorsForm', () => {
     render(
       <PublicationReleaseContributorsForm
         publicationId="publication-id"
-        releaseId="release-id"
+        releaseVersionId="release-id"
         publicationContributors={testPublicationContributors}
         releaseContributors={testReleaseContributors}
       />,

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationScheduledReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationScheduledReleases.test.tsx
@@ -1,6 +1,6 @@
 import PublicationScheduledReleases from '@admin/pages/publication/components/PublicationScheduledReleases';
 import _releaseService, {
-  ReleaseSummaryWithPermissions,
+  ReleaseVersionSummaryWithPermissions,
 } from '@admin/services/releaseService';
 import {
   render as baseRender,
@@ -17,7 +17,7 @@ const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
 describe('PublicationScheduledReleases', () => {
   const testPublicationId = 'publication-1';
 
-  const testRelease1: ReleaseSummaryWithPermissions = {
+  const testRelease1: ReleaseVersionSummaryWithPermissions = {
     amendment: false,
     approvalStatus: 'Approved',
     id: 'release-1',
@@ -43,7 +43,7 @@ describe('PublicationScheduledReleases', () => {
     latestRelease: false,
   };
 
-  const testRelease2: ReleaseSummaryWithPermissions = {
+  const testRelease2: ReleaseVersionSummaryWithPermissions = {
     ...testRelease1,
     approvalStatus: 'Approved',
     id: 'release-2',

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationUnpublishedReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationUnpublishedReleases.test.tsx
@@ -2,8 +2,8 @@ import baseRender from '@common-test/render';
 import PublicationUnpublishedReleases from '@admin/pages/publication/components/PublicationUnpublishedReleases';
 import _publicationService from '@admin/services/publicationService';
 import _releaseService, {
-  ReleasePermissions,
-  ReleaseSummaryWithPermissions,
+  ReleaseVersionPermissions,
+  ReleaseVersionSummaryWithPermissions,
 } from '@admin/services/releaseService';
 import { PaginatedList } from '@common/services/types/pagination';
 import { screen, waitFor, within } from '@testing-library/react';
@@ -22,7 +22,7 @@ const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
 describe('PublicationUnpublishedReleases', () => {
   const testPublicationId = 'publication-1';
 
-  const testPermissions: ReleasePermissions = {
+  const testPermissions: ReleaseVersionPermissions = {
     canAddPrereleaseUsers: false,
     canUpdateRelease: true,
     canDeleteRelease: true,
@@ -30,7 +30,7 @@ describe('PublicationUnpublishedReleases', () => {
     canViewRelease: true,
   };
 
-  const testRelease1: ReleaseSummaryWithPermissions = {
+  const testRelease1: ReleaseVersionSummaryWithPermissions = {
     amendment: false,
     approvalStatus: 'Approved',
     id: 'release-1',
@@ -49,7 +49,7 @@ describe('PublicationUnpublishedReleases', () => {
     latestRelease: false,
   };
 
-  const testRelease2: ReleaseSummaryWithPermissions = {
+  const testRelease2: ReleaseVersionSummaryWithPermissions = {
     amendment: false,
     approvalStatus: 'Draft',
     id: 'release-2',
@@ -67,7 +67,7 @@ describe('PublicationUnpublishedReleases', () => {
     latestRelease: false,
   };
 
-  const testRelease3: ReleaseSummaryWithPermissions = {
+  const testRelease3: ReleaseVersionSummaryWithPermissions = {
     amendment: true,
     approvalStatus: 'HigherLevelReview',
     id: 'release-3',
@@ -85,15 +85,16 @@ describe('PublicationUnpublishedReleases', () => {
     latestRelease: false,
   };
 
-  const testReleasesPage1: PaginatedList<ReleaseSummaryWithPermissions> = {
-    paging: {
-      page: 1,
-      pageSize: 20,
-      totalPages: 1,
-      totalResults: 3,
-    },
-    results: [testRelease1, testRelease2, testRelease3],
-  };
+  const testReleasesPage1: PaginatedList<ReleaseVersionSummaryWithPermissions> =
+    {
+      paging: {
+        page: 1,
+        pageSize: 20,
+        totalPages: 1,
+        totalResults: 3,
+      },
+      results: [testRelease1, testRelease2, testRelease3],
+    };
 
   beforeEach(() => {
     releaseService.getReleaseStatus.mockResolvedValue({

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseCreatePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseCreatePage.tsx
@@ -68,7 +68,7 @@ const ReleaseCreatePage = ({
     history.push(
       generatePath(releaseSummaryRoute.path, {
         publicationId,
-        releaseId: createdRelease.id,
+        releaseVersionId: createdRelease.id,
       }),
     );
   };

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseDataGuidancePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseDataGuidancePage.tsx
@@ -60,7 +60,7 @@ const ReleaseDataGuidancePage = ({
               renderDataCatalogueLink={
                 model.release.published ? (
                   <Link
-                    to={`${publicAppUrl}/data-catalogue?publicationId=${model.release.publicationId}&releaseId=${model.release.id}`}
+                    to={`${publicAppUrl}/data-catalogue?publicationId=${model.release.publicationId}&releaseVersionId=${model.release.id}`}
                   >
                     data catalogue
                   </Link>

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseDataGuidancePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseDataGuidancePage.tsx
@@ -4,7 +4,7 @@ import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
 import releaseDataGuidanceService, {
   ReleaseDataGuidance,
 } from '@admin/services/releaseDataGuidanceService';
-import releaseService, { Release } from '@admin/services/releaseService';
+import releaseService, { ReleaseVersion } from '@admin/services/releaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import ReleaseDataGuidancePageContent from '@common/modules/release/components/ReleaseDataGuidancePageContent';
@@ -19,26 +19,26 @@ interface LocationState {
 
 interface Model {
   dataGuidance: ReleaseDataGuidance;
-  release: Release;
+  release: ReleaseVersion;
 }
 
 const ReleaseDataGuidancePage = ({
   match,
   location,
 }: RouteComponentProps<ReleaseRouteParams, StaticContext, LocationState>) => {
-  const { releaseId } = match.params;
+  const { releaseVersionId } = match.params;
 
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const [dataGuidance, release] = await Promise.all([
-      releaseDataGuidanceService.getDataGuidance(releaseId),
-      releaseService.getRelease(releaseId),
+      releaseDataGuidanceService.getDataGuidance(releaseVersionId),
+      releaseService.getRelease(releaseVersionId),
     ]);
 
     return {
       dataGuidance,
       release,
     };
-  }, [releaseId]);
+  }, [releaseVersionId]);
 
   const { publicAppUrl } = useConfig();
 

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -4,7 +4,7 @@ import PageTitle from '@admin/components/PageTitle';
 import PreviousNextLinks from '@admin/components/PreviousNextLinks';
 import ProtectedRoute from '@admin/components/ProtectedRoute';
 import { useAuthContext } from '@admin/contexts/AuthContext';
-import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
+import { ReleaseVersionContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
 import { getReleaseApprovalStatusLabel } from '@admin/pages/release/utils/releaseSummaryUtil';
 import releaseQueries from '@admin/queries/releaseQueries';
 import {
@@ -69,14 +69,14 @@ const routes = [
 
 interface MatchProps {
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
 }
 
 const ReleasePageContainer = ({
   match,
   location,
 }: RouteComponentProps<MatchProps>) => {
-  const { publicationId, releaseId } = match.params;
+  const { publicationId, releaseVersionId } = match.params;
 
   const { user } = useAuthContext();
 
@@ -84,7 +84,7 @@ const ReleasePageContainer = ({
     data: release,
     isLoading: loadingRelease,
     refetch,
-  } = useQuery(releaseQueries.get(releaseId));
+  } = useQuery(releaseQueries.get(releaseVersionId));
 
   const navRoutes = useMemo(() => {
     return allNavRoutes.filter(route => {
@@ -100,7 +100,7 @@ const ReleasePageContainer = ({
       route =>
         generatePath<ReleaseRouteParams>(route.path, {
           publicationId,
-          releaseId,
+          releaseVersionId,
         }) === location.pathname,
     ) || 0;
 
@@ -117,7 +117,7 @@ const ReleasePageContainer = ({
         label: previousRoute.title,
         linkTo: generatePath<ReleaseRouteParams>(previousRoute.path, {
           publicationId,
-          releaseId,
+          releaseVersionId,
         }),
       }
     : undefined;
@@ -127,7 +127,7 @@ const ReleasePageContainer = ({
         label: nextRoute.title,
         linkTo: generatePath<ReleaseRouteParams>(nextRoute.path, {
           publicationId,
-          releaseId,
+          releaseVersionId,
         }),
       }
     : undefined;
@@ -170,19 +170,22 @@ const ReleasePageContainer = ({
               title: route.title,
               to: generatePath<ReleaseRouteParams>(route.path, {
                 publicationId,
-                releaseId,
+                releaseVersionId,
               }),
             }))}
             label="Release"
           />
 
-          <ReleaseContextProvider release={release} onReleaseChange={refetch}>
+          <ReleaseVersionContextProvider
+            releaseVersion={release}
+            onReleaseChange={refetch}
+          >
             <Switch>
               {routes.map(route => (
                 <ProtectedRoute exact key={route.path} {...route} />
               ))}
             </Switch>
-          </ReleaseContextProvider>
+          </ReleaseVersionContextProvider>
 
           {currentRouteIndex > -1 && (
             <PreviousNextLinks

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusEditPage.tsx
@@ -1,17 +1,17 @@
 import ReleaseStatusChecklist from '@admin/pages/release/components/ReleaseStatusChecklist';
 import ReleaseStatusForm from '@admin/pages/release/components/ReleaseStatusForm';
 import { ReleaseStatusPermissions } from '@admin/services/permissionService';
-import releaseService, { Release } from '@admin/services/releaseService';
+import releaseService, { ReleaseVersion } from '@admin/services/releaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import { formatISO } from 'date-fns';
 import React from 'react';
 
 interface Props {
-  release: Release;
+  release: ReleaseVersion;
   statusPermissions: ReleaseStatusPermissions;
   onCancel: () => void;
-  onUpdate: (values: Release) => void;
+  onUpdate: (values: ReleaseVersion) => void;
 }
 
 const ReleaseStatusEditPage = ({

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -2,7 +2,7 @@ import StatusBlock from '@admin/components/StatusBlock';
 import { useConfig } from '@admin/contexts/ConfigContext';
 import { useLastLocation } from '@admin/contexts/LastLocationContext';
 import ReleasePublishingStatus from '@admin/pages/release/components/ReleasePublishingStatus';
-import { useReleaseContext } from '@admin/pages/release/contexts/ReleaseContext';
+import { useReleaseVersionContext } from '@admin/pages/release/contexts/ReleaseContext';
 import ReleaseStatusEditPage from '@admin/pages/release/ReleaseStatusEditPage';
 import permissionService, {
   ReleaseStatusPermissions,
@@ -43,26 +43,26 @@ export default function ReleaseStatusPage() {
   const lastLocation = useLastLocation();
 
   const {
-    releaseId,
-    release: contextRelease,
+    releaseVersionId,
+    releaseVersion: contextRelease,
     onReleaseChange,
-  } = useReleaseContext();
+  } = useReleaseVersionContext();
 
   const { value: release, setState: setRelease } = useAsyncHandledRetry(
     async () =>
       lastLocation && lastLocation !== location
-        ? releaseService.getRelease(releaseId)
+        ? releaseService.getRelease(releaseVersionId)
         : contextRelease,
-    [releaseId],
+    [releaseVersionId],
   );
 
   const { value: releaseStatuses } = useAsyncRetry<ReleaseStatus[]>(
-    () => releaseService.getReleaseStatuses(releaseId),
-    [releaseId, release],
+    () => releaseService.getReleaseStatuses(releaseVersionId),
+    [releaseVersionId, release],
   );
 
   const { value: statusPermissions } = useAsyncRetry<ReleaseStatusPermissions>(
-    () => permissionService.getReleaseStatusPermissions(releaseId),
+    () => permissionService.getReleaseStatusPermissions(releaseVersionId),
   );
 
   const { publicAppUrl } = useConfig();
@@ -119,7 +119,7 @@ export default function ReleaseStatusPage() {
         {release.approvalStatus === 'Approved' && (
           <SummaryListItem term="Release process status">
             <ReleasePublishingStatus
-              releaseId={releaseId}
+              releaseId={releaseVersionId}
               refreshPeriod={1000}
               onChange={handlePublishingStatusChange}
             />

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -119,7 +119,7 @@ export default function ReleaseStatusPage() {
         {release.approvalStatus === 'Approved' && (
           <SummaryListItem term="Release process status">
             <ReleasePublishingStatus
-              releaseId={releaseVersionId}
+              releaseVersionId={releaseVersionId}
               refreshPeriod={1000}
               onChange={handlePublishingStatusChange}
             />

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
@@ -2,7 +2,7 @@ import { useLastLocation } from '@admin/contexts/LastLocationContext';
 import ReleaseSummaryForm, {
   ReleaseSummaryFormValues,
 } from '@admin/pages/release/components/ReleaseSummaryForm';
-import { useReleaseContext } from '@admin/pages/release/contexts/ReleaseContext';
+import { useReleaseVersionContext } from '@admin/pages/release/contexts/ReleaseContext';
 import {
   ReleaseRouteParams,
   releaseSummaryRoute,
@@ -20,17 +20,17 @@ export default function ReleaseSummaryEditPage({
   const lastLocation = useLastLocation();
 
   const {
-    releaseId,
-    release: contextRelease,
+    releaseVersionId,
+    releaseVersion: contextRelease,
     onReleaseChange,
-  } = useReleaseContext();
+  } = useReleaseVersionContext();
 
   const { value: release, isLoading } = useAsyncRetry(
     async () =>
       lastLocation && lastLocation !== location
-        ? releaseService.getRelease(releaseId)
+        ? releaseService.getRelease(releaseVersionId)
         : contextRelease,
-    [releaseId],
+    [releaseVersionId],
   );
 
   const handleSubmit = async (values: ReleaseSummaryFormValues) => {
@@ -38,7 +38,7 @@ export default function ReleaseSummaryEditPage({
       throw new Error('Could not update missing release');
     }
 
-    await releaseService.updateRelease(releaseId, {
+    await releaseService.updateRelease(releaseVersionId, {
       year: Number(values.timePeriodCoverageStartYear),
       timePeriodCoverage: {
         value: values.timePeriodCoverageCode,
@@ -52,7 +52,7 @@ export default function ReleaseSummaryEditPage({
     history.push(
       generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
         publicationId: release.publicationId,
-        releaseId,
+        releaseVersionId,
       }),
     );
   };
@@ -65,7 +65,7 @@ export default function ReleaseSummaryEditPage({
     history.push(
       generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
         publicationId: release.publicationId,
-        releaseId,
+        releaseVersionId,
       }),
     );
   };

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryPage.tsx
@@ -1,6 +1,6 @@
 import ButtonLink from '@admin/components/ButtonLink';
 import { useLastLocation } from '@admin/contexts/LastLocationContext';
-import { useReleaseContext } from '@admin/pages/release/contexts/ReleaseContext';
+import { useReleaseVersionContext } from '@admin/pages/release/contexts/ReleaseContext';
 import {
   ReleaseRouteParams,
   releaseSummaryEditRoute,
@@ -21,14 +21,15 @@ const ReleaseSummaryPage = () => {
   const location = useLocation();
   const lastLocation = useLastLocation();
 
-  const { release: contextRelease, releaseId } = useReleaseContext();
+  const { releaseVersion: contextRelease, releaseVersionId } =
+    useReleaseVersionContext();
 
   const { value: release, isLoading } = useAsyncRetry(
     async () =>
       lastLocation && lastLocation !== location
-        ? releaseService.getRelease(releaseId)
+        ? releaseService.getRelease(releaseVersionId)
         : contextRelease,
-    [releaseId],
+    [releaseVersionId],
   );
 
   return (
@@ -53,13 +54,17 @@ const ReleaseSummaryPage = () => {
             </SummaryListItem>
           </SummaryList>
 
-          <Gate condition={() => permissionService.canUpdateRelease(releaseId)}>
+          <Gate
+            condition={() =>
+              permissionService.canUpdateRelease(releaseVersionId)
+            }
+          >
             <ButtonLink
               to={generatePath<ReleaseRouteParams>(
                 releaseSummaryEditRoute.path,
                 {
                   publicationId: release.publicationId,
-                  releaseId,
+                  releaseVersionId,
                 },
               )}
             >

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testReleaseVersion.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testReleaseVersion.ts
@@ -1,9 +1,9 @@
-import { Release } from '@admin/services/releaseService';
+import { ReleaseVersion } from '@admin/services/releaseService';
 
 // eslint-disable-next-line import/prefer-default-export
-export const testRelease: Release = {
+export const testReleaseVersion: ReleaseVersion = {
   id: 'release-1',
-  releaseId: 'release-series-1',
+  releaseId: 'parent-release-1',
   slug: 'release-1-slug',
   approvalStatus: 'Draft',
   latestRelease: false,

--- a/src/explore-education-statistics-admin/src/pages/release/__tests__/ReleaseStatusPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/__tests__/ReleaseStatusPage.test.tsx
@@ -1,10 +1,12 @@
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
-import { testRelease } from '@admin/pages/release/__data__/testRelease';
-import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
+import { testReleaseVersion } from '@admin/pages/release/__data__/testReleaseVersion';
+import { ReleaseVersionContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
 import _permissionService, {
   ReleaseStatusPermissions,
 } from '@admin/services/permissionService';
-import _releaseService, { Release } from '@admin/services/releaseService';
+import _releaseService, {
+  ReleaseVersion,
+} from '@admin/services/releaseService';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -65,7 +67,7 @@ describe('ReleaseStatusPage', () => {
     });
 
     renderPage({
-      ...testRelease,
+      ...testReleaseVersion,
       approvalStatus: 'Approved',
       publishScheduled: '2021-01-15',
       nextReleaseDate: {
@@ -132,13 +134,13 @@ describe('ReleaseStatusPage', () => {
     expect(screen.queryByText('Edit release status')).not.toBeInTheDocument();
   });
 
-  function renderPage(release: Release = testRelease) {
+  function renderPage(release: ReleaseVersion = testReleaseVersion) {
     return render(
       <MemoryRouter>
         <TestConfigContextProvider>
-          <ReleaseContextProvider release={release}>
+          <ReleaseVersionContextProvider releaseVersion={release}>
             <ReleaseStatusPage />
-          </ReleaseContextProvider>
+          </ReleaseVersionContextProvider>
         </TestConfigContextProvider>
       </MemoryRouter>,
     );

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStages.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStages.tsx
@@ -40,7 +40,9 @@ export default function ReleasePublishingStages({
         )}
       <ul className="govuk-list">
         {Object.entries(currentStatus).map(([key, val]) => {
-          if (['overallStage', 'releaseId', 'lastUpdated'].includes(key)) {
+          if (
+            ['overallStage', 'releaseVersionId', 'lastUpdated'].includes(key)
+          ) {
             return null;
           }
           const { color, text } = getStatusDetail(val);

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStatus.tsx
@@ -5,18 +5,18 @@ import { ReleaseStageStatus } from '@admin/services/releaseService';
 import React from 'react';
 
 interface ReleasePublishingStatusProps {
-  releaseId: string;
+  releaseVersionId: string;
   refreshPeriod?: number;
   onChange?: (status: ReleaseStageStatus) => void;
 }
 
 export default function ReleasePublishingStatus({
-  releaseId,
+  releaseVersionId,
   refreshPeriod,
   onChange,
 }: ReleasePublishingStatusProps) {
   const { currentStatus, currentStatusDetail } = useReleasePublishingStatus({
-    releaseId,
+    releaseVersionId,
     refreshPeriod,
     onChange,
   });

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
@@ -15,7 +15,7 @@ import {
 } from '@admin/routes/releaseRoutes';
 import { PublicationRouteParams } from '@admin/routes/routes';
 import {
-  Release,
+  ReleaseVersion,
   ReleaseChecklist,
   ReleaseChecklistError,
   ReleaseChecklistWarning,
@@ -34,7 +34,7 @@ interface ChecklistMessage {
 
 interface Props {
   checklist: ReleaseChecklist;
-  release: Release;
+  release: ReleaseVersion;
 }
 
 const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
@@ -42,7 +42,7 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
 
   const releaseRouteParams = useMemo<ReleaseRouteParams>(
     () => ({
-      releaseId: release.id,
+      releaseVersionId: release.id,
       publicationId: release.publicationId,
     }),
     [release.id, release.publicationId],

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -1,6 +1,6 @@
 import { ReleaseStatusPermissions } from '@admin/services/permissionService';
 import {
-  Release,
+  ReleaseVersion,
   ReleaseChecklistErrorCode,
 } from '@admin/services/releaseService';
 import Button from '@common/components/Button';
@@ -83,7 +83,7 @@ const fallbackErrorMapping = mapFallbackFieldError<ReleaseStatusFormValues>({
 });
 
 interface Props {
-  release: Release;
+  release: ReleaseVersion;
   statusPermissions: ReleaseStatusPermissions;
   onCancel: () => void;
   onSubmit: (values: ReleaseStatusFormValues) => Promise<void> | void;

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleasePublishingStatus.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleasePublishingStatus.test.tsx
@@ -16,7 +16,7 @@ describe('ReleasePublishingStatus', () => {
       publishingStage: 'NotStarted',
     });
 
-    render(<ReleasePublishingStatus releaseId="release-1" />);
+    render(<ReleasePublishingStatus releaseVersionId="release-1" />);
 
     expect(await screen.findByText('Started')).toBeInTheDocument();
 
@@ -32,7 +32,7 @@ describe('ReleasePublishingStatus', () => {
       overallStage: 'Started',
     });
 
-    render(<ReleasePublishingStatus releaseId="release-1" />);
+    render(<ReleasePublishingStatus releaseVersionId="release-1" />);
 
     expect(await screen.findByText('Started')).toBeInTheDocument();
 
@@ -64,7 +64,10 @@ describe('ReleasePublishingStatus', () => {
     const handleChange = jest.fn();
 
     render(
-      <ReleasePublishingStatus releaseId="release-1" onChange={handleChange} />,
+      <ReleasePublishingStatus
+        releaseVersionId="release-1"
+        onChange={handleChange}
+      />,
     );
 
     expect(await screen.findByText('Started')).toBeInTheDocument();
@@ -104,7 +107,10 @@ describe('ReleasePublishingStatus', () => {
     const handleChange = jest.fn();
 
     render(
-      <ReleasePublishingStatus releaseId="release-1" onChange={handleChange} />,
+      <ReleasePublishingStatus
+        releaseVersionId="release-1"
+        onChange={handleChange}
+      />,
     );
 
     expect(await screen.findByText('Started')).toBeInTheDocument();

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
@@ -1,10 +1,10 @@
 import ReleaseStatusChecklist from '@admin/pages/release/components/ReleaseStatusChecklist';
-import { testRelease } from '@admin/pages/release/__data__/testRelease';
-import { render, screen } from '@testing-library/react';
+import {testReleaseVersion} from '@admin/pages/release/__data__/testReleaseVersion';
+import {render, screen} from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter } from 'react-router';
-import { AuthContextTestProvider, User } from '@admin/contexts/AuthContext';
-import { GlobalPermissions } from '@admin/services/authService';
+import {MemoryRouter} from 'react-router';
+import {AuthContextTestProvider, User} from '@admin/contexts/AuthContext';
+import {GlobalPermissions} from '@admin/services/authService';
 
 describe('ReleaseStatusChecklist', () => {
   test('renders correctly with errors', () => {
@@ -24,19 +24,19 @@ describe('ReleaseStatusChecklist', () => {
               valid: false,
               warnings: [],
               errors: [
-                { code: 'DataFileImportsMustBeCompleted' },
-                { code: 'DataFileReplacementsMustBeCompleted' },
-                { code: 'PublicDataGuidanceRequired' },
-                { code: 'ReleaseNoteRequired' },
-                { code: 'SummarySectionContainsEmptyHtmlBlock' },
-                { code: 'EmptyContentSectionExists' },
-                { code: 'GenericSectionsContainEmptyHtmlBlock' },
-                { code: 'RelatedDashboardsSectionContainsEmptyHtmlBlock' },
-                { code: 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock' },
-                { code: 'PublicApiDataSetImportsMustBeCompleted' },
-                { code: 'PublicApiDataSetCancellationsMustBeResolved' },
-                { code: 'PublicApiDataSetFailuresMustBeResolved' },
-                { code: 'PublicApiDataSetMappingsMustBeCompleted' },
+                {code: 'DataFileImportsMustBeCompleted'},
+                {code: 'DataFileReplacementsMustBeCompleted'},
+                {code: 'PublicDataGuidanceRequired'},
+                {code: 'ReleaseNoteRequired'},
+                {code: 'SummarySectionContainsEmptyHtmlBlock'},
+                {code: 'EmptyContentSectionExists'},
+                {code: 'GenericSectionsContainEmptyHtmlBlock'},
+                {code: 'RelatedDashboardsSectionContainsEmptyHtmlBlock'},
+                {code: 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock'},
+                {code: 'PublicApiDataSetImportsMustBeCompleted'},
+                {code: 'PublicApiDataSetCancellationsMustBeResolved'},
+                {code: 'PublicApiDataSetFailuresMustBeResolved'},
+                {code: 'PublicApiDataSetMappingsMustBeCompleted'},
               ],
             }}
             release={testReleaseVersion}
@@ -47,11 +47,11 @@ describe('ReleaseStatusChecklist', () => {
     );
 
     expect(
-      screen.queryByRole('heading', { name: 'All checks passed' }),
+      screen.queryByRole('heading', {name: 'All checks passed'}),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Errors' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Errors'})).toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', { name: 'Warnings' }),
+      screen.queryByRole('heading', {name: 'Warnings'}),
     ).not.toBeInTheDocument();
 
     expect(screen.getByText('13 issues')).toBeInTheDocument();
@@ -191,22 +191,22 @@ describe('ReleaseStatusChecklist', () => {
               valid: false,
               warnings: [],
               errors: [
-                { code: 'DataFileImportsMustBeCompleted' },
-                { code: 'DataFileReplacementsMustBeCompleted' },
-                { code: 'PublicDataGuidanceRequired' },
-                { code: 'ReleaseNoteRequired' },
-                { code: 'SummarySectionContainsEmptyHtmlBlock' },
-                { code: 'EmptyContentSectionExists' },
-                { code: 'GenericSectionsContainEmptyHtmlBlock' },
-                { code: 'RelatedDashboardsSectionContainsEmptyHtmlBlock' },
-                { code: 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock' },
-                { code: 'PublicApiDataSetImportsMustBeCompleted' },
-                { code: 'PublicApiDataSetCancellationsMustBeResolved' },
-                { code: 'PublicApiDataSetFailuresMustBeResolved' },
-                { code: 'PublicApiDataSetMappingsMustBeCompleted' },
+                {code: 'DataFileImportsMustBeCompleted'},
+                {code: 'DataFileReplacementsMustBeCompleted'},
+                {code: 'PublicDataGuidanceRequired'},
+                {code: 'ReleaseNoteRequired'},
+                {code: 'SummarySectionContainsEmptyHtmlBlock'},
+                {code: 'EmptyContentSectionExists'},
+                {code: 'GenericSectionsContainEmptyHtmlBlock'},
+                {code: 'RelatedDashboardsSectionContainsEmptyHtmlBlock'},
+                {code: 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock'},
+                {code: 'PublicApiDataSetImportsMustBeCompleted'},
+                {code: 'PublicApiDataSetCancellationsMustBeResolved'},
+                {code: 'PublicApiDataSetFailuresMustBeResolved'},
+                {code: 'PublicApiDataSetMappingsMustBeCompleted'},
               ],
             }}
-            release={testRelease}
+            release={testReleaseVersion}
           />
         </MemoryRouter>
         ,
@@ -265,7 +265,7 @@ describe('ReleaseStatusChecklist', () => {
           checklist={{
             valid: true,
             warnings: [
-              { code: 'NoMethodology' },
+              {code: 'NoMethodology'},
               {
                 code: 'MethodologyNotApproved',
                 methodologyId: 'methodology-1',
@@ -274,11 +274,11 @@ describe('ReleaseStatusChecklist', () => {
                 code: 'MethodologyNotApproved',
                 methodologyId: 'methodology-2',
               },
-              { code: 'NoNextReleaseDate' },
-              { code: 'NoFootnotesOnSubjects', totalSubjects: 3 },
-              { code: 'NoFeaturedTables' },
-              { code: 'NoDataFiles' },
-              { code: 'NoPublicPreReleaseAccessList' },
+              {code: 'NoNextReleaseDate'},
+              {code: 'NoFootnotesOnSubjects', totalSubjects: 3},
+              {code: 'NoFeaturedTables'},
+              {code: 'NoDataFiles'},
+              {code: 'NoPublicPreReleaseAccessList'},
             ],
             errors: [],
           }}
@@ -288,13 +288,13 @@ describe('ReleaseStatusChecklist', () => {
     );
 
     expect(
-      screen.queryByRole('heading', { name: 'All checks passed' }),
+      screen.queryByRole('heading', {name: 'All checks passed'}),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', { name: 'Errors' }),
+      screen.queryByRole('heading', {name: 'Errors'}),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole('heading', { name: 'Warnings' }),
+      screen.getByRole('heading', {name: 'Warnings'}),
     ).toBeInTheDocument();
 
     expect(screen.getByText('8 things')).toBeInTheDocument();
@@ -366,8 +366,8 @@ describe('ReleaseStatusChecklist', () => {
         <ReleaseStatusChecklist
           checklist={{
             valid: true,
-            warnings: [{ code: 'NoMethodology' }],
-            errors: [{ code: 'PublicDataGuidanceRequired' }],
+            warnings: [{code: 'NoMethodology'}],
+            errors: [{code: 'PublicDataGuidanceRequired'}],
           }}
           release={testReleaseVersion}
         />
@@ -375,11 +375,11 @@ describe('ReleaseStatusChecklist', () => {
     );
 
     expect(
-      screen.queryByRole('heading', { name: 'All checks passed' }),
+      screen.queryByRole('heading', {name: 'All checks passed'}),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Errors' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Errors'})).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', { name: 'Warnings' }),
+      screen.getByRole('heading', {name: 'Warnings'}),
     ).toBeInTheDocument();
 
     expect(screen.getByText('1 issue')).toBeInTheDocument();
@@ -413,13 +413,13 @@ describe('ReleaseStatusChecklist', () => {
     );
 
     expect(
-      screen.getByRole('heading', { name: 'All checks passed' }),
+      screen.getByRole('heading', {name: 'All checks passed'}),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', { name: 'Errors' }),
+      screen.queryByRole('heading', {name: 'Errors'}),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', { name: 'Warnings' }),
+      screen.queryByRole('heading', {name: 'Warnings'}),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
@@ -1,10 +1,10 @@
 import ReleaseStatusChecklist from '@admin/pages/release/components/ReleaseStatusChecklist';
-import {testReleaseVersion} from '@admin/pages/release/__data__/testReleaseVersion';
-import {render, screen} from '@testing-library/react';
+import { testReleaseVersion } from '@admin/pages/release/__data__/testReleaseVersion';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
-import {MemoryRouter} from 'react-router';
-import {AuthContextTestProvider, User} from '@admin/contexts/AuthContext';
-import {GlobalPermissions} from '@admin/services/authService';
+import { MemoryRouter } from 'react-router';
+import { AuthContextTestProvider, User } from '@admin/contexts/AuthContext';
+import { GlobalPermissions } from '@admin/services/authService';
 
 describe('ReleaseStatusChecklist', () => {
   test('renders correctly with errors', () => {
@@ -24,19 +24,19 @@ describe('ReleaseStatusChecklist', () => {
               valid: false,
               warnings: [],
               errors: [
-                {code: 'DataFileImportsMustBeCompleted'},
-                {code: 'DataFileReplacementsMustBeCompleted'},
-                {code: 'PublicDataGuidanceRequired'},
-                {code: 'ReleaseNoteRequired'},
-                {code: 'SummarySectionContainsEmptyHtmlBlock'},
-                {code: 'EmptyContentSectionExists'},
-                {code: 'GenericSectionsContainEmptyHtmlBlock'},
-                {code: 'RelatedDashboardsSectionContainsEmptyHtmlBlock'},
-                {code: 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock'},
-                {code: 'PublicApiDataSetImportsMustBeCompleted'},
-                {code: 'PublicApiDataSetCancellationsMustBeResolved'},
-                {code: 'PublicApiDataSetFailuresMustBeResolved'},
-                {code: 'PublicApiDataSetMappingsMustBeCompleted'},
+                { code: 'DataFileImportsMustBeCompleted' },
+                { code: 'DataFileReplacementsMustBeCompleted' },
+                { code: 'PublicDataGuidanceRequired' },
+                { code: 'ReleaseNoteRequired' },
+                { code: 'SummarySectionContainsEmptyHtmlBlock' },
+                { code: 'EmptyContentSectionExists' },
+                { code: 'GenericSectionsContainEmptyHtmlBlock' },
+                { code: 'RelatedDashboardsSectionContainsEmptyHtmlBlock' },
+                { code: 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock' },
+                { code: 'PublicApiDataSetImportsMustBeCompleted' },
+                { code: 'PublicApiDataSetCancellationsMustBeResolved' },
+                { code: 'PublicApiDataSetFailuresMustBeResolved' },
+                { code: 'PublicApiDataSetMappingsMustBeCompleted' },
               ],
             }}
             release={testReleaseVersion}
@@ -47,11 +47,11 @@ describe('ReleaseStatusChecklist', () => {
     );
 
     expect(
-      screen.queryByRole('heading', {name: 'All checks passed'}),
+      screen.queryByRole('heading', { name: 'All checks passed' }),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Errors'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Errors' })).toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', {name: 'Warnings'}),
+      screen.queryByRole('heading', { name: 'Warnings' }),
     ).not.toBeInTheDocument();
 
     expect(screen.getByText('13 issues')).toBeInTheDocument();
@@ -191,19 +191,19 @@ describe('ReleaseStatusChecklist', () => {
               valid: false,
               warnings: [],
               errors: [
-                {code: 'DataFileImportsMustBeCompleted'},
-                {code: 'DataFileReplacementsMustBeCompleted'},
-                {code: 'PublicDataGuidanceRequired'},
-                {code: 'ReleaseNoteRequired'},
-                {code: 'SummarySectionContainsEmptyHtmlBlock'},
-                {code: 'EmptyContentSectionExists'},
-                {code: 'GenericSectionsContainEmptyHtmlBlock'},
-                {code: 'RelatedDashboardsSectionContainsEmptyHtmlBlock'},
-                {code: 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock'},
-                {code: 'PublicApiDataSetImportsMustBeCompleted'},
-                {code: 'PublicApiDataSetCancellationsMustBeResolved'},
-                {code: 'PublicApiDataSetFailuresMustBeResolved'},
-                {code: 'PublicApiDataSetMappingsMustBeCompleted'},
+                { code: 'DataFileImportsMustBeCompleted' },
+                { code: 'DataFileReplacementsMustBeCompleted' },
+                { code: 'PublicDataGuidanceRequired' },
+                { code: 'ReleaseNoteRequired' },
+                { code: 'SummarySectionContainsEmptyHtmlBlock' },
+                { code: 'EmptyContentSectionExists' },
+                { code: 'GenericSectionsContainEmptyHtmlBlock' },
+                { code: 'RelatedDashboardsSectionContainsEmptyHtmlBlock' },
+                { code: 'ReleaseMustContainKeyStatOrNonEmptyHeadlineBlock' },
+                { code: 'PublicApiDataSetImportsMustBeCompleted' },
+                { code: 'PublicApiDataSetCancellationsMustBeResolved' },
+                { code: 'PublicApiDataSetFailuresMustBeResolved' },
+                { code: 'PublicApiDataSetMappingsMustBeCompleted' },
               ],
             }}
             release={testReleaseVersion}
@@ -265,7 +265,7 @@ describe('ReleaseStatusChecklist', () => {
           checklist={{
             valid: true,
             warnings: [
-              {code: 'NoMethodology'},
+              { code: 'NoMethodology' },
               {
                 code: 'MethodologyNotApproved',
                 methodologyId: 'methodology-1',
@@ -274,11 +274,11 @@ describe('ReleaseStatusChecklist', () => {
                 code: 'MethodologyNotApproved',
                 methodologyId: 'methodology-2',
               },
-              {code: 'NoNextReleaseDate'},
-              {code: 'NoFootnotesOnSubjects', totalSubjects: 3},
-              {code: 'NoFeaturedTables'},
-              {code: 'NoDataFiles'},
-              {code: 'NoPublicPreReleaseAccessList'},
+              { code: 'NoNextReleaseDate' },
+              { code: 'NoFootnotesOnSubjects', totalSubjects: 3 },
+              { code: 'NoFeaturedTables' },
+              { code: 'NoDataFiles' },
+              { code: 'NoPublicPreReleaseAccessList' },
             ],
             errors: [],
           }}
@@ -288,13 +288,13 @@ describe('ReleaseStatusChecklist', () => {
     );
 
     expect(
-      screen.queryByRole('heading', {name: 'All checks passed'}),
+      screen.queryByRole('heading', { name: 'All checks passed' }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', {name: 'Errors'}),
+      screen.queryByRole('heading', { name: 'Errors' }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole('heading', {name: 'Warnings'}),
+      screen.getByRole('heading', { name: 'Warnings' }),
     ).toBeInTheDocument();
 
     expect(screen.getByText('8 things')).toBeInTheDocument();
@@ -366,8 +366,8 @@ describe('ReleaseStatusChecklist', () => {
         <ReleaseStatusChecklist
           checklist={{
             valid: true,
-            warnings: [{code: 'NoMethodology'}],
-            errors: [{code: 'PublicDataGuidanceRequired'}],
+            warnings: [{ code: 'NoMethodology' }],
+            errors: [{ code: 'PublicDataGuidanceRequired' }],
           }}
           release={testReleaseVersion}
         />
@@ -375,11 +375,11 @@ describe('ReleaseStatusChecklist', () => {
     );
 
     expect(
-      screen.queryByRole('heading', {name: 'All checks passed'}),
+      screen.queryByRole('heading', { name: 'All checks passed' }),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Errors'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Errors' })).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', {name: 'Warnings'}),
+      screen.getByRole('heading', { name: 'Warnings' }),
     ).toBeInTheDocument();
 
     expect(screen.getByText('1 issue')).toBeInTheDocument();
@@ -413,13 +413,13 @@ describe('ReleaseStatusChecklist', () => {
     );
 
     expect(
-      screen.getByRole('heading', {name: 'All checks passed'}),
+      screen.getByRole('heading', { name: 'All checks passed' }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', {name: 'Errors'}),
+      screen.queryByRole('heading', { name: 'Errors' }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', {name: 'Warnings'}),
+      screen.queryByRole('heading', { name: 'Warnings' }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
@@ -39,7 +39,7 @@ describe('ReleaseStatusChecklist', () => {
                 { code: 'PublicApiDataSetMappingsMustBeCompleted' },
               ],
             }}
-            release={testRelease}
+            release={testReleaseVersion}
           />
         </MemoryRouter>
         ,
@@ -282,7 +282,7 @@ describe('ReleaseStatusChecklist', () => {
             ],
             errors: [],
           }}
-          release={testRelease}
+          release={testReleaseVersion}
         />
       </MemoryRouter>,
     );
@@ -369,7 +369,7 @@ describe('ReleaseStatusChecklist', () => {
             warnings: [{ code: 'NoMethodology' }],
             errors: [{ code: 'PublicDataGuidanceRequired' }],
           }}
-          release={testRelease}
+          release={testReleaseVersion}
         />
       </MemoryRouter>,
     );
@@ -407,7 +407,7 @@ describe('ReleaseStatusChecklist', () => {
             warnings: [],
             errors: [],
           }}
-          release={testRelease}
+          release={testReleaseVersion}
         />
       </MemoryRouter>,
     );

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -1,4 +1,4 @@
-import { testRelease } from '@admin/pages/release/__data__/testRelease';
+import { testReleaseVersion } from '@admin/pages/release/__data__/testReleaseVersion';
 import { ReleaseStatusPermissions } from '@admin/services/permissionService';
 import { ReleaseChecklistErrorCode } from '@admin/services/releaseService';
 import { createServerValidationErrorMock } from '@common-test/createAxiosErrorMock';
@@ -21,7 +21,7 @@ describe('ReleaseStatusForm', () => {
   test('renders with all status options enabled', () => {
     render(
       <ReleaseStatusForm
-        release={testRelease}
+        release={testReleaseVersion}
         statusPermissions={testStatusPermissions}
         onCancel={noop}
         onSubmit={noop}
@@ -49,7 +49,7 @@ describe('ReleaseStatusForm', () => {
   test('renders with Approved status option disabled', () => {
     render(
       <ReleaseStatusForm
-        release={testRelease}
+        release={testReleaseVersion}
         statusPermissions={{
           ...testStatusPermissions,
           canMarkApproved: false,
@@ -80,7 +80,7 @@ describe('ReleaseStatusForm', () => {
   test('renders with HigherLevelReview and Approved status options disabled', () => {
     render(
       <ReleaseStatusForm
-        release={testRelease}
+        release={testReleaseVersion}
         statusPermissions={{
           ...testStatusPermissions,
           canMarkHigherLevelReview: false,
@@ -112,7 +112,7 @@ describe('ReleaseStatusForm', () => {
   test('renders with all options disabled', () => {
     render(
       <ReleaseStatusForm
-        release={testRelease}
+        release={testReleaseVersion}
         statusPermissions={{
           canMarkDraft: false,
           canMarkHigherLevelReview: false,
@@ -145,7 +145,7 @@ describe('ReleaseStatusForm', () => {
     render(
       <ReleaseStatusForm
         release={{
-          ...testRelease,
+          ...testReleaseVersion,
           approvalStatus: 'HigherLevelReview',
           nextReleaseDate: {
             month: 10,
@@ -193,7 +193,7 @@ describe('ReleaseStatusForm', () => {
 
       const { user } = render(
         <ReleaseStatusForm
-          release={testRelease}
+          release={testReleaseVersion}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
           onSubmit={handleSubmit}
@@ -223,7 +223,7 @@ describe('ReleaseStatusForm', () => {
 
       const { user } = render(
         <ReleaseStatusForm
-          release={testRelease}
+          release={testReleaseVersion}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
           onSubmit={handleSubmit}
@@ -271,7 +271,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'HigherLevelReview',
           }}
           statusPermissions={testStatusPermissions}
@@ -298,7 +298,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'HigherLevelReview',
           }}
           statusPermissions={testStatusPermissions}
@@ -326,7 +326,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'HigherLevelReview',
           }}
           statusPermissions={testStatusPermissions}
@@ -372,7 +372,7 @@ describe('ReleaseStatusForm', () => {
       render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
@@ -406,7 +406,7 @@ describe('ReleaseStatusForm', () => {
       render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
             publishScheduled: '2020-12-15',
           }}
@@ -447,7 +447,7 @@ describe('ReleaseStatusForm', () => {
       render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
             preReleaseUsersOrInvitesAdded: true,
           }}
@@ -474,7 +474,7 @@ describe('ReleaseStatusForm', () => {
       render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
             preReleaseUsersOrInvitesAdded: false,
           }}
@@ -501,7 +501,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
@@ -526,7 +526,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
@@ -551,7 +551,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
@@ -578,7 +578,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
@@ -614,7 +614,7 @@ describe('ReleaseStatusForm', () => {
 
         const { user } = render(
           <ReleaseStatusForm
-            release={testRelease}
+            release={testReleaseVersion}
             statusPermissions={testStatusPermissions}
             onCancel={noop}
             onSubmit={handleSubmit}
@@ -647,7 +647,7 @@ describe('ReleaseStatusForm', () => {
 
       const { user } = render(
         <ReleaseStatusForm
-          release={testRelease}
+          release={testReleaseVersion}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
           onSubmit={handleSubmit}
@@ -676,7 +676,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             publishScheduled: format(new Date(), 'yyyy-MM-dd'),
             approvalStatus: 'Approved',
           }}
@@ -721,7 +721,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
@@ -765,7 +765,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
@@ -807,7 +807,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
@@ -868,7 +868,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
@@ -938,7 +938,7 @@ describe('ReleaseStatusForm', () => {
       const { user } = render(
         <ReleaseStatusForm
           release={{
-            ...testRelease,
+            ...testReleaseVersion,
             approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
@@ -987,7 +987,7 @@ describe('ReleaseStatusForm', () => {
         render(
           <ReleaseStatusForm
             release={{
-              ...testRelease,
+              ...testReleaseVersion,
               approvalStatus: 'Approved',
               amendment: true,
               notifySubscribers: true,
@@ -1014,7 +1014,7 @@ describe('ReleaseStatusForm', () => {
         const { user } = render(
           <ReleaseStatusForm
             release={{
-              ...testRelease,
+              ...testReleaseVersion,
               approvalStatus: 'Approved',
               amendment: true,
               notifySubscribers: false,
@@ -1064,7 +1064,7 @@ describe('ReleaseStatusForm', () => {
         const { user } = render(
           <ReleaseStatusForm
             release={{
-              ...testRelease,
+              ...testReleaseVersion,
               approvalStatus: 'Approved',
               amendment: true,
               notifySubscribers: false,
@@ -1107,7 +1107,7 @@ describe('ReleaseStatusForm', () => {
         const { user } = render(
           <ReleaseStatusForm
             release={{
-              ...testRelease,
+              ...testReleaseVersion,
               approvalStatus: 'Approved',
               amendment: true,
               notifySubscribers: true,

--- a/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
@@ -159,19 +159,19 @@ const ReleaseContentPageLoaded = () => {
 const ReleaseContentPage = ({
   match,
 }: RouteComponentProps<ReleaseRouteParams>) => {
-  const { releaseId } = match.params;
+  const { releaseVersionId } = match.params;
 
   const { value, isLoading } =
     useAsyncRetry<ReleaseContentContextState>(async () => {
       const { release, unattachedDataBlocks } =
-        await releaseContentService.getContent(releaseId);
+        await releaseContentService.getContent(releaseVersionId);
 
       const canUpdateRelease = await permissionService.canUpdateRelease(
-        releaseId,
+        releaseVersionId,
       );
 
       const featuredTables = await featuredTableService.listFeaturedTables(
-        releaseId,
+        releaseVersionId,
       );
 
       return {
@@ -180,7 +180,7 @@ const ReleaseContentPage = ({
         canUpdateRelease,
         featuredTables,
       };
-    }, [releaseId]);
+    }, [releaseVersionId]);
 
   return (
     <LoadingSpinner loading={isLoading}>

--- a/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
@@ -102,7 +102,9 @@ const ReleaseContentPageLoaded = () => {
                       {release.publication.title}
                     </h2>
 
-                    <ReleaseContentHubContextProvider releaseId={release.id}>
+                    <ReleaseContentHubContextProvider
+                      releaseVersionId={release.id}
+                    >
                       <ReleaseContent
                         transformFeaturedTableLinks={
                           canPreviewRelease
@@ -141,7 +143,7 @@ const ReleaseContentPageLoaded = () => {
                 )}
                 {editingMode === 'table-preview' && (
                   <ReleasePreviewTableTool
-                    releaseId={release.id}
+                    releaseVersionId={release.id}
                     releaseType={release.type}
                     publication={release.publication}
                     featuredTableId={previewFeaturedTableId}

--- a/src/explore-education-statistics-admin/src/pages/release/content/__tests__/ReleaseContentPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/__tests__/ReleaseContentPage.test.tsx
@@ -842,7 +842,7 @@ describe('ReleaseContentPage', () => {
     initialEntries: string[] = [
       generatePath<ReleaseRouteParams>(releaseContentRoute.path, {
         publicationId: 'publication-1',
-        releaseId: 'release-1',
+        releaseVersionId: 'release-1',
       }),
     ],
   ) => {

--- a/src/explore-education-statistics-admin/src/pages/release/content/__tests__/ReleaseContentPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/__tests__/ReleaseContentPage.test.tsx
@@ -5,7 +5,7 @@ import {
   ReleaseRouteParams,
 } from '@admin/routes/releaseRoutes';
 import _releaseContentService, {
-  EditableRelease,
+  EditableReleaseVersion,
   ReleaseContent,
 } from '@admin/services/releaseContentService';
 import _featuredTableService, {
@@ -64,7 +64,7 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
 >;
 
 describe('ReleaseContentPage', () => {
-  const testEditableRelease: EditableRelease = {
+  const testEditableRelease: EditableReleaseVersion = {
     approvalStatus: 'Draft',
     content: [
       {
@@ -718,7 +718,7 @@ describe('ReleaseContentPage', () => {
     });
 
     test('transforms featured table links to buttons which open the table tool preview on scheduled releases', async () => {
-      const testScheduledRelease: EditableRelease = {
+      const testScheduledRelease: EditableReleaseVersion = {
         ...testReleaseContent.release,
         approvalStatus: 'Approved',
         publishScheduled: '3000-01-01',
@@ -774,7 +774,7 @@ describe('ReleaseContentPage', () => {
     });
 
     test('does not transform featured table links on published releases', async () => {
-      const testPublishedRelease: EditableRelease = {
+      const testPublishedRelease: EditableReleaseVersion = {
         ...testReleaseContent.release,
         approvalStatus: 'Approved',
         published: '2023-01-01',

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/AddKeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/AddKeyStatistics.tsx
@@ -55,7 +55,7 @@ const AddKeyStatistics = ({ release }: KeyStatisticsProps) => {
             statistic.
           </WarningMessage>
           <KeyStatDataBlockSelectForm
-            releaseId={release.id}
+            releaseVersionId={release.id}
             onSelect={addKeyStatDataBlock}
             onCancel={() => setFormType(undefined)}
           />

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/AddKeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/AddKeyStatistics.tsx
@@ -22,8 +22,11 @@ const AddKeyStatistics = ({ release }: KeyStatisticsProps) => {
 
   const addKeyStatDataBlock = useCallback(
     async (dataBlockId: string) => {
-      await addKeyStatisticDataBlock({ releaseId: release.id, dataBlockId });
-      await updateUnattachedDataBlocks({ releaseId: release.id });
+      await addKeyStatisticDataBlock({
+        releaseVersionId: release.id,
+        dataBlockId,
+      });
+      await updateUnattachedDataBlocks({ releaseVersionId: release.id });
       setFormType(undefined);
     },
     [release.id, addKeyStatisticDataBlock, updateUnattachedDataBlocks],
@@ -32,7 +35,7 @@ const AddKeyStatistics = ({ release }: KeyStatisticsProps) => {
   const addKeyStatText = useCallback(
     async (newKeyStatText: KeyStatisticTextCreateRequest) => {
       await addKeyStatisticText({
-        releaseId: release.id,
+        releaseVersionId: release.id,
         keyStatisticText: newKeyStatText,
       });
       setFormType(undefined);

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/AddSecondaryStats.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/AddSecondaryStats.tsx
@@ -1,18 +1,18 @@
 import { useEditingContext } from '@admin/contexts/EditingContext';
 import DataBlockSelectForm from '@admin/pages/release/content/components/DataBlockSelectForm';
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
-import { EditableRelease } from '@admin/services/releaseContentService';
+import { EditableReleaseVersion } from '@admin/services/releaseContentService';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ModalConfirm from '@common/components/ModalConfirm';
 import React, { useState } from 'react';
 
 interface Props {
-  release: EditableRelease;
+  releaseVersion: EditableReleaseVersion;
   updating?: boolean;
 }
 
-const AddSecondaryStats = ({ release, updating = false }: Props) => {
+const AddSecondaryStats = ({ releaseVersion, updating = false }: Props) => {
   const [isFormOpen, setIsFormOpen] = useState<boolean>(false);
   const { editingMode } = useEditingContext();
 
@@ -44,12 +44,13 @@ const AddSecondaryStats = ({ release, updating = false }: Props) => {
             }
             onConfirm={async () => {
               await Promise.all(
-                release.keyStatisticsSecondarySection.content.map(
+                releaseVersion.keyStatisticsSecondarySection.content.map(
                   async content => {
-                    if (release.keyStatisticsSecondarySection?.content) {
+                    if (releaseVersion.keyStatisticsSecondarySection?.content) {
                       await deleteContentSectionBlock({
-                        releaseVersionId: release.id,
-                        sectionId: release.keyStatisticsSecondarySection.id,
+                        releaseVersionId: releaseVersion.id,
+                        sectionId:
+                          releaseVersion.keyStatisticsSecondarySection.id,
                         blockId: content.id,
                         sectionKey: 'keyStatisticsSecondarySection',
                       });
@@ -71,23 +72,25 @@ const AddSecondaryStats = ({ release, updating = false }: Props) => {
   return (
     <DataBlockSelectForm
       id="secondaryStats-dataBlockSelectForm"
-      releaseId={release.id}
+      releaseVersionId={releaseVersion.id}
       label="Select a data block to show alongside the headline facts and figures as secondary headline statistics."
       onSelect={async selectedDataBlockId => {
         await Promise.all(
-          release.keyStatisticsSecondarySection.content.map(async content => {
-            await deleteContentSectionBlock({
-              releaseVersionId: release.id,
-              sectionId: release.keyStatisticsSecondarySection.id,
-              blockId: content.id,
-              sectionKey: 'keyStatisticsSecondarySection',
-            });
-          }),
+          releaseVersion.keyStatisticsSecondarySection.content.map(
+            async content => {
+              await deleteContentSectionBlock({
+                releaseVersionId: releaseVersion.id,
+                sectionId: releaseVersion.keyStatisticsSecondarySection.id,
+                blockId: content.id,
+                sectionKey: 'keyStatisticsSecondarySection',
+              });
+            },
+          ),
         );
 
         await attachContentSectionBlock({
-          releaseVersionId: release.id,
-          sectionId: release.keyStatisticsSecondarySection.id,
+          releaseVersionId: releaseVersion.id,
+          sectionId: releaseVersion.keyStatisticsSecondarySection.id,
           sectionKey: 'keyStatisticsSecondarySection',
           block: {
             contentBlockId: selectedDataBlockId,

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/AddSecondaryStats.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/AddSecondaryStats.tsx
@@ -48,7 +48,7 @@ const AddSecondaryStats = ({ release, updating = false }: Props) => {
                   async content => {
                     if (release.keyStatisticsSecondarySection?.content) {
                       await deleteContentSectionBlock({
-                        releaseId: release.id,
+                        releaseVersionId: release.id,
                         sectionId: release.keyStatisticsSecondarySection.id,
                         blockId: content.id,
                         sectionKey: 'keyStatisticsSecondarySection',
@@ -77,7 +77,7 @@ const AddSecondaryStats = ({ release, updating = false }: Props) => {
         await Promise.all(
           release.keyStatisticsSecondarySection.content.map(async content => {
             await deleteContentSectionBlock({
-              releaseId: release.id,
+              releaseVersionId: release.id,
               sectionId: release.keyStatisticsSecondarySection.id,
               blockId: content.id,
               sectionKey: 'keyStatisticsSecondarySection',
@@ -86,7 +86,7 @@ const AddSecondaryStats = ({ release, updating = false }: Props) => {
         );
 
         await attachContentSectionBlock({
-          releaseId: release.id,
+          releaseVersionId: release.id,
           sectionId: release.keyStatisticsSecondarySection.id,
           sectionKey: 'keyStatisticsSecondarySection',
           block: {

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/DataBlockSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/DataBlockSelectForm.tsx
@@ -9,7 +9,7 @@ import React, { useState } from 'react';
 
 interface Props {
   id: string;
-  releaseId: string;
+  releaseVersionId: string;
   onSelect: (selectedDataBlockId: string) => void;
   onCancel?: () => void;
   hideCancel?: boolean;
@@ -18,7 +18,7 @@ interface Props {
 
 const DataBlockSelectForm = ({
   id,
-  releaseId,
+  releaseVersionId,
   onSelect,
   onCancel = () => {},
   hideCancel = false,
@@ -40,8 +40,9 @@ const DataBlockSelectForm = ({
           summary="Data block preview"
           open
         >
+          {/* TODO rename to releaseVersionId */}
           <DataBlockTabs
-            releaseId={releaseId}
+            releaseId={releaseVersionId}
             dataBlock={selectedDataBlock}
             id={`${id}-dataBlockPreview`}
             getInfographic={getChartFile}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStat.tsx
@@ -41,11 +41,11 @@ const EditableKeyStat = ({
           isReordering={isReordering}
           onRemove={async () => {
             await deleteKeyStatistic({
-              releaseId,
+              releaseVersionId: releaseId,
               keyStatisticId: keyStat.id,
             });
             await updateUnattachedDataBlocks({
-              releaseId,
+              releaseVersionId: releaseId,
             });
           }}
           onSubmit={async values => {
@@ -54,7 +54,7 @@ const EditableKeyStat = ({
             };
 
             await updateKeyStatisticDataBlock({
-              releaseId,
+              releaseVersionId: releaseId,
               keyStatisticId: keyStat.id,
               request,
             });
@@ -70,7 +70,7 @@ const EditableKeyStat = ({
           isReordering={isReordering}
           onRemove={async () => {
             await deleteKeyStatistic({
-              releaseId,
+              releaseVersionId: releaseId,
               keyStatisticId: keyStat.id,
             });
           }}
@@ -79,7 +79,7 @@ const EditableKeyStat = ({
               ...values,
             };
             await updateKeyStatisticText({
-              releaseId,
+              releaseVersionId: releaseId,
               keyStatisticId: keyStat.id,
               request,
             });

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStat.tsx
@@ -12,7 +12,7 @@ interface EditableKeyStatProps {
   isEditing?: boolean;
   isReordering?: boolean;
   keyStat: KeyStatistic;
-  releaseId: string;
+  releaseVersionId: string;
   testId?: string;
 }
 
@@ -20,7 +20,7 @@ const EditableKeyStat = ({
   isEditing = false,
   isReordering = false,
   keyStat,
-  releaseId,
+  releaseVersionId,
   testId = 'keyStat',
 }: EditableKeyStatProps) => {
   const {
@@ -35,17 +35,17 @@ const EditableKeyStat = ({
       return (
         <EditableKeyStatDataBlock
           keyStat={keyStat}
-          releaseId={releaseId}
+          releaseVersionId={releaseVersionId}
           testId={testId}
           isEditing={isEditing}
           isReordering={isReordering}
           onRemove={async () => {
             await deleteKeyStatistic({
-              releaseVersionId: releaseId,
+              releaseVersionId,
               keyStatisticId: keyStat.id,
             });
             await updateUnattachedDataBlocks({
-              releaseVersionId: releaseId,
+              releaseVersionId,
             });
           }}
           onSubmit={async values => {
@@ -54,7 +54,7 @@ const EditableKeyStat = ({
             };
 
             await updateKeyStatisticDataBlock({
-              releaseVersionId: releaseId,
+              releaseVersionId,
               keyStatisticId: keyStat.id,
               request,
             });
@@ -70,7 +70,7 @@ const EditableKeyStat = ({
           isReordering={isReordering}
           onRemove={async () => {
             await deleteKeyStatistic({
-              releaseVersionId: releaseId,
+              releaseVersionId,
               keyStatisticId: keyStat.id,
             });
           }}
@@ -79,7 +79,7 @@ const EditableKeyStat = ({
               ...values,
             };
             await updateKeyStatisticText({
-              releaseVersionId: releaseId,
+              releaseVersionId,
               keyStatisticId: keyStat.id,
               request,
             });

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlock.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlock.tsx
@@ -15,7 +15,7 @@ export interface EditableKeyStatDataBlockProps {
   isEditing?: boolean;
   isReordering?: boolean;
   keyStat: KeyStatisticDataBlock;
-  releaseId: string;
+  releaseVersionId: string;
   testId?: string;
   onRemove: () => void;
   onSubmit: (values: KeyStatDataBlockFormValues) => void;
@@ -25,7 +25,7 @@ export default function EditableKeyStatDataBlock({
   isEditing = false,
   isReordering = false,
   keyStat,
-  releaseId,
+  releaseVersionId,
   testId = 'keyStat',
   onRemove,
   onSubmit,
@@ -36,7 +36,7 @@ export default function EditableKeyStatDataBlock({
     value: dataBlockValues,
     isLoading,
     error,
-  } = useKeyStatQuery(releaseId, keyStat.dataBlockParentId);
+  } = useKeyStatQuery(releaseVersionId, keyStat.dataBlockParentId);
 
   const handleSubmit = useCallback(
     async (values: KeyStatDataBlockFormValues) => {

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatDataBlockSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatDataBlockSelectForm.tsx
@@ -8,7 +8,7 @@ import React, { useMemo, useState } from 'react';
 import KeyStatDataBlock from '@common/modules/find-statistics/components/KeyStatDataBlock';
 
 interface Props {
-  releaseId: string;
+  releaseVersionId: string;
   onSelect: (selectedDataBlockId: string) => void;
   onCancel?: () => void;
   hideCancel?: boolean;
@@ -16,7 +16,7 @@ interface Props {
 }
 
 const KeyStatDataBlockSelectForm = ({
-  releaseId,
+  releaseVersionId,
   onSelect,
   onCancel = () => {},
   hideCancel = false,
@@ -50,8 +50,9 @@ const KeyStatDataBlockSelectForm = ({
           summary="Key statistic preview"
           open
         >
+          {/* TODO rename to releaseVersionId */}
           <KeyStatDataBlock
-            releaseId={releaseId}
+            releaseId={releaseVersionId}
             dataBlockParentId={selectedDataBlock.dataBlockParentId}
           />
         </Details>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
@@ -43,7 +43,7 @@ const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
   const saveOrder = useCallback(async () => {
     if (reorderKeyStatistics) {
       await reorderKeyStatistics({
-        releaseId: release.id,
+        releaseVersionId: release.id,
         keyStatistics,
       });
       toggleReordering.off();

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
@@ -2,7 +2,7 @@ import BlockDroppable from '@admin/components/editable/BlockDroppable';
 import EditableKeyStat from '@admin/pages/release/content/components/EditableKeyStat';
 import styles from '@admin/pages/release/content/components/KeyStatistics.module.scss';
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
-import { EditableRelease } from '@admin/services/releaseContentService';
+import { EditableReleaseVersion } from '@admin/services/releaseContentService';
 import Button from '@common/components/Button';
 import useToggle from '@common/hooks/useToggle';
 import { KeyStatContainer } from '@common/modules/find-statistics/components/KeyStat';
@@ -14,7 +14,7 @@ import { DragDropContext, Draggable, DropResult } from '@hello-pangea/dnd';
 import AddKeyStatistics from '@admin/pages/release/content/components/AddKeyStatistics';
 
 export interface KeyStatisticsProps {
-  release: EditableRelease;
+  release: EditableReleaseVersion;
   isEditing?: boolean;
 }
 
@@ -109,7 +109,7 @@ const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
                         <EditableKeyStat
                           key={keyStat.id}
                           keyStat={keyStat}
-                          releaseId={release.id}
+                          releaseVersionId={release.id}
                           isEditing={isEditing}
                           isReordering={isReordering}
                         />

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/RelatedPagesSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/RelatedPagesSection.tsx
@@ -1,7 +1,7 @@
 import EditableLink from '@admin/components/editable/EditableLink';
 import { useEditingContext } from '@admin/contexts/EditingContext';
 import releaseContentRelatedInformationService from '@admin/services/releaseContentRelatedInformationService';
-import { EditableRelease } from '@admin/services/releaseContentService';
+import { EditableReleaseVersion } from '@admin/services/releaseContentService';
 import Button from '@common/components/Button';
 import { FormFieldset } from '@common/components/form';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
@@ -16,7 +16,7 @@ import React, { useState } from 'react';
 type FormValues = Omit<BasicLink, 'id'>;
 
 interface Props {
-  release: EditableRelease;
+  release: EditableReleaseVersion;
 }
 
 export default function RelatedPagesSection({ release }: Props) {

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseBlock.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseBlock.tsx
@@ -10,21 +10,22 @@ import Gate from '@common/components/Gate';
 
 interface Props {
   block: Block;
-  releaseId: string;
+  releaseVersionId: string;
   transformFeaturedTableLinks?: (url: string, text: string) => void;
   visible?: boolean;
 }
 
 const ReleaseBlock = ({
   block,
-  releaseId,
+  releaseVersionId,
   transformFeaturedTableLinks,
   visible,
 }: Props) => {
-  const getChartFile = useGetChartFile(releaseId);
+  const getChartFile = useGetChartFile(releaseVersionId);
 
+  // TODO rename to releaseVersionId
   const transformImageAttributes = useReleaseImageAttributeTransformer({
-    releaseVersionId: releaseId,
+    releaseId: releaseVersionId,
   });
 
   if (block.type === 'EmbedBlockLink') {
@@ -37,11 +38,12 @@ const ReleaseBlock = ({
 
   if (block.type === 'DataBlock') {
     return (
+      // TODO rename to releaseVersionId
       <Gate condition={!!visible}>
         <DataBlockTabs
           key={block.id}
           dataBlock={block}
-          releaseId={releaseId}
+          releaseId={releaseVersionId}
           getInfographic={getChartFile}
         />
       </Gate>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseBlock.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseBlock.tsx
@@ -24,7 +24,7 @@ const ReleaseBlock = ({
   const getChartFile = useGetChartFile(releaseId);
 
   const transformImageAttributes = useReleaseImageAttributeTransformer({
-    releaseId,
+    releaseVersionId: releaseId,
   });
 
   if (block.type === 'EmbedBlockLink') {

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -70,7 +70,7 @@ const ReleaseContent = ({
 
   const addSummaryBlock = useCallback(async () => {
     await addContentSectionBlock({
-      releaseId: release.id,
+      releaseVersionId: release.id,
       sectionId: release.summarySection.id,
       sectionKey: 'summarySection',
       block: {
@@ -84,7 +84,7 @@ const ReleaseContent = ({
   const addRelatedDashboardsBlock = useCallback(async () => {
     if (release.relatedDashboardsSection) {
       await addContentSectionBlock({
-        releaseId: release.id,
+        releaseVersionId: release.id,
         sectionId: release.relatedDashboardsSection.id,
         sectionKey: 'relatedDashboardsSection',
         block: {
@@ -209,7 +209,7 @@ const ReleaseContent = ({
                       allowComments
                       block={block}
                       publicationId={release.publication.id}
-                      releaseId={release.id}
+                      releaseVersionId={release.id}
                       sectionId={release.summarySection.id}
                       sectionKey="summarySection"
                     />
@@ -288,7 +288,7 @@ const ReleaseContent = ({
                       releaseDataGuidanceRoute.path,
                       {
                         publicationId: release.publication.id,
-                        releaseId: release.id,
+                        releaseVersionId: release.id,
                       },
                     ),
                     state: {
@@ -308,7 +308,7 @@ const ReleaseContent = ({
                         preReleaseAccessListRoute.path,
                         {
                           publicationId: release.publication.id,
-                          releaseId: release.id,
+                          releaseVersionId: release.id,
                         },
                       ),
                       state: {
@@ -433,7 +433,7 @@ const ReleaseContent = ({
                   releaseDataGuidanceRoute.path,
                   {
                     publicationId: release.publication.id,
-                    releaseId: release.id,
+                    releaseVersionId: release.id,
                   },
                 ),
                 state: {
@@ -464,7 +464,7 @@ const ReleaseContent = ({
                     allowComments
                     block={block}
                     publicationId={release.publication.id}
-                    releaseId={release.id}
+                    releaseVersionId={release.id}
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     sectionId={release.relatedDashboardsSection!.id}
                     sectionKey="relatedDashboardsSection"

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -200,7 +200,7 @@ const ReleaseContent = ({
                   renderBlock={block => (
                     <ReleaseBlock
                       block={block}
-                      releaseId={release.id}
+                      releaseVersionId={release.id}
                       transformFeaturedTableLinks={transformFeaturedTableLinks}
                     />
                   )}
@@ -395,7 +395,7 @@ const ReleaseContent = ({
       <hr />
 
       <ReleaseHeadlines
-        release={release}
+        releaseVersion={release}
         transformFeaturedTableLinks={transformFeaturedTableLinks}
       />
 
@@ -457,7 +457,7 @@ const ReleaseContent = ({
                 blocks={release.relatedDashboardsSection.content}
                 sectionId={release.relatedDashboardsSection.id}
                 renderBlock={block => (
-                  <ReleaseBlock block={block} releaseId={release.id} />
+                  <ReleaseBlock block={block} releaseVersionId={release.id} />
                 )}
                 renderEditableBlock={block => (
                   <ReleaseEditableBlock

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordion.tsx
@@ -26,7 +26,7 @@ const ReleaseContentAccordion = ({
 
   const addAccordionSection = useCallback(async () => {
     await addContentSection({
-      releaseId: release.id,
+      releaseVersionId: release.id,
       order: release.content.length,
     });
   }, [release.id, release.content.length, addContentSection]);
@@ -41,7 +41,7 @@ const ReleaseContentAccordion = ({
           return acc;
         }, {});
 
-      await updateContentSectionsOrder({ releaseId: release.id, order });
+      await updateContentSectionsOrder({ releaseVersionId: release.id, order });
     },
     [id, release.id, updateContentSectionsOrder],
   );

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordion.tsx
@@ -1,6 +1,6 @@
 import EditableAccordion from '@admin/components/editable/EditableAccordion';
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
-import { EditableRelease } from '@admin/services/releaseContentService';
+import { EditableReleaseVersion } from '@admin/services/releaseContentService';
 import { Dictionary } from '@common/types';
 import orderBy from 'lodash/orderBy';
 import React, { useCallback } from 'react';
@@ -8,7 +8,7 @@ import ReleaseContentAccordionSection from './ReleaseContentAccordionSection';
 
 interface ReleaseContentAccordionProps {
   id?: string;
-  release: EditableRelease;
+  release: EditableReleaseVersion;
   sectionName: string;
   transformFeaturedTableLinks?: (url: string, text: string) => void;
   onSectionOpen: ({ id, title }: { id: string; title: string }) => void;

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -67,7 +67,7 @@ const ReleaseContentAccordionSection = ({
 
   const addBlock = useCallback(async () => {
     await actions.addContentSectionBlock({
-      releaseId: release.id,
+      releaseVersionId: release.id,
       sectionId,
       sectionKey: 'content',
       block: {
@@ -81,7 +81,7 @@ const ReleaseContentAccordionSection = ({
   const addEmbedBlock = useCallback(
     async (embedBlock: EditableEmbedFormValues) => {
       await actions.addEmbedSectionBlock({
-        releaseId: release.id,
+        releaseVersionId: release.id,
         sectionId,
         sectionKey: 'content',
         request: {
@@ -97,7 +97,7 @@ const ReleaseContentAccordionSection = ({
   const attachDataBlock = useCallback(
     async (contentBlockId: string) => {
       await actions.attachContentSectionBlock({
-        releaseId: release.id,
+        releaseVersionId: release.id,
         sectionId,
         sectionKey: 'content',
         block: {
@@ -116,7 +116,7 @@ const ReleaseContentAccordionSection = ({
     }, {});
 
     await actions.updateSectionBlockOrder({
-      releaseId: release.id,
+      releaseVersionId: release.id,
       sectionId,
       sectionKey: 'content',
       order,
@@ -128,7 +128,7 @@ const ReleaseContentAccordionSection = ({
       await actions.updateContentSectionHeading({
         sectionId,
         title,
-        releaseId: release.id,
+        releaseVersionId: release.id,
       });
     },
     [actions, sectionId, release.id],
@@ -137,7 +137,7 @@ const ReleaseContentAccordionSection = ({
   const handleRemoveSection = useCallback(async () => {
     await actions.removeContentSection({
       sectionId,
-      releaseId: release.id,
+      releaseVersionId: release.id,
     });
   }, [actions, sectionId, release.id]);
 
@@ -206,7 +206,7 @@ const ReleaseContentAccordionSection = ({
                 sectionKey="content"
                 editable={!isReordering}
                 publicationId={release.publication.id}
-                releaseId={release.id}
+                releaseVersionId={release.id}
                 visible={open}
               />
             )}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -192,7 +192,7 @@ const ReleaseContentAccordionSection = ({
             renderBlock={block => (
               <ReleaseBlock
                 block={block}
-                releaseId={release.id}
+                releaseVersionId={release.id}
                 transformFeaturedTableLinks={transformFeaturedTableLinks}
                 visible={open}
               />
@@ -217,7 +217,7 @@ const ReleaseContentAccordionSection = ({
               {showDataBlockForm && (
                 <DataBlockSelectForm
                   id={`dataBlockSelectForm-${sectionId}`}
-                  releaseId={release.id}
+                  releaseVersionId={release.id}
                   onSelect={async selectedDataBlockId => {
                     await attachDataBlock(selectedDataBlockId);
                     toggleDataBlockForm.off();

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseEditableBlock.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseEditableBlock.tsx
@@ -34,7 +34,7 @@ interface Props {
   block: EditableBlock;
   editable?: boolean;
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
   sectionId: string;
   sectionKey: ContentSectionKeys;
   visible?: boolean;
@@ -46,7 +46,7 @@ const ReleaseEditableBlock = ({
   block,
   editable = true,
   publicationId,
-  releaseId,
+  releaseVersionId,
   sectionId,
   sectionKey,
   visible,
@@ -72,13 +72,13 @@ const ReleaseEditableBlock = ({
 
   const { hub } = useReleaseContentHubContext();
 
-  const getChartFile = useGetChartFile(releaseId);
+  const getChartFile = useGetChartFile(releaseVersionId);
 
   const { handleImageUpload, handleImageUploadCancel } =
-    useReleaseImageUpload(releaseId);
+    useReleaseImageUpload(releaseVersionId);
 
   const transformImageAttributes = useReleaseImageAttributeTransformer({
-    releaseId,
+    releaseVersionId,
   });
 
   const [showCommentAddForm, toggleCommentAddForm] = useToggle(false);
@@ -166,7 +166,7 @@ const ReleaseEditableBlock = ({
   const handleSave = useCallback(
     async (content: string) => {
       await updateContentSectionBlock({
-        releaseId,
+        releaseVersionId,
         sectionId,
         sectionKey,
         blockId: block.id,
@@ -179,7 +179,7 @@ const ReleaseEditableBlock = ({
       block.id,
       updateContentSectionBlock,
       removeUnsavedBlock,
-      releaseId,
+      releaseVersionId,
       sectionId,
       sectionKey,
     ],
@@ -197,17 +197,23 @@ const ReleaseEditableBlock = ({
 
   const handleDelete = useCallback(async () => {
     await deleteContentSectionBlock({
-      releaseId,
+      releaseVersionId,
       sectionId,
       sectionKey,
       blockId: block.id,
     });
-  }, [block.id, deleteContentSectionBlock, releaseId, sectionId, sectionKey]);
+  }, [
+    block.id,
+    deleteContentSectionBlock,
+    releaseVersionId,
+    sectionId,
+    sectionKey,
+  ]);
 
   const handleSaveEmbedBlock = useCallback(
     async (updatedBlock: EditableEmbedFormValues) => {
       await updateEmbedSectionBlock({
-        releaseId,
+        releaseVersionId,
         sectionId,
         sectionKey,
         blockId: block.id,
@@ -223,7 +229,7 @@ const ReleaseEditableBlock = ({
       block.id,
       updateEmbedSectionBlock,
       removeUnsavedBlock,
-      releaseId,
+      releaseVersionId,
       sectionId,
       sectionKey,
     ],
@@ -231,12 +237,18 @@ const ReleaseEditableBlock = ({
 
   const handleDeleteEmbedBlock = useCallback(async () => {
     await deleteEmbedSectionBlock({
-      releaseId,
+      releaseVersionId,
       sectionId,
       sectionKey,
       blockId: block.id,
     });
-  }, [block.id, deleteEmbedSectionBlock, releaseId, sectionId, sectionKey]);
+  }, [
+    block.id,
+    deleteEmbedSectionBlock,
+    releaseVersionId,
+    sectionId,
+    sectionKey,
+  ]);
 
   const handleBlur = useCallback(
     (isDirty: boolean) => {
@@ -250,7 +262,7 @@ const ReleaseEditableBlock = ({
   const handleSaveComment = useCallback(
     async (comment: CommentCreate) => {
       const newComment = await addBlockComment({
-        releaseId,
+        releaseVersionId,
         sectionId,
         sectionKey,
         blockId: block.id,
@@ -264,7 +276,7 @@ const ReleaseEditableBlock = ({
     [
       addBlockComment,
       block.id,
-      releaseId,
+      releaseVersionId,
       sectionId,
       sectionKey,
       updateUnresolvedComments,
@@ -281,20 +293,20 @@ const ReleaseEditableBlock = ({
   const handleDeleteComment = useCallback(
     async (commentId: string) => {
       await deleteBlockComment({
-        releaseId,
+        releaseVersionId,
         sectionId,
         sectionKey,
         blockId: block.id,
         commentId,
       });
     },
-    [block.id, deleteBlockComment, releaseId, sectionId, sectionKey],
+    [block.id, deleteBlockComment, releaseVersionId, sectionId, sectionKey],
   );
 
   const handleSaveUpdatedComment = useCallback(
     async (comment: Comment) => {
       await updateBlockComment({
-        releaseId,
+        releaseVersionId,
         sectionId,
         sectionKey,
         blockId: block.id,
@@ -305,7 +317,7 @@ const ReleaseEditableBlock = ({
     },
     [
       block.id,
-      releaseId,
+      releaseVersionId,
       sectionId,
       sectionKey,
       updateBlockComment,
@@ -333,7 +345,7 @@ const ReleaseEditableBlock = ({
                 releaseDataBlockEditRoute.path,
                 {
                   publicationId,
-                  releaseId,
+                  releaseVersionId,
                   dataBlockId: block.id,
                 },
               )}
@@ -341,7 +353,7 @@ const ReleaseEditableBlock = ({
             >
               <Gate condition={!!visible}>
                 <DataBlockTabs
-                  releaseId={releaseId}
+                  releaseId={releaseVersionId}
                   id={blockId}
                   dataBlock={block}
                   getInfographic={getChartFile}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseEditableBlock.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseEditableBlock.tsx
@@ -77,8 +77,9 @@ const ReleaseEditableBlock = ({
   const { handleImageUpload, handleImageUploadCancel } =
     useReleaseImageUpload(releaseVersionId);
 
+  // TODO rename to releaseVersionId
   const transformImageAttributes = useReleaseImageAttributeTransformer({
-    releaseVersionId,
+    releaseId: releaseVersionId,
   });
 
   const [showCommentAddForm, toggleCommentAddForm] = useToggle(false);
@@ -351,6 +352,7 @@ const ReleaseEditableBlock = ({
               )}
               onDelete={editable ? handleDelete : undefined}
             >
+              {/* TODO rename to releaseVersionId */}
               <Gate condition={!!visible}>
                 <DataBlockTabs
                   releaseId={releaseVersionId}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
@@ -26,7 +26,7 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
 
   const addBlock = useCallback(async () => {
     await actions.addContentSectionBlock({
-      releaseId: release.id,
+      releaseVersionId: release.id,
       sectionId: release.headlinesSection.id,
       sectionKey: 'headlinesSection',
       block: {
@@ -58,7 +58,7 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
               allowComments
               block={block}
               publicationId={release.publication.id}
-              releaseId={release.id}
+              releaseVersionId={release.id}
               sectionId={release.headlinesSection.id}
               sectionKey="headlinesSection"
             />

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
@@ -5,7 +5,7 @@ import KeyStatistics from '@admin/pages/release/content/components/KeyStatistics
 import ReleaseBlock from '@admin/pages/release/content/components/ReleaseBlock';
 import ReleaseEditableBlock from '@admin/pages/release/content/components/ReleaseEditableBlock';
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
-import { EditableRelease } from '@admin/services/releaseContentService';
+import { EditableReleaseVersion } from '@admin/services/releaseContentService';
 import Button from '@common/components/Button';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
@@ -14,20 +14,23 @@ import React, { useCallback } from 'react';
 import AddSecondaryStats from './AddSecondaryStats';
 
 interface Props {
-  release: EditableRelease;
+  releaseVersion: EditableReleaseVersion;
   transformFeaturedTableLinks?: (url: string, text: string) => void;
 }
 
-const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
+const ReleaseHeadlines = ({
+  releaseVersion,
+  transformFeaturedTableLinks,
+}: Props) => {
   const { editingMode } = useEditingContext();
   const actions = useReleaseContentActions();
 
-  const getChartFile = useGetChartFile(release.id);
+  const getChartFile = useGetChartFile(releaseVersion.id);
 
   const addBlock = useCallback(async () => {
     await actions.addContentSectionBlock({
-      releaseVersionId: release.id,
-      sectionId: release.headlinesSection.id,
+      releaseVersionId: releaseVersion.id,
+      sectionId: releaseVersion.headlinesSection.id,
       sectionKey: 'headlinesSection',
       block: {
         type: 'HtmlBlock',
@@ -35,21 +38,24 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
         body: '',
       },
     });
-  }, [actions, release.id, release.headlinesSection.id]);
+  }, [actions, releaseVersion.id, releaseVersion.headlinesSection.id]);
 
   const headlinesTab = (
     <TabsSection title="Summary">
       <section data-scroll id="releaseHeadlines-keyStatistics">
-        <KeyStatistics release={release} isEditing={editingMode === 'edit'} />
+        <KeyStatistics
+          release={releaseVersion}
+          isEditing={editingMode === 'edit'}
+        />
       </section>
       <section id="releaseHeadlines-headlines">
         <EditableSectionBlocks
-          blocks={release.headlinesSection.content}
-          sectionId={release.headlinesSection.id}
+          blocks={releaseVersion.headlinesSection.content}
+          sectionId={releaseVersion.headlinesSection.id}
           renderBlock={block => (
             <ReleaseBlock
               block={block}
-              releaseId={release.id}
+              releaseVersionId={releaseVersion.id}
               transformFeaturedTableLinks={transformFeaturedTableLinks}
             />
           )}
@@ -57,16 +63,16 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
             <ReleaseEditableBlock
               allowComments
               block={block}
-              publicationId={release.publication.id}
-              releaseVersionId={release.id}
-              sectionId={release.headlinesSection.id}
+              publicationId={releaseVersion.publication.id}
+              releaseVersionId={releaseVersion.id}
+              sectionId={releaseVersion.headlinesSection.id}
               sectionKey="headlinesSection"
             />
           )}
         />
 
         {editingMode === 'edit' &&
-          release.headlinesSection.content?.length === 0 && (
+          releaseVersion.headlinesSection.content?.length === 0 && (
             <div className="govuk-!-margin-bottom-8 govuk-!-text-align-centre">
               <Button variant="secondary" onClick={addBlock}>
                 Add a headlines text block
@@ -84,23 +90,24 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
         data-scroll
         id="release-headlines-header"
       >
-        Headline facts and figures - {release.yearTitle}
+        Headline facts and figures - {releaseVersion.yearTitle}
       </h2>
 
-      {release.keyStatisticsSecondarySection.content?.length ? (
+      {releaseVersion.keyStatisticsSecondarySection.content?.length ? (
         <>
-          <AddSecondaryStats release={release} updating />
+          <AddSecondaryStats releaseVersion={releaseVersion} updating />
+          {/* TODO rename to releaseVersionId */}
           <DataBlockTabs
-            releaseId={release.id}
+            releaseId={releaseVersion.id}
             id="releaseHeadlines-dataBlock"
-            dataBlock={release.keyStatisticsSecondarySection.content[0]}
+            dataBlock={releaseVersion.keyStatisticsSecondarySection.content[0]}
             getInfographic={getChartFile}
             firstTabs={headlinesTab}
           />
         </>
       ) : (
         <>
-          <AddSecondaryStats release={release} />
+          <AddSecondaryStats releaseVersion={releaseVersion} />
           <Tabs id="releaseHeadlines-dataBlock">{headlinesTab}</Tabs>
         </>
       )}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNotesSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNotesSection.tsx
@@ -3,7 +3,7 @@ import ReleaseNoteForm, {
   ReleaseNoteFormValues,
 } from '@admin/pages/release/content/components/ReleaseNoteForm';
 import ReleaseNote from '@admin/pages/release/content/components/ReleaseNote';
-import { EditableRelease } from '@admin/services/releaseContentService';
+import { EditableReleaseVersion } from '@admin/services/releaseContentService';
 import releaseNoteService from '@admin/services/releaseNoteService';
 import Button from '@common/components/Button';
 import Details from '@common/components/Details';
@@ -12,7 +12,7 @@ import { ReleaseNote as ReleaseNoteData } from '@common/services/publicationServ
 import React, { useState } from 'react';
 
 interface Props {
-  release: EditableRelease;
+  release: EditableReleaseVersion;
 }
 
 export default function ReleaseNotesSection({ release }: Props) {

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableTool.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableTool.tsx
@@ -18,13 +18,13 @@ import { ReleaseType } from '@common/services/types/releaseType';
 
 interface Props {
   featuredTableId?: string;
-  releaseId: string;
+  releaseVersionId: string;
   releaseType: ReleaseType;
   publication: Publication | ContentPublication;
 }
 const ReleasePreviewTableTool = ({
   featuredTableId,
-  releaseId,
+  releaseVersionId,
   releaseType,
   publication,
 }: Props) => {
@@ -34,20 +34,20 @@ const ReleasePreviewTableTool = ({
     InitialTableToolState | undefined
   >(async () => {
     const [featuredTables, subjects] = await Promise.all([
-      tableBuilderService.listReleaseFeaturedTables(releaseId),
-      tableBuilderService.listReleaseSubjects(releaseId),
+      tableBuilderService.listReleaseFeaturedTables(releaseVersionId),
+      tableBuilderService.listReleaseSubjects(releaseVersionId),
     ]);
 
     if (dataBlockId) {
       const { table, query } = await dataBlockService.getDataBlock(dataBlockId);
 
       const [subjectMeta, tableData] = await Promise.all([
-        tableBuilderService.getSubjectMeta(query.subjectId, releaseId),
+        tableBuilderService.getSubjectMeta(query.subjectId, releaseVersionId),
         tableBuilderService.getTableData(
           {
             ...query,
           },
-          releaseVersionId: releaseId,
+          releaseId: releaseVersionId,
         ),
       ]);
 
@@ -61,7 +61,7 @@ const ReleasePreviewTableTool = ({
         query: {
           ...query,
           publicationId: publication.id,
-          releaseId,
+          releaseVersionId,
         },
         subjectMeta,
         response: {
@@ -77,14 +77,14 @@ const ReleasePreviewTableTool = ({
       featuredTables,
       query: {
         publicationId: publication.id,
-        releaseId,
+        releaseVersionId,
         subjectId: '',
         indicators: [],
         filters: [],
         locationIds: [],
       },
     };
-  }, [releaseId, dataBlockId]);
+  }, [releaseVersionId, dataBlockId]);
 
   return (
     <LoadingSpinner loading={isLoading}>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableTool.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableTool.tsx
@@ -11,10 +11,10 @@ import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHead
 import tableBuilderService from '@common/services/tableBuilderService';
 import ButtonText from '@common/components/ButtonText';
 import ReleasePreviewTableToolFinalStep from '@admin/pages/release/content/components/ReleasePreviewTableToolFinalStep';
-import {Publication} from '@admin/services/publicationService';
-import {Publication as ContentPublication} from '@common/services/publicationService';
-import React, {useState} from 'react';
-import {ReleaseType} from '@common/services/types/releaseType';
+import { Publication } from '@admin/services/publicationService';
+import { Publication as ContentPublication } from '@common/services/publicationService';
+import React, { useState } from 'react';
+import { ReleaseType } from '@common/services/types/releaseType';
 
 interface Props {
   featuredTableId?: string;
@@ -24,14 +24,14 @@ interface Props {
 }
 
 const ReleasePreviewTableTool = ({
-                                   featuredTableId,
-                                   releaseVersionId,
-                                   releaseType,
-                                   publication,
-                                 }: Props) => {
+  featuredTableId,
+  releaseVersionId,
+  releaseType,
+  publication,
+}: Props) => {
   const [dataBlockId, setDataBlockId] = useState(featuredTableId ?? '');
 
-  const {value: initialState, isLoading} = useAsyncHandledRetry<
+  const { value: initialState, isLoading } = useAsyncHandledRetry<
     InitialTableToolState | undefined
   >(async () => {
     const [featuredTables, subjects] = await Promise.all([
@@ -40,7 +40,7 @@ const ReleasePreviewTableTool = ({
     ]);
 
     if (dataBlockId) {
-      const {table, query} = await dataBlockService.getDataBlock(dataBlockId);
+      const { table, query } = await dataBlockService.getDataBlock(dataBlockId);
 
       const [subjectMeta, tableData] = await Promise.all([
         tableBuilderService.getSubjectMeta(query.subjectId, releaseVersionId),
@@ -62,7 +62,8 @@ const ReleasePreviewTableTool = ({
         query: {
           ...query,
           publicationId: publication.id,
-          releaseVersionId,
+          // TODO rename to releaseVersionId
+          releaseId: releaseVersionId,
         },
         subjectMeta,
         response: {
@@ -78,7 +79,8 @@ const ReleasePreviewTableTool = ({
       featuredTables,
       query: {
         publicationId: publication.id,
-        releaseVersionId,
+        // TODO rename to releaseVersionId
+        releaseId: releaseVersionId,
         subjectId: '',
         indicators: [],
         filters: [],
@@ -107,7 +109,7 @@ const ReleasePreviewTableTool = ({
                 {featuredTable.name}
               </ButtonText>
             )}
-            finalStep={({query, table, tableHeaders, onReorder}) => (
+            finalStep={({ query, table, tableHeaders, onReorder }) => (
               <WizardStep>
                 {wizardStepProps => (
                   <>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableTool.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableTool.tsx
@@ -47,7 +47,7 @@ const ReleasePreviewTableTool = ({
           {
             ...query,
           },
-          releaseId,
+          releaseVersionId: releaseId,
         ),
       ]);
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableTool.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleasePreviewTableTool.tsx
@@ -11,10 +11,10 @@ import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHead
 import tableBuilderService from '@common/services/tableBuilderService';
 import ButtonText from '@common/components/ButtonText';
 import ReleasePreviewTableToolFinalStep from '@admin/pages/release/content/components/ReleasePreviewTableToolFinalStep';
-import { Publication } from '@admin/services/publicationService';
-import { Publication as ContentPublication } from '@common/services/publicationService';
-import React, { useState } from 'react';
-import { ReleaseType } from '@common/services/types/releaseType';
+import {Publication} from '@admin/services/publicationService';
+import {Publication as ContentPublication} from '@common/services/publicationService';
+import React, {useState} from 'react';
+import {ReleaseType} from '@common/services/types/releaseType';
 
 interface Props {
   featuredTableId?: string;
@@ -22,15 +22,16 @@ interface Props {
   releaseType: ReleaseType;
   publication: Publication | ContentPublication;
 }
+
 const ReleasePreviewTableTool = ({
-  featuredTableId,
-  releaseVersionId,
-  releaseType,
-  publication,
-}: Props) => {
+                                   featuredTableId,
+                                   releaseVersionId,
+                                   releaseType,
+                                   publication,
+                                 }: Props) => {
   const [dataBlockId, setDataBlockId] = useState(featuredTableId ?? '');
 
-  const { value: initialState, isLoading } = useAsyncHandledRetry<
+  const {value: initialState, isLoading} = useAsyncHandledRetry<
     InitialTableToolState | undefined
   >(async () => {
     const [featuredTables, subjects] = await Promise.all([
@@ -39,7 +40,7 @@ const ReleasePreviewTableTool = ({
     ]);
 
     if (dataBlockId) {
-      const { table, query } = await dataBlockService.getDataBlock(dataBlockId);
+      const {table, query} = await dataBlockService.getDataBlock(dataBlockId);
 
       const [subjectMeta, tableData] = await Promise.all([
         tableBuilderService.getSubjectMeta(query.subjectId, releaseVersionId),
@@ -47,7 +48,7 @@ const ReleasePreviewTableTool = ({
           {
             ...query,
           },
-          releaseId: releaseVersionId,
+          releaseVersionId,
         ),
       ]);
 
@@ -106,7 +107,7 @@ const ReleasePreviewTableTool = ({
                 {featuredTable.name}
               </ButtonText>
             )}
-            finalStep={({ query, table, tableHeaders, onReorder }) => (
+            finalStep={({query, table, tableHeaders, onReorder}) => (
               <WizardStep>
                 {wizardStepProps => (
                   <>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStat.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStat.test.tsx
@@ -49,7 +49,9 @@ describe('EditableKeyStat', () => {
     };
 
     test('renders correctly', async () => {
-      render(<EditableKeyStat releaseId="release-1" keyStat={keyStatText} />);
+      render(
+        <EditableKeyStat releaseVersionId="release-1" keyStat={keyStatText} />,
+      );
 
       await waitFor(() => {
         expect(
@@ -158,7 +160,10 @@ describe('EditableKeyStat', () => {
       );
 
       render(
-        <EditableKeyStat releaseId="release-1" keyStat={keyStatDataBlock} />,
+        <EditableKeyStat
+          releaseVersionId="release-1"
+          keyStat={keyStatDataBlock}
+        />,
       );
 
       await waitFor(() => {
@@ -197,7 +202,7 @@ describe('EditableKeyStat', () => {
 
       render(
         <EditableKeyStat
-          releaseId="release-1"
+          releaseVersionId="release-1"
           keyStat={keyStatDataBlock}
           isEditing
         />,
@@ -250,7 +255,7 @@ describe('EditableKeyStat', () => {
 
       render(
         <EditableKeyStat
-          releaseId="release-1"
+          releaseVersionId="release-1"
           keyStat={keyStatDataBlock}
           isEditing
         />,
@@ -283,7 +288,7 @@ describe('EditableKeyStat', () => {
     test('invalid `keyStat` renders null', async () => {
       const { container } = render(
         <EditableKeyStat
-          releaseId="release-1"
+          releaseVersionId="release-1"
           keyStat={
             {
               id: 'KeyStat-1',

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
@@ -81,7 +81,7 @@ describe('EditableKeyStatDataBlock', () => {
 
     render(
       <EditableKeyStatDataBlock
-        releaseId="release-1"
+        releaseVersionId="release-1"
         keyStat={keyStatDataBlock}
         onRemove={noop}
         onSubmit={noop}
@@ -122,7 +122,7 @@ describe('EditableKeyStatDataBlock', () => {
     render(
       <EditableKeyStatDataBlock
         isEditing
-        releaseId="release-1"
+        releaseVersionId="release-1"
         keyStat={keyStatDataBlock}
         onRemove={noop}
         onSubmit={noop}
@@ -157,7 +157,7 @@ describe('EditableKeyStatDataBlock', () => {
 
     render(
       <EditableKeyStatDataBlock
-        releaseId="release-1"
+        releaseVersionId="release-1"
         keyStat={{ ...keyStatDataBlock, trend: undefined }}
         onRemove={noop}
         onSubmit={noop}
@@ -176,7 +176,7 @@ describe('EditableKeyStatDataBlock', () => {
 
     render(
       <EditableKeyStatDataBlock
-        releaseId="release-1"
+        releaseVersionId="release-1"
         keyStat={{ ...keyStatDataBlock, guidanceTitle: undefined }}
         onRemove={noop}
         onSubmit={noop}
@@ -202,7 +202,7 @@ describe('EditableKeyStatDataBlock', () => {
 
     render(
       <EditableKeyStatDataBlock
-        releaseId="release-1"
+        releaseVersionId="release-1"
         keyStat={{ ...keyStatDataBlock, guidanceText: undefined }}
         onRemove={noop}
         onSubmit={noop}
@@ -231,7 +231,7 @@ describe('EditableKeyStatDataBlock', () => {
 
     render(
       <EditableKeyStatDataBlock
-        releaseId="release-1"
+        releaseVersionId="release-1"
         keyStat={keyStatDataBlock}
         isEditing
         onRemove={onRemove}
@@ -260,7 +260,7 @@ describe('EditableKeyStatDataBlock', () => {
 
     render(
       <EditableKeyStatDataBlock
-        releaseId="release-1"
+        releaseVersionId="release-1"
         keyStat={keyStatDataBlock}
         isEditing
         onRemove={noop}
@@ -294,7 +294,7 @@ describe('EditableKeyStatDataBlock', () => {
 
     render(
       <EditableKeyStatDataBlock
-        releaseId="release-1"
+        releaseVersionId="release-1"
         keyStat={keyStatDataBlock}
         isEditing
         onRemove={noop}
@@ -335,7 +335,7 @@ describe('EditableKeyStatDataBlock', () => {
 
     render(
       <EditableKeyStatDataBlock
-        releaseId="release-1"
+        releaseVersionId="release-1"
         keyStat={keyStatDataBlock}
         onRemove={onRemove}
         onSubmit={noop}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseContent.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseContent.test.tsx
@@ -150,7 +150,9 @@ describe('ReleaseContent', () => {
     return baseRender(
       <TestConfigContextProvider>
         unattachedDataBlocks: [], unattachedDataBlocks: [],
-        <ReleaseContentHubContextProvider releaseId={releaseContent.release.id}>
+        <ReleaseContentHubContextProvider
+          releaseVersionId={releaseContent.release.id}
+        >
           <ReleaseContentProvider
             value={{
               ...releaseContent,

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseContentAccordionSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseContentAccordionSection.test.tsx
@@ -32,7 +32,7 @@ describe('ReleaseContentAccordionSection', () => {
           }}
         >
           <ReleaseContentHubContextProvider
-            releaseId={testReleaseContent.release.id}
+            releaseVersionId={testReleaseContent.release.id}
           >
             <EditableAccordion
               onAddSection={noop}
@@ -89,7 +89,7 @@ describe('ReleaseContentAccordionSection', () => {
             }}
           >
             <ReleaseContentHubContextProvider
-              releaseId={testReleaseContent.release.id}
+              releaseVersionId={testReleaseContent.release.id}
             >
               <EditableAccordion
                 onAddSection={noop}
@@ -138,7 +138,7 @@ describe('ReleaseContentAccordionSection', () => {
           }}
         >
           <ReleaseContentHubContextProvider
-            releaseId={testReleaseContent.release.id}
+            releaseVersionId={testReleaseContent.release.id}
           >
             <EditableAccordion
               onAddSection={noop}
@@ -189,7 +189,7 @@ describe('ReleaseContentAccordionSection', () => {
           }}
         >
           <ReleaseContentHubContextProvider
-            releaseId={testReleaseContent.release.id}
+            releaseVersionId={testReleaseContent.release.id}
           >
             <EditableAccordion
               onAddSection={noop}
@@ -228,7 +228,7 @@ describe('ReleaseContentAccordionSection', () => {
           }}
         >
           <ReleaseContentHubContextProvider
-            releaseId={testReleaseContent.release.id}
+            releaseVersionId={testReleaseContent.release.id}
           >
             <EditableAccordion
               onAddSection={noop}
@@ -283,7 +283,7 @@ describe('ReleaseContentAccordionSection', () => {
           }}
         >
           <ReleaseContentHubContextProvider
-            releaseId={testReleaseContent.release.id}
+            releaseVersionId={testReleaseContent.release.id}
           >
             <EditableAccordion
               onAddSection={noop}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseEditableBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseEditableBlock.test.tsx
@@ -174,7 +174,7 @@ describe('ReleaseEditableBlock', () => {
       if (methodName === 'LockContentBlock') {
         return Promise.resolve<ReleaseContentBlockLockEvent>({
           id: 'content-block-id',
-          releaseId: 'release-1',
+          releaseVersionId: 'release-1',
           sectionId: 'section-1',
           locked: '2022-02-16T12:05:00Z',
           lockedUntil: '2022-02-16T12:15:00Z',
@@ -586,7 +586,7 @@ describe('ReleaseEditableBlock', () => {
     // Simulates lock being renewed
     onContentBlockLocked({
       id: 'content-block-id',
-      releaseId: 'release-1',
+      releaseVersionId: 'release-1',
       sectionId: 'section-1',
       locked: '2022-02-16T12:08:00Z',
       lockedUntil: '2022-02-16T12:18:00Z',
@@ -632,7 +632,7 @@ describe('ReleaseEditableBlock', () => {
       if (methodName === 'LockContentBlock') {
         return Promise.resolve<ReleaseContentBlockLockEvent>({
           id: 'content-block-id',
-          releaseId: 'release-1',
+          releaseVersionId: 'release-1',
           sectionId: 'section-1',
           locked: '2022-02-16T12:00:00Z',
           lockedUntil: '2022-02-16T12:20:00Z',
@@ -739,7 +739,7 @@ describe('ReleaseEditableBlock', () => {
     // Simulates locking of block by other user
     onContentBlockLocked({
       id: 'content-block-id',
-      releaseId: 'release-1',
+      releaseVersionId: 'release-1',
       sectionId: 'section-1',
       locked: '2022-02-16T12:00:00Z',
       lockedUntil: '2022-02-16T12:10:00Z',
@@ -1324,7 +1324,9 @@ describe('ReleaseEditableBlock', () => {
         }}
       >
         unattachedDataBlocks: [],
-        <ReleaseContentHubContextProvider releaseId={releaseContent.release.id}>
+        <ReleaseContentHubContextProvider
+          releaseVersionId={releaseContent.release.id}
+        >
           <ReleaseContentProvider
             value={{
               ...releaseContent,

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseEditableBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseEditableBlock.test.tsx
@@ -63,7 +63,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({})}
@@ -93,7 +93,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({
@@ -134,7 +134,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({
@@ -188,7 +188,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({})}
@@ -237,7 +237,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({
@@ -280,7 +280,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({
@@ -334,7 +334,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({
@@ -371,7 +371,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({
@@ -406,7 +406,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({
@@ -470,7 +470,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({
@@ -551,7 +551,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({
@@ -646,7 +646,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({
@@ -721,7 +721,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({})}
@@ -771,7 +771,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({})}
@@ -791,7 +791,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableContentBlock({})}
@@ -822,7 +822,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableEmbedBlock({})}
@@ -839,7 +839,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         sectionId="section-1"
         sectionKey="content"
         block={generateEditableDataBlock({})}
@@ -854,7 +854,7 @@ describe('ReleaseEditableBlock', () => {
       render(
         <ReleaseEditableBlock
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           sectionId="section-1"
           sectionKey="content"
           block={generateEditableDataBlock({ comments: testComments })}
@@ -887,7 +887,7 @@ describe('ReleaseEditableBlock', () => {
       render(
         <ReleaseEditableBlock
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           sectionId="section-1"
           sectionKey="content"
           block={generateEditableDataBlock({ comments: testComments })}
@@ -922,7 +922,7 @@ describe('ReleaseEditableBlock', () => {
       render(
         <ReleaseEditableBlock
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           sectionId="section-1"
           sectionKey="content"
           block={generateEditableDataBlock({ comments: testComments })}
@@ -965,7 +965,7 @@ describe('ReleaseEditableBlock', () => {
       render(
         <ReleaseEditableBlock
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           sectionId="section-1"
           sectionKey="content"
           block={generateEditableDataBlock({ comments: testComments })}
@@ -1001,7 +1001,7 @@ describe('ReleaseEditableBlock', () => {
       render(
         <ReleaseEditableBlock
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           sectionId="section-1"
           sectionKey="content"
           block={generateEditableDataBlock({ comments: testComments })}
@@ -1039,7 +1039,7 @@ describe('ReleaseEditableBlock', () => {
       render(
         <ReleaseEditableBlock
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           sectionId="section-1"
           sectionKey="content"
           block={generateEditableDataBlock({ comments: testComments })}
@@ -1085,7 +1085,7 @@ describe('ReleaseEditableBlock', () => {
       render(
         <ReleaseEditableBlock
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           sectionId="section-1"
           sectionKey="content"
           block={generateEditableEmbedBlock({ comments: testComments })}
@@ -1118,7 +1118,7 @@ describe('ReleaseEditableBlock', () => {
       render(
         <ReleaseEditableBlock
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           sectionId="section-1"
           sectionKey="content"
           block={generateEditableEmbedBlock({ comments: testComments })}
@@ -1153,7 +1153,7 @@ describe('ReleaseEditableBlock', () => {
       render(
         <ReleaseEditableBlock
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           sectionId="section-1"
           sectionKey="content"
           block={generateEditableEmbedBlock({ comments: testComments })}
@@ -1196,7 +1196,7 @@ describe('ReleaseEditableBlock', () => {
       render(
         <ReleaseEditableBlock
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           sectionId="section-1"
           sectionKey="content"
           block={generateEditableEmbedBlock({ comments: testComments })}
@@ -1232,7 +1232,7 @@ describe('ReleaseEditableBlock', () => {
       render(
         <ReleaseEditableBlock
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           sectionId="section-1"
           sectionKey="content"
           block={generateEditableEmbedBlock({ comments: testComments })}
@@ -1270,7 +1270,7 @@ describe('ReleaseEditableBlock', () => {
       render(
         <ReleaseEditableBlock
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           sectionId="section-1"
           sectionKey="content"
           block={generateEditableEmbedBlock({ comments: testComments })}

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/ReleaseContentContext.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/ReleaseContentContext.tsx
@@ -4,7 +4,7 @@ import {
   ReleaseDispatchAction,
 } from '@admin/pages/release/content/contexts/ReleaseContentContextActionTypes';
 import { FeaturedTable } from '@admin/services/featuredTableService';
-import { EditableRelease } from '@admin/services/releaseContentService';
+import { EditableReleaseVersion } from '@admin/services/releaseContentService';
 import { EditableBlock } from '@admin/services/types/content';
 import { useLoggedImmerReducer } from '@common/hooks/useLoggedReducer';
 import { ContentSection } from '@common/services/publicationService';
@@ -17,7 +17,7 @@ export type ReleaseContentContextDispatch = (
 ) => void;
 
 export interface ReleaseContentContextState {
-  release: EditableRelease;
+  release: EditableReleaseVersion;
   canUpdateRelease: boolean;
   featuredTables?: FeaturedTable[];
   unattachedDataBlocks: DataBlock[];

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/useReleaseContentActions.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/useReleaseContentActions.ts
@@ -26,9 +26,9 @@ export default function useReleaseContentActions() {
   const dispatch = useReleaseContentDispatch();
 
   const updateUnattachedDataBlocks = useCallback(
-    async ({ releaseId }: { releaseId: string }) => {
+    async ({ releaseVersionId }: { releaseVersionId: string }) => {
       const unattachedDataBlocks =
-        await dataBlockService.getUnattachedDataBlocks(releaseId);
+        await dataBlockService.getUnattachedDataBlocks(releaseVersionId);
 
       dispatch({
         type: 'SET_UNATTACHED_DATABLOCKS',
@@ -40,18 +40,18 @@ export default function useReleaseContentActions() {
 
   const deleteContentSectionBlock = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       sectionId,
       blockId,
       sectionKey,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
       blockId: string;
       sectionKey: ContentSectionKeys;
     }) => {
       await releaseContentService.deleteContentSectionBlock(
-        releaseId,
+        releaseVersionId,
         sectionId,
         blockId,
       );
@@ -60,27 +60,27 @@ export default function useReleaseContentActions() {
         payload: { meta: { sectionId, blockId, sectionKey } },
       });
 
-      await updateUnattachedDataBlocks({ releaseId });
+      await updateUnattachedDataBlocks({ releaseVersionId });
     },
     [dispatch, updateUnattachedDataBlocks],
   );
 
   const updateContentSectionBlock = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       sectionId,
       blockId,
       sectionKey,
       bodyContent,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
       blockId: string;
       sectionKey: ContentSectionKeys;
       bodyContent: string;
     }) => {
       const updateBlock = await releaseContentService.updateContentSectionBlock(
-        releaseId,
+        releaseVersionId,
         sectionId,
         blockId,
         { body: bodyContent },
@@ -99,13 +99,13 @@ export default function useReleaseContentActions() {
 
   const addBlockComment = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       sectionId,
       sectionKey,
       blockId,
       comment,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
       sectionKey: ContentSectionKeys;
       blockId: string;
@@ -113,7 +113,7 @@ export default function useReleaseContentActions() {
     }): Promise<Comment> => {
       const newComment =
         await releaseContentCommentService.addContentSectionComment(
-          releaseId,
+          releaseVersionId,
           sectionId,
           blockId,
           comment,
@@ -139,7 +139,7 @@ export default function useReleaseContentActions() {
       blockId,
       commentId,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
       sectionKey: ContentSectionKeys;
       blockId: string;
@@ -165,7 +165,7 @@ export default function useReleaseContentActions() {
       blockId,
       comment,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
       sectionKey: ContentSectionKeys;
       blockId: string;
@@ -187,18 +187,18 @@ export default function useReleaseContentActions() {
 
   const addContentSectionBlock = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       sectionId,
       sectionKey,
       block,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
       sectionKey: ContentSectionKeys;
       block: ContentBlockPostModel;
     }) => {
       const newBlock = await releaseContentService.addContentSectionBlock(
-        releaseId,
+        releaseVersionId,
         sectionId,
         block,
       );
@@ -208,25 +208,25 @@ export default function useReleaseContentActions() {
         payload: { meta: { sectionId, sectionKey }, block: newBlock },
       });
 
-      await updateUnattachedDataBlocks({ releaseId });
+      await updateUnattachedDataBlocks({ releaseVersionId });
     },
     [dispatch, updateUnattachedDataBlocks],
   );
 
   const addEmbedSectionBlock = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       sectionId,
       sectionKey,
       request,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
       sectionKey: ContentSectionKeys;
       request: EmbedBlockCreateRequest;
     }) => {
       const newBlock = await releaseContentService.addEmbedSectionBlock(
-        releaseId,
+        releaseVersionId,
         request,
       );
 
@@ -240,17 +240,20 @@ export default function useReleaseContentActions() {
 
   const deleteEmbedSectionBlock = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       sectionId,
       blockId,
       sectionKey,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
       blockId: string;
       sectionKey: ContentSectionKeys;
     }) => {
-      await releaseContentService.deleteEmbedSectionBlock(releaseId, blockId);
+      await releaseContentService.deleteEmbedSectionBlock(
+        releaseVersionId,
+        blockId,
+      );
       dispatch({
         type: 'REMOVE_SECTION_BLOCK',
         payload: { meta: { sectionId, blockId, sectionKey } },
@@ -261,20 +264,20 @@ export default function useReleaseContentActions() {
 
   const updateEmbedSectionBlock = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       sectionId,
       blockId,
       sectionKey,
       request,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
       blockId: string;
       sectionKey: ContentSectionKeys;
       request: EmbedBlockUpdateRequest;
     }) => {
       const updateBlock = await releaseContentService.updateEmbedSectionBlock(
-        releaseId,
+        releaseVersionId,
         blockId,
         request,
       );
@@ -292,18 +295,18 @@ export default function useReleaseContentActions() {
 
   const attachContentSectionBlock = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       sectionId,
       sectionKey,
       block,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
       sectionKey: ContentSectionKeys;
       block: ContentBlockAttachRequest;
     }) => {
       const newBlock = await releaseContentService.attachContentSectionBlock(
-        releaseId,
+        releaseVersionId,
         sectionId,
         block,
       );
@@ -313,26 +316,26 @@ export default function useReleaseContentActions() {
         payload: { meta: { sectionId, sectionKey }, block: newBlock },
       });
 
-      await updateUnattachedDataBlocks({ releaseId });
+      await updateUnattachedDataBlocks({ releaseVersionId });
     },
     [dispatch, updateUnattachedDataBlocks],
   );
 
   const updateSectionBlockOrder = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       sectionId,
       sectionKey,
       order,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
       sectionKey: ContentSectionKeys;
       order: Dictionary<number>;
     }) => {
       const sectionContent =
         await releaseContentService.updateContentSectionBlocksOrder(
-          releaseId,
+          releaseVersionId,
           sectionId,
           order,
         );
@@ -349,9 +352,15 @@ export default function useReleaseContentActions() {
   );
 
   const addContentSection = useCallback(
-    async ({ releaseId, order }: { releaseId: string; order: number }) => {
+    async ({
+      releaseVersionId,
+      order,
+    }: {
+      releaseVersionId: string;
+      order: number;
+    }) => {
       const newSection = await releaseContentService.addContentSection(
-        releaseId,
+        releaseVersionId,
         order,
       );
       dispatch({
@@ -366,14 +375,14 @@ export default function useReleaseContentActions() {
 
   const updateContentSectionsOrder = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       order,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       order: Dictionary<number>;
     }) => {
       const content = await releaseContentService.updateContentSectionsOrder(
-        releaseId,
+        releaseVersionId,
         order,
       );
 
@@ -389,14 +398,14 @@ export default function useReleaseContentActions() {
 
   const removeContentSection = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       sectionId,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
     }) => {
       const content = await releaseContentService.removeContentSection(
-        releaseId,
+        releaseVersionId,
         sectionId,
       );
 
@@ -412,16 +421,16 @@ export default function useReleaseContentActions() {
 
   const updateContentSectionHeading = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       sectionId,
       title,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       sectionId: string;
       title: string;
     }) => {
       const section = await releaseContentService.updateContentSectionHeading(
-        releaseId,
+        releaseVersionId,
         sectionId,
         title,
       );
@@ -439,16 +448,19 @@ export default function useReleaseContentActions() {
 
   const addKeyStatisticDataBlock = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       dataBlockId,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       dataBlockId: string;
     }) => {
       const keyStatisticDataBlock =
-        await keyStatisticService.createKeyStatisticDataBlock(releaseId, {
-          dataBlockId,
-        });
+        await keyStatisticService.createKeyStatisticDataBlock(
+          releaseVersionId,
+          {
+            dataBlockId,
+          },
+        );
       dispatch({
         type: 'ADD_KEY_STATISTIC',
         payload: { keyStatistic: keyStatisticDataBlock },
@@ -459,15 +471,15 @@ export default function useReleaseContentActions() {
 
   const addKeyStatisticText = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       keyStatisticText,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       keyStatisticText: KeyStatisticTextSaveRequest;
     }) => {
       const createdKeyStatText =
         await keyStatisticService.createKeyStatisticText(
-          releaseId,
+          releaseVersionId,
           keyStatisticText,
         );
       dispatch({
@@ -480,17 +492,17 @@ export default function useReleaseContentActions() {
 
   const updateKeyStatisticDataBlock = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       keyStatisticId,
       request,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       keyStatisticId: string;
       request: KeyStatisticDataBlockUpdateRequest;
     }) => {
       const updatedKeyStatisticDataBlock =
         await keyStatisticService.updateKeyStatisticDataBlock(
-          releaseId,
+          releaseVersionId,
           keyStatisticId,
           request,
         );
@@ -504,17 +516,17 @@ export default function useReleaseContentActions() {
 
   const updateKeyStatisticText = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       keyStatisticId,
       request,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       keyStatisticId: string;
       request: KeyStatisticTextUpdateRequest;
     }) => {
       const updatedKeyStatisticText =
         await keyStatisticService.updateKeyStatisticText(
-          releaseId,
+          releaseVersionId,
           keyStatisticId,
           request,
         );
@@ -528,13 +540,16 @@ export default function useReleaseContentActions() {
 
   const deleteKeyStatistic = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       keyStatisticId,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       keyStatisticId: string;
     }) => {
-      await keyStatisticService.deleteKeyStatistic(releaseId, keyStatisticId);
+      await keyStatisticService.deleteKeyStatistic(
+        releaseVersionId,
+        keyStatisticId,
+      );
 
       dispatch({
         type: 'REMOVE_KEY_STATISTIC',
@@ -546,15 +561,15 @@ export default function useReleaseContentActions() {
 
   const reorderKeyStatistics = useCallback(
     async ({
-      releaseId,
+      releaseVersionId,
       keyStatistics,
     }: {
-      releaseId: string;
+      releaseVersionId: string;
       keyStatistics: KeyStatistic[];
     }) => {
       const reorderedKeyStatistics =
         await keyStatisticService.reorderKeyStatistics(
-          releaseId,
+          releaseVersionId,
           keyStatistics.map(ks => ks.id),
         );
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/utils/getUnresolvedComments.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/content/utils/getUnresolvedComments.ts
@@ -1,4 +1,4 @@
-import { EditableRelease } from '@admin/services/releaseContentService';
+import { EditableReleaseVersion } from '@admin/services/releaseContentService';
 import { EditableBlock } from '@admin/services/types/content';
 import { BlockCommentIds } from '@admin/contexts/EditingContext';
 
@@ -33,7 +33,9 @@ const getContentSectionComments = (
   }, {});
 };
 
-const getUnresolvedComments = (release: EditableRelease): BlockCommentIds => {
+const getUnresolvedComments = (
+  release: EditableReleaseVersion,
+): BlockCommentIds => {
   return {
     ...getContentSectionComments(release.summarySection.content),
     ...getContentSectionComments(release.headlinesSection.content),

--- a/src/explore-education-statistics-admin/src/pages/release/contexts/ReleaseContext.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/contexts/ReleaseContext.tsx
@@ -1,43 +1,45 @@
-import { Release } from '@admin/services/releaseService';
+import { ReleaseVersion } from '@admin/services/releaseService';
 import noop from 'lodash/noop';
 import React, { createContext, ReactNode, useContext, useMemo } from 'react';
 
-export interface ReleaseContextState {
-  release: Release;
-  releaseId: string;
+export interface ReleaseVersionContextState {
+  releaseVersion: ReleaseVersion;
+  releaseVersionId: string;
   onReleaseChange: () => void;
 }
 
-const ReleaseContext = createContext<ReleaseContextState | undefined>(
-  undefined,
-);
+const ReleaseVersionContext = createContext<
+  ReleaseVersionContextState | undefined
+>(undefined);
 
-interface ReleaseContextProviderProps {
+interface ReleaseVersionContextProviderProps {
   children: ReactNode;
-  release: Release;
+  releaseVersion: ReleaseVersion;
   onReleaseChange?: () => void;
 }
 
-export const ReleaseContextProvider = ({
+export const ReleaseVersionContextProvider = ({
   children,
-  release,
+  releaseVersion,
   onReleaseChange = noop,
-}: ReleaseContextProviderProps) => {
-  const value = useMemo<ReleaseContextState>(() => {
+}: ReleaseVersionContextProviderProps) => {
+  const value = useMemo<ReleaseVersionContextState>(() => {
     return {
-      release,
-      releaseId: release.id,
+      releaseVersion,
+      releaseVersionId: releaseVersion.id,
       onReleaseChange,
     };
-  }, [onReleaseChange, release]);
+  }, [onReleaseChange, releaseVersion]);
 
   return (
-    <ReleaseContext.Provider value={value}>{children}</ReleaseContext.Provider>
+    <ReleaseVersionContext.Provider value={value}>
+      {children}
+    </ReleaseVersionContext.Provider>
   );
 };
 
-export function useReleaseContext() {
-  const context = useContext(ReleaseContext);
+export function useReleaseVersionContext() {
+  const context = useContext(ReleaseVersionContext);
 
   if (!context) {
     throw new Error(

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseAncillaryFilePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseAncillaryFilePage.tsx
@@ -18,15 +18,15 @@ import { generatePath, RouteComponentProps } from 'react-router';
 export default function ReleaseAncillaryFilePage({
   history,
   match: {
-    params: { publicationId, releaseId, fileId },
+    params: { publicationId, releaseVersionId, fileId },
   },
 }: RouteComponentProps<ReleaseAncillaryFileRouteParams>) {
   const { data: file, isLoading: isLoadingFile } = useQuery(
-    releaseAncillaryFileQueries.get(releaseId, fileId),
+    releaseAncillaryFileQueries.get(releaseVersionId, fileId),
   );
 
   const { data: allFiles = [], isLoading: isLoadingAllFiles } = useQuery(
-    releaseAncillaryFileQueries.list(releaseId),
+    releaseAncillaryFileQueries.list(releaseVersionId),
   );
 
   const navigateBack = useCallback(
@@ -34,15 +34,15 @@ export default function ReleaseAncillaryFilePage({
       history.push(
         generatePath<ReleaseRouteParams>(releaseAncillaryFilesRoute.path, {
           publicationId,
-          releaseId,
+          releaseVersionId,
         }),
       ),
-    [history, publicationId, releaseId],
+    [history, publicationId, releaseVersionId],
   );
 
   const handleSubmit = useCallback(
     async ({ title, summary, file: newFile }: AncillaryFileFormValues) => {
-      await releaseAncillaryFileService.updateFile(releaseId, fileId, {
+      await releaseAncillaryFileService.updateFile(releaseVersionId, fileId, {
         title,
         summary,
         file: newFile,
@@ -50,7 +50,7 @@ export default function ReleaseAncillaryFilePage({
 
       navigateBack();
     },
-    [fileId, navigateBack, releaseId],
+    [fileId, navigateBack, releaseVersionId],
   );
 
   return (
@@ -60,7 +60,7 @@ export default function ReleaseAncillaryFilePage({
         back
         to={generatePath<ReleaseRouteParams>(releaseAncillaryFilesRoute.path, {
           publicationId,
-          releaseId,
+          releaseVersionId,
         })}
       >
         Back

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -1,9 +1,9 @@
 import Link from '@admin/components/Link';
-import { useConfig } from '@admin/contexts/ConfigContext';
+import {useConfig} from '@admin/contexts/ConfigContext';
 import ApiDataSetVersionSummaryList from '@admin/pages/release/data/components/ApiDataSetVersionSummaryList';
 import DeleteDraftVersionButton from '@admin/pages/release/data/components/DeleteDraftVersionButton';
 import ApiDataSetCreateModal from '@admin/pages/release/data/components/ApiDataSetCreateModal';
-import { useReleaseVersionContext } from '@admin/pages/release/contexts/ReleaseContext';
+import {useReleaseVersionContext} from '@admin/pages/release/contexts/ReleaseContext';
 import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
 import {
   releaseApiDataSetLocationsMappingRoute,
@@ -11,19 +11,19 @@ import {
   ReleaseDataSetRouteParams,
   ReleaseRouteParams,
 } from '@admin/routes/releaseRoutes';
-import { DataSetStatus } from '@admin/services/apiDataSetService';
+import {DataSetStatus} from '@admin/services/apiDataSetService';
 import apiDataSetVersionService from '@admin/services/apiDataSetVersionService';
 import ContentHtml from '@common/components/ContentHtml';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import SummaryCard from '@common/components/SummaryCard';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
-import Tag, { TagProps } from '@common/components/Tag';
+import Tag, {TagProps} from '@common/components/Tag';
 import TaskList from '@common/components/TaskList';
 import TaskListItem from '@common/components/TaskListItem';
-import { useQuery } from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 import React from 'react';
-import { generatePath, useHistory, useParams } from 'react-router-dom';
+import {generatePath, useHistory, useParams} from 'react-router-dom';
 
 // TODO: Version mapping
 const showDraftVersionTasks = false;
@@ -33,11 +33,11 @@ const showChangelog = false;
 const showVersionHistory = false;
 
 export default function ReleaseApiDataSetDetailsPage() {
-  const { dataSetId } = useParams<ReleaseDataSetRouteParams>();
+  const {dataSetId} = useParams<ReleaseDataSetRouteParams>();
   const history = useHistory();
 
-  const { publicAppUrl } = useConfig();
-  const { releaseVersion } = useReleaseVersionContext();
+  const {publicAppUrl} = useConfig();
+  const {releaseVersion} = useReleaseVersionContext();
 
   const {
     data: dataSet,
@@ -156,7 +156,7 @@ export default function ReleaseApiDataSetDetailsPage() {
                 </Tag>
               </SummaryListItem>
               <SummaryListItem term="Summary">
-                <ContentHtml html={dataSet.summary} />
+                <ContentHtml html={dataSet.summary}/>
               </SummaryListItem>
             </SummaryList>
 
@@ -182,8 +182,8 @@ export default function ReleaseApiDataSetDetailsPage() {
                           to={generatePath<ReleaseDataSetRouteParams>(
                             releaseApiDataSetLocationsMappingRoute.path,
                             {
-                              publicationId: release.publicationId,
-                              releaseId: release.id,
+                              publicationId: releaseVersion.publicationId,
+                              releaseVersionId: releaseVersion.id,
                               dataSetId,
                             },
                           )}
@@ -257,7 +257,7 @@ export default function ReleaseApiDataSetDetailsPage() {
                   releaseVersionId={releaseVersion.id}
                   submitText="Confirm new data set version"
                   title="Create a new API data set version"
-                  onSubmit={async ({ releaseFileId }) => {
+                  onSubmit={async ({releaseFileId}) => {
                     await apiDataSetVersionService.createVersion({
                       dataSetId: dataSet.id,
                       releaseFileId,

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -1,9 +1,9 @@
 import Link from '@admin/components/Link';
-import {useConfig} from '@admin/contexts/ConfigContext';
+import { useConfig } from '@admin/contexts/ConfigContext';
 import ApiDataSetVersionSummaryList from '@admin/pages/release/data/components/ApiDataSetVersionSummaryList';
 import DeleteDraftVersionButton from '@admin/pages/release/data/components/DeleteDraftVersionButton';
 import ApiDataSetCreateModal from '@admin/pages/release/data/components/ApiDataSetCreateModal';
-import {useReleaseVersionContext} from '@admin/pages/release/contexts/ReleaseContext';
+import { useReleaseVersionContext } from '@admin/pages/release/contexts/ReleaseContext';
 import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
 import {
   releaseApiDataSetLocationsMappingRoute,
@@ -11,19 +11,19 @@ import {
   ReleaseDataSetRouteParams,
   ReleaseRouteParams,
 } from '@admin/routes/releaseRoutes';
-import {DataSetStatus} from '@admin/services/apiDataSetService';
+import { DataSetStatus } from '@admin/services/apiDataSetService';
 import apiDataSetVersionService from '@admin/services/apiDataSetVersionService';
 import ContentHtml from '@common/components/ContentHtml';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import SummaryCard from '@common/components/SummaryCard';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
-import Tag, {TagProps} from '@common/components/Tag';
+import Tag, { TagProps } from '@common/components/Tag';
 import TaskList from '@common/components/TaskList';
 import TaskListItem from '@common/components/TaskListItem';
-import {useQuery} from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import React from 'react';
-import {generatePath, useHistory, useParams} from 'react-router-dom';
+import { generatePath, useHistory, useParams } from 'react-router-dom';
 
 // TODO: Version mapping
 const showDraftVersionTasks = false;
@@ -33,11 +33,11 @@ const showChangelog = false;
 const showVersionHistory = false;
 
 export default function ReleaseApiDataSetDetailsPage() {
-  const {dataSetId} = useParams<ReleaseDataSetRouteParams>();
+  const { dataSetId } = useParams<ReleaseDataSetRouteParams>();
   const history = useHistory();
 
-  const {publicAppUrl} = useConfig();
-  const {releaseVersion} = useReleaseVersionContext();
+  const { publicAppUrl } = useConfig();
+  const { releaseVersion } = useReleaseVersionContext();
 
   const {
     data: dataSet,
@@ -156,7 +156,7 @@ export default function ReleaseApiDataSetDetailsPage() {
                 </Tag>
               </SummaryListItem>
               <SummaryListItem term="Summary">
-                <ContentHtml html={dataSet.summary}/>
+                <ContentHtml html={dataSet.summary} />
               </SummaryListItem>
             </SummaryList>
 
@@ -257,7 +257,7 @@ export default function ReleaseApiDataSetDetailsPage() {
                   releaseVersionId={releaseVersion.id}
                   submitText="Confirm new data set version"
                   title="Create a new API data set version"
-                  onSubmit={async ({releaseFileId}) => {
+                  onSubmit={async ({ releaseFileId }) => {
                     await apiDataSetVersionService.createVersion({
                       dataSetId: dataSet.id,
                       releaseFileId,

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -3,7 +3,7 @@ import { useConfig } from '@admin/contexts/ConfigContext';
 import ApiDataSetVersionSummaryList from '@admin/pages/release/data/components/ApiDataSetVersionSummaryList';
 import DeleteDraftVersionButton from '@admin/pages/release/data/components/DeleteDraftVersionButton';
 import ApiDataSetCreateModal from '@admin/pages/release/data/components/ApiDataSetCreateModal';
-import { useReleaseContext } from '@admin/pages/release/contexts/ReleaseContext';
+import { useReleaseVersionContext } from '@admin/pages/release/contexts/ReleaseContext';
 import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
 import {
   releaseApiDataSetLocationsMappingRoute,
@@ -37,7 +37,7 @@ export default function ReleaseApiDataSetDetailsPage() {
   const history = useHistory();
 
   const { publicAppUrl } = useConfig();
-  const { release } = useReleaseContext();
+  const { releaseVersion } = useReleaseVersionContext();
 
   const {
     data: dataSet,
@@ -50,7 +50,7 @@ export default function ReleaseApiDataSetDetailsPage() {
     },
   });
 
-  const canUpdateRelease = release.approvalStatus !== 'Approved';
+  const canUpdateRelease = releaseVersion.approvalStatus !== 'Approved';
 
   const columnSizeClassName =
     dataSet?.latestLiveVersion && dataSet?.draftVersion
@@ -61,7 +61,7 @@ export default function ReleaseApiDataSetDetailsPage() {
     <ApiDataSetVersionSummaryList
       dataSetVersion={dataSet?.draftVersion}
       id="draft-version-summary"
-      publicationId={release.publicationId}
+      publicationId={releaseVersion.publicationId}
       collapsibleButtonHiddenText="for draft version"
       actions={
         canUpdateRelease && dataSet.draftVersion.status !== 'Processing' ? (
@@ -71,8 +71,8 @@ export default function ReleaseApiDataSetDetailsPage() {
             onDeleted={() =>
               history.push(
                 generatePath<ReleaseRouteParams>(releaseApiDataSetsRoute.path, {
-                  publicationId: release.publicationId,
-                  releaseId: release.id,
+                  publicationId: releaseVersion.publicationId,
+                  releaseVersionId: releaseVersion.id,
                 }),
               )
             }
@@ -88,7 +88,7 @@ export default function ReleaseApiDataSetDetailsPage() {
     <ApiDataSetVersionSummaryList
       dataSetVersion={dataSet.latestLiveVersion}
       id="live-version-summary"
-      publicationId={release.publicationId}
+      publicationId={releaseVersion.publicationId}
       collapsibleButtonHiddenText="for latest live version"
       actions={
         <ul className="govuk-list">
@@ -133,8 +133,8 @@ export default function ReleaseApiDataSetDetailsPage() {
         back
         className="govuk-!-margin-bottom-6"
         to={generatePath<ReleaseRouteParams>(releaseApiDataSetsRoute.path, {
-          releaseId: release.id,
-          publicationId: release.publicationId,
+          releaseVersionId: releaseVersion.id,
+          publicationId: releaseVersion.publicationId,
         })}
       >
         Back to API data sets
@@ -248,11 +248,13 @@ export default function ReleaseApiDataSetDetailsPage() {
             </div>
             {canUpdateRelease &&
               !dataSet.draftVersion &&
-              !dataSet.previousReleaseIds.includes(release.releaseId) && (
+              !dataSet.previousReleaseIds.includes(
+                releaseVersion.releaseId,
+              ) && (
                 <ApiDataSetCreateModal
                   buttonText="Create a new version of this data set"
-                  publicationId={release.publicationId}
-                  releaseId={release.id}
+                  publicationId={releaseVersion.publicationId}
+                  releaseVersionId={releaseVersion.id}
                   submitText="Confirm new data set version"
                   title="Create a new API data set version"
                   onSubmit={async ({ releaseFileId }) => {

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetLocationsMappingPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetLocationsMappingPage.tsx
@@ -1,10 +1,8 @@
 import Link from '@admin/components/Link';
 import ButtonLink from '@admin/components/ButtonLink';
-import ApiDataSetUnmappedAndManuallyMappedLocationsTable
-  from '@admin/pages/release/data/components/ApiDataSetUnmappedAndManuallyMappedLocationsTable';
+import ApiDataSetUnmappedAndManuallyMappedLocationsTable from '@admin/pages/release/data/components/ApiDataSetUnmappedAndManuallyMappedLocationsTable';
 import ApiDataSetNewLocationsTable from '@admin/pages/release/data/components/ApiDataSetNewLocationsTable';
-import ApiDataSetAutoMappedLocationsTable
-  from '@admin/pages/release/data/components/ApiDataSetAutoMappedLocationsTable';
+import ApiDataSetAutoMappedLocationsTable from '@admin/pages/release/data/components/ApiDataSetAutoMappedLocationsTable';
 import getApiDataSetLocationMappings from '@admin/pages/release/data/utils/getApiDataSetLocationMappings';
 import getUnmappedLocationErrors from '@admin/pages/release/data/utils/getUnmappedLocationErrors';
 import {
@@ -18,23 +16,23 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import ErrorSummary from '@common/components/ErrorSummary';
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
-import PageNav, {NavItem} from '@common/components/PageNav';
+import PageNav, { NavItem } from '@common/components/PageNav';
 import locationLevelsMap from '@common/utils/locationLevelsMap';
-import {useQuery} from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import React from 'react';
-import {generatePath, useParams} from 'react-router-dom';
+import { generatePath, useParams } from 'react-router-dom';
 import camelCase from 'lodash/camelCase';
 
 export default function ReleaseApiDataSetLocationsMappingPage() {
-  const {dataSetId, releaseVersionId, publicationId} =
+  const { dataSetId, releaseVersionId, publicationId } =
     useParams<ReleaseDataSetRouteParams>();
 
-  const {data: dataSet, isLoading: isLoadingDataSet} = useQuery(
+  const { data: dataSet, isLoading: isLoadingDataSet } = useQuery(
     apiDataSetQueries.get(dataSetId),
   );
 
   const {
-    data: locationsMapping = {levels: {}},
+    data: locationsMapping = { levels: {} },
     isLoading: isLoadingMapping,
   } = useQuery({
     ...apiDataSetVersionQueries.getLocationsMapping(
@@ -80,7 +78,7 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
         };
       }),
     },
-    {id: 'auto-mapped-locations', text: 'Auto mapped locations'},
+    { id: 'auto-mapped-locations', text: 'Auto mapped locations' },
   ];
 
   return (
@@ -101,7 +99,7 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
       </Link>
       <LoadingSpinner loading={isLoadingDataSet || isLoadingMapping}>
         <div className="govuk-grid-row">
-          <PageNav items={navItems}/>
+          <PageNav items={navItems} />
           <div className="govuk-grid-column-three-quarters">
             <span className="govuk-caption-l">Map locations</span>
             <h2>{dataSet?.title}</h2>

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetLocationsMappingPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetLocationsMappingPage.tsx
@@ -1,8 +1,10 @@
 import Link from '@admin/components/Link';
 import ButtonLink from '@admin/components/ButtonLink';
-import ApiDataSetUnmappedAndManuallyMappedLocationsTable from '@admin/pages/release/data/components/ApiDataSetUnmappedAndManuallyMappedLocationsTable';
+import ApiDataSetUnmappedAndManuallyMappedLocationsTable
+  from '@admin/pages/release/data/components/ApiDataSetUnmappedAndManuallyMappedLocationsTable';
 import ApiDataSetNewLocationsTable from '@admin/pages/release/data/components/ApiDataSetNewLocationsTable';
-import ApiDataSetAutoMappedLocationsTable from '@admin/pages/release/data/components/ApiDataSetAutoMappedLocationsTable';
+import ApiDataSetAutoMappedLocationsTable
+  from '@admin/pages/release/data/components/ApiDataSetAutoMappedLocationsTable';
 import getApiDataSetLocationMappings from '@admin/pages/release/data/utils/getApiDataSetLocationMappings';
 import getUnmappedLocationErrors from '@admin/pages/release/data/utils/getUnmappedLocationErrors';
 import {
@@ -16,23 +18,23 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import ErrorSummary from '@common/components/ErrorSummary';
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
-import PageNav, { NavItem } from '@common/components/PageNav';
+import PageNav, {NavItem} from '@common/components/PageNav';
 import locationLevelsMap from '@common/utils/locationLevelsMap';
-import { useQuery } from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 import React from 'react';
-import { generatePath, useParams } from 'react-router-dom';
+import {generatePath, useParams} from 'react-router-dom';
 import camelCase from 'lodash/camelCase';
 
 export default function ReleaseApiDataSetLocationsMappingPage() {
-  const { dataSetId, releaseId, publicationId } =
+  const {dataSetId, releaseVersionId, publicationId} =
     useParams<ReleaseDataSetRouteParams>();
 
-  const { data: dataSet, isLoading: isLoadingDataSet } = useQuery(
+  const {data: dataSet, isLoading: isLoadingDataSet} = useQuery(
     apiDataSetQueries.get(dataSetId),
   );
 
   const {
-    data: locationsMapping = { levels: {} },
+    data: locationsMapping = {levels: {}},
     isLoading: isLoadingMapping,
   } = useQuery({
     ...apiDataSetVersionQueries.getLocationsMapping(
@@ -78,7 +80,7 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
         };
       }),
     },
-    { id: 'auto-mapped-locations', text: 'Auto mapped locations' },
+    {id: 'auto-mapped-locations', text: 'Auto mapped locations'},
   ];
 
   return (
@@ -90,7 +92,7 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
           releaseApiDataSetDetailsRoute.path,
           {
             publicationId,
-            releaseId,
+            releaseVersionId,
             dataSetId,
           },
         )}
@@ -99,7 +101,7 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
       </Link>
       <LoadingSpinner loading={isLoadingDataSet || isLoadingMapping}>
         <div className="govuk-grid-row">
-          <PageNav items={navItems} />
+          <PageNav items={navItems}/>
           <div className="govuk-grid-column-three-quarters">
             <span className="govuk-caption-l">Map locations</span>
             <h2>{dataSet?.title}</h2>
@@ -198,7 +200,7 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
                   releaseApiDataSetDetailsRoute.path,
                   {
                     publicationId,
-                    releaseId,
+                    releaseVersionId,
                     dataSetId: dataSet.id,
                   },
                 )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
@@ -23,23 +23,23 @@ interface FormValues {
 export default function ReleaseDataFilePage({
   history,
   match: {
-    params: { publicationId, releaseId, fileId },
+    params: { publicationId, releaseVersionId, fileId },
   },
 }: RouteComponentProps<ReleaseDataFileRouteParams>) {
   const { value: dataFile, isLoading: dataFileLoading } = useAsyncRetry(
-    () => releaseDataFileService.getDataFile(releaseId, fileId),
-    [releaseId, fileId],
+    () => releaseDataFileService.getDataFile(releaseVersionId, fileId),
+    [releaseVersionId, fileId],
   );
 
   const handleSubmit = async (values: FormValues) => {
-    await releaseDataFileService.updateFile(releaseId, fileId, {
+    await releaseDataFileService.updateFile(releaseVersionId, fileId, {
       title: values.title,
     });
 
     history.push(
       generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
         publicationId,
-        releaseId,
+        releaseVersionId,
       }),
     );
   };
@@ -51,7 +51,7 @@ export default function ReleaseDataFilePage({
         back
         to={generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
           publicationId,
-          releaseId,
+          releaseVersionId,
         })}
       >
         Back

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacePage.tsx
@@ -27,7 +27,7 @@ import { generatePath, RouteComponentProps } from 'react-router';
 const ReleaseDataFileReplacePage = ({
   history,
   match: {
-    params: { publicationId, releaseId, fileId },
+    params: { publicationId, releaseVersionId, fileId },
   },
 }: RouteComponentProps<ReleaseDataFileReplaceRouteParams>) => {
   const {
@@ -36,8 +36,8 @@ const ReleaseDataFileReplacePage = ({
     setState: setDataFile,
     retry: fetchDataFile,
   } = useAsyncHandledRetry(
-    () => releaseDataFileService.getDataFile(releaseId, fileId),
-    [releaseId, fileId],
+    () => releaseDataFileService.getDataFile(releaseVersionId, fileId),
+    [releaseVersionId, fileId],
   );
 
   const {
@@ -49,7 +49,10 @@ const ReleaseDataFileReplacePage = ({
     if (!dataFile?.replacedBy) {
       return undefined;
     }
-    return releaseDataFileService.getDataFile(releaseId, dataFile.replacedBy);
+    return releaseDataFileService.getDataFile(
+      releaseVersionId,
+      dataFile.replacedBy,
+    );
   }, [dataFile]);
 
   const handleStatusChange = async (
@@ -62,7 +65,7 @@ const ReleaseDataFileReplacePage = ({
         rows: totalRows,
         status,
         permissions: await permissionService.getDataFilePermissions(
-          releaseId,
+          releaseVersionId,
           file.id,
         ),
       },
@@ -74,7 +77,7 @@ const ReleaseDataFileReplacePage = ({
     { totalRows, status }: DataFileImportStatus,
   ) => {
     const permissions = await permissionService.getDataFilePermissions(
-      releaseId,
+      releaseVersionId,
       file.id,
     );
     setReplacementDataFile({
@@ -94,13 +97,13 @@ const ReleaseDataFileReplacePage = ({
     let file: DataFile;
 
     if (values.uploadType === 'csv') {
-      file = await releaseDataFileService.uploadDataFiles(releaseId, {
+      file = await releaseDataFileService.uploadDataFiles(releaseVersionId, {
         replacingFileId: currentFile.id,
         dataFile: values.dataFile as File,
         metadataFile: values.metadataFile as File,
       });
     } else {
-      file = await releaseDataFileService.uploadZipDataFile(releaseId, {
+      file = await releaseDataFileService.uploadZipDataFile(releaseVersionId, {
         replacingFileId: currentFile.id,
         zipFile: values.zipFile as File,
       });
@@ -116,7 +119,7 @@ const ReleaseDataFileReplacePage = ({
       value: {
         ...file,
         permissions: await permissionService.getDataFilePermissions(
-          releaseId,
+          releaseVersionId,
           file.id,
         ),
       },
@@ -132,7 +135,7 @@ const ReleaseDataFileReplacePage = ({
       onConfirm={async () => {
         if (replacementDataFile?.id) {
           await releaseDataFileService.deleteDataFiles(
-            releaseId,
+            releaseVersionId,
             replacementDataFile.id,
           );
         }
@@ -191,7 +194,7 @@ const ReleaseDataFileReplacePage = ({
         back
         to={generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
           publicationId,
-          releaseId,
+          releaseVersionId,
         })}
       >
         Back
@@ -212,7 +215,7 @@ const ReleaseDataFileReplacePage = ({
               <DataFileDetailsTable
                 dataFile={dataFile}
                 replacementDataFile={replacementDataFile}
-                releaseId={releaseId}
+                releaseId={releaseVersionId}
                 onStatusChange={handleStatusChange}
                 onReplacementStatusChange={handleReplacementStatusChange}
               />
@@ -237,7 +240,7 @@ const ReleaseDataFileReplacePage = ({
                   <DataFileReplacementPlan
                     cancelButton={replacementCancelButton}
                     publicationId={publicationId}
-                    releaseId={releaseId}
+                    releaseVersionId={releaseVersionId}
                     fileId={dataFile.id}
                     replacementFileId={replacementDataFile.id}
                     onReplacement={() => {
@@ -246,7 +249,7 @@ const ReleaseDataFileReplacePage = ({
                           releaseDataFileReplacementCompleteRoute.path,
                           {
                             publicationId,
-                            releaseId,
+                            releaseVersionId,
                             fileId: replacementDataFile.id,
                           },
                         ),

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacePage.tsx
@@ -215,7 +215,7 @@ const ReleaseDataFileReplacePage = ({
               <DataFileDetailsTable
                 dataFile={dataFile}
                 replacementDataFile={replacementDataFile}
-                releaseId={releaseVersionId}
+                releaseVersionId={releaseVersionId}
                 onStatusChange={handleStatusChange}
                 onReplacementStatusChange={handleReplacementStatusChange}
               />

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacementCompletePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacementCompletePage.tsx
@@ -18,7 +18,7 @@ import { generatePath, RouteComponentProps } from 'react-router';
 const ReleaseDataFileReplacementCompletePage = ({
   match,
 }: RouteComponentProps<ReleaseDataFileReplaceRouteParams>) => {
-  const { publicationId, releaseId, fileId } = match.params;
+  const { publicationId, releaseVersionId, fileId } = match.params;
 
   // Run the replacement plan against itself so we can just get the
   // data blocks and footnotes in a convenient way.
@@ -27,15 +27,20 @@ const ReleaseDataFileReplacementCompletePage = ({
     isLoading,
     error,
   } = useAsyncRetry(
-    () => dataReplacementService.getReplacementPlan(releaseId, fileId, fileId),
-    [releaseId, fileId],
+    () =>
+      dataReplacementService.getReplacementPlan(
+        releaseVersionId,
+        fileId,
+        fileId,
+      ),
+    [releaseVersionId, fileId],
   );
 
   const dataFilePath = generatePath<ReleaseDataFileReplaceRouteParams>(
     releaseDataFileReplaceRoute.path,
     {
       publicationId,
-      releaseId,
+      releaseVersionId,
       fileId,
     },
   );
@@ -85,7 +90,7 @@ const ReleaseDataFileReplacementCompletePage = ({
                           releaseDataBlocksRoute.path,
                           {
                             publicationId,
-                            releaseId,
+                            releaseVersionId,
                             dataBlockId: dataBlock.id,
                           },
                         )}
@@ -115,7 +120,7 @@ const ReleaseDataFileReplacementCompletePage = ({
                           releaseFootnotesRoute.path,
                           {
                             publicationId,
-                            releaseId,
+                            releaseVersionId,
                             footnoteId: footnote.id,
                           },
                         )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
@@ -1,5 +1,5 @@
 import { useAuthContext } from '@admin/contexts/AuthContext';
-import { useReleaseContext } from '@admin/pages/release/contexts/ReleaseContext';
+import { useReleaseVersionContext } from '@admin/pages/release/contexts/ReleaseContext';
 import ReleaseApiDataSetsSection from '@admin/pages/release/data/components/ReleaseApiDataSetsSection';
 import ReleaseDataGuidanceSection from '@admin/pages/release/data/components/ReleaseDataGuidanceSection';
 import ReleaseDataReorderSection from '@admin/pages/release/data/components/ReleaseDataReorderSection';
@@ -15,14 +15,14 @@ import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React, { useState } from 'react';
 
 const ReleaseDataPage = () => {
-  const { release, releaseId } = useReleaseContext();
+  const { releaseVersion, releaseVersionId } = useReleaseVersionContext();
   const { user } = useAuthContext();
 
   const [dataFiles, setDataFiles] = useState<DataFile[]>([]);
 
   const { value: canUpdateRelease = false, isLoading } = useAsyncHandledRetry(
-    () => permissionService.canUpdateRelease(releaseId),
-    [releaseId],
+    () => permissionService.canUpdateRelease(releaseVersionId),
+    [releaseVersionId],
   );
 
   return (
@@ -33,8 +33,8 @@ const ReleaseDataPage = () => {
           title="Data uploads"
         >
           <ReleaseDataUploadsSection
-            publicationId={release.publicationId}
-            releaseId={releaseId}
+            publicationId={releaseVersion.publicationId}
+            releaseVersionId={releaseVersionId}
             canUpdateRelease={canUpdateRelease}
             onDataFilesChange={setDataFiles}
           />
@@ -44,8 +44,8 @@ const ReleaseDataPage = () => {
           title="Supporting file uploads"
         >
           <ReleaseFileUploadsSection
-            publicationId={release.publicationId}
-            releaseId={releaseId}
+            publicationId={releaseVersion.publicationId}
+            releaseId={releaseVersionId}
             canUpdateRelease={canUpdateRelease}
           />
         </TabsSection>
@@ -58,7 +58,7 @@ const ReleaseDataPage = () => {
             // Track data files so that we can re-render this
             // section automatically whenever there is a change
             key={dataFiles.filter(file => file.status === 'COMPLETE').length}
-            releaseId={releaseId}
+            releaseId={releaseVersionId}
             canUpdateRelease={canUpdateRelease}
           />
         </TabsSection>
@@ -69,7 +69,7 @@ const ReleaseDataPage = () => {
         >
           <ReleaseDataReorderSection
             key={dataFiles.filter(file => file.status === 'COMPLETE').length}
-            releaseId={releaseId}
+            releaseId={releaseVersionId}
             canUpdateRelease={canUpdateRelease}
           />
         </TabsSection>

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
@@ -45,7 +45,7 @@ const ReleaseDataPage = () => {
         >
           <ReleaseFileUploadsSection
             publicationId={releaseVersion.publicationId}
-            releaseId={releaseVersionId}
+            releaseVersionId={releaseVersionId}
             canUpdateRelease={canUpdateRelease}
           />
         </TabsSection>
@@ -58,7 +58,7 @@ const ReleaseDataPage = () => {
             // Track data files so that we can re-render this
             // section automatically whenever there is a change
             key={dataFiles.filter(file => file.status === 'COMPLETE').length}
-            releaseId={releaseVersionId}
+            releaseVersionId={releaseVersionId}
             canUpdateRelease={canUpdateRelease}
           />
         </TabsSection>
@@ -69,7 +69,7 @@ const ReleaseDataPage = () => {
         >
           <ReleaseDataReorderSection
             key={dataFiles.filter(file => file.status === 'COMPLETE').length}
-            releaseId={releaseVersionId}
+            releaseVersionId={releaseVersionId}
             canUpdateRelease={canUpdateRelease}
           />
         </TabsSection>

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseAncilllaryFilePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseAncilllaryFilePage.test.tsx
@@ -113,7 +113,7 @@ describe('ReleaseAncillaryFilePage', () => {
         releaseAncillaryFileRoute.path,
         {
           publicationId: 'publication-1',
-          releaseId: 'release-1',
+          releaseVersionId: 'release-1',
           fileId: 'file-1',
         },
       ),

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -1,7 +1,7 @@
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
-import { testRelease } from '@admin/pages/release/__data__/testRelease';
+import { testReleaseVersion } from '@admin/pages/release/__data__/testReleaseVersion';
 import ReleaseApiDataSetDetailsPage from '@admin/pages/release/data/ReleaseApiDataSetDetailsPage';
-import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
+import { ReleaseVersionContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
 import {
   releaseApiDataSetDetailsRoute,
   ReleaseDataSetRouteParams,
@@ -11,7 +11,7 @@ import _apiDataSetService, {
   ApiDataSetDraftVersion,
   ApiDataSetLiveVersion,
 } from '@admin/services/apiDataSetService';
-import { Release } from '@admin/services/releaseService';
+import { ReleaseVersion } from '@admin/services/releaseService';
 import render from '@common-test/render';
 import { screen, within } from '@testing-library/react';
 import React from 'react';
@@ -302,7 +302,9 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       latestLiveVersion: testLiveVersion,
     });
 
-    renderPage({ release: { ...testRelease, approvalStatus: 'Approved' } });
+    renderPage({
+      releaseVersion: { ...testReleaseVersion, approvalStatus: 'Approved' },
+    });
 
     expect(
       await screen.findByText('Draft version details'),
@@ -339,7 +341,9 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       latestLiveVersion: testLiveVersion,
     });
 
-    renderPage({ release: { ...testRelease, approvalStatus: 'Approved' } });
+    renderPage({
+      releaseVersion: { ...testReleaseVersion, approvalStatus: 'Approved' },
+    });
 
     expect(
       await screen.findByText('Latest live version details'),
@@ -379,8 +383,8 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     });
 
     renderPage({
-      release: {
-        ...testRelease,
+      releaseVersion: {
+        ...testReleaseVersion,
         releaseId: testDataSet.previousReleaseIds[0],
       },
     });
@@ -396,19 +400,23 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  function renderPage(options?: { release?: Release; dataSetId?: string }) {
-    const { release = testRelease, dataSetId = 'data-set-id' } = options ?? {};
+  function renderPage(options?: {
+    releaseVersion?: ReleaseVersion;
+    dataSetId?: string;
+  }) {
+    const { releaseVersion = testReleaseVersion, dataSetId = 'data-set-id' } =
+      options ?? {};
 
     render(
       <TestConfigContextProvider>
-        <ReleaseContextProvider release={release}>
+        <ReleaseVersionContextProvider releaseVersion={releaseVersion}>
           <MemoryRouter
             initialEntries={[
               generatePath<ReleaseDataSetRouteParams>(
                 releaseApiDataSetDetailsRoute.path,
                 {
-                  publicationId: release.publicationId,
-                  releaseId: release.id,
+                  publicationId: releaseVersion.publicationId,
+                  releaseVersionId: releaseVersion.id,
                   dataSetId,
                 },
               ),
@@ -419,7 +427,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
               path={releaseApiDataSetDetailsRoute.path}
             />
           </MemoryRouter>
-        </ReleaseContextProvider>
+        </ReleaseVersionContextProvider>
       </TestConfigContextProvider>,
     );
   }

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetLocationsMappingPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetLocationsMappingPage.test.tsx
@@ -1,7 +1,7 @@
-import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
-import { testRelease } from '@admin/pages/release/__data__/testRelease';
+import {TestConfigContextProvider} from '@admin/contexts/ConfigContext';
+import {testReleaseVersion} from '@admin/pages/release/__data__/testReleaseVersion';
 import ReleaseApiDataSetLocationsMappingPage from '@admin/pages/release/data/ReleaseApiDataSetLocationsMappingPage';
-import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
+import {ReleaseVersionContextProvider} from '@admin/pages/release/contexts/ReleaseContext';
 import {
   releaseApiDataSetLocationsMappingRoute,
   ReleaseDataSetRouteParams,
@@ -11,11 +11,11 @@ import _apiDataSetService, {
 } from '@admin/services/apiDataSetService';
 import testLocationsMapping from '@admin/pages/release/data/__data__/testLocationsMapping';
 import _apiDataSetVersionService from '@admin/services/apiDataSetVersionService';
-import { Release } from '@admin/services/releaseService';
+import {ReleaseVersion} from '@admin/services/releaseService';
 import render from '@common-test/render';
-import { screen, within } from '@testing-library/react';
+import {screen, within} from '@testing-library/react';
 import React from 'react';
-import { generatePath, MemoryRouter, Route } from 'react-router-dom';
+import {generatePath, MemoryRouter, Route} from 'react-router-dom';
 
 jest.mock('@admin/services/apiDataSetService');
 jest.mock('@admin/services/apiDataSetVersionService');
@@ -418,19 +418,19 @@ describe('ReleaseApiDataSetLocationsMappingPage', () => {
     expect(screen.queryByTestId('auto-mapped')).not.toBeInTheDocument();
   });
 
-  function renderPage(options?: { release?: Release; dataSetId?: string }) {
-    const { release = testRelease, dataSetId = 'data-set-id' } = options ?? {};
+  function renderPage(options?: { releaseVersion?: ReleaseVersion; dataSetId?: string }) {
+    const {releaseVersion = testReleaseVersion, dataSetId = 'data-set-id'} = options ?? {};
 
     render(
       <TestConfigContextProvider>
-        <ReleaseContextProvider release={release}>
+        <ReleaseVersionContextProvider releaseVersion={releaseVersion}>
           <MemoryRouter
             initialEntries={[
               generatePath<ReleaseDataSetRouteParams>(
                 releaseApiDataSetLocationsMappingRoute.path,
                 {
-                  publicationId: release.publicationId,
-                  releaseId: release.id,
+                  publicationId: releaseVersion.publicationId,
+                  releaseVersionId: releaseVersion.id,
                   dataSetId,
                 },
               ),
@@ -441,7 +441,7 @@ describe('ReleaseApiDataSetLocationsMappingPage', () => {
               path={releaseApiDataSetLocationsMappingRoute.path}
             />
           </MemoryRouter>
-        </ReleaseContextProvider>
+        </ReleaseVersionContextProvider>
       </TestConfigContextProvider>,
     );
   }

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetLocationsMappingPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetLocationsMappingPage.test.tsx
@@ -1,7 +1,7 @@
-import {TestConfigContextProvider} from '@admin/contexts/ConfigContext';
-import {testReleaseVersion} from '@admin/pages/release/__data__/testReleaseVersion';
+import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
+import { testReleaseVersion } from '@admin/pages/release/__data__/testReleaseVersion';
 import ReleaseApiDataSetLocationsMappingPage from '@admin/pages/release/data/ReleaseApiDataSetLocationsMappingPage';
-import {ReleaseVersionContextProvider} from '@admin/pages/release/contexts/ReleaseContext';
+import { ReleaseVersionContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
 import {
   releaseApiDataSetLocationsMappingRoute,
   ReleaseDataSetRouteParams,
@@ -11,11 +11,11 @@ import _apiDataSetService, {
 } from '@admin/services/apiDataSetService';
 import testLocationsMapping from '@admin/pages/release/data/__data__/testLocationsMapping';
 import _apiDataSetVersionService from '@admin/services/apiDataSetVersionService';
-import {ReleaseVersion} from '@admin/services/releaseService';
+import { ReleaseVersion } from '@admin/services/releaseService';
 import render from '@common-test/render';
-import {screen, within} from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import React from 'react';
-import {generatePath, MemoryRouter, Route} from 'react-router-dom';
+import { generatePath, MemoryRouter, Route } from 'react-router-dom';
 
 jest.mock('@admin/services/apiDataSetService');
 jest.mock('@admin/services/apiDataSetVersionService');
@@ -418,8 +418,12 @@ describe('ReleaseApiDataSetLocationsMappingPage', () => {
     expect(screen.queryByTestId('auto-mapped')).not.toBeInTheDocument();
   });
 
-  function renderPage(options?: { releaseVersion?: ReleaseVersion; dataSetId?: string }) {
-    const {releaseVersion = testReleaseVersion, dataSetId = 'data-set-id'} = options ?? {};
+  function renderPage(options?: {
+    releaseVersion?: ReleaseVersion;
+    dataSetId?: string;
+  }) {
+    const { releaseVersion = testReleaseVersion, dataSetId = 'data-set-id' } =
+      options ?? {};
 
     render(
       <TestConfigContextProvider>

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFilePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFilePage.test.tsx
@@ -151,7 +151,7 @@ describe('ReleaseDataFilePage', () => {
     history.push(
       generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
         publicationId: 'publication-1',
-        releaseId: 'release-1',
+        releaseVersionId: 'release-1',
         fileId: 'file-1',
       }),
     );

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
@@ -97,7 +97,7 @@ describe('ReleaseDataFileReplacePage', () => {
           generatePath<ReleaseDataFileReplaceRouteParams>(
             releaseDataFileReplaceRoute.path,
             {
-              releaseId: 'release-1',
+              releaseVersionId: 'release-1',
               publicationId: 'publication-1',
               fileId: 'file-1',
             },
@@ -149,7 +149,7 @@ describe('ReleaseDataFileReplacePage', () => {
           generatePath<ReleaseDataFileReplaceRouteParams>(
             releaseDataFileReplaceRoute.path,
             {
-              releaseId: 'release-1',
+              releaseVersionId: 'release-1',
               publicationId: 'publication-1',
               fileId: 'file-1',
             },
@@ -200,7 +200,7 @@ describe('ReleaseDataFileReplacePage', () => {
           generatePath<ReleaseDataFileReplaceRouteParams>(
             releaseDataFileReplaceRoute.path,
             {
-              releaseId: 'release-1',
+              releaseVersionId: 'release-1',
               publicationId: 'publication-1',
               fileId: 'file-1',
             },
@@ -284,7 +284,7 @@ describe('ReleaseDataFileReplacePage', () => {
           generatePath<ReleaseDataFileReplaceRouteParams>(
             releaseDataFileReplaceRoute.path,
             {
-              releaseId: 'release-1',
+              releaseVersionId: 'release-1',
               publicationId: 'publication-1',
               fileId: 'file-1',
             },
@@ -360,7 +360,7 @@ describe('ReleaseDataFileReplacePage', () => {
           generatePath<ReleaseDataFileReplaceRouteParams>(
             releaseDataFileReplaceRoute.path,
             {
-              releaseId: 'release-1',
+              releaseVersionId: 'release-1',
               publicationId: 'publication-1',
               fileId: 'file-1',
             },
@@ -417,7 +417,7 @@ describe('ReleaseDataFileReplacePage', () => {
           generatePath<ReleaseDataFileReplaceRouteParams>(
             releaseDataFileReplaceRoute.path,
             {
-              releaseId: 'release-1',
+              releaseVersionId: 'release-1',
               publicationId: 'publication-1',
               fileId: 'file-1',
             },
@@ -469,7 +469,7 @@ describe('ReleaseDataFileReplacePage', () => {
           generatePath<ReleaseDataFileReplaceRouteParams>(
             releaseDataFileReplaceRoute.path,
             {
-              releaseId: 'release-1',
+              releaseVersionId: 'release-1',
               publicationId: 'publication-1',
               fileId: 'file-1',
             },
@@ -517,7 +517,7 @@ describe('ReleaseDataFileReplacePage', () => {
           generatePath<ReleaseDataFileReplaceRouteParams>(
             releaseDataFileReplaceRoute.path,
             {
-              releaseId: 'release-1',
+              releaseVersionId: 'release-1',
               publicationId: 'publication-1',
               fileId: 'file-1',
             },
@@ -590,7 +590,7 @@ describe('ReleaseDataFileReplacePage', () => {
           generatePath<ReleaseDataFileReplaceRouteParams>(
             releaseDataFileReplaceRoute.path,
             {
-              releaseId: 'release-1',
+              releaseVersionId: 'release-1',
               publicationId: 'publication-1',
               fileId: 'file-1',
             },
@@ -651,7 +651,7 @@ describe('ReleaseDataFileReplacePage', () => {
           generatePath<ReleaseDataFileReplaceRouteParams>(
             releaseDataFileReplaceRoute.path,
             {
-              releaseId: 'release-1',
+              releaseVersionId: 'release-1',
               publicationId: 'publication-1',
               fileId: 'file-1',
             },

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacementCompletePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacementCompletePage.test.tsx
@@ -58,7 +58,7 @@ describe('ReleaseDataFilePage', () => {
         releaseDataFileReplacementCompleteRoute.path,
         {
           publicationId: 'publication-1',
-          releaseId: 'release-1',
+          releaseVersionId: 'release-1',
           fileId: 'file-1',
         },
       ),

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/AncillaryFileSummaryList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/AncillaryFileSummaryList.tsx
@@ -17,7 +17,7 @@ interface Props {
   canUpdateRelease?: boolean;
   file: AncillaryFile;
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
   onDelete?: () => void;
 }
 
@@ -25,7 +25,7 @@ export default function AncillaryFileSummaryList({
   canUpdateRelease,
   file,
   publicationId,
-  releaseId,
+  releaseVersionId,
   onDelete,
 }: Props) {
   return (
@@ -36,7 +36,7 @@ export default function AncillaryFileSummaryList({
         <ButtonText
           onClick={() =>
             releaseAncillaryFileService.downloadFile(
-              releaseId,
+              releaseVersionId,
               file.id,
               file.filename,
             )
@@ -73,7 +73,7 @@ export default function AncillaryFileSummaryList({
                   releaseAncillaryFileRoute.path,
                   {
                     publicationId,
-                    releaseId,
+                    releaseVersionId,
                     fileId: file.id,
                   },
                 )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateModal.tsx
@@ -19,7 +19,7 @@ import { generatePath } from 'react-router-dom';
 interface Props {
   buttonText?: ReactNode | string;
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
   submitText?: string;
   title?: string;
   onSubmit: (values: ApiDataSetCreateFormValues) => void;
@@ -28,7 +28,7 @@ interface Props {
 export default function ApiDataSetCreateModal({
   buttonText = 'Create API data set',
   publicationId,
-  releaseId,
+  releaseVersionId,
   submitText,
   title = 'Create a new API data set',
   onSubmit,
@@ -36,7 +36,7 @@ export default function ApiDataSetCreateModal({
   const [isOpen, toggleOpen] = useToggle(false);
 
   const { data: dataSetCandidates = [], isLoading } = useQuery({
-    ...apiDataSetCandidateQueries.list(releaseId),
+    ...apiDataSetCandidateQueries.list(releaseVersionId),
     enabled: isOpen,
   });
 
@@ -67,7 +67,7 @@ export default function ApiDataSetCreateModal({
               <Link
                 to={generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
                   publicationId,
-                  releaseId,
+                  releaseVersionId,
                 })}
               >
                 Data and files

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetVersionSummaryList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetVersionSummaryList.tsx
@@ -49,7 +49,7 @@ export default function ApiDataSetVersionSummaryList({
       <SummaryListItem term="Release">
         <Link
           to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
-            releaseId: dataSetVersion.releaseVersion.id,
+            releaseVersionId: dataSetVersion.releaseVersion.id,
             publicationId,
           })}
         >

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileDetailsTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileDetailsTable.tsx
@@ -12,7 +12,7 @@ interface Props {
   children?: ReactNode;
   dataFile: DataFile;
   replacementDataFile?: DataFile;
-  releaseId: string;
+  releaseVersionId: string;
   onStatusChange?: ImporterStatusChangeHandler;
   onReplacementStatusChange?: ImporterStatusChangeHandler;
 }
@@ -21,7 +21,7 @@ const DataFileDetailsTable = ({
   children,
   dataFile,
   replacementDataFile,
-  releaseId,
+  releaseVersionId,
   onStatusChange,
   onReplacementStatusChange,
 }: Props) => {
@@ -54,7 +54,7 @@ const DataFileDetailsTable = ({
             <ButtonText
               onClick={() =>
                 releaseDataFileService.downloadFile(
-                  releaseId,
+                  releaseVersionId,
                   dataFile.id,
                   dataFile.fileName,
                 )
@@ -68,7 +68,7 @@ const DataFileDetailsTable = ({
               <ButtonText
                 onClick={() =>
                   releaseDataFileService.downloadFile(
-                    releaseId,
+                    releaseVersionId,
                     replacementDataFile.id,
                     replacementDataFile.fileName,
                   )
@@ -85,7 +85,7 @@ const DataFileDetailsTable = ({
             <ButtonText
               onClick={() =>
                 releaseDataFileService.downloadFile(
-                  releaseId,
+                  releaseVersionId,
                   dataFile.metaFileId,
                   dataFile.metaFileName,
                 )
@@ -99,7 +99,7 @@ const DataFileDetailsTable = ({
               <ButtonText
                 onClick={() =>
                   releaseDataFileService.downloadFile(
-                    releaseId,
+                    releaseVersionId,
                     replacementDataFile.metaFileId,
                     replacementDataFile.metaFileName,
                   )
@@ -140,7 +140,7 @@ const DataFileDetailsTable = ({
           <th scope="row">Status</th>
           <td data-testid="Status">
             <ImporterStatus
-              releaseId={releaseId}
+              releaseVersionId={releaseVersionId}
               dataFile={dataFile}
               onStatusChange={onStatusChange}
             />
@@ -148,7 +148,7 @@ const DataFileDetailsTable = ({
           {replacementDataFile && (
             <td data-testid="Replacement Status">
               <ImporterStatus
-                releaseId={releaseId}
+                releaseVersionId={releaseVersionId}
                 dataFile={replacementDataFile}
                 onStatusChange={onReplacementStatusChange}
               />

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
@@ -31,7 +31,7 @@ import sanitizeHtml from '@common/utils/sanitizeHtml';
 interface Props {
   cancelButton: ReactNode;
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
   fileId: string;
   replacementFileId: string;
   onReplacement?: () => void;
@@ -40,7 +40,7 @@ interface Props {
 const DataFileReplacementPlan = ({
   cancelButton,
   publicationId,
-  releaseId,
+  releaseVersionId,
   fileId,
   replacementFileId,
   onReplacement,
@@ -57,11 +57,11 @@ const DataFileReplacementPlan = ({
   } = useAsyncRetry(
     () =>
       dataReplacementService.getReplacementPlan(
-        releaseId,
+        releaseVersionId,
         fileId,
         replacementFileId,
       ),
-    [releaseId, fileId, replacementFileId],
+    [releaseVersionId, fileId, replacementFileId],
   );
 
   const hasInvalidDataBlocks = useMemo<boolean>(
@@ -224,7 +224,7 @@ const DataFileReplacementPlan = ({
                           releaseDataBlockEditRoute.path,
                           {
                             publicationId,
-                            releaseId,
+                            releaseVersionId,
                             dataBlockId: dataBlock.id,
                           },
                         )}
@@ -240,7 +240,7 @@ const DataFileReplacementPlan = ({
                       }
                       onConfirm={async () => {
                         await dataBlockService.deleteDataBlock(
-                          releaseId,
+                          releaseVersionId,
                           dataBlock.id,
                         );
                         reloadPlan();
@@ -363,7 +363,7 @@ const DataFileReplacementPlan = ({
                           releaseFootnotesEditRoute.path,
                           {
                             publicationId,
-                            releaseId,
+                            releaseVersionId,
                             footnoteId: footnote.id,
                           },
                         )}
@@ -378,7 +378,7 @@ const DataFileReplacementPlan = ({
                         }
                         onConfirm={async () => {
                           await footnoteService.deleteFootnote(
-                            releaseId,
+                            releaseVersionId,
                             footnote.id,
                           );
                           reloadPlan();
@@ -408,7 +408,7 @@ const DataFileReplacementPlan = ({
                   toggleSubmitting.on();
 
                   await dataReplacementService.replaceData(
-                    releaseId,
+                    releaseVersionId,
                     fileId,
                     replacementFileId,
                   );

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataUploadCancelButton.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataUploadCancelButton.tsx
@@ -7,13 +7,13 @@ import ErrorMessage from '@common/components/ErrorMessage';
 import React from 'react';
 
 interface Props {
-  releaseId: string;
+  releaseVersionId: string;
   fileId: string;
 }
 
-const DataUploadCancelButton = ({ releaseId, fileId }: Props) => {
+const DataUploadCancelButton = ({ releaseVersionId, fileId }: Props) => {
   const [{ error }, cancelImport] = useAsyncCallback(() =>
-    releaseDataFileService.cancelImport(releaseId, fileId),
+    releaseDataFileService.cancelImport(releaseVersionId, fileId),
   );
   const [showCancelButton, toggleShowCancelButton] = useToggle(true);
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DraftApiDataSetsTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DraftApiDataSetsTable.tsx
@@ -30,14 +30,14 @@ interface Props {
   canUpdateRelease: boolean;
   dataSets: DraftApiDataSetSummary[];
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
 }
 
 export default function DraftApiDataSetsTable({
   canUpdateRelease,
   dataSets,
   publicationId,
-  releaseId,
+  releaseVersionId,
 }: Props) {
   if (!dataSets.length) {
     return <InsetText>No draft API data sets for this publication.</InsetText>;
@@ -125,7 +125,7 @@ export default function DraftApiDataSetsTable({
                         releaseApiDataSetDetailsRoute.path,
                         {
                           publicationId,
-                          releaseId,
+                          releaseVersionId,
                           dataSetId: dataSet.id,
                         },
                       )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
@@ -84,12 +84,12 @@ export type ImporterStatusChangeHandler = (
 ) => void;
 
 interface ImporterStatusProps {
-  releaseId: string;
+  releaseVersionId: string;
   dataFile: DataFile;
   onStatusChange?: ImporterStatusChangeHandler;
 }
 const ImporterStatus = ({
-  releaseId,
+  releaseVersionId,
   dataFile,
   onStatusChange,
 }: ImporterStatusProps) => {
@@ -100,7 +100,7 @@ const ImporterStatus = ({
 
   const fetchStatus = useCallback(async () => {
     const nextStatus = await releaseDataFileService.getDataFileImportStatus(
-      releaseId,
+      releaseVersionId,
       dataFile,
     );
 
@@ -109,7 +109,7 @@ const ImporterStatus = ({
     if (onStatusChange && nextStatus.status !== dataFile.status) {
       onStatusChange(dataFile, nextStatus);
     }
-  }, [releaseId, dataFile, onStatusChange]);
+  }, [releaseVersionId, dataFile, onStatusChange]);
 
   const [cancelInterval] = useInterval(fetchStatus, 5000);
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/LiveApiDataSetsTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/LiveApiDataSetsTable.tsx
@@ -94,7 +94,7 @@ export default function LiveApiDataSetsTable({
                         </>
                       }
                       publicationId={publicationId}
-                      releaseId={releaseVersionId}
+                      releaseVersionId={releaseVersionId}
                       submitText="Confirm new data set version"
                       title="Create a new API data set version"
                       onSubmit={async ({ releaseFileId }) => {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/LiveApiDataSetsTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/LiveApiDataSetsTable.tsx
@@ -76,7 +76,7 @@ export default function LiveApiDataSetsTable({
                     releaseApiDataSetDetailsRoute.path,
                     {
                       publicationId,
-                      releaseId: releaseVersionId,
+                      releaseVersionId,
                       dataSetId: dataSet.id,
                     },
                   )}
@@ -107,7 +107,7 @@ export default function LiveApiDataSetsTable({
                             releaseApiDataSetDetailsRoute.path,
                             {
                               publicationId,
-                              releaseId: releaseVersionId,
+                              releaseVersionId,
                               dataSetId: dataSet.id,
                             },
                           ),

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseApiDataSetsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseApiDataSetsSection.tsx
@@ -1,5 +1,5 @@
 import { useAuthContext } from '@admin/contexts/AuthContext';
-import { useReleaseContext } from '@admin/pages/release/contexts/ReleaseContext';
+import { useReleaseVersionContext } from '@admin/pages/release/contexts/ReleaseContext';
 import ApiDataSetCreateModal from '@admin/pages/release/data/components/ApiDataSetCreateModal';
 import DraftApiDataSetsTable, {
   DraftApiDataSetSummary,
@@ -22,11 +22,11 @@ import { generatePath, useHistory } from 'react-router-dom';
 
 export default function ReleaseApiDataSetsSection() {
   const history = useHistory();
-  const { release } = useReleaseContext();
+  const { releaseVersion } = useReleaseVersionContext();
   const { user } = useAuthContext();
 
   const { data: dataSets = [], isLoading: hasDataSetsLoading } = useQuery({
-    ...apiDataSetQueries.list(release.publicationId),
+    ...apiDataSetQueries.list(releaseVersion.publicationId),
     refetchInterval: 20_000,
   });
 
@@ -38,7 +38,7 @@ export default function ReleaseApiDataSetsSection() {
     dataSet => dataSet.latestLiveVersion && !dataSet.draftVersion,
   ) as LiveApiDataSetSummary[];
 
-  const canUpdateRelease = release.approvalStatus !== 'Approved';
+  const canUpdateRelease = releaseVersion.approvalStatus !== 'Approved';
 
   return (
     <>
@@ -65,7 +65,7 @@ export default function ReleaseApiDataSetsSection() {
           still download and explore your data by creating their own tables.
         </p>
 
-        {!release.published && (
+        {!releaseVersion.published && (
           <strong>
             Changes will not be made in the public API until this release has
             been published.
@@ -79,8 +79,8 @@ export default function ReleaseApiDataSetsSection() {
           <>
             {canUpdateRelease ? (
               <ApiDataSetCreateModal
-                publicationId={release.publicationId}
-                releaseId={release.id}
+                publicationId={releaseVersion.publicationId}
+                releaseVersionId={releaseVersion.id}
                 onSubmit={async ({ releaseFileId }) => {
                   const dataSet = await apiDataSetService.createDataSet({
                     releaseFileId,
@@ -89,8 +89,8 @@ export default function ReleaseApiDataSetsSection() {
                     generatePath<ReleaseDataSetRouteParams>(
                       releaseApiDataSetDetailsRoute.path,
                       {
-                        publicationId: release.publicationId,
-                        releaseId: release.id,
+                        publicationId: releaseVersion.publicationId,
+                        releaseVersionId: releaseVersion.id,
                         dataSetId: dataSet.id,
                       },
                     ),
@@ -115,8 +115,8 @@ export default function ReleaseApiDataSetsSection() {
                 <DraftApiDataSetsTable
                   canUpdateRelease={canUpdateRelease}
                   dataSets={draftDataSets}
-                  publicationId={release.publicationId}
-                  releaseId={release.id}
+                  publicationId={releaseVersion.publicationId}
+                  releaseVersionId={releaseVersion.id}
                 />
               </>
             )}
@@ -128,9 +128,9 @@ export default function ReleaseApiDataSetsSection() {
                 <LiveApiDataSetsTable
                   canUpdateRelease={canUpdateRelease}
                   dataSets={liveDataSets}
-                  publicationId={release.publicationId}
-                  releaseVersionId={release.id}
-                  releaseId={release.releaseId}
+                  publicationId={releaseVersion.publicationId}
+                  releaseVersionId={releaseVersion.id}
+                  releaseId={releaseVersion.releaseId}
                 />
               </>
             )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataGuidanceSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataGuidanceSection.tsx
@@ -40,20 +40,23 @@ const initialReleaseDataGuidance = `
 `;
 
 interface Props {
-  releaseId: string;
+  releaseVersionId: string;
   canUpdateRelease: boolean;
 }
 
 const formId = 'dataGuidanceForm';
 
-const ReleaseDataGuidanceSection = ({ releaseId, canUpdateRelease }: Props) => {
+const ReleaseDataGuidanceSection = ({
+  releaseVersionId,
+  canUpdateRelease,
+}: Props) => {
   const {
     value: dataGuidance,
     isLoading,
     setState: setDataGuidance,
   } = useAsyncHandledRetry(
-    () => releaseDataGuidanceService.getDataGuidance(releaseId),
-    [releaseId, canUpdateRelease],
+    () => releaseDataGuidanceService.getDataGuidance(releaseVersionId),
+    [releaseVersionId, canUpdateRelease],
   );
 
   const [isEditing, toggleEditing] = useToggle(canUpdateRelease);
@@ -61,7 +64,10 @@ const ReleaseDataGuidanceSection = ({ releaseId, canUpdateRelease }: Props) => {
   const handleSubmit = async (values: DataGuidanceFormValues) => {
     await minDelay(async () => {
       const updatedGuidance =
-        await releaseDataGuidanceService.updateDataGuidance(releaseId, values);
+        await releaseDataGuidanceService.updateDataGuidance(
+          releaseVersionId,
+          values,
+        );
 
       setDataGuidance({ value: updatedGuidance });
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataReorderSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataReorderSection.tsx
@@ -19,15 +19,18 @@ import adminTableBuilderService from '@admin/services/tableBuilderService';
 import React, { useState } from 'react';
 
 interface Props {
-  releaseId: string;
+  releaseVersionId: string;
   canUpdateRelease: boolean;
 }
 
-const ReleaseDataReorderSection = ({ releaseId, canUpdateRelease }: Props) => {
+const ReleaseDataReorderSection = ({
+  releaseVersionId,
+  canUpdateRelease,
+}: Props) => {
   const { value: subjects, isLoading: isLoadingSubjects } =
     useAsyncHandledRetry(
-      () => tableBuilderService.listReleaseSubjects(releaseId),
-      [releaseId],
+      () => tableBuilderService.listReleaseSubjects(releaseVersionId),
+      [releaseVersionId],
     );
   const [reorderingFilters, setReorderingFilters] = useState<Subject>();
   const [reorderingIndicators, setReorderingIndicators] = useState<Subject>();
@@ -37,7 +40,7 @@ const ReleaseDataReorderSection = ({ releaseId, canUpdateRelease }: Props) => {
     updatedFilters: UpdateFiltersRequest,
   ) => {
     await adminTableBuilderService.updateFilters(
-      releaseId,
+      releaseVersionId,
       subjectId,
       updatedFilters,
     );
@@ -49,7 +52,7 @@ const ReleaseDataReorderSection = ({ releaseId, canUpdateRelease }: Props) => {
     updatedIndicators: UpdateIndicatorsRequest,
   ) => {
     await adminTableBuilderService.updateIndicators(
-      releaseId,
+      releaseVersionId,
       subjectId,
       updatedIndicators,
     );
@@ -122,7 +125,7 @@ const ReleaseDataReorderSection = ({ releaseId, canUpdateRelease }: Props) => {
           <div aria-live="polite">
             {reorderingFilters && (
               <ReorderFiltersList
-                releaseId={releaseId}
+                releaseVersionId={releaseVersionId}
                 subject={reorderingFilters}
                 onCancel={() => setReorderingFilters(undefined)}
                 onSave={handleSaveFilters}
@@ -130,7 +133,7 @@ const ReleaseDataReorderSection = ({ releaseId, canUpdateRelease }: Props) => {
             )}
             {reorderingIndicators && (
               <ReorderIndicatorsList
-                releaseId={releaseId}
+                releaseVersionId={releaseVersionId}
                 subject={reorderingIndicators}
                 onCancel={() => setReorderingIndicators(undefined)}
                 onSave={handleSaveIndicators}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -32,7 +32,7 @@ import { useQuery } from '@tanstack/react-query';
 
 interface Props {
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
   canUpdateRelease: boolean;
   onDataFilesChange?: (dataFiles: DataFile[]) => void;
 }
@@ -44,7 +44,7 @@ interface DeleteDataFile {
 
 const ReleaseDataUploadsSection = ({
   publicationId,
-  releaseId,
+  releaseVersionId,
   canUpdateRelease,
   onDataFilesChange,
 }: Props) => {
@@ -86,7 +86,7 @@ const ReleaseDataUploadsSection = ({
     { totalRows, status }: DataFileImportStatus,
   ) => {
     const permissions = await permissionService.getDataFilePermissions(
-      releaseId,
+      releaseVersionId,
       dataFile.id,
     );
 
@@ -116,7 +116,7 @@ const ReleaseDataUploadsSection = ({
             return;
           }
           newFiles.push(
-            await releaseDataFileService.uploadDataFiles(releaseId, {
+            await releaseDataFileService.uploadDataFiles(releaseVersionId, {
               title: values.subjectTitle,
               dataFile: values.dataFile as File,
               metadataFile: values.metadataFile as File,
@@ -150,7 +150,7 @@ const ReleaseDataUploadsSection = ({
       setActiveFileIds(newFiles.map(file => file.id));
       setDataFiles(currentDataFiles => [...currentDataFiles, ...newFiles]);
     },
-    [releaseId],
+    [releaseVersionId],
   );
 
   return (
@@ -203,7 +203,7 @@ const ReleaseDataUploadsSection = ({
             onReorder={async (fileIds: string[]) => {
               setDataFiles(
                 await releaseDataFileService.updateDataFilesOrder(
-                  releaseId,
+                  releaseVersionId,
                   fileIds,
                 ),
               );
@@ -223,7 +223,7 @@ const ReleaseDataUploadsSection = ({
                   )}
                   <DataFileDetailsTable
                     dataFile={dataFile}
-                    releaseId={releaseId}
+                    releaseId={releaseVersionId}
                     onStatusChange={handleStatusChange}
                   >
                     {canUpdateRelease &&
@@ -237,7 +237,7 @@ const ReleaseDataUploadsSection = ({
                                   releaseDataFileRoute.path,
                                   {
                                     publicationId,
-                                    releaseId,
+                                    releaseVersionId,
                                     fileId: dataFile.id,
                                   },
                                 )}
@@ -263,7 +263,10 @@ const ReleaseDataUploadsSection = ({
                           <ButtonText
                             onClick={() =>
                               releaseDataFileService
-                                .getDeleteDataFilePlan(releaseId, dataFile)
+                                .getDeleteDataFilePlan(
+                                  releaseVersionId,
+                                  dataFile,
+                                )
                                 .then(plan => {
                                   setDeleteDataFile({
                                     plan,
@@ -278,7 +281,7 @@ const ReleaseDataUploadsSection = ({
                       )}
                     {dataFile.permissions.canCancelImport && (
                       <DataUploadCancelButton
-                        releaseId={releaseId}
+                        releaseId={releaseVersionId}
                         fileId={dataFile.id}
                       />
                     )}
@@ -304,7 +307,10 @@ const ReleaseDataUploadsSection = ({
             setFileDeleting(deleteDataFile, true);
 
             try {
-              await releaseDataFileService.deleteDataFiles(releaseId, file.id);
+              await releaseDataFileService.deleteDataFiles(
+                releaseVersionId,
+                file.id,
+              );
 
               setDataFiles(currentDataFiles =>
                 currentDataFiles.filter(dataFile => dataFile.id !== file.id),

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -5,7 +5,7 @@ import DataFileDetailsTable from '@admin/pages/release/data/components/DataFileD
 import DataFileUploadForm, {
   DataFileUploadFormValues,
 } from '@admin/pages/release/data/components/DataFileUploadForm';
-import {terminalImportStatuses} from '@admin/pages/release/data/components/ImporterStatus';
+import { terminalImportStatuses } from '@admin/pages/release/data/components/ImporterStatus';
 import releaseDataFileQueries from '@admin/queries/releaseDataFileQueries';
 import {
   releaseDataFileReplaceRoute,
@@ -26,9 +26,9 @@ import ModalConfirm from '@common/components/ModalConfirm';
 import WarningMessage from '@common/components/WarningMessage';
 import logger from '@common/services/logger';
 import DataUploadCancelButton from '@admin/pages/release/data/components/DataUploadCancelButton';
-import React, {useCallback, useEffect, useState} from 'react';
-import {generatePath} from 'react-router';
-import {useQuery} from '@tanstack/react-query';
+import React, { useCallback, useEffect, useState } from 'react';
+import { generatePath } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
 
 interface Props {
   publicationId: string;
@@ -43,16 +43,16 @@ interface DeleteDataFile {
 }
 
 const ReleaseDataUploadsSection = ({
-                                     publicationId,
-                                     releaseVersionId,
-                                     canUpdateRelease,
-                                     onDataFilesChange,
-                                   }: Props) => {
+  publicationId,
+  releaseVersionId,
+  canUpdateRelease,
+  onDataFilesChange,
+}: Props) => {
   const [deleteDataFile, setDeleteDataFile] = useState<DeleteDataFile>();
   const [activeFileIds, setActiveFileIds] = useState<string[]>();
   const [dataFiles, setDataFiles] = useState<DataFile[]>([]);
 
-  const {data: initialDataFiles = [], isLoading} = useQuery(
+  const { data: initialDataFiles = [], isLoading } = useQuery(
     releaseDataFileQueries.list(releaseVersionId),
   );
 
@@ -74,16 +74,16 @@ const ReleaseDataUploadsSection = ({
         file.fileName !== dataFile.file.fileName
           ? file
           : {
-            ...file,
-            isDeleting: deleting,
-          },
+              ...file,
+              isDeleting: deleting,
+            },
       ),
     );
   };
 
   const handleStatusChange = async (
     dataFile: DataFile,
-    {totalRows, status}: DataFileImportStatus,
+    { totalRows, status }: DataFileImportStatus,
   ) => {
     const permissions = await permissionService.getDataFilePermissions(
       releaseVersionId,
@@ -97,11 +97,11 @@ const ReleaseDataUploadsSection = ({
         file.fileName !== dataFile.fileName
           ? file
           : {
-            ...dataFile,
-            rows: totalRows,
-            status,
-            permissions,
-          },
+              ...dataFile,
+              rows: totalRows,
+              status,
+              permissions,
+            },
       ),
     );
   };
@@ -184,14 +184,14 @@ const ReleaseDataUploadsSection = ({
         </ul>
       </InsetText>
       {canUpdateRelease ? (
-        <DataFileUploadForm dataFiles={dataFiles} onSubmit={handleSubmit}/>
+        <DataFileUploadForm dataFiles={dataFiles} onSubmit={handleSubmit} />
       ) : (
         <WarningMessage>
           This release has been approved, and can no longer be updated.
         </WarningMessage>
       )}
 
-      <hr className="govuk-!-margin-top-6 govuk-!-margin-bottom-6"/>
+      <hr className="govuk-!-margin-top-6 govuk-!-margin-bottom-6" />
 
       <LoadingSpinner loading={isLoading}>
         {dataFiles.length > 0 ? (
@@ -217,9 +217,9 @@ const ReleaseDataUploadsSection = ({
                 headingTag="h3"
                 open={activeFileIds?.includes(dataFile.id)}
               >
-                <div style={{position: 'relative'}}>
+                <div style={{ position: 'relative' }}>
                   {dataFile.isDeleting && (
-                    <LoadingSpinner text="Deleting files" overlay/>
+                    <LoadingSpinner text="Deleting files" overlay />
                   )}
                   <DataFileDetailsTable
                     dataFile={dataFile}
@@ -301,7 +301,7 @@ const ReleaseDataUploadsSection = ({
           onExit={() => setDeleteDataFile(undefined)}
           onCancel={() => setDeleteDataFile(undefined)}
           onConfirm={async () => {
-            const {file} = deleteDataFile;
+            const { file } = deleteDataFile;
 
             setDeleteDataFile(undefined);
             setFileDeleting(deleteDataFile, true);
@@ -326,49 +326,49 @@ const ReleaseDataUploadsSection = ({
 
           {deleteDataFile.plan.deleteDataBlockPlan.dependentDataBlocks.length >
             0 && (
-              <>
-                <p>The following data blocks will also be deleted:</p>
+            <>
+              <p>The following data blocks will also be deleted:</p>
 
-                <ul>
-                  {deleteDataFile.plan.deleteDataBlockPlan.dependentDataBlocks.map(
-                    block => (
-                      <li key={block.name}>
-                        <p>{block.name}</p>
-                        {block.contentSectionHeading && (
-                          <p>
-                            {`It will also be removed from the "${block.contentSectionHeading}" content section.`}
-                          </p>
-                        )}
-                        {block.infographicFilesInfo.length > 0 && (
-                          <p>
-                            The following infographic files will also be removed:
-                            <ul>
-                              {block.infographicFilesInfo.map(fileInfo => (
-                                <li key={fileInfo.filename}>
-                                  <p>{fileInfo.filename}</p>
-                                </li>
-                              ))}
-                            </ul>
-                          </p>
-                        )}
-                        {block.isKeyStatistic && (
-                          <p>
-                            A key statistic associated with this data block will
-                            be removed.
-                          </p>
-                        )}
-                        {block.featuredTable && (
-                          <p>
-                            The featured table "{`${block.featuredTable?.name}`}"
-                            using this data block will be removed.
-                          </p>
-                        )}
-                      </li>
-                    ),
-                  )}
-                </ul>
-              </>
-            )}
+              <ul>
+                {deleteDataFile.plan.deleteDataBlockPlan.dependentDataBlocks.map(
+                  block => (
+                    <li key={block.name}>
+                      <p>{block.name}</p>
+                      {block.contentSectionHeading && (
+                        <p>
+                          {`It will also be removed from the "${block.contentSectionHeading}" content section.`}
+                        </p>
+                      )}
+                      {block.infographicFilesInfo.length > 0 && (
+                        <p>
+                          The following infographic files will also be removed:
+                          <ul>
+                            {block.infographicFilesInfo.map(fileInfo => (
+                              <li key={fileInfo.filename}>
+                                <p>{fileInfo.filename}</p>
+                              </li>
+                            ))}
+                          </ul>
+                        </p>
+                      )}
+                      {block.isKeyStatistic && (
+                        <p>
+                          A key statistic associated with this data block will
+                          be removed.
+                        </p>
+                      )}
+                      {block.featuredTable && (
+                        <p>
+                          The featured table "{`${block.featuredTable?.name}`}"
+                          using this data block will be removed.
+                        </p>
+                      )}
+                    </li>
+                  ),
+                )}
+              </ul>
+            </>
+          )}
           {deleteDataFile.plan.footnoteIds.length > 0 && (
             <p>
               {`${deleteDataFile.plan.footnoteIds.length} ${

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -5,7 +5,7 @@ import DataFileDetailsTable from '@admin/pages/release/data/components/DataFileD
 import DataFileUploadForm, {
   DataFileUploadFormValues,
 } from '@admin/pages/release/data/components/DataFileUploadForm';
-import { terminalImportStatuses } from '@admin/pages/release/data/components/ImporterStatus';
+import {terminalImportStatuses} from '@admin/pages/release/data/components/ImporterStatus';
 import releaseDataFileQueries from '@admin/queries/releaseDataFileQueries';
 import {
   releaseDataFileReplaceRoute,
@@ -26,9 +26,9 @@ import ModalConfirm from '@common/components/ModalConfirm';
 import WarningMessage from '@common/components/WarningMessage';
 import logger from '@common/services/logger';
 import DataUploadCancelButton from '@admin/pages/release/data/components/DataUploadCancelButton';
-import React, { useCallback, useEffect, useState } from 'react';
-import { generatePath } from 'react-router';
-import { useQuery } from '@tanstack/react-query';
+import React, {useCallback, useEffect, useState} from 'react';
+import {generatePath} from 'react-router';
+import {useQuery} from '@tanstack/react-query';
 
 interface Props {
   publicationId: string;
@@ -43,17 +43,17 @@ interface DeleteDataFile {
 }
 
 const ReleaseDataUploadsSection = ({
-  publicationId,
-  releaseVersionId,
-  canUpdateRelease,
-  onDataFilesChange,
-}: Props) => {
+                                     publicationId,
+                                     releaseVersionId,
+                                     canUpdateRelease,
+                                     onDataFilesChange,
+                                   }: Props) => {
   const [deleteDataFile, setDeleteDataFile] = useState<DeleteDataFile>();
   const [activeFileIds, setActiveFileIds] = useState<string[]>();
   const [dataFiles, setDataFiles] = useState<DataFile[]>([]);
 
-  const { data: initialDataFiles = [], isLoading } = useQuery(
-    releaseDataFileQueries.list(releaseId),
+  const {data: initialDataFiles = [], isLoading} = useQuery(
+    releaseDataFileQueries.list(releaseVersionId),
   );
 
   // Store the data files on state so we can reliably update them
@@ -74,16 +74,16 @@ const ReleaseDataUploadsSection = ({
         file.fileName !== dataFile.file.fileName
           ? file
           : {
-              ...file,
-              isDeleting: deleting,
-            },
+            ...file,
+            isDeleting: deleting,
+          },
       ),
     );
   };
 
   const handleStatusChange = async (
     dataFile: DataFile,
-    { totalRows, status }: DataFileImportStatus,
+    {totalRows, status}: DataFileImportStatus,
   ) => {
     const permissions = await permissionService.getDataFilePermissions(
       releaseVersionId,
@@ -97,11 +97,11 @@ const ReleaseDataUploadsSection = ({
         file.fileName !== dataFile.fileName
           ? file
           : {
-              ...dataFile,
-              rows: totalRows,
-              status,
-              permissions,
-            },
+            ...dataFile,
+            rows: totalRows,
+            status,
+            permissions,
+          },
       ),
     );
   };
@@ -129,7 +129,7 @@ const ReleaseDataUploadsSection = ({
             return;
           }
           newFiles.push(
-            await releaseDataFileService.uploadZipDataFile(releaseId, {
+            await releaseDataFileService.uploadZipDataFile(releaseVersionId, {
               title: values.subjectTitle,
               zipFile: values.zipFile as File,
             }),
@@ -139,7 +139,7 @@ const ReleaseDataUploadsSection = ({
         case 'bulkZip':
           newFiles.push(
             ...(await releaseDataFileService.uploadBulkZipDataFile(
-              releaseId,
+              releaseVersionId,
               values.bulkZipFile as File,
             )),
           );
@@ -184,14 +184,14 @@ const ReleaseDataUploadsSection = ({
         </ul>
       </InsetText>
       {canUpdateRelease ? (
-        <DataFileUploadForm dataFiles={dataFiles} onSubmit={handleSubmit} />
+        <DataFileUploadForm dataFiles={dataFiles} onSubmit={handleSubmit}/>
       ) : (
         <WarningMessage>
           This release has been approved, and can no longer be updated.
         </WarningMessage>
       )}
 
-      <hr className="govuk-!-margin-top-6 govuk-!-margin-bottom-6" />
+      <hr className="govuk-!-margin-top-6 govuk-!-margin-bottom-6"/>
 
       <LoadingSpinner loading={isLoading}>
         {dataFiles.length > 0 ? (
@@ -217,9 +217,9 @@ const ReleaseDataUploadsSection = ({
                 headingTag="h3"
                 open={activeFileIds?.includes(dataFile.id)}
               >
-                <div style={{ position: 'relative' }}>
+                <div style={{position: 'relative'}}>
                   {dataFile.isDeleting && (
-                    <LoadingSpinner text="Deleting files" overlay />
+                    <LoadingSpinner text="Deleting files" overlay/>
                   )}
                   <DataFileDetailsTable
                     dataFile={dataFile}
@@ -250,7 +250,7 @@ const ReleaseDataUploadsSection = ({
                                   releaseDataFileReplaceRoute.path,
                                   {
                                     publicationId,
-                                    releaseId,
+                                    releaseVersionId,
                                     fileId: dataFile.id,
                                   },
                                 )}
@@ -301,7 +301,7 @@ const ReleaseDataUploadsSection = ({
           onExit={() => setDeleteDataFile(undefined)}
           onCancel={() => setDeleteDataFile(undefined)}
           onConfirm={async () => {
-            const { file } = deleteDataFile;
+            const {file} = deleteDataFile;
 
             setDeleteDataFile(undefined);
             setFileDeleting(deleteDataFile, true);
@@ -326,49 +326,49 @@ const ReleaseDataUploadsSection = ({
 
           {deleteDataFile.plan.deleteDataBlockPlan.dependentDataBlocks.length >
             0 && (
-            <>
-              <p>The following data blocks will also be deleted:</p>
+              <>
+                <p>The following data blocks will also be deleted:</p>
 
-              <ul>
-                {deleteDataFile.plan.deleteDataBlockPlan.dependentDataBlocks.map(
-                  block => (
-                    <li key={block.name}>
-                      <p>{block.name}</p>
-                      {block.contentSectionHeading && (
-                        <p>
-                          {`It will also be removed from the "${block.contentSectionHeading}" content section.`}
-                        </p>
-                      )}
-                      {block.infographicFilesInfo.length > 0 && (
-                        <p>
-                          The following infographic files will also be removed:
-                          <ul>
-                            {block.infographicFilesInfo.map(fileInfo => (
-                              <li key={fileInfo.filename}>
-                                <p>{fileInfo.filename}</p>
-                              </li>
-                            ))}
-                          </ul>
-                        </p>
-                      )}
-                      {block.isKeyStatistic && (
-                        <p>
-                          A key statistic associated with this data block will
-                          be removed.
-                        </p>
-                      )}
-                      {block.featuredTable && (
-                        <p>
-                          The featured table "{`${block.featuredTable?.name}`}"
-                          using this data block will be removed.
-                        </p>
-                      )}
-                    </li>
-                  ),
-                )}
-              </ul>
-            </>
-          )}
+                <ul>
+                  {deleteDataFile.plan.deleteDataBlockPlan.dependentDataBlocks.map(
+                    block => (
+                      <li key={block.name}>
+                        <p>{block.name}</p>
+                        {block.contentSectionHeading && (
+                          <p>
+                            {`It will also be removed from the "${block.contentSectionHeading}" content section.`}
+                          </p>
+                        )}
+                        {block.infographicFilesInfo.length > 0 && (
+                          <p>
+                            The following infographic files will also be removed:
+                            <ul>
+                              {block.infographicFilesInfo.map(fileInfo => (
+                                <li key={fileInfo.filename}>
+                                  <p>{fileInfo.filename}</p>
+                                </li>
+                              ))}
+                            </ul>
+                          </p>
+                        )}
+                        {block.isKeyStatistic && (
+                          <p>
+                            A key statistic associated with this data block will
+                            be removed.
+                          </p>
+                        )}
+                        {block.featuredTable && (
+                          <p>
+                            The featured table "{`${block.featuredTable?.name}`}"
+                            using this data block will be removed.
+                          </p>
+                        )}
+                      </li>
+                    ),
+                  )}
+                </ul>
+              </>
+            )}
           {deleteDataFile.plan.footnoteIds.length > 0 && (
             <p>
               {`${deleteDataFile.plan.footnoteIds.length} ${

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -223,7 +223,7 @@ const ReleaseDataUploadsSection = ({
                   )}
                   <DataFileDetailsTable
                     dataFile={dataFile}
-                    releaseId={releaseVersionId}
+                    releaseVersionId={releaseVersionId}
                     onStatusChange={handleStatusChange}
                   >
                     {canUpdateRelease &&
@@ -281,7 +281,7 @@ const ReleaseDataUploadsSection = ({
                       )}
                     {dataFile.permissions.canCancelImport && (
                       <DataUploadCancelButton
-                        releaseId={releaseVersionId}
+                        releaseVersionId={releaseVersionId}
                         fileId={dataFile.id}
                       />
                     )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -18,13 +18,13 @@ import React, { useCallback, useMemo, useState } from 'react';
 
 interface Props {
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
   canUpdateRelease: boolean;
 }
 
 export default function ReleaseFileUploadsSection({
   publicationId,
-  releaseId,
+  releaseVersionId,
   canUpdateRelease,
 }: Props) {
   const [deleteFile, setDeleteFile] = useState<AncillaryFile>();
@@ -32,8 +32,8 @@ export default function ReleaseFileUploadsSection({
   const queryClient = useQueryClient();
 
   const listFilesQuery = useMemo(
-    () => releaseAncillaryFileQueries.list(releaseId),
-    [releaseId],
+    () => releaseAncillaryFileQueries.list(releaseVersionId),
+    [releaseVersionId],
   );
 
   const { data: files = [], isLoading } = useQuery(listFilesQuery);
@@ -54,16 +54,19 @@ export default function ReleaseFileUploadsSection({
 
   const handleSubmit = useCallback(
     async (values: AncillaryFileFormValues) => {
-      const newFile = await releaseAncillaryFileService.createFile(releaseId, {
-        title: values.title,
-        file: values.file as File,
-        summary: values.summary,
-      });
+      const newFile = await releaseAncillaryFileService.createFile(
+        releaseVersionId,
+        {
+          title: values.title,
+          file: values.file as File,
+          summary: values.summary,
+        },
+      );
 
       queryClient.setQueryData(listFilesQuery.queryKey, [...files, newFile]);
       await queryClient.invalidateQueries(listFilesQuery.queryKey);
     },
-    [files, listFilesQuery.queryKey, queryClient, releaseId],
+    [files, listFilesQuery.queryKey, queryClient, releaseVersionId],
   );
 
   return (
@@ -136,7 +139,7 @@ export default function ReleaseFileUploadsSection({
                     canUpdateRelease={canUpdateRelease}
                     file={file}
                     publicationId={publicationId}
-                    releaseVersionId={releaseId}
+                    releaseVersionId={releaseVersionId}
                     onDelete={() => setDeleteFile(file)}
                   />
                 </div>
@@ -160,7 +163,7 @@ export default function ReleaseFileUploadsSection({
 
             try {
               await releaseAncillaryFileService.deleteFile(
-                releaseId,
+                releaseVersionId,
                 deleteFile.id,
               );
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -136,7 +136,7 @@ export default function ReleaseFileUploadsSection({
                     canUpdateRelease={canUpdateRelease}
                     file={file}
                     publicationId={publicationId}
-                    releaseId={releaseId}
+                    releaseVersionId={releaseId}
                     onDelete={() => setDeleteFile(file)}
                   />
                 </div>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderFiltersList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderFiltersList.tsx
@@ -21,20 +21,20 @@ export type UpdateFiltersRequest = UpdatedFilter[];
 
 interface Props {
   subject: Subject;
-  releaseId: string;
+  releaseVersionId: string;
   onCancel: () => void;
   onSave: (subjectId: string, requestFilters: UpdateFiltersRequest) => void;
 }
 
 const ReorderFiltersList = ({
-  releaseId,
+  releaseVersionId,
   subject,
   onCancel,
   onSave,
 }: Props) => {
   const { value: subjectMeta, isLoading } = useAsyncHandledRetry(
-    () => tableBuilderService.getSubjectMeta(subject.id, releaseId),
-    [subject.id, releaseId],
+    () => tableBuilderService.getSubjectMeta(subject.id, releaseVersionId),
+    [subject.id, releaseVersionId],
   );
 
   const [filters, setFilters] = useState<FormattedFilters[]>([]);

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderIndicatorsList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReorderIndicatorsList.tsx
@@ -19,7 +19,7 @@ interface UpdatedIndicator {
 export type UpdateIndicatorsRequest = UpdatedIndicator[];
 
 interface Props {
-  releaseId: string;
+  releaseVersionId: string;
   subject: Subject;
   onCancel: () => void;
   onSave: (
@@ -29,14 +29,14 @@ interface Props {
 }
 
 const ReorderIndicatorsList = ({
-  releaseId,
+  releaseVersionId,
   subject,
   onCancel,
   onSave,
 }: Props) => {
   const { value: subjectMeta, isLoading } = useAsyncHandledRetry(
-    () => tableBuilderService.getSubjectMeta(subject.id, releaseId),
-    [subject.id, releaseId],
+    () => tableBuilderService.getSubjectMeta(subject.id, releaseVersionId),
+    [subject.id, releaseVersionId],
   );
 
   const [indicators, setIndicators] = useState<FormattedIndicators[]>([]);

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateModal.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateModal.test.tsx
@@ -34,7 +34,7 @@ describe('ApiDataSetCreateModal', () => {
     const { user } = render(
       <ApiDataSetCreateModal
         publicationId="publication-id"
-        releaseId="release-id"
+        releaseVersionId="release-id"
         onSubmit={noop}
       />,
     );
@@ -58,7 +58,7 @@ describe('ApiDataSetCreateModal', () => {
     const { user } = render(
       <ApiDataSetCreateModal
         publicationId="publication-id"
-        releaseId="release-id"
+        releaseVersionId="release-id"
         onSubmit={noop}
       />,
     );
@@ -104,7 +104,7 @@ describe('ApiDataSetCreateModal', () => {
     const { user } = render(
       <ApiDataSetCreateModal
         publicationId="publication-id"
-        releaseId="release-id"
+        releaseVersionId="release-id"
         onSubmit={handleSubmit}
       />,
       { history },

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
@@ -380,7 +380,7 @@ describe('DataReplacementPlan', () => {
         <DataFileReplacementPlan
           cancelButton={<button type="button">Cancel</button>}
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           fileId="file-1"
           replacementFileId="file-2"
         />
@@ -594,7 +594,7 @@ describe('DataReplacementPlan', () => {
         <DataFileReplacementPlan
           cancelButton={<button type="button">Cancel</button>}
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           fileId="file-1"
           replacementFileId="file-2"
         />
@@ -682,7 +682,7 @@ describe('DataReplacementPlan', () => {
         <DataFileReplacementPlan
           cancelButton={<button type="button">Cancel</button>}
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           fileId="file-1"
           replacementFileId="file-2"
         />
@@ -713,7 +713,7 @@ describe('DataReplacementPlan', () => {
       <DataFileReplacementPlan
         cancelButton={<button type="button">Cancel</button>}
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
         fileId="file-1"
         replacementFileId="file-2"
       />,
@@ -739,7 +739,7 @@ describe('DataReplacementPlan', () => {
         <DataFileReplacementPlan
           cancelButton={<button type="button">Cancel</button>}
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           fileId="file-1"
           replacementFileId="file-2"
         />
@@ -784,7 +784,7 @@ describe('DataReplacementPlan', () => {
         <DataFileReplacementPlan
           cancelButton={<button type="button">Cancel</button>}
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           fileId="file-1"
           replacementFileId="file-2"
         />
@@ -816,7 +816,7 @@ describe('DataReplacementPlan', () => {
         <DataFileReplacementPlan
           cancelButton={<button type="button">Cancel</button>}
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           fileId="file-1"
           replacementFileId="file-2"
         />
@@ -862,7 +862,7 @@ describe('DataReplacementPlan', () => {
         <DataFileReplacementPlan
           cancelButton={<button type="button">Cancel</button>}
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           fileId="file-1"
           replacementFileId="file-2"
         />
@@ -937,7 +937,7 @@ describe('DataReplacementPlan', () => {
         <DataFileReplacementPlan
           cancelButton={<button type="button">Cancel</button>}
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           fileId="file-1"
           replacementFileId="file-2"
         />
@@ -970,7 +970,7 @@ describe('DataReplacementPlan', () => {
         <DataFileReplacementPlan
           cancelButton={<button type="button">Cancel</button>}
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           fileId="file-1"
           replacementFileId="file-2"
         />
@@ -1023,7 +1023,7 @@ describe('DataReplacementPlan', () => {
         <DataFileReplacementPlan
           cancelButton={<button type="button">Cancel</button>}
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           fileId="file-1"
           replacementFileId="file-2"
         />
@@ -1101,7 +1101,7 @@ describe('DataReplacementPlan', () => {
         <DataFileReplacementPlan
           cancelButton={<button type="button">Cancel</button>}
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           fileId="file-1"
           replacementFileId="file-2"
         />

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DraftApiDataSetsTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DraftApiDataSetsTable.test.tsx
@@ -108,7 +108,7 @@ describe('DraftApiDataSetsTable', () => {
         canUpdateRelease
         dataSets={testDataSets}
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
       />,
     );
 
@@ -250,7 +250,7 @@ describe('DraftApiDataSetsTable', () => {
         canUpdateRelease={false}
         dataSets={testDataSets}
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
       />,
     );
 
@@ -352,7 +352,7 @@ describe('DraftApiDataSetsTable', () => {
         canUpdateRelease
         dataSets={[]}
         publicationId="publication-1"
-        releaseId="release-1"
+        releaseVersionId="release-1"
       />,
     );
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ImporterStatus.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ImporterStatus.test.tsx
@@ -36,7 +36,9 @@ describe('ImporterStatus', () => {
   });
 
   test('renders initial complete status correctly', () => {
-    render(<ImporterStatus releaseId="release-1" dataFile={testDataFile} />);
+    render(
+      <ImporterStatus releaseVersionId="release-1" dataFile={testDataFile} />,
+    );
 
     expect(screen.getByText('Complete')).toBeInTheDocument();
     expect(screen.queryByRole('group')).not.toBeInTheDocument();
@@ -50,7 +52,9 @@ describe('ImporterStatus', () => {
       totalRows: 100,
     });
 
-    render(<ImporterStatus releaseId="release-1" dataFile={testDataFile} />);
+    render(
+      <ImporterStatus releaseVersionId="release-1" dataFile={testDataFile} />,
+    );
 
     expect(
       releaseDataFileService.getDataFileImportStatus,
@@ -67,7 +71,7 @@ describe('ImporterStatus', () => {
 
     render(
       <ImporterStatus
-        releaseId="release-1"
+        releaseVersionId="release-1"
         dataFile={{
           ...testDataFile,
           status: 'QUEUED',
@@ -98,7 +102,7 @@ describe('ImporterStatus', () => {
 
     render(
       <ImporterStatus
-        releaseId="release-1"
+        releaseVersionId="release-1"
         dataFile={{
           ...testDataFile,
           status: 'QUEUED',
@@ -176,7 +180,7 @@ describe('ImporterStatus', () => {
 
     render(
       <ImporterStatus
-        releaseId="release-1"
+        releaseVersionId="release-1"
         dataFile={{
           ...testDataFile,
           status: 'QUEUED',

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseApiDataSetsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseApiDataSetsSection.test.tsx
@@ -1,6 +1,6 @@
 import { AuthContextTestProvider, User } from '@admin/contexts/AuthContext';
-import { testRelease } from '@admin/pages/release/__data__/testRelease';
-import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
+import { testReleaseVersion } from '@admin/pages/release/__data__/testReleaseVersion';
+import { ReleaseVersionContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
 import ReleaseApiDataSetsSection from '@admin/pages/release/data/components/ReleaseApiDataSetsSection';
 import _apiDataSetCandidateService, {
   ApiDataSetCandidate,
@@ -9,7 +9,7 @@ import _apiDataSetService, {
   ApiDataSetSummary,
 } from '@admin/services/apiDataSetService';
 import { GlobalPermissions } from '@admin/services/authService';
-import { Release } from '@admin/services/releaseService';
+import { ReleaseVersion } from '@admin/services/releaseService';
 import render, { CustomRenderResult } from '@common-test/render';
 import { createMemoryHistory, History } from 'history';
 import { screen, waitFor, within } from '@testing-library/react';
@@ -168,8 +168,8 @@ describe('ReleaseApiDataSetsSection', () => {
     apiDataSetService.listDataSets.mockResolvedValue([]);
 
     renderPage({
-      release: {
-        ...testRelease,
+      releaseVersion: {
+        ...testReleaseVersion,
         approvalStatus: 'Approved',
       },
     });
@@ -280,23 +280,23 @@ describe('ReleaseApiDataSetsSection', () => {
   });
 
   function renderPage(options?: {
-    release?: Release;
+    releaseVersion?: ReleaseVersion;
     user?: User;
     history?: History;
   }): CustomRenderResult {
     const {
-      release = testRelease,
+      releaseVersion = testReleaseVersion,
       user = testBauUser,
       history = createMemoryHistory(),
     } = options ?? {};
 
     return render(
       <AuthContextTestProvider user={user}>
-        <ReleaseContextProvider release={release}>
+        <ReleaseVersionContextProvider releaseVersion={releaseVersion}>
           <Router history={history}>
             <ReleaseApiDataSetsSection />
           </Router>
-        </ReleaseContextProvider>
+        </ReleaseVersionContextProvider>
       </AuthContextTestProvider>,
     );
   }

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataGuidanceSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataGuidanceSection.test.tsx
@@ -73,7 +73,10 @@ describe('ReleaseDataGuidanceSection', () => {
       );
 
       render(
-        <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
+        <ReleaseDataGuidanceSection
+          releaseVersionId="release-1"
+          canUpdateRelease
+        />,
       );
 
       await waitFor(() => {
@@ -93,7 +96,10 @@ describe('ReleaseDataGuidanceSection', () => {
       });
 
       render(
-        <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
+        <ReleaseDataGuidanceSection
+          releaseVersionId="release-1"
+          canUpdateRelease
+        />,
       );
 
       await waitFor(() => {
@@ -122,7 +128,10 @@ describe('ReleaseDataGuidanceSection', () => {
       });
 
       render(
-        <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
+        <ReleaseDataGuidanceSection
+          releaseVersionId="release-1"
+          canUpdateRelease
+        />,
       );
 
       await waitFor(() => {
@@ -146,7 +155,10 @@ describe('ReleaseDataGuidanceSection', () => {
       );
 
       const { user } = render(
-        <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
+        <ReleaseDataGuidanceSection
+          releaseVersionId="release-1"
+          canUpdateRelease
+        />,
       );
 
       await waitFor(() => {
@@ -263,7 +275,10 @@ describe('ReleaseDataGuidanceSection', () => {
       );
 
       const { user } = render(
-        <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
+        <ReleaseDataGuidanceSection
+          releaseVersionId="release-1"
+          canUpdateRelease
+        />,
       );
 
       await waitFor(() => {
@@ -414,7 +429,10 @@ describe('ReleaseDataGuidanceSection', () => {
       );
 
       const { user } = render(
-        <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
+        <ReleaseDataGuidanceSection
+          releaseVersionId="release-1"
+          canUpdateRelease
+        />,
       );
 
       await waitFor(() => {
@@ -452,7 +470,10 @@ describe('ReleaseDataGuidanceSection', () => {
       );
 
       const { user } = render(
-        <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
+        <ReleaseDataGuidanceSection
+          releaseVersionId="release-1"
+          canUpdateRelease
+        />,
       );
 
       await waitFor(() => {
@@ -495,7 +516,10 @@ describe('ReleaseDataGuidanceSection', () => {
       );
 
       const { user } = render(
-        <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
+        <ReleaseDataGuidanceSection
+          releaseVersionId="release-1"
+          canUpdateRelease
+        />,
       );
 
       await waitFor(() => {
@@ -531,7 +555,10 @@ describe('ReleaseDataGuidanceSection', () => {
       );
 
       const { user } = render(
-        <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
+        <ReleaseDataGuidanceSection
+          releaseVersionId="release-1"
+          canUpdateRelease
+        />,
       );
 
       await waitFor(() => {
@@ -569,7 +596,10 @@ describe('ReleaseDataGuidanceSection', () => {
       );
 
       const { user } = render(
-        <ReleaseDataGuidanceSection releaseId="release-1" canUpdateRelease />,
+        <ReleaseDataGuidanceSection
+          releaseVersionId="release-1"
+          canUpdateRelease
+        />,
       );
 
       await waitFor(() => {
@@ -644,7 +674,7 @@ describe('ReleaseDataGuidanceSection', () => {
 
       render(
         <ReleaseDataGuidanceSection
-          releaseId="release-1"
+          releaseVersionId="release-1"
           canUpdateRelease={false}
         />,
       );
@@ -665,7 +695,7 @@ describe('ReleaseDataGuidanceSection', () => {
 
       render(
         <ReleaseDataGuidanceSection
-          releaseId="release-1"
+          releaseVersionId="release-1"
           canUpdateRelease={false}
         />,
       );
@@ -687,7 +717,7 @@ describe('ReleaseDataGuidanceSection', () => {
 
       render(
         <ReleaseDataGuidanceSection
-          releaseId="release-1"
+          releaseVersionId="release-1"
           canUpdateRelease={false}
         />,
       );
@@ -707,7 +737,7 @@ describe('ReleaseDataGuidanceSection', () => {
 
       render(
         <ReleaseDataGuidanceSection
-          releaseId="release-1"
+          releaseVersionId="release-1"
           canUpdateRelease={false}
         />,
       );
@@ -734,7 +764,7 @@ describe('ReleaseDataGuidanceSection', () => {
 
       const { user } = render(
         <ReleaseDataGuidanceSection
-          releaseId="release-1"
+          releaseVersionId="release-1"
           canUpdateRelease={false}
         />,
       );

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -132,7 +132,7 @@ describe('ReleaseDataUploadsSection', () => {
       <MemoryRouter>
         <ReleaseDataUploadsSection
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           canUpdateRelease
         />
       </MemoryRouter>,
@@ -210,7 +210,7 @@ describe('ReleaseDataUploadsSection', () => {
       <MemoryRouter>
         <ReleaseDataUploadsSection
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           canUpdateRelease
         />
       </MemoryRouter>,
@@ -242,7 +242,7 @@ describe('ReleaseDataUploadsSection', () => {
       <MemoryRouter>
         <ReleaseDataUploadsSection
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           canUpdateRelease
         />
       </MemoryRouter>,
@@ -273,7 +273,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -331,7 +331,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -415,7 +415,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -477,7 +477,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -516,7 +516,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -548,7 +548,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -574,7 +574,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -604,7 +604,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -648,7 +648,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -729,7 +729,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -829,7 +829,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -1038,7 +1038,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -1105,7 +1105,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -1167,7 +1167,7 @@ describe('ReleaseDataUploadsSection', () => {
           <MemoryRouter>
             <ReleaseDataUploadsSection
               publicationId="publication-1"
-              releaseId="release-1"
+              releaseVersionId="release-1"
               canUpdateRelease
             />
           </MemoryRouter>,
@@ -1201,7 +1201,7 @@ describe('ReleaseDataUploadsSection', () => {
           <MemoryRouter>
             <ReleaseDataUploadsSection
               publicationId="publication-1"
-              releaseId="release-1"
+              releaseVersionId="release-1"
               canUpdateRelease
             />
           </MemoryRouter>,
@@ -1236,7 +1236,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -1284,7 +1284,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -1335,7 +1335,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -1383,7 +1383,7 @@ describe('ReleaseDataUploadsSection', () => {
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -5,9 +5,9 @@ import _releaseDataFileService, {
   UploadDataFilesRequest,
   UploadZipDataFileRequest,
 } from '@admin/services/releaseDataFileService';
-import {screen, waitFor, within} from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
-import {MemoryRouter} from 'react-router';
+import { MemoryRouter } from 'react-router';
 import _permissionService, {
   DataFilePermissions,
 } from '@admin/services/permissionService';
@@ -150,7 +150,7 @@ describe('ReleaseDataUploadsSection', () => {
     const section1 = within(sections[0]);
 
     expect(
-      section1.getByRole('button', {name: /Test data 1/}),
+      section1.getByRole('button', { name: /Test data 1/ }),
     ).toBeInTheDocument();
 
     expect(section1.getByTestId('Subject title')).toHaveTextContent(
@@ -173,7 +173,7 @@ describe('ReleaseDataUploadsSection', () => {
     const section2 = within(sections[1]);
 
     expect(
-      section2.getByRole('button', {name: /Test data 2/}),
+      section2.getByRole('button', { name: /Test data 2/ }),
     ).toBeInTheDocument();
 
     expect(section2.getByTestId('Subject title')).toHaveTextContent(
@@ -227,7 +227,7 @@ describe('ReleaseDataUploadsSection', () => {
     const section1 = getAccordionSection(0);
 
     expect(
-      section1.getByRole('button', {name: /Test data 1/}),
+      section1.getByRole('button', { name: /Test data 1/ }),
     ).toBeInTheDocument();
 
     expect(section1.getByTestId('Status')).toHaveTextContent(
@@ -262,7 +262,7 @@ describe('ReleaseDataUploadsSection', () => {
   describe('deleting data file', () => {
     test('does not render delete files button if file is not ready for deletion', async () => {
       releaseDataFileService.getDataFiles.mockResolvedValue([
-        {...testDataFiles[0], status: 'QUEUED'},
+        { ...testDataFiles[0], status: 'QUEUED' },
         testDataFiles[1],
       ]);
       releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
@@ -288,13 +288,13 @@ describe('ReleaseDataUploadsSection', () => {
       const section1 = within(sections[0]);
       expect(section1.getByTestId('Status')).toHaveTextContent('Queued');
       expect(
-        section1.queryByRole('button', {name: 'Delete files'}),
+        section1.queryByRole('button', { name: 'Delete files' }),
       ).not.toBeInTheDocument();
 
       const section2 = within(sections[1]);
       expect(section2.getByTestId('Status')).toHaveTextContent('Complete');
       expect(
-        section2.getByRole('button', {name: 'Delete files'}),
+        section2.getByRole('button', { name: 'Delete files' }),
       ).toBeInTheDocument();
     });
 
@@ -327,7 +327,7 @@ describe('ReleaseDataUploadsSection', () => {
         footnoteIds: ['footnote-1'],
       });
 
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -411,7 +411,7 @@ describe('ReleaseDataUploadsSection', () => {
       });
       releaseDataFileService.deleteDataFiles.mockResolvedValue();
 
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -466,7 +466,7 @@ describe('ReleaseDataUploadsSection', () => {
   describe('replace data file', () => {
     test('does not render replace data button if file import is not completed', async () => {
       releaseDataFileService.getDataFiles.mockResolvedValue([
-        {...testDataFiles[0], status: 'QUEUED'},
+        { ...testDataFiles[0], status: 'QUEUED' },
         testDataFiles[1],
       ]);
       releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
@@ -493,19 +493,19 @@ describe('ReleaseDataUploadsSection', () => {
       const section1 = within(sections[0]);
       expect(section1.getByTestId('Status')).toHaveTextContent('Queued');
       expect(
-        section1.queryByRole('link', {name: 'Replace data'}),
+        section1.queryByRole('link', { name: 'Replace data' }),
       ).not.toBeInTheDocument();
 
       const section2 = within(sections[1]);
       expect(section2.getByTestId('Status')).toHaveTextContent('Complete');
       expect(
-        section2.getByRole('link', {name: 'Replace data'}),
+        section2.getByRole('link', { name: 'Replace data' }),
       ).toBeInTheDocument();
     });
 
     test('renders replace data button with correct link', async () => {
       releaseDataFileService.getDataFiles.mockResolvedValue([
-        {...testDataFiles[0], status: 'QUEUED'},
+        { ...testDataFiles[0], status: 'QUEUED' },
         testDataFiles[1],
       ]);
       releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
@@ -530,7 +530,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section2 = within(sections[1]);
       expect(
-        section2.getByRole('link', {name: 'Replace data'}),
+        section2.getByRole('link', { name: 'Replace data' }),
       ).toHaveAttribute(
         'href',
         '/publication/publication-1/release/release-1/data/data-2/replace',
@@ -544,7 +544,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('show validation message when no subject title', async () => {
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -570,7 +570,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('shows validation message when non-unique subject title', async () => {
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -600,7 +600,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('cannot submit with invalid values when trying to upload CSV files', async () => {
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -644,7 +644,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('cannot submit with invalid values when trying to upload ZIP file', async () => {
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -690,7 +690,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('cannot submit with invalid values when trying to upload bulk ZIP file', async () => {
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -725,7 +725,7 @@ describe('ReleaseDataUploadsSection', () => {
       releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
         testQueuedImportStatus,
       );
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -773,13 +773,13 @@ describe('ReleaseDataUploadsSection', () => {
       const section1 = within(sections[0]);
 
       expect(
-        section1.getByRole('button', {name: /Test data 1/}),
+        section1.getByRole('button', { name: /Test data 1/ }),
       ).toBeInTheDocument();
 
       const section2 = within(sections[1]);
 
       expect(
-        section2.getByRole('button', {name: /Test data 2/}),
+        section2.getByRole('button', { name: /Test data 2/ }),
       ).toBeInTheDocument();
 
       expect(section2.getByTestId('Subject title')).toHaveTextContent(
@@ -789,7 +789,7 @@ describe('ReleaseDataUploadsSection', () => {
       const section3 = within(sections[2]);
 
       expect(
-        section3.getByRole('button', {name: /Test title/}),
+        section3.getByRole('button', { name: /Test title/ }),
       ).toBeInTheDocument();
 
       expect(section3.getByTestId('Subject title')).toHaveTextContent(
@@ -825,7 +825,7 @@ describe('ReleaseDataUploadsSection', () => {
         testQueuedImportStatus,
       );
 
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -868,11 +868,11 @@ describe('ReleaseDataUploadsSection', () => {
       expect(sections).toHaveLength(3);
 
       expect(
-        section1.getByRole('button', {name: /Test data 1/}),
+        section1.getByRole('button', { name: /Test data 1/ }),
       ).toBeInTheDocument();
 
       expect(
-        section2.getByRole('button', {name: /Test data 2/}),
+        section2.getByRole('button', { name: /Test data 2/ }),
       ).toBeInTheDocument();
 
       expect(section2.getByTestId('Subject title')).toHaveTextContent(
@@ -880,7 +880,7 @@ describe('ReleaseDataUploadsSection', () => {
       );
 
       expect(
-        section3.getByRole('button', {name: /Test zip title/}),
+        section3.getByRole('button', { name: /Test zip title/ }),
       ).toBeInTheDocument();
 
       expect(section3.getByTestId('Subject title')).toHaveTextContent(
@@ -924,7 +924,7 @@ describe('ReleaseDataUploadsSection', () => {
         testQueuedImportStatus,
       );
 
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -962,15 +962,15 @@ describe('ReleaseDataUploadsSection', () => {
       expect(sections).toHaveLength(4);
 
       expect(
-        section1.getByRole('button', {name: /Test data 1/}),
+        section1.getByRole('button', { name: /Test data 1/ }),
       ).toBeInTheDocument();
 
       expect(
-        section2.getByRole('button', {name: /Test data 2/}),
+        section2.getByRole('button', { name: /Test data 2/ }),
       ).toBeInTheDocument();
 
       expect(
-        section3.getByRole('button', {name: /Test zip title/}),
+        section3.getByRole('button', { name: /Test zip title/ }),
       ).toBeInTheDocument();
       expect(section3.getByTestId('Subject title')).toHaveTextContent(
         'Test zip title',
@@ -996,7 +996,7 @@ describe('ReleaseDataUploadsSection', () => {
       );
 
       expect(
-        section4.getByRole('button', {name: /Test zip title 2/}),
+        section4.getByRole('button', { name: /Test zip title 2/ }),
       ).toBeInTheDocument();
       expect(section4.getByTestId('Subject title')).toHaveTextContent(
         'Test zip title 2',
@@ -1034,7 +1034,7 @@ describe('ReleaseDataUploadsSection', () => {
         {} as DataFilePermissions,
       );
 
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1101,7 +1101,7 @@ describe('ReleaseDataUploadsSection', () => {
         {} as DataFilePermissions,
       );
 
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1180,7 +1180,7 @@ describe('ReleaseDataUploadsSection', () => {
         const section = getAccordionSection(0);
 
         expect(
-          section.getByRole('button', {name: 'Cancel'}),
+          section.getByRole('button', { name: 'Cancel' }),
         ).toBeInTheDocument();
       });
 
@@ -1214,7 +1214,7 @@ describe('ReleaseDataUploadsSection', () => {
         const section = getAccordionSection(0);
 
         expect(
-          section.queryByRole('button', {name: 'Cancel'}),
+          section.queryByRole('button', { name: 'Cancel' }),
         ).not.toBeInTheDocument();
       });
     });
@@ -1232,7 +1232,7 @@ describe('ReleaseDataUploadsSection', () => {
         testUploadedDataFile,
       ]);
 
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1248,7 +1248,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section = getAccordionSection(0);
 
-      await user.click(section.getByRole('button', {name: 'Cancel'}));
+      await user.click(section.getByRole('button', { name: 'Cancel' }));
 
       await waitFor(() => {
         expect(
@@ -1268,10 +1268,10 @@ describe('ReleaseDataUploadsSection', () => {
         ),
       ).toBeInTheDocument();
 
-      expect(modal.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
+      expect(modal.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
 
       expect(
-        modal.getByRole('button', {name: 'Confirm'}),
+        modal.getByRole('button', { name: 'Confirm' }),
       ).toBeInTheDocument();
     });
 
@@ -1280,7 +1280,7 @@ describe('ReleaseDataUploadsSection', () => {
         testUploadedDataFile,
       ]);
 
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1296,7 +1296,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section = getAccordionSection(0);
 
-      await user.click(section.getByRole('button', {name: 'Cancel'}));
+      await user.click(section.getByRole('button', { name: 'Cancel' }));
 
       await waitFor(() => {
         expect(
@@ -1305,7 +1305,7 @@ describe('ReleaseDataUploadsSection', () => {
       });
 
       const modal = within(screen.getByRole('dialog'));
-      await user.click(modal.getByRole('button', {name: 'Confirm'}));
+      await user.click(modal.getByRole('button', { name: 'Confirm' }));
 
       await waitFor(() => {
         expect(releaseDataFileService.cancelImport).toHaveBeenCalledWith(
@@ -1322,7 +1322,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       expect(
-        section.queryByRole('button', {name: 'Cancel'}),
+        section.queryByRole('button', { name: 'Cancel' }),
       ).not.toBeInTheDocument();
     });
 
@@ -1331,7 +1331,7 @@ describe('ReleaseDataUploadsSection', () => {
         testUploadedDataFile,
       ]);
 
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1347,7 +1347,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section = getAccordionSection(0);
 
-      await user.click(section.getByRole('button', {name: 'Cancel'}));
+      await user.click(section.getByRole('button', { name: 'Cancel' }));
 
       await waitFor(() => {
         expect(
@@ -1356,7 +1356,7 @@ describe('ReleaseDataUploadsSection', () => {
       });
 
       const modal = within(screen.getByRole('dialog'));
-      await user.click(modal.getByRole('button', {name: 'Cancel'}));
+      await user.click(modal.getByRole('button', { name: 'Cancel' }));
 
       await waitFor(() => {
         expect(releaseDataFileService.cancelImport).not.toHaveBeenCalled();
@@ -1368,7 +1368,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       expect(
-        section.getByRole('button', {name: 'Cancel'}),
+        section.getByRole('button', { name: 'Cancel' }),
       ).toBeInTheDocument();
     });
 
@@ -1379,7 +1379,7 @@ describe('ReleaseDataUploadsSection', () => {
       releaseDataFileService.getDataFiles.mockResolvedValue([
         testUploadedDataFile,
       ]);
-      const {user} = render(
+      const { user } = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1395,7 +1395,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section = getAccordionSection(0);
 
-      await user.click(section.getByRole('button', {name: 'Cancel'}));
+      await user.click(section.getByRole('button', { name: 'Cancel' }));
 
       await waitFor(() => {
         expect(
@@ -1404,7 +1404,7 @@ describe('ReleaseDataUploadsSection', () => {
       });
 
       const modal = within(screen.getByRole('dialog'));
-      await user.click(modal.getByRole('button', {name: 'Confirm'}));
+      await user.click(modal.getByRole('button', { name: 'Confirm' }));
 
       await waitFor(() => {
         expect(releaseDataFileService.cancelImport).toHaveBeenCalledWith(
@@ -1422,7 +1422,7 @@ describe('ReleaseDataUploadsSection', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
       expect(
-        section.queryByRole('button', {name: 'Cancel'}),
+        section.queryByRole('button', { name: 'Cancel' }),
       ).not.toBeInTheDocument();
 
       expect(screen.getByText('Cancellation failed')).toBeInTheDocument();

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -5,9 +5,9 @@ import _releaseDataFileService, {
   UploadDataFilesRequest,
   UploadZipDataFileRequest,
 } from '@admin/services/releaseDataFileService';
-import { screen, waitFor, within } from '@testing-library/react';
+import {screen, waitFor, within} from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter } from 'react-router';
+import {MemoryRouter} from 'react-router';
 import _permissionService, {
   DataFilePermissions,
 } from '@admin/services/permissionService';
@@ -150,7 +150,7 @@ describe('ReleaseDataUploadsSection', () => {
     const section1 = within(sections[0]);
 
     expect(
-      section1.getByRole('button', { name: /Test data 1/ }),
+      section1.getByRole('button', {name: /Test data 1/}),
     ).toBeInTheDocument();
 
     expect(section1.getByTestId('Subject title')).toHaveTextContent(
@@ -173,7 +173,7 @@ describe('ReleaseDataUploadsSection', () => {
     const section2 = within(sections[1]);
 
     expect(
-      section2.getByRole('button', { name: /Test data 2/ }),
+      section2.getByRole('button', {name: /Test data 2/}),
     ).toBeInTheDocument();
 
     expect(section2.getByTestId('Subject title')).toHaveTextContent(
@@ -227,7 +227,7 @@ describe('ReleaseDataUploadsSection', () => {
     const section1 = getAccordionSection(0);
 
     expect(
-      section1.getByRole('button', { name: /Test data 1/ }),
+      section1.getByRole('button', {name: /Test data 1/}),
     ).toBeInTheDocument();
 
     expect(section1.getByTestId('Status')).toHaveTextContent(
@@ -262,7 +262,7 @@ describe('ReleaseDataUploadsSection', () => {
   describe('deleting data file', () => {
     test('does not render delete files button if file is not ready for deletion', async () => {
       releaseDataFileService.getDataFiles.mockResolvedValue([
-        { ...testDataFiles[0], status: 'QUEUED' },
+        {...testDataFiles[0], status: 'QUEUED'},
         testDataFiles[1],
       ]);
       releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
@@ -288,13 +288,13 @@ describe('ReleaseDataUploadsSection', () => {
       const section1 = within(sections[0]);
       expect(section1.getByTestId('Status')).toHaveTextContent('Queued');
       expect(
-        section1.queryByRole('button', { name: 'Delete files' }),
+        section1.queryByRole('button', {name: 'Delete files'}),
       ).not.toBeInTheDocument();
 
       const section2 = within(sections[1]);
       expect(section2.getByTestId('Status')).toHaveTextContent('Complete');
       expect(
-        section2.getByRole('button', { name: 'Delete files' }),
+        section2.getByRole('button', {name: 'Delete files'}),
       ).toBeInTheDocument();
     });
 
@@ -327,7 +327,7 @@ describe('ReleaseDataUploadsSection', () => {
         footnoteIds: ['footnote-1'],
       });
 
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -411,7 +411,7 @@ describe('ReleaseDataUploadsSection', () => {
       });
       releaseDataFileService.deleteDataFiles.mockResolvedValue();
 
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -466,7 +466,7 @@ describe('ReleaseDataUploadsSection', () => {
   describe('replace data file', () => {
     test('does not render replace data button if file import is not completed', async () => {
       releaseDataFileService.getDataFiles.mockResolvedValue([
-        { ...testDataFiles[0], status: 'QUEUED' },
+        {...testDataFiles[0], status: 'QUEUED'},
         testDataFiles[1],
       ]);
       releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
@@ -493,19 +493,19 @@ describe('ReleaseDataUploadsSection', () => {
       const section1 = within(sections[0]);
       expect(section1.getByTestId('Status')).toHaveTextContent('Queued');
       expect(
-        section1.queryByRole('link', { name: 'Replace data' }),
+        section1.queryByRole('link', {name: 'Replace data'}),
       ).not.toBeInTheDocument();
 
       const section2 = within(sections[1]);
       expect(section2.getByTestId('Status')).toHaveTextContent('Complete');
       expect(
-        section2.getByRole('link', { name: 'Replace data' }),
+        section2.getByRole('link', {name: 'Replace data'}),
       ).toBeInTheDocument();
     });
 
     test('renders replace data button with correct link', async () => {
       releaseDataFileService.getDataFiles.mockResolvedValue([
-        { ...testDataFiles[0], status: 'QUEUED' },
+        {...testDataFiles[0], status: 'QUEUED'},
         testDataFiles[1],
       ]);
       releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
@@ -530,7 +530,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section2 = within(sections[1]);
       expect(
-        section2.getByRole('link', { name: 'Replace data' }),
+        section2.getByRole('link', {name: 'Replace data'}),
       ).toHaveAttribute(
         'href',
         '/publication/publication-1/release/release-1/data/data-2/replace',
@@ -544,7 +544,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('show validation message when no subject title', async () => {
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -570,7 +570,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('shows validation message when non-unique subject title', async () => {
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -600,7 +600,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('cannot submit with invalid values when trying to upload CSV files', async () => {
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -644,7 +644,7 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('cannot submit with invalid values when trying to upload ZIP file', async () => {
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -690,11 +690,11 @@ describe('ReleaseDataUploadsSection', () => {
     });
 
     test('cannot submit with invalid values when trying to upload bulk ZIP file', async () => {
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -725,7 +725,7 @@ describe('ReleaseDataUploadsSection', () => {
       releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
         testQueuedImportStatus,
       );
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -773,13 +773,13 @@ describe('ReleaseDataUploadsSection', () => {
       const section1 = within(sections[0]);
 
       expect(
-        section1.getByRole('button', { name: /Test data 1/ }),
+        section1.getByRole('button', {name: /Test data 1/}),
       ).toBeInTheDocument();
 
       const section2 = within(sections[1]);
 
       expect(
-        section2.getByRole('button', { name: /Test data 2/ }),
+        section2.getByRole('button', {name: /Test data 2/}),
       ).toBeInTheDocument();
 
       expect(section2.getByTestId('Subject title')).toHaveTextContent(
@@ -789,7 +789,7 @@ describe('ReleaseDataUploadsSection', () => {
       const section3 = within(sections[2]);
 
       expect(
-        section3.getByRole('button', { name: /Test title/ }),
+        section3.getByRole('button', {name: /Test title/}),
       ).toBeInTheDocument();
 
       expect(section3.getByTestId('Subject title')).toHaveTextContent(
@@ -825,7 +825,7 @@ describe('ReleaseDataUploadsSection', () => {
         testQueuedImportStatus,
       );
 
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -868,11 +868,11 @@ describe('ReleaseDataUploadsSection', () => {
       expect(sections).toHaveLength(3);
 
       expect(
-        section1.getByRole('button', { name: /Test data 1/ }),
+        section1.getByRole('button', {name: /Test data 1/}),
       ).toBeInTheDocument();
 
       expect(
-        section2.getByRole('button', { name: /Test data 2/ }),
+        section2.getByRole('button', {name: /Test data 2/}),
       ).toBeInTheDocument();
 
       expect(section2.getByTestId('Subject title')).toHaveTextContent(
@@ -880,7 +880,7 @@ describe('ReleaseDataUploadsSection', () => {
       );
 
       expect(
-        section3.getByRole('button', { name: /Test zip title/ }),
+        section3.getByRole('button', {name: /Test zip title/}),
       ).toBeInTheDocument();
 
       expect(section3.getByTestId('Subject title')).toHaveTextContent(
@@ -924,11 +924,11 @@ describe('ReleaseDataUploadsSection', () => {
         testQueuedImportStatus,
       );
 
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
-            releaseId="release-1"
+            releaseVersionId="release-1"
             canUpdateRelease
           />
         </MemoryRouter>,
@@ -962,15 +962,15 @@ describe('ReleaseDataUploadsSection', () => {
       expect(sections).toHaveLength(4);
 
       expect(
-        section1.getByRole('button', { name: /Test data 1/ }),
+        section1.getByRole('button', {name: /Test data 1/}),
       ).toBeInTheDocument();
 
       expect(
-        section2.getByRole('button', { name: /Test data 2/ }),
+        section2.getByRole('button', {name: /Test data 2/}),
       ).toBeInTheDocument();
 
       expect(
-        section3.getByRole('button', { name: /Test zip title/ }),
+        section3.getByRole('button', {name: /Test zip title/}),
       ).toBeInTheDocument();
       expect(section3.getByTestId('Subject title')).toHaveTextContent(
         'Test zip title',
@@ -996,7 +996,7 @@ describe('ReleaseDataUploadsSection', () => {
       );
 
       expect(
-        section4.getByRole('button', { name: /Test zip title 2/ }),
+        section4.getByRole('button', {name: /Test zip title 2/}),
       ).toBeInTheDocument();
       expect(section4.getByTestId('Subject title')).toHaveTextContent(
         'Test zip title 2',
@@ -1034,7 +1034,7 @@ describe('ReleaseDataUploadsSection', () => {
         {} as DataFilePermissions,
       );
 
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1101,7 +1101,7 @@ describe('ReleaseDataUploadsSection', () => {
         {} as DataFilePermissions,
       );
 
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1180,7 +1180,7 @@ describe('ReleaseDataUploadsSection', () => {
         const section = getAccordionSection(0);
 
         expect(
-          section.getByRole('button', { name: 'Cancel' }),
+          section.getByRole('button', {name: 'Cancel'}),
         ).toBeInTheDocument();
       });
 
@@ -1214,7 +1214,7 @@ describe('ReleaseDataUploadsSection', () => {
         const section = getAccordionSection(0);
 
         expect(
-          section.queryByRole('button', { name: 'Cancel' }),
+          section.queryByRole('button', {name: 'Cancel'}),
         ).not.toBeInTheDocument();
       });
     });
@@ -1232,7 +1232,7 @@ describe('ReleaseDataUploadsSection', () => {
         testUploadedDataFile,
       ]);
 
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1248,7 +1248,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section = getAccordionSection(0);
 
-      await user.click(section.getByRole('button', { name: 'Cancel' }));
+      await user.click(section.getByRole('button', {name: 'Cancel'}));
 
       await waitFor(() => {
         expect(
@@ -1268,10 +1268,10 @@ describe('ReleaseDataUploadsSection', () => {
         ),
       ).toBeInTheDocument();
 
-      expect(modal.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+      expect(modal.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
 
       expect(
-        modal.getByRole('button', { name: 'Confirm' }),
+        modal.getByRole('button', {name: 'Confirm'}),
       ).toBeInTheDocument();
     });
 
@@ -1280,7 +1280,7 @@ describe('ReleaseDataUploadsSection', () => {
         testUploadedDataFile,
       ]);
 
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1296,7 +1296,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section = getAccordionSection(0);
 
-      await user.click(section.getByRole('button', { name: 'Cancel' }));
+      await user.click(section.getByRole('button', {name: 'Cancel'}));
 
       await waitFor(() => {
         expect(
@@ -1305,7 +1305,7 @@ describe('ReleaseDataUploadsSection', () => {
       });
 
       const modal = within(screen.getByRole('dialog'));
-      await user.click(modal.getByRole('button', { name: 'Confirm' }));
+      await user.click(modal.getByRole('button', {name: 'Confirm'}));
 
       await waitFor(() => {
         expect(releaseDataFileService.cancelImport).toHaveBeenCalledWith(
@@ -1322,7 +1322,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       expect(
-        section.queryByRole('button', { name: 'Cancel' }),
+        section.queryByRole('button', {name: 'Cancel'}),
       ).not.toBeInTheDocument();
     });
 
@@ -1331,7 +1331,7 @@ describe('ReleaseDataUploadsSection', () => {
         testUploadedDataFile,
       ]);
 
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1347,7 +1347,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section = getAccordionSection(0);
 
-      await user.click(section.getByRole('button', { name: 'Cancel' }));
+      await user.click(section.getByRole('button', {name: 'Cancel'}));
 
       await waitFor(() => {
         expect(
@@ -1356,7 +1356,7 @@ describe('ReleaseDataUploadsSection', () => {
       });
 
       const modal = within(screen.getByRole('dialog'));
-      await user.click(modal.getByRole('button', { name: 'Cancel' }));
+      await user.click(modal.getByRole('button', {name: 'Cancel'}));
 
       await waitFor(() => {
         expect(releaseDataFileService.cancelImport).not.toHaveBeenCalled();
@@ -1368,7 +1368,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       expect(
-        section.getByRole('button', { name: 'Cancel' }),
+        section.getByRole('button', {name: 'Cancel'}),
       ).toBeInTheDocument();
     });
 
@@ -1379,7 +1379,7 @@ describe('ReleaseDataUploadsSection', () => {
       releaseDataFileService.getDataFiles.mockResolvedValue([
         testUploadedDataFile,
       ]);
-      const { user } = render(
+      const {user} = render(
         <MemoryRouter>
           <ReleaseDataUploadsSection
             publicationId="publication-1"
@@ -1395,7 +1395,7 @@ describe('ReleaseDataUploadsSection', () => {
 
       const section = getAccordionSection(0);
 
-      await user.click(section.getByRole('button', { name: 'Cancel' }));
+      await user.click(section.getByRole('button', {name: 'Cancel'}));
 
       await waitFor(() => {
         expect(
@@ -1404,7 +1404,7 @@ describe('ReleaseDataUploadsSection', () => {
       });
 
       const modal = within(screen.getByRole('dialog'));
-      await user.click(modal.getByRole('button', { name: 'Confirm' }));
+      await user.click(modal.getByRole('button', {name: 'Confirm'}));
 
       await waitFor(() => {
         expect(releaseDataFileService.cancelImport).toHaveBeenCalledWith(
@@ -1422,7 +1422,7 @@ describe('ReleaseDataUploadsSection', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
       expect(
-        section.queryByRole('button', { name: 'Cancel' }),
+        section.queryByRole('button', {name: 'Cancel'}),
       ).not.toBeInTheDocument();
 
       expect(screen.getByText('Cancellation failed')).toBeInTheDocument();

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseFileUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseFileUploadsSection.test.tsx
@@ -46,7 +46,7 @@ describe('ReleaseFileUploadsSection', () => {
       <MemoryRouter>
         <ReleaseFileUploadsSection
           publicationId="publication-1"
-          releaseId="release-1"
+          releaseVersionId="release-1"
           canUpdateRelease
         />
       </MemoryRouter>,

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReorderFiltersList.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReorderFiltersList.test.tsx
@@ -112,7 +112,7 @@ describe('ReorderFiltersList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderFiltersList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -162,7 +162,7 @@ describe('ReorderFiltersList', () => {
     );
     render(
       <ReorderFiltersList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -179,7 +179,7 @@ describe('ReorderFiltersList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderFiltersList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -209,7 +209,7 @@ describe('ReorderFiltersList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderFiltersList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -256,7 +256,7 @@ describe('ReorderFiltersList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderFiltersList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -286,7 +286,7 @@ describe('ReorderFiltersList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderFiltersList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -324,7 +324,7 @@ describe('ReorderFiltersList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderFiltersList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -376,7 +376,7 @@ describe('ReorderFiltersList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderFiltersList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -407,7 +407,7 @@ describe('ReorderFiltersList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderFiltersList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={handleSave}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReorderIndicatorsList.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReorderIndicatorsList.test.tsx
@@ -74,7 +74,7 @@ describe('ReorderIndicatorsList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderIndicatorsList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -115,7 +115,7 @@ describe('ReorderIndicatorsList', () => {
     );
     render(
       <ReorderIndicatorsList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -132,7 +132,7 @@ describe('ReorderIndicatorsList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderIndicatorsList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -164,7 +164,7 @@ describe('ReorderIndicatorsList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderIndicatorsList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -194,7 +194,7 @@ describe('ReorderIndicatorsList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderIndicatorsList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={noop}
@@ -225,7 +225,7 @@ describe('ReorderIndicatorsList', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     render(
       <ReorderIndicatorsList
-        releaseId="release-1"
+        releaseVersionId="release-1"
         subject={testSubject}
         onCancel={noop}
         onSave={handleSave}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockCreatePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockCreatePage.tsx
@@ -19,12 +19,12 @@ const ReleaseDataBlockCreatePage = ({
   history,
 }: RouteComponentProps<ReleaseRouteParams>) => {
   const {
-    params: { publicationId, releaseId },
+    params: { publicationId, releaseVersionId },
   } = match;
 
   const { value: canUpdateRelease, isLoading } = useAsyncHandledRetry(
-    () => permissionService.canUpdateRelease(releaseId),
-    [releaseId],
+    () => permissionService.canUpdateRelease(releaseVersionId),
+    [releaseVersionId],
   );
 
   const handleDataBlockSave = useCallback(
@@ -34,13 +34,13 @@ const ReleaseDataBlockCreatePage = ({
           releaseDataBlockEditRoute.path,
           {
             publicationId,
-            releaseId,
+            releaseVersionId,
             dataBlockId: dataBlock.id,
           },
         ),
       );
     },
-    [history, publicationId, releaseId],
+    [history, publicationId, releaseVersionId],
   );
 
   return (
@@ -50,7 +50,7 @@ const ReleaseDataBlockCreatePage = ({
         className="govuk-!-margin-bottom-6"
         to={generatePath<ReleaseRouteParams>(releaseDataBlocksRoute.path, {
           publicationId,
-          releaseId,
+          releaseVersionId,
         })}
       >
         Back
@@ -62,7 +62,7 @@ const ReleaseDataBlockCreatePage = ({
         <section>
           {canUpdateRelease ? (
             <DataBlockPageTabs
-              releaseId={releaseId}
+              releaseVersionId={releaseVersionId}
               onDataBlockSave={handleDataBlockSave}
             />
           ) : (

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
@@ -33,7 +33,7 @@ const ReleaseDataBlockEditPage = ({
   history,
 }: RouteComponentProps<ReleaseDataBlockRouteParams>) => {
   const {
-    params: { publicationId, releaseId, dataBlockId },
+    params: { publicationId, releaseVersionId, dataBlockId },
   } = match;
 
   const config = useConfig();
@@ -48,14 +48,14 @@ const ReleaseDataBlockEditPage = ({
   } = useAsyncHandledRetry<Model>(async () => {
     const [dataBlock, canUpdateRelease] = await Promise.all([
       dataBlocksService.getDataBlock(dataBlockId),
-      permissionService.canUpdateRelease(releaseId),
+      permissionService.canUpdateRelease(releaseVersionId),
     ]);
 
     return {
       dataBlock,
       canUpdateRelease,
     };
-  }, [releaseId, dataBlockId]);
+  }, [releaseVersionId, dataBlockId]);
 
   const handleDataBlockSave = useCallback(
     async (nextDataBlock: ReleaseDataBlock) => {
@@ -84,10 +84,10 @@ const ReleaseDataBlockEditPage = ({
     history.push(
       generatePath<ReleaseRouteParams>(releaseDataBlocksRoute.path, {
         publicationId,
-        releaseId,
+        releaseVersionId,
       }),
     );
-  }, [history, publicationId, releaseId]);
+  }, [history, publicationId, releaseVersionId]);
 
   const { canUpdateRelease, dataBlock } = model ?? {};
 
@@ -98,7 +98,7 @@ const ReleaseDataBlockEditPage = ({
         className="govuk-!-margin-bottom-6"
         to={generatePath<ReleaseRouteParams>(releaseDataBlocksRoute.path, {
           publicationId,
-          releaseId,
+          releaseVersionId,
         })}
       >
         Back
@@ -110,7 +110,7 @@ const ReleaseDataBlockEditPage = ({
         <DataBlockSelector
           canUpdate={canUpdateRelease}
           publicationId={publicationId}
-          releaseId={releaseId}
+          releaseVersionId={releaseVersionId}
           dataBlockId={dataBlockId}
         />
 
@@ -160,13 +160,13 @@ const ReleaseDataBlockEditPage = ({
               {canUpdateRelease ? (
                 <DataBlockPageTabs
                   key={dataBlockId}
-                  releaseId={releaseId}
+                  releaseVersionId={releaseVersionId}
                   dataBlock={dataBlock}
                   onDataBlockSave={handleDataBlockSave}
                 />
               ) : (
                 <DataBlockPageReadOnlyTabs
-                  releaseId={releaseId}
+                  releaseId={releaseVersionId}
                   dataBlock={dataBlock}
                 />
               )}
@@ -174,7 +174,7 @@ const ReleaseDataBlockEditPage = ({
 
             {isDeleting && canUpdateRelease && (
               <DataBlockDeletePlanModal
-                releaseId={releaseId}
+                releaseId={releaseVersionId}
                 dataBlockId={dataBlockId}
                 onConfirm={handleDataBlockDelete}
                 onCancel={toggleDeleting.off}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
@@ -166,7 +166,7 @@ const ReleaseDataBlockEditPage = ({
                 />
               ) : (
                 <DataBlockPageReadOnlyTabs
-                  releaseId={releaseVersionId}
+                  releaseVersionId={releaseVersionId}
                   dataBlock={dataBlock}
                 />
               )}
@@ -174,7 +174,7 @@ const ReleaseDataBlockEditPage = ({
 
             {isDeleting && canUpdateRelease && (
               <DataBlockDeletePlanModal
-                releaseId={releaseVersionId}
+                releaseVersionId={releaseVersionId}
                 dataBlockId={dataBlockId}
                 onConfirm={handleDataBlockDelete}
                 onCancel={toggleDeleting.off}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
@@ -236,7 +236,7 @@ const ReleaseDataBlocksPage = ({
 
       {deleteDataBlock && (
         <DataBlockDeletePlanModal
-          releaseId={releaseVersionId}
+          releaseVersionId={releaseVersionId}
           dataBlockId={deleteDataBlock.id}
           onConfirm={handleDelete}
           onCancel={handleDeleteCancel}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
@@ -28,7 +28,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 const ReleaseDataBlocksPage = ({
   match,
 }: RouteComponentProps<ReleaseRouteParams>) => {
-  const { publicationId, releaseId } = match.params;
+  const { publicationId, releaseVersionId } = match.params;
 
   const [deleteDataBlock, setDeleteDataBlock] =
     useState<ReleaseDataBlockSummary>();
@@ -36,12 +36,12 @@ const ReleaseDataBlocksPage = ({
   const queryClient = useQueryClient();
 
   const listFeaturedTablesQuery = useMemo(
-    () => featuredTableQueries.list(releaseId),
-    [releaseId],
+    () => featuredTableQueries.list(releaseVersionId),
+    [releaseVersionId],
   );
   const listDataBlocksQuery = useMemo(
-    () => dataBlockQueries.list(releaseId),
-    [releaseId],
+    () => dataBlockQueries.list(releaseVersionId),
+    [releaseVersionId],
   );
 
   const { data: dataBlocks = [], isLoading: isLoadingDataBlocks } =
@@ -49,7 +49,7 @@ const ReleaseDataBlocksPage = ({
   const { data: featuredTables = [], isLoading: isLoadingFeaturedTables } =
     useQuery(listFeaturedTablesQuery);
   const { data: canUpdateRelease = true, isLoading: isLoadingPermissions } =
-    useQuery(permissionQueries.canUpdateRelease(releaseId));
+    useQuery(permissionQueries.canUpdateRelease(releaseVersionId));
 
   const handleDelete = useCallback(async () => {
     if (!deleteDataBlock) {
@@ -87,19 +87,19 @@ const ReleaseDataBlocksPage = ({
   const handleSaveOrder = useCallback(
     async (reorderedTables: FeaturedTable[]) => {
       await featuredTableService.reorderFeaturedTables(
-        releaseId,
+        releaseVersionId,
         reorderedTables?.map(table => table.id) ?? [],
       );
       await queryClient.invalidateQueries(listFeaturedTablesQuery.queryKey);
     },
-    [listFeaturedTablesQuery, queryClient, releaseId],
+    [listFeaturedTablesQuery, queryClient, releaseVersionId],
   );
 
   const createPath = generatePath<ReleaseRouteParams>(
     releaseDataBlockCreateRoute.path,
     {
       publicationId,
-      releaseId,
+      releaseVersionId,
     },
   );
 
@@ -141,7 +141,7 @@ const ReleaseDataBlocksPage = ({
           <ButtonLink
             to={generatePath<ReleaseRouteParams>(releaseTableToolRoute.path, {
               publicationId,
-              releaseId,
+              releaseVersionId,
             })}
           >
             Go to table tool
@@ -159,7 +159,7 @@ const ReleaseDataBlocksPage = ({
           dataBlocks={dataBlocks}
           featuredTables={featuredTables}
           publicationId={publicationId}
-          releaseId={releaseId}
+          releaseVersionId={releaseVersionId}
           onDelete={setDeleteDataBlock}
           onSaveOrder={handleSaveOrder}
         />
@@ -207,7 +207,7 @@ const ReleaseDataBlocksPage = ({
                         releaseDataBlockEditRoute.path,
                         {
                           publicationId,
-                          releaseId,
+                          releaseVersionId,
                           dataBlockId: dataBlock.id,
                         },
                       )}
@@ -236,7 +236,7 @@ const ReleaseDataBlocksPage = ({
 
       {deleteDataBlock && (
         <DataBlockDeletePlanModal
-          releaseId={releaseId}
+          releaseId={releaseVersionId}
           dataBlockId={deleteDataBlock.id}
           onConfirm={handleDelete}
           onCancel={handleDeleteCancel}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseTableToolPage.tsx
@@ -7,15 +7,15 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import ReleasePreviewTableTool from '@admin/pages/release/content/components/ReleasePreviewTableTool';
 import React from 'react';
 import { generatePath, RouteComponentProps } from 'react-router-dom';
-import { useReleaseContext } from '@admin/pages/release/contexts/ReleaseContext';
+import { useReleaseVersionContext } from '@admin/pages/release/contexts/ReleaseContext';
 import { useQuery } from '@tanstack/react-query';
 import publicationQueries from '@admin/queries/publicationQueries';
 
 const ReleaseTableToolPage = ({
   match,
 }: RouteComponentProps<ReleaseRouteParams>) => {
-  const { releaseId, publicationId } = match.params;
-  const { release } = useReleaseContext();
+  const { releaseVersionId, publicationId } = match.params;
+  const { releaseVersion } = useReleaseVersionContext();
 
   const { data: publication, isLoading } = useQuery(
     publicationQueries.get(publicationId),
@@ -28,7 +28,7 @@ const ReleaseTableToolPage = ({
         className="govuk-!-margin-bottom-6"
         to={generatePath<ReleaseRouteParams>(releaseDataBlocksRoute.path, {
           publicationId,
-          releaseId,
+          releaseVersionId,
         })}
       >
         Back
@@ -36,9 +36,9 @@ const ReleaseTableToolPage = ({
       <LoadingSpinner loading={isLoading}>
         {publication && (
           <ReleasePreviewTableTool
-            releaseId={releaseId}
+            releaseId={releaseVersionId}
             publication={publication}
-            releaseType={release.type}
+            releaseType={releaseVersion.type}
           />
         )}
       </LoadingSpinner>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseTableToolPage.tsx
@@ -36,7 +36,7 @@ const ReleaseTableToolPage = ({
       <LoadingSpinner loading={isLoading}>
         {publication && (
           <ReleasePreviewTableTool
-            releaseId={releaseVersionId}
+            releaseVersionId={releaseVersionId}
             publication={publication}
             releaseType={releaseVersion.type}
           />

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
@@ -546,7 +546,7 @@ describe('ReleaseDataBlockEditPage', () => {
               releaseDataBlockEditRoute.path,
               {
                 publicationId: 'publication-1',
-                releaseId: 'release-1',
+                releaseVersionId: 'release-1',
                 dataBlockId: 'block-1',
               },
             ),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksCreatePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksCreatePage.test.tsx
@@ -42,7 +42,7 @@ describe('ReleaseDataBlockCreatePage', () => {
               releaseDataBlockEditRoute.path,
               {
                 publicationId: 'publication-1',
-                releaseId: 'release-1',
+                releaseVersionId: 'release-1',
                 dataBlockId: 'block-1',
               },
             ),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksPage.test.tsx
@@ -470,7 +470,7 @@ describe('ReleaseDataBlocksPage', () => {
       <MemoryRouter
         initialEntries={[
           generatePath<ReleaseRouteParams>(releaseDataBlocksRoute.path, {
-            releaseId: 'release-1',
+            releaseVersionId: 'release-1',
             publicationId: 'publication-1',
           }),
         ]}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
@@ -7,12 +7,12 @@ import {
 import _publicationService, {
   Publication,
 } from '@admin/services/publicationService';
-import { Release } from '@admin/services/releaseService';
+import { ReleaseVersion } from '@admin/services/releaseService';
 import _tableBuilderService from '@common/services/tableBuilderService';
 import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { generatePath, MemoryRouter, Route } from 'react-router-dom';
-import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
+import { ReleaseVersionContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
 
 jest.mock('@admin/services/publicationService');
 jest.mock('@admin/services/permissionService');
@@ -35,7 +35,7 @@ const testPublication: Publication = {
   topic: { id: 'topic-1', title: 'Test topic' },
 };
 
-const testRelease: Release = {
+const testRelease: ReleaseVersion = {
   id: '123',
   releaseId: '456',
   slug: '123',
@@ -131,16 +131,16 @@ describe('ReleaseTableToolPage', () => {
         initialEntries={[
           generatePath<ReleaseRouteParams>(releaseTableToolRoute.path, {
             publicationId: 'publication-1',
-            releaseId: 'release-1',
+            releaseVersionId: 'release-1',
           }),
         ]}
       >
-        <ReleaseContextProvider release={testRelease}>
+        <ReleaseVersionContextProvider releaseVersion={testRelease}>
           <Route
             component={ReleaseTableToolPage}
             path={releaseTableToolRoute.path}
           />
-        </ReleaseContextProvider>
+        </ReleaseVersionContextProvider>
       </MemoryRouter>,
     );
   };

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDeletePlanModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDeletePlanModal.tsx
@@ -4,7 +4,7 @@ import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import React from 'react';
 
 interface Props {
-  releaseId: string;
+  releaseVersionId: string;
   dataBlockId: string;
   onConfirm: () => void;
   onCancel: () => void;
@@ -12,15 +12,15 @@ interface Props {
 }
 
 const DataBlockDeletePlanModal = ({
-  releaseId,
+  releaseVersionId,
   dataBlockId,
   onConfirm,
   onCancel,
   onExit,
 }: Props) => {
   const { value: deletePlan } = useAsyncRetry(
-    () => dataBlocksService.getDeleteBlockPlan(releaseId, dataBlockId),
-    [releaseId, dataBlockId],
+    () => dataBlocksService.getDeleteBlockPlan(releaseVersionId, dataBlockId),
+    [releaseVersionId, dataBlockId],
   );
 
   if (!deletePlan) {
@@ -32,7 +32,7 @@ const DataBlockDeletePlanModal = ({
       title="Delete data block"
       open
       onConfirm={async () => {
-        await dataBlocksService.deleteDataBlock(releaseId, dataBlockId);
+        await dataBlocksService.deleteDataBlock(releaseVersionId, dataBlockId);
         onConfirm();
       }}
       onExit={onExit}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
@@ -22,6 +22,7 @@ interface Model {
 }
 
 interface Props {
+  // TODO rename to releaseVersionId
   releaseId: string;
   dataBlock: ReleaseDataBlock;
 }

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
@@ -30,12 +30,15 @@ interface Props {
 const testId = (dataBlock: ReleaseDataBlock) =>
   `Data block - ${dataBlock.name}`;
 
-const DataBlockPageReadOnlyTabs = ({ releaseId, dataBlock }: Props) => {
+const DataBlockPageReadOnlyTabs = ({ releaseVersionId, dataBlock }: Props) => {
   const { value: model, isLoading } = useAsyncRetry<Model>(async () => {
-    const tableData = await tableBuilderService.getTableData(
-      dataBlock.query,
-      releaseId,
-    );
+    const query: ReleaseTableDataQuery = {
+      ...dataBlock.query,
+      // TODO rename to releaseVersionId
+      releaseId: releaseVersionId,
+    };
+
+    const tableData = await tableBuilderService.getTableData(query);
     const table = mapFullTable(tableData);
 
     const tableHeaders = mapTableHeadersConfig(
@@ -47,7 +50,7 @@ const DataBlockPageReadOnlyTabs = ({ releaseId, dataBlock }: Props) => {
       table,
       tableHeaders,
     };
-  }, [releaseId, dataBlock]);
+  }, [releaseVersionId, dataBlock]);
 
   return (
     <LoadingSpinner text="Loading data block" loading={isLoading}>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
@@ -1,14 +1,14 @@
 import TableTabSection from '@admin/pages/release/datablocks/components/TableTabSection';
-import {ReleaseDataBlock} from '@admin/services/dataBlockService';
+import { ReleaseDataBlock } from '@admin/services/dataBlockService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import ChartRenderer from '@common/modules/charts/components/ChartRenderer';
-import {AxesConfiguration} from '@common/modules/charts/types/chart';
-import {FullTable} from '@common/modules/table-tool/types/fullTable';
-import {TableHeadersConfig} from '@common/modules/table-tool/types/tableHeaders';
+import { AxesConfiguration } from '@common/modules/charts/types/chart';
+import { FullTable } from '@common/modules/table-tool/types/fullTable';
+import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
 import tableBuilderService, {
@@ -29,8 +29,8 @@ interface Props {
 const testId = (dataBlock: ReleaseDataBlock) =>
   `Data block - ${dataBlock.name}`;
 
-const DataBlockPageReadOnlyTabs = ({releaseVersionId, dataBlock}: Props) => {
-  const {value: model, isLoading} = useAsyncRetry<Model>(async () => {
+const DataBlockPageReadOnlyTabs = ({ releaseVersionId, dataBlock }: Props) => {
+  const { value: model, isLoading } = useAsyncRetry<Model>(async () => {
     const query: ReleaseTableDataQuery = {
       ...dataBlock.query,
       // TODO rename to releaseVersionId
@@ -73,7 +73,7 @@ const DataBlockPageReadOnlyTabs = ({releaseVersionId, dataBlock}: Props) => {
                 {dataBlock.charts.map((chart, index) => {
                   const key = index;
 
-                  const axes = {...chart.axes} as Required<AxesConfiguration>;
+                  const axes = { ...chart.axes } as Required<AxesConfiguration>;
 
                   return (
                     <ChartRenderer

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
@@ -1,14 +1,14 @@
 import TableTabSection from '@admin/pages/release/datablocks/components/TableTabSection';
-import { ReleaseDataBlock } from '@admin/services/dataBlockService';
+import {ReleaseDataBlock} from '@admin/services/dataBlockService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import ChartRenderer from '@common/modules/charts/components/ChartRenderer';
-import { AxesConfiguration } from '@common/modules/charts/types/chart';
-import { FullTable } from '@common/modules/table-tool/types/fullTable';
-import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
+import {AxesConfiguration} from '@common/modules/charts/types/chart';
+import {FullTable} from '@common/modules/table-tool/types/fullTable';
+import {TableHeadersConfig} from '@common/modules/table-tool/types/tableHeaders';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
 import tableBuilderService, {
@@ -22,16 +22,15 @@ interface Model {
 }
 
 interface Props {
-  // TODO rename to releaseVersionId
-  releaseId: string;
+  releaseVersionId: string;
   dataBlock: ReleaseDataBlock;
 }
 
 const testId = (dataBlock: ReleaseDataBlock) =>
   `Data block - ${dataBlock.name}`;
 
-const DataBlockPageReadOnlyTabs = ({ releaseVersionId, dataBlock }: Props) => {
-  const { value: model, isLoading } = useAsyncRetry<Model>(async () => {
+const DataBlockPageReadOnlyTabs = ({releaseVersionId, dataBlock}: Props) => {
+  const {value: model, isLoading} = useAsyncRetry<Model>(async () => {
     const query: ReleaseTableDataQuery = {
       ...dataBlock.query,
       // TODO rename to releaseVersionId
@@ -74,7 +73,7 @@ const DataBlockPageReadOnlyTabs = ({ releaseVersionId, dataBlock }: Props) => {
                 {dataBlock.charts.map((chart, index) => {
                   const key = index;
 
-                  const axes = { ...chart.axes } as Required<AxesConfiguration>;
+                  const axes = {...chart.axes} as Required<AxesConfiguration>;
 
                   return (
                     <ChartRenderer

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -66,7 +66,8 @@ const DataBlockPageTabs = ({
         initialStep: 1,
         subjects,
         query: {
-          releaseVersionId,
+          // TODO rename to releaseVersionId
+          releaseId: releaseVersionId,
           subjectId: '',
           locationIds: [],
           filters: [],
@@ -82,7 +83,7 @@ const DataBlockPageTabs = ({
       includeGeoJson: dataBlock.charts.some(chart => chart.type === 'map'),
     };
 
-    const tableData = await tableBuilderService.getTableData(query, releaseId);
+    const tableData = await tableBuilderService.getTableData(query);
     const { initialStep, subjectMeta } = await getInitialStepSubjectMeta(
       query,
       tableData,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -75,9 +75,10 @@ const DataBlockPageTabs = ({
       };
     }
 
+    // TODO rename to releaseVersionId
     const query: ReleaseTableDataQuery = {
       ...dataBlock.query,
-      releaseVersionId,
+      releaseId: releaseVersionId,
       includeGeoJson: dataBlock.charts.some(chart => chart.type === 'map'),
     };
 
@@ -189,7 +190,7 @@ const DataBlockPageTabs = ({
         ...nextDataBlock,
         query: {
           ...(omit(nextDataBlock.query, [
-            'releaseVersionId',
+            'releaseId',
           ]) as SavedDataBlock['query']),
         },
       };
@@ -410,7 +411,7 @@ const DataBlockPageTabs = ({
                   key={saveNumber}
                   dataBlock={dataBlock}
                   query={query}
-                  releaseId={releaseVersionId}
+                  releaseVersionId={releaseVersionId}
                   table={response.table}
                   onDataBlockSave={handleDataBlockSave}
                   onTableUpdate={handleChartTableUpdate}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -80,10 +80,12 @@ const DataBlockPageTabs = ({
     const query: ReleaseTableDataQuery = {
       ...dataBlock.query,
       releaseId: releaseVersionId,
-      includeGeoJson: dataBlock.charts.some(chart => chart.type === 'map'),
     };
 
-    const tableData = await tableBuilderService.getTableData(query);
+    const tableData = await tableBuilderService.getTableData(
+      query,
+      releaseVersionId,
+    );
     const { initialStep, subjectMeta } = await getInitialStepSubjectMeta(
       query,
       tableData,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSelector.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSelector.tsx
@@ -20,21 +20,21 @@ const emptyDataBlocks: ReleaseDataBlockSummary[] = [];
 interface Props {
   canUpdate?: boolean;
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
   dataBlockId: string;
 }
 
 const DataBlockSelector = ({
   canUpdate = true,
   publicationId,
-  releaseId,
+  releaseVersionId,
   dataBlockId,
 }: Props) => {
   const history = useHistory();
 
   const { value: dataBlocks = emptyDataBlocks, isLoading } = useAsyncRetry(
-    () => dataBlockService.listDataBlocks(releaseId),
-    [releaseId],
+    () => dataBlockService.listDataBlocks(releaseVersionId),
+    [releaseVersionId],
   );
 
   const dataBlockOptions = useMemo<SelectOption[]>(() => {
@@ -52,7 +52,7 @@ const DataBlockSelector = ({
     releaseDataBlockCreateRoute.path,
     {
       publicationId,
-      releaseId,
+      releaseVersionId,
     },
   );
 
@@ -82,7 +82,7 @@ const DataBlockSelector = ({
                 releaseDataBlockEditRoute.path,
                 {
                   publicationId,
-                  releaseId,
+                  releaseVersionId,
                   dataBlockId: e.target.value,
                 },
               ),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/FeaturedTablesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/FeaturedTablesTable.tsx
@@ -22,7 +22,7 @@ interface Props {
   dataBlocks: ReleaseDataBlockSummary[];
   featuredTables: FeaturedTable[];
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
   onDelete: (dataBlock: ReleaseDataBlockSummary) => void;
   onSaveOrder: (reorderedTables: FeaturedTable[]) => Promise<void>;
 }
@@ -32,7 +32,7 @@ export default function FeaturedTablesTable({
   dataBlocks,
   featuredTables,
   publicationId,
-  releaseId,
+  releaseVersionId,
   onDelete,
   onSaveOrder,
 }: Props) {
@@ -125,7 +125,7 @@ export default function FeaturedTablesTable({
                             releaseDataBlockEditRoute.path,
                             {
                               publicationId,
-                              releaseId,
+                              releaseVersionId,
                               dataBlockId: featuredTable.dataBlockId,
                             },
                           )}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
@@ -88,7 +88,12 @@ describe('DataBlockPageTabs', () => {
   test('renders uninitialised table tool when no data block is selected', async () => {
     tableBuilderService.listReleaseSubjects.mockResolvedValue(testSubjects);
 
-    render(<DataBlockPageTabs releaseId="release-1" onDataBlockSave={noop} />);
+    render(
+      <DataBlockPageTabs
+        releaseVersionId="release-version-1"
+        onDataBlockSave={noop}
+      />,
+    );
 
     await waitFor(() => {
       const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
@@ -112,7 +117,12 @@ describe('DataBlockPageTabs', () => {
   test('renders the data source form without other tabs when no data block is selected', async () => {
     tableBuilderService.listReleaseSubjects.mockResolvedValue(testSubjects);
 
-    render(<DataBlockPageTabs releaseId="release-1" onDataBlockSave={noop} />);
+    render(
+      <DataBlockPageTabs
+        releaseVersionId="release-version-1"
+        onDataBlockSave={noop}
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Data source')).toBeInTheDocument();
@@ -130,7 +140,7 @@ describe('DataBlockPageTabs', () => {
 
     render(
       <DataBlockPageTabs
-        releaseId="release-1"
+        releaseVersionId="release-version-1"
         dataBlock={testDataBlock}
         onDataBlockSave={noop}
       />,
@@ -159,7 +169,7 @@ describe('DataBlockPageTabs', () => {
 
     render(
       <DataBlockPageTabs
-        releaseId="release-1"
+        releaseVersionId="release-version-1"
         dataBlock={testDataBlock}
         onDataBlockSave={noop}
       />,
@@ -185,7 +195,7 @@ describe('DataBlockPageTabs', () => {
 
     render(
       <DataBlockPageTabs
-        releaseId="release-1"
+        releaseVersionId="release-version-1"
         dataBlock={testDataBlock}
         onDataBlockSave={noop}
       />,
@@ -213,7 +223,7 @@ describe('DataBlockPageTabs', () => {
 
     render(
       <DataBlockPageTabs
-        releaseId="release-1"
+        releaseVersionId="release-version-1"
         dataBlock={{
           ...testDataBlock,
           table: {
@@ -254,7 +264,7 @@ describe('DataBlockPageTabs', () => {
 
       render(
         <DataBlockPageTabs
-          releaseId="release-1"
+          releaseVersionId="release-version-1"
           dataBlock={testDataBlock}
           onDataBlockSave={noop}
         />,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
@@ -101,7 +101,7 @@ export type TableQueryUpdateHandler = (
 interface Props {
   data: TableDataResult[];
   meta: FullTableMeta;
-  releaseId: string;
+  releaseVersionId: string;
   initialChart?: Chart;
   tableTitle: string;
   onChartSave: (chart: Chart, file?: File) => Promise<void>;
@@ -112,7 +112,7 @@ interface Props {
 const ChartBuilder = ({
   data,
   meta,
-  releaseId,
+  releaseVersionId,
   initialChart,
   tableTitle,
   onChartSave,
@@ -133,7 +133,7 @@ const ChartBuilder = ({
 
   const { axes, map, definition, options, legend } = chartBuilderState;
 
-  const getChartFile = useGetChartFile(releaseId);
+  const getChartFile = useGetChartFile(releaseVersionId);
 
   const [submitError, setSubmitError] = useState<ValidationProblemDetails>();
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
@@ -103,7 +103,7 @@ const ChartBuilderTabSection = ({
 
       const tableData = await tableBuilderService.getTableData(
         nextQuery,
-        releaseId,
+        releaseVersionId,
       );
 
       onTableUpdate({
@@ -111,7 +111,7 @@ const ChartBuilderTabSection = ({
         query: nextQuery,
       });
     },
-    [onTableUpdate, query, releaseId],
+    [onTableUpdate, query, releaseVersionId],
   );
 
   return (

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
@@ -22,7 +22,7 @@ export type ChartBuilderTableUpdateHandler = (params: {
 interface Props {
   dataBlock: ReleaseDataBlock;
   query: TableDataQuery;
-  releaseId: string;
+  releaseVersionId: string;
   table: FullTable;
   onDataBlockSave: (dataBlock: SavedDataBlock) => void;
   onTableUpdate: ChartBuilderTableUpdateHandler;
@@ -31,7 +31,7 @@ interface Props {
 const ChartBuilderTabSection = ({
   dataBlock,
   query,
-  releaseId,
+  releaseVersionId,
   table,
   onDataBlockSave,
   onTableUpdate,
@@ -52,7 +52,7 @@ const ChartBuilderTabSection = ({
 
       if (chart.type === 'infographic' && file) {
         const { id } = await releaseChartFileService.uploadChartFile(
-          releaseId,
+          releaseVersionId,
           { file },
         );
 
@@ -68,14 +68,17 @@ const ChartBuilderTabSection = ({
         charts: [chartToSave],
       });
     },
-    [dataBlock, onDataBlockSave, query, releaseId],
+    [dataBlock, onDataBlockSave, query, releaseVersionId],
   );
 
   const handleChartDelete = useCallback(
     async (chart: Chart) => {
       // Cleanup potential infographic chart file if required
       if (chart.type === 'infographic' && chart.fileId) {
-        await releaseChartFileService.deleteChartFile(releaseId, chart.fileId);
+        await releaseChartFileService.deleteChartFile(
+          releaseVersionId,
+          chart.fileId,
+        );
       }
 
       await onDataBlockSave({
@@ -83,7 +86,7 @@ const ChartBuilderTabSection = ({
         charts: [],
       });
     },
-    [dataBlock, onDataBlockSave, releaseId],
+    [dataBlock, onDataBlockSave, releaseVersionId],
   );
 
   const handleTableQueryUpdate: TableQueryUpdateHandler = useCallback(
@@ -113,7 +116,7 @@ const ChartBuilderTabSection = ({
 
   return (
     <ChartBuilder
-      releaseId={releaseId}
+      releaseVersionId={releaseVersionId}
       data={table.results}
       meta={meta}
       initialChart={dataBlock.charts[0]}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilder.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilder.test.tsx
@@ -30,7 +30,7 @@ describe('ChartBuilder', () => {
     render(
       <ChartBuilderFormsContextProvider initialForms={testFormState}>
         <ChartBuilder
-          releaseId="release-1"
+          releaseVersionId="release-1"
           data={testFullTable.results}
           meta={testFullTable.subjectMeta}
           tableTitle="Table title"
@@ -68,7 +68,7 @@ describe('ChartBuilder', () => {
     render(
       <ChartBuilderFormsContextProvider initialForms={testFormState}>
         <ChartBuilder
-          releaseId="release-1"
+          releaseVersionId="release-1"
           data={testFullTable.results}
           meta={testFullTable.subjectMeta}
           tableTitle="Table title"
@@ -114,7 +114,7 @@ describe('ChartBuilder', () => {
       const { user } = render(
         <ChartBuilderFormsContextProvider initialForms={testFormState}>
           <ChartBuilder
-            releaseId="release-1"
+            releaseVersionId="release-1"
             data={testFullTable.results}
             meta={testFullTable.subjectMeta}
             tableTitle="Table title"
@@ -192,7 +192,7 @@ describe('ChartBuilder', () => {
       render(
         <ChartBuilderFormsContextProvider initialForms={testFormState}>
           <ChartBuilder
-            releaseId="release-1"
+            releaseVersionId="release-1"
             data={testFullTable.results}
             meta={testFullTable.subjectMeta}
             tableTitle="Table title"
@@ -269,7 +269,7 @@ describe('ChartBuilder', () => {
       const { user } = render(
         <ChartBuilderFormsContextProvider initialForms={testFormState}>
           <ChartBuilder
-            releaseId="release-1"
+            releaseVersionId="release-1"
             data={testFullTable.results}
             meta={testFullTable.subjectMeta}
             tableTitle="Table title"

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/ReleaseFootnoteCreatePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/ReleaseFootnoteCreatePage.tsx
@@ -14,18 +14,18 @@ const ReleaseFootnoteCreatePage = ({
   match,
   history,
 }: RouteComponentProps<ReleaseRouteParams>) => {
-  const { publicationId, releaseId } = match.params;
+  const { publicationId, releaseVersionId } = match.params;
 
   const { value: footnoteMeta, isLoading } = useAsyncHandledRetry(
-    () => footnoteService.getFootnoteMeta(releaseId),
-    [releaseId],
+    () => footnoteService.getFootnoteMeta(releaseVersionId),
+    [releaseVersionId],
   );
 
   const footnotesPath = generatePath<ReleaseRouteParams>(
     releaseFootnotesRoute.path,
     {
       publicationId,
-      releaseId,
+      releaseVersionId,
     },
   );
 
@@ -42,7 +42,7 @@ const ReleaseFootnoteCreatePage = ({
           <FootnoteForm
             footnoteMeta={footnoteMeta}
             onSubmit={async values => {
-              await footnoteService.createFootnote(releaseId, values);
+              await footnoteService.createFootnote(releaseVersionId, values);
               history.push(footnotesPath);
             }}
             cancelButton={

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/ReleaseFootnoteEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/ReleaseFootnoteEditPage.tsx
@@ -15,25 +15,25 @@ const ReleaseFootnoteEditPage = ({
   match,
   history,
 }: RouteComponentProps<ReleaseFootnoteRouteParams>) => {
-  const { publicationId, releaseId, footnoteId } = match.params;
+  const { publicationId, releaseVersionId, footnoteId } = match.params;
 
   const { value: footnoteMeta, isLoading: isFootnoteMetaLoading } =
     useAsyncHandledRetry(
-      () => footnoteService.getFootnoteMeta(releaseId),
-      [releaseId],
+      () => footnoteService.getFootnoteMeta(releaseVersionId),
+      [releaseVersionId],
     );
 
   const { value: footnote, isLoading: isFootnoteLoading } =
     useAsyncHandledRetry(
-      () => footnoteService.getFootnote(releaseId, footnoteId),
-      [releaseId, footnoteId],
+      () => footnoteService.getFootnote(releaseVersionId, footnoteId),
+      [releaseVersionId, footnoteId],
     );
 
   const footnotesPath = generatePath<ReleaseRouteParams>(
     releaseFootnotesRoute.path,
     {
       publicationId,
-      releaseId,
+      releaseVersionId,
     },
   );
 
@@ -52,7 +52,7 @@ const ReleaseFootnoteEditPage = ({
             footnoteMeta={footnoteMeta}
             onSubmit={async values => {
               await footnoteService.updateFootnote(
-                releaseId,
+                releaseVersionId,
                 footnoteId,
                 values,
               );

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/ReleaseFootnotesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/ReleaseFootnotesPage.tsx
@@ -21,19 +21,19 @@ import { generatePath, RouteComponentProps } from 'react-router';
 const ReleaseFootnotesPage = ({
   match,
 }: RouteComponentProps<ReleaseRouteParams>) => {
-  const { publicationId, releaseId } = match.params;
+  const { publicationId, releaseVersionId } = match.params;
   const [isReordering, toggleIsReordering] = useToggle(false);
 
   const { value: canUpdateRelease = false, isLoading: isPermissionLoading } =
     useAsyncHandledRetry(
-      () => permissionService.canUpdateRelease(releaseId),
-      [releaseId],
+      () => permissionService.canUpdateRelease(releaseVersionId),
+      [releaseVersionId],
     );
 
   const { value: footnoteMeta, isLoading: isFootnoteMetaLoading } =
     useAsyncHandledRetry(
-      () => footnoteService.getFootnoteMeta(releaseId),
-      [releaseId],
+      () => footnoteService.getFootnoteMeta(releaseVersionId),
+      [releaseVersionId],
     );
 
   const {
@@ -41,8 +41,8 @@ const ReleaseFootnotesPage = ({
     setState: setFootnotes,
     isLoading: isFootnotesLoading,
   } = useAsyncHandledRetry(
-    () => footnoteService.getFootnotes(releaseId),
-    [releaseId],
+    () => footnoteService.getFootnotes(releaseVersionId),
+    [releaseVersionId],
   );
 
   const handleReorder = (reorderedFootnotes: Footnote[]) => {
@@ -53,7 +53,7 @@ const ReleaseFootnotesPage = ({
 
   const handleSaveOrder = async () => {
     await footnoteService.updateFootnotesOrder(
-      releaseId,
+      releaseVersionId,
       footnotes?.map(footnote => footnote.id) ?? [],
     );
   };
@@ -71,7 +71,7 @@ const ReleaseFootnotesPage = ({
           <Link
             to={generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
               publicationId,
-              releaseId,
+              releaseVersionId,
             })}
           >
             Data and files
@@ -96,7 +96,7 @@ const ReleaseFootnotesPage = ({
                   releaseFootnotesCreateRoute.path,
                   {
                     publicationId,
-                    releaseId,
+                    releaseVersionId,
                   },
                 )}
               >
@@ -123,13 +123,13 @@ const ReleaseFootnotesPage = ({
 
         <FootnotesList
           publicationId={publicationId}
-          releaseId={releaseId}
+          releaseVersionId={releaseVersionId}
           footnotes={footnotes}
           footnoteMeta={footnoteMeta}
           canUpdateRelease={canUpdateRelease}
           isReordering={isReordering}
           onDelete={async footnote => {
-            await footnoteService.deleteFootnote(releaseId, footnote.id);
+            await footnoteService.deleteFootnote(releaseVersionId, footnote.id);
             setFootnotes({
               value: footnotes?.filter(f => f.id !== footnote.id),
             });

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/__tests__/ReleaseFootnotesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/__tests__/ReleaseFootnotesPage.test.tsx
@@ -279,7 +279,7 @@ function renderPage() {
   history.push(
     generatePath<ReleaseRouteParams>(releaseFootnotesRoute.path, {
       publicationId: 'publication-1',
-      releaseId: 'release-1',
+      releaseVersionId: 'release-1',
     }),
   );
 

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnotesList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnotesList.tsx
@@ -23,7 +23,7 @@ import ContentHtml from '@common/components/ContentHtml';
 
 interface Props {
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
   footnoteMeta: FootnoteMeta;
   footnotes: Footnote[];
   canUpdateRelease: boolean;
@@ -34,7 +34,7 @@ interface Props {
 
 const FootnotesList = ({
   publicationId,
-  releaseId,
+  releaseVersionId,
   footnotes,
   footnoteMeta,
   canUpdateRelease,
@@ -94,7 +94,7 @@ const FootnotesList = ({
                             releaseFootnotesEditRoute.path,
                             {
                               publicationId,
-                              releaseId,
+                              releaseVersionId,
                               footnoteId: id,
                             },
                           )}

--- a/src/explore-education-statistics-admin/src/pages/release/hooks/useReleaseImageUpload.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/hooks/useReleaseImageUpload.ts
@@ -11,7 +11,7 @@ interface UseImageUploadReturn {
 }
 
 export default function useReleaseImageUpload(
-  releaseId: string,
+  releaseVersionId: string,
 ): UseImageUploadReturn {
   const abortController = useRef<AbortController>();
 
@@ -19,12 +19,12 @@ export default function useReleaseImageUpload(
     async (file, onProgress) => {
       abortController.current = new AbortController();
 
-      return releaseImageService.upload(releaseId, file, {
+      return releaseImageService.upload(releaseVersionId, file, {
         signal: abortController.current.signal,
         onProgress,
       });
     },
-    [releaseId],
+    [releaseVersionId],
   );
 
   const handleImageUploadCancel: ImageUploadCancelHandler = useCallback(() => {

--- a/src/explore-education-statistics-admin/src/pages/release/hooks/useReleasePublishingStatus.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/hooks/useReleasePublishingStatus.ts
@@ -14,7 +14,7 @@ export interface StatusDetail {
 
 interface Options {
   refreshPeriod?: number;
-  releaseId: string;
+  releaseVersionId: string;
   onChange?: (status: ReleaseStageStatus) => void;
 }
 
@@ -23,7 +23,7 @@ interface Options {
  */
 export default function useReleasePublishingStatus({
   refreshPeriod = 10000,
-  releaseId,
+  releaseVersionId,
   onChange,
 }: Options): {
   currentStatus?: ReleaseStageStatus;
@@ -38,7 +38,7 @@ export default function useReleasePublishingStatus({
   const timeoutRef = useRef<NodeJS.Timeout>();
 
   const fetchNextStatus = useCallback(async () => {
-    const status = await releaseService.getReleaseStatus(releaseId);
+    const status = await releaseService.getReleaseStatus(releaseVersionId);
 
     const setNextStatus = (nextStatus: ReleaseStageStatus) => {
       setCurrentStatus(prevStatus => {
@@ -63,7 +63,7 @@ export default function useReleasePublishingStatus({
       }
     }
     forceCheck();
-  }, [releaseId, onChange, refreshPeriod]);
+  }, [releaseVersionId, onChange, refreshPeriod]);
 
   function cancelTimer() {
     if (timeoutRef.current) {

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseAccessListPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseAccessListPage.tsx
@@ -18,11 +18,11 @@ const PreReleaseAccessListPage = ({
   match,
   location,
 }: RouteComponentProps<ReleaseRouteParams, StaticContext, LocationState>) => {
-  const { releaseId } = match.params;
+  const { releaseVersionId } = match.params;
 
   const { value: release, isLoading } = useAsyncHandledRetry(
-    () => releaseService.getRelease(releaseId),
-    [releaseId],
+    () => releaseService.getRelease(releaseVersionId),
+    [releaseVersionId],
   );
 
   return (

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseContentPage.tsx
@@ -18,14 +18,14 @@ import { useQuery } from '@tanstack/react-query';
 const PreReleaseContentPage = ({
   match,
 }: RouteComponentProps<ReleaseRouteParams>) => {
-  const { publicationId, releaseId } = match.params;
+  const { publicationId, releaseVersionId } = match.params;
 
   const { data: content, isLoading: isLoadingContent } = useQuery(
-    releaseContentQueries.get(releaseId),
+    releaseContentQueries.get(releaseVersionId),
   );
 
   const { data: featuredTables = [], isLoading: isLoadingFeaturedTables } =
-    useQuery(featuredTableQueries.list(releaseId));
+    useQuery(featuredTableQueries.list(releaseVersionId));
 
   const handleFeaturedTableLinks = (url: string, text: string) => {
     // the url format is `/data-tables/fast-track/<data-block-parent-id>?featuredTables`
@@ -41,7 +41,7 @@ const PreReleaseContentPage = ({
           preReleaseTableToolRoute.path,
           {
             publicationId,
-            releaseId,
+            releaseVersionId,
             dataBlockId: featuredTable?.dataBlockId,
           },
         )}

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologiesPage.tsx
@@ -27,7 +27,7 @@ interface Model {
 const PreReleaseMethodologiesPage = ({
   match,
 }: RouteComponentProps<ReleaseRouteParams>) => {
-  const { publicationId, releaseId } = match.params;
+  const { publicationId, releaseVersionId } = match.params;
 
   const { value: model, isLoading } = useAsyncHandledRetry<Model>(async () => {
     const [externalMethodology, latestMethodologyVersions] = await Promise.all([
@@ -64,7 +64,7 @@ const PreReleaseMethodologiesPage = ({
                         preReleaseMethodologyRoute.path,
                         {
                           publicationId,
-                          releaseId,
+                          releaseVersionId,
                           methodologyId:
                             // If latest methodology version is unapproved, it will
                             // be an unpublished amendment. So we link to previous

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseMethodologyPage.tsx
@@ -17,7 +17,7 @@ import methodologyContentQueries from '@admin/queries/methodologyContentQueries'
 const PreReleaseMethodologyPage = ({
   match,
 }: RouteComponentProps<PreReleaseMethodologyRouteParams>) => {
-  const { methodologyId, publicationId, releaseId } = match.params;
+  const { methodologyId, publicationId, releaseVersionId } = match.params;
 
   const { data: methodologyVersion, isLoading: isMethodologyVersionLoading } =
     useQuery(methodologyQueries.get(methodologyId));
@@ -37,7 +37,7 @@ const PreReleaseMethodologyPage = ({
             preReleaseMethodologiesRoute.path,
             {
               publicationId,
-              releaseId,
+              releaseVersionId,
             },
           )}
         >

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
@@ -49,7 +49,7 @@ export const calculatePraPeriodAdvice = (
 const PreReleasePageContainer = ({
   match,
 }: RouteComponentProps<ReleaseRouteParams>) => {
-  const { publicationId, releaseId } = match.params;
+  const { publicationId, releaseVersionId } = match.params;
 
   const config = useConfig();
   const { user } = useAuthContext();
@@ -61,7 +61,7 @@ const PreReleasePageContainer = ({
   >(async () => {
     try {
       const preReleaseWindowStatus =
-        await permissionService.getPreReleaseWindowStatus(releaseId);
+        await permissionService.getPreReleaseWindowStatus(releaseVersionId);
 
       if (preReleaseWindowStatus.access === 'NoneSet') {
         errorPages.forbidden();
@@ -69,7 +69,7 @@ const PreReleasePageContainer = ({
       }
 
       const preReleaseSummary = await preReleaseService.getPreReleaseSummary(
-        releaseId,
+        releaseVersionId,
       );
       return {
         preReleaseWindowStatus,
@@ -79,7 +79,7 @@ const PreReleasePageContainer = ({
       handleError(err);
       return undefined;
     }
-  }, [errorPages, releaseId]);
+  }, [errorPages, releaseVersionId]);
 
   const renderPage = () => {
     if (!model) {
@@ -166,7 +166,7 @@ const PreReleasePageContainer = ({
               title: route.title,
               to: generatePath<ReleaseRouteParams>(route.path, {
                 publicationId,
-                releaseId,
+                releaseVersionId,
               }),
             }))}
             label="Pre-release"

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
@@ -26,21 +26,21 @@ import { useQuery } from '@tanstack/react-query';
 const PreReleaseTableToolPage = ({
   match,
 }: RouteComponentProps<PreReleaseTableToolRouteParams>) => {
-  const { publicationId, releaseId, dataBlockId } = match.params;
+  const { publicationId, releaseVersionId, dataBlockId } = match.params;
 
   const { data: publication, isLoading: isPublicationLoading } = useQuery(
     publicationQueries.get(publicationId),
   );
 
   const { data: release, isLoading: isReleaseLoading } = useQuery(
-    releaseQueries.get(releaseId),
+    releaseQueries.get(releaseVersionId),
   );
 
   const { value: tableToolState, isLoading: isTableToolStateLoading } =
     useAsyncHandledRetry<InitialTableToolState | undefined>(async () => {
       const [featuredTables, subjects] = await Promise.all([
-        tableBuilderService.listReleaseFeaturedTables(releaseId),
-        tableBuilderService.listReleaseSubjects(releaseId),
+        tableBuilderService.listReleaseFeaturedTables(releaseVersionId),
+        tableBuilderService.listReleaseSubjects(releaseVersionId),
       ]);
 
       if (dataBlockId) {
@@ -49,12 +49,12 @@ const PreReleaseTableToolPage = ({
         );
 
         const [subjectMeta, tableData] = await Promise.all([
-          tableBuilderService.getSubjectMeta(query.subjectId, releaseId),
+          tableBuilderService.getSubjectMeta(query.subjectId, releaseVersionId),
           tableBuilderService.getTableData(
             {
               ...query,
             },
-            releaseId,
+            releaseVersionId,
           ),
         ]);
 
@@ -71,7 +71,7 @@ const PreReleaseTableToolPage = ({
           query: {
             ...query,
             publicationId,
-            releaseId,
+            releaseVersionId,
           },
           subjectMeta,
           response: {
@@ -87,14 +87,14 @@ const PreReleaseTableToolPage = ({
         featuredTables,
         query: {
           publicationId,
-          releaseId,
+          releaseVersionId,
           subjectId: '',
           indicators: [],
           filters: [],
           locationIds: [],
         },
       };
-    }, [publicationId, releaseId, dataBlockId]);
+    }, [publicationId, releaseVersionId, dataBlockId]);
 
   const isLoading =
     isReleaseLoading || isTableToolStateLoading || isPublicationLoading;
@@ -126,7 +126,7 @@ const PreReleaseTableToolPage = ({
                   preReleaseTableToolRoute.path,
                   {
                     publicationId,
-                    releaseId,
+                    releaseVersionId,
                     dataBlockId: featuredTable.dataBlockId,
                   },
                 )}
@@ -146,7 +146,7 @@ const PreReleaseTableToolPage = ({
                       <PreReleaseTableToolFinalStep
                         publication={publication}
                         query={query}
-                        releaseId={releaseId}
+                        releaseVersionId={releaseVersionId}
                         releaseType={release.type}
                         table={table}
                         tableHeaders={tableHeaders}

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
@@ -72,7 +72,8 @@ const PreReleaseTableToolPage = ({
           query: {
             ...query,
             publicationId,
-            releaseVersionId,
+            // TODO rename to releaseVersionId
+            releaseId: releaseVersionId,
           },
           subjectMeta,
           response: {
@@ -88,7 +89,8 @@ const PreReleaseTableToolPage = ({
         featuredTables,
         query: {
           publicationId,
-          releaseVersionId,
+          // TODO rename to releaseVersionId
+          releaseId: releaseVersionId,
           subjectId: '',
           indicators: [],
           filters: [],

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
@@ -54,6 +54,7 @@ const PreReleaseTableToolPage = ({
             {
               ...query,
             },
+            // TODO rename to releaseVersionId
             releaseVersionId,
           ),
         ]);

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
@@ -1,4 +1,4 @@
-import { useReleaseContext } from '@admin/pages/release/contexts/ReleaseContext';
+import { useReleaseVersionContext } from '@admin/pages/release/contexts/ReleaseContext';
 import PreReleaseUserAccessForm from '@admin/pages/release/pre-release/components/PreReleaseUserAccessForm';
 import PublicPreReleaseAccessForm from '@admin/pages/release/pre-release/components/PublicPreReleaseAccessForm';
 import { preReleaseContentRoute } from '@admin/routes/preReleaseRoutes';
@@ -20,20 +20,20 @@ export const releasePreReleaseAccessPageTabs = {
 };
 
 const ReleasePreReleaseAccessPage = () => {
-  const { releaseId } = useReleaseContext();
+  const { releaseVersionId } = useReleaseVersionContext();
 
   const {
     value: release,
     isLoading,
     setState: setRelease,
   } = useAsyncHandledRetry(
-    () => releaseService.getRelease(releaseId),
-    [releaseId],
+    () => releaseService.getRelease(releaseVersionId),
+    [releaseVersionId],
   );
 
   const { value: canUpdateRelease = false } = useAsyncHandledRetry(
-    () => permissionService.canUpdateRelease(releaseId),
-    [releaseId],
+    () => permissionService.canUpdateRelease(releaseVersionId),
+    [releaseVersionId],
   );
 
   return (
@@ -82,7 +82,7 @@ const ReleasePreReleaseAccessPage = () => {
                     preReleaseContentRoute.path,
                     {
                       publicationId: release.publicationId,
-                      releaseId: release.id,
+                      releaseVersionId: release.id,
                     },
                   )}`}
                 />

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
@@ -90,7 +90,7 @@ const ReleasePreReleaseAccessPage = () => {
             )}
 
             <PreReleaseUserAccessForm
-              releaseId={release.id}
+              releaseVersionId={release.id}
               isReleaseApproved={release.approvalStatus === 'Approved'}
               isReleaseLive={release.live}
             />

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseContentPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseContentPage.test.tsx
@@ -254,7 +254,7 @@ describe('PreReleaseContentPage', () => {
     initialEntries: string[] = [
       generatePath<ReleaseRouteParams>(preReleaseContentRoute.path, {
         publicationId: 'publication-1',
-        releaseId: 'release-1',
+        releaseVersionId: 'release-1',
       }),
     ],
   ) => {

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseContentPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseContentPage.test.tsx
@@ -3,7 +3,7 @@ import PreReleaseContentPage from '@admin/pages/release/pre-release/PreReleaseCo
 import { preReleaseContentRoute } from '@admin/routes/preReleaseRoutes';
 import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
 import _releaseContentService, {
-  EditableRelease,
+  EditableReleaseVersion,
   ReleaseContent,
 } from '@admin/services/releaseContentService';
 import _featuredTableService, {
@@ -26,7 +26,7 @@ const featuredTableService = _featuredTableService as jest.Mocked<
 >;
 
 describe('PreReleaseContentPage', () => {
-  const testEditableRelease: EditableRelease = {
+  const testEditableRelease: EditableReleaseVersion = {
     approvalStatus: 'Approved',
     content: [
       {

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologiesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologiesPage.test.tsx
@@ -276,7 +276,7 @@ describe('PreReleaseMethodologiesPage', () => {
     initialEntries: string[] = [
       generatePath<ReleaseRouteParams>(preReleaseMethodologiesRoute.path, {
         publicationId: 'publication-1',
-        releaseId: 'release-1',
+        releaseVersionId: 'release-1',
       }),
     ],
   ) => {

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologyPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseMethodologyPage.test.tsx
@@ -356,7 +356,7 @@ describe('PreReleaseMethodologyPage', () => {
         preReleaseMethodologyRoute.path,
         {
           publicationId: 'publication-1',
-          releaseId: 'release-1',
+          releaseVersionId: 'release-1',
           methodologyId: 'methodology-1',
         },
       ),

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleasePageContainer.test.tsx
@@ -198,7 +198,7 @@ describe('PreReleasePageContainer', () => {
           initialEntries={[
             generatePath<ReleaseRouteParams>(preReleaseRoute.path, {
               publicationId: 'publication-1',
-              releaseId: 'release-1',
+              releaseVersionId: 'release-1',
             }),
           ]}
         >

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -10,7 +10,9 @@ import _dataBlockService, {
 import _publicationService, {
   Publication,
 } from '@admin/services/publicationService';
-import _releaseService, { Release } from '@admin/services/releaseService';
+import _releaseService, {
+  ReleaseVersion,
+} from '@admin/services/releaseService';
 import _tableBuilderService, {
   SubjectMeta,
   TableDataResponse,
@@ -188,7 +190,7 @@ describe('PreReleaseTableToolPage', () => {
     ],
   };
 
-  const testRelease: Release = {
+  const testRelease: ReleaseVersion = {
     id: '123',
     releaseId: '456',
     slug: '123',
@@ -323,7 +325,7 @@ describe('PreReleaseTableToolPage', () => {
 
     expect(step1.getByRole('link', { name: 'Test highlight' })).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-1/prerelease/table-tool/block-1',
+      '/publication/publication-1/release/release-version-1/prerelease/table-tool/block-1',
     );
   });
 
@@ -369,7 +371,7 @@ describe('PreReleaseTableToolPage', () => {
         preReleaseTableToolRoute.path,
         {
           publicationId: 'publication-1',
-          releaseId: 'release-1',
+          releaseVersionId: 'release-version-1',
           dataBlockId: 'block-1',
         },
       ),
@@ -412,7 +414,7 @@ describe('PreReleaseTableToolPage', () => {
         preReleaseTableToolRoute.path,
         {
           publicationId: 'publication-1',
-          releaseId: 'release-1',
+          releaseVersionId: 'release-version-1',
         },
       ),
     ],

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
@@ -1,10 +1,10 @@
-import { testRelease } from '@admin/pages/release/__data__/testRelease';
+import { testReleaseVersion } from '@admin/pages/release/__data__/testReleaseVersion';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import _releaseService from '@admin/services/releaseService';
 import _permissionService from '@admin/services/permissionService';
 import _preReleaseUserService from '@admin/services/preReleaseUserService';
-import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
+import { ReleaseVersionContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
 import { MemoryRouter } from 'react-router';
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
 import ReleasePreReleaseAccessPage from '@admin/pages/release/pre-release/ReleasePreReleaseAccessPage';
@@ -33,7 +33,7 @@ jest.mock('@common/hooks/useMedia', () => ({
 
 describe('ReleasePreReleaseAccessPage', () => {
   test('renders the pre-release users tab', async () => {
-    releaseService.getRelease.mockResolvedValue(testRelease);
+    releaseService.getRelease.mockResolvedValue(testReleaseVersion);
     permissionService.canUpdateRelease.mockResolvedValue(true);
     preReleaseUserService.getUsers.mockResolvedValue([]);
 
@@ -63,7 +63,7 @@ describe('ReleasePreReleaseAccessPage', () => {
   });
 
   test('renders pre-release page link correctly', async () => {
-    releaseService.getRelease.mockResolvedValue(testRelease);
+    releaseService.getRelease.mockResolvedValue(testReleaseVersion);
     permissionService.canUpdateRelease.mockResolvedValue(true);
 
     renderPage();
@@ -78,7 +78,7 @@ describe('ReleasePreReleaseAccessPage', () => {
   });
 
   test('renders the public access list tab', async () => {
-    releaseService.getRelease.mockResolvedValue(testRelease);
+    releaseService.getRelease.mockResolvedValue(testReleaseVersion);
     permissionService.canUpdateRelease.mockResolvedValue(true);
     preReleaseUserService.getUsers.mockResolvedValue([]);
 
@@ -112,9 +112,9 @@ function renderPage() {
   render(
     <MemoryRouter>
       <TestConfigContextProvider>
-        <ReleaseContextProvider release={testRelease}>
+        <ReleaseVersionContextProvider releaseVersion={testReleaseVersion}>
           <ReleasePreReleaseAccessPage />
-        </ReleaseContextProvider>
+        </ReleaseVersionContextProvider>
       </TestConfigContextProvider>
     </MemoryRouter>,
   );

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseTableToolFinalStep.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseTableToolFinalStep.tsx
@@ -23,7 +23,7 @@ import { ReleaseType } from '@common/services/types/releaseType';
 interface TableToolFinalStepProps {
   publication?: Publication;
   query: ReleaseTableDataQuery;
-  releaseId: string;
+  releaseVersionId: string;
   releaseType: ReleaseType;
   table: FullTable;
   tableHeaders: TableHeadersConfig;
@@ -33,7 +33,7 @@ interface TableToolFinalStepProps {
 const PreReleaseTableToolFinalStep = ({
   publication,
   query,
-  releaseId,
+  releaseVersionId,
   releaseType,
   table,
   tableHeaders,
@@ -95,7 +95,7 @@ const PreReleaseTableToolFinalStep = ({
                     preReleaseContentRoute.path,
                     {
                       publicationId: publication.id,
-                      releaseId,
+                      releaseVersionId,
                     },
                   )}
                 >

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseUserAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseUserAccessForm.tsx
@@ -35,7 +35,7 @@ const errorMappings = [
 ];
 
 interface Props {
-  releaseId: string;
+  releaseVersionId: string;
   isReleaseApproved?: boolean;
   isReleaseLive?: boolean;
 }
@@ -44,7 +44,7 @@ const formId = 'preReleaseUserAccessForm';
 const inviteLimit = 50;
 
 export default function PreReleaseUserAccessForm({
-  releaseId,
+  releaseVersionId,
   isReleaseApproved = false,
   isReleaseLive = false,
 }: Props) {
@@ -56,8 +56,8 @@ export default function PreReleaseUserAccessForm({
     error,
     setState: setUsers,
   } = useAsyncRetry(
-    () => preReleaseUserService.getUsers(releaseId),
-    [releaseId],
+    () => preReleaseUserService.getUsers(releaseVersionId),
+    [releaseVersionId],
   );
 
   const [invitePlan, setInvitePlan] = useState<PreReleaseInvitePlan>();
@@ -71,7 +71,7 @@ export default function PreReleaseUserAccessForm({
   const handleSubmit = async (values: FormValues) => {
     setInvitePlan(
       await preReleaseUserService.getInvitePlan(
-        releaseId,
+        releaseVersionId,
         splitAndTrimLines(values.emails),
       ),
     );
@@ -79,7 +79,7 @@ export default function PreReleaseUserAccessForm({
 
   const handleModalSubmit = async (emails: string) => {
     const newUsers = await preReleaseUserService.inviteUsers(
-      releaseId,
+      releaseVersionId,
       splitAndTrimLines(emails),
     );
 
@@ -226,7 +226,7 @@ export default function PreReleaseUserAccessForm({
                           toggleRemoving.on();
 
                           await preReleaseUserService.removeUser(
-                            releaseId,
+                            releaseVersionId,
                             user.email,
                           );
 

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/__tests__/PreReleaseUserAccessForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/__tests__/PreReleaseUserAccessForm.test.tsx
@@ -26,7 +26,7 @@ describe('PreReleaseUserAccessForm', () => {
   test('renders correctly with list of users', async () => {
     preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-    render(<PreReleaseUserAccessForm releaseId="release-1" />);
+    render(<PreReleaseUserAccessForm releaseVersionId="release-1" />);
 
     await waitFor(() => {
       expect(
@@ -56,7 +56,7 @@ describe('PreReleaseUserAccessForm', () => {
   test('renders empty message when there are no users', async () => {
     preReleaseUserService.getUsers.mockResolvedValue([]);
 
-    render(<PreReleaseUserAccessForm releaseId="release-1" />);
+    render(<PreReleaseUserAccessForm releaseVersionId="release-1" />);
 
     await waitFor(() => {
       expect(
@@ -70,7 +70,9 @@ describe('PreReleaseUserAccessForm', () => {
   test('renders correctly when the release is live', async () => {
     preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
-    render(<PreReleaseUserAccessForm releaseId="release-1" isReleaseLive />);
+    render(
+      <PreReleaseUserAccessForm releaseVersionId="release-1" isReleaseLive />,
+    );
 
     await waitFor(() => {
       expect(
@@ -97,7 +99,7 @@ describe('PreReleaseUserAccessForm', () => {
       new Error('Something went wrong'),
     );
 
-    render(<PreReleaseUserAccessForm releaseId="release-1" />);
+    render(<PreReleaseUserAccessForm releaseVersionId="release-1" />);
 
     await waitFor(() => {
       expect(
@@ -113,7 +115,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {
@@ -139,7 +141,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {
@@ -184,7 +186,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {
@@ -222,7 +224,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {
@@ -255,7 +257,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {
@@ -284,7 +286,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {
@@ -310,7 +312,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {
@@ -349,7 +351,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {
@@ -379,7 +381,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {
@@ -421,7 +423,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {
@@ -515,7 +517,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {
@@ -562,7 +564,10 @@ describe('PreReleaseUserAccessForm', () => {
 
     test('confirmation modal displays correct notifications warning when release is approved', async () => {
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" isReleaseApproved />,
+        <PreReleaseUserAccessForm
+          releaseVersionId="release-1"
+          isReleaseApproved
+        />,
       );
 
       await waitFor(() => {
@@ -603,7 +608,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {
@@ -682,7 +687,7 @@ describe('PreReleaseUserAccessForm', () => {
       preReleaseUserService.getUsers.mockResolvedValue(testUsers);
 
       const { user } = render(
-        <PreReleaseUserAccessForm releaseId="release-1" />,
+        <PreReleaseUserAccessForm releaseVersionId="release-1" />,
       );
 
       await waitFor(() => {

--- a/src/explore-education-statistics-admin/src/pages/release/utils/releaseSummaryUtil.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/utils/releaseSummaryUtil.ts
@@ -1,4 +1,4 @@
-import { Release } from '@admin/services/releaseService';
+import { ReleaseVersion } from '@admin/services/releaseService';
 import { ReleaseApprovalStatus } from '@common/services/publicationService';
 
 export const getReleaseApprovalStatusLabel = (
@@ -26,5 +26,5 @@ const getLiveLatestLabel = (isLive: boolean, isLatest: boolean) => {
   return '(not Live)';
 };
 
-export const getReleaseSummaryLabel = (release: Release) =>
+export const getReleaseSummaryLabel = (release: ReleaseVersion) =>
   `${release.title} ${getLiveLatestLabel(release.live, release.latestRelease)}`;

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -83,7 +83,8 @@ export default function UserInvitePage({
     const userReleaseRoles =
       values.userReleaseRoles?.map(userReleaseRole => {
         return {
-          releaseVersionId: userReleaseRole.releaseVersionId,
+          // TODO rename to releaseVersionId
+          releaseId: userReleaseRole.releaseVersionId,
           releaseRole: userReleaseRole.releaseRole,
         };
       }) ?? [];

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -22,7 +22,7 @@ import { RouteComponentProps } from 'react-router';
 import orderBy from 'lodash/orderBy';
 
 export interface InviteUserReleaseRole {
-  releaseId: string;
+  releaseVersionId: string;
   releaseTitle?: string;
   releaseRole: string;
 }
@@ -40,7 +40,7 @@ export interface UserInviteFormValues {
   userPublicationRoles?: InviteUserPublicationRole[];
   publicationId?: string;
   publicationRole?: string;
-  releaseId?: string;
+  releaseVersionId?: string;
   releaseRole?: string;
 }
 
@@ -83,7 +83,7 @@ export default function UserInvitePage({
     const userReleaseRoles =
       values.userReleaseRoles?.map(userReleaseRole => {
         return {
-          releaseId: userReleaseRole.releaseId,
+          releaseVersionId: userReleaseRole.releaseVersionId,
           releaseRole: userReleaseRole.releaseRole,
         };
       }) ?? [];
@@ -114,7 +114,7 @@ export default function UserInvitePage({
       roleId: Yup.string().required('Choose role for the user'),
       userReleaseRoles: Yup.array().of(
         Yup.object({
-          releaseId: Yup.string().required(
+          releaseVersionId: Yup.string().required(
             'Choose release to give the user access to',
           ),
           releaseTitle: Yup.string(),
@@ -132,7 +132,7 @@ export default function UserInvitePage({
       ),
       publicationId: Yup.string(),
       publicationRole: Yup.string(),
-      releaseId: Yup.string(),
+      releaseVersionId: Yup.string(),
       releaseRole: Yup.string(),
     });
   }, []);

--- a/src/explore-education-statistics-admin/src/pages/users/__tests__/UserInvitePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/__tests__/UserInvitePage.test.tsx
@@ -105,7 +105,7 @@ describe('UserInvitePage', () => {
       );
 
       expect(
-        screen.getByTestId('inviteUserForm-releaseId-error'),
+        screen.getByTestId('inviteUserForm-releaseVersionId-error'),
       ).toHaveTextContent('Choose release to give the user access to');
     });
 
@@ -148,7 +148,7 @@ describe('UserInvitePage', () => {
       );
 
       expect(
-        screen.getByTestId('inviteUserForm-releaseId-error'),
+        screen.getByTestId('inviteUserForm-releaseVersionId-error'),
       ).toHaveTextContent('You can only add one role for each release');
     });
 
@@ -450,7 +450,7 @@ describe('UserInvitePage', () => {
       email: 'test@test.com',
       roleId: 'role-1-id',
       userReleaseRoles: [
-        { releaseId: 'release-1-id', releaseRole: 'Approver' },
+        { releaseVersionId: 'release-1-id', releaseRole: 'Approver' },
       ],
       userPublicationRoles: [
         { publicationId: 'publication-1-id', publicationRole: 'Approver' },

--- a/src/explore-education-statistics-admin/src/pages/users/__tests__/UserInvitePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/__tests__/UserInvitePage.test.tsx
@@ -450,7 +450,7 @@ describe('UserInvitePage', () => {
       email: 'test@test.com',
       roleId: 'role-1-id',
       userReleaseRoles: [
-        { releaseVersionId: 'release-1-id', releaseRole: 'Approver' },
+        { releaseId: 'release-1-id', releaseRole: 'Approver' },
       ],
       userPublicationRoles: [
         { publicationId: 'publication-1-id', publicationRole: 'Approver' },

--- a/src/explore-education-statistics-admin/src/pages/users/components/InviteUserReleaseRoleForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/InviteUserReleaseRoleForm.tsx
@@ -32,20 +32,24 @@ export default function InviteUserReleaseRoleForm({
   const selectedUserReleaseRoles = watch('userReleaseRoles') ?? [];
 
   const handleAddUserReleaseRole = () => {
-    const releaseId = getValues('releaseId');
+    const releaseVersionId = getValues('releaseVersionId');
     const releaseRole = getValues('releaseRole');
 
-    if (selectedUserReleaseRoles.find(role => role.releaseId === releaseId)) {
-      setError('releaseId', {
+    if (
+      selectedUserReleaseRoles.find(
+        role => role.releaseVersionId === releaseVersionId,
+      )
+    ) {
+      setError('releaseVersionId', {
         type: 'custom',
         message: 'You can only add one role for each release',
       });
       return;
     }
 
-    if (!releaseId || !releaseRole) {
-      if (!releaseId) {
-        setError('releaseId', {
+    if (!releaseVersionId || !releaseRole) {
+      if (!releaseVersionId) {
+        setError('releaseVersionId', {
           type: 'custom',
           message: 'Choose release to give the user access to',
         });
@@ -60,12 +64,12 @@ export default function InviteUserReleaseRoleForm({
       return;
     }
 
-    if (releaseId && releaseRole) {
+    if (releaseVersionId && releaseRole) {
       setValue('userReleaseRoles', [
         ...selectedUserReleaseRoles,
-        { releaseId, releaseRole },
+        { releaseVersionId, releaseRole },
       ]);
-      resetField('releaseId');
+      resetField('releaseVersionId');
       resetField('releaseRole');
     }
   };
@@ -93,7 +97,7 @@ export default function InviteUserReleaseRoleForm({
     >
       <FormFieldSelect<UserInviteFormValues>
         label="Release"
-        name="releaseId"
+        name="releaseVersionId"
         placeholder="Choose release"
         options={releases?.map(release => ({
           label: release.title,
@@ -132,12 +136,14 @@ export default function InviteUserReleaseRoleForm({
             {orderBy(
               selectedUserReleaseRoles,
               userReleaseRole =>
-                releaseTitlesById[userReleaseRole.releaseId].title,
+                releaseTitlesById[userReleaseRole.releaseVersionId].title,
             ).map(userReleaseRole => (
               <tr
-                key={`${userReleaseRole.releaseId}_${userReleaseRole.releaseRole}`}
+                key={`${userReleaseRole.releaseVersionId}_${userReleaseRole.releaseRole}`}
               >
-                <td>{releaseTitlesById[userReleaseRole.releaseId].title}</td>
+                <td>
+                  {releaseTitlesById[userReleaseRole.releaseVersionId].title}
+                </td>
                 <td>{userReleaseRole.releaseRole}</td>
                 <td>
                   <ButtonText

--- a/src/explore-education-statistics-admin/src/pages/users/components/ReleaseAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/ReleaseAccessForm.tsx
@@ -23,7 +23,7 @@ const addReleaseFormErrorMappings = [
 ];
 
 interface FormValues {
-  releaseId: string;
+  releaseVersionId: string;
   releaseRole: string;
 }
 
@@ -56,7 +56,7 @@ export default function ReleaseAccessForm({
     <FormProvider
       errorMappings={addReleaseFormErrorMappings}
       initialValues={{
-        releaseId: orderBy(releases, release => release)?.[0]?.id ?? '',
+        releaseVersionId: orderBy(releases, release => release)?.[0]?.id ?? '',
         releaseRole:
           orderBy(releaseRoles, releaseRole => releaseRole)?.[0] ?? '',
       }}
@@ -74,7 +74,7 @@ export default function ReleaseAccessForm({
                 <div className="govuk-grid-column-one-half">
                   <FormFieldSelect<FormValues>
                     label="Release"
-                    name="releaseId"
+                    name="releaseVersionId"
                     options={releases?.map(release => ({
                       label: release.title,
                       value: release.id,

--- a/src/explore-education-statistics-admin/src/pages/users/components/ReleaseAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/ReleaseAccessForm.tsx
@@ -23,7 +23,7 @@ const addReleaseFormErrorMappings = [
 ];
 
 interface FormValues {
-  releaseVersionId: string;
+  releaseId: string;
   releaseRole: string;
 }
 
@@ -56,7 +56,7 @@ export default function ReleaseAccessForm({
     <FormProvider
       errorMappings={addReleaseFormErrorMappings}
       initialValues={{
-        releaseVersionId: orderBy(releases, release => release)?.[0]?.id ?? '',
+        releaseId: orderBy(releases, release => release)?.[0]?.id ?? '',
         releaseRole:
           orderBy(releaseRoles, releaseRole => releaseRole)?.[0] ?? '',
       }}
@@ -74,7 +74,7 @@ export default function ReleaseAccessForm({
                 <div className="govuk-grid-column-one-half">
                   <FormFieldSelect<FormValues>
                     label="Release"
-                    name="releaseVersionId"
+                    name="releaseId"
                     options={releases?.map(release => ({
                       label: release.title,
                       value: release.id,

--- a/src/explore-education-statistics-admin/src/pages/users/components/__tests__/ReleaseAccessForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/__tests__/ReleaseAccessForm.test.tsx
@@ -74,7 +74,7 @@ describe('ReleaseAccessForm', () => {
     });
 
     expect(userService.addUserReleaseRole).toHaveBeenCalledWith('user-1-id', {
-      releaseId: 'release-1-id',
+      releaseVersionId: 'release-1-id',
       releaseRole: 'Contributor',
     });
     expect(handleUpdate).toHaveBeenCalledTimes(1);

--- a/src/explore-education-statistics-admin/src/pages/users/components/__tests__/ReleaseAccessForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/__tests__/ReleaseAccessForm.test.tsx
@@ -74,7 +74,7 @@ describe('ReleaseAccessForm', () => {
     });
 
     expect(userService.addUserReleaseRole).toHaveBeenCalledWith('user-1-id', {
-      releaseVersionId: 'release-1-id',
+      releaseId: 'release-1-id',
       releaseRole: 'Contributor',
     });
     expect(handleUpdate).toHaveBeenCalledTimes(1);

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContent.tsx
@@ -65,7 +65,7 @@ const PrototypeReleaseContent = ({
 
   const addSummaryBlock = useCallback(async () => {
     await addContentSectionBlock({
-      releaseId: release.id,
+      releaseVersionId: release.id,
       sectionId: release.summarySection.id,
       sectionKey: 'summarySection',
       block: {
@@ -79,7 +79,7 @@ const PrototypeReleaseContent = ({
   const addRelatedDashboardsBlock = useCallback(async () => {
     if (release.relatedDashboardsSection) {
       await addContentSectionBlock({
-        releaseId: release.id,
+        releaseVersionId: release.id,
         sectionId: release.relatedDashboardsSection.id,
         sectionKey: 'relatedDashboardsSection',
         block: {
@@ -173,7 +173,7 @@ const PrototypeReleaseContent = ({
                       allowComments
                       block={block}
                       publicationId={release.publication.id}
-                      releaseId={release.id}
+                      releaseVersionId={release.id}
                     />
                   )}
                 />
@@ -250,7 +250,7 @@ const PrototypeReleaseContent = ({
                       releaseDataGuidanceRoute.path,
                       {
                         publicationId: release.publication.id,
-                        releaseId: release.id,
+                        releaseVersionId: release.id,
                       },
                     ),
                     state: {
@@ -270,7 +270,7 @@ const PrototypeReleaseContent = ({
                         preReleaseAccessListRoute.path,
                         {
                           publicationId: release.publication.id,
-                          releaseId: release.id,
+                          releaseVersionId: release.id,
                         },
                       ),
                       state: {
@@ -395,7 +395,7 @@ const PrototypeReleaseContent = ({
                   releaseDataGuidanceRoute.path,
                   {
                     publicationId: release.publication.id,
-                    releaseId: release.id,
+                    releaseVersionId: release.id,
                   },
                 ),
                 state: {
@@ -426,7 +426,7 @@ const PrototypeReleaseContent = ({
                     allowComments
                     block={block}
                     publicationId={release.publication.id}
-                    releaseId={release.id}
+                    releaseVersionId={release.id}
                   />
                 )}
               />

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContent.tsx
@@ -164,7 +164,7 @@ const PrototypeReleaseContent = ({
                   renderBlock={block => (
                     <ReleaseBlock
                       block={block}
-                      releaseId={release.id}
+                      releaseVersionId={release.id}
                       transformFeaturedTableLinks={transformFeaturedTableLinks}
                     />
                   )}
@@ -419,7 +419,7 @@ const PrototypeReleaseContent = ({
                 blocks={release.relatedDashboardsSection.content}
                 sectionId={release.relatedDashboardsSection.id}
                 renderBlock={block => (
-                  <ReleaseBlock block={block} releaseId={release.id} />
+                  <ReleaseBlock block={block} releaseVersionId={release.id} />
                 )}
                 renderEditableBlock={block => (
                   <PrototypeReleaseEditableBlock

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContentAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContentAccordion.tsx
@@ -24,7 +24,7 @@ const ReleaseContentAccordion = ({
 
   const addAccordionSection = useCallback(async () => {
     await addContentSection({
-      releaseId: release.id,
+      releaseVersionId: release.id,
       order: release.content.length,
     });
   }, [release.id, release.content.length, addContentSection]);
@@ -39,7 +39,7 @@ const ReleaseContentAccordion = ({
           return acc;
         }, {});
 
-      await updateContentSectionsOrder({ releaseId: release.id, order });
+      await updateContentSectionsOrder({ releaseVersionId: release.id, order });
     },
     [id, release.id, updateContentSectionsOrder],
   );

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContentAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContentAccordion.tsx
@@ -1,6 +1,6 @@
 import EditableAccordion from '@admin/components/editable/EditableAccordion';
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
-import { EditableRelease } from '@admin/services/releaseContentService';
+import { EditableReleaseVersion } from '@admin/services/releaseContentService';
 import { Dictionary } from '@common/types';
 import orderBy from 'lodash/orderBy';
 import React, { useCallback } from 'react';
@@ -8,7 +8,7 @@ import PrototypeReleaseContentAccordionSection from './PrototypeReleaseContentAc
 
 interface ReleaseContentAccordionProps {
   id?: string;
-  release: EditableRelease;
+  release: EditableReleaseVersion;
   sectionName: string;
   transformFeaturedTableLinks?: (url: string, text: string) => void;
 }

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContentAccordionSection.tsx
@@ -192,7 +192,7 @@ const ReleaseContentAccordionSection = ({
             renderBlock={block => (
               <ReleaseBlock
                 block={block}
-                releaseId={release.id}
+                releaseVersionId={release.id}
                 transformFeaturedTableLinks={transformFeaturedTableLinks}
                 visible={open}
               />
@@ -215,7 +215,7 @@ const ReleaseContentAccordionSection = ({
               {showDataBlockForm && (
                 <DataBlockSelectForm
                   id={`dataBlockSelectForm-${sectionId}`}
-                  releaseId={release.id}
+                  releaseVersionId={release.id}
                   onSelect={async selectedDataBlockId => {
                     await attachDataBlock(selectedDataBlockId);
                     toggleDataBlockForm.off();

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContentAccordionSection.tsx
@@ -67,7 +67,7 @@ const ReleaseContentAccordionSection = ({
 
   const addBlock = useCallback(async () => {
     await actions.addContentSectionBlock({
-      releaseId: release.id,
+      releaseVersionId: release.id,
       sectionId,
       sectionKey: 'content',
       block: {
@@ -81,7 +81,7 @@ const ReleaseContentAccordionSection = ({
   const addEmbedBlock = useCallback(
     async (embedBlock: EditableEmbedFormValues) => {
       await actions.addEmbedSectionBlock({
-        releaseId: release.id,
+        releaseVersionId: release.id,
         sectionId,
         sectionKey: 'content',
         request: {
@@ -97,7 +97,7 @@ const ReleaseContentAccordionSection = ({
   const attachDataBlock = useCallback(
     async (contentBlockId: string) => {
       await actions.attachContentSectionBlock({
-        releaseId: release.id,
+        releaseVersionId: release.id,
         sectionId,
         sectionKey: 'content',
         block: {
@@ -116,7 +116,7 @@ const ReleaseContentAccordionSection = ({
     }, {});
 
     await actions.updateSectionBlockOrder({
-      releaseId: release.id,
+      releaseVersionId: release.id,
       sectionId,
       sectionKey: 'content',
       order,
@@ -128,7 +128,7 @@ const ReleaseContentAccordionSection = ({
       await actions.updateContentSectionHeading({
         sectionId,
         title,
-        releaseId: release.id,
+        releaseVersionId: release.id,
       });
     },
     [actions, sectionId, release.id],
@@ -137,7 +137,7 @@ const ReleaseContentAccordionSection = ({
   const handleRemoveSection = useCallback(async () => {
     await actions.removeContentSection({
       sectionId,
-      releaseId: release.id,
+      releaseVersionId: release.id,
     });
   }, [actions, sectionId, release.id]);
 
@@ -204,7 +204,7 @@ const ReleaseContentAccordionSection = ({
                 block={block}
                 editable={!isReordering}
                 publicationId={release.publication.id}
-                releaseId={release.id}
+                releaseVersionId={release.id}
                 visible={open}
               />
             )}

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseEditableBlock.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseEditableBlock.tsx
@@ -44,8 +44,9 @@ const PrototypeReleaseEditableBlock = ({
   const { handleImageUpload, handleImageUploadCancel } =
     useReleaseImageUpload(releaseVersionId);
 
+  // TODO rename to releaseVersionId
   const transformImageAttributes = useReleaseImageAttributeTransformer({
-    releaseVersionId,
+    releaseId: releaseVersionId,
   });
 
   const [showCommentAddForm, toggleCommentAddForm] = useToggle(false);
@@ -76,6 +77,7 @@ const PrototypeReleaseEditableBlock = ({
               )}
               onDelete={noop}
             >
+              {/* TODO rename to releaseVersionId */}
               <Gate condition={!!visible}>
                 <DataBlockTabs
                   releaseId={releaseVersionId}

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseEditableBlock.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseEditableBlock.tsx
@@ -26,7 +26,7 @@ interface Props {
   block: EditableBlock;
   editable?: boolean;
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
   visible?: boolean;
 }
 
@@ -36,16 +36,16 @@ const PrototypeReleaseEditableBlock = ({
   block,
   editable = true,
   publicationId,
-  releaseId,
+  releaseVersionId,
   visible,
 }: Props) => {
-  const getChartFile = useGetChartFile(releaseId);
+  const getChartFile = useGetChartFile(releaseVersionId);
 
   const { handleImageUpload, handleImageUploadCancel } =
-    useReleaseImageUpload(releaseId);
+    useReleaseImageUpload(releaseVersionId);
 
   const transformImageAttributes = useReleaseImageAttributeTransformer({
-    releaseId,
+    releaseVersionId,
   });
 
   const [showCommentAddForm, toggleCommentAddForm] = useToggle(false);
@@ -70,7 +70,7 @@ const PrototypeReleaseEditableBlock = ({
                 releaseDataBlockEditRoute.path,
                 {
                   publicationId,
-                  releaseId,
+                  releaseVersionId,
                   dataBlockId: block.id,
                 },
               )}
@@ -78,7 +78,7 @@ const PrototypeReleaseEditableBlock = ({
             >
               <Gate condition={!!visible}>
                 <DataBlockTabs
-                  releaseId={releaseId}
+                  releaseId={releaseVersionId}
                   id={blockId}
                   dataBlock={block}
                   getInfographic={getChartFile}

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseHeadlines.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseHeadlines.tsx
@@ -26,7 +26,7 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
 
   const addBlock = useCallback(async () => {
     await actions.addContentSectionBlock({
-      releaseId: release.id,
+      releaseVersionId: release.id,
       sectionId: release.headlinesSection.id,
       sectionKey: 'headlinesSection',
       block: {
@@ -58,7 +58,7 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
               allowComments
               block={block}
               publicationId={release.publication.id}
-              releaseId={release.id}
+              releaseVersionId={release.id}
             />
           )}
         />

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseHeadlines.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseHeadlines.tsx
@@ -4,7 +4,7 @@ import useGetChartFile from '@admin/hooks/useGetChartFile';
 import KeyStatistics from '@admin/pages/release/content/components/KeyStatistics';
 import ReleaseBlock from '@admin/pages/release/content/components/ReleaseBlock';
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
-import { EditableRelease } from '@admin/services/releaseContentService';
+import { EditableReleaseVersion } from '@admin/services/releaseContentService';
 import Button from '@common/components/Button';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
@@ -14,7 +14,7 @@ import AddSecondaryStats from '@admin/pages/release/content/components/AddSecond
 import PrototypeReleaseEditableBlock from './PrototypeReleaseEditableBlock';
 
 interface Props {
-  release: EditableRelease;
+  release: EditableReleaseVersion;
   transformFeaturedTableLinks?: (url: string, text: string) => void;
 }
 
@@ -49,7 +49,7 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
           renderBlock={block => (
             <ReleaseBlock
               block={block}
-              releaseId={release.id}
+              releaseVersionId={release.id}
               transformFeaturedTableLinks={transformFeaturedTableLinks}
             />
           )}
@@ -83,7 +83,9 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
 
       {release.keyStatisticsSecondarySection.content?.length ? (
         <>
-          <AddSecondaryStats release={release} updating />
+          <AddSecondaryStats releaseVersion={release} updating />
+
+          {/* TODO rename to releaseVersionId */}
           <DataBlockTabs
             releaseId={release.id}
             id="releaseHeadlines-dataBlock"
@@ -94,7 +96,7 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
         </>
       ) : (
         <>
-          <AddSecondaryStats release={release} />
+          <AddSecondaryStats releaseVersion={release} />
           <Tabs id="releaseHeadlines-dataBlock">{headlinesTab}</Tabs>
         </>
       )}

--- a/src/explore-education-statistics-admin/src/queries/dataBlockQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/dataBlockQueries.ts
@@ -2,10 +2,10 @@ import dataBlockService from '@admin/services/dataBlockService';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 const dataBlockQueries = createQueryKeys('dataBlocks', {
-  list(releaseId: string) {
+  list(releaseVersionId: string) {
     return {
-      queryKey: [releaseId],
-      queryFn: () => dataBlockService.listDataBlocks(releaseId),
+      queryKey: [releaseVersionId],
+      queryFn: () => dataBlockService.listDataBlocks(releaseVersionId),
     };
   },
 });

--- a/src/explore-education-statistics-admin/src/queries/featuredTableQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/featuredTableQueries.ts
@@ -2,10 +2,10 @@ import featuredTableService from '@admin/services/featuredTableService';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 const featuredTableQueries = createQueryKeys('featuredTable', {
-  list(releaseId: string) {
+  list(releaseVersionId: string) {
     return {
-      queryKey: [releaseId],
-      queryFn: () => featuredTableService.listFeaturedTables(releaseId),
+      queryKey: [releaseVersionId],
+      queryFn: () => featuredTableService.listFeaturedTables(releaseVersionId),
     };
   },
 });

--- a/src/explore-education-statistics-admin/src/queries/permissionQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/permissionQueries.ts
@@ -2,10 +2,10 @@ import permissionService from '@admin/services/permissionService';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 const permissionQueries = createQueryKeys('releaseDataBlocks', {
-  canUpdateRelease(releaseId: string) {
+  canUpdateRelease(releaseVersionId: string) {
     return {
-      queryKey: [releaseId],
-      queryFn: () => permissionService.canUpdateRelease(releaseId),
+      queryKey: [releaseVersionId],
+      queryFn: () => permissionService.canUpdateRelease(releaseVersionId),
     };
   },
   canUpdateMethodology(methodologyId: string) {

--- a/src/explore-education-statistics-admin/src/queries/releaseAncillaryFileQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/releaseAncillaryFileQueries.ts
@@ -2,16 +2,17 @@ import releaseAncillaryFileService from '@admin/services/releaseAncillaryFileSer
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 const releaseAncillaryFileQueries = createQueryKeys('releaseAncillaryFile', {
-  get(releaseId: string, fileId: string) {
+  get(releaseVersionId: string, fileId: string) {
     return {
-      queryKey: [releaseId, fileId],
-      queryFn: () => releaseAncillaryFileService.getFile(releaseId, fileId),
+      queryKey: [releaseVersionId, fileId],
+      queryFn: () =>
+        releaseAncillaryFileService.getFile(releaseVersionId, fileId),
     };
   },
-  list(releaseId: string) {
+  list(releaseVersionId: string) {
     return {
-      queryKey: [releaseId],
-      queryFn: () => releaseAncillaryFileService.listFiles(releaseId),
+      queryKey: [releaseVersionId],
+      queryFn: () => releaseAncillaryFileService.listFiles(releaseVersionId),
     };
   },
 });

--- a/src/explore-education-statistics-admin/src/queries/releaseContentQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/releaseContentQueries.ts
@@ -2,10 +2,10 @@ import { createQueryKeys } from '@lukemorales/query-key-factory';
 import releaseContentService from '@admin/services/releaseContentService';
 
 const releaseContentQueries = createQueryKeys('releaseContent', {
-  get(releaseId: string) {
+  get(releaseVersionId: string) {
     return {
-      queryKey: [releaseId],
-      queryFn: () => releaseContentService.getContent(releaseId),
+      queryKey: [releaseVersionId],
+      queryFn: () => releaseContentService.getContent(releaseVersionId),
     };
   },
 });

--- a/src/explore-education-statistics-admin/src/queries/releasePermissionQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/releasePermissionQueries.ts
@@ -2,16 +2,16 @@ import { createQueryKeys } from '@lukemorales/query-key-factory';
 import releasePermissionService from '@admin/services/releasePermissionService';
 
 const releasePermissionQueries = createQueryKeys('releasePermission', {
-  listRoles(releaseId: string) {
+  listRoles(releaseVersionId: string) {
     return {
-      queryKey: [releaseId],
-      queryFn: () => releasePermissionService.listRoles(releaseId),
+      queryKey: [releaseVersionId],
+      queryFn: () => releasePermissionService.listRoles(releaseVersionId),
     };
   },
-  listInvites(releaseId: string) {
+  listInvites(releaseVersionId: string) {
     return {
-      queryKey: [releaseId],
-      queryFn: () => releasePermissionService.listInvites(releaseId),
+      queryKey: [releaseVersionId],
+      queryFn: () => releasePermissionService.listInvites(releaseVersionId),
     };
   },
 });

--- a/src/explore-education-statistics-admin/src/queries/releaseQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/releaseQueries.ts
@@ -14,10 +14,10 @@ const releaseQueries = createQueryKeys('release', {
     queryKey: null,
     queryFn: () => releaseService.listReleasesForApproval(),
   },
-  get(releaseId: string) {
+  get(releaseVersionId: string) {
     return {
-      queryKey: [releaseId],
-      queryFn: () => releaseService.getRelease(releaseId),
+      queryKey: [releaseVersionId],
+      queryFn: () => releaseService.getRelease(releaseVersionId),
     };
   },
 });

--- a/src/explore-education-statistics-admin/src/routes/preReleaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/preReleaseRoutes.ts
@@ -16,28 +16,28 @@ export type PreReleaseMethodologyRouteParams = ReleaseRouteParams & {
 };
 
 export const preReleaseContentRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/prerelease/content',
+  path: '/publication/:publicationId/release/:releaseVersionId/prerelease/content',
   title: 'Content',
   component: PreReleaseContentPage,
   exact: true,
 };
 
 export const preReleaseMethodologiesRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/prerelease/methodologies',
+  path: '/publication/:publicationId/release/:releaseVersionId/prerelease/methodologies',
   title: 'Methodologies',
   component: PreReleaseMethodologiesPage,
   exact: true,
 };
 
 export const preReleaseMethodologyRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/prerelease/methodologies/:methodologyId',
+  path: '/publication/:publicationId/release/:releaseVersionId/prerelease/methodologies/:methodologyId',
   title: 'Methodology',
   component: PreReleaseMethodologyPage,
   exact: true,
 };
 
 export const preReleaseTableToolRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/prerelease/table-tool/:dataBlockId?',
+  path: '/publication/:publicationId/release/:releaseVersionId/prerelease/table-tool/:dataBlockId?',
   title: 'Table tool',
   component: PreReleaseTableToolPage,
   exact: true,

--- a/src/explore-education-statistics-admin/src/routes/publicationRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/publicationRoutes.ts
@@ -23,12 +23,12 @@ export type PublicationEditReleaseSeriesLegacyLinkRouteParams = {
 
 export type PublicationTeamRouteParams = {
   publicationId: string;
-  releaseId?: string;
+  releaseVersionId?: string;
 };
 
 export type PublicationManageTeamRouteParams = {
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
 };
 
 export interface PublicationRouteProps extends RouteProps {
@@ -73,20 +73,20 @@ export const publicationContactRoute: PublicationRouteProps = {
 };
 
 export const publicationTeamAccessRoute: PublicationRouteProps = {
-  path: '/publication/:publicationId/team/:releaseId?',
+  path: '/publication/:publicationId/team/:releaseVersionId?',
   title: 'Team access',
   component: PublicationTeamAccessPage,
 };
 
 export const publicationManageReleaseContributorsPageRoute: PublicationRouteProps =
   {
-    path: '/publication/:publicationId/team/:releaseId/manage-contributors',
+    path: '/publication/:publicationId/team/:releaseVersionId/manage-contributors',
     title: 'Add contributors',
     component: PublicationManageReleaseContributorsPage,
   };
 
 export const publicationInviteUsersPageRoute: PublicationRouteProps = {
-  path: '/publication/:publicationId/team/:releaseId/invite-users',
+  path: '/publication/:publicationId/team/:releaseVersionId/invite-users',
   title: 'Invite users',
   component: PublicationInviteUsersPage,
 };

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -117,7 +117,7 @@ export const releaseApiDataSetDetailsRoute: ReleaseRouteProps = {
 };
 
 export const releaseApiDataSetLocationsMappingRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId/locations-mapping',
+  path: '/publication/:publicationId/release/:releaseVersionId/api-data-sets/:dataSetId/locations-mapping',
   title: 'API data set locations mapping',
   component: ReleaseApiDataSetLocationsMappingPage,
   protectionAction: permissions => permissions.isBauUser,

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -22,7 +22,7 @@ import ReleaseSummaryPage from '@admin/pages/release/ReleaseSummaryPage';
 
 export type ReleaseRouteParams = {
   publicationId: string;
-  releaseId: string;
+  releaseVersionId: string;
 };
 
 export type ReleaseDataBlockRouteParams = ReleaseRouteParams & {
@@ -55,62 +55,62 @@ export interface ReleaseRouteProps extends ProtectedRouteProps {
 }
 
 export const releaseSummaryRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/summary',
+  path: '/publication/:publicationId/release/:releaseVersionId/summary',
   title: 'Summary',
   component: ReleaseSummaryPage,
 };
 
 export const releaseSummaryEditRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/summary/edit',
+  path: '/publication/:publicationId/release/:releaseVersionId/summary/edit',
   title: 'Edit summary',
   component: ReleaseSummaryEditPage,
 };
 
 export const releaseDataRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/data',
+  path: '/publication/:publicationId/release/:releaseVersionId/data',
   title: 'Data and files',
   component: ReleaseDataPage,
 };
 
 export const releaseAncillaryFilesRoute: ReleaseRouteProps = {
-  path: `/publication/:publicationId/release/:releaseId/data#${releaseDataPageTabIds.fileUploads}`,
+  path: `/publication/:publicationId/release/:releaseVersionId/data#${releaseDataPageTabIds.fileUploads}`,
   title: 'Data and files',
   component: ReleaseDataPage,
 };
 
 export const releaseAncillaryFileRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/ancillary/:fileId',
+  path: '/publication/:publicationId/release/:releaseVersionId/ancillary/:fileId',
   title: 'Ancillary file',
   component: ReleaseAncillaryFilePage,
 };
 
 export const releaseDataFileRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/data/:fileId',
+  path: '/publication/:publicationId/release/:releaseVersionId/data/:fileId',
   title: 'Data file',
   component: ReleaseDataFilePage,
 };
 
 export const releaseDataFileReplaceRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/data/:fileId/replace',
+  path: '/publication/:publicationId/release/:releaseVersionId/data/:fileId/replace',
   title: 'Replace data file',
   component: ReleaseDataFileReplacePage,
 };
 
 export const releaseDataFileReplacementCompleteRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/data/:fileId/replacement-complete',
+  path: '/publication/:publicationId/release/:releaseVersionId/data/:fileId/replacement-complete',
   title: 'Replacement complete',
   component: ReleaseDataFileReplacementCompletePage,
 };
 
 export const releaseApiDataSetsRoute: ReleaseRouteProps = {
-  path: `/publication/:publicationId/release/:releaseId/data#${releaseDataPageTabIds.apiDataSets}`,
+  path: `/publication/:publicationId/release/:releaseVersionId/data#${releaseDataPageTabIds.apiDataSets}`,
   title: 'API data sets',
   component: ReleaseDataPage,
   protectionAction: permissions => permissions.isBauUser,
 };
 
 export const releaseApiDataSetDetailsRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId',
+  path: '/publication/:publicationId/release/:releaseVersionId/api-data-sets/:dataSetId',
   title: 'API data set details',
   component: ReleaseApiDataSetDetailsPage,
   protectionAction: permissions => permissions.isBauUser,
@@ -124,61 +124,61 @@ export const releaseApiDataSetLocationsMappingRoute: ReleaseRouteProps = {
 };
 
 export const releaseFootnotesRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/footnotes',
+  path: '/publication/:publicationId/release/:releaseVersionId/footnotes',
   title: 'Footnotes',
   component: ReleaseFootnotesPage,
 };
 
 export const releaseFootnotesCreateRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/create-footnote',
+  path: '/publication/:publicationId/release/:releaseVersionId/create-footnote',
   title: 'Create footnote',
   component: ReleaseFootnoteCreatePage,
 };
 
 export const releaseFootnotesEditRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/footnotes/:footnoteId',
+  path: '/publication/:publicationId/release/:releaseVersionId/footnotes/:footnoteId',
   title: 'Edit footnote',
   component: ReleaseFootnoteEditPage,
 };
 
 export const releaseDataBlocksRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/data-blocks',
+  path: '/publication/:publicationId/release/:releaseVersionId/data-blocks',
   title: 'Data blocks',
   component: ReleaseDataBlocksPage,
 };
 
 export const releaseTableToolRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/data-blocks/table-tool',
+  path: '/publication/:publicationId/release/:releaseVersionId/data-blocks/table-tool',
   title: 'Table tool',
   component: ReleaseTableToolPage,
 };
 
 export const releaseDataBlockCreateRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/data-blocks/create',
+  path: '/publication/:publicationId/release/:releaseVersionId/data-blocks/create',
   title: 'Create data block',
   component: ReleaseDataBlockCreatePage,
 };
 
 export const releaseDataBlockEditRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/data-blocks/:dataBlockId',
+  path: '/publication/:publicationId/release/:releaseVersionId/data-blocks/:dataBlockId',
   title: 'Edit data block',
   component: ReleaseDataBlockEditPage,
 };
 
 export const releaseContentRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/content',
+  path: '/publication/:publicationId/release/:releaseVersionId/content',
   title: 'Content',
   component: ReleaseContentPage,
 };
 
 export const releaseStatusRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/status',
+  path: '/publication/:publicationId/release/:releaseVersionId/status',
   title: 'Sign off',
   component: ReleasePublishStatusPage,
 };
 
 export const releasePreReleaseAccessRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/prerelease-access',
+  path: '/publication/:publicationId/release/:releaseVersionId/prerelease-access',
   title: 'Pre-release access',
   component: ReleasePreReleaseAccessPage,
 };

--- a/src/explore-education-statistics-admin/src/routes/routes.ts
+++ b/src/explore-education-statistics-admin/src/routes/routes.ts
@@ -151,7 +151,7 @@ export const methodologyRoute: ProtectedRouteProps = {
 };
 
 export const releaseRoute: ProtectedRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId',
+  path: '/publication/:publicationId/release/:releaseVersionId',
   protectionAction: permissions => permissions.canAccessAnalystPages,
   component: ReleasePageContainer,
 };
@@ -164,20 +164,20 @@ export const releaseCreateRoute: ProtectedRouteProps = {
 };
 
 export const preReleaseRoute: ProtectedRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/prerelease',
+  path: '/publication/:publicationId/release/:releaseVersionId/prerelease',
   component: PreReleasePageContainer,
   protectionAction: permissions => permissions.canAccessPrereleasePages,
 };
 
 export const preReleaseAccessListRoute: ProtectedRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/prerelease-access-list',
+  path: '/publication/:publicationId/release/:releaseVersionId/prerelease-access-list',
   component: PreReleaseAccessListPage,
   protectionAction: permissions => permissions.canAccessPrereleasePages,
   exact: true,
 };
 
 export const releaseDataGuidanceRoute: ProtectedRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/data-guidance',
+  path: '/publication/:publicationId/release/:releaseVersionId/data-guidance',
   component: ReleaseDataGuidancePage,
   protectionAction: permissions => permissions.canAccessPrereleasePages,
   exact: true,

--- a/src/explore-education-statistics-admin/src/services/dataBlockService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataBlockService.ts
@@ -41,8 +41,8 @@ export interface DeleteDataBlockPlan {
 }
 
 const dataBlockService = {
-  listDataBlocks(releaseId: string): Promise<ReleaseDataBlockSummary[]> {
-    return client.get(`/releases/${releaseId}/data-blocks`);
+  listDataBlocks(releaseVersionId: string): Promise<ReleaseDataBlockSummary[]> {
+    return client.get(`/releases/${releaseVersionId}/data-blocks`);
   },
 
   getDataBlock(dataBlockId: string): Promise<ReleaseDataBlock> {
@@ -50,10 +50,10 @@ const dataBlockService = {
   },
 
   createDataBlock(
-    releaseId: string,
+    releaseVersionId: string,
     dataBlock: CreateReleaseDataBlock,
   ): Promise<ReleaseDataBlock> {
-    return client.post(`/releases/${releaseId}/data-blocks`, dataBlock);
+    return client.post(`/releases/${releaseVersionId}/data-blocks`, dataBlock);
   },
 
   updateDataBlock(
@@ -66,22 +66,22 @@ const dataBlockService = {
     );
   },
 
-  deleteDataBlock(releaseId: string, id: string): Promise<void> {
-    return client.delete(`/releases/${releaseId}/data-blocks/${id}`);
+  deleteDataBlock(releaseVersionId: string, id: string): Promise<void> {
+    return client.delete(`/releases/${releaseVersionId}/data-blocks/${id}`);
   },
 
   getDeleteBlockPlan(
-    releaseId: string,
+    releaseVersionId: string,
     id: string,
   ): Promise<DeleteDataBlockPlan> {
     return client.get(
-      `/releases/${releaseId}/data-blocks/${id}/delete-plan`,
+      `/releases/${releaseVersionId}/data-blocks/${id}/delete-plan`,
       {},
     );
   },
 
-  getUnattachedDataBlocks(releaseId: string): Promise<DataBlock[]> {
-    return client.get(`/release/${releaseId}/data-blocks/unattached`);
+  getUnattachedDataBlocks(releaseVersionId: string): Promise<DataBlock[]> {
+    return client.get(`/release/${releaseVersionId}/data-blocks/unattached`);
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -101,21 +101,21 @@ export interface DataReplacementPlan {
 
 const dataReplacementService = {
   getReplacementPlan(
-    releaseId: string,
+    releaseVersionId: string,
     fileId: string,
     replacementFileId: string,
   ): Promise<DataReplacementPlan> {
     return client.get(
-      `releases/${releaseId}/data/${fileId}/replacement-plan/${replacementFileId}`,
+      `releases/${releaseVersionId}/data/${fileId}/replacement-plan/${replacementFileId}`,
     );
   },
   replaceData(
-    releaseId: string,
+    releaseVersionId: string,
     fileId: string,
     replacementFileId: string,
   ): Promise<void> {
     return client.post(
-      `releases/${releaseId}/data/${fileId}/replacement/${replacementFileId}`,
+      `releases/${releaseVersionId}/data/${fileId}/replacement/${replacementFileId}`,
     );
   },
 };

--- a/src/explore-education-statistics-admin/src/services/featuredTableService.ts
+++ b/src/explore-education-statistics-admin/src/services/featuredTableService.ts
@@ -22,40 +22,51 @@ type FeaturedTableUpdateRequest = FeaturedTableBasic;
 
 const featuredTableService = {
   getFeaturedTable(
-    releaseId: string,
+    releaseVersionId: string,
     dataBlockId: string,
   ): Promise<FeaturedTable> {
-    return client.get(`/releases/${releaseId}/featured-tables/${dataBlockId}`);
+    return client.get(
+      `/releases/${releaseVersionId}/featured-tables/${dataBlockId}`,
+    );
   },
-  listFeaturedTables(releaseId: string): Promise<FeaturedTable[]> {
-    return client.get(`/releases/${releaseId}/featured-tables`);
+  listFeaturedTables(releaseVersionId: string): Promise<FeaturedTable[]> {
+    return client.get(`/releases/${releaseVersionId}/featured-tables`);
   },
   createFeaturedTable(
-    releaseId: string,
+    releaseVersionId: string,
     featuredTable: FeaturedTableCreateRequest,
   ): Promise<FeaturedTable> {
-    return client.post(`/releases/${releaseId}/featured-tables`, featuredTable);
+    return client.post(
+      `/releases/${releaseVersionId}/featured-tables`,
+      featuredTable,
+    );
   },
   updateFeaturedTable(
-    releaseId: string,
+    releaseVersionId: string,
     dataBlockId: string,
     featuredTable: FeaturedTableUpdateRequest,
   ): Promise<FeaturedTable> {
     return client.post(
-      `/releases/${releaseId}/featured-tables/${dataBlockId}`,
+      `/releases/${releaseVersionId}/featured-tables/${dataBlockId}`,
       featuredTable,
     );
   },
-  deleteFeaturedTable(releaseId: string, dataBlockId: string): Promise<void> {
+  deleteFeaturedTable(
+    releaseVersionId: string,
+    dataBlockId: string,
+  ): Promise<void> {
     return client.delete(
-      `/releases/${releaseId}/featured-tables/${dataBlockId}`,
+      `/releases/${releaseVersionId}/featured-tables/${dataBlockId}`,
     );
   },
   reorderFeaturedTables(
-    releaseId: string,
+    releaseVersionId: string,
     newOrder: string[],
   ): Promise<FeaturedTable[]> {
-    return client.put(`releases/${releaseId}/featured-tables/order`, newOrder);
+    return client.put(
+      `releases/${releaseVersionId}/featured-tables/order`,
+      newOrder,
+    );
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/footnoteService.ts
+++ b/src/explore-education-statistics-admin/src/services/footnoteService.ts
@@ -78,39 +78,42 @@ export interface FootnoteMeta {
 }
 
 const footnoteService = {
-  getFootnoteMeta(releaseId: string): Promise<FootnoteMeta> {
-    return client.get(`/releases/${releaseId}/footnotes-meta`);
+  getFootnoteMeta(releaseVersionId: string): Promise<FootnoteMeta> {
+    return client.get(`/releases/${releaseVersionId}/footnotes-meta`);
   },
-  getFootnotes(releaseId: string): Promise<Footnote[]> {
-    return client.get(`/releases/${releaseId}/footnotes`);
+  getFootnotes(releaseVersionId: string): Promise<Footnote[]> {
+    return client.get(`/releases/${releaseVersionId}/footnotes`);
   },
-  getFootnote(releaseId: string, id: string): Promise<Footnote> {
-    return client.get(`/releases/${releaseId}/footnotes/${id}`);
+  getFootnote(releaseVersionId: string, id: string): Promise<Footnote> {
+    return client.get(`/releases/${releaseVersionId}/footnotes/${id}`);
   },
-  createFootnote(releaseId: string, footnote: BaseFootnote): Promise<Footnote> {
+  createFootnote(
+    releaseVersionId: string,
+    footnote: BaseFootnote,
+  ): Promise<Footnote> {
     return client.post(
-      `/releases/${releaseId}/footnotes`,
+      `/releases/${releaseVersionId}/footnotes`,
       footnoteToFlatFootnote(footnote),
     );
   },
   updateFootnote(
-    releaseId: string,
+    releaseVersionId: string,
     id: string,
     footnote: BaseFootnote,
   ): Promise<Footnote> {
     return client.put(
-      `/releases/${releaseId}/footnotes/${id}`,
+      `/releases/${releaseVersionId}/footnotes/${id}`,
       footnoteToFlatFootnote(footnote),
     );
   },
-  deleteFootnote(releaseId: string, id: string): Promise<void> {
-    return client.delete(`/releases/${releaseId}/footnotes/${id}`);
+  deleteFootnote(releaseVersionId: string, id: string): Promise<void> {
+    return client.delete(`/releases/${releaseVersionId}/footnotes/${id}`);
   },
   updateFootnotesOrder(
-    releaseId: string,
+    releaseVersionId: string,
     footnoteIds: string[],
   ): Promise<string[]> {
-    return client.patch(`/releases/${releaseId}/footnotes/`, {
+    return client.patch(`/releases/${releaseVersionId}/footnotes/`, {
       footnoteIds,
     });
   },

--- a/src/explore-education-statistics-admin/src/services/hubs/releaseContentHub.ts
+++ b/src/explore-education-statistics-admin/src/services/hubs/releaseContentHub.ts
@@ -6,7 +6,7 @@ import Hub, { Subscription } from './utils/Hub';
 export interface ReleaseContentBlockLockEvent {
   id: string;
   sectionId: string;
-  releaseId: string;
+  releaseVersionId: string;
   locked: string;
   lockedUntil: string;
   lockedBy: UserDetails;
@@ -15,16 +15,16 @@ export interface ReleaseContentBlockLockEvent {
 export interface ReleaseContentBlockUnlockEvent {
   id: string;
   sectionId: string;
-  releaseId: string;
+  releaseVersionId: string;
 }
 
 export class ReleaseContentHub extends Hub {
-  async joinReleaseGroup(releaseId: string): Promise<void> {
-    await this.send('JoinReleaseGroup', { id: releaseId });
+  async joinReleaseGroup(releaseVersionId: string): Promise<void> {
+    await this.send('JoinReleaseGroup', { id: releaseVersionId });
   }
 
-  async leaveReleaseGroup(releaseId: string): Promise<void> {
-    await this.send('LeaveReleaseGroup', { id: releaseId });
+  async leaveReleaseGroup(releaseVersionId: string): Promise<void> {
+    await this.send('LeaveReleaseGroup', { id: releaseVersionId });
   }
 
   lockContentBlock(

--- a/src/explore-education-statistics-admin/src/services/importStatusService.ts
+++ b/src/explore-education-statistics-admin/src/services/importStatusService.ts
@@ -5,7 +5,8 @@ export interface ImportStatus {
   subjectId: string;
   publicationId: string;
   publicationTitle: string;
-  releaseVersionId: string;
+  // TODO rename to releaseVersionId
+  releaseId: string;
   releaseTitle: string;
   dataFileName: string;
   totalRows?: number;

--- a/src/explore-education-statistics-admin/src/services/importStatusService.ts
+++ b/src/explore-education-statistics-admin/src/services/importStatusService.ts
@@ -5,7 +5,7 @@ export interface ImportStatus {
   subjectId: string;
   publicationId: string;
   publicationTitle: string;
-  releaseId: string;
+  releaseVersionId: string;
   releaseTitle: string;
   dataFileName: string;
   totalRows?: number;

--- a/src/explore-education-statistics-admin/src/services/keyStatisticService.ts
+++ b/src/explore-education-statistics-admin/src/services/keyStatisticService.ts
@@ -31,55 +31,64 @@ export type KeyStatisticTextUpdateRequest = KeyStatisticTextSaveRequest;
 
 const keyStatisticService = {
   createKeyStatisticDataBlock(
-    releaseId: string,
+    releaseVersionId: string,
     request: KeyStatisticDataBlockCreateRequest,
   ): Promise<KeyStatisticDataBlock> {
     return client.post(
-      `/release/${releaseId}/key-statistic-data-block`,
+      `/release/${releaseVersionId}/key-statistic-data-block`,
       request,
     );
   },
 
   createKeyStatisticText(
-    releaseId: string,
+    releaseVersionId: string,
     request: KeyStatisticTextCreateRequest,
   ): Promise<KeyStatisticText> {
-    return client.post(`/release/${releaseId}/key-statistic-text`, request);
+    return client.post(
+      `/release/${releaseVersionId}/key-statistic-text`,
+      request,
+    );
   },
 
   updateKeyStatisticDataBlock(
-    releaseId: string,
+    releaseVersionId: string,
     keyStatisticId: string,
     request: KeyStatisticDataBlockUpdateRequest,
   ): Promise<KeyStatisticDataBlock> {
     return client.put(
-      `/release/${releaseId}/key-statistic-data-block/${keyStatisticId}`,
+      `/release/${releaseVersionId}/key-statistic-data-block/${keyStatisticId}`,
       request,
     );
   },
 
   updateKeyStatisticText(
-    releaseId: string,
+    releaseVersionId: string,
     keyStatisticId: string,
     request: KeyStatisticTextUpdateRequest,
   ): Promise<KeyStatisticText> {
     return client.put(
-      `/release/${releaseId}/key-statistic-text/${keyStatisticId}`,
+      `/release/${releaseVersionId}/key-statistic-text/${keyStatisticId}`,
       request,
     );
   },
 
-  deleteKeyStatistic(releaseId: string, keyStatisticId: string): Promise<void> {
+  deleteKeyStatistic(
+    releaseVersionId: string,
+    keyStatisticId: string,
+  ): Promise<void> {
     return client.delete(
-      `/release/${releaseId}/key-statistic/${keyStatisticId}`,
+      `/release/${releaseVersionId}/key-statistic/${keyStatisticId}`,
     );
   },
 
   reorderKeyStatistics(
-    releaseId: string,
+    releaseVersionId: string,
     order: string[],
   ): Promise<KeyStatistic[]> {
-    return client.put(`/release/${releaseId}/key-statistic/order`, order);
+    return client.put(
+      `/release/${releaseVersionId}/key-statistic/order`,
+      order,
+    );
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/permissionService.ts
+++ b/src/explore-education-statistics-admin/src/services/permissionService.ts
@@ -43,16 +43,16 @@ const permissionService = {
   canAccessPrereleasePages(user?: User): Promise<boolean> {
     return Promise.resolve(!!user?.permissions.canAccessPrereleasePages);
   },
-  canUpdateRelease(releaseId: string): Promise<boolean> {
-    return client.get(`/permissions/release/${releaseId}/update`);
+  canUpdateRelease(releaseVersionId: string): Promise<boolean> {
+    return client.get(`/permissions/release/${releaseVersionId}/update`);
   },
   getReleaseStatusPermissions(
-    releaseId: string,
+    releaseVersionId: string,
   ): Promise<ReleaseStatusPermissions> {
-    return client.get(`/permissions/release/${releaseId}/status`);
+    return client.get(`/permissions/release/${releaseVersionId}/status`);
   },
-  canMakeAmendmentOfRelease(releaseId: string): Promise<boolean> {
-    return client.get(`/permissions/release/${releaseId}/amend`);
+  canMakeAmendmentOfRelease(releaseVersionId: string): Promise<boolean> {
+    return client.get(`/permissions/release/${releaseVersionId}/amend`);
   },
   canCreatePublicationForTopic(topicId: string): Promise<boolean> {
     return client.get(`/permissions/topic/${topicId}/publication/create`);
@@ -66,14 +66,14 @@ const permissionService = {
     return client.get(`/permissions/methodology/${methodologyId}/status`);
   },
   getPreReleaseWindowStatus(
-    releaseId: string,
+    releaseVersionId: string,
   ): Promise<PreReleaseWindowStatus> {
     return client
       .get<{
         access: PreReleaseAccess;
         start: string;
         scheduledPublishDate: string;
-      }>(`/permissions/release/${releaseId}/prerelease/status`)
+      }>(`/permissions/release/${releaseVersionId}/prerelease/status`)
       .then(status => ({
         access: status.access,
         start: parseISO(status.start),
@@ -81,11 +81,11 @@ const permissionService = {
       }));
   },
   getDataFilePermissions(
-    releaseId: string,
+    releaseVersionId: string,
     fileId: string,
   ): Promise<DataFilePermissions> {
     return client.get<DataFilePermissions>(
-      `/permissions/release/${releaseId}/data/${fileId}`,
+      `/permissions/release/${releaseVersionId}/data/${fileId}`,
     );
   },
 };

--- a/src/explore-education-statistics-admin/src/services/preReleaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/preReleaseService.ts
@@ -10,8 +10,10 @@ export interface PreReleaseSummary {
 }
 
 const preReleaseService = {
-  getPreReleaseSummary(releaseId: string): Promise<PreReleaseSummary> {
-    return client.get<PreReleaseSummary>(`/release/${releaseId}/prerelease`);
+  getPreReleaseSummary(releaseVersionId: string): Promise<PreReleaseSummary> {
+    return client.get<PreReleaseSummary>(
+      `/release/${releaseVersionId}/prerelease`,
+    );
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/preReleaseUserService.ts
+++ b/src/explore-education-statistics-admin/src/services/preReleaseUserService.ts
@@ -11,24 +11,27 @@ export interface PreReleaseInvitePlan {
 }
 
 const preReleaseUserService = {
-  getUsers(releaseId: string): Promise<PreReleaseUser[]> {
-    return client.get(`/release/${releaseId}/prerelease-users`);
+  getUsers(releaseVersionId: string): Promise<PreReleaseUser[]> {
+    return client.get(`/release/${releaseVersionId}/prerelease-users`);
   },
   getInvitePlan(
-    releaseId: string,
+    releaseVersionId: string,
     emails: string[],
   ): Promise<PreReleaseInvitePlan> {
-    return client.post(`/release/${releaseId}/prerelease-users-plan`, {
+    return client.post(`/release/${releaseVersionId}/prerelease-users-plan`, {
       emails,
     });
   },
-  inviteUsers(releaseId: string, emails: string[]): Promise<PreReleaseUser[]> {
-    return client.post(`/release/${releaseId}/prerelease-users`, {
+  inviteUsers(
+    releaseVersionId: string,
+    emails: string[],
+  ): Promise<PreReleaseUser[]> {
+    return client.post(`/release/${releaseVersionId}/prerelease-users`, {
       emails,
     });
   },
-  removeUser(releaseId: string, email: string): Promise<void> {
-    return client.delete(`/release/${releaseId}/prerelease-users`, {
+  removeUser(releaseVersionId: string, email: string): Promise<void> {
+    return client.delete(`/release/${releaseVersionId}/prerelease-users`, {
       data: {
         email,
       },

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -1,5 +1,5 @@
 import { MethodologyVersion } from '@admin/services/methodologyService';
-import { ReleaseSummary } from '@admin/services/releaseService';
+import { ReleaseVersionSummary } from '@admin/services/releaseService';
 import { IdTitlePair } from '@admin/services/types/common';
 import client from '@admin/services/utils/service';
 import {
@@ -174,7 +174,9 @@ const publicationService = {
     return client.put(`publication/${publicationId}/contact`, updatedContact);
   },
 
-  listReleases<TReleaseSummary extends ReleaseSummary = ReleaseSummary>(
+  listReleases<
+    TReleaseSummary extends ReleaseVersionSummary = ReleaseVersionSummary,
+  >(
     publicationId: string,
     params?: ListReleasesParams,
   ): Promise<PaginatedList<TReleaseSummary>> {

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -85,7 +85,7 @@ export interface ReleaseSeriesLegacyLinkAddRequest {
 
 export interface ReleaseSeriesItemUpdateRequest {
   id: string;
-  releaseId?: string;
+  releaseVersionId?: string;
   legacyLinkDescription?: string;
   legacyLinkUrl?: string;
 }

--- a/src/explore-education-statistics-admin/src/services/releaseAncillaryFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseAncillaryFileService.ts
@@ -49,18 +49,18 @@ function mapFile({ name, ...file }: AncillaryFileInfo): AncillaryFile {
 }
 
 const releaseAncillaryFileService = {
-  listFiles(releaseId: string): Promise<AncillaryFile[]> {
+  listFiles(releaseVersionId: string): Promise<AncillaryFile[]> {
     return client
-      .get<AncillaryFileInfo[]>(`/release/${releaseId}/ancillary`)
+      .get<AncillaryFileInfo[]>(`/release/${releaseVersionId}/ancillary`)
       .then(response => response.map(mapFile));
   },
-  getFile(releaseId: string, fileId: string): Promise<AncillaryFile> {
+  getFile(releaseVersionId: string, fileId: string): Promise<AncillaryFile> {
     return client
-      .get<AncillaryFileInfo>(`/release/${releaseId}/file/${fileId}`)
+      .get<AncillaryFileInfo>(`/release/${releaseVersionId}/file/${fileId}`)
       .then(mapFile);
   },
   async createFile(
-    releaseId: string,
+    releaseVersionId: string,
     request: UploadAncillaryFileRequest,
   ): Promise<AncillaryFile> {
     const data = new FormData();
@@ -69,14 +69,14 @@ const releaseAncillaryFileService = {
     data.append('summary', request.summary);
 
     const file = await client.post<AncillaryFileInfo>(
-      `/release/${releaseId}/ancillary`,
+      `/release/${releaseVersionId}/ancillary`,
       data,
     );
 
     return mapFile(file);
   },
   async updateFile(
-    releaseId: string,
+    releaseVersionId: string,
     fileId: string,
     request: AncillaryFileUpdateRequest,
   ): Promise<AncillaryFile> {
@@ -88,18 +88,24 @@ const releaseAncillaryFileService = {
     }
 
     const file = await client.put<AncillaryFileInfo>(
-      `release/${releaseId}/ancillary/${fileId}`,
+      `release/${releaseVersionId}/ancillary/${fileId}`,
       data,
     );
 
     return mapFile(file);
   },
-  deleteFile(releaseId: string, fileId: string): Promise<void> {
-    return client.delete<void>(`/release/${releaseId}/ancillary/${fileId}`);
+  deleteFile(releaseVersionId: string, fileId: string): Promise<void> {
+    return client.delete<void>(
+      `/release/${releaseVersionId}/ancillary/${fileId}`,
+    );
   },
-  downloadFile(releaseId: string, id: string, fileName: string): Promise<void> {
+  downloadFile(
+    releaseVersionId: string,
+    id: string,
+    fileName: string,
+  ): Promise<void> {
     return client
-      .get<Blob>(`/release/${releaseId}/file/${id}/download`, {
+      .get<Blob>(`/release/${releaseVersionId}/file/${id}/download`, {
         responseType: 'blob',
       })
       .then(response => downloadFile(response, fileName));

--- a/src/explore-education-statistics-admin/src/services/releaseChartFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseChartFileService.ts
@@ -31,28 +31,31 @@ function mapFile(file: FileInfo): ChartFile {
 
 const releaseChartFileService = {
   async uploadChartFile(
-    releaseId: string,
+    releaseVersionId: string,
     request: UploadChartFileRequest,
   ): Promise<ChartFile> {
     const data = new FormData();
     data.append('file', request.file);
 
     const file = await client.post<FileInfo>(
-      `/release/${releaseId}/chart`,
+      `/release/${releaseVersionId}/chart`,
       data,
     );
 
     return mapFile(file);
   },
 
-  async deleteChartFile(releaseId: string, id: string): Promise<void> {
-    return client.delete<void>(`/release/${releaseId}/chart/${id}`);
+  async deleteChartFile(releaseVersionId: string, id: string): Promise<void> {
+    return client.delete<void>(`/release/${releaseVersionId}/chart/${id}`);
   },
 
-  getChartFile(releaseId: string, id: string): Promise<Blob> {
-    return client.get<Blob>(`/release/${releaseId}/file/${id}/download`, {
-      responseType: 'blob',
-    });
+  getChartFile(releaseVersionId: string, id: string): Promise<Blob> {
+    return client.get<Blob>(
+      `/release/${releaseVersionId}/file/${id}/download`,
+      {
+        responseType: 'blob',
+      },
+    );
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/releaseContentCommentService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseContentCommentService.ts
@@ -6,23 +6,23 @@ export type CommentUpdate = Pick<Comment, 'id' | 'content'>;
 
 const releaseContentCommentService = {
   getContentSectionComments(
-    releaseId: string,
+    releaseVersionId: string,
     sectionId: string,
     contentBlockId: string,
   ): Promise<Comment[]> {
     return client.get(
-      `/release/${releaseId}/content/section/${sectionId}/block/${contentBlockId}/comments`,
+      `/release/${releaseVersionId}/content/section/${sectionId}/block/${contentBlockId}/comments`,
     );
   },
 
   addContentSectionComment(
-    releaseId: string,
+    releaseVersionId: string,
     sectionId: string,
     contentBlockId: string,
     comment: CommentCreate,
   ): Promise<Comment> {
     return client.post(
-      `/release/${releaseId}/content/section/${sectionId}/block/${contentBlockId}/comments/add`,
+      `/release/${releaseVersionId}/content/section/${sectionId}/block/${contentBlockId}/comments/add`,
       comment,
     );
   },

--- a/src/explore-education-statistics-admin/src/services/releaseContentRelatedInformationService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseContentRelatedInformationService.ts
@@ -2,30 +2,34 @@ import client from '@admin/services/utils/service';
 import { BasicLink, Release } from '@common/services/publicationService';
 
 const releaseContentRelatedInformationService = {
-  getAll: (releaseId: string): Promise<Release['relatedInformation']> => {
-    return client.get(`/release/${releaseId}/content/related-information`);
+  getAll: (
+    releaseVersionId: string,
+  ): Promise<Release['relatedInformation']> => {
+    return client.get(
+      `/release/${releaseVersionId}/content/related-information`,
+    );
   },
   create: (
-    releaseId: string,
+    releaseVersionId: string,
     link: Omit<BasicLink, 'id'>,
   ): Promise<BasicLink[]> => {
     return client.post(
-      `/release/${releaseId}/content/related-information`,
+      `/release/${releaseVersionId}/content/related-information`,
       link,
     );
   },
   update: (
-    releaseId: string,
+    releaseVersionId: string,
     link: { id: string; description: string; url: string },
   ): Promise<BasicLink[]> => {
     return client.put(
-      `/release/${releaseId}/content/related-information/${link.id}`,
+      `/release/${releaseVersionId}/content/related-information/${link.id}`,
       link,
     );
   },
-  delete: (releaseId: string, linkId: string): Promise<BasicLink[]> => {
+  delete: (releaseVersionId: string, linkId: string): Promise<BasicLink[]> => {
     return client.delete(
-      `/release/${releaseId}/content/related-information/${linkId}`,
+      `/release/${releaseVersionId}/content/related-information/${linkId}`,
     );
   },
 };

--- a/src/explore-education-statistics-admin/src/services/releaseContentService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseContentService.ts
@@ -19,7 +19,7 @@ import { Dictionary } from '@common/types';
 
 type ContentSectionViewModel = ContentSection<EditableBlock>;
 
-export interface EditableRelease
+export interface EditableReleaseVersion
   extends Omit<
     Release<EditableContentBlock, EditableDataBlock, EditableEmbedBlock>,
     'published'
@@ -31,7 +31,7 @@ export interface EditableRelease
 }
 
 export interface ReleaseContent {
-  release: EditableRelease;
+  release: EditableReleaseVersion;
   unattachedDataBlocks: DataBlock[];
 }
 
@@ -41,125 +41,133 @@ export interface ContentBlockAttachRequest {
 }
 
 const releaseContentService = {
-  getContent(releaseId: string, isPrerelease = false): Promise<ReleaseContent> {
-    return client.get<ReleaseContent>(`/release/${releaseId}/content`, {
+  getContent(
+    releaseVersionId: string,
+    isPrerelease = false,
+  ): Promise<ReleaseContent> {
+    return client.get<ReleaseContent>(`/release/${releaseVersionId}/content`, {
       params: { isPrerelease },
     });
   },
   addContentSection(
-    releaseId: string,
+    releaseVersionId: string,
     order: number,
   ): Promise<ContentSectionViewModel> {
     return client.post<ContentSectionViewModel>(
-      `/release/${releaseId}/content/sections/add`,
+      `/release/${releaseVersionId}/content/sections/add`,
       { order },
     );
   },
   updateContentSectionsOrder(
-    releaseId: string,
+    releaseVersionId: string,
     order: Dictionary<number>,
   ): Promise<ContentSectionViewModel[]> {
     return client.put<ContentSectionViewModel[]>(
-      `/release/${releaseId}/content/sections/order`,
+      `/release/${releaseVersionId}/content/sections/order`,
       order,
     );
   },
   removeContentSection(
-    releaseId: string,
+    releaseVersionId: string,
     sectionId: string,
   ): Promise<ContentSectionViewModel[]> {
     return client.delete<ContentSectionViewModel[]>(
-      `/release/${releaseId}/content/section/${sectionId}`,
+      `/release/${releaseVersionId}/content/section/${sectionId}`,
     );
   },
 
   addContentSectionBlock(
-    releaseId: string,
+    releaseVersionId: string,
     sectionId: string,
     block: ContentBlockPostModel,
   ): Promise<EditableContentBlock> {
     return client.post<EditableContentBlock>(
-      `/release/${releaseId}/content/section/${sectionId}/blocks/add`,
+      `/release/${releaseVersionId}/content/section/${sectionId}/blocks/add`,
       block,
     );
   },
 
   addEmbedSectionBlock(
-    releaseId: string,
+    releaseVersionId: string,
     request: EmbedBlockCreateRequest,
   ): Promise<EditableEmbedBlock> {
     return client.post<EditableEmbedBlock>(
-      `/release/${releaseId}/embed-blocks`,
+      `/release/${releaseVersionId}/embed-blocks`,
       request,
     );
   },
 
   updateEmbedSectionBlock(
-    releaseId: string,
+    releaseVersionId: string,
     contentBlockId: string,
     request: EmbedBlockUpdateRequest,
   ): Promise<EditableEmbedBlock> {
     return client.put<EditableEmbedBlock>(
-      `/release/${releaseId}/embed-blocks/${contentBlockId}`,
+      `/release/${releaseVersionId}/embed-blocks/${contentBlockId}`,
       request,
     );
   },
 
-  deleteEmbedSectionBlock(releaseId: string, blockId: string): Promise<void> {
-    return client.delete(`/release/${releaseId}/embed-blocks/${blockId}`);
+  deleteEmbedSectionBlock(
+    releaseVersionId: string,
+    blockId: string,
+  ): Promise<void> {
+    return client.delete(
+      `/release/${releaseVersionId}/embed-blocks/${blockId}`,
+    );
   },
 
   updateContentSectionHeading(
-    releaseId: string,
+    releaseVersionId: string,
     sectionId: string,
     heading: string,
   ): Promise<ContentSectionViewModel> {
     return client.put<ContentSectionViewModel>(
-      `/release/${releaseId}/content/section/${sectionId}/heading`,
+      `/release/${releaseVersionId}/content/section/${sectionId}/heading`,
       { heading },
     );
   },
 
   updateContentSectionBlock(
-    releaseId: string,
+    releaseVersionId: string,
     sectionId: string,
     blockId: string,
     block: ContentBlockPutModel,
   ): Promise<EditableContentBlock> {
     return client.put<EditableContentBlock>(
-      `/release/${releaseId}/content/section/${sectionId}/block/${blockId}`,
+      `/release/${releaseVersionId}/content/section/${sectionId}/block/${blockId}`,
       block,
     );
   },
 
   updateContentSectionBlocksOrder(
-    releaseId: string,
+    releaseVersionId: string,
     sectionId: string,
     order: Dictionary<number>,
   ): Promise<EditableBlock[]> {
     return client.put<EditableBlock[]>(
-      `/release/${releaseId}/content/section/${sectionId}/blocks/order`,
+      `/release/${releaseVersionId}/content/section/${sectionId}/blocks/order`,
       order,
     );
   },
 
   deleteContentSectionBlock(
-    releaseId: string,
+    releaseVersionId: string,
     sectionId: string,
     blockId: string,
   ): Promise<void> {
     return client.delete(
-      `/release/${releaseId}/content/section/${sectionId}/block/${blockId}`,
+      `/release/${releaseVersionId}/content/section/${sectionId}/block/${blockId}`,
     );
   },
 
   attachContentSectionBlock(
-    releaseId: string,
+    releaseVersionId: string,
     sectionId: string,
     block: ContentBlockAttachRequest,
   ): Promise<EditableBlock> {
     return client.post<EditableBlock>(
-      `/release/${releaseId}/content/section/${sectionId}/blocks/attach`,
+      `/release/${releaseVersionId}/content/section/${sectionId}/blocks/attach`,
       block,
     );
   },

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -102,21 +102,21 @@ function mapFile({ name, ...file }: DataFileInfo): DataFile {
 }
 
 const releaseDataFileService = {
-  getDataFiles(releaseId: string): Promise<DataFile[]> {
+  getDataFiles(releaseVersionId: string): Promise<DataFile[]> {
     return client
-      .get<DataFileInfo[]>(`/release/${releaseId}/data`)
+      .get<DataFileInfo[]>(`/release/${releaseVersionId}/data`)
       .then(response => {
         const dataFiles = response.filter(file => file.metaFileName.length > 0);
         return dataFiles.map(mapFile);
       });
   },
-  getDataFile(releaseId: string, fileId: string): Promise<DataFile> {
+  getDataFile(releaseVersionId: string, fileId: string): Promise<DataFile> {
     return client
-      .get<DataFileInfo>(`/release/${releaseId}/data/${fileId}`)
+      .get<DataFileInfo>(`/release/${releaseVersionId}/data/${fileId}`)
       .then(mapFile);
   },
   async uploadDataFiles(
-    releaseId: string,
+    releaseVersionId: string,
     request: UploadDataFilesRequest,
   ): Promise<DataFile> {
     const { dataFile, metadataFile, ...params } = request;
@@ -126,7 +126,7 @@ const releaseDataFileService = {
     data.append('metaFile', metadataFile);
 
     const file = await client.post<DataFileInfo>(
-      `/release/${releaseId}/data`,
+      `/release/${releaseVersionId}/data`,
       data,
       {
         params,
@@ -136,7 +136,7 @@ const releaseDataFileService = {
     return mapFile(file);
   },
   async uploadZipDataFile(
-    releaseId: string,
+    releaseVersionId: string,
     request: UploadZipDataFileRequest,
   ): Promise<DataFile> {
     const { zipFile, ...params } = request;
@@ -145,7 +145,7 @@ const releaseDataFileService = {
     data.append('zipFile', zipFile);
 
     const file = await client.post<DataFileInfo>(
-      `/release/${releaseId}/zip-data`,
+      `/release/${releaseVersionId}/zip-data`,
       data,
       {
         params,
@@ -169,52 +169,58 @@ const releaseDataFileService = {
     return files.map(file => mapFile(file));
   },
   updateDataFilesOrder(
-    releaseId: string,
+    releaseVersionId: string,
     order: string[],
   ): Promise<DataFile[]> {
     return client
-      .put<DataFileInfo[]>(`/release/${releaseId}/data/order`, order)
+      .put<DataFileInfo[]>(`/release/${releaseVersionId}/data/order`, order)
       .then(response => {
         const dataFiles = response.filter(file => file.metaFileName.length > 0);
         return dataFiles.map(mapFile);
       });
   },
   getDataFileImportStatus(
-    releaseId: string,
+    releaseVersionId: string,
     dataFile: DataFile,
   ): Promise<DataFileImportStatus> {
     return client.get<DataFileImportStatus>(
-      `/release/${releaseId}/data/${dataFile.id}/import/status`,
+      `/release/${releaseVersionId}/data/${dataFile.id}/import/status`,
     );
   },
 
   getDeleteDataFilePlan(
-    releaseId: string,
+    releaseVersionId: string,
     dataFile: DataFile,
   ): Promise<DeleteDataFilePlan> {
     return client.get<DeleteDataFilePlan>(
-      `/release/${releaseId}/data/${dataFile.id}/delete-plan`,
+      `/release/${releaseVersionId}/data/${dataFile.id}/delete-plan`,
     );
   },
-  deleteDataFiles(releaseId: string, fileId: string): Promise<void> {
-    return client.delete<void>(`/release/${releaseId}/data/${fileId}`);
+  deleteDataFiles(releaseVersionId: string, fileId: string): Promise<void> {
+    return client.delete<void>(`/release/${releaseVersionId}/data/${fileId}`);
   },
-  downloadFile(releaseId: string, id: string, fileName: string): Promise<void> {
+  downloadFile(
+    releaseVersionId: string,
+    id: string,
+    fileName: string,
+  ): Promise<void> {
     return client
-      .get<Blob>(`/release/${releaseId}/file/${id}/download`, {
+      .get<Blob>(`/release/${releaseVersionId}/file/${id}/download`, {
         responseType: 'blob',
       })
       .then(response => downloadFile(response, fileName));
   },
   updateFile(
-    releaseId: string,
+    releaseVersionId: string,
     fileId: string,
     data: DataFileUpdateRequest,
   ): Promise<void> {
-    return client.patch(`/release/${releaseId}/data/${fileId}`, data);
+    return client.patch(`/release/${releaseVersionId}/data/${fileId}`, data);
   },
-  cancelImport(releaseId: string, fileId: string): Promise<void> {
-    return client.post(`/release/${releaseId}/data/${fileId}/import/cancel`);
+  cancelImport(releaseVersionId: string, fileId: string): Promise<void> {
+    return client.post(
+      `/release/${releaseVersionId}/data/${fileId}/import/cancel`,
+    );
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/releaseDataGuidanceService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataGuidanceService.ts
@@ -8,11 +8,11 @@ export interface ReleaseDataGuidance {
 }
 
 const releaseDataGuidanceService = {
-  getDataGuidance(releaseId: string): Promise<ReleaseDataGuidance> {
-    return client.get(`/release/${releaseId}/data-guidance`);
+  getDataGuidance(releaseVersionId: string): Promise<ReleaseDataGuidance> {
+    return client.get(`/release/${releaseVersionId}/data-guidance`);
   },
   updateDataGuidance(
-    releaseId: string,
+    releaseVersionId: string,
     data: {
       content: string;
       dataSets: {
@@ -21,7 +21,7 @@ const releaseDataGuidanceService = {
       }[];
     },
   ): Promise<ReleaseDataGuidance> {
-    return client.patch(`/release/${releaseId}/data-guidance`, data);
+    return client.patch(`/release/${releaseVersionId}/data-guidance`, data);
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/releaseFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseFileService.ts
@@ -3,9 +3,9 @@ import downloadFile from '@common/utils/file/downloadFile';
 import parseContentDisposition from '@common/utils/http/parseContentDisposition';
 
 const releaseFileService = {
-  downloadAllFilesZip(releaseId: string): Promise<void> {
+  downloadAllFilesZip(releaseVersionId: string): Promise<void> {
     return client
-      .get<Blob>(`/release/${releaseId}/files`, {
+      .get<Blob>(`/release/${releaseVersionId}/files`, {
         responseType: 'blob',
         rawResponse: true,
       })

--- a/src/explore-education-statistics-admin/src/services/releaseImageService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseImageService.ts
@@ -5,7 +5,7 @@ import { AxiosProgressEvent } from 'axios';
 
 const releaseImageService = {
   upload(
-    releaseId: string,
+    releaseVersionId: string,
     file: File,
     options: {
       signal?: AbortSignal;
@@ -15,7 +15,7 @@ const releaseImageService = {
     const data = new FormData();
     data.append('file', file);
 
-    return client.post(`/releases/${releaseId}/images`, data, {
+    return client.post(`/releases/${releaseVersionId}/images`, data, {
       signal: options.signal,
       onUploadProgress(event: AxiosProgressEvent) {
         options.onProgress?.(event.loaded, event.total ?? 0);

--- a/src/explore-education-statistics-admin/src/services/releaseNoteService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseNoteService.ts
@@ -3,24 +3,26 @@ import { ReleaseNote } from '@common/services/publicationService';
 
 const releaseNoteService = {
   create: (
-    releaseId: string,
-    releaseNote: Omit<ReleaseNote, 'id' | 'on' | 'releaseId'>,
+    releaseVersionId: string,
+    releaseNote: Omit<ReleaseNote, 'id' | 'on' | 'releaseVersionId'>,
   ): Promise<ReleaseNote[]> => {
     return client.post(
-      `/release/${releaseId}/content/release-note`,
+      `/release/${releaseVersionId}/content/release-note`,
       releaseNote,
     );
   },
-  delete: (id: string, releaseId: string): Promise<ReleaseNote[]> => {
-    return client.delete(`/release/${releaseId}/content/release-note/${id}`);
+  delete: (id: string, releaseVersionId: string): Promise<ReleaseNote[]> => {
+    return client.delete(
+      `/release/${releaseVersionId}/content/release-note/${id}`,
+    );
   },
   edit: (
     id: string,
-    releaseId: string,
-    releaseNote: Omit<ReleaseNote, 'id' | 'releaseId'>,
+    releaseVersionId: string,
+    releaseNote: Omit<ReleaseNote, 'id' | 'releaseVersionId'>,
   ): Promise<ReleaseNote[]> => {
     return client.put(
-      `/release/${releaseId}/content/release-note/${id}`,
+      `/release/${releaseVersionId}/content/release-note/${id}`,
       releaseNote,
     );
   },

--- a/src/explore-education-statistics-admin/src/services/releasePermissionService.ts
+++ b/src/explore-education-statistics-admin/src/services/releasePermissionService.ts
@@ -13,11 +13,11 @@ export interface UserReleaseInvite {
 }
 
 const releasePermissionService = {
-  listRoles(releaseId: string): Promise<UserReleaseRole[]> {
-    return client.get(`/releases/${releaseId}/roles`);
+  listRoles(releaseVersionId: string): Promise<UserReleaseRole[]> {
+    return client.get(`/releases/${releaseVersionId}/roles`);
   },
-  listInvites(releaseId: string): Promise<UserReleaseInvite[]> {
-    return client.get(`/releases/${releaseId}/invites`);
+  listInvites(releaseVersionId: string): Promise<UserReleaseInvite[]> {
+    return client.get(`/releases/${releaseVersionId}/invites`);
   },
   listPublicationContributors(
     publicationId: string,
@@ -25,10 +25,12 @@ const releasePermissionService = {
     return client.get(`/publications/${publicationId}/contributors`);
   },
   updateReleaseContributors(
-    releaseId: string,
+    releaseVersionId: string,
     userIds: string[],
   ): Promise<void> {
-    return client.put(`/releases/${releaseId}/contributors`, { userIds });
+    return client.put(`/releases/${releaseVersionId}/contributors`, {
+      userIds,
+    });
   },
   removeAllUserContributorPermissionsForPublication(
     publicationId: string,

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -133,7 +133,7 @@ type TaskStage =
   | 'Scheduled';
 
 export interface ReleaseStageStatus {
-  releaseId?: string;
+  releaseVersionId?: string;
   contentStage?: TaskStage;
   filesStage?: TaskStage;
   publishingStage?: PublishingStage;
@@ -208,34 +208,36 @@ const releaseService = {
     );
   },
 
-  getRelease(releaseId: string): Promise<ReleaseVersion> {
-    return client.get(`/releases/${releaseId}`);
+  getRelease(releaseVersionId: string): Promise<ReleaseVersion> {
+    return client.get(`/releases/${releaseVersionId}`);
   },
 
-  getReleaseStatuses(releaseId: string): Promise<ReleaseStatus[]> {
-    return client.get(`/releases/${releaseId}/status`);
+  getReleaseStatuses(releaseVersionId: string): Promise<ReleaseStatus[]> {
+    return client.get(`/releases/${releaseVersionId}/status`);
   },
 
   updateRelease(
-    releaseId: string,
+    releaseVersionId: string,
     updateRequest: UpdateReleaseVersionRequest,
   ): Promise<ReleaseVersion> {
-    return client.put(`/releases/${releaseId}`, updateRequest);
+    return client.put(`/releases/${releaseVersionId}`, updateRequest);
   },
 
   createReleaseStatus(
-    releaseId: string,
+    releaseVersionId: string,
     createRequest: CreateReleaseStatusRequest,
   ): Promise<ReleaseVersion> {
-    return client.post(`/releases/${releaseId}/status`, createRequest);
+    return client.post(`/releases/${releaseVersionId}/status`, createRequest);
   },
 
-  getDeleteReleasePlan(releaseId: string): Promise<DeleteReleasePlan> {
-    return client.get<DeleteReleasePlan>(`/release/${releaseId}/delete-plan`);
+  getDeleteReleasePlan(releaseVersionId: string): Promise<DeleteReleasePlan> {
+    return client.get<DeleteReleasePlan>(
+      `/release/${releaseVersionId}/delete-plan`,
+    );
   },
 
-  deleteRelease(releaseId: string): Promise<void> {
-    return client.delete(`/release/${releaseId}`);
+  deleteRelease(releaseVersionId: string): Promise<void> {
+    return client.delete(`/release/${releaseVersionId}`);
   },
 
   listDraftReleases(): Promise<DashboardReleaseVersionSummary[]> {
@@ -250,18 +252,18 @@ const releaseService = {
     return client.get('/releases/approvals');
   },
 
-  getReleaseStatus(releaseId: string): Promise<ReleaseStageStatus> {
+  getReleaseStatus(releaseVersionId: string): Promise<ReleaseStageStatus> {
     return client.get<ReleaseStageStatus>(
-      `/releases/${releaseId}/stage-status`,
+      `/releases/${releaseVersionId}/stage-status`,
     );
   },
 
-  getReleaseChecklist(releaseId: string): Promise<ReleaseChecklist> {
-    return client.get(`/releases/${releaseId}/checklist`);
+  getReleaseChecklist(releaseVersionId: string): Promise<ReleaseChecklist> {
+    return client.get(`/releases/${releaseVersionId}/checklist`);
   },
 
-  createReleaseAmendment(releaseId: string): Promise<IdResponse> {
-    return client.post(`/release/${releaseId}/amendment`);
+  createReleaseAmendment(releaseVersionId: string): Promise<IdResponse> {
+    return client.post(`/release/${releaseVersionId}/amendment`);
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -11,7 +11,7 @@ import {
 import { ReleaseType } from '@common/services/types/releaseType';
 import { PartialDate } from '@common/utils/date/partialDate';
 
-export interface ReleasePermissions {
+export interface ReleaseVersionPermissions {
   canAddPrereleaseUsers: boolean;
   canViewRelease: boolean;
   canUpdateRelease: boolean;
@@ -19,7 +19,7 @@ export interface ReleasePermissions {
   canMakeAmendmentOfRelease: boolean;
 }
 
-export interface Release {
+export interface ReleaseVersion {
   id: string;
   releaseId: string;
   slug: string;
@@ -44,10 +44,10 @@ export interface Release {
   preReleaseUsersOrInvitesAdded?: boolean;
   year: number;
   yearTitle: string;
-  permissions?: ReleasePermissions;
+  permissions?: ReleaseVersionPermissions;
 }
 
-export interface ReleaseSummary {
+export interface ReleaseVersionSummary {
   id: string;
   title: string;
   slug: string;
@@ -63,19 +63,21 @@ export interface ReleaseSummary {
   amendment: boolean;
   latestRelease: boolean;
   previousVersionId?: string;
-  permissions?: ReleasePermissions;
+  permissions?: ReleaseVersionPermissions;
   publication?: PublicationSummary;
 }
 
-export interface DashboardReleaseSummary extends ReleaseSummaryWithPermissions {
+export interface DashboardReleaseVersionSummary
+  extends ReleaseVersionSummaryWithPermissions {
   publication: PublicationSummary;
 }
 
-export interface ReleaseSummaryWithPermissions extends ReleaseSummary {
-  permissions: ReleasePermissions;
+export interface ReleaseVersionSummaryWithPermissions
+  extends ReleaseVersionSummary {
+  permissions: ReleaseVersionPermissions;
 }
 
-interface BaseReleaseRequest {
+interface BaseReleaseVersionRequest {
   year: number;
   timePeriodCoverage: {
     value: string;
@@ -83,12 +85,12 @@ interface BaseReleaseRequest {
   type: ReleaseType;
 }
 
-export interface CreateReleaseRequest extends BaseReleaseRequest {
+export interface CreateReleaseVersionRequest extends BaseReleaseVersionRequest {
   publicationId: string;
   templateReleaseId?: string;
 }
 
-export interface UpdateReleaseRequest extends BaseReleaseRequest {
+export interface UpdateReleaseVersionRequest extends BaseReleaseVersionRequest {
   preReleaseAccessList?: string;
 }
 
@@ -183,14 +185,6 @@ export interface ReleaseChecklist {
   warnings: ReleaseChecklistWarning[];
 }
 
-export interface ReleasePublicationStatus {
-  publishScheduled: string;
-  nextReleaseDate?: PartialDate;
-  approvalStatus: ReleaseApprovalStatus;
-  amendment: boolean;
-  live: boolean;
-}
-
 export interface ReleaseStatus {
   releaseStatusId: string;
   internalReleaseNote: string;
@@ -205,14 +199,16 @@ export interface DeleteReleasePlan {
 }
 
 const releaseService = {
-  createRelease(createRequest: CreateReleaseRequest): Promise<Release> {
+  createRelease(
+    createRequest: CreateReleaseVersionRequest,
+  ): Promise<ReleaseVersion> {
     return client.post(
       `/publications/${createRequest.publicationId}/releases`,
       createRequest,
     );
   },
 
-  getRelease(releaseId: string): Promise<Release> {
+  getRelease(releaseId: string): Promise<ReleaseVersion> {
     return client.get(`/releases/${releaseId}`);
   },
 
@@ -222,15 +218,15 @@ const releaseService = {
 
   updateRelease(
     releaseId: string,
-    updateRequest: UpdateReleaseRequest,
-  ): Promise<Release> {
+    updateRequest: UpdateReleaseVersionRequest,
+  ): Promise<ReleaseVersion> {
     return client.put(`/releases/${releaseId}`, updateRequest);
   },
 
   createReleaseStatus(
     releaseId: string,
     createRequest: CreateReleaseStatusRequest,
-  ): Promise<Release> {
+  ): Promise<ReleaseVersion> {
     return client.post(`/releases/${releaseId}/status`, createRequest);
   },
 
@@ -242,24 +238,16 @@ const releaseService = {
     return client.delete(`/release/${releaseId}`);
   },
 
-  listDraftReleases(): Promise<DashboardReleaseSummary[]> {
+  listDraftReleases(): Promise<DashboardReleaseVersionSummary[]> {
     return client.get('/releases/draft');
   },
 
-  listScheduledReleases(): Promise<DashboardReleaseSummary[]> {
+  listScheduledReleases(): Promise<DashboardReleaseVersionSummary[]> {
     return client.get('/releases/scheduled');
   },
 
-  listReleasesForApproval(): Promise<DashboardReleaseSummary[]> {
+  listReleasesForApproval(): Promise<DashboardReleaseVersionSummary[]> {
     return client.get('/releases/approvals');
-  },
-
-  getReleasePublicationStatus(
-    releaseId: string,
-  ): Promise<ReleasePublicationStatus> {
-    return client.get<ReleasePublicationStatus>(
-      `/releases/${releaseId}/publication-status`,
-    );
   },
 
   getReleaseStatus(releaseId: string): Promise<ReleaseStageStatus> {

--- a/src/explore-education-statistics-admin/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-admin/src/services/tableBuilderService.ts
@@ -4,22 +4,22 @@ import { UpdateIndicatorsRequest } from '@admin/pages/release/data/components/Re
 
 const tableBuilderService = {
   updateFilters(
-    releaseId: string,
+    releaseVersionId: string,
     subjectId: string,
     data: UpdateFiltersRequest,
   ): Promise<void> {
     return client.patch(
-      `data/release/${releaseId}/meta/subject/${subjectId}/filters`,
+      `data/release/${releaseVersionId}/meta/subject/${subjectId}/filters`,
       data,
     );
   },
   updateIndicators(
-    releaseId: string,
+    releaseVersionId: string,
     subjectId: string,
     data: UpdateIndicatorsRequest,
   ): Promise<void> {
     return client.patch(
-      `data/release/${releaseId}/meta/subject/${subjectId}/indicators`,
+      `data/release/${releaseVersionId}/meta/subject/${subjectId}/indicators`,
       data,
     );
   },

--- a/src/explore-education-statistics-admin/src/services/userService.ts
+++ b/src/explore-education-statistics-admin/src/services/userService.ts
@@ -33,7 +33,7 @@ export interface UserPublicationRole {
 }
 
 export interface UserReleaseRoleSubmission {
-  releaseId: string;
+  releaseVersionId: string;
   releaseRole: string;
 }
 
@@ -45,7 +45,7 @@ export interface UserPublicationRoleSubmission {
 export interface UserInvite {
   email: string;
   roleId: string;
-  userReleaseRoles: { releaseId: string; releaseRole: string }[];
+  userReleaseRoles: { releaseVersionId: string; releaseRole: string }[];
   userPublicationRoles: { publicationId: string; publicationRole: string }[];
 }
 
@@ -99,7 +99,7 @@ export interface UsersService {
   inviteContributor: (
     email: string,
     publicationId: string,
-    releaseIds: string[],
+    releaseVersionIds: string[],
   ) => Promise<boolean>;
   removeContributorReleaseInvites: (
     email: string,
@@ -176,13 +176,13 @@ const userService: UsersService = {
   inviteContributor(
     email: string,
     publicationId: string,
-    releaseIds: string[],
+    releaseVersionIds: string[],
   ): Promise<boolean> {
     return client.post(
       `/user-management/publications/${publicationId}/invites/contributor`,
       {
         email,
-        releaseIds,
+        releaseVersionIds,
       },
     );
   },

--- a/src/explore-education-statistics-admin/src/services/userService.ts
+++ b/src/explore-education-statistics-admin/src/services/userService.ts
@@ -1,5 +1,5 @@
 import client from '@admin/services/utils/service';
-import { IdTitlePair } from 'src/services/types/common';
+import {IdTitlePair} from 'src/services/types/common';
 
 export interface UserStatus {
   id: string;
@@ -33,7 +33,8 @@ export interface UserPublicationRole {
 }
 
 export interface UserReleaseRoleSubmission {
-  releaseVersionId: string;
+  // TODO rename to releaseVersionId
+  releaseId: string;
   releaseRole: string;
 }
 
@@ -45,7 +46,11 @@ export interface UserPublicationRoleSubmission {
 export interface UserInvite {
   email: string;
   roleId: string;
-  userReleaseRoles: { releaseVersionId: string; releaseRole: string }[];
+  userReleaseRoles: {
+    // TODO rename to releaseVersionId
+    releaseId: string;
+    releaseRole: string
+  }[];
   userPublicationRoles: { publicationId: string; publicationRole: string }[];
 }
 
@@ -74,9 +79,13 @@ export interface ResourceRoles {
 
 export interface UsersService {
   getRoles(): Promise<Role[]>;
+
   getReleases(): Promise<IdTitlePair[]>;
+
   getResourceRoles(): Promise<ResourceRoles>;
+
   getUser(userId: string): Promise<User>;
+
   addUserReleaseRole: (
     userId: string,
     userReleaseRole: UserReleaseRoleSubmission,
@@ -93,13 +102,17 @@ export interface UsersService {
   ) => Promise<boolean>;
 
   getUsers(): Promise<UserStatus[]>;
+
   getPreReleaseUsers(): Promise<UserStatus[]>;
+
   getPendingInvites(): Promise<PendingInvite[]>;
+
   inviteUser: (invite: UserInvite) => Promise<boolean>;
   inviteContributor: (
     email: string,
     publicationId: string,
-    releaseVersionIds: string[],
+    // TODO rename to releaseVersionId
+    releaseIds: string[],
   ) => Promise<boolean>;
   removeContributorReleaseInvites: (
     email: string,
@@ -182,7 +195,8 @@ const userService: UsersService = {
       `/user-management/publications/${publicationId}/invites/contributor`,
       {
         email,
-        releaseVersionIds,
+        // TODO rename to releaseVersionId
+        releaseIds: releaseVersionIds,
       },
     );
   },
@@ -192,7 +206,7 @@ const userService: UsersService = {
   ): Promise<boolean> {
     return client.delete(
       `/user-management/publications/${publicationId}/release-invites/contributor`,
-      { data: { email } },
+      {data: {email}},
     );
   },
   cancelInvite(email: string): Promise<boolean> {

--- a/src/explore-education-statistics-admin/src/services/userService.ts
+++ b/src/explore-education-statistics-admin/src/services/userService.ts
@@ -1,5 +1,5 @@
 import client from '@admin/services/utils/service';
-import {IdTitlePair} from 'src/services/types/common';
+import { IdTitlePair } from 'src/services/types/common';
 
 export interface UserStatus {
   id: string;
@@ -49,7 +49,7 @@ export interface UserInvite {
   userReleaseRoles: {
     // TODO rename to releaseVersionId
     releaseId: string;
-    releaseRole: string
+    releaseRole: string;
   }[];
   userPublicationRoles: { publicationId: string; publicationRole: string }[];
 }
@@ -206,7 +206,7 @@ const userService: UsersService = {
   ): Promise<boolean> {
     return client.delete(
       `/user-management/publications/${publicationId}/release-invites/contributor`,
-      {data: {email}},
+      { data: { email } },
     );
   },
   cancelInvite(email: string): Promise<boolean> {

--- a/src/explore-education-statistics-admin/test/generators/releaseContentGenerators.ts
+++ b/src/explore-education-statistics-admin/test/generators/releaseContentGenerators.ts
@@ -1,5 +1,5 @@
 import {
-  EditableRelease,
+  EditableReleaseVersion,
   ReleaseContent,
 } from '@admin/services/releaseContentService';
 import {
@@ -177,7 +177,7 @@ export function generateEditableRelease({
   type = 'OfficialStatistics',
   updates = defaultUpdates,
   yearTitle = '2020/21',
-}: Partial<EditableRelease>): EditableRelease {
+}: Partial<EditableReleaseVersion>): EditableReleaseVersion {
   const releaseSlug = title.replaceAll(' ', '-');
   return {
     approvalStatus,

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -26,6 +26,7 @@ export interface DataBlockTabsProps {
   lastTabs?: ReactNode;
   getInfographic?: GetInfographic;
   id?: string;
+  // TODO rename to releaseVersionId
   releaseId: string;
   onToggle?: (section: { id: string; title: string }) => void;
 }

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatDataBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatDataBlock.tsx
@@ -5,6 +5,7 @@ import KeyStat from '@common/modules/find-statistics/components/KeyStat';
 
 export interface KeyStatDataBlockProps {
   children?: ReactNode;
+  // TODO rename to releaseVersionId
   releaseId: string;
   dataBlockParentId: string;
   trend?: string;

--- a/src/explore-education-statistics-common/src/modules/release/hooks/useReleaseImageAttributeTransformer.ts
+++ b/src/explore-education-statistics-common/src/modules/release/hooks/useReleaseImageAttributeTransformer.ts
@@ -7,23 +7,26 @@ export type ImageAttributeTransformer = (
 ) => Dictionary<string>;
 
 export default function useReleaseImageAttributeTransformer(options: {
-  releaseId: string;
+  releaseVersionId: string;
   rootUrl?: string;
 }): ImageAttributeTransformer {
-  const { releaseId, rootUrl = '' } = options;
+  const { releaseVersionId, rootUrl = '' } = options;
 
   return useCallback(
     ({ src, srcset, ...attributes }: Dictionary<string>) => {
       return {
         ...attributes,
         src: src
-          ? `${rootUrl}${replaceReleaseIdPlaceholders(src, releaseId)}`
+          ? `${rootUrl}${replaceReleaseIdPlaceholders(src, releaseVersionId)}`
           : '',
         srcset: srcset
-          ? `${rootUrl}${replaceReleaseIdPlaceholders(srcset, releaseId)}`
+          ? `${rootUrl}${replaceReleaseIdPlaceholders(
+              srcset,
+              releaseVersionId,
+            )}`
           : '',
       };
     },
-    [releaseId, rootUrl],
+    [releaseVersionId, rootUrl],
   );
 }

--- a/src/explore-education-statistics-common/src/modules/release/hooks/useReleaseImageAttributeTransformer.ts
+++ b/src/explore-education-statistics-common/src/modules/release/hooks/useReleaseImageAttributeTransformer.ts
@@ -7,26 +7,24 @@ export type ImageAttributeTransformer = (
 ) => Dictionary<string>;
 
 export default function useReleaseImageAttributeTransformer(options: {
-  releaseVersionId: string;
+  // TODO rename to releaseVersionId
+  releaseId: string;
   rootUrl?: string;
 }): ImageAttributeTransformer {
-  const { releaseVersionId, rootUrl = '' } = options;
+  const { releaseId, rootUrl = '' } = options;
 
   return useCallback(
     ({ src, srcset, ...attributes }: Dictionary<string>) => {
       return {
         ...attributes,
         src: src
-          ? `${rootUrl}${replaceReleaseIdPlaceholders(src, releaseVersionId)}`
+          ? `${rootUrl}${replaceReleaseIdPlaceholders(src, releaseId)}`
           : '',
         srcset: srcset
-          ? `${rootUrl}${replaceReleaseIdPlaceholders(
-              srcset,
-              releaseVersionId,
-            )}`
+          ? `${rootUrl}${replaceReleaseIdPlaceholders(srcset, releaseId)}`
           : '',
       };
     },
-    [releaseVersionId, rootUrl],
+    [releaseId, rootUrl],
   );
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -1,12 +1,12 @@
 import SubmitError from '@common/components/form/util/SubmitError';
 import WarningMessage from '@common/components/WarningMessage';
 import locationLevelsMap from '@common/utils/locationLevelsMap';
-import {ConfirmContextProvider} from '@common/contexts/ConfirmContext';
+import { ConfirmContextProvider } from '@common/contexts/ConfirmContext';
 import FiltersForm, {
   FilterFormSubmitHandler,
   TableQueryErrorCode,
 } from '@common/modules/table-tool/components/FiltersForm';
-import {LocationFiltersFormSubmitHandler} from '@common/modules/table-tool/components/LocationFiltersForm';
+import { LocationFiltersFormSubmitHandler } from '@common/modules/table-tool/components/LocationFiltersForm';
 import LocationStep from '@common/modules/table-tool/components/LocationStep';
 import PreviousStepModalConfirm from '@common/modules/table-tool/components/PreviousStepModalConfirm';
 import PublicationForm, {
@@ -20,9 +20,9 @@ import TimePeriodForm, {
 } from '@common/modules/table-tool/components/TimePeriodForm';
 import Wizard from '@common/modules/table-tool/components/Wizard';
 import WizardStep from '@common/modules/table-tool/components/WizardStep';
-import {FullTable} from '@common/modules/table-tool/types/fullTable';
-import {SelectedPublication} from '@common/modules/table-tool/types/selectedPublication';
-import {TableHeadersConfig} from '@common/modules/table-tool/types/tableHeaders';
+import { FullTable } from '@common/modules/table-tool/types/fullTable';
+import { SelectedPublication } from '@common/modules/table-tool/types/selectedPublication';
+import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 import applyTableHeadersOrder from '@common/modules/table-tool/utils/applyTableHeadersOrder';
 import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/getDefaultTableHeadersConfig';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
@@ -39,9 +39,9 @@ import tableBuilderService, {
   Subject,
   SubjectMeta,
 } from '@common/services/tableBuilderService';
-import React, {ReactElement, ReactNode, useMemo, useState} from 'react';
-import {useImmer} from 'use-immer';
-import {Dictionary} from 'lodash';
+import React, { ReactElement, ReactNode, useMemo, useState } from 'react';
+import { useImmer } from 'use-immer';
+import { Dictionary } from 'lodash';
 
 const defaultLocationStepTitle = 'Choose locations';
 const defaultDataSetStepTitle = 'Select a data set';
@@ -89,9 +89,9 @@ export interface TableToolWizardProps {
   onPublicationStepBack?: () => void;
   onStepChange?: (nextStep: number, previousStep: number) => void;
   onStepSubmit?: ({
-                    nextStepNumber,
-                    nextStepTitle,
-                  }: {
+    nextStepNumber,
+    nextStepTitle,
+  }: {
     nextStepNumber: number;
     nextStepTitle: string;
   }) => void;
@@ -112,24 +112,24 @@ export interface TableToolWizardProps {
 }
 
 export default function TableToolWizard({
-                                          currentStep,
-                                          finalStep,
-                                          hidePublicationStep,
-                                          initialState = {},
-                                          loadingFastTrack = false,
-                                          renderFeaturedTableLink,
-                                          scrollOnMount,
-                                          showTableQueryErrorDownload = true,
-                                          themeMeta = [],
-                                          onPublicationFormSubmit,
-                                          onPublicationStepBack,
-                                          onStepChange,
-                                          onStepSubmit,
-                                          onSubjectFormSubmit,
-                                          onSubjectStepBack,
-                                          onSubmit,
-                                          onTableQueryError,
-                                        }: TableToolWizardProps) {
+  currentStep,
+  finalStep,
+  hidePublicationStep,
+  initialState = {},
+  loadingFastTrack = false,
+  renderFeaturedTableLink,
+  scrollOnMount,
+  showTableQueryErrorDownload = true,
+  themeMeta = [],
+  onPublicationFormSubmit,
+  onPublicationStepBack,
+  onStepChange,
+  onStepSubmit,
+  onSubjectFormSubmit,
+  onSubjectStepBack,
+  onSubmit,
+  onTableQueryError,
+}: TableToolWizardProps) {
   const [state, updateState] = useImmer<TableToolState>({
     initialStep: 1,
     subjects: [],
@@ -174,8 +174,8 @@ export default function TableToolWizard({
   };
 
   const handlePublicationFormSubmit: PublicationFormSubmitHandler = async ({
-                                                                             publication,
-                                                                           }) => {
+    publication,
+  }) => {
     onPublicationFormSubmit?.(publication);
 
     const [subjects, featuredTables] = await Promise.all([
@@ -214,7 +214,7 @@ export default function TableToolWizard({
     });
 
     setDataSetStepTitle(updatedDataSetTitle);
-    onStepSubmit?.({nextStepNumber: 2, nextStepTitle: updatedDataSetTitle});
+    onStepSubmit?.({ nextStepNumber: 2, nextStepTitle: updatedDataSetTitle });
   };
 
   const handlePublicationStepBack = () => {
@@ -231,12 +231,12 @@ export default function TableToolWizard({
     });
 
     onSubjectStepBack?.(state.selectedPublication);
-    onStepSubmit?.({nextStepNumber: 2, nextStepTitle: dataSetStepTitle});
+    onStepSubmit?.({ nextStepNumber: 2, nextStepTitle: dataSetStepTitle });
   };
 
   const handleDataSetFormSubmit: DataSetFormSubmitHandler = async ({
-                                                                     subjectId: selectedSubjectId,
-                                                                   }) => {
+    subjectId: selectedSubjectId,
+  }) => {
     if (state.selectedPublication) {
       onSubjectFormSubmit?.({
         publication: state.selectedPublication,
@@ -266,11 +266,11 @@ export default function TableToolWizard({
       draft.query.timePeriod = undefined;
     });
 
-    onStepSubmit?.({nextStepNumber: 3, nextStepTitle: updatedLocationsTitle});
+    onStepSubmit?.({ nextStepNumber: 3, nextStepTitle: updatedLocationsTitle });
   };
 
   const handleLocationStepBack = async () => {
-    const {releaseId, subjectId} = state.query;
+    const { releaseId, subjectId } = state.query;
 
     const nextSubjectMeta = await tableBuilderService.getSubjectMeta(
       subjectId,
@@ -281,11 +281,11 @@ export default function TableToolWizard({
       draft.subjectMeta = nextSubjectMeta;
     });
 
-    onStepSubmit?.({nextStepNumber: 3, nextStepTitle: locationStepTitle});
+    onStepSubmit?.({ nextStepNumber: 3, nextStepTitle: locationStepTitle });
   };
 
   const handleLocationFiltersFormSubmit: LocationFiltersFormSubmitHandler =
-    async ({locationIds}) => {
+    async ({ locationIds }) => {
       const nextSubjectMeta = await tableBuilderService.filterSubjectMeta(
         {
           locationIds,
@@ -294,7 +294,7 @@ export default function TableToolWizard({
         state.query.releaseId,
       );
 
-      const {timePeriod} = state.query;
+      const { timePeriod } = state.query;
 
       // Check if selected time period is in the time period options so can reset it if not.
       const hasStartTimePeriod = nextSubjectMeta.timePeriod.options.some(
@@ -332,7 +332,7 @@ export default function TableToolWizard({
     };
 
   const handleTimePeriodStepBack = async () => {
-    const {releaseId, subjectId, locationIds} = state.query;
+    const { releaseId, subjectId, locationIds } = state.query;
 
     const nextSubjectMeta = await tableBuilderService.filterSubjectMeta(
       {
@@ -354,7 +354,7 @@ export default function TableToolWizard({
 
   const handleTimePeriodFormSubmit: TimePeriodFormSubmitHandler =
     async values => {
-      const {releaseId, subjectId, locationIds} = state.query;
+      const { releaseId, subjectId, locationIds } = state.query;
       const [startYear, startCode] = parseYearCodeTuple(values.start);
       const [endYear, endCode] = parseYearCodeTuple(values.end);
 
@@ -405,11 +405,11 @@ export default function TableToolWizard({
         };
       });
 
-      onStepSubmit?.({nextStepNumber: 5, nextStepTitle: stepTitles.filter});
+      onStepSubmit?.({ nextStepNumber: 5, nextStepTitle: stepTitles.filter });
     };
 
   const handleFiltersStepBack = async () => {
-    const {releaseId, subjectId, locationIds, timePeriod} = state.query;
+    const { releaseId, subjectId, locationIds, timePeriod } = state.query;
 
     const nextSubjectMeta = await tableBuilderService.filterSubjectMeta(
       {
@@ -425,13 +425,13 @@ export default function TableToolWizard({
       draft.subjectMeta.filters = nextSubjectMeta.filters;
     });
 
-    onStepSubmit?.({nextStepNumber: 5, nextStepTitle: stepTitles.filter});
+    onStepSubmit?.({ nextStepNumber: 5, nextStepTitle: stepTitles.filter });
   };
 
   const handleFiltersFormSubmit: FilterFormSubmitHandler = async ({
-                                                                    filters,
-                                                                    indicators,
-                                                                  }) => {
+    filters,
+    indicators,
+  }) => {
     updateState(draft => {
       draft.response = undefined;
     });
@@ -474,7 +474,7 @@ export default function TableToolWizard({
       };
     });
 
-    onStepSubmit?.({nextStepNumber: 6, nextStepTitle: stepTitles.final});
+    onStepSubmit?.({ nextStepNumber: 6, nextStepTitle: stepTitles.final });
   };
 
   const orderedTableHeaders: TableHeadersConfig | undefined = useMemo(() => {
@@ -483,9 +483,9 @@ export default function TableToolWizard({
 
     return state.response?.tableHeaders && reorderedOrSavedTableHeaders
       ? applyTableHeadersOrder({
-        reorderedTableHeaders: reorderedOrSavedTableHeaders,
-        defaultTableHeaders: state.response.tableHeaders,
-      })
+          reorderedTableHeaders: reorderedOrSavedTableHeaders,
+          defaultTableHeaders: state.response.tableHeaders,
+        })
       : state.response?.tableHeaders;
   }, [
     initialState.response?.tableHeaders,
@@ -497,7 +497,7 @@ export default function TableToolWizard({
 
   return (
     <ConfirmContextProvider>
-      {({askConfirm}) => (
+      {({ askConfirm }) => (
         <>
           <Wizard
             scrollOnMount={scrollOnMount}
@@ -617,7 +617,7 @@ export default function TableToolWizard({
               })}
           </Wizard>
 
-          <PreviousStepModalConfirm/>
+          <PreviousStepModalConfirm />
         </>
       )}
     </ConfirmContextProvider>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -194,7 +194,7 @@ export default function TableToolWizard({
     updateState(draft => {
       draft.subjects = subjects;
       draft.featuredTables = featuredTables;
-      draft.query.releaseId = undefined;
+      draft.query.releaseVersionId = undefined;
       draft.query.publicationId = publication.id;
       draft.selectedPublication = {
         ...publication,
@@ -245,7 +245,7 @@ export default function TableToolWizard({
 
     const nextSubjectMeta = await tableBuilderService.getSubjectMeta(
       selectedSubjectId,
-      state.query.releaseId,
+      state.query.releaseVersionId,
     );
 
     setReorderedTableHeaders(undefined);
@@ -268,11 +268,11 @@ export default function TableToolWizard({
   };
 
   const handleLocationStepBack = async () => {
-    const { releaseId, subjectId } = state.query;
+    const { releaseVersionId, subjectId } = state.query;
 
     const nextSubjectMeta = await tableBuilderService.getSubjectMeta(
       subjectId,
-      releaseId,
+      releaseVersionId,
     );
 
     updateState(draft => {
@@ -289,7 +289,7 @@ export default function TableToolWizard({
           locationIds,
           subjectId: state.query.subjectId,
         },
-        state.query.releaseId,
+        state.query.releaseVersionId,
       );
 
       const { timePeriod } = state.query;
@@ -337,7 +337,7 @@ export default function TableToolWizard({
         subjectId,
         locationIds,
       },
-      releaseId,
+      releaseVersionId,
     );
 
     updateState(draft => {
@@ -352,7 +352,7 @@ export default function TableToolWizard({
 
   const handleTimePeriodFormSubmit: TimePeriodFormSubmitHandler =
     async values => {
-      const { releaseId, subjectId, locationIds } = state.query;
+      const { releaseVersionId, subjectId, locationIds } = state.query;
       const [startYear, startCode] = parseYearCodeTuple(values.start);
       const [endYear, endCode] = parseYearCodeTuple(values.end);
 
@@ -367,7 +367,7 @@ export default function TableToolWizard({
             endCode,
           },
         },
-        releaseId,
+        releaseVersionId,
       );
 
       const indicatorValues = new Set(
@@ -407,7 +407,7 @@ export default function TableToolWizard({
     };
 
   const handleFiltersStepBack = async () => {
-    const { releaseId, subjectId, locationIds, timePeriod } = state.query;
+    const { releaseVersionId, subjectId, locationIds, timePeriod } = state.query;
 
     const nextSubjectMeta = await tableBuilderService.filterSubjectMeta(
       {
@@ -415,7 +415,7 @@ export default function TableToolWizard({
         locationIds,
         timePeriod,
       },
-      releaseId,
+      releaseVersionId,
     );
 
     updateState(draft => {
@@ -448,7 +448,7 @@ export default function TableToolWizard({
         filters: updatedReleaseTableDataQuery.filters,
         indicators: updatedReleaseTableDataQuery.indicators,
       } as FullTableQuery,
-      updatedReleaseTableDataQuery.releaseId,
+      updatedReleaseTableDataQuery.releaseVersionId,
     );
 
     if (!tableData.results.length || !tableData.subjectMeta) {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -194,7 +194,7 @@ export default function TableToolWizard({
     updateState(draft => {
       draft.subjects = subjects;
       draft.featuredTables = featuredTables;
-      draft.query.releaseVersionId = undefined;
+      draft.query.releaseId = undefined;
       draft.query.publicationId = publication.id;
       draft.selectedPublication = {
         ...publication,
@@ -245,7 +245,7 @@ export default function TableToolWizard({
 
     const nextSubjectMeta = await tableBuilderService.getSubjectMeta(
       selectedSubjectId,
-      state.query.releaseVersionId,
+      state.query.releaseId,
     );
 
     setReorderedTableHeaders(undefined);
@@ -268,11 +268,11 @@ export default function TableToolWizard({
   };
 
   const handleLocationStepBack = async () => {
-    const { releaseVersionId, subjectId } = state.query;
+    const { releaseId, subjectId } = state.query;
 
     const nextSubjectMeta = await tableBuilderService.getSubjectMeta(
       subjectId,
-      releaseVersionId,
+      releaseId,
     );
 
     updateState(draft => {
@@ -289,7 +289,7 @@ export default function TableToolWizard({
           locationIds,
           subjectId: state.query.subjectId,
         },
-        state.query.releaseVersionId,
+        state.query.releaseId,
       );
 
       const { timePeriod } = state.query;
@@ -337,7 +337,7 @@ export default function TableToolWizard({
         subjectId,
         locationIds,
       },
-      releaseVersionId,
+      releaseId,
     );
 
     updateState(draft => {
@@ -367,7 +367,7 @@ export default function TableToolWizard({
             endCode,
           },
         },
-        releaseVersionId,
+        releaseId,
       );
 
       const indicatorValues = new Set(
@@ -407,7 +407,7 @@ export default function TableToolWizard({
     };
 
   const handleFiltersStepBack = async () => {
-    const { releaseVersionId, subjectId, locationIds, timePeriod } = state.query;
+    const { releaseId, subjectId, locationIds, timePeriod } = state.query;
 
     const nextSubjectMeta = await tableBuilderService.filterSubjectMeta(
       {
@@ -415,7 +415,7 @@ export default function TableToolWizard({
         locationIds,
         timePeriod,
       },
-      releaseVersionId,
+      releaseId,
     );
 
     updateState(draft => {
@@ -448,7 +448,7 @@ export default function TableToolWizard({
         filters: updatedReleaseTableDataQuery.filters,
         indicators: updatedReleaseTableDataQuery.indicators,
       } as FullTableQuery,
-      updatedReleaseTableDataQuery.releaseVersionId,
+      updatedReleaseTableDataQuery.releaseId,
     );
 
     if (!tableData.results.length || !tableData.subjectMeta) {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -1,12 +1,12 @@
 import SubmitError from '@common/components/form/util/SubmitError';
 import WarningMessage from '@common/components/WarningMessage';
 import locationLevelsMap from '@common/utils/locationLevelsMap';
-import { ConfirmContextProvider } from '@common/contexts/ConfirmContext';
+import {ConfirmContextProvider} from '@common/contexts/ConfirmContext';
 import FiltersForm, {
   FilterFormSubmitHandler,
   TableQueryErrorCode,
 } from '@common/modules/table-tool/components/FiltersForm';
-import { LocationFiltersFormSubmitHandler } from '@common/modules/table-tool/components/LocationFiltersForm';
+import {LocationFiltersFormSubmitHandler} from '@common/modules/table-tool/components/LocationFiltersForm';
 import LocationStep from '@common/modules/table-tool/components/LocationStep';
 import PreviousStepModalConfirm from '@common/modules/table-tool/components/PreviousStepModalConfirm';
 import PublicationForm, {
@@ -20,9 +20,9 @@ import TimePeriodForm, {
 } from '@common/modules/table-tool/components/TimePeriodForm';
 import Wizard from '@common/modules/table-tool/components/Wizard';
 import WizardStep from '@common/modules/table-tool/components/WizardStep';
-import { FullTable } from '@common/modules/table-tool/types/fullTable';
-import { SelectedPublication } from '@common/modules/table-tool/types/selectedPublication';
-import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
+import {FullTable} from '@common/modules/table-tool/types/fullTable';
+import {SelectedPublication} from '@common/modules/table-tool/types/selectedPublication';
+import {TableHeadersConfig} from '@common/modules/table-tool/types/tableHeaders';
 import applyTableHeadersOrder from '@common/modules/table-tool/utils/applyTableHeadersOrder';
 import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/getDefaultTableHeadersConfig';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
@@ -39,9 +39,9 @@ import tableBuilderService, {
   Subject,
   SubjectMeta,
 } from '@common/services/tableBuilderService';
-import React, { ReactElement, ReactNode, useMemo, useState } from 'react';
-import { useImmer } from 'use-immer';
-import { Dictionary } from 'lodash';
+import React, {ReactElement, ReactNode, useMemo, useState} from 'react';
+import {useImmer} from 'use-immer';
+import {Dictionary} from 'lodash';
 
 const defaultLocationStepTitle = 'Choose locations';
 const defaultDataSetStepTitle = 'Select a data set';
@@ -89,17 +89,19 @@ export interface TableToolWizardProps {
   onPublicationStepBack?: () => void;
   onStepChange?: (nextStep: number, previousStep: number) => void;
   onStepSubmit?: ({
-    nextStepNumber,
-    nextStepTitle,
-  }: {
+                    nextStepNumber,
+                    nextStepTitle,
+                  }: {
     nextStepNumber: number;
     nextStepTitle: string;
   }) => void;
+
   onSubjectFormSubmit?(params: {
     publication: SelectedPublication;
     release: SelectedPublication['selectedRelease'];
     subjectId: string;
   }): void;
+
   onSubjectStepBack?: (publication?: SelectedPublication) => void;
   onSubmit?: (table: FullTable) => void;
   onTableQueryError?: (
@@ -110,24 +112,24 @@ export interface TableToolWizardProps {
 }
 
 export default function TableToolWizard({
-  currentStep,
-  finalStep,
-  hidePublicationStep,
-  initialState = {},
-  loadingFastTrack = false,
-  renderFeaturedTableLink,
-  scrollOnMount,
-  showTableQueryErrorDownload = true,
-  themeMeta = [],
-  onPublicationFormSubmit,
-  onPublicationStepBack,
-  onStepChange,
-  onStepSubmit,
-  onSubjectFormSubmit,
-  onSubjectStepBack,
-  onSubmit,
-  onTableQueryError,
-}: TableToolWizardProps) {
+                                          currentStep,
+                                          finalStep,
+                                          hidePublicationStep,
+                                          initialState = {},
+                                          loadingFastTrack = false,
+                                          renderFeaturedTableLink,
+                                          scrollOnMount,
+                                          showTableQueryErrorDownload = true,
+                                          themeMeta = [],
+                                          onPublicationFormSubmit,
+                                          onPublicationStepBack,
+                                          onStepChange,
+                                          onStepSubmit,
+                                          onSubjectFormSubmit,
+                                          onSubjectStepBack,
+                                          onSubmit,
+                                          onTableQueryError,
+                                        }: TableToolWizardProps) {
   const [state, updateState] = useImmer<TableToolState>({
     initialStep: 1,
     subjects: [],
@@ -172,8 +174,8 @@ export default function TableToolWizard({
   };
 
   const handlePublicationFormSubmit: PublicationFormSubmitHandler = async ({
-    publication,
-  }) => {
+                                                                             publication,
+                                                                           }) => {
     onPublicationFormSubmit?.(publication);
 
     const [subjects, featuredTables] = await Promise.all([
@@ -212,7 +214,7 @@ export default function TableToolWizard({
     });
 
     setDataSetStepTitle(updatedDataSetTitle);
-    onStepSubmit?.({ nextStepNumber: 2, nextStepTitle: updatedDataSetTitle });
+    onStepSubmit?.({nextStepNumber: 2, nextStepTitle: updatedDataSetTitle});
   };
 
   const handlePublicationStepBack = () => {
@@ -229,12 +231,12 @@ export default function TableToolWizard({
     });
 
     onSubjectStepBack?.(state.selectedPublication);
-    onStepSubmit?.({ nextStepNumber: 2, nextStepTitle: dataSetStepTitle });
+    onStepSubmit?.({nextStepNumber: 2, nextStepTitle: dataSetStepTitle});
   };
 
   const handleDataSetFormSubmit: DataSetFormSubmitHandler = async ({
-    subjectId: selectedSubjectId,
-  }) => {
+                                                                     subjectId: selectedSubjectId,
+                                                                   }) => {
     if (state.selectedPublication) {
       onSubjectFormSubmit?.({
         publication: state.selectedPublication,
@@ -264,11 +266,11 @@ export default function TableToolWizard({
       draft.query.timePeriod = undefined;
     });
 
-    onStepSubmit?.({ nextStepNumber: 3, nextStepTitle: updatedLocationsTitle });
+    onStepSubmit?.({nextStepNumber: 3, nextStepTitle: updatedLocationsTitle});
   };
 
   const handleLocationStepBack = async () => {
-    const { releaseId, subjectId } = state.query;
+    const {releaseId, subjectId} = state.query;
 
     const nextSubjectMeta = await tableBuilderService.getSubjectMeta(
       subjectId,
@@ -279,11 +281,11 @@ export default function TableToolWizard({
       draft.subjectMeta = nextSubjectMeta;
     });
 
-    onStepSubmit?.({ nextStepNumber: 3, nextStepTitle: locationStepTitle });
+    onStepSubmit?.({nextStepNumber: 3, nextStepTitle: locationStepTitle});
   };
 
   const handleLocationFiltersFormSubmit: LocationFiltersFormSubmitHandler =
-    async ({ locationIds }) => {
+    async ({locationIds}) => {
       const nextSubjectMeta = await tableBuilderService.filterSubjectMeta(
         {
           locationIds,
@@ -292,7 +294,7 @@ export default function TableToolWizard({
         state.query.releaseId,
       );
 
-      const { timePeriod } = state.query;
+      const {timePeriod} = state.query;
 
       // Check if selected time period is in the time period options so can reset it if not.
       const hasStartTimePeriod = nextSubjectMeta.timePeriod.options.some(
@@ -330,7 +332,7 @@ export default function TableToolWizard({
     };
 
   const handleTimePeriodStepBack = async () => {
-    const { releaseId, subjectId, locationIds } = state.query;
+    const {releaseId, subjectId, locationIds} = state.query;
 
     const nextSubjectMeta = await tableBuilderService.filterSubjectMeta(
       {
@@ -352,7 +354,7 @@ export default function TableToolWizard({
 
   const handleTimePeriodFormSubmit: TimePeriodFormSubmitHandler =
     async values => {
-      const { releaseVersionId, subjectId, locationIds } = state.query;
+      const {releaseId, subjectId, locationIds} = state.query;
       const [startYear, startCode] = parseYearCodeTuple(values.start);
       const [endYear, endCode] = parseYearCodeTuple(values.end);
 
@@ -403,11 +405,11 @@ export default function TableToolWizard({
         };
       });
 
-      onStepSubmit?.({ nextStepNumber: 5, nextStepTitle: stepTitles.filter });
+      onStepSubmit?.({nextStepNumber: 5, nextStepTitle: stepTitles.filter});
     };
 
   const handleFiltersStepBack = async () => {
-    const { releaseId, subjectId, locationIds, timePeriod } = state.query;
+    const {releaseId, subjectId, locationIds, timePeriod} = state.query;
 
     const nextSubjectMeta = await tableBuilderService.filterSubjectMeta(
       {
@@ -423,13 +425,13 @@ export default function TableToolWizard({
       draft.subjectMeta.filters = nextSubjectMeta.filters;
     });
 
-    onStepSubmit?.({ nextStepNumber: 5, nextStepTitle: stepTitles.filter });
+    onStepSubmit?.({nextStepNumber: 5, nextStepTitle: stepTitles.filter});
   };
 
   const handleFiltersFormSubmit: FilterFormSubmitHandler = async ({
-    filters,
-    indicators,
-  }) => {
+                                                                    filters,
+                                                                    indicators,
+                                                                  }) => {
     updateState(draft => {
       draft.response = undefined;
     });
@@ -472,7 +474,7 @@ export default function TableToolWizard({
       };
     });
 
-    onStepSubmit?.({ nextStepNumber: 6, nextStepTitle: stepTitles.final });
+    onStepSubmit?.({nextStepNumber: 6, nextStepTitle: stepTitles.final});
   };
 
   const orderedTableHeaders: TableHeadersConfig | undefined = useMemo(() => {
@@ -481,9 +483,9 @@ export default function TableToolWizard({
 
     return state.response?.tableHeaders && reorderedOrSavedTableHeaders
       ? applyTableHeadersOrder({
-          reorderedTableHeaders: reorderedOrSavedTableHeaders,
-          defaultTableHeaders: state.response.tableHeaders,
-        })
+        reorderedTableHeaders: reorderedOrSavedTableHeaders,
+        defaultTableHeaders: state.response.tableHeaders,
+      })
       : state.response?.tableHeaders;
   }, [
     initialState.response?.tableHeaders,
@@ -495,7 +497,7 @@ export default function TableToolWizard({
 
   return (
     <ConfirmContextProvider>
-      {({ askConfirm }) => (
+      {({askConfirm}) => (
         <>
           <Wizard
             scrollOnMount={scrollOnMount}
@@ -615,7 +617,7 @@ export default function TableToolWizard({
               })}
           </Wizard>
 
-          <PreviousStepModalConfirm />
+          <PreviousStepModalConfirm/>
         </>
       )}
     </ConfirmContextProvider>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -302,7 +302,7 @@ describe('TableToolWizard', () => {
           initialStep: 1,
           query: {
             subjectId: '',
-            releaseVersionId: 'release-1',
+            releaseId: 'release-1',
             locationIds: [],
             filters: [],
             indicators: [],

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -302,7 +302,7 @@ describe('TableToolWizard', () => {
           initialStep: 1,
           query: {
             subjectId: '',
-            releaseId: 'release-1',
+            releaseVersionId: 'release-1',
             locationIds: [],
             filters: [],
             indicators: [],

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
@@ -1705,7 +1705,7 @@ describe('TimePeriodDataTable', () => {
       filters: ['filter-1', 'filter-2', 'filter-3', 'filter-4'],
       indicators: ['indicator-2', 'indicator-1'],
       locationIds: ['location-2', 'location-1'],
-      releaseId: 'release-1-id',
+      releaseVersionId: 'release-1-id',
     };
 
     render(
@@ -1738,7 +1738,7 @@ describe('TimePeriodDataTable', () => {
       filters: ['filter-1', 'filter-4'], // filter-2 and filter-3 are missing
       indicators: ['indicator-2', 'indicator-1'],
       locationIds: ['location-2', 'location-1'],
-      releaseId: 'release-1-id',
+      releaseVersionId: 'release-1-id',
     };
 
     render(

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
@@ -1705,7 +1705,7 @@ describe('TimePeriodDataTable', () => {
       filters: ['filter-1', 'filter-2', 'filter-3', 'filter-4'],
       indicators: ['indicator-2', 'indicator-1'],
       locationIds: ['location-2', 'location-1'],
-      releaseVersionId: 'release-1-id',
+      releaseId: 'release-1-id',
     };
 
     render(
@@ -1738,7 +1738,7 @@ describe('TimePeriodDataTable', () => {
       filters: ['filter-1', 'filter-4'], // filter-2 and filter-3 are missing
       indicators: ['indicator-2', 'indicator-1'],
       locationIds: ['location-2', 'location-1'],
-      releaseVersionId: 'release-1-id',
+      releaseId: 'release-1-id',
     };
 
     render(

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/getInitialStepSubjectMeta.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/getInitialStepSubjectMeta.test.ts
@@ -31,7 +31,7 @@ describe('getInitialStepSubjectMeta', () => {
 
   test('returns `initialStep` of 2 when query does not have a `subjectId`', async () => {
     const query: ReleaseTableDataQuery = {
-      releaseId: 'release-1',
+      releaseVersionId: 'release-1',
       subjectId: '',
       filters: [],
       indicators: [],
@@ -71,7 +71,7 @@ describe('getInitialStepSubjectMeta', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
 
     const query: ReleaseTableDataQuery = {
-      releaseId: 'release-1',
+      releaseVersionId: 'release-1',
       subjectId: 'subject-1',
       locationIds: [],
       indicators: [],
@@ -106,7 +106,7 @@ describe('getInitialStepSubjectMeta', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
 
     const query: ReleaseTableDataQuery = {
-      releaseId: 'release-1',
+      releaseVersionId: 'release-1',
       subjectId: 'subject-1',
       locationIds: ['england'],
       indicators: [],
@@ -152,7 +152,7 @@ describe('getInitialStepSubjectMeta', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
 
     const query: ReleaseTableDataQuery = {
-      releaseId: 'release-1',
+      releaseVersionId: 'release-1',
       subjectId: 'subject-1',
       locationIds: ['england', 'sheffield', 'barnsley'],
       indicators: [],
@@ -246,7 +246,7 @@ describe('getInitialStepSubjectMeta', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
 
     const query: ReleaseTableDataQuery = {
-      releaseId: 'release-1',
+      releaseVersionId: 'release-1',
       subjectId: 'subject-1',
       locationIds: ['england'],
       timePeriod: {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/getInitialStepSubjectMeta.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/getInitialStepSubjectMeta.test.ts
@@ -31,7 +31,7 @@ describe('getInitialStepSubjectMeta', () => {
 
   test('returns `initialStep` of 2 when query does not have a `subjectId`', async () => {
     const query: ReleaseTableDataQuery = {
-      releaseVersionId: 'release-1',
+      releaseId: 'release-1',
       subjectId: '',
       filters: [],
       indicators: [],
@@ -71,7 +71,7 @@ describe('getInitialStepSubjectMeta', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
 
     const query: ReleaseTableDataQuery = {
-      releaseVersionId: 'release-1',
+      releaseId: 'release-1',
       subjectId: 'subject-1',
       locationIds: [],
       indicators: [],
@@ -106,7 +106,7 @@ describe('getInitialStepSubjectMeta', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
 
     const query: ReleaseTableDataQuery = {
-      releaseVersionId: 'release-1',
+      releaseId: 'release-1',
       subjectId: 'subject-1',
       locationIds: ['england'],
       indicators: [],
@@ -152,7 +152,7 @@ describe('getInitialStepSubjectMeta', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
 
     const query: ReleaseTableDataQuery = {
-      releaseVersionId: 'release-1',
+      releaseId: 'release-1',
       subjectId: 'subject-1',
       locationIds: ['england', 'sheffield', 'barnsley'],
       indicators: [],
@@ -246,7 +246,7 @@ describe('getInitialStepSubjectMeta', () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
 
     const query: ReleaseTableDataQuery = {
-      releaseVersionId: 'release-1',
+      releaseId: 'release-1',
       subjectId: 'subject-1',
       locationIds: ['england'],
       timePeriod: {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/getInitialStepSubjectMeta.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/getInitialStepSubjectMeta.ts
@@ -22,7 +22,7 @@ export default async function getInitialStepSubjectMeta(
   query: ReleaseTableDataQuery,
   tableData?: TableDataResponse,
 ): Promise<InitialStepSubjectMeta> {
-  if (!query.releaseId) {
+  if (!query.releaseVersionId) {
     return {
       initialStep: 1,
     };
@@ -36,7 +36,7 @@ export default async function getInitialStepSubjectMeta(
 
   const subjectMeta = await tableBuilderService.getSubjectMeta(
     query.subjectId,
-    query.releaseId,
+    query.releaseVersionId,
   );
 
   // Just do really basic checks to see if table can be rendered

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/getInitialStepSubjectMeta.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/getInitialStepSubjectMeta.ts
@@ -22,7 +22,7 @@ export default async function getInitialStepSubjectMeta(
   query: ReleaseTableDataQuery,
   tableData?: TableDataResponse,
 ): Promise<InitialStepSubjectMeta> {
-  if (!query.releaseVersionId) {
+  if (!query.releaseId) {
     return {
       initialStep: 1,
     };
@@ -36,7 +36,7 @@ export default async function getInitialStepSubjectMeta(
 
   const subjectMeta = await tableBuilderService.getSubjectMeta(
     query.subjectId,
-    query.releaseVersionId,
+    query.releaseId,
   );
 
   // Just do really basic checks to see if table can be rendered

--- a/src/explore-education-statistics-common/src/services/permalinkService.ts
+++ b/src/explore-education-statistics-common/src/services/permalinkService.ts
@@ -40,7 +40,7 @@ export interface PermalinkSnapshot {
 }
 
 interface CreatePermalink {
-  releaseId?: string;
+  releaseVersionId?: string;
   query: TableDataQuery;
   configuration: {
     tableHeaders: UnmappedTableHeadersConfig;

--- a/src/explore-education-statistics-common/src/services/permalinkService.ts
+++ b/src/explore-education-statistics-common/src/services/permalinkService.ts
@@ -40,7 +40,7 @@ export interface PermalinkSnapshot {
 }
 
 interface CreatePermalink {
-  releaseVersionId?: string;
+  releaseId?: string;
   query: TableDataQuery;
   configuration: {
     tableHeaders: UnmappedTableHeadersConfig;

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -44,6 +44,7 @@ export interface ReleaseSeriesItem {
   id: string;
   isLegacyLink: boolean;
   description: string;
+  // TODO rename to releaseVersionId
   releaseId?: string;
   releaseSlug?: string;
   legacyLinkUrl?: string;

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -140,7 +140,7 @@ export interface TableDataQuery extends FullTableQuery {
 }
 
 export interface ReleaseTableDataQuery extends TableDataQuery {
-  releaseId?: string;
+  releaseVersionId?: string;
 }
 
 export interface FullTableQuery {
@@ -219,38 +219,38 @@ const tableBuilderService = {
   ): Promise<FeaturedTable[]> {
     return dataApi.get(`/publications/${publicationId}/featured-tables`);
   },
-  listReleaseSubjects(releaseId: string): Promise<Subject[]> {
-    return dataApi.get(`/releases/${releaseId}/subjects`);
+  listReleaseSubjects(releaseVersionId: string): Promise<Subject[]> {
+    return dataApi.get(`/releases/${releaseVersionId}/subjects`);
   },
-  listReleaseFeaturedTables(releaseId: string): Promise<FeaturedTable[]> {
-    return dataApi.get(`/releases/${releaseId}/featured-tables`);
+  listReleaseFeaturedTables(releaseVersionId: string): Promise<FeaturedTable[]> {
+    return dataApi.get(`/releases/${releaseVersionId}/featured-tables`);
   },
   async getSubjectMeta(
     subjectId: string,
-    releaseId?: string,
+    releaseVersionId?: string,
   ): Promise<SubjectMeta> {
-    return releaseId
-      ? dataApi.get(`/release/${releaseId}/meta/subject/${subjectId}`)
+    return releaseVersionId
+      ? dataApi.get(`/release/${releaseVersionId}/meta/subject/${subjectId}`)
       : dataApi.get(`/meta/subject/${subjectId}`);
   },
   async filterSubjectMeta(
     query: LocationsOrTimePeriodsQuery,
-    releaseId?: string,
+    releaseVersionId?: string,
   ): Promise<SubjectMeta> {
-    return releaseId
-      ? dataApi.post(`/release/${releaseId}/meta/subject`, query)
+    return releaseVersionId
+      ? dataApi.post(`/release/${releaseVersionId}/meta/subject`, query)
       : dataApi.post('/meta/subject', query);
   },
   async getTableData(
     query: FullTableQuery,
-    releaseId?: string,
+    releaseVersionId?: string,
   ): Promise<TableDataResponse> {
     return releaseId
-      ? dataApi.post(`/tablebuilder/release/${releaseId}`, query)
+      ? dataApi.post(`/tablebuilder/release/${releaseVersionId}`, query)
       : dataApi.post('/tablebuilder', query);
   },
   async getTableCsv({
-    releaseId,
+    releaseVersionId,
     ...query
   }: ReleaseTableDataQuery): Promise<Blob> {
     const config: AxiosRequestConfig = {
@@ -260,16 +260,16 @@ const tableBuilderService = {
       responseType: 'blob',
     };
 
-    return releaseId
-      ? dataApi.post(`/tablebuilder/release/${releaseId}`, query, config)
+    return releaseVersionId
+      ? dataApi.post(`/tablebuilder/release/${releaseVersionId}`, query, config)
       : dataApi.post('/tablebuilder', query, config);
   },
   async getDataBlockTableData(
-    releaseId: string,
+    releaseVersionId: string,
     dataBlockParentId: string,
   ): Promise<TableDataResponse> {
     return dataApi.get(
-      `/tablebuilder/release/${releaseId}/data-block/${dataBlockParentId}`,
+      `/tablebuilder/release/${releaseVersionId}/data-block/${dataBlockParentId}`,
     );
   },
   getFastTrackTableAndReleaseMeta(

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -140,7 +140,8 @@ export interface TableDataQuery extends FullTableQuery {
 }
 
 export interface ReleaseTableDataQuery extends TableDataQuery {
-  releaseVersionId?: string;
+  // TODO rename to releaseVersionId
+  releaseId?: string;
 }
 
 export interface FullTableQuery {
@@ -219,38 +220,38 @@ const tableBuilderService = {
   ): Promise<FeaturedTable[]> {
     return dataApi.get(`/publications/${publicationId}/featured-tables`);
   },
-  listReleaseSubjects(releaseVersionId: string): Promise<Subject[]> {
-    return dataApi.get(`/releases/${releaseVersionId}/subjects`);
+  listReleaseSubjects(releaseId: string): Promise<Subject[]> {
+    return dataApi.get(`/releases/${releaseId}/subjects`);
   },
-  listReleaseFeaturedTables(releaseVersionId: string): Promise<FeaturedTable[]> {
-    return dataApi.get(`/releases/${releaseVersionId}/featured-tables`);
+  listReleaseFeaturedTables(releaseId: string): Promise<FeaturedTable[]> {
+    return dataApi.get(`/releases/${releaseId}/featured-tables`);
   },
   async getSubjectMeta(
     subjectId: string,
-    releaseVersionId?: string,
+    releaseId?: string,
   ): Promise<SubjectMeta> {
-    return releaseVersionId
-      ? dataApi.get(`/release/${releaseVersionId}/meta/subject/${subjectId}`)
+    return releaseId
+      ? dataApi.get(`/release/${releaseId}/meta/subject/${subjectId}`)
       : dataApi.get(`/meta/subject/${subjectId}`);
   },
   async filterSubjectMeta(
     query: LocationsOrTimePeriodsQuery,
-    releaseVersionId?: string,
+    releaseId?: string,
   ): Promise<SubjectMeta> {
-    return releaseVersionId
-      ? dataApi.post(`/release/${releaseVersionId}/meta/subject`, query)
+    return releaseId
+      ? dataApi.post(`/release/${releaseId}/meta/subject`, query)
       : dataApi.post('/meta/subject', query);
   },
   async getTableData(
     query: FullTableQuery,
-    releaseVersionId?: string,
+    releaseId?: string,
   ): Promise<TableDataResponse> {
     return releaseId
-      ? dataApi.post(`/tablebuilder/release/${releaseVersionId}`, query)
+      ? dataApi.post(`/tablebuilder/release/${releaseId}`, query)
       : dataApi.post('/tablebuilder', query);
   },
   async getTableCsv({
-    releaseVersionId,
+    releaseId,
     ...query
   }: ReleaseTableDataQuery): Promise<Blob> {
     const config: AxiosRequestConfig = {
@@ -260,16 +261,16 @@ const tableBuilderService = {
       responseType: 'blob',
     };
 
-    return releaseVersionId
-      ? dataApi.post(`/tablebuilder/release/${releaseVersionId}`, query, config)
+    return releaseId
+      ? dataApi.post(`/tablebuilder/release/${releaseId}`, query, config)
       : dataApi.post('/tablebuilder', query, config);
   },
   async getDataBlockTableData(
-    releaseVersionId: string,
+    releaseId: string,
     dataBlockParentId: string,
   ): Promise<TableDataResponse> {
     return dataApi.get(
-      `/tablebuilder/release/${releaseVersionId}/data-block/${dataBlockParentId}`,
+      `/tablebuilder/release/${releaseId}/data-block/${dataBlockParentId}`,
     );
   },
   getFastTrackTableAndReleaseMeta(

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -244,6 +244,7 @@ const tableBuilderService = {
   },
   async getTableData(
     query: FullTableQuery,
+    // TODO rename to releaseVersionId
     releaseId?: string,
   ): Promise<TableDataResponse> {
     return releaseId

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
@@ -27,7 +27,7 @@ const PublicationSectionBlocks = ({
   const getReleaseFile = useGetReleaseFile(release.id);
 
   const transformImageAttributes = useReleaseImageAttributeTransformer({
-    releaseVersionId: release.id,
+    releaseId: release.id,
     rootUrl: process.env.CONTENT_API_BASE_URL.replace('/api', ''),
   });
 

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
@@ -27,7 +27,7 @@ const PublicationSectionBlocks = ({
   const getReleaseFile = useGetReleaseFile(release.id);
 
   const transformImageAttributes = useReleaseImageAttributeTransformer({
-    releaseId: release.id,
+    releaseVersionId: release.id,
     rootUrl: process.env.CONTENT_API_BASE_URL.replace('/api', ''),
   });
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -90,7 +90,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
         featuredTables,
         query: {
           ...fastTrack.query,
-          releaseId: selectedPublication?.selectedRelease.id,
+          releaseVersionId: selectedPublication?.selectedRelease.id,
         },
         selectedPublication,
         subjectMeta,
@@ -108,7 +108,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
         featuredTables,
         query: {
           publicationId: selectedPublication?.id,
-          releaseId: selectedPublication?.selectedRelease.id,
+          releaseVersionId: selectedPublication?.selectedRelease.id,
           subjectId: selectedSubjectId,
           indicators: [],
           filters: [],
@@ -125,7 +125,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
       featuredTables,
       query: {
         publicationId: selectedPublication?.id,
-        releaseId: selectedPublication?.selectedRelease.id,
+        releaseVersionId: selectedPublication?.selectedRelease.id,
         subjectId: '',
         indicators: [],
         filters: [],

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -90,6 +90,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
         featuredTables,
         query: {
           ...fastTrack.query,
+          // TODO rename to releaseVersionId
           releaseId: selectedPublication?.selectedRelease.id,
         },
         selectedPublication,
@@ -108,6 +109,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
         featuredTables,
         query: {
           publicationId: selectedPublication?.id,
+          // TODO rename to releaseVersionId
           releaseId: selectedPublication?.selectedRelease.id,
           subjectId: selectedSubjectId,
           indicators: [],
@@ -125,6 +127,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
       featuredTables,
       query: {
         publicationId: selectedPublication?.id,
+        // TODO rename to releaseVersionId
         releaseId: selectedPublication?.selectedRelease.id,
         subjectId: '',
         indicators: [],

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -90,7 +90,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
         featuredTables,
         query: {
           ...fastTrack.query,
-          releaseVersionId: selectedPublication?.selectedRelease.id,
+          releaseId: selectedPublication?.selectedRelease.id,
         },
         selectedPublication,
         subjectMeta,
@@ -108,7 +108,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
         featuredTables,
         query: {
           publicationId: selectedPublication?.id,
-          releaseVersionId: selectedPublication?.selectedRelease.id,
+          releaseId: selectedPublication?.selectedRelease.id,
           subjectId: selectedSubjectId,
           indicators: [],
           filters: [],
@@ -125,7 +125,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
       featuredTables,
       query: {
         publicationId: selectedPublication?.id,
-        releaseVersionId: selectedPublication?.selectedRelease.id,
+        releaseId: selectedPublication?.selectedRelease.id,
         subjectId: '',
         indicators: [],
         filters: [],

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
@@ -38,10 +38,10 @@ const TableToolShare = ({ tableHeaders, query }: Props) => {
     setPermalinkError(undefined);
     setPermalinkLoading(true);
 
-    const { releaseId } = query;
+    const { releaseVersionId } = query;
     try {
       const { id } = await permalinkService.createPermalink({
-        releaseId,
+        releaseVersionId,
         query,
         configuration: {
           tableHeaders: mapUnmappedTableHeaders(tableHeaders),

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolShare.tsx
@@ -38,10 +38,10 @@ const TableToolShare = ({ tableHeaders, query }: Props) => {
     setPermalinkError(undefined);
     setPermalinkLoading(true);
 
-    const { releaseVersionId } = query;
+    const { releaseId } = query;
     try {
       const { id } = await permalinkService.createPermalink({
-        releaseVersionId,
+        releaseId,
         query,
         configuration: {
           tableHeaders: mapUnmappedTableHeaders(tableHeaders),

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolShare.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolShare.test.tsx
@@ -19,7 +19,7 @@ const permalinkService = _permalinkService as jest.Mocked<
 >;
 
 const tableQuery: ReleaseTableDataQuery = {
-  releaseId: 'release-1',
+  releaseVersionId: 'release-1',
   ...testQuery,
 };
 
@@ -53,7 +53,7 @@ describe('TableToolShare', () => {
       expect(permalinkService.createPermalink).toHaveBeenCalledWith<
         Parameters<typeof permalinkService.createPermalink>
       >({
-        releaseId: 'release-1',
+        releaseVersionId: 'release-1',
         query: tableQuery,
         configuration: {
           tableHeaders: mapUnmappedTableHeaders(testTableHeaders),

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolShare.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolShare.test.tsx
@@ -19,7 +19,7 @@ const permalinkService = _permalinkService as jest.Mocked<
 >;
 
 const tableQuery: ReleaseTableDataQuery = {
-  releaseVersionId: 'release-1',
+  releaseId: 'release-1',
   ...testQuery,
 };
 
@@ -53,7 +53,7 @@ describe('TableToolShare', () => {
       expect(permalinkService.createPermalink).toHaveBeenCalledWith<
         Parameters<typeof permalinkService.createPermalink>
       >({
-        releaseVersionId: 'release-1',
+        releaseId: 'release-1',
         query: tableQuery,
         configuration: {
           tableHeaders: mapUnmappedTableHeaders(testTableHeaders),

--- a/tests/robot-tests/tests/admin/authentication/register.robot
+++ b/tests/robot-tests/tests/admin/authentication/register.robot
@@ -30,7 +30,7 @@ Invite the user as an Analyst with publication and release roles
     user waits until h1 is visible    Invite user
     user enters text into element    name:userEmail    %{PENDING_INVITE_USER_EMAIL}
 
-    user chooses select option    name:releaseId    ${RELEASE_NAME}
+    user chooses select option    name:releaseVersionId    ${RELEASE_NAME}
     user chooses select option    name:releaseRole    Approver
     user clicks button    Add release role
 

--- a/tests/robot-tests/tests/admin/bau/invite_new_users.robot
+++ b/tests/robot-tests/tests/admin/bau/invite_new_users.robot
@@ -58,7 +58,7 @@ Invite a new user with release and publication roles
 
     user enters text into element    name:userEmail    ${EMAIL}
 
-    user chooses select option    name:releaseId    ${RELEASE1_NAME}
+    user chooses select option    name:releaseVersionId    ${RELEASE1_NAME}
     user chooses select option    name:releaseRole    Approver
     user clicks button    Add release role
 
@@ -66,7 +66,7 @@ Invite a new user with release and publication roles
     ${ROW}=    user gets table row    ${RELEASE1_NAME}    testid:release-role-table
     user checks element contains    ${ROW}    Approver
 
-    user chooses select option    name:releaseId    ${RELEASE2_NAME}
+    user chooses select option    name:releaseVersionId    ${RELEASE2_NAME}
     user chooses select option    name:releaseRole    Contributor
     user clicks button    Add release role
 
@@ -76,7 +76,7 @@ Invite a new user with release and publication roles
     ${ROW}=    user gets table row    ${RELEASE2_NAME}    testid:release-role-table
     user checks element contains    ${ROW}    Contributor
 
-    user chooses select option    name:releaseId    ${RELEASE3_NAME}
+    user chooses select option    name:releaseVersionId    ${RELEASE3_NAME}
     user chooses select option    name:releaseRole    PrereleaseViewer
     user clicks button    Add release role
 

--- a/tests/robot-tests/tests/admin/bau/manage_users_page.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_users_page.robot
@@ -79,8 +79,8 @@ Check the initial manage user page
     user checks select contains option    //*[@name="roleId"]    Prerelease User
     user checks selected option label    //*[@name="roleId"]    Choose role
 
-    user checks select contains option    name:releaseVersionId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
-    user checks select contains option    name:releaseVersionId    ${PUBLICATION_2_NAME} - ${RELEASE_2_NAME}
+    user checks select contains option    name:releaseId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
+    user checks select contains option    name:releaseId    ${PUBLICATION_2_NAME} - ${RELEASE_2_NAME}
     user checks select contains x options    name:releaseRole    5
     user checks select contains option    name:releaseRole    Approver
     user checks select contains option    name:releaseRole    Contributor
@@ -95,7 +95,7 @@ Check the initial manage user page
     user checks select contains option    name:publicationRole    Approver
 
 Give the user prerelease access to a release
-    user chooses select option    name:releaseVersionId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
+    user chooses select option    name:releaseId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
     user chooses select option    name:releaseRole    PrereleaseViewer
     user clicks button    Add release access
     user checks table body has x rows    1    testid:releaseAccessTable
@@ -111,7 +111,7 @@ Give the user prerelease access to a release
     user checks selected option label    //*[@name="roleId"]    Prerelease User
 
 Give the user approver access to a release
-    user chooses select option    name:releaseVersionId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
+    user chooses select option    name:releaseId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
     user chooses select option    name:releaseRole    Approver
     user clicks button    Add release access
     user checks table body has x rows    2    testid:releaseAccessTable
@@ -177,7 +177,7 @@ Remove publication owner access for one of the publications from user while they
     user checks selected option label    //*[@name="roleId"]    BAU User
 
 Give the user approver access to a release while they are BAU
-    user chooses select option    name:releaseVersionId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
+    user chooses select option    name:releaseId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
     user chooses select option    name:releaseRole    Approver
     user clicks button    Add release access
     user checks table body has x rows    1    testid:releaseAccessTable
@@ -198,7 +198,7 @@ Remove publication owner access for the final publication from user while they a
     user checks selected option label    //*[@name="roleId"]    BAU User
 
 Give the user approver access to a release while they are BAU and manually set their role to Analyst
-    user chooses select option    name:releaseVersionId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
+    user chooses select option    name:releaseId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
     user chooses select option    name:releaseRole    Approver
     user clicks button    Add release access
     user checks table body has x rows    1    testid:releaseAccessTable

--- a/tests/robot-tests/tests/admin/bau/manage_users_page.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_users_page.robot
@@ -79,8 +79,8 @@ Check the initial manage user page
     user checks select contains option    //*[@name="roleId"]    Prerelease User
     user checks selected option label    //*[@name="roleId"]    Choose role
 
-    user checks select contains option    name:releaseId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
-    user checks select contains option    name:releaseId    ${PUBLICATION_2_NAME} - ${RELEASE_2_NAME}
+    user checks select contains option    name:releaseVersionId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
+    user checks select contains option    name:releaseVersionId    ${PUBLICATION_2_NAME} - ${RELEASE_2_NAME}
     user checks select contains x options    name:releaseRole    5
     user checks select contains option    name:releaseRole    Approver
     user checks select contains option    name:releaseRole    Contributor
@@ -95,7 +95,7 @@ Check the initial manage user page
     user checks select contains option    name:publicationRole    Approver
 
 Give the user prerelease access to a release
-    user chooses select option    name:releaseId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
+    user chooses select option    name:releaseVersionId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
     user chooses select option    name:releaseRole    PrereleaseViewer
     user clicks button    Add release access
     user checks table body has x rows    1    testid:releaseAccessTable
@@ -111,7 +111,7 @@ Give the user prerelease access to a release
     user checks selected option label    //*[@name="roleId"]    Prerelease User
 
 Give the user approver access to a release
-    user chooses select option    name:releaseId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
+    user chooses select option    name:releaseVersionId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
     user chooses select option    name:releaseRole    Approver
     user clicks button    Add release access
     user checks table body has x rows    2    testid:releaseAccessTable
@@ -177,7 +177,7 @@ Remove publication owner access for one of the publications from user while they
     user checks selected option label    //*[@name="roleId"]    BAU User
 
 Give the user approver access to a release while they are BAU
-    user chooses select option    name:releaseId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
+    user chooses select option    name:releaseVersionId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
     user chooses select option    name:releaseRole    Approver
     user clicks button    Add release access
     user checks table body has x rows    1    testid:releaseAccessTable
@@ -198,7 +198,7 @@ Remove publication owner access for the final publication from user while they a
     user checks selected option label    //*[@name="roleId"]    BAU User
 
 Give the user approver access to a release while they are BAU and manually set their role to Analyst
-    user chooses select option    name:releaseId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
+    user chooses select option    name:releaseVersionId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
     user chooses select option    name:releaseRole    Approver
     user clicks button    Add release access
     user checks table body has x rows    1    testid:releaseAccessTable


### PR DESCRIPTION
This PR:
- renames Release to ReleaseVersion in the Admin front end codebase.

It retains all uses of "releaseId" as a releaseVersionId in common and public front end codebases, and adds TODOs against those places where Admin uses those shared components referring to a releaseVersionId as "releaseId" still for compatibility.