### PR TITLE
EES-5362 Add admin endpoint for data set version changelog

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1748,6 +1748,7 @@
         "ReleaseApproval:PublishReleaseContentCronSchedule": "[parameters('publishReleaseContentCronSchedule')]",
         "TableBuilder:MaxTableCellsAllowed": "[parameters('tableBuilderMaxTableCellsAllowed')]",
         "PublicDataDbExists": "[parameters('publicDataDbExists')]",
+        "PublicDataApi:Url": "[concat('https://', parameters('publicApiUrl'))]",
         "PublicDataProcessor:Url": "[concat('https://', variables('publicDataProcessorName'), '.azurewebsites.net')]",
         "PublicDataProcessor:AppRegistrationClientId": "[parameters('publicDataProcessorAppRegistrationClientId')]"
       }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/appsettings.IntegrationTest.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/appsettings.IntegrationTest.json
@@ -38,5 +38,8 @@
   "PublicDataProcessor": {
     "Url": "http://localhost:7074"
   },
+  "PublicDataApi": {
+    "Url": "http://localhost:5050"
+  },
   "PublicDataDbExists": true
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -41,5 +42,26 @@ public class DataSetVersionsController(IDataSetVersionService dataSetVersionServ
                 dataSetVersionId: dataSetVersionId,
                 cancellationToken: cancellationToken)
             .HandleFailuresOrNoContent(convertNotFoundToNoContent: false);
+    }
+
+    [HttpGet("{dataSetVersionId:guid}/changes")]
+    [Produces("application/json")]
+    public async Task<ActionResult> GetVersionChanges(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken)
+    {
+        // We use a streaming approach as we don't have to share the public API view models
+        // with the admin. This means we can avoid inefficiently re-serializing a second JSON
+        // response and don't need to load the original response into memory.
+        return await dataSetVersionService
+            .GetVersionChanges(
+                dataSetVersionId: dataSetVersionId,
+                cancellationToken: cancellationToken)
+            .OnSuccessVoid(async response =>
+            {
+                Response.ContentType = response.Content.Headers.ContentType?.ToString();
+                await response.Content.CopyToAsync(Response.BodyWriter.AsStream(), cancellationToken);
+            })
+            .HandleFailuresOrNoOp();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
@@ -30,5 +31,9 @@ public interface IDataSetVersionService
     Task<Either<ActionResult, DataSetVersionSummaryViewModel>> CreateNextVersion(
         Guid releaseFileId,
         Guid dataSetId,
+        CancellationToken cancellationToken = default);
+
+    Task<Either<ActionResult, HttpResponseMessage>> GetVersionChanges(
+        Guid dataSetVersionId,
         CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPublicDataApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPublicDataApiClient.cs
@@ -1,0 +1,17 @@
+#nullable enable
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
+
+public interface IPublicDataApiClient
+{
+    Task<Either<ActionResult, HttpResponseMessage>> GetDataSetVersionChanges(
+        Guid dataSetId,
+        string dataSetVersion,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient.cs
@@ -1,0 +1,72 @@
+#nullable enable
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
+
+public class PublicDataApiClient(
+    ILogger<PublicDataApiClient> logger,
+    HttpClient httpClient)
+    : IPublicDataApiClient
+{
+    public async Task<Either<ActionResult, HttpResponseMessage>> GetDataSetVersionChanges(
+        Guid dataSetId,
+        string dataSetVersion,
+        CancellationToken cancellationToken = default)
+    {
+        return await SendRequest(
+            () => httpClient.GetAsync(
+                $"api/v1/data-sets/{dataSetId}/versions/{dataSetVersion}/changes",
+                cancellationToken
+            ),
+            cancellationToken
+        );
+    }
+
+    private async Task<Either<ActionResult, HttpResponseMessage>> SendRequest(
+        Func<Task<HttpResponseMessage>> requestFunction,
+        CancellationToken cancellationToken)
+    {
+        var response = await requestFunction();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.BadRequest:
+                    return new BadRequestObjectResult(
+                        await response.Content.ReadFromJsonAsync<ValidationProblemViewModel>(cancellationToken)
+                    );
+                default:
+                    var body = await response.Content.ReadAsStringAsync(cancellationToken);
+                    var request = response.RequestMessage!;
+
+                    logger.LogError(
+                        """
+                        Request {Method} {AbsolutePath} failed with status code {StatusCode}.
+
+                        Body: {Body}
+                        """,
+                        request.Method,
+                        request.RequestUri!.AbsolutePath,
+                        response.StatusCode,
+                        body
+                    );
+
+                    response.EnsureSuccessStatusCode();
+                    break;
+            }
+        }
+
+        return response;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Settings/PublicDataApiOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Settings/PublicDataApiOptions.cs
@@ -1,0 +1,9 @@
+#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Settings;
+
+public class PublicDataApiOptions
+{
+    public const string Section = "PublicDataApi";
+
+    public string Url { get; init; } = string.Empty;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Settings/PublicDataProcessorOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Settings/PublicDataProcessorOptions.cs
@@ -5,7 +5,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Settings;
 
 internal class PublicDataProcessorOptions
 {
-    public static readonly string Section = "PublicDataProcessor";
+    public const string Section = "PublicDataProcessor";
 
     public string Url { get; init; } = string.Empty;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -77,6 +77,7 @@ using Notify.Interfaces;
 using Semver;
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Thinktecture;
@@ -352,6 +353,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
 
             services.Configure<PublicDataProcessorOptions>(
                 configuration.GetRequiredSection(PublicDataProcessorOptions.Section));
+            services.Configure<PublicDataApiOptions>(
+                configuration.GetRequiredSection(PublicDataApiOptions.Section));
             services.Configure<PreReleaseOptions>(configuration);
             services.Configure<LocationsOptions>(configuration.GetRequiredSection(LocationsOptions.Locations));
             services.Configure<ReleaseApprovalOptions>(
@@ -457,6 +460,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                 services.AddHttpClient<IProcessorClient, ProcessorClient>((provider, httpClient) =>
                 {
                     var options = provider.GetRequiredService<IOptions<PublicDataProcessorOptions>>();
+                    httpClient.BaseAddress = new Uri(options.Value.Url);
+                    httpClient.DefaultRequestHeaders.Add(HeaderNames.UserAgent, "EES Admin");
+                });
+
+                services.AddHttpClient<IPublicDataApiClient, PublicDataApiClient>((provider, httpClient) =>
+                {
+                    var options = provider.GetRequiredService<IOptions<PublicDataApiOptions>>();
                     httpClient.BaseAddress = new Uri(options.Value.Url);
                     httpClient.DefaultRequestHeaders.Add(HeaderNames.UserAgent, "EES Admin");
                 });
@@ -828,6 +838,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
         {
             return Task.FromResult(new Either<ActionResult, Unit>(Unit.Instance));
         }
+
+        public Task<Either<ActionResult, HttpResponseMessage>> GetVersionChanges(
+            Guid dataSetVersionId,
+            CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
     }
 
     internal class NoOpDataSetVersionMappingService : IDataSetVersionMappingService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -40,6 +40,9 @@
     "PublishReleaseContentCronSchedule": "0 1-59/2 * * * *"
   },
   "PublicDataDbExists": false,
+  "PublicDataApi": {
+    "Url": "http://localhost:5050"
+  },
   "PublicDataProcessor": {
     "Url": "http://localhost:7074"
   }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandlerTests.cs
@@ -2,6 +2,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using Microsoft.AspNetCore.Http;
 using static GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlerContextFactory;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Security.AuthorizationHandlers;
@@ -49,6 +50,12 @@ public class ViewDataSetVersionAuthorizationHandlerTests
 
     private static ViewDataSetVersionAuthorizationHandler BuildHandler()
     {
-        return new ViewDataSetVersionAuthorizationHandler();
+        // TODO: EES-5374 - Remove when authentication is added for admin API
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        return new ViewDataSetVersionAuthorizationHandler(httpContextAccessor);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/ContentApiOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/ContentApiOptions.cs
@@ -2,7 +2,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 
 public class ContentApiOptions
 {
-    public static readonly string Section = "ContentApi";
+    public const string Section = "ContentApi";
 
     public string Url { get; init; } = string.Empty;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/MiniProfilerOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/MiniProfilerOptions.cs
@@ -2,7 +2,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 
 public class MiniProfilerOptions
 {
-    public static readonly string Section = "MiniProfiler";
+    public const string Section = "MiniProfiler";
 
     public bool Enabled { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandler.cs
@@ -5,7 +5,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Au
 
 public class ViewDataSetVersionRequirement : IAuthorizationRequirement;
 
-public class ViewDataSetVersionAuthorizationHandler 
+public class ViewDataSetVersionAuthorizationHandler(
+    IHttpContextAccessor httpContextAccessor)
     : AuthorizationHandler<ViewDataSetVersionRequirement, DataSetVersion>
 {
     protected override Task HandleRequirementAsync(
@@ -13,6 +14,13 @@ public class ViewDataSetVersionAuthorizationHandler
         ViewDataSetVersionRequirement requirement,
         DataSetVersion dataSetVersion)
     {
+        // TODO: EES-5374 - Temporary workaround until authentication is added for admin API
+        if (httpContextAccessor.HttpContext?.Request.Headers.UserAgent.Contains("EES Admin") == true)
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
         if (dataSetVersion.Status is DataSetVersionStatus.Published
             or DataSetVersionStatus.Deprecated
             or DataSetVersionStatus.Withdrawn)


### PR DESCRIPTION
## :warning: Depends on #5104

This PR adds the admin endpoint for fetching a data set version's changelog.

The endpoint is accessed via: `GET /api/public-data/data-set-versions/{dataSetVersionId}/changes`

We have implemented this by proxying requests to the public API's changelog endpoint via the admin. We have implemented it like this to avoid sharing view models and other code between the public API and the admin (keeping separation of concerns). Additionally, we can optimise by streaming the public API's response directly to the client rather than re-serialising into a second JSON response.

**Note** - This endpoint will not be fully functional until authentication is added to the public API to allow the admin API to fetch changelogs for draft data set versions. This should be implemented in [EES-5374](https://dfedigital.atlassian.net/browse/EES-5374). 

In the meantime, the endpoint should return a 500 response for any draft data set versions as the public API will respond to the admin client with a 403.