### PR TITLE
EES-4930 Send Public API subscription notifications

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1104,6 +1104,7 @@
     "ees-notifier-templateid-subscription-confirmation": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-notifier-templateid-subscription-confirmation')]",
     "ees-notifier-templateid-subscription-verification": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-notifier-templateid-subscription-verification')]",
     "ees-notifier-templateid-api-subscription-confirmation": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-notifier-templateid-api-subscription-confirmation')]",
+    "ees-notifier-templateid-api-subscription-notification": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-notifier-templateid-api-subscription-notification')]",
     "ees-notifier-templateid-api-subscription-verification": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-notifier-templateid-api-subscription-verification')]",
 
     "ees-openidconnect-clientid": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-openidconnect-clientid')]",
@@ -2891,6 +2892,7 @@
         "GovUkNotify:EmailTemplates:SubscriptionConfirmationId": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-notifier-templateid-subscription-confirmation'), '2018-02-14').secretUriWithVersion, ')')]",
         "GovUkNotify:EmailTemplates:SubscriptionVerificationId": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-notifier-templateid-subscription-verification'), '2018-02-14').secretUriWithVersion, ')')]",
         "GovUkNotify:EmailTemplates:ApiSubscriptionConfirmationId": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-notifier-templateid-api-subscription-confirmation'), '2018-02-14').secretUriWithVersion, ')')]",
+        "GovUkNotify:EmailTemplates:ApiSubscriptionNotificationId": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-notifier-templateid-api-subscription-notification'), '2018-02-14').secretUriWithVersion, ')')]",
         "GovUkNotify:EmailTemplates:ApiSubscriptionVerificationId": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-notifier-templateid-api-subscription-verification'), '2018-02-14').secretUriWithVersion, ')')]"
       }
     },

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -539,10 +539,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IUserInviteRepository, UserInviteRepository>();
             services.AddTransient<IFileUploadsValidatorService, FileUploadsValidatorService>();
             services.AddTransient<IReleaseFileBlobService, PrivateReleaseFileBlobService>();
-            services.AddScoped<IPrivateBlobStorageService, PrivateBlobStorageService>(provider =>
+            services.AddTransient<IPrivateBlobStorageService, PrivateBlobStorageService>(provider =>
                 new PrivateBlobStorageService(configuration.GetValue<string>("CoreStorage"),
                     provider.GetRequiredService<ILogger<IBlobStorageService>>()));
-            services.AddScoped<IPublicBlobStorageService, PublicBlobStorageService>(provider =>
+            services.AddTransient<IPublicBlobStorageService, PublicBlobStorageService>(provider =>
                 new PublicBlobStorageService(configuration.GetValue<string>("PublicStorage"),
                     provider.GetRequiredService<ILogger<IBlobStorageService>>()));
             services.AddTransient<IPublisherTableStorageService, PublisherTableStorageService>(_ =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -174,15 +174,14 @@ public class DataSetFileService : IDataSetFileService
             .ToListAsync();
     }
 
-    public async Task<Either<ActionResult, DataSetFileViewModel>> GetDataSetFile(
-        Guid dataSetId)
+    public async Task<Either<ActionResult, DataSetFileViewModel>> GetDataSetFile(Guid dataSetFileId)
     {
         var releaseFile = await _contentDbContext.ReleaseFiles
             .Include(rf => rf.ReleaseVersion.Publication.Topic.Theme)
             .Include(rf => rf.ReleaseVersion.Publication.SupersededBy)
             .Include(rf => rf.File)
             .Where(rf =>
-                rf.File.DataSetFileId == dataSetId
+                rf.File.DataSetFileId == dataSetFileId
                 && rf.ReleaseVersion.Published.HasValue
                 && DateTime.UtcNow >= rf.ReleaseVersion.Published.Value)
             .OrderByDescending(rf => rf.ReleaseVersion.Version)
@@ -329,7 +328,8 @@ public class DataSetFileService : IDataSetFileService
             .ToList();
     }
 
-    private static List<string> GetOrderedFilters(List<FilterMeta> metaFilters, List<FilterSequenceEntry>? filterSequenceEntries)
+    private static List<string> GetOrderedFilters(
+        List<FilterMeta> metaFilters, List<FilterSequenceEntry>? filterSequenceEntries)
     {
         var filterSequence = filterSequenceEntries?
             .Select(fs => fs.Id)
@@ -343,7 +343,8 @@ public class DataSetFileService : IDataSetFileService
         return filters.Select(f => f.Label).ToList();
     }
 
-    private static List<string> GetOrderedIndicators(List<IndicatorMeta> metaIndicators, List<IndicatorGroupSequenceEntry>? indicatorGroupSequenceEntries)
+    private static List<string> GetOrderedIndicators(
+        List<IndicatorMeta> metaIndicators, List<IndicatorGroupSequenceEntry>? indicatorGroupSequenceEntries)
     {
         var indicatorSequence = indicatorGroupSequenceEntries?
             .SelectMany(seq => seq.ChildSequence)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
@@ -26,8 +26,7 @@ public interface IDataSetFileService
         int pageSize,
         CancellationToken cancellationToken = default);
 
-    Task<Either<ActionResult, DataSetFileViewModel>> GetDataSetFile(
-        Guid dataSetId);
+    Task<Either<ActionResult, DataSetFileViewModel>> GetDataSetFile(Guid dataSetFileId);
 
     Task<Either<ActionResult, List<DataSetSitemapItemViewModel>>> ListSitemapItems(
         CancellationToken cancellationToken = default);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Program.cs
@@ -80,8 +80,8 @@ void LoadLocationCache()
 
 async Task ClearQueues()
 {
-    var config = host.Services.GetRequiredService<IConfiguration>();
-    var connectionString = config.GetValue<string>("CoreStorage");
+    var config = host.Services.GetRequiredService<IOptions<AppSettingsOptions>>().Value;
+    var connectionString = config.PrivateStorageConnectionString;
 
     var importsPendingQueueClient = new QueueClient(connectionString, queueName: ImportsPendingQueue);
     await importsPendingQueueClient.CreateIfNotExistsAsync();
@@ -94,8 +94,8 @@ async Task ClearQueues()
 
 async Task RestartImports()
 {
-    var config = host.Services.GetRequiredService<IConfiguration>();
-    var connectionString = config.GetValue<string>("CoreStorage");
+    var config = host.Services.GetRequiredService<IOptions<AppSettingsOptions>>().Value;
+    var connectionString = config.PrivateStorageConnectionString;
 
     QueueClientOptions queueOptions = 
         new() { MessageEncoding = QueueMessageEncoding.Base64 };

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ApiNotificationMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ApiNotificationMessage.cs
@@ -1,0 +1,22 @@
+using System;
+using FluentValidation;
+using Semver;
+
+namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model;
+
+public record ApiNotificationMessage
+{
+    public required Guid DataSetId { get; init; }
+    public required SemVersion Version { get; init; }
+
+    public class Validator : AbstractValidator<ApiNotificationMessage>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.DataSetId)
+                .NotEmpty();
+            RuleFor(request => request.Version)
+                .NotNull();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ApiNotificationMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ApiNotificationMessage.cs
@@ -15,7 +15,7 @@ public record ApiNotificationMessage
             RuleFor(request => request.DataSetId)
                 .NotEmpty();
             RuleFor(request => request.Version)
-                .NotNull();
+                .NotEmpty();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ApiNotificationMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ApiNotificationMessage.cs
@@ -6,6 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 public record ApiNotificationMessage
 {
     public required Guid DataSetId { get; init; }
+    public required Guid DataSetFileId { get; init; }
     public required string Version { get; init; }
 
     public class Validator : AbstractValidator<ApiNotificationMessage>
@@ -13,6 +14,8 @@ public record ApiNotificationMessage
         public Validator()
         {
             RuleFor(request => request.DataSetId)
+                .NotEmpty();
+            RuleFor(request => request.DataSetFileId)
                 .NotEmpty();
             RuleFor(request => request.Version)
                 .NotEmpty();

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ApiNotificationMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ApiNotificationMessage.cs
@@ -1,13 +1,12 @@
 using System;
 using FluentValidation;
-using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 
 public record ApiNotificationMessage
 {
     public required Guid DataSetId { get; init; }
-    public required SemVersion Version { get; init; }
+    public required string Version { get; init; }
 
     public class Validator : AbstractValidator<ApiNotificationMessage>
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ApiSubscription.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ApiSubscription.cs
@@ -1,7 +1,7 @@
-using Azure;
-using Azure.Data.Tables;
 using System;
 using System.Runtime.Serialization;
+using Azure;
+using Azure.Data.Tables;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ApiSubscriptionStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ApiSubscriptionStatus.cs
@@ -2,6 +2,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 
 public enum ApiSubscriptionStatus
 {
-    SubscriptionPending,
+    Pending,
     Subscribed
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/Constants.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/Constants.cs
@@ -1,4 +1,4 @@
-namespace GovUk.Education.ExploreEducationStatistics.Notifier;
+namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 
 public static class Constants
 {
@@ -7,5 +7,11 @@ public static class Constants
         public const string PublicationPendingSubscriptionsTableName = "PendingSubscriptions";
         public const string PublicationSubscriptionsTableName = "Subscriptions";
         public const string ApiSubscriptionsTableName = "ApiSubscriptions";
+    }
+
+    public static class  NotifierQueueStorage
+    {
+        public const string ReleaseNotificationQueue = "release-notifications";
+        public const string ApiNotificationQueue = "api-notifications";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/Constants.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/Constants.cs
@@ -12,3 +12,12 @@ public static class NotifierQueueStorage
     public const string ReleaseNotificationQueue = "release-notifications";
     public const string ApiNotificationQueue = "api-notifications";
 }
+
+public static class NotifierEmailTemplateFields
+{
+    public const string DataSetTitle = "data_set_title";
+    public const string DataSetUrl = "data_set_url";
+    public const string DataSetVersion = "data_set_version";
+    public const string UnsubscribeUrl = "unsubscribe_url";
+    public const string VerificationUrl = "verification_url";
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/Constants.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/Constants.cs
@@ -1,10 +1,10 @@
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 
-public static class NotifierTableStorageTableNames
+public static class NotifierTableStorage
 {
-    public const string PublicationPendingSubscriptionsTableName = "PendingSubscriptions";
-    public const string PublicationSubscriptionsTableName = "Subscriptions";
-    public const string ApiSubscriptionsTableName = "ApiSubscriptions";
+    public const string PublicationPendingSubscriptionsTable = "PendingSubscriptions";
+    public const string PublicationSubscriptionsTable = "Subscriptions";
+    public const string ApiSubscriptionsTable = "ApiSubscriptions";
 }
 
 public static class NotifierQueueStorage

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/Constants.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/Constants.cs
@@ -1,17 +1,14 @@
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 
-public static class Constants
+public static class NotifierTableStorageTableNames
 {
-    public static class NotifierTableStorageTableNames
-    {
-        public const string PublicationPendingSubscriptionsTableName = "PendingSubscriptions";
-        public const string PublicationSubscriptionsTableName = "Subscriptions";
-        public const string ApiSubscriptionsTableName = "ApiSubscriptions";
-    }
+    public const string PublicationPendingSubscriptionsTableName = "PendingSubscriptions";
+    public const string PublicationSubscriptionsTableName = "Subscriptions";
+    public const string ApiSubscriptionsTableName = "ApiSubscriptions";
+}
 
-    public static class  NotifierQueueStorage
-    {
-        public const string ReleaseNotificationQueue = "release-notifications";
-        public const string ApiNotificationQueue = "api-notifications";
-    }
+public static class NotifierQueueStorage
+{
+    public const string ReleaseNotificationQueue = "release-notifications";
+    public const string ApiNotificationQueue = "api-notifications";
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/INotifierClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/INotifierClient.cs
@@ -8,4 +8,7 @@ public interface INotifierClient
 {
     public Task NotifyPublicationSubscribers(
         IReadOnlyList<ReleaseNotificationMessage> messages, CancellationToken cancellationToken = default);
+
+    public Task NotifyApiSubscribers(
+        IReadOnlyList<ApiNotificationMessage> messages, CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/NotifierClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/NotifierClient.cs
@@ -10,7 +10,7 @@ public class NotifierClient(string connectionString) : INotifierClient
     private readonly QueueServiceClient _queueServiceClient = new(connectionString);
 
     public async Task NotifyPublicationSubscribers(
-        IReadOnlyList<ReleaseNotificationMessage> messages, 
+        IReadOnlyList<ReleaseNotificationMessage> messages,
         CancellationToken cancellationToken = default)
     {
         await _queueServiceClient.SendMessagesAsJson(NotifierQueueStorage.ReleaseNotificationQueue,
@@ -19,7 +19,7 @@ public class NotifierClient(string connectionString) : INotifierClient
     }
 
     public async Task NotifyApiSubscribers(
-        IReadOnlyList<ApiNotificationMessage> messages, 
+        IReadOnlyList<ApiNotificationMessage> messages,
         CancellationToken cancellationToken = default)
     {
         await _queueServiceClient.SendMessagesAsJson(NotifierQueueStorage.ApiNotificationQueue,

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/NotifierClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/NotifierClient.cs
@@ -13,7 +13,7 @@ public class NotifierClient(string connectionString) : INotifierClient
         IReadOnlyList<ReleaseNotificationMessage> messages, 
         CancellationToken cancellationToken = default)
     {
-        await _queueServiceClient.SendMessagesAsJson(NotifierQueues.ReleaseNotificationQueue,
+        await _queueServiceClient.SendMessagesAsJson(Constants.NotifierQueueStorage.ReleaseNotificationQueue,
             messages,
             cancellationToken);
     }
@@ -22,7 +22,7 @@ public class NotifierClient(string connectionString) : INotifierClient
         IReadOnlyList<ApiNotificationMessage> messages, 
         CancellationToken cancellationToken = default)
     {
-        await _queueServiceClient.SendMessagesAsJson(NotifierQueues.ApiNotificationQueue,
+        await _queueServiceClient.SendMessagesAsJson(Constants.NotifierQueueStorage.ApiNotificationQueue,
             messages,
             cancellationToken);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/NotifierClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/NotifierClient.cs
@@ -13,7 +13,7 @@ public class NotifierClient(string connectionString) : INotifierClient
         IReadOnlyList<ReleaseNotificationMessage> messages, 
         CancellationToken cancellationToken = default)
     {
-        await _queueServiceClient.SendMessagesAsJson(Constants.NotifierQueueStorage.ReleaseNotificationQueue,
+        await _queueServiceClient.SendMessagesAsJson(NotifierQueueStorage.ReleaseNotificationQueue,
             messages,
             cancellationToken);
     }
@@ -22,7 +22,7 @@ public class NotifierClient(string connectionString) : INotifierClient
         IReadOnlyList<ApiNotificationMessage> messages, 
         CancellationToken cancellationToken = default)
     {
-        await _queueServiceClient.SendMessagesAsJson(Constants.NotifierQueueStorage.ApiNotificationQueue,
+        await _queueServiceClient.SendMessagesAsJson(NotifierQueueStorage.ApiNotificationQueue,
             messages,
             cancellationToken);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/NotifierClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/NotifierClient.cs
@@ -10,9 +10,19 @@ public class NotifierClient(string connectionString) : INotifierClient
     private readonly QueueServiceClient _queueServiceClient = new(connectionString);
 
     public async Task NotifyPublicationSubscribers(
-        IReadOnlyList<ReleaseNotificationMessage> messages, CancellationToken cancellationToken = default)
+        IReadOnlyList<ReleaseNotificationMessage> messages, 
+        CancellationToken cancellationToken = default)
     {
         await _queueServiceClient.SendMessagesAsJson(NotifierQueues.ReleaseNotificationQueue,
+            messages,
+            cancellationToken);
+    }
+
+    public async Task NotifyApiSubscribers(
+        IReadOnlyList<ApiNotificationMessage> messages, 
+        CancellationToken cancellationToken = default)
+    {
+        await _queueServiceClient.SendMessagesAsJson(NotifierQueues.ApiNotificationQueue,
             messages,
             cancellationToken);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/NotifierQueues.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/NotifierQueues.cs
@@ -1,6 +1,7 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model;
+namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 
 public static class NotifierQueues
 {
     public const string ReleaseNotificationQueue = "release-notifications";
+    public const string ApiNotificationQueue = "api-notifications";
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/NotifierQueues.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/NotifierQueues.cs
@@ -1,7 +1,0 @@
-namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model;
-
-public static class NotifierQueues
-{
-    public const string ReleaseNotificationQueue = "release-notifications";
-    public const string ApiNotificationQueue = "api-notifications";
-}

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ApiSubscriptionFunctionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ApiSubscriptionFunctionsTests.cs
@@ -67,7 +67,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             Assert.Equal(_dataSetId, response.DataSetId);
             Assert.Equal(DataSetTitle, response.DataSetTitle);
             Assert.Equal(Email, response.Email);
-            Assert.Equal(ApiSubscriptionStatus.SubscriptionPending, response.Status);
+            Assert.Equal(ApiSubscriptionStatus.Pending, response.Status);
 
             // Assert that the verification link contains a valid token
             var extractedEmail = ExtractEmailFromSubscriptionLinkToken(verificationLink);
@@ -81,7 +81,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             Assert.Equal(Email, subscription.RowKey);
             Assert.Equal(_dataSetId.ToString(), subscription.PartitionKey);
             Assert.Equal(DataSetTitle, subscription.DataSetTitle);
-            Assert.Equal(ApiSubscriptionStatus.SubscriptionPending, subscription.Status);
+            Assert.Equal(ApiSubscriptionStatus.Pending, subscription.Status);
             subscription.Expiry.AssertEqual(DateTimeOffset.UtcNow.AddHours(1));
             subscription.Timestamp.AssertUtcNow();
         }
@@ -94,7 +94,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                 PartitionKey = _dataSetId.ToString(),
                 RowKey = Email,
                 DataSetTitle = DataSetTitle,
-                Status = ApiSubscriptionStatus.SubscriptionPending,
+                Status = ApiSubscriptionStatus.Pending,
                 Expiry = DateTimeOffset.UtcNow.AddHours(1),
             };
 
@@ -232,7 +232,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                 PartitionKey = _dataSetId.ToString(),
                 RowKey = Email,
                 DataSetTitle = DataSetTitle,
-                Status = ApiSubscriptionStatus.SubscriptionPending,
+                Status = ApiSubscriptionStatus.Pending,
                 Expiry = DateTime.UtcNow.AddHours(1),
             };
 
@@ -343,7 +343,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                 PartitionKey = _dataSetId.ToString(),
                 RowKey = Email,
                 DataSetTitle = DataSetTitle,
-                Status = ApiSubscriptionStatus.SubscriptionPending,
+                Status = ApiSubscriptionStatus.Pending,
                 Expiry = DateTimeOffset.UtcNow.AddHours(-1)
             };
 
@@ -446,7 +446,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                 PartitionKey = _dataSetId.ToString(),
                 RowKey = Email,
                 DataSetTitle = DataSetTitle,
-                Status = ApiSubscriptionStatus.SubscriptionPending,
+                Status = ApiSubscriptionStatus.Pending,
                 Expiry = DateTimeOffset.UtcNow,
             };
 
@@ -523,7 +523,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                 PartitionKey = Email,
                 RowKey = Guid.NewGuid().ToString(),
                 DataSetTitle = DataSetTitle,
-                Status = ApiSubscriptionStatus.SubscriptionPending,
+                Status = ApiSubscriptionStatus.Pending,
                 Expiry = DateTime.UtcNow.AddHours(-1),
             };
 
@@ -532,7 +532,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                 PartitionKey = Email,
                 RowKey = Guid.NewGuid().ToString(),
                 DataSetTitle = DataSetTitle,
-                Status = ApiSubscriptionStatus.SubscriptionPending,
+                Status = ApiSubscriptionStatus.Pending,
                 Expiry = DateTime.UtcNow.AddHours(1),
             };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ApiSubscriptionFunctionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ApiSubscriptionFunctionsTests.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Functions;
@@ -10,11 +15,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Moq;
 using Notify.Models.Responses;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Tests.Functions;
@@ -48,13 +48,14 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                     null,
                     null))
                 .Returns(It.IsAny<EmailNotificationResponse>())
-                .Callback((string email,
-                           string templateId,
-                           Dictionary<string, dynamic> values,
-                           string clientReference,
-                           string emailReplyToId,
-                           string oneClickUnsubscribeURL)
-                    => verificationLink = values["verification_link"]); ;
+                .Callback((
+                        string email,
+                        string templateId,
+                        Dictionary<string, dynamic> values,
+                        string clientReference,
+                        string emailReplyToId,
+                        string oneClickUnsubscribeURL)
+                    => verificationLink = values["verification_link"]);
 
             var result = await RequestPendingApiSubscription(
                 dataSetId: _dataSetId,
@@ -148,7 +149,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
-            validationProblem.AssertHasNotEmptyError(expectedPath: nameof(PendingApiSubscriptionCreateRequest.Email).ToLowerFirst());
+            validationProblem.AssertHasNotEmptyError(
+                expectedPath: nameof(PendingApiSubscriptionCreateRequest.Email).ToLowerFirst());
         }
 
         [Theory]
@@ -165,7 +167,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
-            validationProblem.AssertHasEmailError(expectedPath: nameof(PendingApiSubscriptionCreateRequest.Email).ToLowerFirst());
+            validationProblem.AssertHasEmailError(
+                expectedPath: nameof(PendingApiSubscriptionCreateRequest.Email).ToLowerFirst());
         }
 
         [Fact]
@@ -178,7 +181,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
-            validationProblem.AssertHasNotEmptyError(expectedPath: nameof(PendingApiSubscriptionCreateRequest.DataSetId).ToLowerFirst());
+            validationProblem.AssertHasNotEmptyError(
+                expectedPath: nameof(PendingApiSubscriptionCreateRequest.DataSetId).ToLowerFirst());
         }
 
         [Theory]
@@ -193,7 +197,8 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
-            validationProblem.AssertHasNotEmptyError(expectedPath: nameof(PendingApiSubscriptionCreateRequest.DataSetTitle).ToLowerFirst());
+            validationProblem.AssertHasNotEmptyError(
+                expectedPath: nameof(PendingApiSubscriptionCreateRequest.DataSetTitle).ToLowerFirst());
         }
 
         private async Task<IActionResult> RequestPendingApiSubscription(
@@ -249,12 +254,13 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                     null,
                     null))
                 .Returns(It.IsAny<EmailNotificationResponse>())
-                .Callback((string email,
-                           string templateId,
-                           Dictionary<string, dynamic> values,
-                           string clientReference,
-                           string emailReplyToId,
-                           string oneClickUnsubscribeURL)
+                .Callback((
+                        string email,
+                        string templateId,
+                        Dictionary<string, dynamic> values,
+                        string clientReference,
+                        string emailReplyToId,
+                        string oneClickUnsubscribeURL)
                     => unsubscribeLink = values["unsubscribe_link"]);
 
             var tokenService = GetRequiredService<ITokenService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ApiSubscriptionFunctionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ApiSubscriptionFunctionsTests.cs
@@ -26,7 +26,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
     private const string DataSetTitle = "data set title";
     private const string Email = "test@test.com";
 
-    public class RequestPendingApiSubscriptionTests(NotifierFunctionsIntegrationTestFixture fixture)
+    public class RequestPendingSubscriptionTests(NotifierFunctionsIntegrationTestFixture fixture)
         : ApiSubscriptionFunctionsTests(fixture)
     {
         [Fact]
@@ -56,7 +56,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                         string oneClickUnsubscribeUrl)
                     => verificationLink = personalisation[NotifierEmailTemplateFields.VerificationUrl]);
 
-            var result = await RequestPendingApiSubscription(
+            var result = await RequestPendingSubscription(
                 dataSetId: _dataSetId,
                 dataSetTitle: DataSetTitle,
                 email: Email);
@@ -99,7 +99,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
             await CreateApiSubscription(subscription);
 
-            var result = await RequestPendingApiSubscription(
+            var result = await RequestPendingSubscription(
                 dataSetId: _dataSetId,
                 dataSetTitle: DataSetTitle,
                 email: Email);
@@ -124,7 +124,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
             await CreateApiSubscription(subscription);
 
-            var result = await RequestPendingApiSubscription(
+            var result = await RequestPendingSubscription(
                 dataSetId: _dataSetId,
                 dataSetTitle: DataSetTitle,
                 email: Email);
@@ -141,7 +141,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         [InlineData("")]
         public async Task EmailEmpty_400(string? email)
         {
-            var result = await RequestPendingApiSubscription(
+            var result = await RequestPendingSubscription(
                 dataSetId: _dataSetId,
                 dataSetTitle: DataSetTitle,
                 email: email!);
@@ -159,7 +159,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         [InlineData("@test")]
         public async Task EmailNotValid_400(string email)
         {
-            var result = await RequestPendingApiSubscription(
+            var result = await RequestPendingSubscription(
                 dataSetId: _dataSetId,
                 dataSetTitle: DataSetTitle,
                 email: email);
@@ -173,7 +173,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         [Fact]
         public async Task DataSetIdEmpty_400()
         {
-            var result = await RequestPendingApiSubscription(
+            var result = await RequestPendingSubscription(
                 dataSetId: Guid.Empty,
                 dataSetTitle: DataSetTitle,
                 email: Email);
@@ -189,7 +189,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         [InlineData("")]
         public async Task DataSetTitleEmpty_400(string? dataSetTitle)
         {
-            var result = await RequestPendingApiSubscription(
+            var result = await RequestPendingSubscription(
                 dataSetId: _dataSetId,
                 dataSetTitle: dataSetTitle!,
                 email: Email);
@@ -200,7 +200,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                 expectedPath: nameof(PendingApiSubscriptionCreateRequest.DataSetTitle).ToLowerFirst());
         }
 
-        private async Task<IActionResult> RequestPendingApiSubscription(
+        private async Task<IActionResult> RequestPendingSubscription(
             Guid dataSetId,
             string dataSetTitle,
             string email)
@@ -212,9 +212,9 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                 Email = email
             };
 
-            var apiSubscriptionManager = GetRequiredService<ApiSubscriptionFunctions>();
+            var functions = GetRequiredService<ApiSubscriptionFunctions>();
 
-            return await apiSubscriptionManager.RequestPendingApiSubscription(
+            return await functions.RequestPendingSubscription(
                 request: request,
                 cancellationToken: CancellationToken.None);
         }
@@ -230,7 +230,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         }
     }
 
-    public class VerifyApiSubscriptionTests(NotifierFunctionsIntegrationTestFixture fixture)
+    public class VerifySubscriptionTests(NotifierFunctionsIntegrationTestFixture fixture)
         : ApiSubscriptionFunctionsTests(fixture)
     {
         [Fact]
@@ -275,7 +275,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var subscribeToken = tokenService.GenerateToken(pendingSubscription.RowKey,
                 pendingSubscription.Expiry.Value.UtcDateTime);
 
-            var result = await VerifyApiSubscription(
+            var result = await VerifySubscription(
                 dataSetId: _dataSetId,
                 token: subscribeToken);
 
@@ -309,7 +309,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var tokenService = GetRequiredService<ITokenService>();
             var subscribeToken = tokenService.GenerateToken(Email, DateTime.UtcNow);
 
-            var result = await VerifyApiSubscription(
+            var result = await VerifySubscription(
                 dataSetId: _dataSetId,
                 token: subscribeToken);
 
@@ -332,7 +332,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var tokenService = GetRequiredService<ITokenService>();
             var subscribeToken = tokenService.GenerateToken(verifiedSubscription.RowKey, DateTime.UtcNow);
 
-            var result = await VerifyApiSubscription(
+            var result = await VerifySubscription(
                 dataSetId: _dataSetId,
                 token: subscribeToken);
 
@@ -360,7 +360,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             var tokenService = GetRequiredService<ITokenService>();
             var subscribeToken = tokenService.GenerateToken(verifiedSubscription.RowKey, DateTime.UtcNow);
 
-            var result = await VerifyApiSubscription(
+            var result = await VerifySubscription(
                 dataSetId: _dataSetId,
                 token: subscribeToken);
 
@@ -374,7 +374,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         [Fact]
         public async Task SubscribeTokenInvalid_400()
         {
-            var result = await VerifyApiSubscription(
+            var result = await VerifySubscription(
                 dataSetId: _dataSetId,
                 token: "");
 
@@ -385,13 +385,13 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
                 expectedCode: ValidationMessages.AuthorizationTokenInvalid.Code);
         }
 
-        private async Task<IActionResult> VerifyApiSubscription(
+        private async Task<IActionResult> VerifySubscription(
             Guid dataSetId,
             string token)
         {
-            var apiSubscriptionManager = GetRequiredService<ApiSubscriptionFunctions>();
+            var functions = GetRequiredService<ApiSubscriptionFunctions>();
 
-            return await apiSubscriptionManager.VerifyApiSubscription(
+            return await functions.VerifySubscription(
                 request: null!,
                 dataSetId: dataSetId,
                 token: token,
@@ -409,7 +409,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         }
     }
 
-    public class ApiUnsubscribeTests(NotifierFunctionsIntegrationTestFixture fixture)
+    public class UnsubscribeTests(NotifierFunctionsIntegrationTestFixture fixture)
         : ApiSubscriptionFunctionsTests(fixture)
     {
         [Fact]
@@ -520,9 +520,9 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             Guid dataSetId,
             string token)
         {
-            var apiSubscriptionManager = GetRequiredService<ApiSubscriptionFunctions>();
+            var functions = GetRequiredService<ApiSubscriptionFunctions>();
 
-            return await apiSubscriptionManager.ApiUnsubscribe(
+            return await functions.Unsubscribe(
                 request: null!,
                 dataSetId: dataSetId,
                 token: token,
@@ -530,7 +530,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
         }
     }
 
-    public class RemoveExpiredApiSubscriptionsTests(NotifierFunctionsIntegrationTestFixture fixture)
+    public class RemoveExpiredSubscriptionsTests(NotifierFunctionsIntegrationTestFixture fixture)
         : ApiSubscriptionFunctionsTests(fixture)
     {
         [Fact]
@@ -565,7 +565,7 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
 
             await CreateApiSubscriptions(pendingAndExpiredSubscription, pendingSubscription, subscribedSubscription);
 
-            await RemoveExpiredApiSubscriptions();
+            await RemoveExpiredSubscriptions();
 
             var subscriptions = await QueryApiSubscriptions();
 
@@ -575,11 +575,11 @@ public abstract class ApiSubscriptionFunctionsTests(NotifierFunctionsIntegration
             Assert.Single(subscriptions, s => s.RowKey == subscribedSubscription.RowKey);
         }
 
-        private async Task RemoveExpiredApiSubscriptions(TimerInfo? timerInfo = null)
+        private async Task RemoveExpiredSubscriptions(TimerInfo? timerInfo = null)
         {
-            var apiSubscriptionManager = GetRequiredService<ApiSubscriptionFunctions>();
+            var functions = GetRequiredService<ApiSubscriptionFunctions>();
 
-            await apiSubscriptionManager.RemoveExpiredApiSubscriptions(
+            await functions.RemoveExpiredSubscriptions(
                 timerInfo: timerInfo ?? new TimerInfo(),
                 cancellationToken: CancellationToken.None);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/PublicationSubscriptionFunctionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/PublicationSubscriptionFunctionsTests.cs
@@ -14,10 +14,10 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Common.TableStorageTableNames;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Repositories.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Repositories;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Tests.Functions;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/PublicationSubscriptionFunctionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/PublicationSubscriptionFunctionsTests.cs
@@ -94,7 +94,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
     public async Task DoesNotSendEmailAgainIfSubIsPending()
     {
         // Arrange (data)
-        await AddTestSubscription(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName,
+        await AddTestSubscription(NotifierTableStorage.PublicationPendingSubscriptionsTable,
             new SubscriptionEntity("test-id-2",
                 "test2@test.com",
                 "Test Publication Title 2",
@@ -160,7 +160,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
     public async Task SendsConfirmationEmailIfUserAlreadySubscribed()
     {
         // Arrange (data)
-        await AddTestSubscription(NotifierTableStorageTableNames.PublicationSubscriptionsTableName,
+        await AddTestSubscription(NotifierTableStorage.PublicationSubscriptionsTable,
             new SubscriptionEntity("test-id-3",
                 "test3@test.com",
                 "Test Publication Title 3",
@@ -407,7 +407,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
     public async Task SendsSubscriptionConfirmationEmail()
     {
         // Arrange (data)
-        await AddTestSubscription(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName,
+        await AddTestSubscription(NotifierTableStorage.PublicationPendingSubscriptionsTable,
             new SubscriptionEntity("test-id-4",
                 "test4@test.com",
                 "Test Publication Title 4",
@@ -468,7 +468,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
     public async Task Unsubscribes()
     {
         // Arrange (data)
-        await AddTestSubscription(NotifierTableStorageTableNames.PublicationSubscriptionsTableName,
+        await AddTestSubscription(NotifierTableStorage.PublicationSubscriptionsTable,
             new SubscriptionEntity("test-id-5",
                 "test5@test.com",
                 "Test Publication Title 5",

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/PublicationSubscriptionFunctionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/PublicationSubscriptionFunctionsTests.cs
@@ -70,7 +70,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
 
         // Act
         var result =
-            await notifierFunction.RequestPendingSubscriptionFunc(request,
+            await notifierFunction.RequestPendingSubscription(request,
                 new TestFunctionContext(),
                 new CancellationToken());
 
@@ -134,7 +134,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
 
         // Act
         var result =
-            await notifierFunction.RequestPendingSubscriptionFunc(request,
+            await notifierFunction.RequestPendingSubscription(request,
                 new TestFunctionContext(),
                 new CancellationToken());
 
@@ -200,7 +200,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
 
         // Act
         var result =
-            await notifierFunction.RequestPendingSubscriptionFunc(request,
+            await notifierFunction.RequestPendingSubscription(request,
                 new TestFunctionContext(),
                 new CancellationToken());
 
@@ -258,7 +258,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
 
         // Act
         var result =
-            await notifierFunction.RequestPendingSubscriptionFunc(request,
+            await notifierFunction.RequestPendingSubscription(request,
                 new TestFunctionContext(),
                 new CancellationToken());
 
@@ -303,7 +303,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
 
         // Act
         var result =
-            await notifierFunction.RequestPendingSubscriptionFunc(request,
+            await notifierFunction.RequestPendingSubscription(request,
                 new TestFunctionContext(),
                 new CancellationToken());
 
@@ -348,7 +348,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
 
         // Act
         var result =
-            await notifierFunction.RequestPendingSubscriptionFunc(request,
+            await notifierFunction.RequestPendingSubscription(request,
                 new TestFunctionContext(),
                 new CancellationToken());
 
@@ -393,7 +393,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
 
         // Act
         var result =
-            await notifierFunction.RequestPendingSubscriptionFunc(request,
+            await notifierFunction.RequestPendingSubscription(request,
                 new TestFunctionContext(),
                 new CancellationToken());
 
@@ -444,7 +444,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
 
         // Act
         var result =
-            await notifierFunction.VerifySubscriptionFunc(new TestFunctionContext(),
+            await notifierFunction.VerifySubscription(new TestFunctionContext(),
                 "test-id-4",
                 "verification-code-4");
 
@@ -496,7 +496,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
 
         // Act
         var result =
-            await notifierFunction.PublicationUnsubscribeFunc(new TestFunctionContext(),
+            await notifierFunction.Unsubscribe(new TestFunctionContext(),
                 "test-id-5",
                 "unsubscription-code-5");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/PublicationSubscriptionFunctionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/PublicationSubscriptionFunctionsTests.cs
@@ -94,7 +94,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
     public async Task DoesNotSendEmailAgainIfSubIsPending()
     {
         // Arrange (data)
-        await AddTestSubscription(Constants.NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName,
+        await AddTestSubscription(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName,
             new SubscriptionEntity("test-id-2",
                 "test2@test.com",
                 "Test Publication Title 2",
@@ -160,7 +160,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
     public async Task SendsConfirmationEmailIfUserAlreadySubscribed()
     {
         // Arrange (data)
-        await AddTestSubscription(Constants.NotifierTableStorageTableNames.PublicationSubscriptionsTableName,
+        await AddTestSubscription(NotifierTableStorageTableNames.PublicationSubscriptionsTableName,
             new SubscriptionEntity("test-id-3",
                 "test3@test.com",
                 "Test Publication Title 3",
@@ -407,7 +407,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
     public async Task SendsSubscriptionConfirmationEmail()
     {
         // Arrange (data)
-        await AddTestSubscription(Constants.NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName,
+        await AddTestSubscription(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName,
             new SubscriptionEntity("test-id-4",
                 "test4@test.com",
                 "Test Publication Title 4",
@@ -468,7 +468,7 @@ public class PublicationSubscriptionFunctionsTests(NotifierFunctionsIntegrationT
     public async Task Unsubscribes()
     {
         // Arrange (data)
-        await AddTestSubscription(Constants.NotifierTableStorageTableNames.PublicationSubscriptionsTableName,
+        await AddTestSubscription(NotifierTableStorageTableNames.PublicationSubscriptionsTableName,
             new SubscriptionEntity("test-id-5",
                 "test5@test.com",
                 "Test Publication Title 5",

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ReleaseNotifierTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ReleaseNotifierTests.cs
@@ -70,7 +70,7 @@ public class ReleaseNotifierTests
         // other mocks
         var publicationSubscriptionRepository = new Mock<IPublicationSubscriptionRepository>(MockBehavior.Strict);
         publicationSubscriptionRepository.Setup(mock =>
-                mock.GetTable(Constants.NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
+                mock.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
             .ReturnsAsync(cloudTable.Object);
 
         var tokenService = new Mock<ITokenService>(MockBehavior.Strict);
@@ -160,7 +160,7 @@ public class ReleaseNotifierTests
         // other mocks
         var publicationSubscriptionRepository = new Mock<IPublicationSubscriptionRepository>(MockBehavior.Strict);
         publicationSubscriptionRepository.Setup(mock =>
-                mock.GetTable(Constants.NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
+                mock.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
             .ReturnsAsync(cloudTable.Object);
 
         var tokenService = new Mock<ITokenService>(MockBehavior.Strict);
@@ -265,7 +265,7 @@ public class ReleaseNotifierTests
         // other mocks
         var publicationSubscriptionRepository = new Mock<IPublicationSubscriptionRepository>(MockBehavior.Strict);
         publicationSubscriptionRepository.Setup(mock =>
-                mock.GetTable(Constants.NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
+                mock.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
             .ReturnsAsync(cloudTable.Object);
 
         var tokenService = new Mock<ITokenService>(MockBehavior.Strict);
@@ -388,7 +388,7 @@ public class ReleaseNotifierTests
         // other mocks
         var publicationSubscriptionRepository = new Mock<IPublicationSubscriptionRepository>(MockBehavior.Strict);
         publicationSubscriptionRepository.Setup(mock =>
-                mock.GetTable(Constants.NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
+                mock.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
             .ReturnsAsync(cloudTable.Object);
 
         var tokenService = new Mock<ITokenService>(MockBehavior.Strict);
@@ -493,7 +493,7 @@ public class ReleaseNotifierTests
         // other mocks
         var publicationSubscriptionRepository = new Mock<IPublicationSubscriptionRepository>(MockBehavior.Strict);
         publicationSubscriptionRepository.Setup(mock =>
-                mock.GetTable(Constants.NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
+                mock.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
             .ReturnsAsync(cloudTable.Object);
 
         var tokenService = new Mock<ITokenService>(MockBehavior.Strict);

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ReleaseNotifierTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ReleaseNotifierTests.cs
@@ -70,7 +70,7 @@ public class ReleaseNotifierTests
         // other mocks
         var publicationSubscriptionRepository = new Mock<IPublicationSubscriptionRepository>(MockBehavior.Strict);
         publicationSubscriptionRepository.Setup(mock =>
-                mock.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
+                mock.GetTable(NotifierTableStorage.PublicationSubscriptionsTable))
             .ReturnsAsync(cloudTable.Object);
 
         var tokenService = new Mock<ITokenService>(MockBehavior.Strict);
@@ -160,7 +160,7 @@ public class ReleaseNotifierTests
         // other mocks
         var publicationSubscriptionRepository = new Mock<IPublicationSubscriptionRepository>(MockBehavior.Strict);
         publicationSubscriptionRepository.Setup(mock =>
-                mock.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
+                mock.GetTable(NotifierTableStorage.PublicationSubscriptionsTable))
             .ReturnsAsync(cloudTable.Object);
 
         var tokenService = new Mock<ITokenService>(MockBehavior.Strict);
@@ -265,7 +265,7 @@ public class ReleaseNotifierTests
         // other mocks
         var publicationSubscriptionRepository = new Mock<IPublicationSubscriptionRepository>(MockBehavior.Strict);
         publicationSubscriptionRepository.Setup(mock =>
-                mock.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
+                mock.GetTable(NotifierTableStorage.PublicationSubscriptionsTable))
             .ReturnsAsync(cloudTable.Object);
 
         var tokenService = new Mock<ITokenService>(MockBehavior.Strict);
@@ -388,7 +388,7 @@ public class ReleaseNotifierTests
         // other mocks
         var publicationSubscriptionRepository = new Mock<IPublicationSubscriptionRepository>(MockBehavior.Strict);
         publicationSubscriptionRepository.Setup(mock =>
-                mock.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
+                mock.GetTable(NotifierTableStorage.PublicationSubscriptionsTable))
             .ReturnsAsync(cloudTable.Object);
 
         var tokenService = new Mock<ITokenService>(MockBehavior.Strict);
@@ -493,7 +493,7 @@ public class ReleaseNotifierTests
         // other mocks
         var publicationSubscriptionRepository = new Mock<IPublicationSubscriptionRepository>(MockBehavior.Strict);
         publicationSubscriptionRepository.Setup(mock =>
-                mock.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName))
+                mock.GetTable(NotifierTableStorage.PublicationSubscriptionsTable))
             .ReturnsAsync(cloudTable.Object);
 
         var tokenService = new Mock<ITokenService>(MockBehavior.Strict);

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ReleaseNotifierTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ReleaseNotifierTests.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Common.TableStorageTableNames;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.TableStorageTestUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Tests.Functions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ReleaseNotifierTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ReleaseNotifierTests.cs
@@ -36,7 +36,7 @@ public class ReleaseNotifierTests
     };
 
     [Fact]
-    public async Task ReleaseNotifierFunc()
+    public async Task NotifySubscribers()
     {
         var publication1Id = Guid.NewGuid();
 
@@ -113,7 +113,7 @@ public class ReleaseNotifierTests
             },
         };
 
-        await function.ReleaseNotifierFunc(
+        await function.NotifySubscribers(
             releaseNotificationMessage,
             new TestFunctionContext());
 
@@ -136,7 +136,7 @@ public class ReleaseNotifierTests
     }
 
     [Fact]
-    public async Task ReleaseNotifierFunc_MultipleSubs()
+    public async Task NotifySubscribers_MultipleSubs()
     {
         var publication1Id = Guid.NewGuid();
 
@@ -202,7 +202,7 @@ public class ReleaseNotifierTests
             SupersededPublications = new List<IdTitleViewModel>(),
         };
 
-        await function.ReleaseNotifierFunc(
+        await function.NotifySubscribers(
             releaseNotificationMessage,
             new TestFunctionContext());
 
@@ -230,7 +230,7 @@ public class ReleaseNotifierTests
     }
 
     [Fact]
-    public async Task ReleaseNotifierFunc_MultipleSupersededPublicationSubs()
+    public async Task NotifySubscribers_MultipleSupersededPublicationSubs()
     {
         var publication1Id = Guid.NewGuid();
 
@@ -314,7 +314,7 @@ public class ReleaseNotifierTests
             },
         };
 
-        await function.ReleaseNotifierFunc(
+        await function.NotifySubscribers(
             releaseNotificationMessage,
             new TestFunctionContext());
 
@@ -345,7 +345,7 @@ public class ReleaseNotifierTests
     }
 
     [Fact]
-    public async Task ReleaseNotifierFunc_MultipleSupersededPublications()
+    public async Task NotifySubscribers_MultipleSupersededPublications()
     {
         var publication1Id = Guid.NewGuid();
 
@@ -436,7 +436,7 @@ public class ReleaseNotifierTests
             },
         };
 
-        await function.ReleaseNotifierFunc(
+        await function.NotifySubscribers(
             releaseNotificationMessage,
             new TestFunctionContext());
 
@@ -459,7 +459,7 @@ public class ReleaseNotifierTests
     }
 
     [Fact]
-    public async Task ReleaseNotifierFunc_Amendment()
+    public async Task NotifySubscribers_Amendment()
     {
         var publication1Id = Guid.NewGuid();
 
@@ -537,7 +537,7 @@ public class ReleaseNotifierTests
             },
         };
 
-        await function.ReleaseNotifierFunc(
+        await function.NotifySubscribers(
             releaseNotificationMessage,
             new TestFunctionContext());
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/NotifierFunctionsIntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/NotifierFunctionsIntegrationTest.cs
@@ -69,7 +69,7 @@ public abstract class NotifierFunctionsIntegrationTest
         var dataTableStorageService = new DataTableStorageService(StorageConnectionString());
 
         await dataTableStorageService.BatchManipulateEntities(
-            tableName: Constants.NotifierTableStorageTableNames.ApiSubscriptionsTableName,
+            tableName: NotifierTableStorageTableNames.ApiSubscriptionsTableName,
             entities: subscriptions,
             tableTransactionActionType: TableTransactionActionType.Add);
     }
@@ -79,7 +79,7 @@ public abstract class NotifierFunctionsIntegrationTest
         var dataTableStorageService = new DataTableStorageService(StorageConnectionString());
 
         await dataTableStorageService.CreateEntity(
-            tableName: Constants.NotifierTableStorageTableNames.ApiSubscriptionsTableName,
+            tableName: NotifierTableStorageTableNames.ApiSubscriptionsTableName,
             entity: subscription);
     }
 
@@ -91,7 +91,7 @@ public abstract class NotifierFunctionsIntegrationTest
         var dataTableStorageService = new DataTableStorageService(StorageConnectionString());
 
         return await dataTableStorageService.GetEntityIfExists<ApiSubscription>(
-            tableName: Constants.NotifierTableStorageTableNames.ApiSubscriptionsTableName,
+            tableName: NotifierTableStorageTableNames.ApiSubscriptionsTableName,
             partitionKey: dataSetId.ToString(),
             rowKey: email,
             select: select);
@@ -105,7 +105,7 @@ public abstract class NotifierFunctionsIntegrationTest
         var dataTableStorageService = new DataTableStorageService(StorageConnectionString());
 
         var pagedSubscriptions = await dataTableStorageService.QueryEntities(
-            tableName: Constants.NotifierTableStorageTableNames.ApiSubscriptionsTableName,
+            tableName: NotifierTableStorageTableNames.ApiSubscriptionsTableName,
             filter: filter,
             maxPerPage: maxPerPage,
             select: select,

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/NotifierFunctionsIntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/NotifierFunctionsIntegrationTest.cs
@@ -33,8 +33,8 @@ public abstract class NotifierFunctionsIntegrationTest
 
     public Task DisposeAsync()
     {
-        MockUtils.VerifyAllMocks(fixture._notificationClient);
-        fixture._notificationClient.Reset();
+        MockUtils.VerifyAllMocks(fixture.NotificationClient);
+        fixture.NotificationClient.Reset();
 
         return ClearAzureDataTableTestData(StorageConnectionString());
     }
@@ -44,17 +44,17 @@ public abstract class NotifierFunctionsIntegrationTest
         return fixture.StorageConnectionString();
     }
 
-    public AppSettingsOptions GetAppSettingsOptions()
+    protected AppSettingsOptions GetAppSettingsOptions()
     {
         return GetRequiredService<IOptions<AppSettingsOptions>>().Value;
     }
 
-    public GovUkNotifyOptions GetGovUkNotifyOptions()
+    protected GovUkNotifyOptions GetGovUkNotifyOptions()
     {
         return GetRequiredService<IOptions<GovUkNotifyOptions>>().Value;
     }
 
-    public async Task AddTestSubscription(string tableName, SubscriptionEntity subscription)
+    protected async Task AddTestSubscription(string tableName, SubscriptionEntity subscription)
     {
         var storageAccount = CloudStorageAccount.Parse(StorageConnectionString());
         var tableClient = storageAccount.CreateCloudTableClient();
@@ -64,7 +64,7 @@ public abstract class NotifierFunctionsIntegrationTest
         await table.ExecuteAsync(TableOperation.InsertOrReplace(subscription));
     }
 
-    public async Task CreateApiSubscriptions(params ApiSubscription[] subscriptions)
+    protected async Task CreateApiSubscriptions(params ApiSubscription[] subscriptions)
     {
         var dataTableStorageService = new DataTableStorageService(StorageConnectionString());
 
@@ -74,7 +74,7 @@ public abstract class NotifierFunctionsIntegrationTest
             tableTransactionActionType: TableTransactionActionType.Add);
     }
 
-    public async Task CreateApiSubscription(ApiSubscription subscription)
+    protected async Task CreateApiSubscription(ApiSubscription subscription)
     {
         var dataTableStorageService = new DataTableStorageService(StorageConnectionString());
 
@@ -83,7 +83,7 @@ public abstract class NotifierFunctionsIntegrationTest
             entity: subscription);
     }
 
-    public async Task<ApiSubscription?> GetApiSubscriptionIfExists(
+    protected async Task<ApiSubscription?> GetApiSubscriptionIfExists(
         Guid dataSetId,
         string email,
         IEnumerable<string>? select = null)
@@ -97,7 +97,7 @@ public abstract class NotifierFunctionsIntegrationTest
             select: select);
     }
 
-    public async Task<IReadOnlyList<ApiSubscription>> QueryApiSubscriptions(
+    protected async Task<IReadOnlyList<ApiSubscription>> QueryApiSubscriptions(
         Expression<Func<ApiSubscription, bool>>? filter = null,
         int? maxPerPage = null,
         IEnumerable<string>? select = null)
@@ -124,7 +124,7 @@ public abstract class NotifierFunctionsIntegrationTest
 // ReSharper disable once ClassNeverInstantiated.Global
 public class NotifierFunctionsIntegrationTestFixture : FunctionsIntegrationTestFixture, IAsyncLifetime
 {
-    public readonly Mock<INotificationClient> _notificationClient = new(MockBehavior.Strict);
+    public readonly Mock<INotificationClient> NotificationClient = new(MockBehavior.Strict);
 
     private readonly AzuriteContainer _azuriteContainer = new AzuriteBuilder()
         .WithImage("mcr.microsoft.com/azure-storage/azurite:3.31.0")
@@ -166,7 +166,7 @@ public class NotifierFunctionsIntegrationTestFixture : FunctionsIntegrationTestF
             .ConfigureServices((hostContext, services) =>
             {
                 services
-                    .ReplaceService(_notificationClient);
+                    .ReplaceService(NotificationClient);
             });
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/NotifierFunctionsIntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/NotifierFunctionsIntegrationTest.cs
@@ -69,7 +69,7 @@ public abstract class NotifierFunctionsIntegrationTest
         var dataTableStorageService = new DataTableStorageService(StorageConnectionString());
 
         await dataTableStorageService.BatchManipulateEntities(
-            tableName: NotifierTableStorageTableNames.ApiSubscriptionsTableName,
+            tableName: NotifierTableStorage.ApiSubscriptionsTable,
             entities: subscriptions,
             tableTransactionActionType: TableTransactionActionType.Add);
     }
@@ -79,7 +79,7 @@ public abstract class NotifierFunctionsIntegrationTest
         var dataTableStorageService = new DataTableStorageService(StorageConnectionString());
 
         await dataTableStorageService.CreateEntity(
-            tableName: NotifierTableStorageTableNames.ApiSubscriptionsTableName,
+            tableName: NotifierTableStorage.ApiSubscriptionsTable,
             entity: subscription);
     }
 
@@ -91,7 +91,7 @@ public abstract class NotifierFunctionsIntegrationTest
         var dataTableStorageService = new DataTableStorageService(StorageConnectionString());
 
         return await dataTableStorageService.GetEntityIfExists<ApiSubscription>(
-            tableName: NotifierTableStorageTableNames.ApiSubscriptionsTableName,
+            tableName: NotifierTableStorage.ApiSubscriptionsTable,
             partitionKey: dataSetId.ToString(),
             rowKey: email,
             select: select);
@@ -105,7 +105,7 @@ public abstract class NotifierFunctionsIntegrationTest
         var dataTableStorageService = new DataTableStorageService(StorageConnectionString());
 
         var pagedSubscriptions = await dataTableStorageService.QueryEntities(
-            tableName: NotifierTableStorageTableNames.ApiSubscriptionsTableName,
+            tableName: NotifierTableStorage.ApiSubscriptionsTable,
             filter: filter,
             maxPerPage: maxPerPage,
             select: select,

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Configuration/GovUkNotifyOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Configuration/GovUkNotifyOptions.cs
@@ -24,8 +24,8 @@ public class GovUkNotifyOptions
 
         public string ApiSubscriptionConfirmationId { get; init; } = null!;
 
-        public string ApiSubscriptionVerificationId { get; init; } = null!;
-
         public string ApiSubscriptionNotificationId { get; init; } = null!;
+
+        public string ApiSubscriptionVerificationId { get; init; } = null!;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Configuration/GovUkNotifyOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Configuration/GovUkNotifyOptions.cs
@@ -25,5 +25,7 @@ public class GovUkNotifyOptions
         public string ApiSubscriptionConfirmationId { get; init; } = null!;
 
         public string ApiSubscriptionVerificationId { get; init; } = null!;
+
+        public string ApiSubscriptionNotificationId { get; init; } = null!;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
@@ -11,6 +11,7 @@ using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Http;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Functions;
 
@@ -94,5 +95,17 @@ public class ApiSubscriptionFunctions(
         CancellationToken cancellationToken)
     {
         await apiSubscriptionService.RemoveExpiredApiSubscriptions(cancellationToken);
+    }
+
+    [Function("NotifyApiSubscribers")]
+    public async Task NotifyApiSubscribers(
+        [QueueTrigger(NotifierQueues.ApiNotificationQueue)] ApiNotificationMessage msg,
+        FunctionContext context,
+        CancellationToken cancellationToken)
+    {
+        await apiSubscriptionService.NotifyApiSubscribers(
+            dataSetId: msg.DataSetId,
+            version: msg.Version,
+            cancellationToken: cancellationToken);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
@@ -18,7 +18,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier.Functions;
 public class ApiSubscriptionFunctions(
     ILogger<ApiSubscriptionFunctions> logger,
     IApiSubscriptionService apiSubscriptionService,
-    IValidator<PendingApiSubscriptionCreateRequest> newPendingApiSubscriptionRequestValidator)
+    IValidator<PendingApiSubscriptionCreateRequest> newPendingApiSubscriptionRequestValidator,
+    IValidator<ApiNotificationMessage> apiNotificationMessageValidator)
 {
     [Function("RequestPendingApiSubscription")]
     public async Task<IActionResult> RequestPendingApiSubscription(
@@ -99,12 +100,13 @@ public class ApiSubscriptionFunctions(
 
     [Function("NotifyApiSubscribers")]
     public async Task NotifyApiSubscribers(
-        [QueueTrigger(NotifierQueueStorage.ApiNotificationQueue)] ApiNotificationMessage msg,
+        [QueueTrigger(NotifierQueueStorage.ApiNotificationQueue)] ApiNotificationMessage message,
         CancellationToken cancellationToken)
     {
+        await apiNotificationMessageValidator.ValidateAndThrowAsync(message, cancellationToken);
         await apiSubscriptionService.NotifyApiSubscribers(
-            dataSetId: msg.DataSetId,
-            version: msg.Version,
+            dataSetId: message.DataSetId,
+            version: message.Version,
             cancellationToken: cancellationToken);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
@@ -106,6 +106,7 @@ public class ApiSubscriptionFunctions(
         await apiNotificationMessageValidator.ValidateAndThrowAsync(message, cancellationToken);
         await apiSubscriptionService.NotifyApiSubscribers(
             dataSetId: message.DataSetId,
+            dataSetFileId: message.DataSetFileId,
             version: message.Version,
             cancellationToken: cancellationToken);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
@@ -99,7 +99,7 @@ public class ApiSubscriptionFunctions(
 
     [Function("NotifyApiSubscribers")]
     public async Task NotifyApiSubscribers(
-        [QueueTrigger(NotifierQueues.ApiNotificationQueue)] ApiNotificationMessage msg,
+        [QueueTrigger(Constants.NotifierQueueStorage.ApiNotificationQueue)] ApiNotificationMessage msg,
         FunctionContext context,
         CancellationToken cancellationToken)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
@@ -21,8 +21,18 @@ public class ApiSubscriptionFunctions(
     IValidator<PendingApiSubscriptionCreateRequest> newPendingApiSubscriptionRequestValidator,
     IValidator<ApiNotificationMessage> apiNotificationMessageValidator)
 {
-    [Function("RequestPendingApiSubscription")]
-    public async Task<IActionResult> RequestPendingApiSubscription(
+    private static class FunctionNames
+    {
+        private const string Base = "PublicApiSubscriptions_";
+        public const string NotifySubscribers = $"{Base}{nameof(NotifySubscribers)}";
+        public const string RequestPendingSubscription = $"{Base}{nameof(RequestPendingSubscription)}";
+        public const string RemoveExpiredSubscriptions = $"{Base}{nameof(RemoveExpiredSubscriptions)}";
+        public const string Unsubscribe = $"{Base}{nameof(Unsubscribe)}";
+        public const string VerifySubscription = $"{Base}{nameof(VerifySubscription)}";
+    }
+
+    [Function(FunctionNames.RequestPendingSubscription)]
+    public async Task<IActionResult> RequestPendingSubscription(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "public-api/request-pending-subscription")]
         [FromBody] PendingApiSubscriptionCreateRequest request,
         CancellationToken cancellationToken)
@@ -39,13 +49,13 @@ public class ApiSubscriptionFunctions(
         }
         catch (Exception ex)
         {
-            logger.LogError(exception: ex, "Exception occured while executing '{FunctionName}'", nameof(RequestPendingApiSubscription));
+            logger.LogError(ex, "Exception occured while executing '{FunctionName}'", nameof(RequestPendingSubscription));
             return new StatusCodeResult(StatusCodes.Status500InternalServerError);
         }
     }
 
-    [Function("VerifyApiSubscription")]
-    public async Task<IActionResult> VerifyApiSubscription(
+    [Function(FunctionNames.VerifySubscription)]
+    public async Task<IActionResult> VerifySubscription(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "public-api/{dataSetId:guid}/verify-subscription/{token}")]
         HttpRequest request,
         Guid dataSetId,
@@ -62,13 +72,13 @@ public class ApiSubscriptionFunctions(
         }
         catch (Exception ex)
         {
-            logger.LogError(exception: ex, "Exception occured while executing '{FunctionName}'", nameof(VerifyApiSubscription));
+            logger.LogError(exception: ex, "Exception occured while executing '{FunctionName}'", nameof(VerifySubscription));
             return new StatusCodeResult(StatusCodes.Status500InternalServerError);
         }
     }
 
-    [Function("ApiUnsubscribe")]
-    public async Task<IActionResult> ApiUnsubscribe(
+    [Function(FunctionNames.Unsubscribe)]
+    public async Task<IActionResult> Unsubscribe(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "public-api/{dataSetId:guid}/unsubscribe/{token}")]
         HttpRequest request,
         Guid dataSetId,
@@ -85,21 +95,21 @@ public class ApiSubscriptionFunctions(
         }
         catch (Exception ex)
         {
-            logger.LogError(exception: ex, "Exception occured while executing '{FunctionName}'", nameof(ApiUnsubscribe));
+            logger.LogError(exception: ex, "Exception occured while executing '{FunctionName}'", nameof(Unsubscribe));
             return new StatusCodeResult(StatusCodes.Status500InternalServerError);
         }
     }
 
-    [Function("RemoveExpiredApiSubscriptions")]
-    public async Task RemoveExpiredApiSubscriptions(
+    [Function(FunctionNames.RemoveExpiredSubscriptions)]
+    public async Task RemoveExpiredSubscriptions(
         [TimerTrigger("0 * * * * *")] TimerInfo timerInfo,
         CancellationToken cancellationToken)
     {
         await apiSubscriptionService.RemoveExpiredApiSubscriptions(cancellationToken);
     }
 
-    [Function("NotifyApiSubscribers")]
-    public async Task NotifyApiSubscribers(
+    [Function(FunctionNames.NotifySubscribers)]
+    public async Task NotifySubscribers(
         [QueueTrigger(NotifierQueueStorage.ApiNotificationQueue)] ApiNotificationMessage message,
         CancellationToken cancellationToken)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
@@ -1,17 +1,17 @@
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.Functions.Worker;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Notifier.Requests;
-using FromBodyAttribute = Microsoft.Azure.Functions.Worker.Http.FromBodyAttribute;
-using GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
-using System;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Http;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Requests;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using FromBodyAttribute = Microsoft.Azure.Functions.Worker.Http.FromBodyAttribute;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Functions;
 
@@ -54,9 +54,9 @@ public class ApiSubscriptionFunctions(
         try
         {
             return await apiSubscriptionService.VerifySubscription(
-                dataSetId: dataSetId,
-                token: token,
-                cancellationToken: cancellationToken)
+                    dataSetId: dataSetId,
+                    token: token,
+                    cancellationToken: cancellationToken)
                 .HandleFailuresOr(subscription => new OkObjectResult(subscription));
         }
         catch (Exception ex)
@@ -77,9 +77,9 @@ public class ApiSubscriptionFunctions(
         try
         {
             return await apiSubscriptionService.Unsubscribe(
-                dataSetId: dataSetId,
-                token: token,
-                cancellationToken: cancellationToken)
+                    dataSetId: dataSetId,
+                    token: token,
+                    cancellationToken: cancellationToken)
                 .HandleFailuresOrNoContent(convertNotFoundToNoContent: false);
         }
         catch (Exception ex)
@@ -100,7 +100,6 @@ public class ApiSubscriptionFunctions(
     [Function("NotifyApiSubscribers")]
     public async Task NotifyApiSubscribers(
         [QueueTrigger(NotifierQueueStorage.ApiNotificationQueue)] ApiNotificationMessage msg,
-        FunctionContext context,
         CancellationToken cancellationToken)
     {
         await apiSubscriptionService.NotifyApiSubscribers(

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ApiSubscriptionFunctions.cs
@@ -99,7 +99,7 @@ public class ApiSubscriptionFunctions(
 
     [Function("NotifyApiSubscribers")]
     public async Task NotifyApiSubscribers(
-        [QueueTrigger(Constants.NotifierQueueStorage.ApiNotificationQueue)] ApiNotificationMessage msg,
+        [QueueTrigger(NotifierQueueStorage.ApiNotificationQueue)] ApiNotificationMessage msg,
         FunctionContext context,
         CancellationToken cancellationToken)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/PublicationSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/PublicationSubscriptionFunctions.cs
@@ -15,8 +15,8 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Requests;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Types;
 using FromBodyAttribute = Microsoft.Azure.Functions.Worker.Http.FromBodyAttribute;
-using static GovUk.Education.ExploreEducationStatistics.Common.TableStorageTableNames;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Repositories.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Functions;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/PublicationSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/PublicationSubscriptionFunctions.cs
@@ -54,7 +54,7 @@ public class PublicationSubscriptionFunctions(
 
         var subscription = await publicationSubscriptionRepository.GetSubscription(req.Id, req.Email);
         var pendingSubscriptionTable =
-            await _publicationSubscriptionRepository.GetTable(Constants.NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
+            await _publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
 
         try
         {
@@ -158,7 +158,7 @@ public class PublicationSubscriptionFunctions(
             return new BadRequestObjectResult("Unable to unsubscribe. A valid email address could not be parsed from the given token.");
         }
 
-        var table = await _publicationSubscriptionRepository.GetTable(Constants.NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
+        var table = await _publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
         var sub = await _publicationSubscriptionRepository.RetrieveSubscriber(table, new SubscriptionEntity(id, email));
         if (sub is null)
         {
@@ -189,9 +189,9 @@ public class PublicationSubscriptionFunctions(
 
         if (email != null)
         {
-            var subscriptionsTbl = await _publicationSubscriptionRepository.GetTable(Constants.NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
+            var subscriptionsTbl = await _publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
             var pendingSubscriptionsTbl =
-                await _publicationSubscriptionRepository.GetTable(Constants.NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
+                await _publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
 
             var sub = _publicationSubscriptionRepository
                 .RetrieveSubscriber(pendingSubscriptionsTbl, new SubscriptionEntity(id, email)).Result;
@@ -243,7 +243,7 @@ public class PublicationSubscriptionFunctions(
     {
         logger.LogInformation("{FunctionName} triggered", context.FunctionDefinition.Name);
 
-        var pendingSubscriptionsTbl = await _publicationSubscriptionRepository.GetTable(Constants.NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
+        var pendingSubscriptionsTbl = await _publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
 
         // Remove any pending subscriptions where the token has expired i.e. more than 1 hour old
         var query = new TableQuery<SubscriptionEntity>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/PublicationSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/PublicationSubscriptionFunctions.cs
@@ -59,7 +59,7 @@ public class PublicationSubscriptionFunctions(
 
         var subscription = await publicationSubscriptionRepository.GetSubscription(req.Id, req.Email);
         var pendingSubscriptionTable =
-            await publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
+            await publicationSubscriptionRepository.GetTable(NotifierTableStorage.PublicationPendingSubscriptionsTable);
 
         try
         {
@@ -162,7 +162,7 @@ public class PublicationSubscriptionFunctions(
             return new BadRequestObjectResult("Unable to unsubscribe. A valid email address could not be parsed from the given token.");
         }
 
-        var table = await publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
+        var table = await publicationSubscriptionRepository.GetTable(NotifierTableStorage.PublicationSubscriptionsTable);
         var sub = await publicationSubscriptionRepository.RetrieveSubscriber(table, new SubscriptionEntity(id, email));
         if (sub is null)
         {
@@ -192,9 +192,9 @@ public class PublicationSubscriptionFunctions(
 
         if (email != null)
         {
-            var subscriptionsTbl = await publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
+            var subscriptionsTbl = await publicationSubscriptionRepository.GetTable(NotifierTableStorage.PublicationSubscriptionsTable);
             var pendingSubscriptionsTbl =
-                await publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
+                await publicationSubscriptionRepository.GetTable(NotifierTableStorage.PublicationPendingSubscriptionsTable);
 
             var sub = publicationSubscriptionRepository
                 .RetrieveSubscriber(pendingSubscriptionsTbl, new SubscriptionEntity(id, email)).Result;
@@ -245,7 +245,7 @@ public class PublicationSubscriptionFunctions(
     {
         logger.LogInformation("{FunctionName} triggered", context.FunctionDefinition.Name);
 
-        var pendingSubscriptionsTbl = await publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
+        var pendingSubscriptionsTbl = await publicationSubscriptionRepository.GetTable(NotifierTableStorage.PublicationPendingSubscriptionsTable);
 
         // Remove any pending subscriptions where the token has expired i.e. more than 1 hour old
         var query = new TableQuery<SubscriptionEntity>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/PublicationSubscriptionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/PublicationSubscriptionFunctions.cs
@@ -31,13 +31,18 @@ public class PublicationSubscriptionFunctions(
 {
     private readonly AppSettingsOptions _appSettingsOptions = appSettingsOptions.Value;
     private readonly GovUkNotifyOptions.EmailTemplateOptions _emailTemplateOptions = govUkNotifyOptions.Value.EmailTemplates;
-    private readonly ITokenService _tokenService = tokenService ?? throw new ArgumentNullException(nameof(tokenService));
-    private readonly IEmailService _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
-    private readonly IPublicationSubscriptionRepository _publicationSubscriptionRepository = publicationSubscriptionRepository ?? throw new ArgumentNullException(nameof(publicationSubscriptionRepository));
 
-    [Function("RequestPendingSubscription")]
-    // ReSharper disable once UnusedMember.Global
-    public async Task<IActionResult> RequestPendingSubscriptionFunc(
+    private static class FunctionNames
+    {
+        private const string Base = "PublicationSubscriptions_";
+        public const string RequestPendingSubscription = $"{Base}{nameof(PublicationSubscriptionFunctions.RequestPendingSubscription)}";
+        public const string RemoveExpiredSubscriptions = $"{Base}{nameof(PublicationSubscriptionFunctions.RemoveExpiredSubscriptions)}";
+        public const string Unsubscribe = $"{Base}{nameof(PublicationSubscriptionFunctions.Unsubscribe)}";
+        public const string VerifySubscription = $"{Base}{nameof(PublicationSubscriptionFunctions.VerifySubscription)}";
+    }
+
+    [Function(FunctionNames.RequestPendingSubscription)]
+    public async Task<IActionResult> RequestPendingSubscription(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "publication/request-pending-subscription/")]
         [FromBody] PendingPublicationSubscriptionCreateRequest req,
         FunctionContext context,
@@ -54,7 +59,7 @@ public class PublicationSubscriptionFunctions(
 
         var subscription = await publicationSubscriptionRepository.GetSubscription(req.Id, req.Email);
         var pendingSubscriptionTable =
-            await _publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
+            await publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
 
         try
         {
@@ -71,7 +76,7 @@ public class PublicationSubscriptionFunctions(
                 case SubscriptionStatus.Subscribed:
                     {
                         var unsubscribeToken =
-                            _tokenService.GenerateToken(subscription.Subscriber.RowKey,
+                            tokenService.GenerateToken(subscription.Subscriber.RowKey,
                                 DateTime.UtcNow.AddYears(1));
 
                         var confirmationValues = new Dictionary<string, dynamic>
@@ -83,7 +88,7 @@ public class PublicationSubscriptionFunctions(
                             }
                         };
 
-                        _emailService.SendEmail(
+                        emailService.SendEmail(
                             email: req.Email,
                             templateId: _emailTemplateOptions.SubscriptionConfirmationId,
                             confirmationValues);
@@ -94,8 +99,8 @@ public class PublicationSubscriptionFunctions(
                 case SubscriptionStatus.NotSubscribed:
                     // Verification Token expires in 1 hour
                     var expiryDateTime = DateTime.UtcNow.AddHours(1);
-                    var activationCode = _tokenService.GenerateToken(req.Email, expiryDateTime);
-                    await _publicationSubscriptionRepository.UpdateSubscriber(pendingSubscriptionTable,
+                    var activationCode = tokenService.GenerateToken(req.Email, expiryDateTime);
+                    await publicationSubscriptionRepository.UpdateSubscriber(pendingSubscriptionTable,
                         new SubscriptionEntity(req.Id, req.Email, req.Title, req.Slug, expiryDateTime));
 
                     var values = new Dictionary<string, dynamic>
@@ -107,7 +112,7 @@ public class PublicationSubscriptionFunctions(
                         }
                     };
 
-                    _emailService.SendEmail(
+                    emailService.SendEmail(
                         email: req.Email,
                         templateId: _emailTemplateOptions.SubscriptionVerificationId,
                         values);
@@ -129,7 +134,7 @@ public class PublicationSubscriptionFunctions(
             // Remove the subscriber from storage if we could not successfully send the email & just added it
             if (subscription.Status is not SubscriptionStatus.SubscriptionPending)
             {
-                await _publicationSubscriptionRepository.RemoveSubscriber(pendingSubscriptionTable,
+                await publicationSubscriptionRepository.RemoveSubscriber(pendingSubscriptionTable,
                     new SubscriptionEntity(req.Id, req.Email));
             }
 
@@ -142,9 +147,8 @@ public class PublicationSubscriptionFunctions(
         }
     }
 
-    [Function("PublicationUnsubscribe")]
-    // ReSharper disable once UnusedMember.Global
-    public async Task<IActionResult> PublicationUnsubscribeFunc(
+    [Function(FunctionNames.Unsubscribe)]
+    public async Task<IActionResult> Unsubscribe(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "publication/{id}/unsubscribe/{token}")]
         FunctionContext context,
         string id,
@@ -152,20 +156,20 @@ public class PublicationSubscriptionFunctions(
     {
         logger.LogInformation("{FunctionName} triggered", context.FunctionDefinition.Name);
 
-        var email = _tokenService.GetEmailFromToken(token);
+        var email = tokenService.GetEmailFromToken(token);
         if (email is null)
         {
             return new BadRequestObjectResult("Unable to unsubscribe. A valid email address could not be parsed from the given token.");
         }
 
-        var table = await _publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
-        var sub = await _publicationSubscriptionRepository.RetrieveSubscriber(table, new SubscriptionEntity(id, email));
+        var table = await publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
+        var sub = await publicationSubscriptionRepository.RetrieveSubscriber(table, new SubscriptionEntity(id, email));
         if (sub is null)
         {
             return new UnprocessableEntityObjectResult("Unable to unsubscribe. Given email is not currently subscribed.");
         }
 
-        await _publicationSubscriptionRepository.RemoveSubscriber(table, sub);
+        await publicationSubscriptionRepository.RemoveSubscriber(table, sub);
         return new OkObjectResult(new SubscriptionStateDto()
         {
             Slug = sub.Slug,
@@ -175,9 +179,8 @@ public class PublicationSubscriptionFunctions(
     }
 
 
-    [Function("VerifySubscription")]
-    // ReSharper disable once UnusedMember.Global
-    public async Task<IActionResult> VerifySubscriptionFunc(
+    [Function(FunctionNames.VerifySubscription)]
+    public async Task<IActionResult> VerifySubscription(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "publication/{id}/verify-subscription/{token}")]
         FunctionContext context,
         string id,
@@ -185,29 +188,29 @@ public class PublicationSubscriptionFunctions(
     {
         logger.LogInformation("{FunctionName} triggered", context.FunctionDefinition.Name);
 
-        var email = _tokenService.GetEmailFromToken(token);
+        var email = tokenService.GetEmailFromToken(token);
 
         if (email != null)
         {
-            var subscriptionsTbl = await _publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
+            var subscriptionsTbl = await publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
             var pendingSubscriptionsTbl =
-                await _publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
+                await publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
 
-            var sub = _publicationSubscriptionRepository
+            var sub = publicationSubscriptionRepository
                 .RetrieveSubscriber(pendingSubscriptionsTbl, new SubscriptionEntity(id, email)).Result;
 
             if (sub != null)
             {
                 // Remove the pending subscription from the the file now verified
                 logger.LogDebug("Removing address from pending subscribers");
-                await _publicationSubscriptionRepository.RemoveSubscriber(pendingSubscriptionsTbl, sub);
+                await publicationSubscriptionRepository.RemoveSubscriber(pendingSubscriptionsTbl, sub);
 
                 // Add them to the verified subscribers table
                 logger.LogDebug("Adding address to the verified subscribers");
                 sub.DateTimeCreated = DateTime.UtcNow;
-                await _publicationSubscriptionRepository.UpdateSubscriber(subscriptionsTbl, sub);
+                await publicationSubscriptionRepository.UpdateSubscriber(subscriptionsTbl, sub);
                 var unsubscribeToken =
-                    _tokenService.GenerateToken(sub.RowKey, DateTime.UtcNow.AddYears(1));
+                    tokenService.GenerateToken(sub.RowKey, DateTime.UtcNow.AddYears(1));
 
                 var values = new Dictionary<string, dynamic>
                 {
@@ -218,7 +221,7 @@ public class PublicationSubscriptionFunctions(
                     }
                 };
 
-                _emailService.SendEmail(
+                emailService.SendEmail(
                     email: email,
                     templateId: _emailTemplateOptions.SubscriptionConfirmationId,
                     values);
@@ -235,15 +238,14 @@ public class PublicationSubscriptionFunctions(
         return new BadRequestObjectResult("Verification-Error");
     }
 
-    [Function("RemoveNonVerifiedSubscriptions")]
-    // ReSharper disable once UnusedMember.Global
-    public async Task RemoveNonVerifiedSubscriptionsFunc(
+    [Function(FunctionNames.RemoveExpiredSubscriptions)]
+    public async Task RemoveExpiredSubscriptions(
         [TimerTrigger("0 0 * * * *")] TimerInfo myTimer,
         FunctionContext context)
     {
         logger.LogInformation("{FunctionName} triggered", context.FunctionDefinition.Name);
 
-        var pendingSubscriptionsTbl = await _publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
+        var pendingSubscriptionsTbl = await publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName);
 
         // Remove any pending subscriptions where the token has expired i.e. more than 1 hour old
         var query = new TableQuery<SubscriptionEntity>()
@@ -258,7 +260,7 @@ public class PublicationSubscriptionFunctions(
 
             foreach (var entity in resultSegment.Results)
             {
-                await _publicationSubscriptionRepository.RemoveSubscriber(pendingSubscriptionsTbl, entity);
+                await publicationSubscriptionRepository.RemoveSubscriber(pendingSubscriptionsTbl, entity);
             }
         } while (token != null);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ReleaseNotifier.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ReleaseNotifier.cs
@@ -41,12 +41,12 @@ public class ReleaseNotifier
 
     [Function("ReleaseNotifier")]
     public async Task ReleaseNotifierFunc(
-        [QueueTrigger(Constants.NotifierQueueStorage.ReleaseNotificationQueue)] ReleaseNotificationMessage msg,
+        [QueueTrigger(NotifierQueueStorage.ReleaseNotificationQueue)] ReleaseNotificationMessage msg,
         FunctionContext context)
     {
         _logger.LogInformation("{FunctionName} triggered", context.FunctionDefinition.Name);
 
-        var subscribersTable = await _publicationSubscriptionRepository.GetTable(Constants.NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
+        var subscribersTable = await _publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
 
         var sentEmails = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ReleaseNotifier.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ReleaseNotifier.cs
@@ -38,7 +38,7 @@ public class ReleaseNotifier(
     {
         logger.LogInformation("{FunctionName} triggered", context.FunctionDefinition.Name);
 
-        var subscribersTable = await publicationSubscriptionRepository.GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName);
+        var subscribersTable = await publicationSubscriptionRepository.GetTable(NotifierTableStorage.PublicationSubscriptionsTable);
 
         var sentEmails = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ReleaseNotifier.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ReleaseNotifier.cs
@@ -8,10 +8,8 @@ using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
 using Microsoft.Azure.Cosmos.Table;
 using Microsoft.Extensions.Logging;
-using static GovUk.Education.ExploreEducationStatistics.Notifier.Model.NotifierQueues;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Options;
-using static GovUk.Education.ExploreEducationStatistics.Common.TableStorageTableNames;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Repositories.Interfaces;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Functions;
@@ -43,7 +41,7 @@ public class ReleaseNotifier
 
     [Function("ReleaseNotifier")]
     public async Task ReleaseNotifierFunc(
-        [QueueTrigger(ReleaseNotificationQueue)] ReleaseNotificationMessage msg,
+        [QueueTrigger(Constants.NotifierQueueStorage.ReleaseNotificationQueue)] ReleaseNotificationMessage msg,
         FunctionContext context)
     {
         _logger.LogInformation("{FunctionName} triggered", context.FunctionDefinition.Name);

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/NotifierHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/NotifierHostBuilder.cs
@@ -52,6 +52,8 @@ public static class NotifierHostBuilder
                     .AddTransient<IApiSubscriptionRepository, ApiSubscriptionRepository>()
                     .AddTransient<IApiSubscriptionService, ApiSubscriptionService>()
                     .AddTransient<ITokenService, TokenService>();
+
+                // add configuration here to add fluent validation validators from the Models assembly?
             });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/NotifierHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/NotifierHostBuilder.cs
@@ -1,5 +1,7 @@
+using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Configuration;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Repositories;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Repositories.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Services;
@@ -38,6 +40,8 @@ public static class NotifierHostBuilder
                     .AddApplicationInsightsTelemetryWorkerService()
                     .ConfigureFunctionsApplicationInsights()
                     .AddFluentValidation()
+                    .AddValidatorsFromAssembly(
+                        typeof(ApiNotificationMessage.Validator).Assembly) // Adds *all* validators from Notifier.Model
                     .Configure<AppSettingsOptions>(hostContext.Configuration.GetSection(AppSettingsOptions.Section))
                     .Configure<GovUkNotifyOptions>(hostContext.Configuration.GetSection(GovUkNotifyOptions.Section))
                     .AddTransient<INotificationClient>(serviceProvider =>
@@ -52,8 +56,6 @@ public static class NotifierHostBuilder
                     .AddTransient<IApiSubscriptionRepository, ApiSubscriptionRepository>()
                     .AddTransient<IApiSubscriptionService, ApiSubscriptionService>()
                     .AddTransient<ITokenService, TokenService>();
-
-                // add configuration here to add fluent validation validators from the Models assembly?
             });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/ApiSubscriptionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/ApiSubscriptionRepository.cs
@@ -8,6 +8,7 @@ using Azure.Data.Tables;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Configuration;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Repositories.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
 using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Repositories;

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/ApiSubscriptionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/ApiSubscriptionRepository.cs
@@ -40,7 +40,7 @@ internal class ApiSubscriptionRepository(
             PartitionKey = dataSetId.ToString(),
             RowKey = email,
             DataSetTitle = dataSetTitle,
-            Status = ApiSubscriptionStatus.SubscriptionPending,
+            Status = ApiSubscriptionStatus.Pending,
             Expiry = expiry
         };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/ApiSubscriptionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/ApiSubscriptionRepository.cs
@@ -17,7 +17,7 @@ internal class ApiSubscriptionRepository(
     IOptions<AppSettingsOptions> appSettingsOptions,
     IApiSubscriptionTableStorageService apiSubscriptionTableStorage) : IApiSubscriptionRepository
 {
-    private const string _apiSubscriptionsTableName = Constants.NotifierTableStorageTableNames.ApiSubscriptionsTableName;
+    private const string _apiSubscriptionsTableName = NotifierTableStorageTableNames.ApiSubscriptionsTableName;
 
     public async Task<ApiSubscription?> GetSubscription(
         Guid dataSetId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/ApiSubscriptionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/ApiSubscriptionRepository.cs
@@ -14,15 +14,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier.Repositories;
 internal class ApiSubscriptionRepository(
     IApiSubscriptionTableStorageService apiSubscriptionTableStorage) : IApiSubscriptionRepository
 {
-    private const string ApiSubscriptionsTableName = NotifierTableStorageTableNames.ApiSubscriptionsTableName;
-
     public async Task<ApiSubscription?> GetSubscription(
         Guid dataSetId,
         string email,
         CancellationToken cancellationToken = default)
     {
         return await apiSubscriptionTableStorage.GetEntityIfExists<ApiSubscription>(
-            tableName: ApiSubscriptionsTableName,
+            tableName: NotifierTableStorage.ApiSubscriptionsTable,
             partitionKey: dataSetId.ToString(),
             rowKey: email,
             cancellationToken: cancellationToken);
@@ -45,7 +43,7 @@ internal class ApiSubscriptionRepository(
         };
 
         await apiSubscriptionTableStorage.CreateEntity(
-            tableName: ApiSubscriptionsTableName,
+            tableName: NotifierTableStorage.ApiSubscriptionsTable,
             entity: subscription,
             cancellationToken: cancellationToken);
     }
@@ -55,7 +53,7 @@ internal class ApiSubscriptionRepository(
         CancellationToken cancellationToken = default)
     {
         await apiSubscriptionTableStorage.UpdateEntity(
-            tableName: ApiSubscriptionsTableName,
+            tableName: NotifierTableStorage.ApiSubscriptionsTable,
             entity: subscription,
             cancellationToken: cancellationToken);
     }
@@ -66,7 +64,7 @@ internal class ApiSubscriptionRepository(
         CancellationToken cancellationToken = default)
     {
         await apiSubscriptionTableStorage.DeleteEntity(
-            tableName: ApiSubscriptionsTableName,
+            tableName: NotifierTableStorage.ApiSubscriptionsTable,
             partitionKey: dataSetId.ToString(),
             rowKey: email,
             cancellationToken: cancellationToken);
@@ -81,7 +79,7 @@ internal class ApiSubscriptionRepository(
         filter ??= subscription => true;
 
         return await apiSubscriptionTableStorage.QueryEntities(
-            tableName: ApiSubscriptionsTableName,
+            tableName: NotifierTableStorage.ApiSubscriptionsTable,
             filter: filter,
             maxPerPage: maxPerPage,
             select: select,
@@ -94,7 +92,7 @@ internal class ApiSubscriptionRepository(
         CancellationToken cancellationToken = default)
     {
         await apiSubscriptionTableStorage.BatchManipulateEntities(
-            tableName: ApiSubscriptionsTableName,
+            tableName: NotifierTableStorage.ApiSubscriptionsTable,
             entities: subscriptions,
             tableTransactionActionType: tableTransactionActionType,
             cancellationToken: cancellationToken);

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/ApiSubscriptionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/ApiSubscriptionRepository.cs
@@ -5,19 +5,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Data.Tables;
-using GovUk.Education.ExploreEducationStatistics.Notifier.Configuration;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Repositories.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
-using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Repositories;
 
 internal class ApiSubscriptionRepository(
-    IOptions<AppSettingsOptions> appSettingsOptions,
     IApiSubscriptionTableStorageService apiSubscriptionTableStorage) : IApiSubscriptionRepository
 {
-    private const string _apiSubscriptionsTableName = NotifierTableStorageTableNames.ApiSubscriptionsTableName;
+    private const string ApiSubscriptionsTableName = NotifierTableStorageTableNames.ApiSubscriptionsTableName;
 
     public async Task<ApiSubscription?> GetSubscription(
         Guid dataSetId,
@@ -25,7 +22,7 @@ internal class ApiSubscriptionRepository(
         CancellationToken cancellationToken = default)
     {
         return await apiSubscriptionTableStorage.GetEntityIfExists<ApiSubscription>(
-            tableName: _apiSubscriptionsTableName,
+            tableName: ApiSubscriptionsTableName,
             partitionKey: dataSetId.ToString(),
             rowKey: email,
             cancellationToken: cancellationToken);
@@ -48,7 +45,7 @@ internal class ApiSubscriptionRepository(
         };
 
         await apiSubscriptionTableStorage.CreateEntity(
-            tableName: _apiSubscriptionsTableName,
+            tableName: ApiSubscriptionsTableName,
             entity: subscription,
             cancellationToken: cancellationToken);
     }
@@ -58,7 +55,7 @@ internal class ApiSubscriptionRepository(
         CancellationToken cancellationToken = default)
     {
         await apiSubscriptionTableStorage.UpdateEntity(
-            tableName: _apiSubscriptionsTableName,
+            tableName: ApiSubscriptionsTableName,
             entity: subscription,
             cancellationToken: cancellationToken);
     }
@@ -69,22 +66,22 @@ internal class ApiSubscriptionRepository(
         CancellationToken cancellationToken = default)
     {
         await apiSubscriptionTableStorage.DeleteEntity(
-            tableName: _apiSubscriptionsTableName,
+            tableName: ApiSubscriptionsTableName,
             partitionKey: dataSetId.ToString(),
             rowKey: email,
             cancellationToken: cancellationToken);
     }
 
     public async Task<AsyncPageable<ApiSubscription>> QuerySubscriptions(
-        Expression<Func<ApiSubscription, bool>>? filter = null, 
-        int? maxPerPage = 1000, 
-        IEnumerable<string>? select = null, 
+        Expression<Func<ApiSubscription, bool>>? filter = null,
+        int? maxPerPage = 1000,
+        IEnumerable<string>? select = null,
         CancellationToken cancellationToken = default)
     {
         filter ??= subscription => true;
 
         return await apiSubscriptionTableStorage.QueryEntities(
-            tableName: _apiSubscriptionsTableName,
+            tableName: ApiSubscriptionsTableName,
             filter: filter,
             maxPerPage: maxPerPage,
             select: select,
@@ -93,11 +90,11 @@ internal class ApiSubscriptionRepository(
 
     public async Task BatchManipulateSubscriptions(
         IEnumerable<ApiSubscription> subscriptions,
-        TableTransactionActionType tableTransactionActionType, 
+        TableTransactionActionType tableTransactionActionType,
         CancellationToken cancellationToken = default)
     {
         await apiSubscriptionTableStorage.BatchManipulateEntities(
-            tableName: _apiSubscriptionsTableName,
+            tableName: ApiSubscriptionsTableName,
             entities: subscriptions,
             tableTransactionActionType: tableTransactionActionType,
             cancellationToken: cancellationToken);

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/Interfaces/IApiSubscriptionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/Interfaces/IApiSubscriptionRepository.cs
@@ -12,14 +12,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier.Repositories.Inter
 public interface IApiSubscriptionRepository
 {
     Task<ApiSubscription?> GetSubscription(
-        Guid dataSetId, 
-        string email, 
+        Guid dataSetId,
+        string email,
         CancellationToken cancellationToken = default);
 
     Task CreatePendingSubscription(
         Guid dataSetId,
         string dataSetTitle,
-        string email, 
+        string email,
         DateTimeOffset expiryDateTime,
         CancellationToken cancellationToken = default);
 
@@ -28,7 +28,7 @@ public interface IApiSubscriptionRepository
         CancellationToken cancellationToken = default);
 
     Task DeleteSubscription(
-        Guid dataSetId, 
+        Guid dataSetId,
         string email,
         CancellationToken cancellationToken = default);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/PublicationSubscriptionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/PublicationSubscriptionRepository.cs
@@ -50,7 +50,7 @@ public class PublicationSubscriptionRepository(IOptions<AppSettingsOptions> appS
     public async Task<Subscription> GetSubscription(string id, string email)
     {
         var pendingSub =
-            await RetrieveSubscriber(await GetTable(Constants.NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName),
+            await RetrieveSubscriber(await GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName),
                 new SubscriptionEntity(id, email));
         if (pendingSub is not null)
         {
@@ -61,7 +61,7 @@ public class PublicationSubscriptionRepository(IOptions<AppSettingsOptions> appS
             };
         }
 
-        var activeSubscriber = await RetrieveSubscriber(await GetTable(Constants.NotifierTableStorageTableNames.PublicationSubscriptionsTableName),
+        var activeSubscriber = await RetrieveSubscriber(await GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName),
             new SubscriptionEntity(id, email));
         if (activeSubscriber is not null)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/PublicationSubscriptionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/PublicationSubscriptionRepository.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Configuration;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Repositories.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Types;
 using Microsoft.Azure.Cosmos.Table;
 using Microsoft.Extensions.Options;
-using static GovUk.Education.ExploreEducationStatistics.Common.TableStorageTableNames;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Repositories;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/PublicationSubscriptionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Repositories/PublicationSubscriptionRepository.cs
@@ -50,7 +50,7 @@ public class PublicationSubscriptionRepository(IOptions<AppSettingsOptions> appS
     public async Task<Subscription> GetSubscription(string id, string email)
     {
         var pendingSub =
-            await RetrieveSubscriber(await GetTable(NotifierTableStorageTableNames.PublicationPendingSubscriptionsTableName),
+            await RetrieveSubscriber(await GetTable(NotifierTableStorage.PublicationPendingSubscriptionsTable),
                 new SubscriptionEntity(id, email));
         if (pendingSub is not null)
         {
@@ -61,7 +61,7 @@ public class PublicationSubscriptionRepository(IOptions<AppSettingsOptions> appS
             };
         }
 
-        var activeSubscriber = await RetrieveSubscriber(await GetTable(NotifierTableStorageTableNames.PublicationSubscriptionsTableName),
+        var activeSubscriber = await RetrieveSubscriber(await GetTable(NotifierTableStorage.PublicationSubscriptionsTable),
             new SubscriptionEntity(id, email));
         if (activeSubscriber is not null)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Requests/PendingApiSubscriptionCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Requests/PendingApiSubscriptionCreateRequest.cs
@@ -1,5 +1,5 @@
-using FluentValidation;
 using System;
+using FluentValidation;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Requests;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
@@ -338,11 +338,11 @@ internal class ApiSubscriptionService(
     {
         foreach (var subscriber in subscribers.Values)
         {
-            SendNotification(subscriber, version);
+            SendNotificationEmail(subscriber, version);
         }
     }
 
-    private void SendNotification(ApiSubscription subscription, string version)
+    private void SendNotificationEmail(ApiSubscription subscription, string version)
     {
         var expiryDateTime = DateTime.UtcNow.AddYears(1);
         var unsubscribeToken = tokenService.GenerateToken(subscription.RowKey, expiryDateTime);
@@ -351,7 +351,7 @@ internal class ApiSubscriptionService(
         {
             { "api_dataset", subscription.DataSetTitle },
             {
-                "changelog-link",
+                "changelog_link",
                 $"{appSettingsOptions.Value.PublicAppUrl}/???/{subscription.PartitionKey}/{version}"
             },
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
@@ -20,7 +20,6 @@ using GovUk.Education.ExploreEducationStatistics.Notifier.Validators.ErrorDetail
 using GovUk.Education.ExploreEducationStatistics.Notifier.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using Semver;
 using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Notifier.Validators.ValidationMessages;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Services;
@@ -108,7 +107,7 @@ internal class ApiSubscriptionService(
 
     public async Task NotifyApiSubscribers(
         Guid dataSetId,
-        SemVersion version,
+        string version,
         CancellationToken cancellationToken = default)
     {
         var dataSetSubscribers = await apiSubscriptionRepository.QuerySubscriptions(
@@ -335,7 +334,7 @@ internal class ApiSubscriptionService(
 
     private void BatchNotifySubscribers(
         Page<ApiSubscription> subscribers,
-        SemVersion version)
+        string version)
     {
         foreach (var subscriber in subscribers.Values)
         {
@@ -343,7 +342,7 @@ internal class ApiSubscriptionService(
         }
     }
 
-    private void SendNotification(ApiSubscription subscription, SemVersion version)
+    private void SendNotification(ApiSubscription subscription, string version)
     {
         var expiryDateTime = DateTime.UtcNow.AddYears(1);
         var unsubscribeToken = tokenService.GenerateToken(subscription.RowKey, expiryDateTime);

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
@@ -1,3 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Azure;
 using Azure.Data.Tables;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -15,12 +21,6 @@ using GovUk.Education.ExploreEducationStatistics.Notifier.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Semver;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Threading;
-using System.Threading.Tasks;
 using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Notifier.Validators.ValidationMessages;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Services;
@@ -106,7 +106,6 @@ internal class ApiSubscriptionService(
                 DeleteSubscription(subscription: subscription, cancellationToken: cancellationToken));
     }
 
-
     public async Task NotifyApiSubscribers(
         Guid dataSetId,
         SemVersion version,
@@ -114,7 +113,11 @@ internal class ApiSubscriptionService(
     {
         var dataSetSubscribers = await apiSubscriptionRepository.QuerySubscriptions(
             filter: s => s.PartitionKey == dataSetId.ToString(),
-            select: new List<string>() { nameof(ApiSubscription.PartitionKey), nameof(ApiSubscription.RowKey) },
+            select: new List<string>
+            {
+                nameof(ApiSubscription.PartitionKey),
+                nameof(ApiSubscription.RowKey)
+            },
             cancellationToken: cancellationToken);
 
         await dataSetSubscribers

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
@@ -154,7 +154,7 @@ internal class ApiSubscriptionService(
             ? subscription.Left is NotFoundResult
                 ? Unit.Instance
                 : subscription.Left
-            : subscription.Right.Status is ApiSubscriptionStatus.SubscriptionPending
+            : subscription.Right.Status is ApiSubscriptionStatus.Pending
                 ? ValidationUtils.ValidationResult(new ErrorViewModel
                 {
                     Code = ValidationMessages.ApiPendingSubscriptionAlreadyExists.Code,
@@ -370,7 +370,7 @@ internal class ApiSubscriptionService(
     private async Task<AsyncPageable<ApiSubscription>> GetExpiredApiSubscriptions(CancellationToken cancellationToken)
     {
         Expression<Func<ApiSubscription, bool>> filter = s =>
-            s.Status.Equals(ApiSubscriptionStatus.SubscriptionPending.ToString())
+            s.Status.Equals(ApiSubscriptionStatus.Pending.ToString())
             && s.Expiry <= DateTimeOffset.UtcNow;
 
         return await apiSubscriptionRepository.QuerySubscriptions(

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
@@ -109,6 +109,7 @@ internal class ApiSubscriptionService(
 
     public async Task NotifyApiSubscribers(
         Guid dataSetId,
+        Guid dataSetFileId,
         string version,
         CancellationToken cancellationToken = default)
     {
@@ -131,6 +132,7 @@ internal class ApiSubscriptionService(
             .ForEachAsync(
                 page => BatchNotifySubscribers(
                     subscribers: page,
+                    dataSetFileId: dataSetFileId,
                     version: version),
                 cancellationToken);
     }
@@ -336,20 +338,22 @@ internal class ApiSubscriptionService(
 
     private void BatchNotifySubscribers(
         Page<ApiSubscription> subscribers,
+        Guid dataSetFileId,
         string version)
     {
         foreach (var subscriber in subscribers.Values)
         {
-            SendNotificationEmail(subscriber, version);
+            SendNotificationEmail(subscriber, dataSetFileId, version);
         }
     }
 
     private void SendNotificationEmail(
         ApiSubscription subscription,
+        Guid dataSetFileId,
         string version)
     {
         var token = tokenService.GenerateToken(subscription.RowKey, expiryDateTime: DateTime.UtcNow.AddYears(1));
-        var dataSetUrl = $"{_publicAppUrl}/???/{subscription.PartitionKey}/{version}";
+        var dataSetUrl = $"{_publicAppUrl}/data-catalogue/data-set/{dataSetFileId}";
         var unsubscribeUrl =
             $"{_publicAppUrl}/api-subscriptions/{subscription.PartitionKey}/confirm-unsubscription/{token}";
         var personalisation = new Dictionary<string, dynamic>

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
@@ -110,8 +110,12 @@ internal class ApiSubscriptionService(
         string version,
         CancellationToken cancellationToken = default)
     {
+        Expression<Func<ApiSubscription, bool>> filter = s =>
+            s.PartitionKey == dataSetId.ToString()
+            && s.Status.Equals(ApiSubscriptionStatus.Subscribed.ToString());
+
         var dataSetSubscribers = await apiSubscriptionRepository.QuerySubscriptions(
-            filter: s => s.PartitionKey == dataSetId.ToString(),
+            filter: filter,
             select:
             [
                 nameof(ApiSubscription.PartitionKey),

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionService.cs
@@ -112,11 +112,12 @@ internal class ApiSubscriptionService(
     {
         var dataSetSubscribers = await apiSubscriptionRepository.QuerySubscriptions(
             filter: s => s.PartitionKey == dataSetId.ToString(),
-            select: new List<string>
-            {
+            select:
+            [
                 nameof(ApiSubscription.PartitionKey),
-                nameof(ApiSubscription.RowKey)
-            },
+                nameof(ApiSubscription.RowKey),
+                nameof(ApiSubscription.DataSetTitle)
+            ],
             cancellationToken: cancellationToken);
 
         await dataSetSubscribers
@@ -374,11 +375,11 @@ internal class ApiSubscriptionService(
 
         return await apiSubscriptionRepository.QuerySubscriptions(
             filter: filter,
-            select: new List<string>
-            {
+            select:
+            [
                 nameof(ApiSubscription.PartitionKey),
                 nameof(ApiSubscription.RowKey)
-            },
+            ],
             cancellationToken: cancellationToken);
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionTableStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/ApiSubscriptionTableStorageService.cs
@@ -1,9 +1,9 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Configuration;
-using GovUk.Education.ExploreEducationStatistics.Notifier.Repositories.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
 using Microsoft.Extensions.Options;
 
-namespace GovUk.Education.ExploreEducationStatistics.Notifier.Repositories;
+namespace GovUk.Education.ExploreEducationStatistics.Notifier.Services;
 
 internal class ApiSubscriptionTableStorageService(IOptions<AppSettingsOptions> appSettingsOptions)
     : DataTableStorageService(appSettingsOptions.Value.NotifierStorageConnectionString),

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/Interfaces/IApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/Interfaces/IApiSubscriptionService.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Notifier.ViewModels;
 using Microsoft.AspNetCore.Mvc;
-using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
 
@@ -28,7 +27,7 @@ public interface IApiSubscriptionService
 
     Task NotifyApiSubscribers(
         Guid dataSetId,
-        SemVersion version,
+        string version,
         CancellationToken cancellationToken = default);
 
     Task RemoveExpiredApiSubscriptions(CancellationToken cancellationToken = default);

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/Interfaces/IApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/Interfaces/IApiSubscriptionService.cs
@@ -1,6 +1,7 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Notifier.ViewModels;
 using Microsoft.AspNetCore.Mvc;
+using Semver;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,6 +24,11 @@ public interface IApiSubscriptionService
     Task<Either<ActionResult, Unit>> Unsubscribe(
         Guid dataSetId,
         string token,
+        CancellationToken cancellationToken = default);
+
+    Task NotifyApiSubscribers(
+        Guid dataSetId,
+        SemVersion version,
         CancellationToken cancellationToken = default);
 
     Task RemoveExpiredApiSubscriptions(CancellationToken cancellationToken = default);

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/Interfaces/IApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/Interfaces/IApiSubscriptionService.cs
@@ -27,6 +27,7 @@ public interface IApiSubscriptionService
 
     Task NotifyApiSubscribers(
         Guid dataSetId,
+        Guid dataSetFileId,
         string version,
         CancellationToken cancellationToken = default);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/Interfaces/IApiSubscriptionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/Interfaces/IApiSubscriptionService.cs
@@ -1,10 +1,10 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Notifier.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Semver;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/Interfaces/IApiSubscriptionTableStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/Interfaces/IApiSubscriptionTableStorageService.cs
@@ -1,5 +1,5 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 
-namespace GovUk.Education.ExploreEducationStatistics.Notifier.Repositories.Interfaces;
+namespace GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
 
 public interface IApiSubscriptionTableStorageService : IDataTableStorageService;

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/ViewModels/ApiSubscriptionViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/ViewModels/ApiSubscriptionViewModel.cs
@@ -1,6 +1,6 @@
-using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 using System;
 using System.Text.Json.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.ViewModels;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/appsettings.Local.json.example
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/appsettings.Local.json.example
@@ -9,6 +9,7 @@
       "SubscriptionConfirmationId": "change-me",
       "SubscriptionVerificationId": "change-me",
       "ApiSubscriptionConfirmationId": "change-me",
+      "ApiSubscriptionNotificationId": "change-me",
       "ApiSubscriptionVerificationId": "change-me"
     }
   }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/DataSetPublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/DataSetPublishingService.cs
@@ -76,7 +76,7 @@ public class DataSetPublishingService(
             .Select(CreateApiNotificationMessage)
             .ToList();
 
-        if (!messages.Any())
+        if (messages.Count == 0)
         {
             return;
         }
@@ -134,12 +134,12 @@ public class DataSetPublishingService(
         await publicDataDbContext.SaveChangesAsync();
     }
 
-    private ApiNotificationMessage CreateApiNotificationMessage(DataSetVersion version)
+    private static ApiNotificationMessage CreateApiNotificationMessage(DataSetVersion version)
     {
         return new ApiNotificationMessage
         {
             DataSetId = version.DataSetId,
-            Version = version.FullSemanticVersion()
+            Version = version.Version
         };
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/DataSetPublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/DataSetPublishingService.cs
@@ -17,7 +17,7 @@ public class DataSetPublishingService(
     ContentDbContext contentDbContext,
     PublicDataDbContext publicDataDbContext,
     INotifierClient notifierClient
-    ) : IDataSetPublishingService
+) : IDataSetPublishingService
 {
     public async Task PublishDataSets(Guid[] releaseVersionIds)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.sln.DotSettings
+++ b/src/GovUk.Education.ExploreEducationStatistics.sln.DotSettings
@@ -1,13 +1,11 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                        xmlns:s="clr-namespace:System;assembly=mscorlib"
-                        xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml"
-                        xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-    <s:Boolean x:Key="/Default/UserDictionary/Words/=approver/@EntryIndexedValue">True</s:Boolean>
-    <s:Boolean x:Key="/Default/UserDictionary/Words/=approvers/@EntryIndexedValue">True</s:Boolean>
-    <s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
-    <s:Boolean x:Key="/Default/UserDictionary/Words/=lsip/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=nosniff/@EntryIndexedValue">True</s:Boolean>
-    <s:Boolean x:Key="/Default/UserDictionary/Words/=pcon/@EntryIndexedValue">True</s:Boolean>
-    <s:Boolean x:Key="/Default/UserDictionary/Words/=rscr/@EntryIndexedValue">True</s:Boolean>
-    <s:Boolean x:Key="/Default/UserDictionary/Words/=ukprn/@EntryIndexedValue">True</s:Boolean>
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=approver/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=approvers/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=azurite/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=lsip/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=nosniff/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=pcon/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=rscr/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=ukprn/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
+++ b/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
@@ -129,8 +129,8 @@ const dataSetFileService = {
       params,
     });
   },
-  getDataSetFile(dataSetId: string): Promise<DataSetFile> {
-    return contentApi.get(`/data-set-files/${dataSetId}`);
+  getDataSetFile(dataSetFileId: string): Promise<DataSetFile> {
+    return contentApi.get(`/data-set-files/${dataSetFileId}`);
   },
 };
 export default dataSetFileService;


### PR DESCRIPTION
⚠️ The tests in this PR depend on the change to make Azurite available to the Publisher function integration tests made in #5099 

This PR completes the work originally started by @jack-hive to send Public API subscription notifications, building on the work also added by @jack-hive in #5043, #5076 and #5056 which allowed subscribing and unsubscribing to Public API data sets.

In this PR a new queue triggered function `ApiSubscriptionFunctions.NotifySubscribers` is added to Notifier.

### `ApiSubscriptionFunctions.NotifySubscribers` function

The function expects a `ApiNotificationMessage` queue message as input:

```json
{
    "dataSetId" : "00000000-0000-0000-0000-000000000000",
    "dataSetFileId" : "00000000-0000-0000-0000-000000000000",
    "version" : "1.1"
}
```

On receipt of this message it will send email notifications using Gov.uk Notify for all verified subscribers of the data set.

It uses FluentValidation to throw a validation exception if any of `dataSetId`, `dataSetFileId` or `version` in the queue message are empty.

### Notification email template

The email template is personalised with the data set title, version, a link to the data set file details page, and an unsubscribe link.
It expects values for these placeholders to be provided: `data_set_title`, `data_set_url`, `data_set_version`, `unsubscribe_url`.

![image](https://github.com/user-attachments/assets/be0c6cc7-88e2-4847-b129-12e5a6faf26e)

### Rename Notifier functions

I standardised the naming across all of Notifier's Publication and Public API subscription functions. The full list of functions is now:

```
PublicationSubscriptions_RequestPendingSubscription
PublicationSubscriptions_VerifySubscription
PublicationSubscriptions_Unsubscribe
PublicationSubscriptions_NotifySubscribers
PublicationSubscriptions_RemoveExpiredSubscriptions

PublicApiSubscriptions_RequestPendingSubscription
PublicApiSubscriptions_VerifySubscription
PublicApiSubscriptions_Unsubscribe
PublicApiSubscriptions_NotifySubscribers
PublicApiSubscriptions_RemoveExpiredSubscriptions
```

### Changes to Publisher

The publisher functions have been changed to queue a `ApiNotificationMessage` message on publishing of data sets.

### Full list of changes

This is a record of the changes I made to complete this work.

- Moved `IApiSubscriptionTableStorageService`/`ApiSubscriptionTableStorageService` from `Notifier.Repositories` to `Notifier.Services`.
- Moved `Constants.NotifierTableStorageTableName` and `Constants.NotifierQueueStorage` to outer scope.
- Formatted code and organised imports.
- Remove the unused `IOptions<AppSettingsOptions>` parameter from the `ApiSubscriptionRepository` constructor.
- Removed the unused `FunctionContext` parameter from the `NotifySubscribers` function.
- Added the `ApiSubscriptionNotificationId` environment property to `appsettings.Local.json.example` and the infrastructure ARM template.
- Renamed `ApiSubscriptionStatus` `SubscriptionPending` as `Pending`.
- Changed `ApiNotificationMessage` `Version` from type `SemVersion` to `string` to simplify serialisation.
- Added missing `DataSetTitle` to the fields returned in the `NotifySubscribers` table query, required for the email personalisation.
- Corrected the `NotifySubscribers` table query to exclude `Pending` subscribers from being sent notifications.
- Added validation of the `ApiNotificationMessage` to the `NotifySubscribers` function.
- Tidied up all Public API email template variables.
- Included `DataSetFileId` in `ApiNotificationMessage` and fixed the link to the data set file details page in the email.
- Corrected `dataSetId` for `dataSetFileId` in `DataSetFileService.GetDataSetFile` and `dataSetFileService.ts` to avoid ambiguity.
- Standardised function names across all Publication and Public API subscription functions.
- Added `NotifySubscribersTests` function integration tests.
- Made changes to all of the Gov.uk Notify Public API email templates consistent with the changes in this PR.
- Added new Key Vault secret `ees-notifier-templateid-api-subscription-notification` to all Azure environments (EES-5359).