### PR TITLE
EES-5416 Fix release files not being unlinked when draft data set versions deleted

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
@@ -252,7 +252,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile(FileType.Data))
                 .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextDataSetVersion.SemVersion());
 
             await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -393,7 +393,7 @@ public abstract class DataSetVersionMappingControllerTests(
             // Assert that this update constitutes a major version update, as some locations options
             // are 'ManualNone', indicating that some of the source location options may have been
             // removed thus creating a breaking change.
-            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.SemVersion());
         }
 
         [Theory]
@@ -484,7 +484,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile())
                 .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextDataSetVersion.SemVersion());
 
             await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -609,7 +609,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile(FileType.Data))
                 .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextDataSetVersion.SemVersion());
 
             await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -643,7 +643,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
 
             // Assert that the batch save calculates the next data set version correctly. 
-            Assert.Equal(expectedVersion, updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+            Assert.Equal(expectedVersion, updatedMappings.TargetDataSetVersion.SemVersion());
 
             var updatedReleaseFile = await TestApp.GetDbContext<ContentDbContext>()
                 .ReleaseFiles
@@ -728,7 +728,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile(FileType.Data))
                 .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextDataSetVersion.SemVersion());
 
             await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -1263,7 +1263,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile(FileType.Data))
                 .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextDataSetVersion.SemVersion());
 
             await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -1389,7 +1389,7 @@ public abstract class DataSetVersionMappingControllerTests(
             // belonging to mapped filters have a mapping type of "ManualNone", indicating that 
             // some of the source filter options are no longer available in the target data set
             // version, thus creating a breaking change. 
-            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.SemVersion());
         }
 
         [Theory]
@@ -1483,7 +1483,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile(FileType.Data))
                 .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextDataSetVersion.SemVersion());
 
             await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -1602,7 +1602,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile(FileType.Data))
                 .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextDataSetVersion.SemVersion());
 
             await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -1636,7 +1636,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
 
             // Assert that the batch save calculates the next version number as expected. 
-            Assert.Equal(expectedVersion, updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+            Assert.Equal(expectedVersion, updatedMappings.TargetDataSetVersion.SemVersion());
 
             var updatedReleaseFile = await TestApp.GetDbContext<ContentDbContext>()
                 .ReleaseFiles
@@ -1717,7 +1717,7 @@ public abstract class DataSetVersionMappingControllerTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile(FileType.Data))
                 .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextDataSetVersion.SemVersion());
 
             await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionMappingControllerTests.cs
@@ -9,9 +9,13 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Fixture;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
@@ -243,6 +247,15 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersionMappings.Add(mappings);
             });
 
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextDataSetVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile(FileType.Data))
+                .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+
+            await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
+
             var client = BuildApp().CreateClient();
 
             List<LocationMappingUpdateRequest> updates =
@@ -314,6 +327,7 @@ public abstract class DataSetVersionMappingControllerTests(
 
             var updatedMappings = TestApp.GetDbContext<PublicDataDbContext>()
                 .DataSetVersionMappings
+                .Include(m => m.TargetDataSetVersion)
                 .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
 
             var expectedFullMappings = new Dictionary<GeographicLevel, LocationLevelMappings>
@@ -375,6 +389,11 @@ public abstract class DataSetVersionMappingControllerTests(
             // Assert that the batch saves still show the location mappings as incomplete, as there
             // are still mappings with type "AutoNone" in the plan.
             Assert.False(updatedMappings.LocationMappingsComplete);
+
+            // Assert that this update constitutes a major version update, as some locations options
+            // are 'ManualNone', indicating that some of the source location options may have been
+            // removed thus creating a breaking change.
+            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
         }
 
         [Theory]
@@ -460,6 +479,15 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersionMappings.Add(mappings);
             });
 
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextDataSetVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile())
+                .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+
+            await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
+
             var client = BuildApp().CreateClient();
 
             var mappingCandidateKey = updatedMappingType == MappingType.ManualMapped
@@ -494,14 +522,14 @@ public abstract class DataSetVersionMappingControllerTests(
         }
 
         [Theory]
-        [InlineData(MappingType.ManualMapped, MappingType.AutoNone, "2.0")]
-        [InlineData(MappingType.ManualMapped, MappingType.AutoMapped, "1.1")]
-        [InlineData(MappingType.ManualMapped, MappingType.ManualMapped, "1.1")]
-        [InlineData(MappingType.ManualMapped, MappingType.ManualNone, "2.0")]
-        [InlineData(MappingType.ManualNone, MappingType.AutoNone, "2.0")]
-        [InlineData(MappingType.ManualNone, MappingType.AutoMapped, "2.0")]
-        [InlineData(MappingType.ManualNone, MappingType.ManualMapped, "2.0")]
-        [InlineData(MappingType.ManualNone, MappingType.ManualNone, "2.0")]
+        [InlineData(MappingType.ManualMapped, MappingType.AutoNone, "2.0.0")]
+        [InlineData(MappingType.ManualMapped, MappingType.AutoMapped, "1.1.0")]
+        [InlineData(MappingType.ManualMapped, MappingType.ManualMapped, "1.1.0")]
+        [InlineData(MappingType.ManualMapped, MappingType.ManualNone, "2.0.0")]
+        [InlineData(MappingType.ManualNone, MappingType.AutoNone, "2.0.0")]
+        [InlineData(MappingType.ManualNone, MappingType.AutoMapped, "2.0.0")]
+        [InlineData(MappingType.ManualNone, MappingType.ManualMapped, "2.0.0")]
+        [InlineData(MappingType.ManualNone, MappingType.ManualNone, "2.0.0")]
         public async Task Success_VersionUpdate(
             MappingType updatedMappingType,
             MappingType unchangedMappingType,
@@ -576,6 +604,15 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersionMappings.Add(mappings);
             });
 
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextDataSetVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile(FileType.Data))
+                .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+
+            await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
+
             var client = BuildApp().CreateClient();
 
             var mappingCandidateKey = updatedMappingType == MappingType.ManualMapped
@@ -606,7 +643,13 @@ public abstract class DataSetVersionMappingControllerTests(
                 .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
 
             // Assert that the batch save calculates the next data set version correctly. 
-            Assert.Equal(expectedVersion, updatedMappings.TargetDataSetVersion.Version);
+            Assert.Equal(expectedVersion, updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+
+            var updatedReleaseFile = await TestApp.GetDbContext<ContentDbContext>()
+                .ReleaseFiles
+                .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
+
+            Assert.Equal(expectedVersion, updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         [Fact]
@@ -679,6 +722,15 @@ public abstract class DataSetVersionMappingControllerTests(
             {
                 context.DataSetVersionMappings.Add(mappings);
             });
+
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextDataSetVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile(FileType.Data))
+                .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+
+            await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
             var client = BuildApp().CreateClient();
 
@@ -1206,6 +1258,15 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersionMappings.Add(mappings);
             });
 
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextDataSetVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile(FileType.Data))
+                .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+
+            await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
+
             var client = BuildApp().CreateClient();
 
             List<FilterOptionMappingUpdateRequest> updates =
@@ -1328,7 +1389,7 @@ public abstract class DataSetVersionMappingControllerTests(
             // belonging to mapped filters have a mapping type of "ManualNone", indicating that 
             // some of the source filter options are no longer available in the target data set
             // version, thus creating a breaking change. 
-            Assert.Equal("2.0", updatedMappings.TargetDataSetVersion.Version);
+            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
         }
 
         [Theory]
@@ -1417,6 +1478,15 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersionMappings.Add(mappings);
             });
 
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextDataSetVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile(FileType.Data))
+                .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+
+            await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
+
             var client = BuildApp().CreateClient();
 
             var mappingCandidateKey = updatedMappingType == MappingType.ManualMapped
@@ -1451,14 +1521,14 @@ public abstract class DataSetVersionMappingControllerTests(
         }
 
         [Theory]
-        [InlineData(MappingType.ManualMapped, MappingType.AutoMapped, "1.1")]
-        [InlineData(MappingType.ManualMapped, MappingType.AutoNone, "2.0")]
-        [InlineData(MappingType.ManualMapped, MappingType.ManualMapped, "1.1")]
-        [InlineData(MappingType.ManualMapped, MappingType.ManualNone, "2.0")]
-        [InlineData(MappingType.ManualNone, MappingType.AutoMapped, "2.0")]
-        [InlineData(MappingType.ManualNone, MappingType.AutoNone, "2.0")]
-        [InlineData(MappingType.ManualNone, MappingType.ManualMapped, "2.0")]
-        [InlineData(MappingType.ManualNone, MappingType.ManualNone, "2.0")]
+        [InlineData(MappingType.ManualMapped, MappingType.AutoMapped, "1.1.0")]
+        [InlineData(MappingType.ManualMapped, MappingType.AutoNone, "2.0.0")]
+        [InlineData(MappingType.ManualMapped, MappingType.ManualMapped, "1.1.0")]
+        [InlineData(MappingType.ManualMapped, MappingType.ManualNone, "2.0.0")]
+        [InlineData(MappingType.ManualNone, MappingType.AutoMapped, "2.0.0")]
+        [InlineData(MappingType.ManualNone, MappingType.AutoNone, "2.0.0")]
+        [InlineData(MappingType.ManualNone, MappingType.ManualMapped, "2.0.0")]
+        [InlineData(MappingType.ManualNone, MappingType.ManualNone, "2.0.0")]
         public async Task Success_VersionUpdate(
             MappingType updatedMappingType,
             MappingType unchangedMappingType,
@@ -1527,6 +1597,15 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersionMappings.Add(mappings);
             });
 
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextDataSetVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile(FileType.Data))
+                .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+
+            await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
+
             var client = BuildApp().CreateClient();
 
             var mappingCandidateKey = updatedMappingType == MappingType.ManualMapped
@@ -1557,7 +1636,13 @@ public abstract class DataSetVersionMappingControllerTests(
                 .Single(m => m.TargetDataSetVersionId == nextDataSetVersion.Id);
 
             // Assert that the batch save calculates the next version number as expected. 
-            Assert.Equal(expectedVersion, updatedMappings.TargetDataSetVersion.Version);
+            Assert.Equal(expectedVersion, updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+
+            var updatedReleaseFile = await TestApp.GetDbContext<ContentDbContext>()
+                .ReleaseFiles
+                .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
+
+            Assert.Equal(expectedVersion, updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         [Theory]
@@ -1627,6 +1712,15 @@ public abstract class DataSetVersionMappingControllerTests(
                 context.DataSetVersionMappings.Add(mappings);
             });
 
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextDataSetVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile(FileType.Data))
+                .WithPublicApiDataSetId(nextDataSetVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextDataSetVersion.FullSemanticVersion());
+
+            await TestApp.AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
+
             var client = BuildApp().CreateClient();
 
             var mappingCandidateKey = updatedMappingType == MappingType.ManualMapped
@@ -1659,7 +1753,7 @@ public abstract class DataSetVersionMappingControllerTests(
             // Assert that the batch save calculates the next version number as a major change,
             // as filter options that were in the source data set version no longer appear in the
             // next version. 
-            Assert.Equal("2.0", updatedMappings.TargetDataSetVersion.Version);
+            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.SemVersion());
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
@@ -118,7 +118,7 @@ public abstract class DataSetVersionsControllerTests(
 
             var liveVersion = Assert.Single(viewModel.Results);
             Assert.Equal(currentDataSetVersion.Id, liveVersion.Id);
-            Assert.Equal(currentDataSetVersion.Version, liveVersion.Version);
+            Assert.Equal(currentDataSetVersion.PublicVersion, liveVersion.Version);
             Assert.Equal(currentDataSetVersion.Status, liveVersion.Status);
             Assert.Equal(currentDataSetVersion.VersionType, liveVersion.Type);
             Assert.Equal(releaseFile.ReleaseVersion.Id, liveVersion.ReleaseVersion.Id);
@@ -299,7 +299,7 @@ public abstract class DataSetVersionsControllerTests(
 
             var liveVersion = Assert.Single(viewModel.Results);
             Assert.Equal(targetDataSetVersion.Id, liveVersion.Id);
-            Assert.Equal(targetDataSetVersion.Version, liveVersion.Version);
+            Assert.Equal(targetDataSetVersion.PublicVersion, liveVersion.Version);
             Assert.Equal(targetDataSetVersion.Status, liveVersion.Status);
             Assert.Equal(targetDataSetVersion.VersionType, liveVersion.Type);
             Assert.Equal(targetReleaseFile.ReleaseVersion.Id, liveVersion.ReleaseVersion.Id);
@@ -421,7 +421,7 @@ public abstract class DataSetVersionsControllerTests(
 
             Assert.NotNull(nextVersion);
             Assert.Equal(viewModel.Id, nextVersion.Id);
-            Assert.Equal(viewModel.Version, nextVersion.Version);
+            Assert.Equal(viewModel.Version, nextVersion.PublicVersion);
             Assert.Equal(viewModel.Status, nextVersion.Status);
             Assert.Equal(viewModel.Type, nextVersion.VersionType);
         }
@@ -538,7 +538,7 @@ public abstract class DataSetVersionsControllerTests(
             var viewModel = response.AssertOk<DataSetVersionSummaryViewModel>();
 
             Assert.Equal(viewModel.Id, nextDataSetVersion.Id);
-            Assert.Equal(viewModel.Version, nextDataSetVersion.Version);
+            Assert.Equal(viewModel.Version, nextDataSetVersion.PublicVersion);
             Assert.Equal(viewModel.Status, nextDataSetVersion.Status);
             Assert.Equal(viewModel.Type, nextDataSetVersion.VersionType);
         }
@@ -796,7 +796,7 @@ public abstract class DataSetVersionsControllerTests(
             publicDataApiClient
                 .Setup(c => c.GetDataSetVersionChanges(
                     dataSetVersion.DataSetId,
-                    dataSetVersion.Version,
+                    dataSetVersion.PublicVersion,
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
                     new HttpResponseMessage(HttpStatusCode.OK)
@@ -858,7 +858,7 @@ public abstract class DataSetVersionsControllerTests(
             publicDataApiClient
                 .Setup(c => c.GetDataSetVersionChanges(
                     dataSetVersion.DataSetId,
-                    dataSetVersion.Version,
+                    dataSetVersion.PublicVersion,
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ValidationUtils.ValidationResult());
 
@@ -899,7 +899,7 @@ public abstract class DataSetVersionsControllerTests(
             publicDataApiClient
                 .Setup(c => c.GetDataSetVersionChanges(
                     dataSetVersion.DataSetId,
-                    dataSetVersion.Version,
+                    dataSetVersion.PublicVersion,
                     It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new HttpRequestException());
 
@@ -1004,7 +1004,7 @@ public abstract class DataSetVersionsControllerTests(
 
             Assert.NotNull(viewModel);
             Assert.Equal(nextDataSetVersion.Id, viewModel.Id);
-            Assert.Equal(nextDataSetVersion.Version, viewModel.Version);
+            Assert.Equal(nextDataSetVersion.PublicVersion, viewModel.Version);
             Assert.Equal(nextDataSetVersion.Status, viewModel.Status);
             Assert.Equal(nextDataSetVersion.VersionType, viewModel.Type);
             Assert.Equal(releaseFile.File.DataSetFileId!.Value, viewModel.File.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetsControllerTests.cs
@@ -148,13 +148,13 @@ public abstract class DataSetsControllerTests(
                 () => Assert.Equal(dataSet.Status, dataSetViewModel.Status),
                 () => Assert.Null(dataSetViewModel.SupersedingDataSetId),
                 () => Assert.Equal(draftDataSetVersion.Id, dataSetViewModel.DraftVersion.Id),
-                () => Assert.Equal(draftDataSetVersion.Version, dataSetViewModel.DraftVersion.Version),
+                () => Assert.Equal(draftDataSetVersion.PublicVersion, dataSetViewModel.DraftVersion.Version),
                 () => Assert.Equal(draftDataSetVersion.Status, dataSetViewModel.DraftVersion.Status),
                 () => Assert.Equal(draftDataSetVersion.VersionType, dataSetViewModel.DraftVersion.Type),
                 () => Assert.Equal(draftReleaseVersion.Id, dataSetViewModel.DraftVersion.ReleaseVersion.Id),
                 () => Assert.Equal(draftReleaseVersion.Title, dataSetViewModel.DraftVersion.ReleaseVersion.Title),
                 () => Assert.Equal(liveDataSetVersion.Id, dataSetViewModel.LatestLiveVersion.Id),
-                () => Assert.Equal(liveDataSetVersion.Version, dataSetViewModel.LatestLiveVersion.Version),
+                () => Assert.Equal(liveDataSetVersion.PublicVersion, dataSetViewModel.LatestLiveVersion.Version),
                 () => Assert.Equal(liveDataSetVersion.Status, dataSetViewModel.LatestLiveVersion.Status),
                 () => Assert.Equal(liveDataSetVersion.VersionType, dataSetViewModel.LatestLiveVersion.Type),
                 () => Assert.Equal(liveReleaseVersion.Id, dataSetViewModel.LatestLiveVersion.ReleaseVersion.Id),
@@ -668,7 +668,7 @@ public abstract class DataSetsControllerTests(
             Assert.Equal(dataSet.Status, viewModel.Status);
 
             Assert.Equal(liveDataSetVersion.Id, viewModel.LatestLiveVersion!.Id);
-            Assert.Equal(liveDataSetVersion.Version, viewModel.LatestLiveVersion.Version);
+            Assert.Equal(liveDataSetVersion.PublicVersion, viewModel.LatestLiveVersion.Version);
             Assert.Equal(liveDataSetVersion.Status, viewModel.LatestLiveVersion.Status);
             Assert.Equal(liveDataSetVersion.VersionType, viewModel.LatestLiveVersion.Type);
             Assert.Equal(liveDataSetVersion.TotalResults, viewModel.LatestLiveVersion.TotalResults);
@@ -693,7 +693,7 @@ public abstract class DataSetsControllerTests(
             Assert.Equal(liveReleaseVersion.Title, viewModel.LatestLiveVersion.ReleaseVersion.Title);
 
             Assert.Equal(draftDataSetVersion.Id, viewModel.DraftVersion!.Id);
-            Assert.Equal(draftDataSetVersion.Version, viewModel.DraftVersion.Version);
+            Assert.Equal(draftDataSetVersion.PublicVersion, viewModel.DraftVersion.Version);
             Assert.Equal(draftDataSetVersion.Status, viewModel.DraftVersion.Status);
             Assert.Equal(draftDataSetVersion.VersionType, viewModel.DraftVersion.Type);
             Assert.Equal(draftDataSetVersion.TotalResults, viewModel.DraftVersion.TotalResults);
@@ -850,7 +850,7 @@ public abstract class DataSetsControllerTests(
             Assert.Equal(new[] { releaseVersion.ReleaseId }, viewModel.PreviousReleaseIds);
 
             Assert.Equal(dataSetVersion.Id, viewModel.LatestLiveVersion!.Id);
-            Assert.Equal(dataSetVersion.Version, viewModel.LatestLiveVersion.Version);
+            Assert.Equal(dataSetVersion.PublicVersion, viewModel.LatestLiveVersion.Version);
             Assert.Equal(dataSetVersion.Status, viewModel.LatestLiveVersion.Status);
             Assert.Equal(dataSetVersion.VersionType, viewModel.LatestLiveVersion.Type);
             Assert.Equal(releaseFile.File.DataSetFileId, viewModel.LatestLiveVersion!.File.Id);
@@ -914,7 +914,7 @@ public abstract class DataSetsControllerTests(
             Assert.Equal(new[] { releaseVersion.ReleaseId }, viewModel.PreviousReleaseIds);
 
             Assert.Equal(dataSetVersion.Id, viewModel.DraftVersion!.Id);
-            Assert.Equal(dataSetVersion.Version, viewModel.DraftVersion.Version);
+            Assert.Equal(dataSetVersion.PublicVersion, viewModel.DraftVersion.Version);
             Assert.Equal(dataSetVersion.Status, viewModel.DraftVersion.Status);
             Assert.Equal(dataSetVersion.VersionType, viewModel.DraftVersion.Type);
             Assert.Equal(releaseFile.File.DataSetFileId, viewModel.DraftVersion!.File.Id);
@@ -1131,7 +1131,7 @@ public abstract class DataSetsControllerTests(
             Assert.Equal(dataSet.Summary, content.Summary);
             Assert.Null(dataSet.LatestLiveVersion);
             Assert.Equal(dataSetVersion!.Id, content.DraftVersion!.Id);
-            Assert.Equal(dataSetVersion.Version, content.DraftVersion!.Version);
+            Assert.Equal(dataSetVersion.PublicVersion, content.DraftVersion!.Version);
             Assert.Equal(dataSetVersion.Status, content.DraftVersion!.Status);
             Assert.Equal(dataSetVersion.VersionType, content.DraftVersion!.Type);
             Assert.Equal(releaseFile.File.DataSetFileId, content.DraftVersion!.File.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -454,7 +454,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataSet.Id, deleteDataFilePlan.DeleteApiDataSetVersionPlan.DataSetId);
                 Assert.Equal(dataSet.Title, deleteDataFilePlan.DeleteApiDataSetVersionPlan.DataSetTitle);
                 Assert.Equal(dataSetVersion.Id, deleteDataFilePlan.DeleteApiDataSetVersionPlan.Id);
-                Assert.Equal(dataSetVersion.Version, deleteDataFilePlan.DeleteApiDataSetVersionPlan.Version);
+                Assert.Equal(dataSetVersion.PublicVersion, deleteDataFilePlan.DeleteApiDataSetVersionPlan.Version);
                 Assert.Equal(dataSetVersion.Status, deleteDataFilePlan.DeleteApiDataSetVersionPlan.Status);
                 Assert.False(deleteDataFilePlan.DeleteApiDataSetVersionPlan.Valid);
                 Assert.False(deleteDataFilePlan.Valid);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -393,7 +393,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .WithReleaseVersion(releaseVersion)
                 .WithFile(file)
                 .WithPublicApiDataSetId(dataSet.Id)
-                .WithPublicApiDataSetVersion(dataSetVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(dataSetVersion.SemVersion());
 
             var contextId = Guid.NewGuid().ToString();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -1789,7 +1789,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataSet.Id, replacementPlan.DeleteApiDataSetVersionPlan.DataSetId);
                 Assert.Equal(dataSet.Title, replacementPlan.DeleteApiDataSetVersionPlan.DataSetTitle);
                 Assert.Equal(dataSetVersion.Id, replacementPlan.DeleteApiDataSetVersionPlan.Id);
-                Assert.Equal(dataSetVersion.Version, replacementPlan.DeleteApiDataSetVersionPlan.Version);
+                Assert.Equal(dataSetVersion.PublicVersion, replacementPlan.DeleteApiDataSetVersionPlan.Version);
                 Assert.Equal(dataSetVersion.Status, replacementPlan.DeleteApiDataSetVersionPlan.Status);
                 Assert.False(replacementPlan.DeleteApiDataSetVersionPlan.Valid);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -1736,7 +1736,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ForIndex(0, rv => 
                     rv.SetFile(originalFile)
                     .SetPublicApiDataSetId(dataSet.Id)
-                    .SetPublicApiDataSetVersion(dataSetVersion.FullSemanticVersion()))
+                    .SetPublicApiDataSetVersion(dataSetVersion.SemVersion()))
                 .ForIndex(1, rv => rv.SetFile(replacementFile))
                 .Generate(2)
                 .ToTuple2();
@@ -2735,7 +2735,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ForIndex(0, rv => 
                     rv.SetFile(originalFile)
                     .SetPublicApiDataSetId(dataSet.Id)
-                    .SetPublicApiDataSetVersion(dataSetVersion.FullSemanticVersion()))
+                    .SetPublicApiDataSetVersion(dataSetVersion.SemVersion()))
                 .ForIndex(1, rv => rv.SetFile(replacementFile))
                 .Generate(2)
                 .ToTuple2();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
@@ -125,7 +125,7 @@ internal class DataSetService(
             ? new DataSetVersionSummaryViewModel
             {
                 Id = dataSetVersion.Id,
-                Version = dataSetVersion.Version,
+                Version = dataSetVersion.PublicVersion,
                 Status = dataSetVersion.Status,
                 Type = dataSetVersion.VersionType,
                 ReleaseVersion = MapReleaseVersion(releaseVersionsByDataSetVersionId[dataSetVersion.Id])
@@ -141,7 +141,7 @@ internal class DataSetService(
             ? new DataSetLiveVersionSummaryViewModel
             {
                 Id = dataSetVersion.Id,
-                Version = dataSetVersion.Version,
+                Version = dataSetVersion.PublicVersion,
                 Published = dataSetVersion.Published!.Value,
                 Status = dataSetVersion.Status,
                 Type = dataSetVersion.VersionType,
@@ -251,7 +251,7 @@ internal class DataSetService(
         return new DataSetDraftVersionViewModel
         {
             Id = dataSetVersion.Id,
-            Version = dataSetVersion.Version,
+            Version = dataSetVersion.PublicVersion,
             Status = dataSetVersion.Status,
             Type = dataSetVersion.VersionType,
             File = MapVersionFile(releaseFile),
@@ -292,7 +292,7 @@ internal class DataSetService(
         return new DataSetLiveVersionViewModel
         {
             Id = dataSetVersion.Id,
-            Version = dataSetVersion.Version,
+            Version = dataSetVersion.PublicVersion,
             Status = dataSetVersion.Status,
             Type = dataSetVersion.VersionType,
             File = MapVersionFile(releaseFile),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
@@ -15,6 +15,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Requests;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Dtos;
@@ -29,7 +30,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
 public class DataSetVersionMappingService(
     IPostgreSqlRepository postgreSqlRepository,
     IUserService userService,
-    PublicDataDbContext publicDataDbContext)
+    PublicDataDbContext publicDataDbContext,
+    ContentDbContext contentDbContext)
     : IDataSetVersionMappingService
 {
     private static readonly MappingType[] IncompleteMappingTypes =
@@ -162,39 +164,44 @@ public class DataSetVersionMappingService(
     {
         // Consider the current mappings to produce a major version change if any options from the
         // original data set version are currently not mapped to options in the new version.
-        var majorVersionUpdate = locationMappingTypes
+        var isMajorVersionUpdate = locationMappingTypes
             .Concat(filterAndOptionMappingTypes
                 .Select(mappings => mappings.OptionMappingType))
             .Any(type => NoMappingTypes.Contains(type));
 
-        var currentVersionNumber = await publicDataDbContext
+        var sourceDataSetVersion = await publicDataDbContext
             .DataSetVersionMappings
             .Where(mapping => mapping.TargetDataSetVersionId == nextDataSetVersionId)
             .Select(nextVersion => nextVersion.SourceDataSetVersion)
-            .Select(sourceVersion => new
-            {
-                major = sourceVersion.VersionMajor,
-                minor = sourceVersion.VersionMinor
-            })
             .SingleAsync(cancellationToken);
 
-        var nextVersionNumber = majorVersionUpdate
-            ? new
-            {
-                major = currentVersionNumber.major + 1,
-                minor = 0
-            }
-            : currentVersionNumber with { minor = currentVersionNumber.minor + 1 };
+        var targetDataSetVersion = await publicDataDbContext
+            .DataSetVersionMappings
+            .Where(mapping => mapping.TargetDataSetVersionId == nextDataSetVersionId)
+            .Select(nextVersion => nextVersion.TargetDataSetVersion)
+            .SingleAsync(cancellationToken);
 
-        await publicDataDbContext
-            .DataSetVersions
-            .Where(dataSetVersion => dataSetVersion.Id == nextDataSetVersionId)
-            .ExecuteUpdateAsync(
-                setPropertyCalls: s => s
-                    .SetProperty(dataSetVersion => dataSetVersion.VersionMajor, nextVersionNumber.major)
-                    .SetProperty(dataSetVersion => dataSetVersion.VersionMinor, nextVersionNumber.minor)
-                    .SetProperty(dataSetVersion => dataSetVersion.VersionPatch, 0),
-                cancellationToken: cancellationToken);
+        if (isMajorVersionUpdate)
+        {
+            targetDataSetVersion.VersionMajor = sourceDataSetVersion.VersionMajor + 1;
+            targetDataSetVersion.VersionMinor = 0;
+        }
+        else
+        {
+            targetDataSetVersion.VersionMajor = sourceDataSetVersion.VersionMajor;
+            targetDataSetVersion.VersionMinor = sourceDataSetVersion.VersionMinor + 1;
+        }
+
+        await publicDataDbContext.SaveChangesAsync(cancellationToken);
+
+        var releaseFile = await contentDbContext
+            .ReleaseFiles
+            .Where(rf => rf.Id == targetDataSetVersion.ReleaseFileId)
+            .SingleAsync(cancellationToken);
+
+        releaseFile.PublicApiDataSetVersion = targetDataSetVersion.FullSemanticVersion();
+
+        await contentDbContext.SaveChangesAsync(cancellationToken);
     }
 
     private async Task UpdateMappingCompleteFlags(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
@@ -199,7 +199,7 @@ public class DataSetVersionMappingService(
             .Where(rf => rf.Id == targetDataSetVersion.ReleaseFileId)
             .SingleAsync(cancellationToken);
 
-        releaseFile.PublicApiDataSetVersion = targetDataSetVersion.FullSemanticVersion();
+        releaseFile.PublicApiDataSetVersion = targetDataSetVersion.SemVersion();
 
         await contentDbContext.SaveChangesAsync(cancellationToken);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
@@ -161,7 +161,7 @@ public class DataSetVersionService(
                 .SingleOrNotFoundAsync(cancellationToken: cancellationToken))
             .OnSuccess(dsv => publicDataApiClient.GetDataSetVersionChanges(
                 dataSetId: dsv.DataSetId,
-                dataSetVersion: dsv.Version,
+                dataSetVersion: dsv.PublicVersion,
                 cancellationToken: cancellationToken
             ));
     }
@@ -212,7 +212,7 @@ public class DataSetVersionService(
         return new DataSetLiveVersionSummaryViewModel
         {
             Id = dataSetVersion.Id,
-            Version = dataSetVersion.Version,
+            Version = dataSetVersion.PublicVersion,
             Status = dataSetVersion.Status,
             Type = dataSetVersion.VersionType,
             ReleaseVersion = MapReleaseVersion(releaseVersion),
@@ -229,7 +229,7 @@ public class DataSetVersionService(
         return new DataSetVersionSummaryViewModel
         {
             Id = dataSetVersion.Id,
-            Version = dataSetVersion.Version,
+            Version = dataSetVersion.PublicVersion,
             Status = dataSetVersion.Status,
             Type = dataSetVersion.VersionType,
             ReleaseVersion = MapReleaseVersion(releaseFile.ReleaseVersion)
@@ -301,7 +301,7 @@ public class DataSetVersionService(
         return new DataSetDraftVersionViewModel
         {
             Id = dataSetVersion.Id,
-            Version = dataSetVersion.Version,
+            Version = dataSetVersion.PublicVersion,
             Status = dataSetVersion.Status,
             Type = dataSetVersion.VersionType,
             File = MapVersionFile(releaseFile),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -479,7 +479,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         DataSetId = tuple.apiDataSetVersion.DataSetId,
                         DataSetTitle = tuple.apiDataSetVersion.DataSet.Title,
                         Id = tuple.apiDataSetVersion.Id,
-                        Version = tuple.apiDataSetVersion.Version,
+                        Version = tuple.apiDataSetVersion.PublicVersion,
                         Status = tuple.apiDataSetVersion.Status,
                         Valid = false
                     };

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -122,7 +122,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         DataSetId = tuple.apiDataSetVersion.DataSetId,
                         DataSetTitle = tuple.apiDataSetVersion.DataSet.Title,
                         Id = tuple.apiDataSetVersion.Id,
-                        Version = tuple.apiDataSetVersion.Version,
+                        Version = tuple.apiDataSetVersion.PublicVersion,
                         Status = tuple.apiDataSetVersion.Status,
                         Valid = false,
                     };

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseFileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseFileGeneratorExtensions.cs
@@ -22,6 +22,11 @@ public static class ReleaseFileGeneratorExtensions
             .SetDefault(rf => rf.Summary)
             .SetDefault(rf => rf.Published);
 
+    public static Generator<ReleaseFile> WithId(
+        this Generator<ReleaseFile> generator,
+        Guid id)
+        => generator.ForInstance(s => s.SetId(id));
+
     public static Generator<ReleaseFile> WithFile(
         this Generator<ReleaseFile> generator,
         File file)
@@ -106,6 +111,11 @@ public static class ReleaseFileGeneratorExtensions
         int minor,
         int patch = 0)
         => generator.ForInstance(s => s.SetPublicApiDataSetVersion(major, minor, patch));
+
+    public static InstanceSetters<ReleaseFile> SetId(
+        this InstanceSetters<ReleaseFile> setters,
+        Guid id)
+        => setters.Set(rf => rf.Id, id);
 
     public static InstanceSetters<ReleaseFile> SetFile(
         this InstanceSetters<ReleaseFile> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
@@ -234,7 +234,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
 
             var result = Assert.Single(viewModel.Results);
 
-            Assert.Equal(dataSetVersion.Version, result.Version);
+            Assert.Equal(dataSetVersion.PublicVersion, result.Version);
             Assert.Equal(dataSetVersion.VersionType, result.Type);
             Assert.Equal(dataSetVersion.Status, result.Status);
             Assert.Equal(
@@ -331,7 +331,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
             Assert.Equal(1, viewModel.Paging.PageSize);
             Assert.Equal(1, viewModel.Paging.TotalResults);
             var result = Assert.Single(viewModel.Results);
-            Assert.Equal(dataSet1Version.Version, result.Version);
+            Assert.Equal(dataSet1Version.PublicVersion, result.Version);
         }
 
         [Theory]
@@ -627,7 +627,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
 
             var response = await GetDataSetVersion(
                 dataSet.Id,
-                dataSetVersion.Version,
+                dataSetVersion.PublicVersion,
                 contentApiClient.Object
             );
 
@@ -636,7 +636,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
             MockUtils.VerifyAllMocks(contentApiClient);
 
             Assert.NotNull(viewModel);
-            Assert.Equal(dataSetVersion.Version, viewModel.Version);
+            Assert.Equal(dataSetVersion.PublicVersion, viewModel.Version);
             Assert.Equal(dataSetVersion.VersionType, viewModel.Type);
             Assert.Equal(dataSetVersion.Status, viewModel.Status);
             Assert.Equal(
@@ -693,7 +693,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
 
-            var response = await GetDataSetVersion(dataSet.Id, dataSetVersion.Version);
+            var response = await GetDataSetVersion(dataSet.Id, dataSetVersion.PublicVersion);
 
             response.AssertForbidden();
         }
@@ -718,7 +718,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
 
-            var response = await GetDataSetVersion(dataSet2.Id, dataSetVersion.Version);
+            var response = await GetDataSetVersion(dataSet2.Id, dataSetVersion.PublicVersion);
 
             response.AssertNotFound();
         }
@@ -753,7 +753,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
 
-            var response = await GetDataSetVersion(Guid.NewGuid(), dataSetVersion.Version);
+            var response = await GetDataSetVersion(Guid.NewGuid(), dataSetVersion.PublicVersion);
 
             response.AssertNotFound();
         }
@@ -783,7 +783,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
                 ))
                 .ReturnsAsync([]);
 
-            var response = await GetDataSetVersion(dataSet.Id, dataSetVersion.Version, contentApiClient.Object);
+            var response = await GetDataSetVersion(dataSet.Id, dataSetVersion.PublicVersion, contentApiClient.Object);
 
             response.AssertInternalServerError();
         }
@@ -813,7 +813,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
                 ))
                 .ThrowsAsync(new Exception("Something went wrong"));
 
-            var response = await GetDataSetVersion(dataSet.Id, dataSetVersion.Version, contentApiClient.Object);
+            var response = await GetDataSetVersion(dataSet.Id, dataSetVersion.PublicVersion, contentApiClient.Object);
 
             response.AssertInternalServerError();
         }
@@ -942,7 +942,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
                 context.TimePeriodMetaChanges.AddRange(timePeriodMetaChanges);
             });
 
-            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.Version);
+            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.PublicVersion);
 
             var viewModel = response.AssertOk<DataSetVersionChangesViewModel>(useSystemJson: true);
 
@@ -1016,7 +1016,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
                 context.FilterMetaChanges.AddRange(filterMetaChanges);
             });
 
-            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.Version);
+            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.PublicVersion);
 
             var viewModel = response.AssertOk<DataSetVersionChangesViewModel>(useSystemJson: true);
 
@@ -1123,7 +1123,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
                 context.FilterOptionMetaChanges.AddRange(filterOptionMetaChanges);
             });
 
-            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.Version);
+            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.PublicVersion);
 
             var viewModel = response.AssertOk<DataSetVersionChangesViewModel>(useSystemJson: true);
 
@@ -1236,7 +1236,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
                 context.GeographicLevelMetaChanges.Add(geographicLevelMetaChange);
             });
 
-            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.Version);
+            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.PublicVersion);
 
             var viewModel = response.AssertOk<DataSetVersionChangesViewModel>(useSystemJson: true);
 
@@ -1317,7 +1317,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
                 context.LocationMetaChanges.AddRange(locationMetaChanges);
             });
 
-            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.Version);
+            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.PublicVersion);
 
             var viewModel = response.AssertOk<DataSetVersionChangesViewModel>(useSystemJson: true);
 
@@ -1425,7 +1425,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
                 context.LocationOptionMetaChanges.AddRange(locationOptionMetaChanges);
             });
 
-            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.Version);
+            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.PublicVersion);
 
             var viewModel = response.AssertOk<DataSetVersionChangesViewModel>(useSystemJson: true);
 
@@ -1546,7 +1546,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
                 context.TimePeriodMetaChanges.AddRange(timePeriodMetaChanges);
             });
 
-            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.Version);
+            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.PublicVersion);
 
             var viewModel = response.AssertOk<DataSetVersionChangesViewModel>(useSystemJson: true);
 
@@ -1593,7 +1593,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
 
-            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.Version);
+            var response = await GetDataSetVersionChanges(dataSet.Id, dataSetVersion.PublicVersion);
 
             response.AssertForbidden();
         }
@@ -1618,7 +1618,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
 
-            var response = await GetDataSetVersionChanges(dataSet2.Id, dataSetVersion.Version);
+            var response = await GetDataSetVersionChanges(dataSet2.Id, dataSetVersion.PublicVersion);
 
             response.AssertNotFound();
         }
@@ -1653,7 +1653,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
 
             await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
 
-            var response = await GetDataSetVersionChanges(Guid.NewGuid(), dataSetVersion.Version);
+            var response = await GetDataSetVersionChanges(Guid.NewGuid(), dataSetVersion.PublicVersion);
 
             response.AssertNotFound();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -53,7 +53,7 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
             Assert.Equal(dataSet.Summary, content.Summary);
             Assert.Equal(dataSet.Status, content.Status);
             Assert.Equal(dataSet.SupersedingDataSetId, content.SupersedingDataSetId);
-            Assert.Equal(dataSetVersion.Version, content.LatestVersion.Version);
+            Assert.Equal(dataSetVersion.PublicVersion, content.LatestVersion.Version);
             Assert.Equal(
                 dataSetVersion.Published.TruncateNanoseconds(),
                 content.LatestVersion.Published
@@ -521,7 +521,7 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
 
                 await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
 
-                var response = await GetDataSetMeta(dataSet2.Id, dataSetVersion.Version);
+                var response = await GetDataSetMeta(dataSet2.Id, dataSetVersion.PublicVersion);
 
                 response.AssertNotFound();
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
@@ -519,7 +519,7 @@ public abstract class PublicationsControllerTests(TestApplicationFactory testApp
             Assert.Equal(dataSet.Summary, result.Summary);
             Assert.Equal(dataSet.Status, result.Status);
             Assert.Equal(dataSet.SupersedingDataSetId, result.SupersedingDataSetId);
-            Assert.Equal(dataSetVersion.Version, result.LatestVersion.Version);
+            Assert.Equal(dataSetVersion.PublicVersion, result.LatestVersion.Version);
             Assert.Equal(
                 dataSetVersion.Published.TruncateNanoseconds(),
                 result.LatestVersion.Published

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -202,7 +202,7 @@ internal class DataSetService(
     {
         return new DataSetLatestVersionViewModel
         {
-            Version = latestVersion.Version,
+            Version = latestVersion.PublicVersion,
             Published = latestVersion.Published!.Value,
             TotalResults = latestVersion.TotalResults,
             TimePeriods = MapTimePeriods(latestVersion.MetaSummary!.TimePeriodRange),
@@ -227,7 +227,7 @@ internal class DataSetService(
     {
         return new DataSetVersionViewModel
         {
-            Version = dataSetVersion.Version,
+            Version = dataSetVersion.PublicVersion,
             Type = dataSetVersion.VersionType,
             Status = dataSetVersion.Status,
             Published = dataSetVersion.Published!.Value,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/DataSetVersionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/DataSetVersionTests.cs
@@ -53,7 +53,7 @@ public abstract class DataSetVersionTests
                 .DefaultDataSetVersion()
                 .WithVersionNumber(majorVersion, minorVersion);
 
-            Assert.Equal(formattedVersion, dataSetVersion.Version);
+            Assert.Equal(formattedVersion, dataSetVersion.PublicVersion);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -75,9 +75,9 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public string Version => $"{VersionMajor}.{VersionMinor}";
 
-    public bool IsFirstVersion => Version == "1.0";
-
     public SemVersion FullSemanticVersion() => new(major: VersionMajor, minor: VersionMinor, patch: VersionPatch);
+
+    public bool IsFirstVersion => VersionMajor == 1 && VersionMinor == 0 && VersionPatch == 0;
 
     public DataSetVersionType VersionType
         => VersionMinor == 0 ? DataSetVersionType.Major : DataSetVersionType.Minor;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -73,7 +73,7 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public DateTimeOffset? Updated { get; set; }
 
-    public string Version => $"{VersionMajor}.{VersionMinor}";
+    public string PublicVersion => $"{VersionMajor}.{VersionMinor}";
 
     public SemVersion SemVersion() => new(major: VersionMajor, minor: VersionMinor, patch: VersionPatch);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -75,7 +75,7 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public string Version => $"{VersionMajor}.{VersionMinor}";
 
-    public SemVersion FullSemanticVersion() => new(major: VersionMajor, minor: VersionMinor, patch: VersionPatch);
+    public SemVersion SemVersion() => new(major: VersionMajor, minor: VersionMinor, patch: VersionPatch);
 
     public bool IsFirstVersion => VersionMajor == 1 && VersionMinor == 0 && VersionPatch == 0;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/BulkDeleteDataSetVersionsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/BulkDeleteDataSetVersionsFunctionTests.cs
@@ -124,14 +124,14 @@ public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsI
             });
 
             previousReleaseFile.PublicApiDataSetId = otherDataSet.Id;
-            previousReleaseFile.PublicApiDataSetVersion = otherDataSetVersion.FullSemanticVersion();
+            previousReleaseFile.PublicApiDataSetVersion = otherDataSetVersion.SemVersion();
             targetReleaseFileWithOldFile.PublicApiDataSetId = previousReleaseFile.PublicApiDataSetId;
             targetReleaseFileWithOldFile.PublicApiDataSetVersion = previousReleaseFile.PublicApiDataSetVersion;
 
             foreach (var (targetReleaseFileWithNewFile, index) in targetReleaseFilesWithNewFiles.WithIndex())
             {
                 targetReleaseFileWithNewFile.PublicApiDataSetId = targetDataSets[index].Id;
-                targetReleaseFileWithNewFile.PublicApiDataSetVersion = targetDataSetVersions[index].FullSemanticVersion();
+                targetReleaseFileWithNewFile.PublicApiDataSetVersion = targetDataSetVersions[index].SemVersion();
             }
 
             await AddTestData<ContentDbContext>(context => context.ReleaseFiles.UpdateRange([
@@ -216,12 +216,12 @@ public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsI
             // Assert that the PREVIOUS Release File is still associated with its Public API DataSet
             var previousReleaseFilePostDelete = await contentDataDbContext.ReleaseFiles.SingleAsync(f => f.Id == previousReleaseFile.Id);
             Assert.Equal(otherDataSet.Id, previousReleaseFilePostDelete.PublicApiDataSetId);
-            Assert.Equal(otherDataSetVersion.FullSemanticVersion(), previousReleaseFilePostDelete.PublicApiDataSetVersion);
+            Assert.Equal(otherDataSetVersion.SemVersion(), previousReleaseFilePostDelete.PublicApiDataSetVersion);
 
             // Assert that the TARGET Release File, which points to the OLD File, is still associated with its Public API DataSet
             var targetReleaseFileWithOldFilePostDelete = await contentDataDbContext.ReleaseFiles.SingleAsync(f => f.Id == targetReleaseFileWithOldFile.Id);
             Assert.Equal(otherDataSet.Id, previousReleaseFilePostDelete.PublicApiDataSetId);
-            Assert.Equal(otherDataSetVersion.FullSemanticVersion(), previousReleaseFilePostDelete.PublicApiDataSetVersion);
+            Assert.Equal(otherDataSetVersion.SemVersion(), previousReleaseFilePostDelete.PublicApiDataSetVersion);
         }
 
         [Theory]
@@ -338,11 +338,11 @@ public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsI
             });
 
             release1Version1ReleaseFile.PublicApiDataSetId = release1Version1DataSet.Id;
-            release1Version1ReleaseFile.PublicApiDataSetVersion = release1Version1DataSetVersion.FullSemanticVersion();
+            release1Version1ReleaseFile.PublicApiDataSetVersion = release1Version1DataSetVersion.SemVersion();
             release2Version1ReleaseFile.PublicApiDataSetId = release2Version1DataSet.Id;
-            release2Version1ReleaseFile.PublicApiDataSetVersion = release2Version1DataSetVersion.FullSemanticVersion();
+            release2Version1ReleaseFile.PublicApiDataSetVersion = release2Version1DataSetVersion.SemVersion();
             release2Version2ReleaseFile.PublicApiDataSetId = release1Version1DataSet.Id; // Same Data Set series as release1version1
-            release2Version2ReleaseFile.PublicApiDataSetVersion = release2Version2DataSetVersion.FullSemanticVersion();
+            release2Version2ReleaseFile.PublicApiDataSetVersion = release2Version2DataSetVersion.SemVersion();
 
             await AddTestData<ContentDbContext>(context => context.ReleaseFiles.UpdateRange(
                 release1Version1ReleaseFile,
@@ -428,9 +428,9 @@ public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsI
             var release2Version1ReleaseFilePostDelete = await contentDataDbContext.ReleaseFiles.SingleAsync(f => f.Id == release2Version1ReleaseFile.Id);
 
             Assert.Equal(release1Version1DataSet.Id, release1Version1ReleaseFilePostDelete.PublicApiDataSetId);
-            Assert.Equal(release1Version1DataSetVersion.FullSemanticVersion(), release1Version1ReleaseFilePostDelete.PublicApiDataSetVersion);
+            Assert.Equal(release1Version1DataSetVersion.SemVersion(), release1Version1ReleaseFilePostDelete.PublicApiDataSetVersion);
             Assert.Equal(release2Version1DataSet.Id, release2Version1ReleaseFilePostDelete.PublicApiDataSetId);
-            Assert.Equal(release2Version1DataSetVersion.FullSemanticVersion(), release2Version1ReleaseFilePostDelete.PublicApiDataSetVersion);
+            Assert.Equal(release2Version1DataSetVersion.SemVersion(), release2Version1ReleaseFilePostDelete.PublicApiDataSetVersion);
         }
 
         private static async Task AssertMetadataIsDeleted(PublicDataDbContext publicDataDbContext, DataSetVersion dataSetVersion)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/BulkDeleteDataSetVersionsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/BulkDeleteDataSetVersionsFunctionTests.cs
@@ -1,7 +1,6 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
@@ -13,7 +12,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests.
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using LinqToDB;
 using Microsoft.AspNetCore.Mvc;
-using System.Text.Json;
 using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests.Functions;
@@ -196,7 +194,7 @@ public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsI
 
             var otherDataSetFolderEntries = Directory.GetFileSystemEntries(otherDataSetFolder!.FullName);
             var otherDataSetVersionFolder = Assert.Single(otherDataSetFolderEntries,
-                entry => new DirectoryInfo(entry).Name == $"v{otherDataSetVersion.PublicVersion}");
+                entry => new DirectoryInfo(entry).Name == $"v{otherDataSetVersion.SemVersion()}");
 
             var otherDataSetVersionFolderEntries = Directory.GetFileSystemEntries(otherDataSetVersionFolder);
             Assert.Single(otherDataSetVersionFolderEntries, entry => new System.IO.FileInfo(entry).Name == "version1.txt");
@@ -358,7 +356,7 @@ public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsI
             {
                 var dataSetVersionDirectory = _dataSetVersionPathResolver.DirectoryPath(dataSetVersion);
                 Directory.CreateDirectory(dataSetVersionDirectory);
-                await System.IO.File.Create(Path.Combine(dataSetVersionDirectory, $"{dataSetVersion.PublicVersion}.txt")).DisposeAsync();
+                await System.IO.File.Create(Path.Combine(dataSetVersionDirectory, $"{dataSetVersion.SemVersion()}.txt")).DisposeAsync();
             }
 
             var response = await BulkDeleteDataSetVersions(release2Version2.Id);
@@ -381,14 +379,14 @@ public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsI
             Assert.True(Directory.Exists(release1Version1DataSetVersionDirectory));
 
             var release1Version1DataSetVersionDirectoryEntries = Directory.GetFileSystemEntries(release1Version1DataSetVersionDirectory);
-            Assert.Single(release1Version1DataSetVersionDirectoryEntries, entry => new System.IO.FileInfo(entry).Name == $"{release1Version1DataSetVersion.PublicVersion}.txt");
+            Assert.Single(release1Version1DataSetVersionDirectoryEntries, entry => new System.IO.FileInfo(entry).Name == $"{release1Version1DataSetVersion.SemVersion()}.txt");
 
             // Assert that the parquet folder, and its contents, for the API Data Set Version linked to Release 2 Version 1, has NOT been deleted
             var release2Version1DataSetVersionDirectory = _dataSetVersionPathResolver.DirectoryPath(release2Version1DataSetVersion);
             Assert.True(Directory.Exists(release2Version1DataSetVersionDirectory));
 
             var release2Version1DataSetVersionDirectoryEntries = Directory.GetFileSystemEntries(release2Version1DataSetVersionDirectory);
-            Assert.Single(release2Version1DataSetVersionDirectoryEntries, entry => new System.IO.FileInfo(entry).Name == $"{release2Version1DataSetVersion.PublicVersion}.txt");
+            Assert.Single(release2Version1DataSetVersionDirectoryEntries, entry => new System.IO.FileInfo(entry).Name == $"{release2Version1DataSetVersion.SemVersion()}.txt");
 
             // Assert that the TARGET API Data Set, linked to the release version being deleted, has NOT been deleted
             Assert.NotNull(await publicDataDbContext.DataSets.SingleOrDefaultAsync(ds => ds.Id == release1Version1DataSet.Id));

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/BulkDeleteDataSetVersionsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/BulkDeleteDataSetVersionsFunctionTests.cs
@@ -196,7 +196,7 @@ public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsI
 
             var otherDataSetFolderEntries = Directory.GetFileSystemEntries(otherDataSetFolder!.FullName);
             var otherDataSetVersionFolder = Assert.Single(otherDataSetFolderEntries,
-                entry => new DirectoryInfo(entry).Name == $"v{otherDataSetVersion.Version}");
+                entry => new DirectoryInfo(entry).Name == $"v{otherDataSetVersion.PublicVersion}");
 
             var otherDataSetVersionFolderEntries = Directory.GetFileSystemEntries(otherDataSetVersionFolder);
             Assert.Single(otherDataSetVersionFolderEntries, entry => new System.IO.FileInfo(entry).Name == "version1.txt");
@@ -358,7 +358,7 @@ public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsI
             {
                 var dataSetVersionDirectory = _dataSetVersionPathResolver.DirectoryPath(dataSetVersion);
                 Directory.CreateDirectory(dataSetVersionDirectory);
-                await System.IO.File.Create(Path.Combine(dataSetVersionDirectory, $"{dataSetVersion.Version}.txt")).DisposeAsync();
+                await System.IO.File.Create(Path.Combine(dataSetVersionDirectory, $"{dataSetVersion.PublicVersion}.txt")).DisposeAsync();
             }
 
             var response = await BulkDeleteDataSetVersions(release2Version2.Id);
@@ -381,14 +381,14 @@ public abstract class BulkDeleteDataSetVersionsFunctionTests(ProcessorFunctionsI
             Assert.True(Directory.Exists(release1Version1DataSetVersionDirectory));
 
             var release1Version1DataSetVersionDirectoryEntries = Directory.GetFileSystemEntries(release1Version1DataSetVersionDirectory);
-            Assert.Single(release1Version1DataSetVersionDirectoryEntries, entry => new System.IO.FileInfo(entry).Name == $"{release1Version1DataSetVersion.Version}.txt");
+            Assert.Single(release1Version1DataSetVersionDirectoryEntries, entry => new System.IO.FileInfo(entry).Name == $"{release1Version1DataSetVersion.PublicVersion}.txt");
 
             // Assert that the parquet folder, and its contents, for the API Data Set Version linked to Release 2 Version 1, has NOT been deleted
             var release2Version1DataSetVersionDirectory = _dataSetVersionPathResolver.DirectoryPath(release2Version1DataSetVersion);
             Assert.True(Directory.Exists(release2Version1DataSetVersionDirectory));
 
             var release2Version1DataSetVersionDirectoryEntries = Directory.GetFileSystemEntries(release2Version1DataSetVersionDirectory);
-            Assert.Single(release2Version1DataSetVersionDirectoryEntries, entry => new System.IO.FileInfo(entry).Name == $"{release2Version1DataSetVersion.Version}.txt");
+            Assert.Single(release2Version1DataSetVersionDirectoryEntries, entry => new System.IO.FileInfo(entry).Name == $"{release2Version1DataSetVersion.PublicVersion}.txt");
 
             // Assert that the TARGET API Data Set, linked to the release version being deleted, has NOT been deleted
             Assert.NotNull(await publicDataDbContext.DataSets.SingleOrDefaultAsync(ds => ds.Id == release1Version1DataSet.Id));

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateNextDataSetVersionMappingsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/CreateNextDataSetVersionMappingsFunctionTests.cs
@@ -90,7 +90,7 @@ public abstract class CreateNextDataSetVersionMappingsFunctionTests(
             Assert.Equal(2, updatedDataSet.Versions.Count);
             var nextDataSetVersion = updatedDataSet
                 .Versions
-                .OrderBy(v => v.FullSemanticVersion())
+                .OrderBy(v => v.SemVersion())
                 .Last();
             Assert.Equal(nextDataSetVersion, updatedDataSet.LatestDraftVersion);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/DeleteDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/DeleteDataSetVersionFunctionTests.cs
@@ -67,7 +67,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
             });
 
             releaseFile.PublicApiDataSetId = dataSet.Id;
-            releaseFile.PublicApiDataSetVersion = dataSetVersion.FullSemanticVersion();
+            releaseFile.PublicApiDataSetVersion = dataSetVersion.SemVersion();
 
             await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Update(releaseFile));
 
@@ -177,9 +177,9 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
             });
 
             liveReleaseFile.PublicApiDataSetId = dataSet.Id;
-            liveReleaseFile.PublicApiDataSetVersion = liveDataSetVersion.FullSemanticVersion();
+            liveReleaseFile.PublicApiDataSetVersion = liveDataSetVersion.SemVersion();
             draftReleaseFile.PublicApiDataSetId = dataSet.Id;
-            draftReleaseFile.PublicApiDataSetVersion = draftDataSetVersion.FullSemanticVersion();
+            draftReleaseFile.PublicApiDataSetVersion = draftDataSetVersion.SemVersion();
 
             await AddTestData<ContentDbContext>(context =>
                 context.ReleaseFiles.UpdateRange(liveReleaseFile, draftReleaseFile));
@@ -307,7 +307,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
                 .SingleAsync(f => f.Id == liveReleaseFile.Id);
 
             Assert.Equal(dataSet.Id, updatedLiveReleaseFile.PublicApiDataSetId);
-            Assert.Equal(liveDataSetVersion.FullSemanticVersion(), updatedLiveReleaseFile.PublicApiDataSetVersion);
+            Assert.Equal(liveDataSetVersion.SemVersion(), updatedLiveReleaseFile.PublicApiDataSetVersion);
         }
 
         [Theory]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/DeleteDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/DeleteDataSetVersionFunctionTests.cs
@@ -34,8 +34,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
         {
             ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion()
-                    .WithPublication(DataFixture
-                        .DefaultPublication()))
+                    .WithPublication(DataFixture.DefaultPublication()))
                 .WithFile(DataFixture.DefaultFile(FileType.Data));
 
             await AddTestData<ContentDbContext>(context =>
@@ -52,7 +51,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
 
             DataSetVersion dataSetVersion = DataFixture
                 .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
-                .WithVersionNumber(1, 0, 0)
+                .WithVersionNumber(major: 1, minor: 0)
                 .WithStatus(dataSetVersionStatus)
                 .WithReleaseFileId(releaseFile.Id)
                 .WithDataSet(dataSet)
@@ -129,8 +128,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
         {
             var releaseFiles = DataFixture.DefaultReleaseFile()
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion()
-                    .WithPublication(DataFixture
-                        .DefaultPublication()))
+                    .WithPublication(DataFixture.DefaultPublication()))
                 .WithFile(() => DataFixture.DefaultFile(FileType.Data))
                 .GenerateList(2);
 
@@ -151,7 +149,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
 
             DataSetVersion liveDataSetVersion = DataFixture
                 .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
-                .WithVersionNumber(1, 0, 0)
+                .WithVersionNumber(major: 1, minor: 0)
                 .WithStatusPublished()
                 .WithReleaseFileId(liveReleaseFile.Id)
                 .WithDataSet(dataSet)
@@ -163,7 +161,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
 
             DataSetVersion draftDataSetVersion = DataFixture
                 .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
-                .WithVersionNumber(2, 0, 0)
+                .WithVersionNumber(major: 2, minor: 0, patch: 1)
                 .WithStatus(dataSetVersionStatus)
                 .WithReleaseFileId(draftReleaseFile.Id)
                 .WithDataSet(dataSet)
@@ -327,7 +325,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
 
             DataSetVersion dataSetVersion = DataFixture
                 .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
-                .WithVersionNumber(1, 0, 0)
+                .WithVersionNumber(major: 1, minor: 0)
                 .WithStatus(dataSetVersionStatus)
                 .WithDataSet(dataSet);
 
@@ -351,8 +349,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
         {
             ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion()
-                    .WithPublication(DataFixture
-                        .DefaultPublication()))
+                    .WithPublication(DataFixture.DefaultPublication()))
                 .WithFile(DataFixture.DefaultFile(FileType.Data));
 
             await AddTestData<ContentDbContext>(context =>
@@ -369,7 +366,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
 
             DataSetVersion dataSetVersion = DataFixture
                 .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 2)
-                .WithVersionNumber(1, 0, 0)
+                .WithVersionNumber(major: 1, minor: 0)
                 .WithStatusDraft()
                 .WithReleaseFileId(releaseFile.Id)
                 .WithDataSet(dataSet)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
@@ -1,6 +1,9 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
@@ -464,6 +467,15 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                     FilterMappingPlan = new FilterMappingPlan()
                 }));
 
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile())
+                .WithPublicApiDataSetId(nextVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+
+            await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
+
             await ApplyAutoMappings(instanceId);
 
             var savedImport = await GetDbContext<PublicDataDbContext>()
@@ -541,8 +553,16 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                                 candidate: DataFixture
                                     .DefaultMappableLocationOption())));
 
-            await AddTestData<PublicDataDbContext>(context =>
-                context.DataSetVersionMappings.Add(mappings));
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mappings));
+
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile())
+                .WithPublicApiDataSetId(nextVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+
+            await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
             await ApplyAutoMappings(instanceId);
 
@@ -609,7 +629,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // Some source location options have no equivalent candidate to be mapped to, thus
             // resulting in a major version update.
-            Assert.Equal("2.0", updatedMappings.TargetDataSetVersion.Version);
+            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+
+            var updatedReleaseFile = await GetDbContext<ContentDbContext>()
+                .ReleaseFiles
+                .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
+
+            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         [Fact]
@@ -640,8 +666,16 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                                 targetKey: "location-1-key",
                                 candidate: DataFixture.DefaultMappableLocationOption())));
 
-            await AddTestData<PublicDataDbContext>(context =>
-                context.DataSetVersionMappings.Add(mappings));
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mappings));
+
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile())
+                .WithPublicApiDataSetId(nextVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+
+            await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
             await ApplyAutoMappings(instanceId);
 
@@ -676,7 +710,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // All source location options have equivalent candidates to be mapped to, thus
             // resulting in a minor version update.
-            Assert.Equal("1.1", updatedMappings.TargetDataSetVersion.Version);
+            Assert.Equal("1.1.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+
+            var updatedReleaseFile = await GetDbContext<ContentDbContext>()
+                .ReleaseFiles
+                .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
+
+            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         [Fact]
@@ -722,8 +762,16 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                                 candidate: DataFixture
                                     .DefaultMappableLocationOption())));
 
-            await AddTestData<PublicDataDbContext>(context =>
-                context.DataSetVersionMappings.Add(mappings));
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mappings));
+
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile())
+                .WithPublicApiDataSetId(nextVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+
+            await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
             await ApplyAutoMappings(instanceId);
 
@@ -762,7 +810,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             // All source location options have equivalent candidates to be mapped to, thus
             // resulting in a minor version update. The inclusion of new location options
             // not present in the original version does not matter.
-            Assert.Equal("1.1", updatedMappings.TargetDataSetVersion.Version);
+            Assert.Equal("1.1.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+
+            var updatedReleaseFile = await GetDbContext<ContentDbContext>()
+                .ReleaseFiles
+                .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
+
+            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
     }
 
@@ -807,8 +861,16 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                         .AddOptionCandidate("filter-1-option-3-key", DataFixture
                             .DefaultMappableFilterOption())));
 
-            await AddTestData<PublicDataDbContext>(context =>
-                context.DataSetVersionMappings.Add(mappings));
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mappings));
+
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile())
+                .WithPublicApiDataSetId(nextVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+
+            await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
             await ApplyAutoMappings(instanceId);
 
@@ -878,7 +940,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // Some source filter options have no equivalent candidate to be mapped to, thus
             // resulting in a major version update.
-            Assert.Equal("2.0", updatedMappings.TargetDataSetVersion.Version);
+            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+
+            var updatedReleaseFile = await GetDbContext<ContentDbContext>()
+                .ReleaseFiles
+                .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
+
+            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         [Fact]
@@ -921,8 +989,16 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                         .AddOptionCandidate("filter-2-option-1-key", DataFixture
                             .DefaultMappableFilterOption())));
 
-            await AddTestData<PublicDataDbContext>(context =>
-                context.DataSetVersionMappings.Add(mappings));
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mappings));
+
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile())
+                .WithPublicApiDataSetId(nextVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+
+            await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
             await ApplyAutoMappings(instanceId);
 
@@ -987,7 +1063,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // All source filter options have equivalent candidates to be mapped to, thus
             // resulting in a minor version update.
-            Assert.Equal("1.1", updatedMappings.TargetDataSetVersion.Version);
+            Assert.Equal("1.1.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+
+            var updatedReleaseFile = await GetDbContext<ContentDbContext>()
+                .ReleaseFiles
+                .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
+
+            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         [Fact]
@@ -1024,8 +1106,16 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                         .AddOptionCandidate("filter-2-option-1-key", DataFixture
                             .DefaultMappableFilterOption())));
 
-            await AddTestData<PublicDataDbContext>(context =>
-                context.DataSetVersionMappings.Add(mappings));
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mappings));
+
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile())
+                .WithPublicApiDataSetId(nextVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+
+            await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
             await ApplyAutoMappings(instanceId);
 
@@ -1062,7 +1152,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             // All source filter options have equivalent candidates to be mapped to, thus
             // resulting in a minor version update. The inclusion of new filter options
             // not present in the original version does not matter.
-            Assert.Equal("1.1", updatedMappings.TargetDataSetVersion.Version);
+            Assert.Equal("1.1.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+
+            var updatedReleaseFile = await GetDbContext<ContentDbContext>()
+                .ReleaseFiles
+                .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
+
+            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         // As there is currently no way in the UI for a user to resolve unmapped filters, filters
@@ -1102,8 +1198,16 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                         .AddOptionCandidate("filter-1-option-1-key", DataFixture
                             .DefaultMappableFilterOption())));
 
-            await AddTestData<PublicDataDbContext>(context =>
-                context.DataSetVersionMappings.Add(mappings));
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mappings));
+
+            ReleaseFile releaseFile = DataFixture.DefaultReleaseFile()
+                .WithId(nextVersion.ReleaseFileId)
+                .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
+                .WithFile(DataFixture.DefaultFile())
+                .WithPublicApiDataSetId(nextVersion.DataSetId)
+                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+
+            await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
             await ApplyAutoMappings(instanceId);
 
@@ -1155,7 +1259,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // Some source filter options have no equivalent candidate to be mapped to, thus
             // resulting in a major version update.
-            Assert.Equal("2.0", updatedMappings.TargetDataSetVersion.Version);
+            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+
+            var updatedReleaseFile = await GetDbContext<ContentDbContext>()
+                .ReleaseFiles
+                .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
+
+            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
@@ -472,7 +472,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile())
                 .WithPublicApiDataSetId(nextVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextVersion.SemVersion());
 
             await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -560,7 +560,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile())
                 .WithPublicApiDataSetId(nextVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextVersion.SemVersion());
 
             await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -629,13 +629,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // Some source location options have no equivalent candidate to be mapped to, thus
             // resulting in a major version update.
-            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.SemVersion());
 
             var updatedReleaseFile = await GetDbContext<ContentDbContext>()
                 .ReleaseFiles
                 .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
 
-            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
+            Assert.Equal(updatedMappings.TargetDataSetVersion.SemVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         [Fact]
@@ -673,7 +673,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile())
                 .WithPublicApiDataSetId(nextVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextVersion.SemVersion());
 
             await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -710,13 +710,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // All source location options have equivalent candidates to be mapped to, thus
             // resulting in a minor version update.
-            Assert.Equal("1.1.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+            Assert.Equal("1.1.0", updatedMappings.TargetDataSetVersion.SemVersion());
 
             var updatedReleaseFile = await GetDbContext<ContentDbContext>()
                 .ReleaseFiles
                 .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
 
-            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
+            Assert.Equal(updatedMappings.TargetDataSetVersion.SemVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         [Fact]
@@ -769,7 +769,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile())
                 .WithPublicApiDataSetId(nextVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextVersion.SemVersion());
 
             await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -810,13 +810,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             // All source location options have equivalent candidates to be mapped to, thus
             // resulting in a minor version update. The inclusion of new location options
             // not present in the original version does not matter.
-            Assert.Equal("1.1.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+            Assert.Equal("1.1.0", updatedMappings.TargetDataSetVersion.SemVersion());
 
             var updatedReleaseFile = await GetDbContext<ContentDbContext>()
                 .ReleaseFiles
                 .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
 
-            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
+            Assert.Equal(updatedMappings.TargetDataSetVersion.SemVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
     }
 
@@ -868,7 +868,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile())
                 .WithPublicApiDataSetId(nextVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextVersion.SemVersion());
 
             await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -940,13 +940,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // Some source filter options have no equivalent candidate to be mapped to, thus
             // resulting in a major version update.
-            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.SemVersion());
 
             var updatedReleaseFile = await GetDbContext<ContentDbContext>()
                 .ReleaseFiles
                 .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
 
-            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
+            Assert.Equal(updatedMappings.TargetDataSetVersion.SemVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         [Fact]
@@ -996,7 +996,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile())
                 .WithPublicApiDataSetId(nextVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextVersion.SemVersion());
 
             await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -1063,13 +1063,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // All source filter options have equivalent candidates to be mapped to, thus
             // resulting in a minor version update.
-            Assert.Equal("1.1.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+            Assert.Equal("1.1.0", updatedMappings.TargetDataSetVersion.SemVersion());
 
             var updatedReleaseFile = await GetDbContext<ContentDbContext>()
                 .ReleaseFiles
                 .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
 
-            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
+            Assert.Equal(updatedMappings.TargetDataSetVersion.SemVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         [Fact]
@@ -1113,7 +1113,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile())
                 .WithPublicApiDataSetId(nextVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextVersion.SemVersion());
 
             await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -1152,13 +1152,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             // All source filter options have equivalent candidates to be mapped to, thus
             // resulting in a minor version update. The inclusion of new filter options
             // not present in the original version does not matter.
-            Assert.Equal("1.1.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+            Assert.Equal("1.1.0", updatedMappings.TargetDataSetVersion.SemVersion());
 
             var updatedReleaseFile = await GetDbContext<ContentDbContext>()
                 .ReleaseFiles
                 .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
 
-            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
+            Assert.Equal(updatedMappings.TargetDataSetVersion.SemVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
 
         // As there is currently no way in the UI for a user to resolve unmapped filters, filters
@@ -1205,7 +1205,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                 .WithReleaseVersion(DataFixture.DefaultReleaseVersion())
                 .WithFile(DataFixture.DefaultFile())
                 .WithPublicApiDataSetId(nextVersion.DataSetId)
-                .WithPublicApiDataSetVersion(nextVersion.FullSemanticVersion());
+                .WithPublicApiDataSetVersion(nextVersion.SemVersion());
 
             await AddTestData<ContentDbContext>(context => context.ReleaseFiles.Add(releaseFile));
 
@@ -1259,13 +1259,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // Some source filter options have no equivalent candidate to be mapped to, thus
             // resulting in a major version update.
-            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.FullSemanticVersion());
+            Assert.Equal("2.0.0", updatedMappings.TargetDataSetVersion.SemVersion());
 
             var updatedReleaseFile = await GetDbContext<ContentDbContext>()
                 .ReleaseFiles
                 .SingleAsync(rf => rf.PublicApiDataSetId == updatedMappings.TargetDataSetVersion.DataSetId);
 
-            Assert.Equal(updatedMappings.TargetDataSetVersion.FullSemanticVersion(), updatedReleaseFile.PublicApiDataSetVersion);
+            Assert.Equal(updatedMappings.TargetDataSetVersion.SemVersion(), updatedReleaseFile.PublicApiDataSetVersion);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
@@ -141,7 +141,7 @@ internal class DataSetVersionMappingService(
             .Where(rf => rf.Id == mappings.TargetDataSetVersion.ReleaseFileId)
             .SingleAsync(cancellationToken);
 
-        releaseFile.PublicApiDataSetVersion = mappings.TargetDataSetVersion.FullSemanticVersion();
+        releaseFile.PublicApiDataSetVersion = mappings.TargetDataSetVersion.SemVersion();
 
         await contentDbContext.SaveChangesAsync(cancellationToken);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -161,7 +161,7 @@ internal class DataSetVersionService(
     {
         var releaseFiles = await contentDbContext.ReleaseFiles
             .Where(rf => rf.PublicApiDataSetId == dataSetVersion.DataSetId)
-            .Where(rf => rf.PublicApiDataSetVersion == dataSetVersion.Version)
+            .Where(rf => rf.PublicApiDataSetVersion == dataSetVersion.FullSemanticVersion())
             .ToListAsync(cancellationToken);
 
         await UnlinkReleaseFilesFromApiDataSets(releaseFiles, cancellationToken);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -161,7 +161,7 @@ internal class DataSetVersionService(
     {
         var releaseFiles = await contentDbContext.ReleaseFiles
             .Where(rf => rf.PublicApiDataSetId == dataSetVersion.DataSetId)
-            .Where(rf => rf.PublicApiDataSetVersion == dataSetVersion.FullSemanticVersion())
+            .Where(rf => rf.PublicApiDataSetVersion == dataSetVersion.SemVersion())
             .ToListAsync(cancellationToken);
 
         await UnlinkReleaseFilesFromApiDataSets(releaseFiles, cancellationToken);
@@ -484,7 +484,7 @@ internal class DataSetVersionService(
         CancellationToken cancellationToken)
     {
         releaseFile.PublicApiDataSetId = dataSetVersion.DataSetId;
-        releaseFile.PublicApiDataSetVersion = dataSetVersion.FullSemanticVersion();
+        releaseFile.PublicApiDataSetVersion = dataSetVersion.SemVersion();
         await contentDbContext.SaveChangesAsync(cancellationToken);
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/DataSetVersionPathResolverTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/DataSetVersionPathResolverTests.cs
@@ -141,7 +141,7 @@ public abstract class DataSetVersionPathResolverTests
                 Path.Combine(
                     resolver.BasePath(),
                     version.DataSetId.ToString(),
-                    "v1.0"
+                    "v1.0.0"
                 ),
                 resolver.DirectoryPath(version));
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
@@ -34,7 +34,7 @@ public class DataSetVersionPathResolver : IDataSetVersionPathResolver
     public string BasePath() => _basePath;
 
     public string DirectoryPath(DataSetVersion dataSetVersion)
-        => Path.Combine(_basePath, dataSetVersion.DataSetId.ToString(), $"v{dataSetVersion.PublicVersion}");
+        => Path.Combine(_basePath, dataSetVersion.DataSetId.ToString(), $"v{dataSetVersion.SemVersion()}");
 
     private string GetBasePath()
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
@@ -34,7 +34,7 @@ public class DataSetVersionPathResolver : IDataSetVersionPathResolver
     public string BasePath() => _basePath;
 
     public string DirectoryPath(DataSetVersion dataSetVersion)
-        => Path.Combine(_basePath, dataSetVersion.DataSetId.ToString(), $"v{dataSetVersion.Version}");
+        => Path.Combine(_basePath, dataSetVersion.DataSetId.ToString(), $"v{dataSetVersion.PublicVersion}");
 
     private string GetBasePath()
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/DataSetPublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/DataSetPublishingService.cs
@@ -91,7 +91,7 @@ public class DataSetPublishingService(
             {
                 DataSetId = version.DataSetId,
                 DataSetFileId = dataSetFileIds[version.ReleaseFileId],
-                Version = version.Version
+                Version = version.PublicVersion
             })
             .ToList();
 


### PR DESCRIPTION
This PR fixes a bug where `ReleaseFiles` would continue to reference draft data set versions after they had been deleted. This was due to a couple of issues:

1. For v1+ data set versions, changes to the version number (e.g. when breaking changes are added) were not being made to the `ReleaseFile.PublicApiDataSetVersion` column as well. We now update this when the version number changes.
2. The incorrect version number was being used when querying for `ReleaseFile.PublicApiDataSetVersion`. We were querying with the 'public' version number (using non-standard `major.minor`), whereas the `PublicApiDataSetVersion` is stored with a standard semversion number (using `major.minor.patch`).

To help differentiate between these two version numbers better we've made the following changes to `DataSetVersion`:

- `Version` getter is now `PublicVersion` (the `major.minor` number)
- `FullSemanticVersion` method is now `SemVersion` (the `major.minor.patch` number)

## Breaking changes :warning: 

As part of this, the blob / file storage path has been changed to use the semversion, rather than the public version. This is a breaking change to existing file paths on dev.

Existing API data set versions will be affected until we clear down the files, otherwise, new API data set versions should work.

## Why have patch version numbers?

Currently, we don't use patch version numbers, but we may need these in the future so we're trying to support them as early as possible in case.

One potential use case are data file replacements where we may want to update the underlying data. A data replacement could be considered a bug fix for data and hence has parallels with patch versions. 

Replacements are currently not supported by API data sets, but they will be considered further in post-MVP.