### PR TITLE
EES-4920 Version History: Admin Endpoint to list published versions of an API dataset

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
@@ -51,10 +51,25 @@ public abstract class DataSetVersionsControllerTests(
     public class ListLiveVersionsTests(
         TestApplicationFactory testApp) : DataSetVersionsControllerTests(testApp)
     {
+        private static readonly IReadOnlyList<DataSetVersionStatus> PreviouslyPublishedDataSetVersionStatuses =
+            new List<DataSetVersionStatus>(
+            [
+                DataSetVersionStatus.Published,
+                DataSetVersionStatus.Withdrawn,
+                DataSetVersionStatus.Deprecated
+            ]
+        );
+
+        public static TheoryData<DataSetVersionStatus> PreviouslyPublishedDataSetVersionStatusesData = new(
+            PreviouslyPublishedDataSetVersionStatuses
+        );
+
+        public static TheoryData<DataSetVersionStatus> DraftDataSetVersionStatusesData = new(
+            EnumUtil.GetEnums<DataSetVersionStatus>().Except(PreviouslyPublishedDataSetVersionStatuses)
+        );
+
         [Theory]
-        [InlineData(DataSetVersionStatus.Published)]
-        [InlineData(DataSetVersionStatus.Withdrawn)]
-        [InlineData(DataSetVersionStatus.Deprecated)]
+        [MemberData(nameof(PreviouslyPublishedDataSetVersionStatusesData))]
         public async Task OnlyPreviouslyPublishedVersionsReturned(DataSetVersionStatus dataSetVersionStatus)
         {
             ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
@@ -118,11 +133,7 @@ public abstract class DataSetVersionsControllerTests(
         }
 
         [Theory]
-        [InlineData(DataSetVersionStatus.Processing)]
-        [InlineData(DataSetVersionStatus.Failed)]
-        [InlineData(DataSetVersionStatus.Mapping)]
-        [InlineData(DataSetVersionStatus.Draft)]
-        [InlineData(DataSetVersionStatus.Cancelled)]
+        [MemberData(nameof(DraftDataSetVersionStatusesData))]
         public async Task DraftVersionsNotReturned(DataSetVersionStatus dataSetVersionStatus)
         {
             DataSet dataSet = DataFixture

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
@@ -1,16 +1,15 @@
 #nullable enable
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Public.Data;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
@@ -8,6 +8,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -18,6 +19,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Publi
 [Route("api/public-data/data-set-versions")]
 public class DataSetVersionsController(IDataSetVersionService dataSetVersionService) : ControllerBase
 {
+    [HttpGet("{dataSetId:guid}")]
+    [Produces("application/json")]
+    public async Task<ActionResult<PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>>> ListLiveVersions(
+        [FromQuery] DataSetVersionListRequest request,
+        Guid dataSetId,
+        CancellationToken cancellationToken)
+    {
+        return await dataSetVersionService
+            .ListLiveVersions(
+                dataSetId: dataSetId,
+                page: request.Page,
+                pageSize: request.PageSize,
+                cancellationToken: cancellationToken)
+            .HandleFailuresOrOk();
+    }
+
     [HttpPost]
     [Produces("application/json")]
     public async Task<ActionResult<DataSetVersionSummaryViewModel>> CreateNextVersion(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/DataSetVersionListRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/DataSetVersionListRequest.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+using System.ComponentModel;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
+
+public record DataSetVersionListRequest
+{
+    [DefaultValue(1)]
+    public int Page { get; init; } = 1;
+
+    [DefaultValue(10)]
+    public int PageSize { get; init; } = 10;
+
+    public class Validator : AbstractValidator<DataSetVersionListRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.Page)
+                .GreaterThanOrEqualTo(1);
+            RuleFor(request => request.PageSize)
+                .InclusiveBetween(1, 20);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
@@ -8,6 +8,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using Microsoft.AspNetCore.Mvc;
 using Semver;
@@ -16,6 +17,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.P
 
 public interface IDataSetVersionService
 {
+    Task<Either<ActionResult, PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>>> ListLiveVersions(
+        Guid dataSetId,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken = default);
+
     Task<List<DataSetVersionStatusSummary>> GetStatusesForReleaseVersion(
         Guid releaseVersionId,
         CancellationToken cancellationToken = default);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
@@ -1,10 +1,4 @@
 #nullable enable
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
@@ -19,9 +13,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Semver;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationMessages;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
@@ -34,6 +35,40 @@ public class DataSetVersionService(
     IUserService userService)
     : IDataSetVersionService
 {
+    public async Task<Either<ActionResult, PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>>> ListLiveVersions(
+        Guid dataSetId,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        return await userService.CheckIsBauUser()
+            .OnSuccess(async () =>
+            {
+                var dataSetVersionsQueryable = publicDataDbContext.DataSetVersions
+                    .AsNoTracking()
+                    .Where(ds => ds.DataSetId == dataSetId)
+                    .WherePublicStatus();
+
+                var dataSetVersions = await dataSetVersionsQueryable
+                    .OrderByDescending(dsv => dsv.Published)
+                    .Paginate(page: page, pageSize: pageSize)
+                    .ToListAsync(cancellationToken);
+
+                var releasesByDataSetVersion =
+                    await GetReleasesByDataSetVersion(dataSetVersions, cancellationToken);
+
+                var results = dataSetVersions
+                    .Select(dsv => MapLiveSummaryVersion(dsv, releasesByDataSetVersion[dsv.Id]))
+                    .ToList();
+
+                return new PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>(
+                    results,
+                    totalResults: await dataSetVersionsQueryable.CountAsync(cancellationToken: cancellationToken),
+                    page: page,
+                    pageSize: pageSize);
+            });
+    }
+
     public async Task<List<DataSetVersionStatusSummary>> GetStatusesForReleaseVersion(
         Guid releaseVersionId,
         CancellationToken cancellationToken = default)
@@ -71,7 +106,7 @@ public class DataSetVersionService(
                 .SingleAsync(
                     dataSetVersion => dataSetVersion.Id == processorResponse.DataSetVersionId,
                     cancellationToken))
-            .OnSuccess(MapDraftSummaryVersion);
+            .OnSuccess(async dataSetVersion => await MapDraftSummaryVersion(dataSetVersion, cancellationToken));
     }
 
     public async Task<Either<ActionResult, DataSetVersion>> GetDataSetVersion(
@@ -111,17 +146,59 @@ public class DataSetVersionService(
                 dataSetVersion: dataSetVersion,
                 updateRequest: updateRequest,
                 cancellationToken: cancellationToken))
-            .OnSuccess(MapDraftVersion);
+            .OnSuccess(async dataSetVersion => await MapDraftVersion(dataSetVersion, cancellationToken));
     }
 
-    private static DataSetVersionSummaryViewModel MapDraftSummaryVersion(DataSetVersion dataSetVersion)
+    private async Task<IReadOnlyDictionary<Guid, ReleaseVersion>> GetReleasesByDataSetVersion(
+        IReadOnlyList<DataSetVersion> dataSetVersions,
+        CancellationToken cancellationToken)
     {
+        var dataSetVersionsByReleaseFileId = dataSetVersions
+            .ToDictionary(dsv => dsv.ReleaseFileId);
+
+        var releasesByReleaseFileId = await contentDbContext
+            .ReleaseFiles
+            .Where(releaseFile => dataSetVersionsByReleaseFileId.Keys.Contains(releaseFile.Id))
+            .ToDictionaryAsync(
+                rf => rf.Id,
+                rf => rf.ReleaseVersion,
+                cancellationToken);
+
+        return releasesByReleaseFileId
+            .ToDictionary(
+                d => dataSetVersionsByReleaseFileId[d.Key].Id,
+                d => d.Value
+            );
+    }
+
+    private static DataSetLiveVersionSummaryViewModel MapLiveSummaryVersion(
+        DataSetVersion dataSetVersion,
+        ReleaseVersion releaseVersion)
+    {
+        return new DataSetLiveVersionSummaryViewModel
+        {
+            Id = dataSetVersion.Id,
+            Version = dataSetVersion.Version,
+            Status = dataSetVersion.Status,
+            Type = dataSetVersion.VersionType,
+            ReleaseVersion = MapReleaseVersion(releaseVersion),
+            Published = dataSetVersion.Published!.Value
+        };
+    }
+
+    private async Task<DataSetVersionSummaryViewModel> MapDraftSummaryVersion(
+        DataSetVersion dataSetVersion,
+        CancellationToken cancellationToken)
+    {
+        var releaseFile = await GetReleaseFile(dataSetVersion, cancellationToken);
+
         return new DataSetVersionSummaryViewModel
         {
             Id = dataSetVersion.Id,
             Version = dataSetVersion.Version,
             Status = dataSetVersion.Status,
             Type = dataSetVersion.VersionType,
+            Release = MapReleaseVersion(releaseFile.ReleaseVersion)
         };
     }
 
@@ -181,9 +258,11 @@ public class DataSetVersionService(
         return dataSetVersion;
     }
 
-    private async Task<DataSetDraftVersionViewModel> MapDraftVersion(DataSetVersion dataSetVersion)
+    private async Task<DataSetDraftVersionViewModel> MapDraftVersion(
+        DataSetVersion dataSetVersion,
+        CancellationToken cancellationToken)
     {
-        var releaseFile = await GetReleaseFile(dataSetVersion);
+        var releaseFile = await GetReleaseFile(dataSetVersion, cancellationToken);
 
         return new DataSetDraftVersionViewModel
         {
@@ -206,14 +285,16 @@ public class DataSetVersionService(
         };
     }
 
-    private async Task<ReleaseFile> GetReleaseFile(DataSetVersion dataSetVersion)
+    private async Task<ReleaseFile> GetReleaseFile(
+        DataSetVersion dataSetVersion,
+        CancellationToken cancellationToken)
     {
         return await contentDbContext.ReleaseFiles
             .AsNoTracking()
             .Where(rf => rf.Id == dataSetVersion.ReleaseFileId)
             .Include(rf => rf.ReleaseVersion)
             .Include(rf => rf.File)
-            .SingleAsync();
+            .SingleAsync(cancellationToken);
     }
 
     private static IdTitleViewModel MapVersionFile(ReleaseFile releaseFile)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
@@ -158,6 +158,7 @@ public class DataSetVersionService(
 
         var releasesByReleaseFileId = await contentDbContext
             .ReleaseFiles
+            .Include(rf => rf.ReleaseVersion)
             .Where(releaseFile => dataSetVersionsByReleaseFileId.Keys.Contains(releaseFile.Id))
             .ToDictionaryAsync(
                 rf => rf.Id,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -124,6 +124,7 @@ using ThemeService = GovUk.Education.ExploreEducationStatistics.Admin.Services.T
 using GovUk.Education.ExploreEducationStatistics.Common.Requests;
 using HeaderNames = Microsoft.Net.Http.Headers.HeaderNames;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin
 {
@@ -813,6 +814,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
 
     internal class NoOpDataSetVersionService : IDataSetVersionService
     {
+        public Task<Either<ActionResult, PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>>> ListLiveVersions(
+            Guid dataSetId, 
+            int page, 
+            int pageSize, 
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>.Paginate([], 1, 10));
+        }
+
         public Task<List<DataSetVersionStatusSummary>> GetStatusesForReleaseVersion(
             Guid releaseVersionId,
             CancellationToken cancellationToken = default)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
@@ -68,6 +68,8 @@ public record DataSetVersionSummaryViewModel
 
     [JsonConverter(typeof(StringEnumConverter))]
     public required DataSetVersionType Type { get; init; }
+
+    public required IdTitleViewModel Release { get; init; }
 }
 
 public record DataSetLiveVersionSummaryViewModel : DataSetVersionSummaryViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
@@ -69,7 +69,7 @@ public record DataSetVersionSummaryViewModel
     [JsonConverter(typeof(StringEnumConverter))]
     public required DataSetVersionType Type { get; init; }
 
-    public required IdTitleViewModel Release { get; init; }
+    public required IdTitleViewModel ReleaseVersion { get; init; }
 }
 
 public record DataSetLiveVersionSummaryViewModel : DataSetVersionSummaryViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandler.cs
@@ -1,4 +1,5 @@
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extensions;
 using Microsoft.AspNetCore.Authorization;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
@@ -21,9 +22,7 @@ public class ViewDataSetVersionAuthorizationHandler(
             return Task.CompletedTask;
         }
 
-        if (dataSetVersion.Status is DataSetVersionStatus.Published
-            or DataSetVersionStatus.Deprecated
-            or DataSetVersionStatus.Withdrawn)
+        if (dataSetVersion.IsPublicStatus())
         {
             context.Succeed(requirement);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -1,20 +1,20 @@
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetAuthExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetAuthExtensions.cs
@@ -1,6 +1,4 @@
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
-
-namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Extensions;
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extensions;
 
 public static class DataSetAuthExtensions
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionAuthExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionAuthExtensions.cs
@@ -1,9 +1,23 @@
+using System.Linq.Expressions;
+
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extensions;
 
 public static class DataSetVersionAuthExtensions
 {
+    private static readonly IReadOnlyList<DataSetVersionStatus> PublicStatuses = new List<DataSetVersionStatus>(
+        [
+            DataSetVersionStatus.Published,
+            DataSetVersionStatus.Withdrawn,
+            DataSetVersionStatus.Deprecated
+        ]
+    );
+
+    public static bool IsPublicStatus(this DataSetVersion dataSetVersion)
+        => IsPublicStatus().Compile()(dataSetVersion);
+
     public static IQueryable<DataSetVersion> WherePublicStatus(this IQueryable<DataSetVersion> queryable)
-        => queryable.Where(ds => ds.Status == DataSetVersionStatus.Published
-                                 || ds.Status == DataSetVersionStatus.Withdrawn
-                                 || ds.Status == DataSetVersionStatus.Deprecated);
+        => queryable.Where(IsPublicStatus());
+
+    private static Expression<Func<DataSetVersion, bool>> IsPublicStatus()
+        => dataSetVersion => PublicStatuses.Contains(dataSetVersion.Status);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionAuthExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionAuthExtensions.cs
@@ -1,6 +1,4 @@
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
-
-namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Extensions;
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extensions;
 
 public static class DataSetVersionAuthExtensions
 {


### PR DESCRIPTION
This PR adds a GET endpoint for BAU users to retrieve a **paginated** list of previously published Data Set Versions for a specific Data Set.

BAU Users should be able to see the version history for all previous versions of an API data set (but not any that are in draft status) within the “Api Datasets” tab under any current versions. 
For each version listed they will see its version number, related release, status and a link to view the changelog and a link to view details.

I have chosen to return slightly more data than necessary in the view model, in pursuit of trying to re-use the view-models we already have. I thought the tradeoff of re-using some view-models, on both the backend and client, outweighed the downside of returning more data than we need, for this particular view. In the future, we may need to display more data on this page anyway.

The endpoint will return the following HTTP status codes:
- `200` 
  - with a paginated list of previously published data set versions, if the request was successful
- `403`
  - if the request was made by a non-BAU user

When a successful request is made, the following body is returned:

```json
{
  "paging": {
    "page": 1,
    "pageSize": 10,
    "totalResults": 1,
    "totalPages": 1
  },
  "results": [
    {
      "id": "afbeb08c-b6c8-4e9d-d24e-08dc1cbc809a",
      "version": "1.0",
      "status": "Published",
      "type": "Major",
      "release": {
        "id": "bfbeb08c-b6c8-4e9d-d24e-08dc1cbc809b",
        "title": "My Release Version"
      },
      "published": "2024-08-05T16:34:27.432373+00:00"
    }
  ]
}
```