### PR TITLE
EES-5326: Remove "k" character from boundary level table markup.

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/bau/BoundaryDataPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BoundaryDataPage.tsx
@@ -112,7 +112,7 @@ const BoundaryDataPage = () => {
             <tbody>
               {boundaryLevels.map(boundaryLevel => (
                 <tr key={boundaryLevel.id}>
-                  k<td>{locationLevelsMap[boundaryLevel.level].code}</td>
+                  <td>{locationLevelsMap[boundaryLevel.level].code}</td>
                   <td>{boundaryLevel.label}</td>
                   <td>
                     <FormattedDate format="d MMM yyyy">


### PR DESCRIPTION
"k" character added accidentally caused table head/body misalignment, this PR removes that character.
![image](https://github.com/user-attachments/assets/de11f18c-9f05-487e-a18a-a083252f1aca)
