### PR TITLE
🐛 EES-5329 Ensure `app_public_data_api` has `USAGE` privilege on public schema

### DIFF
--- a/data/public-api-db/00-init.sh
+++ b/data/public-api-db/00-init.sh
@@ -16,16 +16,15 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     GRANT CREATE ON SCHEMA public TO app_public_data_api;
 
     /*
-     * Grant the other application user roles privileges to look up objects on the public schema.
-     */
-    GRANT USAGE ON SCHEMA public TO app_public_data_processor;
-    GRANT USAGE ON SCHEMA public TO app_admin;
-    GRANT USAGE ON SCHEMA public TO app_publisher;
-
-    /*
      * Create a public_data_read_write group role which can be granted to user roles requiring read and write privileges on public schema objects.
      */
     CREATE ROLE public_data_read_write WITH NOLOGIN;
+
+    /*
+     * Allow the public_data_read_write group role to access objects in the public schema.
+     * This does not include the permissions to read (i.e. `SELECT`) or modify (i.e. `INSERT`, `UPDATE`, `DELETE`) the content of those objects.
+     */
+    GRANT USAGE ON SCHEMA public TO public_data_read_write;
 
     /*
      * Grant privileges to the public_data_read_write group role for all tables and sequences in the public schema subsequently created by app_public_data_api.


### PR DESCRIPTION
This PR is a bugfix for https://github.com/dfe-analytical-services/explore-education-statistics/pull/5044. It ensures that the application user role `app_public_data_api` has USAGE privilege to access objects in the public schema.

### Before
The init script ran the equivalent of the following:

```sql
GRANT CREATE ON SCHEMA public TO app_public_data_api;

GRANT USAGE ON SCHEMA public TO app_public_data_processor;
GRANT USAGE ON SCHEMA public TO app_admin;
GRANT USAGE ON SCHEMA public TO app_publisher;

CREATE ROLE public_data_read_write WITH NOLOGIN;

GRANT public_data_read_write TO app_public_data_api;
GRANT public_data_read_write TO app_public_data_processor;
GRANT public_data_read_write TO app_admin;
GRANT public_data_read_write TO app_publisher;
```

Application user role `app_public_data_api` is missing `USAGE` so it cannot access objects in the public schema.

### After:

```sql
CREATE ROLE public_data_read_write WITH NOLOGIN;

GRANT CREATE ON SCHEMA public TO app_public_data_api;

GRANT USAGE ON SCHEMA public TO public_data_read_write;

GRANT public_data_read_write TO app_public_data_api;
GRANT public_data_read_write TO app_public_data_processor;
GRANT public_data_read_write TO app_admin;
GRANT public_data_read_write TO app_publisher;
```

All application user roles can access objects in the public schema through membership of the `public_data_read_write` role.

Note: `USAGE` does not include the permissions to read (i.e. `SELECT`) or modify (i.e. `INSERT`, `UPDATE`, `DELETE`) the content of objects. Those permissions are granted to the `public_data_read_write` role separate to this.

## Testing

### Before

```bash
$ psql -U app_public_data_api -d public_data <<-EOSQL
    SELECT * FROM "__EFMigrationsHistory";
EOSQL
Password for user app_public_data_api:

ERROR:  relation "__EFMigrationsHistory" does not exist
LINE 1: SELECT * FROM "__EFMigrationsHistory";
```

### After

```bash
$ psql -U app_public_data_api -d public_data <<-EOSQL
    SELECT * FROM "__EFMigrationsHistory";
EOSQL
Password for user app_public_data_api:

                          MigrationId                          | ProductVersion
---------------------------------------------------------------+----------------
 20240501113006_InitialMigration                               | 8.0.4
 20240618080650_EES4945_AddDataSetVersionMappingsTable         | 8.0.4
 20240619085713_EES5235_AddFilterOptionMetaLinkSequence        | 8.0.4
 20240711142913_EE5239_AddPreviewTokenTable                    | 8.0.4
 20240718171717_EES5329_GrantPublicDataReadWriteRolePrivileges | 8.0.4
(5 rows)
```

## New version of Public API seed data
There is a reissued version `public-api-16.zip` of the seed data to reflect this change in the `pg_dump` database dump.