### PR TITLE
EES-5382 use key vault RBAC for public api

### DIFF
--- a/infrastructure/templates/public-api/components/functionApp.bicep
+++ b/infrastructure/templates/public-api/components/functionApp.bicep
@@ -355,11 +355,12 @@ var keyVaultPrincipalIds = userAssignedManagedIdentityParams != null
   ? [userAssignedManagedIdentityParams!.principalId]
   : [functionApp.identity.principalId, stagingSlot.identity.principalId]
 
-module functionAppKeyVaultAccessPolicy 'keyVaultAccessPolicy.bicep' = {
-  name: '${functionAppName}FunctionAppKeyVaultAccessPolicy'
+module functionAppKeyVaultRoleAssignments 'keyVaultRoleAssignment.bicep' = {
+  name: '${functionAppName}FunctionAppKeyVaultRoleAssignment'
   params: {
     keyVaultName: keyVaultName
     principalIds: keyVaultPrincipalIds
+    role: 'Secrets User'
   }
 }
 
@@ -457,7 +458,7 @@ module functionAppSlotSettings 'appServiceSlotConfig.bicep' = {
     azureFileShares: azureFileShares
   }
   dependsOn: [
-    functionAppKeyVaultAccessPolicy
+    functionAppKeyVaultRoleAssignments
     slot1FileShare
     slot2FileShare
   ]

--- a/infrastructure/templates/public-api/components/keyVaultRoleAssignment.bicep
+++ b/infrastructure/templates/public-api/components/keyVaultRoleAssignment.bicep
@@ -1,0 +1,38 @@
+@description('Specifies the name of the Key Vault.')
+param keyVaultName string
+
+@description('Specifies the id of the service principals that should inherit this Key Vault policy')
+param principalIds string[]
+
+@description('Specifies the Key Vault role to assign to the service principals. See https://docs.microsoft.com/azure/role-based-access-control/built-in-roles for possible roles to support here.')
+@allowed([
+  'Secrets User'
+])
+param role string
+
+@description('See https://docs.microsoft.com/azure/role-based-access-control/built-in-roles for possible roles to support here.')
+var roleIds = {
+
+  'Secrets User': '4633458b-17de-408a-b874-0445c86b69e6'
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+@description('Look up the built-in role definition')
+resource roleDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  scope: subscription()
+  name: roleIds[role]
+}
+
+@description('Grant the service principals the key vault role')
+resource keyVaultSecretUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-08-01-preview' = [for principalId in principalIds: {
+  scope: keyVault
+  name: guid(resourceGroup().id, principalId, roleDefinition.id)
+  properties: {
+    roleDefinitionId: roleDefinition.id
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}]

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -3658,213 +3658,201 @@
         "enabledForDiskEncryption": true,
         "enabledForTemplateDeployment": true,
         "enableSoftDelete": true,
-        "accessPolicies": []
+        "accessPolicies": [
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[reference(concat('Microsoft.DataFactory/factories/', variables('dataFactoryName')), '2018-06-01', 'Full').identity.principalId]",
+            "permissions": {
+              "keys": [],
+              "secrets": [
+                "Get",
+                "List"
+              ],
+              "certificates": []
+            }
+          },
+          {
+            "tenantId": "[reference(concat('Microsoft.Web/sites/', variables('adminAppName'), '/providers/Microsoft.ManagedIdentity/Identities/default'), '2015-08-31-PREVIEW').tenantId]",
+            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('adminAppName'), '/providers/Microsoft.ManagedIdentity/Identities/default'), '2015-08-31-PREVIEW').principalId]",
+            "permissions": {
+              "keys": [],
+              "secrets": [
+                "Get",
+                "List"
+              ],
+              "certificates": []
+            }
+          },
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('publisherAppName')), '2019-08-01', 'Full').identity.principalId]",
+            "permissions": {
+              "keys": [],
+              "secrets": [
+                "Get",
+                "List"
+              ],
+              "certificates": []
+            }
+          },
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('notificationsAppName')), '2019-08-01', 'Full').identity.principalId]",
+            "permissions": {
+              "keys": [],
+              "secrets": [
+                "Get",
+                "List"
+              ],
+              "certificates": []
+            }
+          },
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('importerAppName')), '2019-08-01', 'Full').identity.principalId]",
+            "permissions": {
+              "keys": [],
+              "secrets": [
+                "Get",
+                "List"
+              ],
+              "certificates": []
+            }
+          },
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('contentAppName')), '2019-08-01', 'Full').identity.principalId]",
+            "permissions": {
+              "keys": [],
+              "secrets": [
+                "Get",
+                "List"
+              ],
+              "certificates": []
+            }
+          },
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('dataAppName')), '2019-08-01', 'Full').identity.principalId]",
+            "permissions": {
+              "keys": [],
+              "secrets": [
+                "Get",
+                "List"
+              ],
+              "certificates": []
+            }
+          },
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "[parameters('devopsSPN')]",
+            // Devops SPN
+            "permissions": {
+              "keys": [],
+              "secrets": [
+                "Get",
+                "List"
+              ],
+              "certificates": []
+            }
+          },
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "a2d80c7b-fa56-4145-9a11-8aa3f9a4a8fe",
+            // EES Admin Group ID
+            "permissions": {
+              "keys": [
+                "Get",
+                "List",
+                "Update",
+                "Create",
+                "Import",
+                "Delete",
+                "Recover",
+                "Backup",
+                "Restore"
+              ],
+              "secrets": [
+                "Get",
+                "List",
+                "Set",
+                "Delete",
+                "Recover",
+                "Backup",
+                "Restore"
+              ],
+              "certificates": [
+                "Get",
+                "List",
+                "Update",
+                "Create",
+                "Import",
+                "Delete",
+                "Recover",
+                "Backup",
+                "Restore",
+                "ManageContacts",
+                "ManageIssuers",
+                "GetIssuers",
+                "ListIssuers",
+                "SetIssuers",
+                "DeleteIssuers"
+              ]
+            }
+          },
+          {
+            "tenantId": "[subscription().tenantId]",
+            "objectId": "976855ee-57b9-438c-bace-b4dfe141bb7e",
+            // EDAP Team
+            "permissions": {
+              "keys": [
+                "Get",
+                "List",
+                "Update",
+                "Create",
+                "Import",
+                "Delete",
+                "Recover",
+                "Backup",
+                "Restore",
+                "Decrypt",
+                "Encrypt",
+                "UnwrapKey",
+                "WrapKey",
+                "Verify",
+                "Sign"
+              ],
+              "secrets": [
+                "Get",
+                "List",
+                "Set",
+                "Delete",
+                "Recover",
+                "Backup",
+                "Restore"
+              ],
+              "certificates": [
+                "Get",
+                "List",
+                "Update",
+                "Create",
+                "Import",
+                "Delete",
+                "Recover",
+                "Backup",
+                "Restore",
+                "ManageContacts",
+                "ManageIssuers",
+                "GetIssuers",
+                "ListIssuers",
+                "SetIssuers",
+                "DeleteIssuers"
+              ]
+            }
+          }
+        ]
       },
       "resources": [
-        {
-          "type": "accessPolicies",
-          "apiVersion": "2016-10-01",
-          "name": "add",
-          "location": "[resourceGroup().location]",
-          "dependsOn": [
-            "[variables('keyVaultName')]"
-          ],
-          "properties": {
-            "accessPolicies": [
-              {
-                "tenantId": "[subscription().tenantId]",
-                "objectId": "[reference(concat('Microsoft.DataFactory/factories/', variables('dataFactoryName')), '2018-06-01', 'Full').identity.principalId]",
-                "permissions": {
-                  "keys": [],
-                  "secrets": [
-                    "Get",
-                    "List"
-                  ],
-                  "certificates": []
-                }
-              },
-              {
-                "tenantId": "[reference(concat('Microsoft.Web/sites/', variables('adminAppName'), '/providers/Microsoft.ManagedIdentity/Identities/default'), '2015-08-31-PREVIEW').tenantId]",
-                "objectId": "[reference(concat('Microsoft.Web/sites/', variables('adminAppName'), '/providers/Microsoft.ManagedIdentity/Identities/default'), '2015-08-31-PREVIEW').principalId]",
-                "permissions": {
-                  "keys": [],
-                  "secrets": [
-                    "Get",
-                    "List"
-                  ],
-                  "certificates": []
-                }
-              },
-              {
-                "tenantId": "[subscription().tenantId]",
-                "objectId": "[reference(concat('Microsoft.Web/sites/', variables('publisherAppName')), '2019-08-01', 'Full').identity.principalId]",
-                "permissions": {
-                  "keys": [],
-                  "secrets": [
-                    "Get",
-                    "List"
-                  ],
-                  "certificates": []
-                }
-              },
-              {
-                "tenantId": "[subscription().tenantId]",
-                "objectId": "[reference(concat('Microsoft.Web/sites/', variables('notificationsAppName')), '2019-08-01', 'Full').identity.principalId]",
-                "permissions": {
-                  "keys": [],
-                  "secrets": [
-                    "Get",
-                    "List"
-                  ],
-                  "certificates": []
-                }
-              },
-              {
-                "tenantId": "[subscription().tenantId]",
-                "objectId": "[reference(concat('Microsoft.Web/sites/', variables('importerAppName')), '2019-08-01', 'Full').identity.principalId]",
-                "permissions": {
-                  "keys": [],
-                  "secrets": [
-                    "Get",
-                    "List"
-                  ],
-                  "certificates": []
-                }
-              },
-              {
-                "tenantId": "[subscription().tenantId]",
-                "objectId": "[reference(concat('Microsoft.Web/sites/', variables('contentAppName')), '2019-08-01', 'Full').identity.principalId]",
-                "permissions": {
-                  "keys": [],
-                  "secrets": [
-                    "Get",
-                    "List"
-                  ],
-                  "certificates": []
-                }
-              },
-              {
-                "tenantId": "[subscription().tenantId]",
-                "objectId": "[reference(concat('Microsoft.Web/sites/', variables('dataAppName')), '2019-08-01', 'Full').identity.principalId]",
-                "permissions": {
-                  "keys": [],
-                  "secrets": [
-                    "Get",
-                    "List"
-                  ],
-                  "certificates": []
-                }
-              },
-              {
-                "tenantId": "[subscription().tenantId]",
-                "objectId": "[parameters('devopsSPN')]",
-                // Devops SPN
-                "permissions": {
-                  "keys": [],
-                  "secrets": [
-                    "Get",
-                    "List"
-                  ],
-                  "certificates": []
-                }
-              },
-              {
-                "tenantId": "[subscription().tenantId]",
-                "objectId": "a2d80c7b-fa56-4145-9a11-8aa3f9a4a8fe",
-                // EES Admin Group ID
-                "permissions": {
-                  "keys": [
-                    "Get",
-                    "List",
-                    "Update",
-                    "Create",
-                    "Import",
-                    "Delete",
-                    "Recover",
-                    "Backup",
-                    "Restore"
-                  ],
-                  "secrets": [
-                    "Get",
-                    "List",
-                    "Set",
-                    "Delete",
-                    "Recover",
-                    "Backup",
-                    "Restore"
-                  ],
-                  "certificates": [
-                    "Get",
-                    "List",
-                    "Update",
-                    "Create",
-                    "Import",
-                    "Delete",
-                    "Recover",
-                    "Backup",
-                    "Restore",
-                    "ManageContacts",
-                    "ManageIssuers",
-                    "GetIssuers",
-                    "ListIssuers",
-                    "SetIssuers",
-                    "DeleteIssuers"
-                  ]
-                }
-              },
-              {
-                "tenantId": "[subscription().tenantId]",
-                "objectId": "976855ee-57b9-438c-bace-b4dfe141bb7e",
-                // EDAP Team
-                "permissions": {
-                  "keys": [
-                    "Get",
-                    "List",
-                    "Update",
-                    "Create",
-                    "Import",
-                    "Delete",
-                    "Recover",
-                    "Backup",
-                    "Restore",
-                    "Decrypt",
-                    "Encrypt",
-                    "UnwrapKey",
-                    "WrapKey",
-                    "Verify",
-                    "Sign"
-                  ],
-                  "secrets": [
-                    "Get",
-                    "List",
-                    "Set",
-                    "Delete",
-                    "Recover",
-                    "Backup",
-                    "Restore"
-                  ],
-                  "certificates": [
-                    "Get",
-                    "List",
-                    "Update",
-                    "Create",
-                    "Import",
-                    "Delete",
-                    "Recover",
-                    "Backup",
-                    "Restore",
-                    "ManageContacts",
-                    "ManageIssuers",
-                    "GetIssuers",
-                    "ListIssuers",
-                    "SetIssuers",
-                    "DeleteIssuers"
-                  ]
-                }
-              }
-            ]
-          }
-        },
         {
           "type": "secrets",
           "name": "ees-storage-core",


### PR DESCRIPTION
This PR:
- returns template.json back to its original state before EES-5387 work began
- adds a new keyVaultRoleAssignments.bicep module
- uses this instead of access policies to grant KV permissions to the Function App

If this all works, I'll also make this change in the "automating App Gateway" PR as well.