### PR TITLE
EES-5024 - adding App Gateway to Bicep deployment

### DIFF
--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -8,13 +8,6 @@ parameters:
     displayName: Does the PostgreSQL Flexible Server require any updates? False by default to avoid unnecessarily lengthy deploys.
     default: false
 
-# This param is helpful for debugging to allow the selection of a particular branch from which to base a deploy from this pipeline.
-# This should be removed in the long term in favour of using the "Resources" selection from the "Run pipeline" dialog.
-#
-#  - name: buildBranchToDeploy
-#    displayName: Build branch to deploy. This allows a person who is manually running the pipeline to specify the use of the latest EESBuildPipeline build that was run against that branch.
-#    default: 'Branch from latest pipeline run'
-
 resources:
   pipelines:
     - pipeline: EESBuildPipeline
@@ -24,11 +17,6 @@ resources:
           - refs/heads/dev
           - refs/heads/test
           - refs/heads/master
-
-# This param is helpful for debugging to allow the selection of a particular branch from which to base a deploy from this pipeline.
-# This should be removed in the long term in favour of using the "Resources" selection from the "Run pipeline" dialog.
-#
-#      branch: ${{ replace(parameters.buildBranchToDeploy, 'Branch from latest pipeline run', '') }}
 
 variables:
   - group: Public API Infrastructure - common
@@ -80,6 +68,7 @@ stages:
     dependsOn: 'Validate_Against_Development'
     environment: 'Development'
     serviceConnection: $(serviceConnectionDevelopment)
+    subscription: $(subscription)
     parameterFile: $(devParamFile)
 
 - template: validate-stage-template.yml
@@ -97,6 +86,7 @@ stages:
     condition: and(succeeded(), eq(variables.isTest, true))
     environment: 'Test'
     serviceConnection: $(serviceConnectionTest)
+    subscription: $(subscription)
     parameterFile: $(testParamFile)
 
 #  - template: validate-stage-template.yml
@@ -114,6 +104,7 @@ stages:
 #      dependsOn: 'Validate_Against_PreProduction'
 #      environment: 'Pre-production'
 #      serviceConnection: $(serviceConnectionPreProduction)
+#      subscription: $(subscription)
 #      parameterFile: $(preProdParamFile)
 #
 #  - template: validate-stage-template.yml
@@ -131,4 +122,5 @@ stages:
 #      dependsOn: 'Validate_Against_Production'
 #      environment: 'Production'
 #      serviceConnection: $(serviceConnectionProduction)
+#      subscription: $(subscription)
 #      parameterFile: $(prodParamFile)

--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -42,6 +42,11 @@ resource psqlFlexibleServerSubnet 'Microsoft.Network/virtualNetworks/subnets@202
   parent: vNet
 }
 
+resource appGatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
+  name: '${subscription}-ees-snet-agw-01'
+  parent: vNet
+}
+
 @description('The fully qualified Azure resource ID of the Network.')
 output vNetRef string = resourceId('Microsoft.Network/VirtualNetworks', vNetName)
 
@@ -83,3 +88,6 @@ output psqlFlexibleServerSubnetStartIpAddress string = parseCidr(psqlFlexibleSer
 
 @description('The last usable IP address for the PSQL Flexible Server Subnet.')
 output psqlFlexibleServerSubnetEndIpAddress string = parseCidr(psqlFlexibleServerSubnet.properties.addressPrefix).lastUsable
+
+@description('The fully qualified Azure resource ID of the App Gateway Subnet.')
+output appGatewaySubnetRef string = appGatewaySubnet.id

--- a/infrastructure/templates/public-api/assign-app-role-to-service-principal-template.yml
+++ b/infrastructure/templates/public-api/assign-app-role-to-service-principal-template.yml
@@ -31,7 +31,7 @@ steps:
 
           echo "Assigning App Role \"${{parameters.appRoleName}}\" from \"${{parameters.protectedResourceAppRegName}}\" to \"${{parameters.servicePrincipalName}}\""
           
-          protectedResourceAppRegId=`az ad sp list --display-name $protectedResourceAppRegName --query [0].id --out tsv`
+          protectedResourceAppRegId=`az ad sp list --display-name ${{parameters.protectedResourceAppRegName}} --query [0].id --out tsv`
 
           az rest -m POST -u https://graph.microsoft.com/v1.0/servicePrincipals/$principalId/appRoleAssignments \
             -b "{\"principalId\": \"$principalId\", \"resourceId\": \"$protectedResourceAppRegId\",\"appRoleId\": \"$appRoleId\"}"

--- a/infrastructure/templates/public-api/components/appGateway.bicep
+++ b/infrastructure/templates/public-api/components/appGateway.bicep
@@ -1,0 +1,232 @@
+@description('Specifies the Key Vault name that this App Gateway will be permitted to get and list certificates from')
+param keyVaultName string
+
+@description('Specifies the Resource Prefix')
+param resourcePrefix string
+
+@description('Specifies the location for all resources')
+param location string
+
+@description('Specifies the id of a dedicated subnet to which this App Gateway will be connected')
+param subnetId string
+
+@description('Specifies an optional suffix for the App Gateway name')
+param instanceName string = ''
+
+@description('Specifies a set of configurations for the App Gateway to use to direct traffic to backend resources')
+param sites {
+  resourceName: string
+  publicHostName: string
+  backendFqdn: string
+  healthProbeRelativeUrl: string
+  certificateKeyVaultSecretName: string
+}[]
+
+@description('Specifies a set of Azure availability zones for the region that this resource should be accessible from. Defaults to all zones')
+@allowed([
+  '1'
+  '2'
+  '3'
+])
+param availabilityZones string[] = [
+  '1'
+  '2'
+  '3'
+]
+
+@description('Specifies a set of tags with which to tag the resource in Azure')
+param tagValues object
+
+var appGatewayFullName = empty(instanceName)
+  ? '${resourcePrefix}-ees-agw'
+  : '${resourcePrefix}-ees-agw-${instanceName}'
+
+var managedIdentityName = empty(instanceName)
+  ? '${resourcePrefix}-ees-id-agw'
+  : '${resourcePrefix}-ees-id-agw-${instanceName}'
+
+// Create a user-assigned managed identity for the App Gateway. App Gateway does not support system-assigned identities.
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: managedIdentityName
+  location: location
+}
+
+// Allow the managed identity to access certificates from Key Vault.
+module managedIdentityKeyVaultAccessPolicy 'keyVaultAccessPolicy.bicep' = {
+  name: '${appGatewayFullName}KeyVaultAccessPolicy'
+  params: {
+    keyVaultName: keyVaultName
+    principalIds: [managedIdentity.properties.principalId]
+  }
+}
+
+module appGatewayKeyVaultRoleAssignments 'keyVaultRoleAssignment.bicep' = {
+  name: 'appGatewayKeyVaultRoleAssignment'
+  params: {
+    keyVaultName: keyVaultName
+    principalIds: [managedIdentity.properties.principalId]
+    role: 'Secrets User'
+  }
+}
+
+// Create public IP addresses for every site we will expose through this App Gateway.
+resource publicIPAddresses 'Microsoft.Network/publicIPAddresses@2021-05-01' = [for site in sites: {
+  name: '${site.resourceName}-pip'
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    publicIPAddressVersion: 'IPv4'
+    publicIPAllocationMethod: 'Static'
+    idleTimeoutInMinutes: 4
+    dnsSettings: {
+      domainNameLabel: replace(site.publicHostName, '.', '')
+      fqdn: '${replace(site.publicHostName, '.', '')}.${location}.cloudapp.azure.com'
+    }
+  }
+}]
+
+// Add a Firewall Policy with OWASP and Bot rulesets, running in Prevention mode.
+module wafPolicy 'wafPolicy.bicep' = {
+  name: 'wafPolicy'
+  params: {
+    name: '${appGatewayFullName}-waf-policy'
+    location: location
+    tagValues: tagValues
+  }
+}
+
+// Create the App Gateway.
+resource appGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {
+  name: appGatewayFullName
+  location: location
+  tags: tagValues
+  zones: availabilityZones
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentity.id}': {}
+    }
+  }
+  properties: {
+    sku: {
+      name: 'WAF_v2'
+      tier: 'WAF_v2'
+      family: 'Generation_1'
+    }
+    gatewayIPConfigurations: [
+      {
+        name: '${appGatewayFullName}-ip-config'
+        properties: {
+          subnet: {
+            id: subnetId
+          }
+        }
+      }
+    ]
+    sslCertificates: [for site in sites: {
+      name: '${site.resourceName}-cert'
+      properties: {
+        keyVaultSecretId: 'https://${keyVaultName}${environment().suffixes.keyvaultDns}/secrets/${site.certificateKeyVaultSecretName}'
+      }
+    }]
+    frontendIPConfigurations: [for site in sites: {
+      name: '${site.resourceName}-public-frontend-ip-config'
+      properties: {
+        privateIPAllocationMethod: 'Dynamic'
+        publicIPAddress: {
+          id: resourceId('Microsoft.Network/publicIPAddresses', '${site.resourceName}-pip')
+        }
+      }
+    }]
+    frontendPorts: [
+      {
+        name: 'port443'
+        properties: {
+          port: 443
+        }
+      }
+    ]
+    backendAddressPools: [for site in sites: {
+      name: '${site.resourceName}-backend-pool'
+      properties: {
+        backendAddresses: [
+          {
+            fqdn: site.backendFqdn
+          }
+        ]
+      }
+    }]
+    backendHttpSettingsCollection: [for site in sites: {
+      name: '${site.resourceName}-backend'
+      properties: {
+        port: 443
+        protocol: 'Https'
+        cookieBasedAffinity: 'Disabled'
+        pickHostNameFromBackendAddress: true
+        requestTimeout: 20
+        probe: {
+          id: resourceId('Microsoft.Network/applicationGateways/probes', appGatewayFullName, '${site.resourceName}-health-probe')
+        }
+      }
+    }]
+    httpListeners: [for site in sites: {
+      name: '${site.resourceName}-listener'
+      properties: {
+        frontendIPConfiguration: {
+          id: resourceId('Microsoft.Network/applicationGateways/frontendIPConfigurations', appGatewayFullName, '${site.resourceName}-public-frontend-ip-config')
+        }
+        frontendPort: {
+          id: resourceId('Microsoft.Network/applicationGateways/frontendPorts', appGatewayFullName, 'port443')
+        }
+        protocol: 'Https'
+        sslCertificate: {
+          id: resourceId('Microsoft.Network/applicationGateways/sslCertificates', appGatewayFullName, '${site.resourceName}-cert')
+        }
+        hostName: site.publicHostName
+        requireServerNameIndication: true
+      }
+    }]
+    requestRoutingRules: [for site in sites: {
+      name: '${site.resourceName}-routing-rule'
+      properties: {
+        ruleType: 'Basic'
+        priority: 1
+        httpListener: {
+          id: resourceId('Microsoft.Network/applicationGateways/httpListeners', appGatewayFullName, '${site.resourceName}-listener')
+        }
+        backendAddressPool: {
+          id: resourceId('Microsoft.Network/applicationGateways/backendAddressPools', appGatewayFullName, '${site.resourceName}-backend-pool')
+        }
+        backendHttpSettings: {
+          id: resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', appGatewayFullName, '${site.resourceName}-backend')
+        }
+      }
+    }]
+    probes: [for site in sites: {
+      name: '${site.resourceName}-health-probe'
+      properties: {
+        protocol: 'Https'
+        path: site.healthProbeRelativeUrl
+        interval: 30
+        timeout: 30
+        unhealthyThreshold: 3
+        pickHostNameFromBackendHttpSettings: true
+        minServers: 0
+        match: {}
+      }
+    }]
+    enableHttp2: true
+    autoscaleConfiguration: {
+      minCapacity: 0
+      maxCapacity: 10
+    }
+    firewallPolicy: {
+      id: wafPolicy.outputs.id
+    }
+  }
+  dependsOn: [
+    publicIPAddresses
+  ]
+}

--- a/infrastructure/templates/public-api/components/appGateway.bicep
+++ b/infrastructure/templates/public-api/components/appGateway.bicep
@@ -52,11 +52,12 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-
 }
 
 // Allow the managed identity to access certificates from Key Vault.
-module managedIdentityKeyVaultAccessPolicy 'keyVaultAccessPolicy.bicep' = {
-  name: '${appGatewayFullName}KeyVaultAccessPolicy'
+module managedIdentityKeyVaultRole 'keyVaultRoleAssignment.bicep' = {
+  name: '${appGatewayFullName}KeyVaultRoleAssignment'
   params: {
     keyVaultName: keyVaultName
     principalIds: [managedIdentity.properties.principalId]
+    role: 'Secrets User'
   }
 }
 

--- a/infrastructure/templates/public-api/components/containerApp.bicep
+++ b/infrastructure/templates/public-api/components/containerApp.bicep
@@ -100,10 +100,10 @@ param entraIdAuthentication {
 }?
 
 var containerImageName = '${acrLoginServer}/${containerAppImageName}'
-var fullApplicationName = toLower('${resourcePrefix}-ca-${containerAppName}')
+var containerApplicationName = toLower('${resourcePrefix}-ca-${containerAppName}')
 
 resource containerApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
-  name: fullApplicationName
+  name: containerApplicationName
   location: location
   identity: {
     type: 'UserAssigned'
@@ -179,5 +179,6 @@ module azureAuthentication 'containerAppAzureAuthentication.bicep' = if (entraId
   }
 }
 
-output containerAppFQDN string = containerApp.properties.configuration.ingress.fqdn
+output containerAppFqdn string = containerApp.properties.configuration.ingress.fqdn
 output containerImage string = containerImageName
+output containerAppName string = containerApp.name

--- a/infrastructure/templates/public-api/components/containerApp.bicep
+++ b/infrastructure/templates/public-api/components/containerApp.bicep
@@ -173,7 +173,7 @@ module azureAuthentication 'containerAppAzureAuthentication.bicep' = if (entraId
   name: '${containerAppName}AzureAuthentication'
   params: {
     clientId: entraIdAuthentication!.appRegistrationClientId
-    containerAppName: fullApplicationName
+    containerAppName: containerApplicationName
     allowedClientIds: entraIdAuthentication!.allowedClientIds
     allowedPrincipalIds: entraIdAuthentication!.allowedPrincipalIds
   }

--- a/infrastructure/templates/public-api/components/keyVaultRoleAssignment.bicep
+++ b/infrastructure/templates/public-api/components/keyVaultRoleAssignment.bicep
@@ -7,6 +7,7 @@ param principalIds string[]
 @description('Specifies the Key Vault role to assign to the service principals. See https://docs.microsoft.com/azure/role-based-access-control/built-in-roles for possible roles to support here.')
 @allowed([
   'Secrets User'
+  'Certificate User'
 ])
 param role string
 
@@ -14,6 +15,7 @@ param role string
 var roleIds = {
 
   'Secrets User': '4633458b-17de-408a-b874-0445c86b69e6'
+  'Certificate User': 'db79e9a7-68ee-4b58-9aeb-b90e7c24fcba'
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {

--- a/infrastructure/templates/public-api/components/wafPolicy.bicep
+++ b/infrastructure/templates/public-api/components/wafPolicy.bicep
@@ -1,0 +1,40 @@
+@description('Specifies the location for all resources')
+param location string
+
+@description('Specifies the name of the policy')
+param name string
+
+@description('Specifies a set of tags with which to tag the resource in Azure')
+param tagValues object
+
+resource policy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2023-11-01' = {
+  name: name
+  location: location
+  properties: {
+    policySettings: {
+      requestBodyCheck: true
+      maxRequestBodySizeInKb: 128
+      fileUploadLimitInMb: 100
+      state: 'Enabled'
+      mode: 'Prevention'
+      requestBodyInspectLimitInKB: 128
+      fileUploadEnforcement: true
+      requestBodyEnforcement: true
+    }
+    managedRules: {
+      managedRuleSets: [
+        {
+          ruleSetType: 'OWASP'
+          ruleSetVersion: '3.2'
+        }
+        {
+          ruleSetType: 'Microsoft_BotManagerRuleSet'
+          ruleSetVersion: '0.1'
+        }
+      ]
+    }
+  }
+  tags: tagValues
+}
+
+output id string = policy.id

--- a/infrastructure/templates/public-api/components/wafPolicy.bicep
+++ b/infrastructure/templates/public-api/components/wafPolicy.bicep
@@ -29,7 +29,7 @@ resource policy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolic
         }
         {
           ruleSetType: 'Microsoft_BotManagerRuleSet'
-          ruleSetVersion: '0.1'
+          ruleSetVersion: '1.0'
         }
       ]
     }

--- a/infrastructure/templates/public-api/deploy-stage-template.yml
+++ b/infrastructure/templates/public-api/deploy-stage-template.yml
@@ -8,6 +8,8 @@ parameters:
     type: string
   - name: serviceConnection
     type: string
+  - name: subscription
+    type: string
   - name: dependsOn
     type: string
     default: ''
@@ -37,8 +39,12 @@ stages:
       runOnce:
         deploy:
           steps:
-          - bash: echo "##vso[task.setvariable variable=dataProcessorFunctionAppName;]$(subscription)-ees-papi-fa-processor"
+          - task: Bash@3
             displayName: 'Set additional pipeline variables'
+            inputs:
+              targetType: 'inline'
+              script: |
+                echo "##vso[task.setvariable variable=dataProcessorFunctionAppName;]$(subscription)-ees-papi-fa-processor"
 
           - download: EESBuildPipeline
             displayName: 'Download Data Processor Function App ZIP file'
@@ -201,9 +207,9 @@ stages:
                   --slot staging \
                   --target-slot production
 
-          - template: assign-app-role-to-service-principal-template.yml
-            parameters:
-              serviceConnection: ${{parameters.serviceConnection}}
-              appRoleName: Admin.Access
-              protectedResourceAppRegName: $subscription-ees-papi-ca-api-appreg
-              servicePrincipalName: $subscription-as-ees-admin
+          # - template: assign-app-role-to-service-principal-template.yml
+          #   parameters:
+          #     serviceConnection: ${{parameters.serviceConnection}}
+          #     appRoleName: Admin.Access
+          #     protectedResourceAppRegName: ${{parameters.subscription}}-ees-papi-ca-api-appreg
+          #     servicePrincipalName: ${{parameters.subscription}}-as-ees-admin

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -102,7 +102,6 @@ var containerAppEnvironmentNameSuffix = '01'
 var dataFilesFileShareMountName = 'public-api-fileshare-mount'
 var dataFilesFileShareMountPath = '/data/public-api-data'
 var publicApiStorageAccountName = '${subscription}eespapisa'
-var appGatewayManagedIdentityName = '${subscription}-ees-id-agw-01'
 
 var tagValues = union(resourceTags ?? {}, {
   Environment: environmentName
@@ -412,11 +411,11 @@ module dataProcessorFunctionAppModule 'components/functionApp.bicep' = {
 }
 
 // Create an Application Gateway to serve public traffic for the Public API Container App.
-module appGateway 'components/appGateway.bicep' = {
+module appGatewayModule 'components/appGateway.bicep' = {
   name: 'appGatewayDeploy'
   params: {
     location: location
-    resourcePrefix: resourcePrefix
+    resourcePrefix: subscription
     instanceName: '01'
     keyVaultName: keyVaultName
     subnetId: vNetModule.outputs.appGatewaySubnetRef
@@ -424,7 +423,7 @@ module appGateway 'components/appGateway.bicep' = {
       {
         resourceName: apiContainerAppModule.outputs.containerAppName
         backendFqdn: apiContainerAppModule.outputs.containerAppFqdn
-        publicHostName: publicUrls.publicApi
+        publicFqdn: replace(publicUrls.publicApi, 'https://', '')
         certificateKeyVaultSecretName: '${apiContainerAppModule.outputs.containerAppName}-certificate'
         healthProbeRelativeUrl: '/docs'
       }

--- a/infrastructure/templates/public-api/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-dev.bicepparam
@@ -5,7 +5,8 @@ param environmentName = 'Development'
 
 param publicUrls = {
   contentApi: 'https://content.dev.explore-education-statistics.service.gov.uk'
-  publicApp: 'https://dev.explore-education-statistics.service.gov.uk'
+  publicSite: 'https://dev.explore-education-statistics.service.gov.uk'
+  publicApi: 'https://dev.statistics.api.education.gov.uk'
 }
 
 // PostgreSQL Database Params

--- a/infrastructure/templates/public-api/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-preprod.bicepparam
@@ -5,7 +5,8 @@ param environmentName = 'Pre-Production'
 
 param publicUrls = {
   contentApi: 'https://s101p02-as-ees-content.azurewebsites.net'
-  publicApp: 'https://pre-production.explore-education-statistics.service.gov.uk'
+  publicSite: 'https://pre-production.explore-education-statistics.service.gov.uk'
+  publicApi: 'https://pre-production.statistics.api.education.gov.uk'
 }
 
 // PostgreSQL Database Params

--- a/infrastructure/templates/public-api/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-prod.bicepparam
@@ -5,7 +5,8 @@ param environmentName = 'Production'
 
 param publicUrls = {
   contentApi: 'https://content.explore-education-statistics.service.gov.uk'
-  publicApp: 'https://explore-education-statistics.service.gov.uk'
+  publicSite: 'https://explore-education-statistics.service.gov.uk'
+  publicApi: 'https://statistics.api.education.gov.uk'
 }
 
 // PostgreSQL Database Params

--- a/infrastructure/templates/public-api/parameters/main-test.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-test.bicepparam
@@ -5,7 +5,8 @@ param environmentName = 'Test'
 
 param publicUrls = {
   contentApi: 'https://content.test.explore-education-statistics.service.gov.uk'
-  publicApp: 'https://test.explore-education-statistics.service.gov.uk'
+  publicSite: 'https://test.explore-education-statistics.service.gov.uk'
+  publicApi: 'https://test.statistics.api.education.gov.uk'
 }
 
 // PostgreSQL Database Params


### PR DESCRIPTION
:warning: The testing of this automation will require some time without an App Gateway on Dev, as the existing one is replaced.  No doubt this'll take a couple of days!  Therefore I've put the "Do No Merge" label on until we agree a window of time to do this.

This PR:
- adds modules for the Bicep App Gateway and its WAF policy.
- adds configuration to host the Public API Container Apps through it.

This PR assumes that a pre-existing certificate for the Container App will have been set up prior to standing up the App Gateway. I've added instructions to do this in the Devops Wiki on the "Rolling out Public API infrastructure" page.