### PR TITLE
EES-5220 fix find stats search ui test

### DIFF
--- a/tests/robot-tests/tests/general_public/statistics_page.robot
+++ b/tests/robot-tests/tests/general_public/statistics_page.robot
@@ -76,6 +76,10 @@ Remove release type filter
     user checks selected option label     id:filters-form-release-type    All release types
 
 Searching
+    # filter by theme first to make sure we get the seed publication on dev.
+    user chooses select option    id:filters-form-theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
+    user checks page contains button    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
+    
     user clicks element    id:searchForm-search
     user presses keys    pupil absence
     user clicks button    Search


### PR DESCRIPTION
Now the search results aren't ordered by relevance it's harder to always find the right one in the UI tests, narrowing it down by theme first should fix it.