### PR TITLE
EES-4368 api data set preview token log

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -32,6 +32,7 @@ import {
   releaseApiDataSetLocationsMappingRoute,
   releaseApiDataSetPreviewRoute,
   releaseApiDataSetPreviewTokenRoute,
+  releaseApiDataSetPreviewTokenLogRoute,
 } from '@admin/routes/releaseRoutes';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Tag from '@common/components/Tag';
@@ -63,6 +64,7 @@ const routes = [
   releaseApiDataSetLocationsMappingRoute,
   releaseApiDataSetPreviewRoute,
   releaseApiDataSetPreviewTokenRoute,
+  releaseApiDataSetPreviewTokenLogRoute,
   releaseSummaryEditRoute,
   releaseFootnotesCreateRoute,
   releaseFootnotesEditRoute,

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -8,6 +8,7 @@ import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
 import {
   releaseApiDataSetLocationsMappingRoute,
   releaseApiDataSetPreviewRoute,
+  releaseApiDataSetPreviewTokenLogRoute,
   releaseApiDataSetsRoute,
   ReleaseDataSetRouteParams,
   ReleaseRouteParams,
@@ -67,20 +68,36 @@ export default function ReleaseApiDataSetDetailsPage() {
       actions={
         <ul className="govuk-list">
           {dataSet.draftVersion.status === 'Draft' && (
-            <li>
-              <Link
-                to={generatePath<ReleaseDataSetRouteParams>(
-                  releaseApiDataSetPreviewRoute.path,
-                  {
-                    publicationId: release.publicationId,
-                    releaseId: release.id,
-                    dataSetId,
-                  },
-                )}
-              >
-                Preview API data set
-              </Link>
-            </li>
+            <>
+              <li>
+                <Link
+                  to={generatePath<ReleaseDataSetRouteParams>(
+                    releaseApiDataSetPreviewRoute.path,
+                    {
+                      publicationId: release.publicationId,
+                      releaseId: release.id,
+                      dataSetId,
+                    },
+                  )}
+                >
+                  Preview API data set
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to={generatePath<ReleaseDataSetRouteParams>(
+                    releaseApiDataSetPreviewTokenLogRoute.path,
+                    {
+                      publicationId: release.publicationId,
+                      releaseId: release.id,
+                      dataSetId,
+                    },
+                  )}
+                >
+                  View API data set token log
+                </Link>
+              </li>
+            </>
           )}
           {canUpdateRelease && dataSet.draftVersion.status !== 'Processing' && (
             <li>

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenLogPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenLogPage.tsx
@@ -1,0 +1,150 @@
+import Link from '@admin/components/Link';
+import {
+  releaseApiDataSetDetailsRoute,
+  releaseApiDataSetPreviewTokenRoute,
+  ReleaseDataSetPreviewTokenRouteParams,
+  ReleaseDataSetRouteParams,
+} from '@admin/routes/releaseRoutes';
+import previewTokenQueries from '@admin/queries/previewTokenQueries';
+import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
+import previewTokenService from '@admin/services/previewTokenService';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import ModalConfirm from '@common/components/ModalConfirm';
+import FormattedDate from '@common/components/FormattedDate';
+import ButtonText from '@common/components/ButtonText';
+import Tag from '@common/components/Tag';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import { useQuery } from '@tanstack/react-query';
+import { generatePath, useParams } from 'react-router-dom';
+import React from 'react';
+
+export default function ReleaseApiDataSetPreviewTokenLogPage() {
+  const { dataSetId, releaseId, publicationId } =
+    useParams<ReleaseDataSetPreviewTokenRouteParams>();
+
+  const { data: dataSet, isLoading: isLoadingDataSet } = useQuery(
+    apiDataSetQueries.get(dataSetId),
+  );
+
+  const {
+    data: previewTokens,
+    isLoading: isLoadingPreviewTokens,
+    refetch: refetchTokens,
+  } = useQuery({
+    ...previewTokenQueries.list(dataSet?.draftVersion?.id ?? ''),
+    enabled: !!dataSet?.draftVersion,
+  });
+
+  const handleRevoke = async (id: string) => {
+    await previewTokenService.revokePreviewToken(id);
+    refetchTokens();
+  };
+
+  return (
+    <>
+      <Link
+        back
+        className="govuk-!-margin-bottom-6"
+        to={generatePath<ReleaseDataSetRouteParams>(
+          releaseApiDataSetDetailsRoute.path,
+          {
+            publicationId,
+            releaseId,
+            dataSetId,
+          },
+        )}
+      >
+        Back to API data set details
+      </Link>
+      <LoadingSpinner loading={isLoadingDataSet || isLoadingPreviewTokens}>
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-three-quarters">
+            <span className="govuk-caption-l">API preview token log</span>
+            <h2>{dataSet?.title}</h2>
+          </div>
+        </div>
+
+        {previewTokens?.length ? (
+          <table>
+            <caption>
+              <VisuallyHidden>
+                Table showing preview tokens for the API data set
+              </VisuallyHidden>
+            </caption>
+            <thead>
+              <tr>
+                <th>Reference</th>
+                <th>User</th>
+                <th>Date generated</th>
+                <th>Status</th>
+                <th>Expiry</th>
+                <th className="govuk-!-text-align-right">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {previewTokens.map(token => {
+                return (
+                  <tr key={token.id}>
+                    <td>{token.label}</td>
+                    <td>{token.createdByEmail}</td>
+                    <td>
+                      <FormattedDate format="d MMMM yyyy, HH:mm">
+                        {token.created}
+                      </FormattedDate>
+                    </td>
+                    <td>
+                      <Tag
+                        colour={token.status === 'Active' ? 'green' : 'grey'}
+                      >
+                        {token.status}
+                      </Tag>
+                    </td>
+                    <td>
+                      <FormattedDate format="d MMMM yyyy, HH:mm">
+                        {token.expiry}
+                      </FormattedDate>
+                    </td>
+                    <td className="govuk-!-text-align-right">
+                      {token.status === 'Active' && (
+                        <>
+                          <Link
+                            to={generatePath<ReleaseDataSetPreviewTokenRouteParams>(
+                              releaseApiDataSetPreviewTokenRoute.path,
+                              {
+                                publicationId,
+                                releaseId,
+                                dataSetId,
+                                previewTokenId: token.id,
+                              },
+                            )}
+                          >
+                            View details
+                            <VisuallyHidden> for {token.label}</VisuallyHidden>
+                          </Link>
+                          <ModalConfirm
+                            title="Revoke this token"
+                            triggerButton={
+                              <ButtonText className="govuk-!-margin-left-2">
+                                Revoke
+                                <VisuallyHidden> {token.label}</VisuallyHidden>
+                              </ButtonText>
+                            }
+                            onConfirm={() => handleRevoke(token.id)}
+                          >
+                            <p>Are you sure you want to revoke this token?</p>
+                          </ModalConfirm>
+                        </>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        ) : (
+          <p>No tokens have been created.</p>
+        )}
+      </LoadingSpinner>
+    </>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenLogPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenLogPage.test.tsx
@@ -1,0 +1,219 @@
+import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
+import { testRelease } from '@admin/pages/release/__data__/testRelease';
+import ReleaseApiDataSetPreviewTokenLogPage from '@admin/pages/release/data/ReleaseApiDataSetPreviewTokenLogPage';
+import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
+import {
+  releaseApiDataSetPreviewTokenLogRoute,
+  ReleaseDataSetRouteParams,
+} from '@admin/routes/releaseRoutes';
+import _apiDataSetService, {
+  ApiDataSet,
+} from '@admin/services/apiDataSetService';
+import _previewTokenService, {
+  PreviewToken,
+} from '@admin/services/previewTokenService';
+import render from '@common-test/render';
+import { screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { generatePath, MemoryRouter, Route } from 'react-router-dom';
+
+jest.mock('@admin/services/apiDataSetService');
+jest.mock('@admin/services/previewTokenService');
+
+const apiDataSetService = jest.mocked(_apiDataSetService);
+const previewTokenService = jest.mocked(_previewTokenService);
+
+describe('ReleaseApiDataSetPreviewTokenPage', () => {
+  const testDataSet: ApiDataSet = {
+    id: 'data-set-id',
+    title: 'Data set title',
+    summary: 'Data set summary',
+    status: 'Draft',
+    draftVersion: {
+      id: 'draft-version-id',
+      version: '2.0',
+      status: 'Draft',
+      type: 'Minor',
+      totalResults: 0,
+      releaseVersion: {
+        id: 'release-2-id',
+        title: 'Test release 2',
+      },
+      file: {
+        id: 'draft-file-id',
+        title: 'Test draft file',
+      },
+    },
+    previousReleaseIds: [],
+  };
+  const testTokens: PreviewToken[] = [
+    {
+      id: 'token-id-1',
+      label: 'Test label 1',
+      status: 'Active',
+      created: '2024-01-01T14:00Z',
+      createdByEmail: 'test-1@hiveit.co.uk',
+      updated: '',
+      expiry: '2024-01-02T14:00Z',
+    },
+    {
+      id: 'token-id-2',
+      label: 'Test label 2',
+      status: 'Expired',
+      created: '2024-02-01T10:00Z',
+      createdByEmail: 'test-2@hiveit.co.uk',
+      updated: '',
+      expiry: '2024-02-02T10:00Z',
+    },
+    {
+      id: 'token-id-3',
+      label: 'Test label 3',
+      status: 'Active',
+      created: '2024-03-01T10:00Z',
+      createdByEmail: 'test-3@hiveit.co.uk',
+      updated: '',
+      expiry: '2024-03-02T10:00Z',
+    },
+  ];
+
+  test('renders the table correctly', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue(testDataSet);
+    previewTokenService.listPreviewTokens.mockResolvedValue(testTokens);
+
+    renderPage();
+
+    expect(await screen.findByText('Data set title')).toBeInTheDocument();
+
+    const rows = within(screen.getByRole('table')).getAllByRole('row');
+    expect(rows).toHaveLength(4);
+
+    const row1Cells = within(rows[1]).getAllByRole('cell');
+    expect(row1Cells[0]).toHaveTextContent('Test label 1');
+    expect(row1Cells[1]).toHaveTextContent('test-1@hiveit.co.uk');
+    expect(row1Cells[2]).toHaveTextContent('1 January 2024, 14:00');
+    expect(row1Cells[3]).toHaveTextContent('Active');
+    expect(row1Cells[4]).toHaveTextContent('2 January 2024, 14:00');
+    expect(
+      within(row1Cells[5]).getByRole('link', {
+        name: 'View details for Test label 1',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/api-data-sets/data-set-id/preview/token-id-1',
+    );
+    expect(
+      within(row1Cells[5]).getByRole('button', { name: 'Revoke Test label 1' }),
+    ).toBeInTheDocument();
+
+    const row2Cells = within(rows[2]).getAllByRole('cell');
+    expect(row2Cells[0]).toHaveTextContent('Test label 2');
+    expect(row2Cells[1]).toHaveTextContent('test-2@hiveit.co.uk');
+    expect(row2Cells[2]).toHaveTextContent('1 February 2024, 10:00');
+    expect(row2Cells[3]).toHaveTextContent('Expired');
+    expect(row2Cells[4]).toHaveTextContent('2 February 2024, 10:00');
+    expect(
+      within(row2Cells[5]).queryByRole('link', {
+        name: 'View details for Test label 2',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row2Cells[5]).queryByRole('button', {
+        name: 'Revoke Test label 2',
+      }),
+    ).not.toBeInTheDocument();
+
+    const row3Cells = within(rows[3]).getAllByRole('cell');
+    expect(row3Cells[0]).toHaveTextContent('Test label 3');
+    expect(row3Cells[1]).toHaveTextContent('test-3@hiveit.co.uk');
+    expect(row3Cells[2]).toHaveTextContent('1 March 2024, 10:00');
+    expect(row3Cells[3]).toHaveTextContent('Active');
+    expect(row3Cells[4]).toHaveTextContent('2 March 2024, 10:00');
+    expect(
+      within(row3Cells[5]).getByRole('link', {
+        name: 'View details for Test label 3',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/api-data-sets/data-set-id/preview/token-id-3',
+    );
+    expect(
+      within(row3Cells[5]).getByRole('button', { name: 'Revoke Test label 3' }),
+    ).toBeInTheDocument();
+  });
+
+  test('revoking a token', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue(testDataSet);
+    previewTokenService.listPreviewTokens.mockResolvedValueOnce(testTokens);
+    previewTokenService.listPreviewTokens.mockResolvedValueOnce(
+      testTokens.map(token => {
+        return token.id === 'token-id-1'
+          ? { ...token, status: 'Expired' }
+          : token;
+      }),
+    );
+
+    const { user } = renderPage();
+
+    expect(await screen.findByText('Data set title')).toBeInTheDocument();
+
+    const rows = within(screen.getByRole('table')).getAllByRole('row');
+    expect(rows).toHaveLength(4);
+
+    await user.click(
+      within(rows[1]).getByRole('button', { name: 'Revoke Test label 1' }),
+    );
+
+    expect(
+      await screen.findByText('Are you sure you want to revoke this token?'),
+    ).toBeInTheDocument();
+
+    expect(previewTokenService.revokePreviewToken).not.toHaveBeenCalled();
+
+    await user.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: 'Confirm',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(previewTokenService.revokePreviewToken).toHaveBeenCalledTimes(1);
+    });
+
+    expect(previewTokenService.revokePreviewToken).toHaveBeenCalledWith(
+      'token-id-1',
+    );
+
+    expect(
+      within(rows[1]).queryByRole('button', { name: 'Revoke Test label 1' }),
+    ).not.toBeInTheDocument();
+    expect(within(rows[1]).getAllByRole('cell')[3]).toHaveTextContent(
+      'Expired',
+    );
+  });
+
+  function renderPage() {
+    return render(
+      <TestConfigContextProvider>
+        <ReleaseContextProvider release={testRelease}>
+          <MemoryRouter
+            initialEntries={[
+              generatePath<ReleaseDataSetRouteParams>(
+                releaseApiDataSetPreviewTokenLogRoute.path,
+                {
+                  publicationId: testRelease.publicationId,
+                  releaseId: testRelease.id,
+                  dataSetId: 'data-set-id',
+                },
+              ),
+            ]}
+          >
+            <Route
+              component={ReleaseApiDataSetPreviewTokenLogPage}
+              path={releaseApiDataSetPreviewTokenLogRoute.path}
+            />
+          </MemoryRouter>
+        </ReleaseContextProvider>
+      </TestConfigContextProvider>,
+    );
+  }
+});

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -3,6 +3,7 @@ import ReleaseApiDataSetDetailsPage from '@admin/pages/release/data/ReleaseApiDa
 import ReleaseApiDataSetLocationsMappingPage from '@admin/pages/release/data/ReleaseApiDataSetLocationsMappingPage';
 import ReleaseApiDataSetPreviewPage from '@admin/pages/release/data/ReleaseApiDataSetPreviewPage';
 import ReleaseApiDataSetPreviewTokenPage from '@admin/pages/release/data/ReleaseApiDataSetPreviewTokenPage';
+import ReleaseApiDataSetPreviewTokenLogPage from '@admin/pages/release/data/ReleaseApiDataSetPreviewTokenLogPage';
 import ReleaseContentPage from '@admin/pages/release/content/ReleaseContentPage';
 import ReleaseDataFilePage from '@admin/pages/release/data/ReleaseDataFilePage';
 import ReleaseAncillaryFilePage from '@admin/pages/release/data/ReleaseAncillaryFilePage';
@@ -141,6 +142,13 @@ export const releaseApiDataSetPreviewTokenRoute: ReleaseRouteProps = {
   path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId/preview/:previewTokenId',
   title: 'API data set preview token',
   component: ReleaseApiDataSetPreviewTokenPage,
+  protectionAction: permissions => permissions.isBauUser,
+};
+
+export const releaseApiDataSetPreviewTokenLogRoute: ReleaseRouteProps = {
+  path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId/token-log',
+  title: 'View API data set token log',
+  component: ReleaseApiDataSetPreviewTokenLogPage,
   protectionAction: permissions => permissions.isBauUser,
 };
 

--- a/src/explore-education-statistics-admin/src/services/previewTokenService.ts
+++ b/src/explore-education-statistics-admin/src/services/previewTokenService.ts
@@ -1,5 +1,4 @@
 import client from '@admin/services/utils/service';
-import { PaginatedList } from '@common/services/types/pagination';
 
 export interface PreviewToken {
   id: string;
@@ -21,18 +20,10 @@ const previewTokenService = {
   getPreviewToken(previewTokenId: string): Promise<PreviewToken> {
     return client.get(`/public-data/preview-tokens/${previewTokenId}`);
   },
-  async listPreviewTokens(dataSetVersionId: string): Promise<PreviewToken[]> {
-    const { results } = await client.get<PaginatedList<PreviewToken>>(
-      '/public-data/preview-tokens',
-      {
-        params: {
-          dataSetVersionId,
-          pageSize: 100,
-        },
-      },
-    );
-
-    return results;
+  listPreviewTokens(dataSetVersionId: string): Promise<PreviewToken[]> {
+    return client.get(`/public-data/preview-tokens`, {
+      params: { dataSetVersionId },
+    });
   },
   revokePreviewToken(previewTokenId: string): Promise<PreviewToken> {
     return client.post(`/public-data/preview-tokens/${previewTokenId}/revoke`);


### PR DESCRIPTION
Adds the preview token log page.

![Screenshot 2024-08-05 174424](https://github.com/user-attachments/assets/0b32f881-39fb-48d0-b353-59eda360f38c)
