### PR TITLE
🐛 EES-4367 Change data set version id to data set id on release API data set preview token page

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
@@ -141,7 +141,7 @@ export default function ReleaseApiDataSetPreviewTokenPage() {
                   <ApiDataSetQuickStart
                     publicApiBaseUrl={publicApiBaseUrl ?? ''}
                     publicApiDocsUrl={publicApiDocsUrl ?? ''}
-                    dataSetId={dataSet.draftVersion?.id}
+                    dataSetId={dataSet.id}
                     dataSetName={dataSet.title}
                     dataSetVersion={dataSet.draftVersion?.version}
                     headingsTag="h4"


### PR DESCRIPTION
This PR fixes a bug on the release API data set preview token page where all instances of the data set Id are currently displaying a data set version Id.

![image](https://github.com/user-attachments/assets/9aef6527-faa1-4a06-b70b-a5d25e6112f1)
