### PR TITLE
EES-5400: Create new endpoint to get GeoJSON for implementing multiple boundary files

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Cache/LocationsForDataBlockCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Cache/LocationsForDataBlockCacheKey.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using System;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Cache;
+
+public record LocationsForDataBlockCacheKey : IBlobCacheKey
+{
+    private Guid ReleaseVersionId { get; }
+    private Guid DataBlockId { get; }
+    private long BoundaryLevelId { get; }
+
+    public LocationsForDataBlockCacheKey(DataBlockVersion dataBlockVersion, long boundaryLevelId) : this(
+        releaseVersionId: dataBlockVersion.ReleaseVersionId,
+        dataBlockId: dataBlockVersion.DataBlockParentId,
+        boundaryLevelId: boundaryLevelId)
+    {
+    }
+
+    public LocationsForDataBlockCacheKey(
+        Guid releaseVersionId,
+        Guid dataBlockId,
+        long boundaryLevelId)
+    {
+        ReleaseVersionId = releaseVersionId;
+        DataBlockId = dataBlockId;
+        BoundaryLevelId = boundaryLevelId;
+    }
+
+    public IBlobContainer Container => BlobContainers.PrivateContent;
+
+    public string Key => PrivateContentDataBlockLocationsPath(
+        ReleaseVersionId,
+        DataBlockId,
+        BoundaryLevelId
+    );
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/TableBuilderController.cs
@@ -46,7 +46,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
         public async Task<ActionResult> Query(
             Guid releaseVersionId,
             [FromBody] FullTableQueryRequest request,
-            [FromQuery] long? boundaryLevelId,
+            [FromQuery] long? boundaryLevelId, // TODO: Remove in EES-5433
             CancellationToken cancellationToken = default)
         {
             if (Request.AcceptsCsv(exact: true))
@@ -73,7 +73,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
         public async Task<ActionResult<TableBuilderResultViewModel>> QueryForDataBlock(
             Guid releaseVersionId,
             Guid dataBlockParentId,
-            [FromQuery] long? boundaryLevelId,
+            [FromQuery] long? boundaryLevelId, // TODO: Remove in EES-5433
             CancellationToken cancellationToken = default)
         {
             return await _dataBlockService
@@ -118,7 +118,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
         {
             return await _userService
                 .CheckCanViewReleaseVersion(dataBlockVersion.ReleaseVersion)
-                .OnSuccess(_ => _tableBuilderService.Query(releaseVersionId, dataBlockVersion.Query, boundaryLevelId, cancellationToken));
+                .OnSuccess(_ => _tableBuilderService.QueryForBoundaryLevel(releaseVersionId, dataBlockVersion.Query, boundaryLevelId, cancellationToken));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -28,9 +28,11 @@ using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Requests;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
@@ -49,6 +51,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Services;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -89,6 +92,7 @@ using ContentReleaseService = GovUk.Education.ExploreEducationStatistics.Content
 using DataGuidanceService = GovUk.Education.ExploreEducationStatistics.Admin.Services.DataGuidanceService;
 using DataSetService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data.DataSetService;
 using GlossaryService = GovUk.Education.ExploreEducationStatistics.Admin.Services.GlossaryService;
+using HeaderNames = Microsoft.Net.Http.Headers.HeaderNames;
 using IContentGlossaryService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IGlossaryService;
 using IContentMethodologyService =
     GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IMethodologyService;
@@ -121,10 +125,6 @@ using ReleaseService = GovUk.Education.ExploreEducationStatistics.Admin.Services
 using ReleaseVersionRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.ReleaseVersionRepository;
 using SameSiteMode = Microsoft.AspNetCore.Http.SameSiteMode;
 using ThemeService = GovUk.Education.ExploreEducationStatistics.Admin.Services.ThemeService;
-using GovUk.Education.ExploreEducationStatistics.Common.Requests;
-using HeaderNames = Microsoft.Net.Http.Headers.HeaderNames;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin
 {
@@ -456,6 +456,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IRedirectsService, RedirectsService>();
             services.AddTransient<IDataSetCandidateService, DataSetCandidateService>();
             services.AddTransient<IPostgreSqlRepository, PostgreSqlRepository>();
+            services.AddTransient<ILocationService, LocationService>();
 
             if (publicDataDbExists)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/FileStoragePathUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/FileStoragePathUtilsTests.cs
@@ -1,7 +1,7 @@
 #nullable enable
-using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using System;
 using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services;
@@ -29,6 +29,13 @@ public class FileStoragePathUtilsTests
             {
                 { "publication-slug", "release-slug", Guid.NewGuid() },
                 { "  publication-SLUG  ", "  release-SLUG  ", Guid.NewGuid() }
+            };
+
+        public static TheoryData<string, string, Guid, long> PublicationReleaseIdAndBoundaryLevelData =
+            new()
+            {
+                { "publication-slug", "release-slug", Guid.NewGuid(), 1 },
+                { "  publication-SLUG  ", "  release-SLUG  ", Guid.NewGuid(), 1 }
             };
 
         [Theory]
@@ -76,6 +83,22 @@ public class FileStoragePathUtilsTests
                 FileStoragePathUtils.PublicContentDataBlockPath(publicationSlug: publicationSlug,
                     releaseSlug: releaseSlug,
                     dataBlockId));
+        }
+
+        [Theory]
+        [MemberData(nameof(PublicationReleaseIdAndBoundaryLevelData))]
+        public void PublicContentDataBlockLocationsPath(
+            string publicationSlug,
+            string releaseSlug,
+            Guid dataBlockId,
+            long boundaryLevelId)
+        {
+            Assert.Equal($"publications/publication-slug/releases/release-slug/data-blocks/{dataBlockId}/{boundaryLevelId}-locations.json",
+                FileStoragePathUtils.PublicContentDataBlockLocationsPath(
+                    publicationSlug: publicationSlug,
+                    releaseSlug: releaseSlug,
+                    dataBlockId,
+                    boundaryLevelId));
         }
 
         [Theory]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/FileStoragePathUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/FileStoragePathUtilsTests.cs
@@ -93,7 +93,7 @@ public class FileStoragePathUtilsTests
             Guid dataBlockId,
             long boundaryLevelId)
         {
-            Assert.Equal($"publications/publication-slug/releases/release-slug/data-blocks/{dataBlockId}/{boundaryLevelId}-locations.json",
+            Assert.Equal($"publications/publication-slug/releases/release-slug/data-blocks/{dataBlockId}-boundary-levels/{dataBlockId}-{boundaryLevelId}.json",
                 FileStoragePathUtils.PublicContentDataBlockLocationsPath(
                     publicationSlug: publicationSlug,
                     releaseSlug: releaseSlug,
@@ -154,6 +154,14 @@ public class FileStoragePathUtilsTests
             }
         }
 
+        private class TestDataWithBoundaryLevelId : TheoryData<Guid, Guid, long>
+        {
+            public TestDataWithBoundaryLevelId()
+            {
+                Add(Guid.NewGuid(), Guid.NewGuid(), 1);
+            }
+        }
+
         [Theory]
         [ClassData(typeof(TestData))]
         public void PrivateContentDataBlockPath(Guid releaseVersionId,
@@ -162,6 +170,20 @@ public class FileStoragePathUtilsTests
             Assert.Equal($"releases/{releaseVersionId}/data-blocks/{dataBlockId}.json",
                 FileStoragePathUtils.PrivateContentDataBlockPath(releaseVersionId: releaseVersionId,
                     dataBlockId: dataBlockId));
+        }
+
+        [Theory]
+        [ClassData(typeof(TestDataWithBoundaryLevelId))]
+        public void PrivateContentDataBlockLocationsPath(
+            Guid releaseVersionId,
+            Guid dataBlockId,
+            long boundaryLevelId)
+        {
+            Assert.Equal($"releases/{releaseVersionId}/data-blocks/{dataBlockId}-boundary-levels/{dataBlockId}-{boundaryLevelId}.json",
+                FileStoragePathUtils.PrivateContentDataBlockLocationsPath(
+                    releaseVersionId,
+                    dataBlockId,
+                    boundaryLevelId));
         }
 
         [Theory]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -1,7 +1,7 @@
 #nullable enable
-using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using System;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Services
@@ -65,6 +65,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             Guid dataBlockId)
         {
             return $"{PublicContentDataBlockParentPath(publicationSlug, releaseSlug)}/{dataBlockId}.json";
+        }
+
+        public static string PublicContentDataBlockLocationsPath(
+            string publicationSlug,
+            string releaseSlug,
+            Guid dataBlockId,
+            long boundaryLevelId)
+        {
+            return $"{PublicContentDataBlockParentPath(publicationSlug, releaseSlug)}/{dataBlockId}/{boundaryLevelId}-locations.json";
         }
 
         public static string PublicContentSubjectMetaParentPath(string publicationSlug, string releaseSlug)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -54,6 +54,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return $"{ReleasesDirectory}/{releaseVersionId}/{DataBlocksDirectory}/{dataBlockId}.json";
         }
 
+        public static string PrivateContentDataBlockLocationsPath(
+            Guid releaseVersionId,
+            Guid dataBlockId,
+            long boundaryLevelId)
+        {
+            return $"{ReleasesDirectory}/{releaseVersionId}/{DataBlocksDirectory}/{dataBlockId}-boundary-levels/{dataBlockId}-{boundaryLevelId}.json";
+        }
+
         public static string PrivateContentSubjectMetaPath(Guid releaseVersionId, Guid subjectId)
         {
             return $"{ReleasesDirectory}/{releaseVersionId}/{SubjectMetaDirectory}/{subjectId}.json";
@@ -73,7 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             Guid dataBlockId,
             long boundaryLevelId)
         {
-            return $"{PublicContentDataBlockParentPath(publicationSlug, releaseSlug)}/{dataBlockId}/{boundaryLevelId}-locations.json";
+            return $"{PublicContentDataBlockParentPath(publicationSlug, releaseSlug)}/{dataBlockId}-boundary-levels/{dataBlockId}-{boundaryLevelId}.json";
         }
 
         public static string PublicContentSubjectMetaParentPath(string publicationSlug, string releaseSlug)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Cache/LocationsForDataBlockCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Cache/LocationsForDataBlockCacheKey.cs
@@ -1,0 +1,45 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using System;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Cache;
+
+public record LocationsForDataBlockCacheKey : IBlobCacheKey
+{
+    private string PublicationSlug { get; }
+    private string ReleaseSlug { get; }
+    private Guid DataBlockParentId { get; }
+    private long BoundaryLevelId { get; }
+
+    public LocationsForDataBlockCacheKey(DataBlockVersion dataBlockVersion, long boundaryLevelId) : this(
+        publicationSlug: dataBlockVersion.ReleaseVersion.Publication.Slug,
+        releaseSlug: dataBlockVersion.ReleaseVersion.Slug,
+        dataBlockParentId: dataBlockVersion.DataBlockParentId,
+        boundaryLevelId: boundaryLevelId)
+    {
+    }
+
+    public LocationsForDataBlockCacheKey(
+        string publicationSlug,
+        string releaseSlug,
+        Guid dataBlockParentId,
+        long boundaryLevelId)
+    {
+        PublicationSlug = publicationSlug;
+        ReleaseSlug = releaseSlug;
+        DataBlockParentId = dataBlockParentId;
+        BoundaryLevelId = boundaryLevelId;
+    }
+
+    public IBlobContainer Container => BlobContainers.PublicContent;
+
+    public string Key => PublicContentDataBlockLocationsPath(
+        PublicationSlug,
+        ReleaseSlug,
+        DataBlockParentId,
+        BoundaryLevelId
+    );
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
@@ -107,7 +107,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
         [HttpGet("tablebuilder/release/{releaseVersionId:guid}/data-block/{dataBlockParentId:guid}")]
         public async Task<ActionResult<TableBuilderResultViewModel>> QueryForTableBuilderResult(
             Guid dataBlockParentId,
-            [FromQuery] long? boundaryLevelId)
+            [FromQuery] long? boundaryLevelId) // TODO: Remove in EES-5433
         {
             var actionResult = await GetLatestPublishedDataBlockVersion(dataBlockParentId)
                 .OnSuccessDo(dataBlockVersion => this
@@ -123,7 +123,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
             return actionResult;
         }
 
-        [HttpGet("tablebuilder/release/data-block/{dataBlockParentId:guid}")]
+        [HttpGet("tablebuilder/release/{releaseVersionId:guid}/data-block/{dataBlockParentId:guid}/geojson")]
         public async Task<ActionResult<Dictionary<string, List<LocationAttributeViewModel>>>> QueryForDataBlockWithGeoJsonResult(
             Guid dataBlockParentId,
             [FromQuery] long boundaryLevelId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
@@ -124,7 +124,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
         }
 
         [HttpGet("tablebuilder/release/data-block/{dataBlockParentId:guid}")]
-        public async Task<ActionResult<Dictionary<string, List<LocationAttributeViewModel>>>> QueryForTableBuilderWithGeoJsonResult(
+        public async Task<ActionResult<Dictionary<string, List<LocationAttributeViewModel>>>> QueryForDataBlockWithGeoJsonResult(
             Guid dataBlockParentId,
             [FromQuery] long boundaryLevelId)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -6,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Api.Cache;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
@@ -156,7 +158,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
                 .HandleFailuresOrOk();
         }
 
-        //[BlobCache(typeof(DataBlockTableResultCacheKey))]
+        [BlobCache(typeof(DataBlockTableResultCacheKey))]
         private Task<Either<ActionResult, TableBuilderResultViewModel>> GetDataBlockTableResult(
             DataBlockVersion dataBlockVersion,
             long? boundaryLevelId = null)
@@ -167,7 +169,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
                 boundaryLevelId);
         }
 
-        //[BlobCache(typeof(DataBlockTableResultCacheKey))] // TODO: Create a GetLocationsCacheKey
+        [BlobCache(typeof(LocationsForDataBlockCacheKey))]
         private Task<Either<ActionResult, Dictionary<string, List<LocationAttributeViewModel>>>> GetLocations(
             DataBlockVersion dataBlockVersion,
             long boundaryLevelId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
@@ -9,9 +9,11 @@ using GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -39,6 +41,18 @@ public class DataBlockService : IDataBlockService
         Guid releaseVersionId,
         Guid dataBlockVersionId,
         long? boundaryLevelId)
+    {
+        return await _persistenceHelper.CheckEntityExists<ReleaseVersion>(releaseVersionId)
+            .OnSuccess(_userService.CheckCanViewReleaseVersion)
+            .OnSuccess(() => CheckDataBlockVersionExists(releaseVersionId: releaseVersionId,
+                dataBlockVersionId: dataBlockVersionId))
+            .OnSuccess(dataBlock => _tableBuilderService.Query(releaseVersionId, dataBlock.Query, boundaryLevelId));
+    }
+
+    public async Task<Either<ActionResult, Dictionary<string, List<LocationAttributeViewModel>>>> GetLocationsForDataBlock(
+        Guid releaseVersionId,
+        Guid dataBlockVersionId,
+        long boundaryLevelId)
     {
         return await _persistenceHelper.CheckEntityExists<ReleaseVersion>(releaseVersionId)
             .OnSuccess(_userService.CheckCanViewReleaseVersion)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
@@ -58,7 +58,7 @@ public class DataBlockService : IDataBlockService
             .OnSuccess(_userService.CheckCanViewReleaseVersion)
             .OnSuccess(() => CheckDataBlockVersionExists(releaseVersionId: releaseVersionId,
                 dataBlockVersionId: dataBlockVersionId))
-            .OnSuccess(dataBlock => _tableBuilderService.Query(releaseVersionId, dataBlock.Query, boundaryLevelId));
+            .OnSuccess(dataBlock => _tableBuilderService.QueryForBoundaryLevel(releaseVersionId, dataBlock.Query, boundaryLevelId));
     }
 
     private async Task<Either<ActionResult, DataBlockVersion>> CheckDataBlockVersionExists(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/Interfaces/IDataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/Interfaces/IDataBlockService.cs
@@ -1,8 +1,10 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces;
@@ -13,4 +15,9 @@ public interface IDataBlockService
         Guid releaseVersionId,
         Guid dataBlockVersionId,
         long? boundaryLevelId);
+
+    Task<Either<ActionResult, Dictionary<string, List<LocationAttributeViewModel>>>> GetLocationsForDataBlock(
+        Guid releaseVersionId,
+        Guid dataBlockVersionId,
+        long boundaryLevelId);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -1,10 +1,12 @@
 #nullable enable
+using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
 using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Requests;
 using GovUk.Education.ExploreEducationStatistics.Common.Rules;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -45,8 +47,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
 using System.Text;
-using FluentValidation;
-using GovUk.Education.ExploreEducationStatistics.Common.Requests;
 using Thinktecture;
 using static GovUk.Education.ExploreEducationStatistics.Common.Utils.StartupUtils;
 
@@ -174,6 +174,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
             services.AddSingleton<DataServiceMemoryCache<BoundaryData>, DataServiceMemoryCache<BoundaryData>>();
             services.AddTransient<IUserService, UserService>();
             services.AddTransient<ICacheKeyService, CacheKeyService>();
+            services.AddTransient<ILocationService, LocationService>();
 
             services
                 .AddAuthentication(options =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/LocationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/LocationServiceTests.cs
@@ -1,0 +1,361 @@
+#nullable enable
+using GeoJSON.Net.Geometry;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
+using Microsoft.Extensions.Options;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils.StatisticsDbUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests;
+
+public class LocationServiceTests
+{
+    private readonly LocationService _sut;
+    private readonly StatisticsDbContext _context;
+    private readonly Mock<IBoundaryDataRepository> _boundaryDataRepository;
+
+    public LocationServiceTests()
+    {
+        _context = InMemoryStatisticsDbContext();
+        _boundaryDataRepository = new Mock<IBoundaryDataRepository>(Strict);
+        _sut = new LocationService(_context, _boundaryDataRepository.Object);
+    }
+
+    private readonly Country _england = new("E92000001", "England");
+    private readonly Region _northEast = new("E12000001", "North East");
+    private readonly Region _northWest = new("E12000002", "North West");
+    private readonly Region _eastMidlands = new("E12000004", "East Midlands");
+    private readonly LocalAuthority _derby = new("E06000015", "", "Derby");
+    private readonly LocalAuthority _nottingham = new("E06000018", "", "Nottingham");
+
+    private static readonly BoundaryLevel _countriesBoundaryLevel = new()
+    {
+        Id = 1,
+        Label = "Countries November 2021",
+        Level = GeographicLevel.Country
+    };
+
+    private static readonly Dictionary<string, object> _properties = new()
+    {
+        { "OBJECTID", 1 },
+        { "ctry17cd", "E92000001" },
+        { "ctry17nm", "England" },
+        { "ctry17nmw", "Lloegr" },
+        { "bng_e", 394881 },
+        { "bng_n", 370341 },
+        { "long", -2 },
+        { "lat", 50 },
+        { "GlobalID", "1277674d-5d60-457d-9322-833b31f77014" },
+    };
+
+    private static readonly BoundaryData _boundaryData = new()
+    {
+        BoundaryLevel = _countriesBoundaryLevel,
+        Code = "E92000001",
+        Name = "England",
+        GeoJson = new(new MultiPolygon([[[
+                    [-71.17351189255714, 42.350224666504324],
+                    [-71.1677360907197, 42.34671571695422],
+                    [-71.16970919072628, 42.35326835618748],
+                    [-71.14341516047716, 42.36174674733808],
+                    [-71.17559093981981, 42.368232175909064],
+                    [-71.17351189255714, 42.350224666504324]]]]),
+                    _properties, "1"
+                ),
+    };
+
+    [Fact]
+    public async Task GetLocationViewModels_NoBoundaryLevel_ReturnsViewModelsWithoutGeoJson()
+    {
+        // Arrange
+        // Setup multiple geographic levels of data where some but not all of the levels have a hierarchy applied.
+        var location1 = new Location
+        {
+            Id = Guid.NewGuid(),
+            GeographicLevel = GeographicLevel.Country,
+            Country = _england
+        };
+
+        var location2 = new Location
+        {
+            Id = Guid.NewGuid(),
+            GeographicLevel = GeographicLevel.Region,
+            Country = _england,
+            Region = _northEast
+        };
+
+        var location3 = new Location
+        {
+            Id = Guid.NewGuid(),
+            GeographicLevel = GeographicLevel.Region,
+            Country = _england,
+            Region = _northWest
+        };
+
+        var location4 = new Location
+        {
+            Id = Guid.NewGuid(),
+            GeographicLevel = GeographicLevel.Region,
+            Country = _england,
+            Region = _eastMidlands
+        };
+
+        var location5 = new Location
+        {
+            Id = Guid.NewGuid(),
+            GeographicLevel = GeographicLevel.LocalAuthority,
+            Country = _england,
+            Region = _eastMidlands,
+            LocalAuthority = _derby
+        };
+
+        var location6 = new Location
+        {
+            Id = Guid.NewGuid(),
+            GeographicLevel = GeographicLevel.LocalAuthority,
+            Country = _england,
+            Region = _eastMidlands,
+            LocalAuthority = _nottingham
+        };
+
+        var locations = new List<Location>
+        {
+            location1, location2, location3, location4, location5, location6
+        };
+
+        var options = Options.Create(new LocationsOptions
+        {
+            Hierarchies = new Dictionary<GeographicLevel, List<string>>
+                {
+                    {
+                        GeographicLevel.LocalAuthority,
+                        new List<string>
+                        {
+                            "Country",
+                            "Region"
+                        }
+                    }
+                }
+        });
+
+        _context.BoundaryLevel.Add(_countriesBoundaryLevel);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetLocationViewModels(
+            locations,
+            null,
+            options.Value.Hierarchies);
+
+        // Assert
+        // Result has Country, Region and Local Authority levels
+        Assert.Equal(3, result.Count);
+        Assert.True(result.ContainsKey("country"));
+        Assert.True(result.ContainsKey("region"));
+        Assert.True(result.ContainsKey("localAuthority"));
+
+        // Expect no hierarchy within the Country level
+        var countries = result["country"];
+
+        var countryOption1 = Assert.Single(countries);
+        Assert.Equal(location1.Id, countryOption1.Id);
+        Assert.Equal(_england.Name, countryOption1.Label);
+        Assert.Equal(_england.Code, countryOption1.Value);
+        Assert.Null(countryOption1.Level);
+        Assert.Null(countryOption1.Options);
+        Assert.Null(countryOption1.GeoJson);
+
+        // Expect no hierarchy within the Region level
+        var regions = result["region"];
+        Assert.Equal(3, regions.Count);
+
+        var regionOption1 = regions[0];
+        Assert.Equal(location2.Id, regionOption1.Id);
+        Assert.Equal(_northEast.Name, regionOption1.Label);
+        Assert.Equal(_northEast.Code, regionOption1.Value);
+        Assert.Null(regionOption1.Level);
+        Assert.Null(regionOption1.Options);
+        Assert.Null(regionOption1.GeoJson);
+
+        var regionOption2 = regions[1];
+        Assert.Equal(location3.Id, regionOption2.Id);
+        Assert.Equal(_northWest.Name, regionOption2.Label);
+        Assert.Equal(_northWest.Code, regionOption2.Value);
+        Assert.Null(regionOption2.Level);
+        Assert.Null(regionOption2.Options);
+        Assert.Null(regionOption2.GeoJson);
+
+        var regionOption3 = regions[2];
+        Assert.Equal(location4.Id, regionOption3.Id);
+        Assert.Equal(_eastMidlands.Name, regionOption3.Label);
+        Assert.Equal(_eastMidlands.Code, regionOption3.Value);
+        Assert.Null(regionOption3.Level);
+        Assert.Null(regionOption3.Options);
+        Assert.Null(regionOption3.GeoJson);
+
+        // Expect a hierarchy of Country-Region-LA within the Local Authority level
+        var localAuthorities = result["localAuthority"];
+
+        var laOption1 = Assert.Single(localAuthorities);
+        Assert.NotNull(laOption1);
+        Assert.Null(laOption1.Id);
+        Assert.Equal(_england.Name, laOption1.Label);
+        Assert.Equal(_england.Code, laOption1.Value);
+        Assert.Equal(GeographicLevel.Country, laOption1.Level);
+        Assert.NotNull(laOption1.Options);
+        Assert.Null(laOption1.GeoJson);
+
+        var laOption1SubOption1 = Assert.Single(laOption1.Options!);
+        Assert.NotNull(laOption1SubOption1);
+        Assert.Null(laOption1SubOption1.Id);
+        Assert.Equal(_eastMidlands.Name, laOption1SubOption1.Label);
+        Assert.Equal(_eastMidlands.Code, laOption1SubOption1.Value);
+        Assert.Equal(GeographicLevel.Region, laOption1SubOption1.Level);
+        Assert.NotNull(laOption1SubOption1.Options);
+        Assert.Equal(2, laOption1SubOption1.Options!.Count);
+        Assert.Null(laOption1SubOption1.GeoJson);
+
+        var laOption1SubOption1SubOption1 = laOption1SubOption1.Options[0];
+        Assert.Equal(location5.Id, laOption1SubOption1SubOption1.Id);
+        Assert.Equal(_derby.Name, laOption1SubOption1SubOption1.Label);
+        Assert.Equal(_derby.Code, laOption1SubOption1SubOption1.Value);
+        Assert.Null(laOption1SubOption1SubOption1.Level);
+        Assert.Null(laOption1SubOption1SubOption1.Options);
+        Assert.Null(laOption1SubOption1SubOption1.GeoJson);
+
+        var laOption1SubOption1SubOption2 = laOption1SubOption1.Options[1];
+        Assert.Equal(location6.Id, laOption1SubOption1SubOption2.Id);
+        Assert.Equal(_nottingham.Name, laOption1SubOption1SubOption2.Label);
+        Assert.Equal(_nottingham.Code, laOption1SubOption1SubOption2.Value);
+        Assert.Null(laOption1SubOption1SubOption2.Level);
+        Assert.Null(laOption1SubOption1SubOption2.Options);
+        Assert.Null(laOption1SubOption1SubOption2.GeoJson);
+    }
+
+    [Fact]
+    public async Task GetLocationViewModels_WithBoundaryLevel_ReturnsViewModelsWithGeoJson()
+    {
+
+        var location1 = new Location
+        {
+            Id = Guid.NewGuid(),
+            GeographicLevel = GeographicLevel.Region,
+            Country = _england,
+            Region = _northEast
+        };
+
+        var location2 = new Location
+        {
+            Id = Guid.NewGuid(),
+            GeographicLevel = GeographicLevel.Region,
+            Country = _england,
+            Region = _northWest
+        };
+
+        var location3 = new Location
+        {
+            Id = Guid.NewGuid(),
+            GeographicLevel = GeographicLevel.Region,
+            Country = _england,
+            Region = _eastMidlands
+        };
+
+        var locations = new List<Location>
+        {
+            location1, location2, location3
+        };
+
+        var options = Options.Create(new LocationsOptions
+        {
+            Hierarchies = new Dictionary<GeographicLevel, List<string>>
+                {
+                    {
+                        GeographicLevel.Region,
+                        new List<string>
+                        {
+                            "Country"
+                        }
+                    }
+                }
+        });
+
+        _context.BoundaryLevel.Add(new() { Id = 123, Label = "Boundary Level 1", Level = GeographicLevel.Region });
+        await _context.SaveChangesAsync();
+
+        _boundaryDataRepository
+            .Setup(s => s.FindByBoundaryLevelAndCodes(
+                It.IsAny<long>(),
+                new List<string> { _northEast.Code!, _northWest.Code!, _eastMidlands.Code! }))
+            .Returns(new Dictionary<string, BoundaryData>
+                {
+                    {
+                        _northEast.Code!,
+                        _boundaryData
+                    },
+                    {
+                        _northWest.Code!,
+                        _boundaryData
+                    },
+                    {
+                        _eastMidlands.Code!,
+                        _boundaryData
+                    }
+                });
+
+        // Act
+        var result = await _sut.GetLocationViewModels(
+            locations,
+            boundaryLevelId: 123,
+            options.Value.Hierarchies);
+
+        // Assert
+        VerifyAllMocks(_boundaryDataRepository);
+
+        // Result only has a Region level
+        Assert.Single(result);
+        Assert.True(result.ContainsKey("region"));
+
+        // Expect a hierarchy of Country-Region within the Region level
+        var regions = result["region"];
+
+        // Country option that groups the Regions does not have GeoJson
+        var regionOption1 = Assert.Single(regions);
+        Assert.Null(regionOption1.Id);
+        Assert.Equal(_england.Name, regionOption1.Label);
+        Assert.Equal(_england.Code, regionOption1.Value);
+        Assert.Null(regionOption1.GeoJson);
+        Assert.Equal(GeographicLevel.Country, regionOption1.Level);
+        Assert.NotNull(regionOption1.Options);
+        Assert.Equal(3, regionOption1.Options!.Count);
+
+        // Each Region option should have GeoJson
+        var regionOption1SubOption1 = regionOption1.Options[0];
+        Assert.Equal(_northEast.Name, regionOption1SubOption1.Label);
+        Assert.Equal(_northEast.Code, regionOption1SubOption1.Value);
+        Assert.NotNull(regionOption1SubOption1.GeoJson);
+        Assert.Null(regionOption1SubOption1.Level);
+        Assert.Null(regionOption1SubOption1.Options);
+
+        var regionOption1SubOption2 = regionOption1.Options[1];
+        Assert.Equal(_northWest.Name, regionOption1SubOption2.Label);
+        Assert.Equal(_northWest.Code, regionOption1SubOption2.Value);
+        Assert.NotNull(regionOption1SubOption2.GeoJson);
+        Assert.Null(regionOption1SubOption2.Level);
+        Assert.Null(regionOption1SubOption2.Options);
+
+        var regionOption1SubOption3 = regionOption1.Options[2];
+        Assert.Equal(_eastMidlands.Name, regionOption1SubOption3.Label);
+        Assert.Equal(_eastMidlands.Code, regionOption1SubOption3.Value);
+        Assert.NotNull(regionOption1SubOption3.GeoJson);
+        Assert.Null(regionOption1SubOption3.Level);
+        Assert.Null(regionOption1SubOption3.Options);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServicePermissionTests.cs
@@ -15,6 +15,7 @@ using System;
 using System.Threading.Tasks;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
+using static Moq.MockBehavior;
 using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
@@ -48,13 +49,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                         MockUtils.SetupCall(statisticsPersistenceHelper, _releaseSubject);
 
-                        var subjectRepository = new Mock<ISubjectRepository>(MockBehavior.Strict);
+                        var subjectRepository = new Mock<ISubjectRepository>(Strict);
 
                         subjectRepository
                             .Setup(s => s.FindPublicationIdForSubject(_subject.Id, default))
                             .ReturnsAsync(PublicationId);
 
-                        var releaseVersionRepository = new Mock<IReleaseVersionRepository>(MockBehavior.Strict);
+                        var releaseVersionRepository = new Mock<IReleaseVersionRepository>(Strict);
 
                         releaseVersionRepository
                             .Setup(s => s.GetLatestPublishedReleaseVersion(PublicationId, default))
@@ -110,6 +111,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
         private TableBuilderService BuildTableBuilderService(
             IFilterItemRepository? filterItemRepository = null,
+            ILocationService? locationService = null,
             IObservationService? observationService = null,
             IPersistenceHelper<StatisticsDbContext>? statisticsPersistenceHelper = null,
             ISubjectResultMetaService? subjectResultMetaService = null,
@@ -117,23 +119,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             ISubjectRepository? subjectRepository = null,
             IUserService? userService = null,
             IReleaseVersionRepository? releaseVersionRepository = null,
-            IOptions<TableBuilderOptions>? options = null)
+            IOptions<TableBuilderOptions>? tableBuilderOptions = null,
+            IOptions<LocationsOptions>? locationsOptions = null)
         {
             return new(
                 Mock.Of<StatisticsDbContext>(),
-                filterItemRepository ?? Mock.Of<IFilterItemRepository>(MockBehavior.Strict),
-                observationService ?? Mock.Of<IObservationService>(MockBehavior.Strict),
+                filterItemRepository ?? Mock.Of<IFilterItemRepository>(Strict),
+                locationService ?? Mock.Of<ILocationService>(Strict),
+                observationService ?? Mock.Of<IObservationService>(Strict),
                 statisticsPersistenceHelper ?? StatisticsPersistenceHelperMock(_subject).Object,
-                subjectResultMetaService ?? Mock.Of<ISubjectResultMetaService>(MockBehavior.Strict),
-                subjectCsvMetaService ?? Mock.Of<ISubjectCsvMetaService>(MockBehavior.Strict),
-                subjectRepository ?? Mock.Of<ISubjectRepository>(MockBehavior.Strict),
-                userService ?? Mock.Of<IUserService>(MockBehavior.Strict),
-                releaseVersionRepository ?? Mock.Of<IReleaseVersionRepository>(MockBehavior.Strict),
-                options ?? Options.Create(new TableBuilderOptions())
+                subjectResultMetaService ?? Mock.Of<ISubjectResultMetaService>(Strict),
+                subjectCsvMetaService ?? Mock.Of<ISubjectCsvMetaService>(Strict),
+                subjectRepository ?? Mock.Of<ISubjectRepository>(Strict),
+                userService ?? Mock.Of<IUserService>(Strict),
+                releaseVersionRepository ?? Mock.Of<IReleaseVersionRepository>(Strict),
+                tableBuilderOptions ?? Options.Create(new TableBuilderOptions()),
+                locationsOptions ?? Options.Create(new LocationsOptions())
             );
         }
 
-        private Mock<IPersistenceHelper<StatisticsDbContext>> StatisticsPersistenceHelperMock(Subject subject)
+        private static Mock<IPersistenceHelper<StatisticsDbContext>> StatisticsPersistenceHelperMock(Subject subject)
         {
             return MockUtils.MockPersistenceHelper<StatisticsDbContext, Subject>(subject.Id, subject);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
@@ -436,7 +436,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     statisticsDbContext: statisticsDbContext,
                     contentDbContext: contentDbContext,
                     filterItemRepository: filterItemRepository.Object,
-                    options: options
+                    tableBuilderOptions: options
                 );
 
                 var result = await service.Query(query);
@@ -799,7 +799,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 var service = BuildTableBuilderService(
                     statisticsDbContext: statisticsDbContext,
                     filterItemRepository: filterItemRepository.Object,
-                    options: options
+                    tableBuilderOptions: options
                 );
 
                 var result = await service.Query(releaseSubject.ReleaseVersionId, query, null);
@@ -1167,7 +1167,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     statisticsDbContext: statisticsDbContext,
                     contentDbContext: contentDbContext,
                     filterItemRepository: filterItemRepository.Object,
-                    options: options
+                    tableBuilderOptions: options
                 );
 
                 using var stream = new MemoryStream();
@@ -1668,7 +1668,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 var service = BuildTableBuilderService(
                     statisticsDbContext: statisticsDbContext,
                     filterItemRepository: filterItemRepository.Object,
-                    options: options
+                    tableBuilderOptions: options
                 );
 
                 using var stream = new MemoryStream();
@@ -1681,7 +1681,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             }
         }
 
-        private static IOptions<TableBuilderOptions> DefaultOptions()
+        private static IOptions<TableBuilderOptions> DefaultTableBuilderOptions()
         {
             return Options.Create(new TableBuilderOptions
             {
@@ -1689,10 +1689,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             });
         }
 
+        private static IOptions<LocationsOptions> DefaultLocationOptions()
+        {
+            return Options.Create(new LocationsOptions
+            {
+                Hierarchies = new()
+                {
+                    { GeographicLevel.LocalAuthority, ["Region"] },
+                    { GeographicLevel.LocalAuthorityDistrict, ["Region"] },
+                    { GeographicLevel.School, ["LocalAuthority"] },
+                }
+            });
+        }
+
         private static TableBuilderService BuildTableBuilderService(
             StatisticsDbContext statisticsDbContext,
             ContentDbContext? contentDbContext = null,
             IFilterItemRepository? filterItemRepository = null,
+            ILocationService? locationService = null,
             IObservationService? observationService = null,
             IPersistenceHelper<StatisticsDbContext>? statisticsPersistenceHelper = null,
             ISubjectResultMetaService? subjectResultMetaService = null,
@@ -1700,11 +1714,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             ISubjectRepository? subjectRepository = null,
             IUserService? userService = null,
             IReleaseVersionRepository? releaseVersionRepository = null,
-            IOptions<TableBuilderOptions>? options = null)
+            IOptions<TableBuilderOptions>? tableBuilderOptions = null,
+            IOptions<LocationsOptions>? locationsOptions = null)
         {
             return new(
                 statisticsDbContext,
                 filterItemRepository ?? Mock.Of<IFilterItemRepository>(Strict),
+                locationService ?? Mock.Of<ILocationService>(Strict),
                 observationService ?? Mock.Of<IObservationService>(Strict),
                 statisticsPersistenceHelper ?? new PersistenceHelper<StatisticsDbContext>(statisticsDbContext),
                 subjectResultMetaService ?? Mock.Of<ISubjectResultMetaService>(Strict),
@@ -1712,7 +1728,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 subjectRepository ?? new SubjectRepository(statisticsDbContext),
                 userService ?? AlwaysTrueUserService().Object,
                 releaseVersionRepository ?? new ReleaseVersionRepository(contentDbContext ?? Mock.Of<ContentDbContext>()),
-                options ?? DefaultOptions()
+                tableBuilderOptions ?? DefaultTableBuilderOptions(),
+                locationsOptions ?? DefaultLocationOptions()
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ILocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ILocationService.cs
@@ -1,0 +1,15 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+public interface ILocationService
+{
+    Task<Dictionary<string, List<LocationAttributeViewModel>>> GetLocationViewModels(
+            List<Location> locations,
+            long? boundaryLevelId,
+            Dictionary<GeographicLevel, List<string>>? hierarchies);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ITableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ITableBuilderService.cs
@@ -2,8 +2,10 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,6 +22,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
             Guid releaseVersionId,
             FullTableQuery query,
             long? boundaryLevelId,
+            CancellationToken cancellationToken = default);
+
+        Task<Either<ActionResult, Dictionary<string, List<LocationAttributeViewModel>>>> Query(
+            Guid releaseVersionId,
+            FullTableQuery query,
+            long boundaryLevelId,
             CancellationToken cancellationToken = default);
 
         Task<Either<ActionResult, Unit>> QueryToCsvStream(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ITableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ITableBuilderService.cs
@@ -24,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
             long? boundaryLevelId,
             CancellationToken cancellationToken = default);
 
-        Task<Either<ActionResult, Dictionary<string, List<LocationAttributeViewModel>>>> Query(
+        Task<Either<ActionResult, Dictionary<string, List<LocationAttributeViewModel>>>> QueryForBoundaryLevel(
             Guid releaseVersionId,
             FullTableQuery query,
             long boundaryLevelId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationService.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services;
+public class LocationService(StatisticsDbContext context, IBoundaryDataRepository boundaryDataRepository) : ILocationService
+{
+    public async Task<Dictionary<string, List<LocationAttributeViewModel>>> GetLocationViewModels(
+            List<Location> locations,
+            long? boundaryLevelId,
+            Dictionary<GeographicLevel, List<string>>? hierarchies)
+    {
+        var boundaryData = await GetBoundaryData(locations, boundaryLevelId);
+
+        return LocationViewModelBuilder.BuildLocationAttributeViewModels(locations, hierarchies, boundaryData)
+            .ToDictionary(
+                pair => pair.Key.ToString().CamelCase(),
+                pair => pair.Value);
+    }
+
+    private async Task<Dictionary<GeographicLevel, Dictionary<string, BoundaryData>>> GetBoundaryData(
+            List<Location> locations,
+            long? boundaryLevelId)
+    {
+        if (!boundaryLevelId.HasValue)
+        {
+            return [];
+        }
+
+        var boundaryLevel = await context.BoundaryLevel.FindAsync(boundaryLevelId)
+            ?? throw new ArgumentOutOfRangeException(nameof(boundaryLevelId));
+
+        var locationsMatchingLevel =
+            locations.Where(location => location.GeographicLevel == boundaryLevel.Level);
+
+        var codes = locationsMatchingLevel
+            .Select(location => location.ToLocationAttribute().GetCodeOrFallback())
+            .ToList();
+
+        var boundaryData = boundaryDataRepository.FindByBoundaryLevelAndCodes(boundaryLevelId.Value, codes);
+
+        return new Dictionary<GeographicLevel, Dictionary<string, BoundaryData>>
+            {
+                {
+                    boundaryLevel.Level,
+                    boundaryData
+                }
+            };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
@@ -116,7 +116,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 });
         }
 
-        public async Task<Either<ActionResult, Dictionary<string, List<LocationAttributeViewModel>>>> Query(
+        public async Task<Either<ActionResult, Dictionary<string, List<LocationAttributeViewModel>>>> QueryForBoundaryLevel(
             Guid releaseVersionId,
             FullTableQuery query,
             long boundaryLevelId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
@@ -37,6 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
     {
         private readonly StatisticsDbContext _context;
         private readonly IFilterItemRepository _filterItemRepository;
+        private readonly ILocationService _locationService;
         private readonly IObservationService _observationService;
         private readonly IPersistenceHelper<StatisticsDbContext> _statisticsPersistenceHelper;
         private readonly ISubjectResultMetaService _subjectResultMetaService;
@@ -45,10 +46,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         private readonly IUserService _userService;
         private readonly IReleaseVersionRepository _releaseVersionRepository;
         private readonly TableBuilderOptions _options;
+        private readonly LocationsOptions _locationOptions;
 
         public TableBuilderService(
             StatisticsDbContext context,
             IFilterItemRepository filterItemRepository,
+            ILocationService locationService,
             IObservationService observationService,
             IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper,
             ISubjectResultMetaService subjectResultMetaService,
@@ -56,10 +59,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             ISubjectRepository subjectRepository,
             IUserService userService,
             IReleaseVersionRepository releaseVersionRepository,
-            IOptions<TableBuilderOptions> options)
+            IOptions<TableBuilderOptions> options,
+            IOptions<LocationsOptions> locationOptions)
         {
             _context = context;
             _filterItemRepository = filterItemRepository;
+            _locationService = locationService;
             _observationService = observationService;
             _statisticsPersistenceHelper = statisticsPersistenceHelper;
             _subjectResultMetaService = subjectResultMetaService;
@@ -68,6 +73,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             _userService = userService;
             _releaseVersionRepository = releaseVersionRepository;
             _options = options.Value;
+            _locationOptions = locationOptions.Value;
         }
 
         public async Task<Either<ActionResult, TableBuilderResultViewModel>> Query(
@@ -75,7 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             CancellationToken cancellationToken = default)
         {
             return await FindLatestPublishedReleaseVersionId(query.SubjectId)
-                .OnSuccess(releaseVersionId => Query(releaseVersionId, query, null, cancellationToken));
+                .OnSuccess(releaseVersionId => Query(releaseVersionId, query, boundaryLevelId: null, cancellationToken));
         }
 
         public async Task<Either<ActionResult, TableBuilderResultViewModel>> Query(
@@ -107,6 +113,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                                     ObservationViewModelBuilder.BuildObservation(observation, query.Indicators))
                             };
                         });
+                });
+        }
+
+        public async Task<Either<ActionResult, Dictionary<string, List<LocationAttributeViewModel>>>> Query(
+            Guid releaseVersionId,
+            FullTableQuery query,
+            long boundaryLevelId,
+            CancellationToken cancellationToken = default)
+        {
+            return await CheckReleaseSubjectExists(subjectId: query.SubjectId,
+                    releaseVersionId: releaseVersionId)
+                .OnSuccess(_userService.CheckCanViewSubjectData)
+                .OnSuccessDo(() => CheckQueryHasValidTableSize(query))
+                .OnSuccess(() => ListQueryObservations(query, cancellationToken))
+                .OnSuccess(async observations =>
+                {
+                    if (observations.Count == 0)
+                    {
+                        return [];
+                    }
+
+                    var locations = observations
+                        .Select(o => o.Location)
+                        .Distinct()
+                        .ToList();
+
+                    return await _locationService.GetLocationViewModels(locations, boundaryLevelId, _locationOptions.Hierarchies);
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.ViewModels/Meta/LocationsMetaViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.ViewModels/Meta/LocationsMetaViewModels.cs
@@ -1,3 +1,4 @@
+using GeoJSON.Net.Feature;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using Newtonsoft.Json;
@@ -16,7 +17,7 @@ public record LocationAttributeViewModel : LabelValue
 {
     public Guid? Id { get; set; }
 
-    public dynamic? GeoJson { get; init; }
+    public Feature? GeoJson { get; init; }
 
     [JsonConverter(typeof(StringEnumConverter), typeof(CamelCaseNamingStrategy))]
     public GeographicLevel? Level { get; init; }


### PR DESCRIPTION
This PR adds a new endpoint which returns location data for a data block, based on the supplied boundary level. Once implemented, this will allow the frontend to have data blocks which reference numerous boundary levels (i.e. if the data spans a number of years, and the boundaries have changed over time), and then call the endpoint to retrieve the appropriate location data.

Due to the relatively large volume of data returned, this data is also cached in blob storage for efficiency/performance.