### PR TITLE
EES-5365 Update to `DuckDB.NET.Data.Full` 1.0.2

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="AspectInjector" Version="2.8.2" />
         <PackageReference Include="Azure.Identity" Version="1.11.3" />
         <PackageReference Include="Dapper" Version="2.1.35" />
-        <PackageReference Include="DuckDB.NET.Data.Full" Version="0.10.2" />
+        <PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.2" />
         <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0" />
         <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.0.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DuckDB.NET.Data.Full" Version="0.10.2" />
+        <PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.2" />
         <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0" />
         <PackageReference Include="linq2db.EntityFrameworkCore" Version="8.1.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="Azure.Identity" Version="1.11.3" />
-        <PackageReference Include="DuckDB.NET.Data.Full" Version="0.10.2" />
+        <PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.2" />
         <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/LocationsDuckDbRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/LocationsDuckDbRepository.cs
@@ -45,11 +45,11 @@ public class LocationsDuckDbRepository(PublicDataDbContext publicDataDbContext) 
         {
             using var appender = duckDbConnection.CreateAppender(table: LocationOptionsTable.TableName);
 
-            var insertRow = appender.CreateRow();
-
             foreach (var link in location.OptionLinks.OrderBy(l => l.Option.Label))
             {
                 var option = link.Option;
+
+                var insertRow = appender.CreateRow();
 
                 insertRow.AppendValue(id++);
                 insertRow.AppendValue(option.Label);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
@@ -948,11 +948,11 @@ public class SeedDataCommand : ICommand
             {
                 using var appender = _duckDbConnection.CreateAppender(table: LocationOptionsTable.TableName);
 
-                var insertRow = appender.CreateRow();
-
                 foreach (var link in location.OptionLinks.OrderBy(l => l.Option.Label))
                 {
                     var option = link.Option;
+
+                    var insertRow = appender.CreateRow();
 
                     insertRow.AppendValue(id++);
                     insertRow.AppendValue(option.Label);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts.csproj
@@ -19,7 +19,7 @@
       <PackageReference Include="CliFx" Version="2.3.5" />
       <PackageReference Include="CliWrap" Version="3.6.6" />
       <PackageReference Include="Dapper" Version="2.1.35" />
-      <PackageReference Include="DuckDB.NET.Data.Full" Version="0.10.2" />
+      <PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.2" />
       <PackageReference Include="linq2db.EntityFrameworkCore" Version="8.1.0" />
       <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>


### PR DESCRIPTION
This PR updates projects related to the Public API to use `DuckDB.NET.Data.Full` 1.0.2.

It fixes the incorrect placement of `CreateRow` in methods `LocationsDuckDbRepository.CreateLocationsTable` and `SeedDataCommand.Seeder.CreateParquetLocationMetaTable` which was causing an error when upgrading between 0.10.2 and 1.0.0.

> System.IndexOutOfRangeException : The table location_options has 9 columns but you are trying to append value for column 10