### PR TITLE
EES-5238 - adding in controller call to invoke the completion of next data set version import

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
@@ -48,6 +48,20 @@ public class DataSetVersionsController(IDataSetVersionService dataSetVersionServ
             .HandleFailuresOrOk();
     }
 
+    [HttpPost]
+    [Produces("application/json")]
+    [Route("complete")]
+    public async Task<ActionResult<DataSetVersionSummaryViewModel>> CompleteNextVersionImport(
+        [FromBody] NextDataSetVersionCompleteImportRequest nextDataSetVersionCompleteImportRequest,
+        CancellationToken cancellationToken)
+    {
+        return await dataSetVersionService
+            .CompleteNextVersionImport(
+                dataSetVersionId: nextDataSetVersionCompleteImportRequest.DataSetVersionId,
+                cancellationToken: cancellationToken)
+            .HandleFailuresOrOk();
+    }
+
     [HttpDelete("{dataSetVersionId:guid}")]
     [Produces("application/json")]
     public async Task<ActionResult> DeleteVersion(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/NextDataSetVersionCompleteImportRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/NextDataSetVersionCompleteImportRequest.cs
@@ -1,0 +1,19 @@
+#nullable enable
+using System;
+using FluentValidation;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
+
+public record NextDataSetVersionCompleteImportRequest
+{
+    public required Guid DataSetVersionId { get; init; }
+
+    public class Validator : AbstractValidator<NextDataSetVersionCompleteImportRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.DataSetVersionId)
+                .NotEmpty();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
@@ -41,6 +41,10 @@ public interface IDataSetVersionService
         Guid dataSetId,
         CancellationToken cancellationToken = default);
 
+    Task<Either<ActionResult, DataSetVersionSummaryViewModel>> CompleteNextVersionImport(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken = default);
+
     Task<Either<ActionResult, HttpResponseMessage>> GetVersionChanges(
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IProcessorClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IProcessorClient.cs
@@ -14,9 +14,13 @@ public interface IProcessorClient
         Guid releaseFileId,
         CancellationToken cancellationToken = default);
 
-    Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateNextDataSetVersion(
+    Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateNextDataSetVersionMappings(
         Guid dataSetId,
         Guid releaseFileId,
+        CancellationToken cancellationToken = default);
+
+    Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CompleteNextDataSetVersionImport(
+        Guid dataSetVersionId,
         CancellationToken cancellationToken = default);
 
     Task<Either<ActionResult, Unit>> BulkDeleteDataSetVersions(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
@@ -40,25 +40,37 @@ internal class ProcessorClient(
             cancellationToken: cancellationToken);
     }
 
-    public async Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateNextDataSetVersion(
+    public async Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateNextDataSetVersionMappings(
         Guid dataSetId,
         Guid releaseFileId,
         CancellationToken cancellationToken = default)
     {
-        var request = new NextDataSetVersionCreateMappingsRequest
+        var request = new NextDataSetVersionMappingsCreateRequest
         {
             ReleaseFileId = releaseFileId,
             DataSetId = dataSetId
         };
 
-        return await SendPost<NextDataSetVersionCreateMappingsRequest, ProcessDataSetVersionResponseViewModel>(
-            "api/CreateNextDataSetVersion",
+        return await SendPost<NextDataSetVersionMappingsCreateRequest, ProcessDataSetVersionResponseViewModel>(
+            "api/CreateNextDataSetVersionMappings",
             request,
             cancellationToken: cancellationToken);
     }
-    
+
+    public async Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CompleteNextDataSetVersionImport(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new NextDataSetVersionCompleteImportRequest { DataSetVersionId = dataSetVersionId };
+
+        return await SendPost<NextDataSetVersionCompleteImportRequest, ProcessDataSetVersionResponseViewModel>(
+            "api/CompleteNextDataSetVersionImport",
+            request,
+            cancellationToken: cancellationToken);
+    }
+
     public async Task<Either<ActionResult, Unit>> BulkDeleteDataSetVersions(
-        Guid releaseVersionId, 
+        Guid releaseVersionId,
         CancellationToken cancellationToken = default)
     {
         return await SendDelete(
@@ -72,7 +84,7 @@ internal class ProcessorClient(
     {
         return await SendDelete(
             $"api/DeleteDataSetVersion/{dataSetVersionId}",
-            response => 
+            response =>
                 response.StatusCode == HttpStatusCode.NotFound ? new NotFoundResult() : null,
             cancellationToken: cancellationToken);
     }
@@ -115,7 +127,7 @@ internal class ProcessorClient(
         await AddBearerToken(cancellationToken);
 
         var response = await requestFunction.Invoke();
-        
+
         var customHandlerResponse = customResponseHandler?.Invoke(response);
 
         if (customHandlerResponse is not null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -160,25 +160,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             });
 
             services.AddControllers(options =>
-            {
-                options.AddCommaSeparatedQueryModelBinderProvider();
-                options.AddTrimStringBinderProvider();
-            })
+                {
+                    options.AddCommaSeparatedQueryModelBinderProvider();
+                    options.AddTrimStringBinderProvider();
+                })
                 .AddControllersAsServices();
 
             services.AddHttpContextAccessor();
 
             services.AddFluentValidation();
-            services.AddValidatorsFromAssembly(typeof(FullTableQueryRequest.Validator).Assembly); // Adds *all* validators from Common
+            services.AddValidatorsFromAssembly(typeof(FullTableQueryRequest.Validator)
+                .Assembly); // Adds *all* validators from Common
 
             services.AddMvc(options =>
-            {
-                options.Filters.Add(new AuthorizeFilter(SecurityPolicies.RegisteredUser.ToString()));
-                options.Filters.Add(new OperationCancelledExceptionFilter());
-                options.Filters.Add(new ProblemDetailsResultFilter());
-                options.EnableEndpointRouting = false;
-                options.AllowEmptyInputInBodyModelBinding = true;
-            })
+                {
+                    options.Filters.Add(new AuthorizeFilter(SecurityPolicies.RegisteredUser.ToString()));
+                    options.Filters.Add(new OperationCancelledExceptionFilter());
+                    options.Filters.Add(new ProblemDetailsResultFilter());
+                    options.EnableEndpointRouting = false;
+                    options.AllowEmptyInputInBodyModelBinding = true;
+                })
                 .AddNewtonsoftJson(options =>
                 {
                     options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
@@ -716,9 +717,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapHub<ReleaseContentHub>("/hubs/release-content");
-            }
+                {
+                    endpoints.MapHub<ReleaseContentHub>("/hubs/release-content");
+                }
             );
 
             app.UseMvc();
@@ -792,32 +793,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             Guid releaseFileId,
             CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-        public Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateNextDataSetVersion(
+        public Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateNextDataSetVersionMappings(
             Guid dataSetId,
             Guid releaseFileId,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CompleteNextDataSetVersionImport(
+            Guid dataSetVersionId,
             CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public Task<Either<ActionResult, Unit>> BulkDeleteDataSetVersions(
             Guid releaseVersionId,
             CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(new Either<ActionResult,Unit>(Unit.Instance));
+            return Task.FromResult(new Either<ActionResult, Unit>(Unit.Instance));
         }
 
         public Task<Either<ActionResult, Unit>> DeleteDataSetVersion(
             Guid dataSetVersionId,
             CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(new Either<ActionResult,Unit>(Unit.Instance));
+            return Task.FromResult(new Either<ActionResult, Unit>(Unit.Instance));
         }
     }
 
     internal class NoOpDataSetVersionService : IDataSetVersionService
     {
         public Task<Either<ActionResult, PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>>> ListLiveVersions(
-            Guid dataSetId, 
-            int page, 
-            int pageSize, 
+            Guid dataSetId,
+            int page,
+            int pageSize,
             CancellationToken cancellationToken = default)
         {
             return Task.FromResult(PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>.Paginate([], 1, 10));
@@ -843,8 +848,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             Guid dataSetId,
             CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
+        public Task<Either<ActionResult, DataSetVersionSummaryViewModel>> CompleteNextVersionImport(
+            Guid dataSetVersionId,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
         public Task<Either<ActionResult, Unit>> DeleteVersion(
-            Guid dataSetVersionId, 
+            Guid dataSetVersionId,
             CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new Either<ActionResult, Unit>(Unit.Instance));
@@ -856,7 +865,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             => throw new NotImplementedException();
 
         public Task<Either<ActionResult, DataSetDraftVersionViewModel>> UpdateVersion(
-            DataSetVersionUpdateRequest updateRequest, 
+            DataSetVersionUpdateRequest updateRequest,
             CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new Either<ActionResult, DataSetDraftVersionViewModel>(new NotFoundResult()));
@@ -870,10 +879,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<Either<ActionResult, BatchLocationMappingUpdatesResponseViewModel>> ApplyBatchLocationMappingUpdates(
-            Guid nextDataSetVersionId,
-            BatchLocationMappingUpdatesRequest request,
-            CancellationToken cancellationToken = default)
+        public Task<Either<ActionResult, BatchLocationMappingUpdatesResponseViewModel>>
+            ApplyBatchLocationMappingUpdates(
+                Guid nextDataSetVersionId,
+                BatchLocationMappingUpdatesRequest request,
+                CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public Task<Either<ActionResult, FilterMappingPlan>> GetFilterMappings(
@@ -881,9 +891,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<Either<ActionResult, BatchFilterOptionMappingUpdatesResponseViewModel>> ApplyBatchFilterOptionMappingUpdates(Guid nextDataSetVersionId,
-            BatchFilterOptionMappingUpdatesRequest request,
-            CancellationToken cancellationToken = default) =>
+        public Task<Either<ActionResult, BatchFilterOptionMappingUpdatesResponseViewModel>>
+            ApplyBatchFilterOptionMappingUpdates(Guid nextDataSetVersionId,
+                BatchFilterOptionMappingUpdatesRequest request,
+                CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/NextDataSetVersionMappingsCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/NextDataSetVersionMappingsCreateRequest.cs
@@ -2,13 +2,13 @@ using FluentValidation;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
 
-public record NextDataSetVersionCreateMappingsRequest
+public record NextDataSetVersionMappingsCreateRequest
 {
     public required Guid DataSetId { get; init; }
 
     public required Guid ReleaseFileId { get; init; }
 
-    public class Validator : AbstractValidator<NextDataSetVersionCreateMappingsRequest>
+    public class Validator : AbstractValidator<NextDataSetVersionMappingsCreateRequest>
     {
         public Validator()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateNextDataSetVersionMappingsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateNextDataSetVersionMappingsFunctionTests.cs
@@ -131,7 +131,7 @@ public abstract class CreateNextDataSetVersionMappingsFunctionTests(
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasNotEmptyError(
-                nameof(NextDataSetVersionCreateMappingsRequest.ReleaseFileId).ToLowerFirst());
+                nameof(NextDataSetVersionMappingsCreateRequest.ReleaseFileId).ToLowerFirst());
         }
 
         [Fact]
@@ -144,7 +144,7 @@ public abstract class CreateNextDataSetVersionMappingsFunctionTests(
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasNotEmptyError(
-                nameof(NextDataSetVersionCreateMappingsRequest.DataSetId).ToLowerFirst());
+                nameof(NextDataSetVersionMappingsCreateRequest.DataSetId).ToLowerFirst());
         }
 
         [Fact]
@@ -160,7 +160,7 @@ public abstract class CreateNextDataSetVersionMappingsFunctionTests(
 
             result.AssertNotFoundWithValidationProblem<DataSet, Guid>(
                 expectedId: dataSetId,
-                expectedPath: nameof(NextDataSetVersionCreateMappingsRequest.DataSetId).ToLowerFirst());
+                expectedPath: nameof(NextDataSetVersionMappingsCreateRequest.DataSetId).ToLowerFirst());
         }
 
         [Fact]
@@ -214,7 +214,7 @@ public abstract class CreateNextDataSetVersionMappingsFunctionTests(
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(NextDataSetVersionCreateMappingsRequest.ReleaseFileId).ToLowerFirst(),
+                expectedPath: nameof(NextDataSetVersionMappingsCreateRequest.ReleaseFileId).ToLowerFirst(),
                 expectedCode: ValidationMessages.FileHasApiDataSetVersion.Code);
         }
 
@@ -323,7 +323,7 @@ public abstract class CreateNextDataSetVersionMappingsFunctionTests(
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(NextDataSetVersionCreateMappingsRequest.ReleaseFileId).ToLowerFirst(),
+                expectedPath: nameof(NextDataSetVersionMappingsCreateRequest.ReleaseFileId).ToLowerFirst(),
                 expectedCode: ValidationMessages.FileNotInDataSetPublication.Code
             );
         }
@@ -346,7 +346,7 @@ public abstract class CreateNextDataSetVersionMappingsFunctionTests(
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(NextDataSetVersionCreateMappingsRequest.DataSetId).ToLowerFirst(),
+                expectedPath: nameof(NextDataSetVersionMappingsCreateRequest.DataSetId).ToLowerFirst(),
                 expectedCode: ValidationMessages.DataSetNoLiveVersion.Code
             );
         }
@@ -397,7 +397,7 @@ public abstract class CreateNextDataSetVersionMappingsFunctionTests(
             var validationProblem = result.AssertBadRequestWithValidationProblem();
 
             validationProblem.AssertHasError(
-                expectedPath: nameof(NextDataSetVersionCreateMappingsRequest.ReleaseFileId).ToLowerFirst(),
+                expectedPath: nameof(NextDataSetVersionMappingsCreateRequest.ReleaseFileId).ToLowerFirst(),
                 expectedCode: ValidationMessages.FileMustBeInDifferentRelease.Code
             );
         }
@@ -470,8 +470,8 @@ public abstract class CreateNextDataSetVersionMappingsFunctionTests(
             DurableTaskClient? durableTaskClient = null)
         {
             var function = GetRequiredService<CreateNextDataSetVersionMappingsFunction>();
-            return await function.CreateNextDataSetVersion(
-                new NextDataSetVersionCreateMappingsRequest
+            return await function.CreateNextDataSetVersionMappings(
+                new NextDataSetVersionMappingsCreateRequest
                 {
                     DataSetId = dataSetId,
                     ReleaseFileId = releaseFileId

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateNextDataSetVersionMappingsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateNextDataSetVersionMappingsFunction.cs
@@ -17,22 +17,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Funct
 public class CreateNextDataSetVersionMappingsFunction(
     ILogger<CreateNextDataSetVersionMappingsFunction> logger,
     IDataSetVersionService dataSetVersionService,
-    IValidator<NextDataSetVersionCreateMappingsRequest> requestValidator)
+    IValidator<NextDataSetVersionMappingsCreateRequest> requestValidator)
 {
-    [Function(nameof(CreateNextDataSetVersion))]
-    public async Task<IActionResult> CreateNextDataSetVersion(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = nameof(CreateNextDataSetVersion))] [FromBody]
-        NextDataSetVersionCreateMappingsRequest mappingsRequest,
+    [Function(nameof(CreateNextDataSetVersionMappings))]
+    public async Task<IActionResult> CreateNextDataSetVersionMappings(
+        [HttpTrigger(
+            AuthorizationLevel.Anonymous, "post",
+            Route = nameof(CreateNextDataSetVersionMappings))]
+        [FromBody]
+        NextDataSetVersionMappingsCreateRequest request,
         [DurableClient] DurableTaskClient client,
         CancellationToken cancellationToken)
     {
         // Identifier of the scheduled processing orchestration instance
         var instanceId = Guid.NewGuid();
 
-        return await requestValidator.Validate(mappingsRequest, cancellationToken)
+        return await requestValidator.Validate(request, cancellationToken)
             .OnSuccess(() => dataSetVersionService.CreateNextVersion(
-                dataSetId: mappingsRequest.DataSetId,
-                releaseFileId: mappingsRequest.ReleaseFileId,
+                dataSetId: request.DataSetId,
+                releaseFileId: request.ReleaseFileId,
                 instanceId,
                 cancellationToken: cancellationToken
             ))
@@ -46,7 +49,7 @@ public class CreateNextDataSetVersionMappingsFunction(
 
                 return new ProcessDataSetVersionResponseViewModel
                 {
-                    DataSetId = mappingsRequest.DataSetId,
+                    DataSetId = request.DataSetId,
                     DataSetVersionId = dataSetVersionId,
                     InstanceId = instanceId
                 };
@@ -60,7 +63,8 @@ public class CreateNextDataSetVersionMappingsFunction(
         Guid instanceId,
         CancellationToken cancellationToken)
     {
-        const string orchestratorName = nameof(ProcessNextDataSetVersionMappingsFunction.ProcessNextDataSetVersionMappings);
+        const string orchestratorName =
+            nameof(ProcessNextDataSetVersionMappingsFunction.ProcessNextDataSetVersionMappings);
 
         var input = new ProcessDataSetVersionContext { DataSetVersionId = dataSetVersionId };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -280,7 +280,7 @@ internal class DataSetVersionService(
         return dataSet is null
             ? ValidationUtils.NotFoundResult<DataSet, Guid>(
                 id: dataSetId,
-                path: nameof(NextDataSetVersionCreateMappingsRequest.DataSetId).ToLowerFirst())
+                path: nameof(NextDataSetVersionMappingsCreateRequest.DataSetId).ToLowerFirst())
             : dataSet;
     }
 
@@ -350,7 +350,7 @@ internal class DataSetVersionService(
         return releaseFile is null
             ? ValidationUtils.NotFoundResult<ReleaseFile, Guid>(
                 id: releaseFileId,
-                path: nameof(NextDataSetVersionCreateMappingsRequest.ReleaseFileId).ToLowerFirst())
+                path: nameof(NextDataSetVersionMappingsCreateRequest.ReleaseFileId).ToLowerFirst())
             : releaseFile;
     }
 
@@ -522,7 +522,7 @@ internal class DataSetVersionService(
         {
             Code = message.Code,
             Message = message.Message,
-            Path = nameof(NextDataSetVersionCreateMappingsRequest.DataSetId).ToLowerFirst(),
+            Path = nameof(NextDataSetVersionMappingsCreateRequest.DataSetId).ToLowerFirst(),
             Detail = new InvalidErrorDetail<Guid>(dataSetId)
         };
     }


### PR DESCRIPTION
This PR:
- adds a controller call to Admin to invoke the Data Processor endpoint that completes the import after mappings are complete.
- renames the original CreateNextDataSetVersion function to be CreateNextDataSetVersionMappings, to be more consistent with other naming around this function.
- adds some missing tests for CreateNextDataSetVersion in Admin.