### PR TITLE
EES-5368 On RebuildIndexes stored procedure, set start time before fetching StartFragPercent values

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20240802123234_Routine_RebuildIndexes.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20240802123234_Routine_RebuildIndexes.sql
@@ -52,7 +52,6 @@ BEGIN
         StartTime  DATETIME2 NOT NULL,
         EndTime    DATETIME2,
         HitTimeout BIT,
-        ReportSent DATETIME2,
         PRIMARY KEY (Id),
     );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/Current_Routine_RebuildIndexes.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/Current_Routine_RebuildIndexes.sql
@@ -52,7 +52,6 @@ BEGIN
         StartTime  DATETIME2 NOT NULL,
         EndTime    DATETIME2,
         HitTimeout BIT,
-        ReportSent DATETIME2,
         PRIMARY KEY (Id),
     );
 


### PR DESCRIPTION
This PR makes a couple of small changes to the RebuildIndexes stored procedure:
- We now set the the overall StartTime before fetching StartFragPercent values
- The ReportSent column has been removed

I've not created an additional migration for this PR, as so far this work has only been deployed to the dev environment. I will manually update the stored procedure on the dev.