### PR TITLE
EES-5366 Updating Swashbuckle.AspNetCore

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.4" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Thinktecture.EntityFrameworkCore.SqlServer" Version="8.1.1" />
     <PackageReference Include="Cronos" Version="0.8.4" />
     <PackageReference Include="Microsoft.Identity.Web" Version="2.18.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.4" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.4" />
         <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.4" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Thinktecture.EntityFrameworkCore.SqlServer" Version="8.1.1" />
   </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/RequiredPropertySchemaFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/RequiredPropertySchemaFilterTests.cs
@@ -15,6 +15,7 @@ public class RequiredPropertySchemaFilterTests
         {
             UseAllOfToExtendReferenceSchemas = true,
             SchemaFilters = [new RequiredPropertySchemaFilter()],
+            SupportNonNullableReferenceTypes = true
         },
         new JsonSerializerDataContractResolver(new JsonSerializerOptions
         {
@@ -45,12 +46,22 @@ public class RequiredPropertySchemaFilterTests
     }
 
     [Fact]
-    public void RequiredNonNullableReferenceTypeMarkedAsRequired()
+    public void RequiredReferenceTypePropertiesMarkedAsRequired()
     {
         var schema = GenerateSchema<TestClassReferenceTypes>();
 
-        Assert.Single(schema.Required);
+        Assert.Equal(2, schema.Required.Count);
         Assert.Contains(nameof(TestClassReferenceTypes.RequiredNonNullable).ToLowerFirst(), schema.Required);
+        Assert.Contains(nameof(TestClassReferenceTypes.RequiredNullable).ToLowerFirst(), schema.Required);
+    }
+
+    [Fact]
+    public void RequiredNullableReferenceTypeMarkedAsNullable()
+    {
+        var schema = GenerateSchema<TestClassReferenceTypes>();
+
+        Assert.True(schema.Properties[nameof(TestClassReferenceTypes.RequiredNullable).ToLowerFirst()].Nullable);
+        Assert.False(schema.Properties[nameof(TestClassReferenceTypes.RequiredNonNullable).ToLowerFirst()].Nullable);
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -39,8 +39,8 @@
         <PackageReference Include="MiniProfiler.EntityFrameworkCore" Version="4.3.8" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
         <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR updates `Swashbuckle.AspNetCore` from `6.5.0 --> 6.6.2`.

Prior to this, there was a bug whereby a `required` but `nullable` property (both for reference and non-reference types) was being flagged as non-nullable by swashbuckle. Issue described here https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2877

A fix for this was made here https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/2879
