### PR TITLE
EES-4947 - updating version number after saves

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
@@ -16,6 +16,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Public.Data;
@@ -226,7 +227,7 @@ public abstract class DataSetVersionMappingControllerTests(
                                 mapping: DataFixture
                                     .DefaultLocationOptionMapping()
                                     .WithSource(DataFixture.DefaultMappableLocationOption())
-                                    .WithNoMapping())
+                                    .WithAutoNone())
                             .AddMapping(
                                 sourceKey: "source-location-3-key",
                                 mapping: DataFixture
@@ -370,6 +371,242 @@ public abstract class DataSetVersionMappingControllerTests(
             updatedMappings.LocationMappingPlan.Levels.AssertDeepEqualTo(
                 expectedFullMappings,
                 ignoreCollectionOrders: true);
+
+            // Assert that the batch saves still show the location mappings as incomplete, as there
+            // are still mappings with type "None" and "AutoNone" in the plan.
+            Assert.False(updatedMappings.LocationMappingsComplete);
+        }
+
+        [Theory]
+        [InlineData(MappingType.ManualMapped, MappingType.AutoNone, false)]
+        [InlineData(MappingType.ManualMapped, MappingType.AutoMapped, true)]
+        [InlineData(MappingType.ManualMapped, MappingType.ManualMapped, true)]
+        [InlineData(MappingType.ManualMapped, MappingType.ManualNone, true)]
+        [InlineData(MappingType.ManualNone, MappingType.AutoNone, false)]
+        [InlineData(MappingType.ManualNone, MappingType.AutoMapped, true)]
+        [InlineData(MappingType.ManualNone, MappingType.ManualMapped, true)]
+        [InlineData(MappingType.ManualNone, MappingType.ManualNone, true)]
+        public async Task Success_MappingsComplete(
+            MappingType updatedMappingType,
+            MappingType unchangedMappingType,
+            bool expectedMappingsComplete)
+        {
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusPublished();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion currentDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 0)
+                .WithStatusPublished()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            DataSetVersion nextDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 1)
+                .WithStatusDraft()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .DefaultLocationMappingPlan()
+                    .AddLevel(
+                        level: GeographicLevel.LocalAuthority,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "source-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping())
+                            .AddCandidate(
+                                targetKey: "target-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption()))
+                    .AddLevel(
+                        level: GeographicLevel.Country,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "source-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithType(unchangedMappingType)
+                                    .WithCandidateKey(unchangedMappingType switch
+                                    {
+                                        MappingType.ManualMapped or MappingType.AutoMapped => "target-location-1-key",
+                                        _ => null
+                                    }))
+                            .AddCandidate(
+                                targetKey: "target-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())));
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersionMappings.Add(mappings);
+            });
+
+            var client = BuildApp().CreateClient();
+
+            var mappingCandidateKey = updatedMappingType == MappingType.ManualMapped
+                ? "target-location-1-key"
+                : null;
+
+            List<LocationMappingUpdateRequest> updates =
+            [
+                new()
+                {
+                    Level = GeographicLevel.LocalAuthority,
+                    SourceKey = "source-location-1-key",
+                    Type = updatedMappingType,
+                    CandidateKey = mappingCandidateKey
+                }
+            ];
+
+            var response = await ApplyBatchLocationMappingUpdates(
+                nextDataSetVersionId: nextDataSetVersion.Id,
+                updates: updates,
+                client);
+
+            response.AssertOk<BatchLocationMappingUpdatesResponseViewModel>();
+
+            var updatedMappings = TestApp.GetDbContext<PublicDataDbContext>()
+                .DataSetVersionMappings
+                .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
+
+            // Assert that the batch save calculates the LocationMappingsComplete flag as expected given
+            // the combination of the requested mapping update and the existing mapping that is untouched. 
+            Assert.Equal(expectedMappingsComplete, updatedMappings.LocationMappingsComplete);
+        }
+
+        [Theory]
+        [InlineData(MappingType.ManualMapped, MappingType.AutoNone, "2.0")]
+        [InlineData(MappingType.ManualMapped, MappingType.AutoMapped, "1.1")]
+        [InlineData(MappingType.ManualMapped, MappingType.ManualMapped, "1.1")]
+        [InlineData(MappingType.ManualMapped, MappingType.ManualNone, "2.0")]
+        [InlineData(MappingType.ManualNone, MappingType.AutoNone, "2.0")]
+        [InlineData(MappingType.ManualNone, MappingType.AutoMapped, "2.0")]
+        [InlineData(MappingType.ManualNone, MappingType.ManualMapped, "2.0")]
+        [InlineData(MappingType.ManualNone, MappingType.ManualNone, "2.0")]
+        public async Task Success_VersionUpdate(
+            MappingType updatedMappingType,
+            MappingType unchangedMappingType,
+            string expectedVersion)
+        {
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusPublished();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion currentDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 0)
+                .WithStatusPublished()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            DataSetVersion nextDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 1)
+                .WithStatusDraft()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .DefaultLocationMappingPlan()
+                    .AddLevel(
+                        level: GeographicLevel.LocalAuthority,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "source-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping())
+                            .AddCandidate(
+                                targetKey: "target-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption()))
+                    .AddLevel(
+                        level: GeographicLevel.Country,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "source-location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithType(unchangedMappingType)
+                                    .WithCandidateKey(unchangedMappingType switch
+                                    {
+                                        MappingType.ManualMapped or MappingType.AutoMapped => "target-location-1-key",
+                                        _ => null
+                                    }))
+                            .AddCandidate(
+                                targetKey: "target-location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())));
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersionMappings.Add(mappings);
+            });
+
+            var client = BuildApp().CreateClient();
+
+            var mappingCandidateKey = updatedMappingType == MappingType.ManualMapped
+                ? "target-location-1-key"
+                : null;
+
+            List<LocationMappingUpdateRequest> updates =
+            [
+                new()
+                {
+                    Level = GeographicLevel.LocalAuthority,
+                    SourceKey = "source-location-1-key",
+                    Type = updatedMappingType,
+                    CandidateKey = mappingCandidateKey
+                }
+            ];
+
+            var response = await ApplyBatchLocationMappingUpdates(
+                nextDataSetVersionId: nextDataSetVersion.Id,
+                updates: updates,
+                client);
+
+            response.AssertOk<BatchLocationMappingUpdatesResponseViewModel>();
+
+            var updatedMappings = TestApp.GetDbContext<PublicDataDbContext>()
+                .DataSetVersionMappings
+                .Include(m => m.TargetDataSetVersion)
+                .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
+
+            // Assert that the batch save calculates the next data set version correctly. 
+            Assert.Equal(expectedVersion, updatedMappings.TargetDataSetVersion.Version);
         }
 
         [Fact]
@@ -933,7 +1170,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
                 context.DataSets.Update(dataSet);
             });
-            
+
             DataSetVersionMapping mappings = DataFixture
                 .DefaultDataSetVersionMapping()
                 .WithSourceDataSetVersionId(currentDataSetVersion.Id)
@@ -1004,24 +1241,24 @@ public abstract class DataSetVersionMappingControllerTests(
                         FilterKey = "filter-1-key",
                         SourceKey = "filter-1-option-1-key",
                         Mapping = mappings.GetFilterOptionMapping(
-                                filterKey: "filter-1-key", 
+                                filterKey: "filter-1-key",
                                 filterOptionKey: "filter-1-option-1-key") with
-                        {
-                            Type = MappingType.ManualMapped,
-                            CandidateKey = "filter-1-option-1-key"
-                        }
+                            {
+                                Type = MappingType.ManualMapped,
+                                CandidateKey = "filter-1-option-1-key"
+                            }
                     },
                     new FilterOptionMappingUpdateResponseViewModel
                     {
                         FilterKey = "filter-2-key",
                         SourceKey = "filter-2-option-1-key",
                         Mapping = mappings.GetFilterOptionMapping(
-                            filterKey: "filter-2-key", 
-                            filterOptionKey: "filter-2-option-1-key") with
-                        {
-                            Type = MappingType.ManualNone,
-                            CandidateKey = null
-                        }
+                                filterKey: "filter-2-key",
+                                filterOptionKey: "filter-2-option-1-key") with
+                            {
+                                Type = MappingType.ManualNone,
+                                CandidateKey = null
+                            }
                     },
                 ]
             };
@@ -1032,12 +1269,14 @@ public abstract class DataSetVersionMappingControllerTests(
 
             var updatedMappings = TestApp.GetDbContext<PublicDataDbContext>()
                 .DataSetVersionMappings
+                .Include(mapping => mapping.TargetDataSetVersion)
                 .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
 
             var expectedFullMappings = new Dictionary<string, FilterMapping>
             {
                 {
-                    "filter-1-key", mappings.GetFilterMapping("filter-1-key") with 
+                    "filter-1-key",
+                    mappings.GetFilterMapping("filter-1-key") with
                     {
                         OptionMappings = new Dictionary<string, FilterOptionMapping>
                         {
@@ -1057,7 +1296,8 @@ public abstract class DataSetVersionMappingControllerTests(
                     }
                 },
                 {
-                    "filter-2-key", mappings.GetFilterMapping("filter-2-key") with 
+                    "filter-2-key",
+                    mappings.GetFilterMapping("filter-2-key") with
                     {
                         OptionMappings = new Dictionary<string, FilterOptionMapping>
                         {
@@ -1079,6 +1319,347 @@ public abstract class DataSetVersionMappingControllerTests(
             updatedMappings.FilterMappingPlan.Mappings.AssertDeepEqualTo(
                 expectedFullMappings,
                 ignoreCollectionOrders: true);
+
+            // Assert that the batch saves show the filter mappings as complete, as there
+            // are no remaining mappings with type "None" or "AutoNone" in the plan.
+            Assert.True(updatedMappings.FilterMappingsComplete);
+
+            // Assert that this update constitutes a major version update, as some filter options
+            // belonging to mapped filters have a mapping type of "ManualNone", indicating that 
+            // some of the source filter options are no longer available in the target data set
+            // version, thus creating a breaking change. 
+            Assert.Equal("2.0", updatedMappings.TargetDataSetVersion.Version);
+        }
+
+        [Theory]
+        [InlineData(MappingType.ManualMapped, MappingType.AutoNone, false)]
+        [InlineData(MappingType.ManualMapped, MappingType.AutoMapped, true)]
+        [InlineData(MappingType.ManualMapped, MappingType.ManualMapped, true)]
+        [InlineData(MappingType.ManualMapped, MappingType.ManualNone, true)]
+        [InlineData(MappingType.ManualNone, MappingType.AutoNone, false)]
+        [InlineData(MappingType.ManualNone, MappingType.AutoMapped, true)]
+        [InlineData(MappingType.ManualNone, MappingType.ManualMapped, true)]
+        [InlineData(MappingType.ManualNone, MappingType.ManualNone, true)]
+        public async Task Success_MappingsComplete(
+            MappingType updatedMappingType,
+            MappingType unchangedMappingType,
+            bool expectedMappingsComplete)
+        {
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusPublished();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion currentDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 0)
+                .WithStatusPublished()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            DataSetVersion nextDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 1)
+                .WithStatusDraft()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoMapped("filter-1-key")
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping()))
+                    .AddFilterMapping("filter-2-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoMapped("filter-2-key")
+                        .AddOptionMapping("filter-2-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithType(unchangedMappingType)
+                            .WithCandidateKey(unchangedMappingType switch
+                            {
+                                MappingType.ManualMapped or MappingType.AutoMapped => "filter-2-option-1-key",
+                                _ => null
+                            })))
+                    // Add an unmappable filter and filter options. Because we don't currently allow the 
+                    // users to update mappings for filters, this should not count against the calculation
+                    // of the FilterMappingsComplete flag.
+                    .AddFilterMapping("filter-3-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoNone()
+                        .AddOptionMapping("filter-3-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithAutoNone()))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption()))
+                    .AddFilterCandidate("filter-2-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-2-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())));
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersionMappings.Add(mappings);
+            });
+
+            var client = BuildApp().CreateClient();
+
+            var mappingCandidateKey = updatedMappingType == MappingType.ManualMapped
+                ? "filter-1-option-1-key"
+                : null;
+
+            List<FilterOptionMappingUpdateRequest> updates =
+            [
+                new()
+                {
+                    FilterKey = "filter-1-key",
+                    SourceKey = "filter-1-option-1-key",
+                    Type = updatedMappingType,
+                    CandidateKey = mappingCandidateKey
+                }
+            ];
+
+            var response = await ApplyBatchFilterOptionMappingUpdates(
+                nextDataSetVersionId: nextDataSetVersion.Id,
+                updates: updates,
+                client);
+
+            response.AssertOk<BatchFilterOptionMappingUpdatesResponseViewModel>();
+
+            var updatedMappings = TestApp.GetDbContext<PublicDataDbContext>()
+                .DataSetVersionMappings
+                .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
+
+            // Assert that the batch save calculates the LocationMappingsComplete flag as expected given the
+            // combination of the requested mapping update and the existing mapping that is untouched. 
+            Assert.Equal(expectedMappingsComplete, updatedMappings.FilterMappingsComplete);
+        }
+
+        [Theory]
+        [InlineData(MappingType.ManualMapped, MappingType.AutoMapped, "1.1")]
+        [InlineData(MappingType.ManualMapped, MappingType.AutoNone, "2.0")]
+        [InlineData(MappingType.ManualMapped, MappingType.ManualMapped, "1.1")]
+        [InlineData(MappingType.ManualMapped, MappingType.ManualNone, "2.0")]
+        [InlineData(MappingType.ManualNone, MappingType.AutoMapped, "2.0")]
+        [InlineData(MappingType.ManualNone, MappingType.AutoNone, "2.0")]
+        [InlineData(MappingType.ManualNone, MappingType.ManualMapped, "2.0")]
+        [InlineData(MappingType.ManualNone, MappingType.ManualNone, "2.0")]
+        public async Task Success_VersionUpdate(
+            MappingType updatedMappingType,
+            MappingType unchangedMappingType,
+            string expectedVersion)
+        {
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusPublished();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion currentDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 0)
+                .WithStatusPublished()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            DataSetVersion nextDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 1)
+                .WithStatusDraft()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoMapped("filter-1-key")
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping()))
+                    .AddFilterMapping("filter-2-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoMapped("filter-2-key")
+                        .AddOptionMapping("filter-2-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithType(unchangedMappingType)
+                            .WithCandidateKey(unchangedMappingType switch
+                            {
+                                MappingType.ManualMapped or MappingType.AutoMapped => "filter-2-option-1-key",
+                                _ => null
+                            })))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption()))
+                    .AddFilterCandidate("filter-2-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-2-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())));
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersionMappings.Add(mappings);
+            });
+
+            var client = BuildApp().CreateClient();
+
+            var mappingCandidateKey = updatedMappingType == MappingType.ManualMapped
+                ? "filter-1-option-1-key"
+                : null;
+
+            List<FilterOptionMappingUpdateRequest> updates =
+            [
+                new()
+                {
+                    FilterKey = "filter-1-key",
+                    SourceKey = "filter-1-option-1-key",
+                    Type = updatedMappingType,
+                    CandidateKey = mappingCandidateKey
+                }
+            ];
+
+            var response = await ApplyBatchFilterOptionMappingUpdates(
+                nextDataSetVersionId: nextDataSetVersion.Id,
+                updates: updates,
+                client);
+
+            response.AssertOk<BatchFilterOptionMappingUpdatesResponseViewModel>();
+
+            var updatedMappings = TestApp.GetDbContext<PublicDataDbContext>()
+                .DataSetVersionMappings
+                .Include(m => m.TargetDataSetVersion)
+                .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
+
+            // Assert that the batch save calculates the next version number as expected. 
+            Assert.Equal(expectedVersion, updatedMappings.TargetDataSetVersion.Version);
+        }
+
+        [Theory]
+        [InlineData(MappingType.ManualMapped)]
+        [InlineData(MappingType.ManualNone)]
+        public async Task Success_VersionUpdates_UnmappableFilter(MappingType updatedMappingType)
+        {
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusPublished();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion currentDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 0)
+                .WithStatusPublished()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            DataSetVersion nextDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 1)
+                .WithStatusDraft()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            DataSetVersionMapping mappings = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(currentDataSetVersion.Id)
+                .WithTargetDataSetVersionId(nextDataSetVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoMapped("filter-1-key")
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping()))
+                    // Add an unmappable filter and filter options. Unlike the calculation of the
+                    // "FilterMappingsComplete" flag, this counts towards the version number having
+                    // to be a major update, as a filter from the source data set version no longer
+                    // appears in the next version.
+                    .AddFilterMapping("filter-3-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithAutoNone()
+                        .AddOptionMapping("filter-3-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithAutoNone()))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption()))
+                    .AddFilterCandidate("filter-2-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-2-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())));
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersionMappings.Add(mappings);
+            });
+
+            var client = BuildApp().CreateClient();
+
+            var mappingCandidateKey = updatedMappingType == MappingType.ManualMapped
+                ? "filter-1-option-1-key"
+                : null;
+
+            List<FilterOptionMappingUpdateRequest> updates =
+            [
+                new()
+                {
+                    FilterKey = "filter-1-key",
+                    SourceKey = "filter-1-option-1-key",
+                    Type = updatedMappingType,
+                    CandidateKey = mappingCandidateKey
+                }
+            ];
+
+            var response = await ApplyBatchFilterOptionMappingUpdates(
+                nextDataSetVersionId: nextDataSetVersion.Id,
+                updates: updates,
+                client);
+
+            response.AssertOk<BatchFilterOptionMappingUpdatesResponseViewModel>();
+
+            var updatedMappings = TestApp.GetDbContext<PublicDataDbContext>()
+                .DataSetVersionMappings
+                .Include(m => m.TargetDataSetVersion)
+                .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
+
+            // Assert that the batch save calculates the next version number as a major change,
+            // as filter options that were in the source data set version no longer appear in the
+            // next version. 
+            Assert.Equal("2.0", updatedMappings.TargetDataSetVersion.Version);
         }
 
         [Fact]
@@ -1109,7 +1690,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
                 context.DataSets.Update(dataSet);
             });
-            
+
             DataSetVersionMapping mappings = DataFixture
                 .DefaultDataSetVersionMapping()
                 .WithSourceDataSetVersionId(currentDataSetVersion.Id)
@@ -1347,7 +1928,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
                 context.DataSets.Update(dataSet);
             });
-            
+
             DataSetVersionMapping mappings = DataFixture
                 .DefaultDataSetVersionMapping()
                 .WithSourceDataSetVersionId(currentDataSetVersion.Id)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
@@ -207,13 +207,13 @@ public abstract class DataSetVersionMappingControllerTests(
                                 mapping: DataFixture
                                     .DefaultLocationOptionMapping()
                                     .WithSource(DataFixture.DefaultMappableLocationOption())
-                                    .WithNoMapping())
+                                    .WithAutoNone())
                             .AddMapping(
                                 sourceKey: "source-location-2-key",
                                 mapping: DataFixture
                                     .DefaultLocationOptionMapping()
                                     .WithSource(DataFixture.DefaultMappableLocationOption())
-                                    .WithNoMapping()
+                                    .WithAutoNone()
                             )
                             .AddCandidate(
                                 targetKey: "target-location-1-key",
@@ -373,7 +373,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 ignoreCollectionOrders: true);
 
             // Assert that the batch saves still show the location mappings as incomplete, as there
-            // are still mappings with type "None" and "AutoNone" in the plan.
+            // are still mappings with type "AutoNone" in the plan.
             Assert.False(updatedMappings.LocationMappingsComplete);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/JsonDtos.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/JsonDtos.cs
@@ -5,7 +5,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model;
 
 /// <summary>
 /// Used as a DTO by <see cref="PostgreSqlRepository" /> to extract arbitrary JSON fragments from JSONB columns.
-/// In order to use this in a DbContext, to must be registered as a DTO by adding the following configuration to
+/// In order to use this in a DbContext, it must be registered as a DTO by adding the following configuration to
 /// the OnModelBuilding() method of the DbContext:
 /// <code>
 /// modelBuilder.Entity&lt;JsonFragment&gt;().HasNoKey().ToView(null);
@@ -15,10 +15,30 @@ public record JsonFragment(string? JsonValue);
 
 /// <summary>
 /// Used as a DTO by <see cref="PostgreSqlRepository" /> to extract boolean results from JSONB queries.
-/// In order to use this in a DbContext, to must be registered as a DTO by adding the following configuration to
+/// In order to use this in a DbContext, it must be registered as a DTO by adding the following configuration to
 /// the OnModelBuilding() method of the DbContext:
 /// <code>
 /// modelBuilder.Entity&lt;JsonBool&gt;().HasNoKey().ToView(null);
 /// </code>
 /// </summary>
 public record JsonBool(bool BoolValue);
+
+/// <summary>
+/// Used as a DTO by <see cref="PostgreSqlRepository" /> to extract int results from JSONB queries.
+/// In order to use this in a DbContext, it must be registered as a DTO by adding the following configuration to
+/// the OnModelBuilding() method of the DbContext:
+/// <code>
+/// modelBuilder.Entity&lt;JsonInt&gt;().HasNoKey().ToView(null);
+/// </code>
+/// </summary>
+public record JsonInt(int IntValue);
+
+/// <summary>
+/// Used as a DTO by <see cref="PostgreSqlRepository" /> to extract string results from JSONB queries.
+/// In order to use this in a DbContext, it must be registered as a DTO by adding the following configuration to
+/// the OnModelBuilding() method of the DbContext:
+/// <code>
+/// modelBuilder.Entity&lt;JsonString&gt;().HasNoKey().ToView(null);
+/// </code>
+/// </summary>
+public record JsonString(string StringValue);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/FilterMappingPlanGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/FilterMappingPlanGeneratorExtensions.cs
@@ -332,7 +332,7 @@ public static class FilterMappingPlanGeneratorExtensions
 
     public static Generator<FilterOptionMapping> WithCandidateKey(
         this Generator<FilterOptionMapping> generator,
-        string candidateKey)
+        string? candidateKey)
         => generator.ForInstance(s => s.SetCandidateKey(candidateKey));
 
     public static InstanceSetters<FilterOptionMapping> SetDefaults(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/LocationMappingPlanGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/LocationMappingPlanGeneratorExtensions.cs
@@ -225,7 +225,7 @@ public static class LocationMappingPlanGeneratorExtensions
 
     public static Generator<LocationOptionMapping> WithCandidateKey(
         this Generator<LocationOptionMapping> generator,
-        string candidateKey)
+        string? candidateKey)
         => generator.ForInstance(s => s.SetCandidateKey(candidateKey));
 
     public static InstanceSetters<LocationOptionMapping> SetDefaults(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Database/PublicDataDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Database/PublicDataDbContext.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Dtos;
 using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
@@ -36,6 +37,8 @@ public class PublicDataDbContext : DbContext
         // They are mapped here to inform EF that they are not entities.
         modelBuilder.Entity<JsonFragment>().HasNoKey().ToView(null);
         modelBuilder.Entity<JsonBool>().HasNoKey().ToView(null);
+        modelBuilder.Entity<JsonString>().HasNoKey().ToView(null);
+        modelBuilder.Entity<FilterAndOptionMappingTypeDto>().HasNoKey().ToView(null);
     }
 
     [SuppressMessage("Security", "EF1002:Risk of vulnerability to SQL injection.")]
@@ -73,8 +76,4 @@ public class PublicDataDbContext : DbContext
     public DbSet<LocationOptionMetaChange> LocationOptionMetaChanges { get; init; } = null!;
     public DbSet<TimePeriodMetaChange> TimePeriodMetaChanges { get; init; } = null!;
     public DbSet<PreviewToken> PreviewTokens { get; init; } = null!;
-
-    public DbSet<JsonFragment> JsonFragments { get; init; } = null!;
-    
-    public DbSet<JsonBool> JsonBool { get; init; } = null!;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Dtos/FilterAndOptionMappingTypeDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Dtos/FilterAndOptionMappingTypeDto.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Dtos;
+
+public record FilterAndOptionMappingTypeDto(MappingType FilterMappingType, MappingType OptionMappingType);
+
+internal class Config : IEntityTypeConfiguration<FilterAndOptionMappingTypeDto>
+{
+    public void Configure(EntityTypeBuilder<FilterAndOptionMappingTypeDto> builder)
+    {
+        builder.Property(dto => dto.FilterMappingType)
+            .IsRequired()
+            .HasColumnType("text")
+            .HasConversion(new EnumToStringConverter<MappingType>());
+
+        builder.Property(dto => dto.OptionMappingType)
+            .IsRequired()
+            .HasColumnType("text")
+            .HasConversion(new EnumToStringConverter<MappingType>());
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/PublicDataDbContextModelSnapshot.cs
@@ -45,6 +45,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                     b.ToView(null, (string)null);
                 });
 
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Common.Model.JsonString", b =>
+                {
+                    b.Property<string>("StringValue")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.ToTable((string)null);
+
+                    b.ToView(null, (string)null);
+                });
+
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DataSet", b =>
                 {
                     b.Property<Guid>("Id")
@@ -233,6 +244,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                         .HasDatabaseName("IX_DataSetVersionMappings_TargetDataSetVersionId");
 
                     b.ToTable("DataSetVersionMappings");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Dtos.FilterAndOptionMappingTypeDto", b =>
+                {
+                    b.Property<string>("FilterMappingType")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("OptionMappingType")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.ToTable((string)null);
+
+                    b.ToView(null, (string)null);
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Public.Data.Model.FilterMeta", b =>


### PR DESCRIPTION
# Overview

This PR:
- adds in code to more intelligently guess the next version number of the next data set version after auto-mapping has completed.
- adds in code to update the "LocationMappingsComplete" and "FilterMappingsComplete" columns after autosaves complete.
- adds in code to update the guessed version number of the next data set version after autosaves complete.

The main idea behind this PR is that we update the expected version number of the next data set version whenever we can, so we can always see what the next version number should be based upon the mapping work undertaken so far.

The other secondary part of this PR ensures that our "MappingsComplete" flags are always up-to-date after autosaves have completed. 

## Creating a better initial version number for the next data set version

When we very first create the skeleton entry for the next DataSetVersion, we allocate it a minor version number update from its predecessor, as we must give it something and it must be unique.

After auto-mappings have completed however, we already can have a really good idea as to whether this should be a minor or major update.  If for instance an entire geographic level has been removed from the next data set version or an entire filter has been removed, or if the number of locations or filters / filter options are less than the original data set version, we can be assured that the next data set version's version number jump will be a major one.

This PR therefore accommodates this and allocates a realistic version number as early as possible.

## Updating the "MappingsComplete" flags after autosave

This wasn't strictly part of this ticket to do, but it has to be done somewhere and it was somewhat related code-wise with the changes being made for calculating version numbers.

After autosaves complete, we're able to determine if the mappings for a given facet are complete based upon the distinct MappingTypes present within the various mappings of that facet.  "LocationMappingsComplete" can be determined for instance by finding all of the distinct MappingTypes across all of the geographic levels, and seeing if any exist that are "AutoNone".

Similarly, "FilterMappingsComplete" can be determined for instance by finding all of the distinct filter option MappingTypes across all of the filters, and seeing if any exist that are "AutoNone".  The important distinction here as opposed to locations however is that if a filter itself has not been successfully auto-mapped, we exclude its filter options from this calculation, because for MVP we have no way to resolve unmapped filters and so we would otherwise end up in a situation where people couldn't complete their filter mappings.  This is why we need to store filter and option mapping type combinations, and hence why we need to register a DTO specifically for the purpose of pulling these mapping type pairs out of the JSONB query results.

## Updating the projected version number after autosave

To calculate the most likely next version number after an autosave occurs, we need to detect any breaking changes and, if any exist, we make it a major update as opposed to a minor one.

To do this, we take the same information about distinct Mapping Types as we used for updating the "MappingsComplete" flags and use it to determine if there are any mapping types that constitute a breaking change.  In other words, we look to see if there are any mappings with type "AutoNone" or "ManualNone", as they indicate that thus far, there is at least one source element that has not successfully been mapped to a candidate.  If we find any, this constitutes a major version update and so we set that on the next data set version.  Otherwise we set a minor version update on it.
