### PR TITLE
EES-5361 Fix amendment cancelling

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -120,6 +120,8 @@ using ReleaseService = GovUk.Education.ExploreEducationStatistics.Admin.Services
 using ReleaseVersionRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.ReleaseVersionRepository;
 using SameSiteMode = Microsoft.AspNetCore.Http.SameSiteMode;
 using ThemeService = GovUk.Education.ExploreEducationStatistics.Admin.Services.ThemeService;
+using HeaderNames = Microsoft.Net.Http.Headers.HeaderNames;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin
 {
@@ -448,21 +450,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IDataSetCandidateService, DataSetCandidateService>();
             services.AddTransient<IPostgreSqlRepository, PostgreSqlRepository>();
 
-            services.AddHttpClient<IProcessorClient, ProcessorClient>((provider, httpClient) =>
-            {
-                var options = provider.GetRequiredService<IOptions<PublicDataProcessorOptions>>();
-                httpClient.BaseAddress = new Uri(options.Value.Url);
-                httpClient.DefaultRequestHeaders.Add(HeaderNames.UserAgent, "EES Admin");
-            });
-
             if (publicDataDbExists)
             {
+                services.AddHttpClient<IProcessorClient, ProcessorClient>((provider, httpClient) =>
+                {
+                    var options = provider.GetRequiredService<IOptions<PublicDataProcessorOptions>>();
+                    httpClient.BaseAddress = new Uri(options.Value.Url);
+                    httpClient.DefaultRequestHeaders.Add(HeaderNames.UserAgent, "EES Admin");
+                });
+
                 services.AddTransient<IDataSetService, DataSetService>();
                 services.AddTransient<IDataSetVersionService, DataSetVersionService>();
                 services.AddTransient<IDataSetVersionMappingService, DataSetVersionMappingService>();
             }
             else
             {
+                services.AddTransient<IProcessorClient, NoOpProcessorClient>();
+
                 // TODO EES-5073 Remove this once PublicDataDbContext is configured in ALL Azure environments.
                 // This is allowing for the PublicDataDbContext to be null.
                 services.AddTransient<IDataSetService, DataSetService>(provider =>
@@ -762,6 +766,32 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             {
                 migration.Apply();
             }
+        }
+    }
+
+    internal class NoOpProcessorClient : IProcessorClient
+    {
+        public Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateDataSet(
+            Guid releaseFileId,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateNextDataSetVersion(
+            Guid dataSetId,
+            Guid releaseFileId,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public Task<Either<ActionResult, Unit>> BulkDeleteDataSetVersions(
+            Guid releaseVersionId,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new Either<ActionResult,Unit>(Unit.Instance));
+        }
+
+        public Task<Either<ActionResult, Unit>> DeleteDataSetVersion(
+            Guid dataSetVersionId,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new Either<ActionResult,Unit>(Unit.Instance));
         }
     }
 


### PR DESCRIPTION
This PR fixes a bug where amendment cancelling resulted in a 500.

This happened because in `ReleaseService#DeleteReleaseVersion`, `_processorClient.BulkDeleteDataSetVersions` tries to interact with Public API infrastructure that isn't currently deployed to environments.

This PR adds `NoOpProcessorClient`, which is used instead of `ProcessorClient` based on the value of the `PublicDataDbExists` configuration variable.