### PR TITLE
EES-4952 - Changelog: Save user inputted Changelog notes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
@@ -11,12 +11,16 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Fixture;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
@@ -25,7 +29,14 @@ using LinqToDB;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Moq;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationMessages;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Public.Data;
 
@@ -477,6 +488,210 @@ public abstract class DataSetVersionsControllerTests(
         private record MockedChanges
         {
             public List<string> Changes { get; init; } = [];
+        }
+    }
+
+    public class UpdateVersionTests(
+        TestApplicationFactory testApp) : DataSetVersionsControllerTests(testApp)
+    {
+        [Theory]
+        [InlineData(DataSetVersionStatus.Failed)]
+        [InlineData(DataSetVersionStatus.Mapping)]
+        [InlineData(DataSetVersionStatus.Draft)]
+        [InlineData(DataSetVersionStatus.Cancelled)]
+        public async Task Success(DataSetVersionStatus dataSetVersionStatus)
+        {
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile(FileType.Data));
+
+            await TestApp.AddTestData<ContentDbContext>(context =>
+            {
+                context.ReleaseFiles.Add(releaseFile);
+            });
+
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusDraft();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion currentDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 0)
+                .WithStatusPublished()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            DataSetVersion nextDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 1)
+                .WithStatus(dataSetVersionStatus)
+                .WithDataSet(dataSet)
+                .WithReleaseFileId(releaseFile.Id)
+                .WithNotes("initial notes.")
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var updateRequest = new DataSetVersionUpdateRequest
+            {
+                DataSetVersionId = nextDataSetVersion.Id,
+                Notes = "updated notes."
+            };
+
+            var response = await UpdateVersion(updateRequest);
+
+            var viewModel = response.AssertOk<DataSetDraftVersionViewModel>();
+
+            Assert.NotNull(viewModel);
+            Assert.Equal(nextDataSetVersion.Id, viewModel.Id);
+            Assert.Equal(nextDataSetVersion.Version, viewModel.Version);
+            Assert.Equal(nextDataSetVersion.Status, viewModel.Status);
+            Assert.Equal(nextDataSetVersion.VersionType, viewModel.Type);
+            Assert.Equal(releaseFile.File.DataSetFileId!.Value, viewModel.File.Id);
+            Assert.Equal(releaseFile.Name, viewModel.File.Title);
+            Assert.Equal(releaseFile.ReleaseVersion.Id, viewModel.ReleaseVersion.Id);
+            Assert.Equal(releaseFile.ReleaseVersion.Title, viewModel.ReleaseVersion.Title);
+            Assert.Equal(nextDataSetVersion.TotalResults, viewModel.TotalResults);
+            Assert.Equal("updated notes.", viewModel.Notes);
+            Assert.Equal(
+                nextDataSetVersion.MetaSummary!.GeographicLevels.Select(l => l.GetEnumLabel()),
+                viewModel.GeographicLevels);
+            Assert.Equal(
+                TimePeriodRangeViewModel.Create(nextDataSetVersion.MetaSummary!.TimePeriodRange),
+                viewModel.TimePeriods);
+            Assert.Equal(
+                nextDataSetVersion.MetaSummary!.Filters,
+                viewModel.Filters);
+            Assert.Equal(
+                nextDataSetVersion.MetaSummary!.Indicators,
+                viewModel.Indicators);
+        }
+
+        [Fact]
+        public async Task NotBauUser_Returns403()
+        {
+            var client = BuildApp(user: AuthenticatedUser()).CreateClient();
+
+            var updateRequest = new DataSetVersionUpdateRequest
+            {
+                DataSetVersionId = Guid.NewGuid()
+            };
+
+            var response = await UpdateVersion(updateRequest, client);
+
+            response.AssertForbidden();
+        }
+
+        [Fact]
+        public async Task DataSetVersionDoesNotExist_Returns404()
+        {
+            var updateRequest = new DataSetVersionUpdateRequest
+            {
+                DataSetVersionId = Guid.NewGuid()
+            };
+
+            var response = await UpdateVersion(updateRequest);
+
+            response.AssertNotFound();
+        }
+
+        [Theory]
+        [InlineData(DataSetVersionStatus.Processing)]
+        [InlineData(DataSetVersionStatus.Published)]
+        [InlineData(DataSetVersionStatus.Deprecated)]
+        [InlineData(DataSetVersionStatus.Withdrawn)]
+        public async Task DataSetVersionCannotBeUpdated_Returns400(DataSetVersionStatus dataSetVersionStatus)
+        {
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusDraft();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion currentDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 0)
+                .WithStatusPublished()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestLiveVersion = dsv);
+
+            DataSetVersion nextDataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 1)
+                .WithStatus(dataSetVersionStatus)
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.AddRange(currentDataSetVersion, nextDataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var updateRequest = new DataSetVersionUpdateRequest
+            {
+                DataSetVersionId = nextDataSetVersion.Id
+            };
+
+            var response = await UpdateVersion(updateRequest);
+
+            var validationProblem = response.AssertValidationProblem();
+
+            validationProblem.AssertHasError(
+                expectedPath: "dataSetVersionId",
+                expectedCode: ValidationMessages.DataSetVersionCannotBeUpdated.Code);
+        }
+
+        [Fact]
+        public async Task DataSetVersionIsFirstVersion_UpdatingNotes_Returns400()
+        {
+            DataSet dataSet = DataFixture
+                .DefaultDataSet()
+                .WithStatusDraft();
+
+            await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+            DataSetVersion dataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
+                .WithVersionNumber(major: 1, minor: 0)
+                .WithStatusDraft()
+                .WithDataSet(dataSet)
+                .FinishWith(dsv => dsv.DataSet.LatestDraftVersion = dsv);
+
+            await TestApp.AddTestData<PublicDataDbContext>(context =>
+            {
+                context.DataSetVersions.Add(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            });
+
+            var updateRequest = new DataSetVersionUpdateRequest
+            {
+                DataSetVersionId = dataSetVersion.Id,
+                Notes = "updated notes."
+            };
+
+            var response = await UpdateVersion(updateRequest);
+
+            var validationProblem = response.AssertValidationProblem();
+
+            validationProblem.AssertHasError(
+                expectedPath: "notes",
+                expectedCode: ValidationMessages.DataSetVersionCannotHaveChangelogNotes.Code);
+        }
+
+        private async Task<HttpResponseMessage> UpdateVersion(
+            DataSetVersionUpdateRequest updateRequest,
+            HttpClient? client = null)
+        {
+            client ??= BuildApp().CreateClient();
+
+            return await client.PatchAsync(BaseUrl, new JsonNetContent(updateRequest));
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -63,5 +64,18 @@ public class DataSetVersionsController(IDataSetVersionService dataSetVersionServ
                 await response.Content.CopyToAsync(Response.BodyWriter.AsStream(), cancellationToken);
             })
             .HandleFailuresOrNoOp();
+    }
+
+    [HttpPatch()]
+    [Produces("application/json")]
+    public async Task<ActionResult<DataSetDraftVersionViewModel>> UpdateVersion(
+        [FromBody] DataSetVersionUpdateRequest dataSetVersionUpdateRequest,
+        CancellationToken cancellationToken)
+    {
+        return await dataSetVersionService
+            .UpdateVersion(
+                updateRequest: dataSetVersionUpdateRequest,
+                cancellationToken: cancellationToken)
+            .HandleFailuresOrOk();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/DataSetVersionUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/DataSetVersionUpdateRequest.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System;
+using FluentValidation;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
+
+public record DataSetVersionUpdateRequest
+{
+    public required Guid DataSetVersionId { get; init; }
+
+    public string? Notes { get; init; }
+
+    public class Validator : AbstractValidator<DataSetVersionUpdateRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.DataSetVersionId)
+                .NotEmpty();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -35,5 +36,9 @@ public interface IDataSetVersionService
 
     Task<Either<ActionResult, HttpResponseMessage>> GetVersionChanges(
         Guid dataSetVersionId,
+        CancellationToken cancellationToken = default);
+
+    Task<Either<ActionResult, DataSetDraftVersionViewModel>> UpdateVersion(
+        DataSetVersionUpdateRequest updateRequest,
         CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
@@ -246,6 +246,7 @@ internal class DataSetService(
             File = MapVersionFile(releaseFile),
             ReleaseVersion = MapReleaseVersion(releaseFile.ReleaseVersion),
             TotalResults = dataSetVersion.TotalResults,
+            Notes = dataSetVersion.Notes,
             GeographicLevels = dataSetVersion.MetaSummary?.GeographicLevels
                 .Select(l => l.GetEnumLabel())
                 .ToList() ?? null,
@@ -286,6 +287,7 @@ internal class DataSetService(
             File = MapVersionFile(releaseFile),
             Published = dataSetVersion.Published!.Value,
             TotalResults = dataSetVersion.TotalResults,
+            Notes = dataSetVersion.Notes,
             ReleaseVersion = MapReleaseVersion(releaseFile.ReleaseVersion),
             GeographicLevels = dataSetVersion.MetaSummary!.GeographicLevels
                 .Select(l => l.GetEnumLabel())

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
@@ -111,7 +111,7 @@ public class DataSetVersionService(
                 dataSetVersion: dataSetVersion,
                 updateRequest: updateRequest,
                 cancellationToken: cancellationToken))
-            .OnSuccess(MapVersion);
+            .OnSuccess(MapDraftVersion);
     }
 
     private static DataSetVersionSummaryViewModel MapDraftSummaryVersion(DataSetVersion dataSetVersion)
@@ -181,7 +181,7 @@ public class DataSetVersionService(
         return dataSetVersion;
     }
 
-    private async Task<DataSetDraftVersionViewModel> MapVersion(DataSetVersion dataSetVersion)
+    private async Task<DataSetDraftVersionViewModel> MapDraftVersion(DataSetVersion dataSetVersion)
     {
         var releaseFile = await GetReleaseFile(dataSetVersion);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
@@ -5,18 +5,24 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Semver;
+using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationMessages;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
 
@@ -92,6 +98,22 @@ public class DataSetVersionService(
                 cancellationToken: cancellationToken));
     }
 
+    public async Task<Either<ActionResult, DataSetDraftVersionViewModel>> UpdateVersion(
+        DataSetVersionUpdateRequest updateRequest,
+        CancellationToken cancellationToken = default)
+    {
+        return await userService.CheckIsBauUser()
+            .OnSuccess(async () => await GetDataSetVersion(
+                dataSetVersionId: updateRequest.DataSetVersionId,
+                cancellationToken: cancellationToken))
+            .OnSuccessDo(dataSetVersion => CheckCanUpdateVersion(dataSetVersion, updateRequest))
+            .OnSuccess(async dataSetVersion => await UpdateVersion(
+                dataSetVersion: dataSetVersion,
+                updateRequest: updateRequest,
+                cancellationToken: cancellationToken))
+            .OnSuccess(MapVersion);
+    }
+
     private static DataSetVersionSummaryViewModel MapDraftSummaryVersion(DataSetVersion dataSetVersion)
     {
         return new DataSetVersionSummaryViewModel
@@ -100,6 +122,115 @@ public class DataSetVersionService(
             Version = dataSetVersion.Version,
             Status = dataSetVersion.Status,
             Type = dataSetVersion.VersionType,
+        };
+    }
+
+    private async Task<Either<ActionResult, DataSetVersion>> GetDataSetVersion(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken)
+    {
+        return await publicDataDbContext.DataSetVersions
+            .AsNoTracking()
+            .Where(dsv => dsv.Id == dataSetVersionId)
+            .SingleOrNotFoundAsync(cancellationToken);
+    }
+
+    private static Either<ActionResult, Unit> CheckCanUpdateVersion(
+        DataSetVersion dataSetVersion,
+        DataSetVersionUpdateRequest updateRequest)
+    {
+        if (!dataSetVersion.CanBeUpdated)
+        {
+            return ValidationUtils.ValidationResult(new ErrorViewModel
+            {
+                Code = ValidationMessages.DataSetVersionCannotBeUpdated.Code,
+                Message = ValidationMessages.DataSetVersionCannotBeUpdated.Message,
+                Detail = new InvalidErrorDetail<Guid>(dataSetVersion.Id),
+                Path = nameof(DataSetVersionUpdateRequest.DataSetVersionId).ToLowerFirst()
+            });
+        }
+
+        if (updateRequest.Notes is not null && dataSetVersion.IsFirstVersion)
+        {
+            return ValidationUtils.ValidationResult(new ErrorViewModel
+            {
+                Code = ValidationMessages.DataSetVersionCannotHaveChangelogNotes.Code,
+                Message = ValidationMessages.DataSetVersionCannotHaveChangelogNotes.Message,
+                Detail = new InvalidErrorDetail<Guid>(dataSetVersion.Id),
+                Path = nameof(DataSetVersionUpdateRequest.Notes).ToLowerFirst()
+            });
+        }
+
+        return Unit.Instance;
+    }
+
+    private async Task<Either<ActionResult, DataSetVersion>> UpdateVersion(
+        DataSetVersion dataSetVersion,
+        DataSetVersionUpdateRequest updateRequest,
+        CancellationToken cancellationToken)
+    {
+        if (updateRequest.Notes is not null)
+        {
+            dataSetVersion.Notes = updateRequest.Notes;
+        }
+
+        publicDataDbContext.DataSetVersions.Update(dataSetVersion);
+
+        await publicDataDbContext.SaveChangesAsync(cancellationToken);
+
+        return dataSetVersion;
+    }
+
+    private async Task<DataSetDraftVersionViewModel> MapVersion(DataSetVersion dataSetVersion)
+    {
+        var releaseFile = await GetReleaseFile(dataSetVersion);
+
+        return new DataSetDraftVersionViewModel
+        {
+            Id = dataSetVersion.Id,
+            Version = dataSetVersion.Version,
+            Status = dataSetVersion.Status,
+            Type = dataSetVersion.VersionType,
+            File = MapVersionFile(releaseFile),
+            ReleaseVersion = MapReleaseVersion(releaseFile.ReleaseVersion),
+            TotalResults = dataSetVersion.TotalResults,
+            Notes = dataSetVersion.Notes,
+            GeographicLevels = dataSetVersion.MetaSummary?.GeographicLevels
+                .Select(l => l.GetEnumLabel())
+                .ToList() ?? null,
+            TimePeriods = dataSetVersion.MetaSummary?.TimePeriodRange is not null
+                ? TimePeriodRangeViewModel.Create(dataSetVersion.MetaSummary.TimePeriodRange)
+                : null,
+            Filters = dataSetVersion.MetaSummary?.Filters ?? null,
+            Indicators = dataSetVersion.MetaSummary?.Indicators ?? null
+        };
+    }
+
+    private async Task<ReleaseFile> GetReleaseFile(DataSetVersion dataSetVersion)
+    {
+        return await contentDbContext.ReleaseFiles
+            .AsNoTracking()
+            .Where(rf => rf.Id == dataSetVersion.ReleaseFileId)
+            .Include(rf => rf.ReleaseVersion)
+            .Include(rf => rf.File)
+            .SingleAsync();
+    }
+
+    private static IdTitleViewModel MapVersionFile(ReleaseFile releaseFile)
+    {
+        return new IdTitleViewModel
+        {
+            Id = releaseFile.File.DataSetFileId!.Value,
+            Title = releaseFile.Name ?? string.Empty,
+        };
+    }
+
+    private static IdTitleViewModel MapReleaseVersion(ReleaseVersion releaseVersion)
+    {
+        return new IdTitleViewModel
+        {
+            Id = releaseVersion.Id,
+            Title = releaseVersion.Title,
         };
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -834,7 +834,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public Task<Either<ActionResult, Unit>> DeleteVersion(
-            Guid dataSetVersionId, CancellationToken cancellationToken = default)
+            Guid dataSetVersionId, 
+            CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new Either<ActionResult, Unit>(Unit.Instance));
         }
@@ -843,6 +844,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             Guid dataSetVersionId,
             CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
+
+        public Task<Either<ActionResult, DataSetDraftVersionViewModel>> UpdateVersion(
+            DataSetVersionUpdateRequest updateRequest, 
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new Either<ActionResult, DataSetDraftVersionViewModel>(new NotFoundResult()));
+        }
     }
 
     internal class NoOpDataSetVersionMappingService : IDataSetVersionMappingService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -54,6 +54,16 @@ public static class ValidationMessages
         Message: "The file provided '{0}' should have a filename ending in '.zip'."
     );
 
+    public static readonly LocalizableMessage DataSetVersionCannotHaveChangelogNotes = new(
+        Code: nameof(DataSetVersionCannotHaveChangelogNotes),
+        Message: "The data set version is the first version of the series, and therefore cannot have any changelog notes."
+    );
+
+    public static readonly LocalizableMessage DataSetVersionCannotBeUpdated = new(
+        Code: nameof(DataSetVersionCannotBeUpdated),
+        Message: "The data set version cannot be updated."
+    );
+
     public static ErrorViewModel GenerateErrorZipFilenameMustEndDotZip(string fullFilename)
     {
         return new ErrorViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
@@ -26,6 +26,8 @@ public abstract record DataSetVersionViewModel
 
     public long TotalResults { get; init; }
 
+    public required string Notes { get; init; }
+
     public TimePeriodRangeViewModel? TimePeriods { get; init; }
 
     public IReadOnlyList<string>? GeographicLevels { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
@@ -190,6 +190,11 @@ public static class DataSetVersionGeneratorExtensions
         Func<IEnumerable<PreviewToken>> previewTokens)
         => generator.ForInstance(s => s.SetPreviewTokens(previewTokens));
 
+    public static Generator<DataSetVersion> WithNotes(
+        this Generator<DataSetVersion> generator,
+        string notes)
+        => generator.ForInstance(s => s.SetNotes(notes));
+
     public static InstanceSetters<DataSetVersion> SetDefaults(this InstanceSetters<DataSetVersion> setters)
         => setters
             .SetDefault(dsv => dsv.Id)
@@ -542,4 +547,9 @@ public static class DataSetVersionGeneratorExtensions
                 }
             }
         );
+
+    public static InstanceSetters<DataSetVersion> SetNotes(
+        this InstanceSetters<DataSetVersion> instanceSetter,
+        string notes)
+        => instanceSetter.Set(dsv => dsv.Notes, notes);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -82,7 +82,7 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
     public DataSetVersionType VersionType
         => VersionMinor == 0 ? DataSetVersionType.Major : DataSetVersionType.Minor;
 
-    public bool CanBeDeleted => Status is DataSetVersionStatus.Failed
+    public bool CanBeUpdated => Status is DataSetVersionStatus.Failed
         or DataSetVersionStatus.Mapping
         or DataSetVersionStatus.Draft
         or DataSetVersionStatus.Cancelled;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -82,10 +82,13 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
     public DataSetVersionType VersionType
         => VersionMinor == 0 ? DataSetVersionType.Major : DataSetVersionType.Minor;
 
-    public bool CanBeUpdated => Status is DataSetVersionStatus.Failed
+    public bool CanBeDeleted => Status is DataSetVersionStatus.Failed
         or DataSetVersionStatus.Mapping
         or DataSetVersionStatus.Draft
         or DataSetVersionStatus.Cancelled;
+
+    public bool CanBeUpdated => Status is DataSetVersionStatus.Mapping
+        or DataSetVersionStatus.Draft;
 
     internal class Config : IEntityTypeConfiguration<DataSetVersion>
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -121,7 +121,7 @@ internal class DataSetVersionService(
         IReadOnlyList<DataSetVersion> dataSetVersions)
     {
         var versionsWhichCanNotBeDeleted = dataSetVersions
-            .Where(dsv => !dsv.CanBeUpdated)
+            .Where(dsv => !dsv.CanBeDeleted)
             .Select(dsv => dsv.Id)
             .ToList();
 
@@ -141,7 +141,7 @@ internal class DataSetVersionService(
 
     private static Either<ActionResult, Unit> CheckCanDeleteDataSetVersion(DataSetVersion dataSetVersion)
     {
-        if (dataSetVersion.CanBeUpdated)
+        if (dataSetVersion.CanBeDeleted)
         {
             return Unit.Instance;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -121,7 +121,7 @@ internal class DataSetVersionService(
         IReadOnlyList<DataSetVersion> dataSetVersions)
     {
         var versionsWhichCanNotBeDeleted = dataSetVersions
-            .Where(dsv => !dsv.CanBeDeleted)
+            .Where(dsv => !dsv.CanBeUpdated)
             .Select(dsv => dsv.Id)
             .ToList();
 
@@ -141,7 +141,7 @@ internal class DataSetVersionService(
 
     private static Either<ActionResult, Unit> CheckCanDeleteDataSetVersion(DataSetVersion dataSetVersion)
     {
-        if (dataSetVersion.CanBeDeleted)
+        if (dataSetVersion.CanBeUpdated)
         {
             return Unit.Instance;
         }


### PR DESCRIPTION
This PR adds a generic PATCH endpoint for BAU users to update a `DataSetVersion`.

Currently, the only properties that can be updated through this endpoint are the changelog `Notes`. In the future, we may add more properties to the request model. The idea is that the request parameters are all optional (aside from the `DataSetVersionId`) - and only the non-null fields will be updated.

The endpoint will return the following HTTP status codes:
- `200` 
  - with a body of `DataSetDraftVersionViewModel` when successfully updated
- `400`
  - when either:
    - the target `DataSetVersion` is in a status whereby it cannot be updated. Namely: `Processing`/`Published`/`Deprecated`/`Withdrawn`
    - the `DataSetVersion` is the **first** version, `1.0`, and we are trying to update the `Notes`. Only versions `>=1.1` can have changelog notes
- `403`
  - if the request was made by a non-BAU user
- `404`
  - if the target `DataSetVersion` does not exist