### PR TITLE
EES-5382 - switch Key Vault to RBAC mode.  Migrate "Get/List secrets" policies to "Key Vault Secrets User" role assignments

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1165,7 +1165,18 @@
         }
       ]
     },
-    "templateBaseUrl": "[concat('https://raw.githubusercontent.com/dfe-analytical-services/explore-education-statistics/', parameters('branch'), '/infrastructure/templates/')]"
+    "templateBaseUrl": "[concat('https://raw.githubusercontent.com/dfe-analytical-services/explore-education-statistics/', parameters('branch'), '/infrastructure/templates/')]",
+    "keyVaultSecretsUserRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
+    "keyVaultSecretsUserPrincipalIds": [
+      "[reference(concat('Microsoft.DataFactory/factories/', variables('dataFactoryName')), '2022-09-01', 'Full').identity.principalId]",
+      "[reference(concat('Microsoft.Web/sites/', variables('adminAppName')), '2022-09-01', 'Full').identity.principalId]",
+      "[reference(concat('Microsoft.Web/sites/', variables('publisherAppName')), '2022-09-01', 'Full').identity.principalId]",
+      "[reference(concat('Microsoft.Web/sites/', variables('notificationsAppName')), '2022-09-01', 'Full').identity.principalId]",
+      "[reference(concat('Microsoft.Web/sites/', variables('importerAppName')), '2022-09-01', 'Full').identity.principalId]",
+      "[reference(concat('Microsoft.Web/sites/', variables('contentAppName')), '2022-09-01', 'Full').identity.principalId]",
+      "[reference(concat('Microsoft.Web/sites/', variables('dataAppName')), '2022-09-01', 'Full').identity.principalId]",
+      "[parameters('devopsSPN')]"
+    ]
   },
   "resources": [
     {
@@ -3658,199 +3669,8 @@
         "enabledForDiskEncryption": true,
         "enabledForTemplateDeployment": true,
         "enableSoftDelete": true,
-        "accessPolicies": [
-          {
-            "tenantId": "[subscription().tenantId]",
-            "objectId": "[reference(concat('Microsoft.DataFactory/factories/', variables('dataFactoryName')), '2018-06-01', 'Full').identity.principalId]",
-            "permissions": {
-              "keys": [],
-              "secrets": [
-                "Get",
-                "List"
-              ],
-              "certificates": []
-            }
-          },
-          {
-            "tenantId": "[reference(concat('Microsoft.Web/sites/', variables('adminAppName'), '/providers/Microsoft.ManagedIdentity/Identities/default'), '2015-08-31-PREVIEW').tenantId]",
-            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('adminAppName'), '/providers/Microsoft.ManagedIdentity/Identities/default'), '2015-08-31-PREVIEW').principalId]",
-            "permissions": {
-              "keys": [],
-              "secrets": [
-                "Get",
-                "List"
-              ],
-              "certificates": []
-            }
-          },
-          {
-            "tenantId": "[subscription().tenantId]",
-            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('publisherAppName')), '2019-08-01', 'Full').identity.principalId]",
-            "permissions": {
-              "keys": [],
-              "secrets": [
-                "Get",
-                "List"
-              ],
-              "certificates": []
-            }
-          },
-          {
-            "tenantId": "[subscription().tenantId]",
-            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('notificationsAppName')), '2019-08-01', 'Full').identity.principalId]",
-            "permissions": {
-              "keys": [],
-              "secrets": [
-                "Get",
-                "List"
-              ],
-              "certificates": []
-            }
-          },
-          {
-            "tenantId": "[subscription().tenantId]",
-            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('importerAppName')), '2019-08-01', 'Full').identity.principalId]",
-            "permissions": {
-              "keys": [],
-              "secrets": [
-                "Get",
-                "List"
-              ],
-              "certificates": []
-            }
-          },
-          {
-            "tenantId": "[subscription().tenantId]",
-            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('contentAppName')), '2019-08-01', 'Full').identity.principalId]",
-            "permissions": {
-              "keys": [],
-              "secrets": [
-                "Get",
-                "List"
-              ],
-              "certificates": []
-            }
-          },
-          {
-            "tenantId": "[subscription().tenantId]",
-            "objectId": "[reference(concat('Microsoft.Web/sites/', variables('dataAppName')), '2019-08-01', 'Full').identity.principalId]",
-            "permissions": {
-              "keys": [],
-              "secrets": [
-                "Get",
-                "List"
-              ],
-              "certificates": []
-            }
-          },
-          {
-            "tenantId": "[subscription().tenantId]",
-            "objectId": "[parameters('devopsSPN')]",
-            // Devops SPN
-            "permissions": {
-              "keys": [],
-              "secrets": [
-                "Get",
-                "List"
-              ],
-              "certificates": []
-            }
-          },
-          {
-            "tenantId": "[subscription().tenantId]",
-            "objectId": "a2d80c7b-fa56-4145-9a11-8aa3f9a4a8fe",
-            // EES Admin Group ID
-            "permissions": {
-              "keys": [
-                "Get",
-                "List",
-                "Update",
-                "Create",
-                "Import",
-                "Delete",
-                "Recover",
-                "Backup",
-                "Restore"
-              ],
-              "secrets": [
-                "Get",
-                "List",
-                "Set",
-                "Delete",
-                "Recover",
-                "Backup",
-                "Restore"
-              ],
-              "certificates": [
-                "Get",
-                "List",
-                "Update",
-                "Create",
-                "Import",
-                "Delete",
-                "Recover",
-                "Backup",
-                "Restore",
-                "ManageContacts",
-                "ManageIssuers",
-                "GetIssuers",
-                "ListIssuers",
-                "SetIssuers",
-                "DeleteIssuers"
-              ]
-            }
-          },
-          {
-            "tenantId": "[subscription().tenantId]",
-            "objectId": "976855ee-57b9-438c-bace-b4dfe141bb7e",
-            // EDAP Team
-            "permissions": {
-              "keys": [
-                "Get",
-                "List",
-                "Update",
-                "Create",
-                "Import",
-                "Delete",
-                "Recover",
-                "Backup",
-                "Restore",
-                "Decrypt",
-                "Encrypt",
-                "UnwrapKey",
-                "WrapKey",
-                "Verify",
-                "Sign"
-              ],
-              "secrets": [
-                "Get",
-                "List",
-                "Set",
-                "Delete",
-                "Recover",
-                "Backup",
-                "Restore"
-              ],
-              "certificates": [
-                "Get",
-                "List",
-                "Update",
-                "Create",
-                "Import",
-                "Delete",
-                "Recover",
-                "Backup",
-                "Restore",
-                "ManageContacts",
-                "ManageIssuers",
-                "GetIssuers",
-                "ListIssuers",
-                "SetIssuers",
-                "DeleteIssuers"
-              ]
-            }
-          }
-        ]
+        "accessPolicies": [],
+        "enableRbacAuthorization": true
       },
       "resources": [
         {
@@ -3902,6 +3722,21 @@
           }
         }
       ]
+    },
+    {
+      "copy": {
+        "name": "keyVaultSecretUsersCopy",
+        "count": "[length(variables('keyVaultSecretsUserPrincipalIds'))]"
+      },
+      "type": "Microsoft.KeyVault/vaults/providers/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[concat(variables('keyVaultName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.KeyVault/vaults',  variables('keyVaultName')), variables('keyVaultSecretsUserRoleDefinitionId'), variables('keyVaultSecretsUserPrincipalIds')[copyIndex()])))]",
+      "properties": {
+        "roleDefinitionId": "[variables('keyVaultSecretsUserRoleDefinitionId')]",
+        "principalId": "[variables('keyVaultSecretsUserPrincipalIds')[copyIndex()]]",
+        "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+        "principalType": "ServicePrincipal"
+      }
     },
     {
       "name": "[concat(variables('dataAppName'), '-autoscale')]",


### PR DESCRIPTION
:warning: Adding "Do Not Merge" on this until Mark Nelson has had a chance to add the new role assignments for the EDAP and EES Admin groups. :warning:  

This PR:
- switches Key Vault to RBAC mode instead of Access Policies
- migrates all existing Access Policies that supply "Get" and "List" secrets privileges to be "Key Vault Secrets User" role assignments instead

As for the EDAP team and the EES Admin Group, we will not have the privileges to assign the appropriate roles for these permissions ourselves or via the DevOps SPN, so this will be done manually by Mark Nelson for us.  The following role assignments should give each group the equivalent of what they currently have in their Access Policies:

## s101-datahub-Delivery Team USR

* Key Vault Certificates Officer
* Key Vault Secrets Officer
* Key Vault Crypto Officer

## s101-datahub-ees-admin USR

* Key Vault Certificates Officer
* Key Vault Secrets Officer

Note that both groups also currently have access to checked items under "Key Management Operations" in their Access Policies, but neither Mark or myself can see easily what built-in role may provide these privileges, so we're tempted to try it out without to start off with and if we find we're unable to perform any normal day-to-day Key Vault tasks, we can look at creating a custom role.
