### PR TITLE
EES-5281 prevent deleting and replacing data for files with api data sets

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTests.cs
@@ -952,7 +952,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Created = DateTime.UtcNow,
                     CreatedById = _user.Id
                 },
-                PublicApiDataSetId = Guid.NewGuid()
+                PublicApiDataSetId = Guid.NewGuid(),
+                PublicApiDataSetVersion = "1.0.1"
             };
 
             var metaReleaseFile = new ReleaseFile
@@ -1004,7 +1005,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("10 Kb", fileInfo.Size);
                 Assert.Equal(dataReleaseFile.File.Created, fileInfo.Created);
                 Assert.Equal(COMPLETE, fileInfo.Status);
-                Assert.True(fileInfo.IsLinkedToApiDataSet);
+                Assert.Equal(dataReleaseFile.PublicApiDataSetId, fileInfo.PublicApiDataSetId);
+                Assert.Equal(dataReleaseFile.PublicApiDataSetVersionString, fileInfo.PublicApiDataSetVersion);
             }
         }
 
@@ -1185,7 +1187,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("10 Kb", fileInfo.Size);
                 Assert.Equal(dataFile.Created, fileInfo.Created);
                 Assert.Equal(COMPLETE, fileInfo.Status);
-                Assert.False(fileInfo.IsLinkedToApiDataSet);
+                Assert.Null(fileInfo.PublicApiDataSetId);
+                Assert.Null(fileInfo.PublicApiDataSetVersion);
             }
         }
 
@@ -1410,6 +1413,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 ReleaseVersion = releaseVersion,
                 Name = "Test subject 1",
                 PublicApiDataSetId = Guid.NewGuid(),
+                PublicApiDataSetVersion = "1.0.1",
                 File = new File
                 {
                     Filename = "test-data-1.csv",
@@ -1505,7 +1509,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("10 Kb", files[0].Size);
                 Assert.Equal(dataReleaseFile1.File.Created, files[0].Created);
                 Assert.Equal(COMPLETE, files[0].Status);
-                Assert.True(files[0].IsLinkedToApiDataSet);
+                Assert.Equal(dataReleaseFile1.PublicApiDataSetId, files[0].PublicApiDataSetId);
+                Assert.Equal(dataReleaseFile1.PublicApiDataSetVersionString, files[0].PublicApiDataSetVersion);
 
                 Assert.Equal(dataReleaseFile2.File.Id, files[1].Id);
                 Assert.Equal("Test subject 2", files[1].Name);
@@ -1518,7 +1523,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("20 Kb", files[1].Size);
                 Assert.Equal(dataReleaseFile2.File.Created, files[1].Created);
                 Assert.Equal(STAGE_2, files[1].Status);
-                Assert.False(files[1].IsLinkedToApiDataSet);
+                Assert.Null(files[1].PublicApiDataSetId);
+                Assert.Null(files[1].PublicApiDataSetVersion);
             }
         }
 
@@ -1639,7 +1645,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("10 Kb", files[0].Size);
                 Assert.Equal(dataRelease1File.File.Created, files[0].Created);
                 Assert.Equal(COMPLETE, files[0].Status);
-                Assert.False(files[0].IsLinkedToApiDataSet);
+                Assert.Null(files[0].PublicApiDataSetId);
+                Assert.Null(files[0].PublicApiDataSetVersion);
             }
         }
 
@@ -1765,7 +1772,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("20 Kb", files[0].Size);
                 Assert.Equal(dataFile2.Created, files[0].Created);
                 Assert.Equal(COMPLETE, files[0].Status);
-                Assert.False(files[0].IsLinkedToApiDataSet);
+                Assert.Null(files[0].PublicApiDataSetId);
+                Assert.Null(files[0].PublicApiDataSetVersion);
             }
         }
 
@@ -1877,7 +1885,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("10 Kb", dataFileInfo.Size);
                 dataFileInfo.Created.AssertUtcNow();
                 Assert.Equal(QUEUED, dataFileInfo.Status);
-                Assert.False(dataFileInfo.IsLinkedToApiDataSet);
+                Assert.Null(dataFileInfo.PublicApiDataSetId);
+                Assert.Null(dataFileInfo.PublicApiDataSetVersion);
             }
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -2053,7 +2062,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("10 Kb", dataFileInfo.Size);
                 dataFileInfo.Created.AssertUtcNow();
                 Assert.Equal(QUEUED, dataFileInfo.Status);
-                Assert.False(dataFileInfo.IsLinkedToApiDataSet);
+                Assert.Null(dataFileInfo.PublicApiDataSetId);
+                Assert.Null(dataFileInfo.PublicApiDataSetVersion);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -2400,7 +2410,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("1 Mb", result.Size);
                 result.Created.AssertUtcNow();
                 Assert.Equal(QUEUED, result.Status);
-                Assert.False(result.IsLinkedToApiDataSet);
+                Assert.Null(result.PublicApiDataSetId);
+                Assert.Null(result.PublicApiDataSetVersion);
             }
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -2727,7 +2738,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("1 Mb", result.Size);
                 result.Created.AssertUtcNow();
                 Assert.Equal(QUEUED, result.Status);
-                Assert.False(result.IsLinkedToApiDataSet);
+                Assert.Null(result.PublicApiDataSetId);
+                Assert.Null(result.PublicApiDataSetVersion);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/DataFileInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/DataFileInfo.cs
@@ -24,6 +24,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
 
         public DataFilePermissions Permissions { get; set; } = new();
 
-        public bool IsLinkedToApiDataSet { get; set; }
+        public Guid? PublicApiDataSetId { get; set; }
+
+        public string? PublicApiDataSetVersion { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
@@ -588,7 +588,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 Status = importStatus,
                 Created = dataReleaseFile.File.Created,
                 Permissions = permissions,
-                IsLinkedToApiDataSet = dataReleaseFile.IsLinkedToApiDataSet
+                PublicApiDataSetId = dataReleaseFile.PublicApiDataSetId,
+                PublicApiDataSetVersion = dataReleaseFile.PublicApiDataSetVersionString,
             };
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -1742,7 +1742,7 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                             viewModel.IsSuperseded),
                     () => Assert.Equal(releaseFile.ReleaseVersion.Published!.Value, viewModel.Published),
                     () => Assert.Equal(releaseFile.PublicApiDataSetId, viewModel.Api?.Id),
-                    () => Assert.Equal(releaseFile.PublicApiVersionString, viewModel.Api?.Version)
+                    () => Assert.Equal(releaseFile.PublicApiDataSetVersionString, viewModel.Api?.Version)
                 );
             });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
@@ -27,7 +27,7 @@ public class ReleaseFile
 
     public SemVersion? PublicApiDataSetVersion { get; set; }
 
-    public string? PublicApiVersionString => PublicApiDataSetVersion is not null
+    public string? PublicApiDataSetVersionString => PublicApiDataSetVersion is not null
         ? $"{PublicApiDataSetVersion.Major}.{PublicApiDataSetVersion.Minor}"
         : null;
 
@@ -36,8 +36,6 @@ public class ReleaseFile
     public List<IndicatorGroupSequenceEntry>? IndicatorSequence { get; set; }
 
     public DateTime? Published { get; set; }
-
-    public bool IsLinkedToApiDataSet => PublicApiDataSetId is not null;
 }
 
 public abstract record SequenceEntry<TEntry, TChild>(TEntry Id, List<TChild> ChildSequence);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -360,7 +360,7 @@ public class DataSetFileService : IDataSetFileService
 
     private static DataSetFileApiViewModel? BuildDataSetFileApiViewModel(ReleaseFile releaseFile)
     {
-        if (releaseFile.PublicApiDataSetId is null || releaseFile.PublicApiVersionString is null)
+        if (releaseFile.PublicApiDataSetId is null || releaseFile.PublicApiDataSetVersionString is null)
         {
             return null;
         }
@@ -368,7 +368,7 @@ public class DataSetFileService : IDataSetFileService
         return new DataSetFileApiViewModel
         {
             Id = releaseFile.PublicApiDataSetId.Value,
-            Version = releaseFile.PublicApiVersionString,
+            Version = releaseFile.PublicApiDataSetVersionString,
         };
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -22,6 +22,7 @@ import releaseDataFileService, {
 import ButtonText from '@common/components/ButtonText';
 import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
+import Modal from '@common/components/Modal';
 import ModalConfirm from '@common/components/ModalConfirm';
 import WarningMessage from '@common/components/WarningMessage';
 import logger from '@common/services/logger';
@@ -244,36 +245,68 @@ const ReleaseDataUploadsSection = ({
                               >
                                 Edit title
                               </Link>
-                              <Link
-                                className="govuk-!-margin-right-4"
-                                to={generatePath<ReleaseDataFileReplaceRouteParams>(
-                                  releaseDataFileReplaceRoute.path,
-                                  {
-                                    publicationId,
-                                    releaseId,
-                                    fileId: dataFile.id,
-                                  },
-                                )}
-                              >
-                                Replace data
-                              </Link>
+                              {dataFile.isLinkedToApiDataSet ? (
+                                <Modal
+                                  showClose
+                                  title="Cannot replace data"
+                                  triggerButton={
+                                    <ButtonText>Replace data</ButtonText>
+                                  }
+                                >
+                                  <p>
+                                    This data file has an API data set linked to
+                                    it. Please remove the API data set before
+                                    replacing the data.
+                                  </p>
+                                </Modal>
+                              ) : (
+                                <Link
+                                  className="govuk-!-margin-right-4"
+                                  to={generatePath<ReleaseDataFileReplaceRouteParams>(
+                                    releaseDataFileReplaceRoute.path,
+                                    {
+                                      publicationId,
+                                      releaseId,
+                                      fileId: dataFile.id,
+                                    },
+                                  )}
+                                >
+                                  Replace data
+                                </Link>
+                              )}
                             </>
                           )}
-
-                          <ButtonText
-                            onClick={() =>
-                              releaseDataFileService
-                                .getDeleteDataFilePlan(releaseId, dataFile)
-                                .then(plan => {
-                                  setDeleteDataFile({
-                                    plan,
-                                    file: dataFile,
-                                  });
-                                })
-                            }
-                          >
-                            Delete files
-                          </ButtonText>
+                          {dataFile.isLinkedToApiDataSet ? (
+                            <Modal
+                              showClose
+                              title="Cannot delete files"
+                              triggerButton={
+                                <ButtonText className="govuk-!-margin-left-3">
+                                  Delete files
+                                </ButtonText>
+                              }
+                            >
+                              <p>
+                                This data file has an API data set linked to it.
+                                Please remove the API data set before deleting.
+                              </p>
+                            </Modal>
+                          ) : (
+                            <ButtonText
+                              onClick={() =>
+                                releaseDataFileService
+                                  .getDeleteDataFilePlan(releaseId, dataFile)
+                                  .then(plan => {
+                                    setDeleteDataFile({
+                                      plan,
+                                      file: dataFile,
+                                    });
+                                  })
+                              }
+                            >
+                              Delete files
+                            </ButtonText>
+                          )}
                         </>
                       )}
                     {dataFile.permissions.canCancelImport && (

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -8,10 +8,12 @@ import DataFileUploadForm, {
 import { terminalImportStatuses } from '@admin/pages/release/data/components/ImporterStatus';
 import releaseDataFileQueries from '@admin/queries/releaseDataFileQueries';
 import {
+  releaseApiDataSetDetailsRoute,
   releaseDataFileReplaceRoute,
   ReleaseDataFileReplaceRouteParams,
   releaseDataFileRoute,
   ReleaseDataFileRouteParams,
+  ReleaseDataSetRouteParams,
 } from '@admin/routes/releaseRoutes';
 import permissionService from '@admin/services/permissionService';
 import releaseDataFileService, {
@@ -245,7 +247,7 @@ const ReleaseDataUploadsSection = ({
                               >
                                 Edit title
                               </Link>
-                              {dataFile.isLinkedToApiDataSet ? (
+                              {dataFile.publicApiDataSetId ? (
                                 <Modal
                                   showClose
                                   title="Cannot replace data"
@@ -257,6 +259,21 @@ const ReleaseDataUploadsSection = ({
                                     This data file has an API data set linked to
                                     it. Please remove the API data set before
                                     replacing the data.
+                                  </p>
+                                  <p>
+                                    <Link
+                                      to={generatePath<ReleaseDataSetRouteParams>(
+                                        releaseApiDataSetDetailsRoute.path,
+                                        {
+                                          publicationId,
+                                          releaseId,
+                                          dataSetId:
+                                            dataFile.publicApiDataSetId,
+                                        },
+                                      )}
+                                    >
+                                      Go to API data set
+                                    </Link>
                                   </p>
                                 </Modal>
                               ) : (
@@ -276,7 +293,7 @@ const ReleaseDataUploadsSection = ({
                               )}
                             </>
                           )}
-                          {dataFile.isLinkedToApiDataSet ? (
+                          {dataFile.publicApiDataSetId ? (
                             <Modal
                               showClose
                               title="Cannot delete files"
@@ -290,10 +307,24 @@ const ReleaseDataUploadsSection = ({
                                 This data file has an API data set linked to it.
                                 Please remove the API data set before deleting.
                               </p>
+                              <p>
+                                <Link
+                                  to={generatePath<ReleaseDataSetRouteParams>(
+                                    releaseApiDataSetDetailsRoute.path,
+                                    {
+                                      publicationId,
+                                      releaseId,
+                                      dataSetId: dataFile.publicApiDataSetId,
+                                    },
+                                  )}
+                                >
+                                  Go to API data set
+                                </Link>
+                              </p>
                             </Modal>
                           ) : (
                             <ButtonText
-                              onClick={() =>
+                              onClick={async () =>
                                 releaseDataFileService
                                   .getDeleteDataFilePlan(releaseId, dataFile)
                                   .then(plan => {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -464,7 +464,7 @@ describe('ReleaseDataUploadsSection', () => {
 
     test('does not allow deleting files when linked to an API data set', async () => {
       releaseDataFileService.getDataFiles.mockResolvedValue([
-        { ...testDataFiles[0], isLinkedToApiDataSet: true },
+        { ...testDataFiles[0], publicApiDataSetId: 'test-data-set-id' },
       ]);
       releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
         testCompleteImportStatus,
@@ -503,6 +503,13 @@ describe('ReleaseDataUploadsSection', () => {
           'This data file has an API data set linked to it. Please remove the API data set before deleting.',
         ),
       ).toBeInTheDocument();
+
+      expect(
+        modal.getByRole('link', { name: 'Go to API data set' }),
+      ).toHaveAttribute(
+        'href',
+        '/publication/publication-1/release/release-1/api-data-sets/test-data-set-id',
+      );
     });
   });
 
@@ -582,7 +589,7 @@ describe('ReleaseDataUploadsSection', () => {
 
     test('does not allow replacing data when linked to an API data set', async () => {
       releaseDataFileService.getDataFiles.mockResolvedValue([
-        { ...testDataFiles[0], isLinkedToApiDataSet: true },
+        { ...testDataFiles[0], publicApiDataSetId: 'test-data-set-id' },
       ]);
       releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
         testCompleteImportStatus,
@@ -619,6 +626,13 @@ describe('ReleaseDataUploadsSection', () => {
           'This data file has an API data set linked to it. Please remove the API data set before replacing the data.',
         ),
       ).toBeInTheDocument();
+
+      expect(
+        modal.getByRole('link', { name: 'Go to API data set' }),
+      ).toHaveAttribute(
+        'href',
+        '/publication/publication-1/release/release-1/api-data-sets/test-data-set-id',
+      );
     });
   });
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -461,6 +461,49 @@ describe('ReleaseDataUploadsSection', () => {
         }),
       ).toBeInTheDocument();
     });
+
+    test('does not allow deleting files when linked to an API data set', async () => {
+      releaseDataFileService.getDataFiles.mockResolvedValue([
+        { ...testDataFiles[0], isLinkedToApiDataSet: true },
+      ]);
+      releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
+        testCompleteImportStatus,
+      );
+
+      const { user } = render(
+        <MemoryRouter>
+          <ReleaseDataUploadsSection
+            publicationId="publication-1"
+            releaseId="release-1"
+            canUpdateRelease
+          />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('accordionSection')).toHaveLength(1);
+      });
+
+      const sections = screen.getAllByTestId('accordionSection');
+
+      await user.click(
+        within(sections[0]).getByRole('button', {
+          name: 'Delete files',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Cannot delete files')).toBeInTheDocument();
+      });
+
+      const modal = within(screen.getByRole('dialog'));
+
+      expect(
+        modal.getByText(
+          'This data file has an API data set linked to it. Please remove the API data set before deleting.',
+        ),
+      ).toBeInTheDocument();
+    });
   });
 
   describe('replace data file', () => {
@@ -535,6 +578,47 @@ describe('ReleaseDataUploadsSection', () => {
         'href',
         '/publication/publication-1/release/release-1/data/data-2/replace',
       );
+    });
+
+    test('does not allow replacing data when linked to an API data set', async () => {
+      releaseDataFileService.getDataFiles.mockResolvedValue([
+        { ...testDataFiles[0], isLinkedToApiDataSet: true },
+      ]);
+      releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
+        testCompleteImportStatus,
+      );
+
+      const { user } = render(
+        <MemoryRouter>
+          <ReleaseDataUploadsSection
+            publicationId="publication-1"
+            releaseId="release-1"
+            canUpdateRelease
+          />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('accordionSection')).toHaveLength(1);
+      });
+
+      const sections = screen.getAllByTestId('accordionSection');
+
+      await user.click(
+        within(sections[0]).getByRole('button', { name: 'Replace data' }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Cannot replace data')).toBeInTheDocument();
+      });
+
+      const modal = within(screen.getByRole('dialog'));
+
+      expect(
+        modal.getByText(
+          'This data file has an API data set linked to it. Please remove the API data set before replacing the data.',
+        ),
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -38,6 +38,7 @@ export interface DataFile {
   created?: string;
   isDeleting?: boolean;
   isCancelling?: boolean;
+  isLinkedToApiDataSet?: boolean;
   permissions: DataFilePermissions;
 }
 

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -38,8 +38,9 @@ export interface DataFile {
   created?: string;
   isDeleting?: boolean;
   isCancelling?: boolean;
-  isLinkedToApiDataSet?: boolean;
   permissions: DataFilePermissions;
+  publicApiDataSetId?: string;
+  publicApiDataSetVersion?: string;
 }
 
 export type UploadDataFilesRequest =


### PR DESCRIPTION
Shows a modal informing the user that they can't replace data / delete data files if the files are linked to an API data set.