### PR TITLE
EES-4382 api data set history page

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -34,6 +34,7 @@ import {
   releaseApiDataSetPreviewRoute,
   releaseApiDataSetPreviewTokenRoute,
   releaseApiDataSetPreviewTokenLogRoute,
+  releaseApiDataSetHistoryPageRoute,
 } from '@admin/routes/releaseRoutes';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Tag from '@common/components/Tag';
@@ -67,6 +68,7 @@ const routes = [
   releaseApiDataSetPreviewRoute,
   releaseApiDataSetPreviewTokenRoute,
   releaseApiDataSetPreviewTokenLogRoute,
+  releaseApiDataSetHistoryPageRoute,
   releaseSummaryEditRoute,
   releaseFootnotesCreateRoute,
   releaseFootnotesEditRoute,

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -8,6 +8,7 @@ import { useReleaseContext } from '@admin/pages/release/contexts/ReleaseContext'
 import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
 import {
   releaseApiDataSetFiltersMappingRoute,
+  releaseApiDataSetHistoryPageRoute,
   releaseApiDataSetLocationsMappingRoute,
   releaseApiDataSetPreviewRoute,
   releaseApiDataSetPreviewTokenLogRoute,
@@ -33,8 +34,6 @@ export type DataSetFinalisingStatus = 'finalising' | 'finalised' | undefined;
 
 // TODO: EES-4367
 const showChangelog = false;
-// TODO: EES-4382
-const showVersionHistory = false;
 
 export default function ReleaseApiDataSetDetailsPage() {
   const { dataSetId } = useParams<ReleaseDataSetRouteParams>();
@@ -173,9 +172,20 @@ export default function ReleaseApiDataSetDetailsPage() {
               <Link to="/todo">View changelog and guidance notes</Link>
             </li>
           )}
-          {showVersionHistory && (
+          {dataSet.latestLiveVersion.version !== '1.0' && (
             <li>
-              <Link to="/todo">View version history</Link>
+              <Link
+                to={generatePath<ReleaseDataSetRouteParams>(
+                  releaseApiDataSetHistoryPageRoute.path,
+                  {
+                    publicationId: release.publicationId,
+                    releaseId: release.id,
+                    dataSetId,
+                  },
+                )}
+              >
+                View version history
+              </Link>
             </li>
           )}
         </ul>

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetHistoryPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetHistoryPage.tsx
@@ -1,0 +1,158 @@
+import Link from '@admin/components/Link';
+import { useConfig } from '@admin/contexts/ConfigContext';
+import {
+  releaseApiDataSetDetailsRoute,
+  ReleaseDataSetPreviewTokenRouteParams,
+  ReleaseDataSetRouteParams,
+  ReleaseRouteParams,
+  releaseSummaryRoute,
+} from '@admin/routes/releaseRoutes';
+import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
+import apiDataSetVersionQueries from '@admin/queries/apiDataSetVersionQueries';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import Tag from '@common/components/Tag';
+import Pagination from '@common/components/Pagination';
+import TagGroup from '@common/components/TagGroup';
+import useQueryParams from '@admin/hooks/useQueryParams';
+import parseNumber from '@common/utils/number/parseNumber';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import { useQuery } from '@tanstack/react-query';
+import { generatePath, useParams } from 'react-router-dom';
+import React, { useState } from 'react';
+
+export default function ReleaseApiDataSetHistoryPage() {
+  const { publicAppUrl } = useConfig();
+  const { page } = useQueryParams<{ page: string }>();
+  const [currentPage, setCurrentPage] = useState<number>(
+    parseNumber(page) ?? 1,
+  );
+
+  const { dataSetId, releaseId, publicationId } =
+    useParams<ReleaseDataSetPreviewTokenRouteParams>();
+
+  const { data: dataSet, isLoading: isLoadingDataSet } = useQuery(
+    apiDataSetQueries.get(dataSetId),
+  );
+
+  const { data: dataSetVersionsData, isLoading: isLoadingVersions } = useQuery({
+    ...apiDataSetVersionQueries.list({
+      dataSetId: dataSet?.id ?? '',
+      page: currentPage,
+    }),
+    enabled: !!dataSet,
+  });
+
+  const { paging, results: dataSetVersions = [] } = dataSetVersionsData ?? {};
+
+  return (
+    <>
+      <Link
+        back
+        className="govuk-!-margin-bottom-6"
+        to={generatePath<ReleaseDataSetRouteParams>(
+          releaseApiDataSetDetailsRoute.path,
+          {
+            publicationId,
+            releaseId,
+            dataSetId,
+          },
+        )}
+      >
+        Back to API data set details
+      </Link>
+      <LoadingSpinner loading={isLoadingDataSet || isLoadingVersions}>
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-three-quarters">
+            <span className="govuk-caption-l">Version history</span>
+            <h2>{dataSet?.title}</h2>
+          </div>
+        </div>
+
+        {dataSetVersions?.length ? (
+          <>
+            <table>
+              <caption className="govuk-visually-hidden">
+                Table showing versions of the API data set
+              </caption>
+              <thead>
+                <tr>
+                  <th>Version</th>
+                  <th>Related release</th>
+                  <th>Status</th>
+                  <th className="govuk-!-text-align-right">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dataSetVersions.map((dataSetVersion, index) => {
+                  return (
+                    <tr key={dataSetVersion.id}>
+                      <td>{dataSetVersion.version}</td>
+                      <td>
+                        <Link
+                          to={generatePath<ReleaseRouteParams>(
+                            releaseSummaryRoute.path,
+                            {
+                              releaseId: dataSetVersion.releaseVersion.id,
+                              publicationId,
+                            },
+                          )}
+                        >
+                          {dataSetVersion.releaseVersion.title}
+                        </Link>
+                      </td>
+
+                      <td>
+                        <TagGroup>
+                          <Tag>{dataSetVersion.status}</Tag>
+                          {currentPage === 1 && index === 0 && (
+                            <Tag>Latest version</Tag>
+                          )}
+                        </TagGroup>
+                      </td>
+
+                      <td className="govuk-!-text-align-right">
+                        {dataSetVersion.version !== '1.0' && (
+                          <Link to="/todo">
+                            View changelog
+                            <VisuallyHidden>
+                              {' '}
+                              for version {dataSetVersion.version}
+                            </VisuallyHidden>
+                          </Link>
+                        )}
+
+                        <a
+                          className="govuk-!-margin-left-2"
+                          href={`${publicAppUrl}/data-catalogue/data-set/${dataSetVersion.file.id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          View live data set
+                          <VisuallyHidden>
+                            {' '}
+                            for version {dataSetVersion.version}
+                          </VisuallyHidden>{' '}
+                          (opens in new tab)
+                        </a>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            {paging && (
+              <Pagination
+                currentPage={currentPage}
+                totalPages={paging.totalPages}
+                renderLink={linkProps => <Link {...linkProps} />}
+                onClick={setCurrentPage}
+              />
+            )}
+          </>
+        ) : (
+          <p>No data set versions have been created.</p>
+        )}
+      </LoadingSpinner>
+    </>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetHistoryPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetHistoryPage.test.tsx
@@ -1,0 +1,268 @@
+import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
+import { testRelease } from '@admin/pages/release/__data__/testRelease';
+import ReleaseApiDataSetHistoryPage from '@admin/pages/release/data/ReleaseApiDataSetHistoryPage';
+import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
+import {
+  releaseApiDataSetHistoryPageRoute,
+  ReleaseDataSetRouteParams,
+} from '@admin/routes/releaseRoutes';
+import _apiDataSetService, {
+  ApiDataSet,
+  ApiDataSetLiveVersionSummary,
+} from '@admin/services/apiDataSetService';
+import _apiDataSetVersionService from '@admin/services/apiDataSetVersionService';
+import render from '@common-test/render';
+import { screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { generatePath, MemoryRouter, Route } from 'react-router-dom';
+
+jest.mock('@admin/services/apiDataSetService');
+jest.mock('@admin/services/apiDataSetVersionService');
+
+const apiDataSetService = jest.mocked(_apiDataSetService);
+const apiDataSetVersionService = jest.mocked(_apiDataSetVersionService);
+
+describe('ReleaseApiDataSetPreviewTokenPage', () => {
+  const testDataSet: ApiDataSet = {
+    id: 'data-set-id',
+    title: 'Data set title',
+    summary: 'Data set summary',
+    status: 'Published',
+    previousReleaseIds: [],
+  };
+
+  const testVersions: ApiDataSetLiveVersionSummary[] = [
+    {
+      id: 'version-3-1-id',
+      file: {
+        id: 'version-3-1-file-id',
+        title: 'version-3-1-file-title',
+      },
+      published: '2024-04-01',
+      releaseVersion: {
+        id: 'release-version-3-1-id',
+        title: 'Release version 3.1',
+      },
+      status: 'Published',
+      type: 'Minor',
+      version: '3.1',
+    },
+    {
+      id: 'version-3-id',
+      file: {
+        id: 'version-3-file-id',
+        title: 'version-3-file-title',
+      },
+      published: '2024-03-01',
+      releaseVersion: {
+        id: 'release-version-3-id',
+        title: 'Release version 3',
+      },
+      status: 'Published',
+      type: 'Major',
+      version: '3.0',
+    },
+    {
+      id: 'version-2-id',
+      file: {
+        id: 'version-2-file-id',
+        title: 'version-2-file-title',
+      },
+      published: '2024-02-01',
+      releaseVersion: {
+        id: 'release-version-2-id',
+        title: 'Release version 2',
+      },
+      status: 'Published',
+      type: 'Major',
+      version: '2.0',
+    },
+    {
+      id: 'version-1-id',
+      file: {
+        id: 'version-1-file-id',
+        title: 'version-1-file-title',
+      },
+      published: '2024-01-01',
+      releaseVersion: {
+        id: 'release-version-1-id',
+        title: 'Release version 1',
+      },
+      status: 'Published',
+      type: 'Major',
+      version: '1.0',
+    },
+  ];
+
+  test('renders the table correctly', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue(testDataSet);
+    apiDataSetVersionService.listVersions.mockResolvedValueOnce({
+      results: testVersions,
+      paging: { page: 1, pageSize: 10, totalPages: 1, totalResults: 4 },
+    });
+    apiDataSetVersionService.listVersions.mockResolvedValueOnce({
+      results: testVersions,
+      paging: { page: 2, pageSize: 10, totalPages: 1, totalResults: 4 },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Data set title')).toBeInTheDocument();
+
+    const rows = within(screen.getByRole('table')).getAllByRole('row');
+    expect(rows).toHaveLength(5);
+
+    const row1Cells = within(rows[1]).getAllByRole('cell');
+    expect(row1Cells[0]).toHaveTextContent('3.1');
+    expect(
+      within(row1Cells[1]).getByRole('link', { name: 'Release version 3.1' }),
+    ).toHaveAttribute(
+      'href',
+      `/publication/${testRelease.publicationId}/release/release-version-3-1-id/summary`,
+    );
+    expect(row1Cells[2]).toHaveTextContent('Published');
+    expect(row1Cells[2]).toHaveTextContent('Latest version');
+    expect(
+      within(row1Cells[3]).getByRole('link', {
+        name: 'View changelog for version 3.1',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(row1Cells[3]).getByRole('link', {
+        name: 'View live data set for version 3.1 (opens in new tab)',
+      }),
+    ).toBeInTheDocument();
+
+    const row2Cells = within(rows[2]).getAllByRole('cell');
+    expect(row2Cells[0]).toHaveTextContent('3.0');
+    expect(
+      within(row2Cells[1]).getByRole('link', { name: 'Release version 3' }),
+    ).toHaveAttribute(
+      'href',
+      `/publication/${testRelease.publicationId}/release/release-version-3-id/summary`,
+    );
+    expect(row2Cells[2]).toHaveTextContent('Published');
+    expect(
+      within(row2Cells[3]).getByRole('link', {
+        name: 'View changelog for version 3.0',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(row2Cells[3]).getByRole('link', {
+        name: 'View live data set for version 3.0 (opens in new tab)',
+      }),
+    ).toBeInTheDocument();
+
+    const row3Cells = within(rows[3]).getAllByRole('cell');
+    expect(row3Cells[0]).toHaveTextContent('2.0');
+    expect(
+      within(row3Cells[1]).getByRole('link', { name: 'Release version 2' }),
+    ).toHaveAttribute(
+      'href',
+      `/publication/${testRelease.publicationId}/release/release-version-2-id/summary`,
+    );
+    expect(row3Cells[2]).toHaveTextContent('Published');
+    expect(
+      within(row3Cells[3]).getByRole('link', {
+        name: 'View changelog for version 2.0',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(row3Cells[3]).getByRole('link', {
+        name: 'View live data set for version 2.0 (opens in new tab)',
+      }),
+    ).toBeInTheDocument();
+
+    const row4Cells = within(rows[4]).getAllByRole('cell');
+    expect(row4Cells[0]).toHaveTextContent('1.0');
+    expect(
+      within(row4Cells[1]).getByRole('link', { name: 'Release version 1' }),
+    ).toHaveAttribute(
+      'href',
+      `/publication/${testRelease.publicationId}/release/release-version-1-id/summary`,
+    );
+    expect(row4Cells[2]).toHaveTextContent('Published');
+    expect(
+      within(row4Cells[3]).queryByRole('link', {
+        name: 'View changelog for version 1.0',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(row4Cells[3]).getByRole('link', {
+        name: 'View live data set for version 1.0 (opens in new tab)',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('pagination', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue(testDataSet);
+    apiDataSetVersionService.listVersions.mockResolvedValueOnce({
+      results: [testVersions[0], testVersions[1]],
+      paging: { page: 1, pageSize: 2, totalPages: 2, totalResults: 4 },
+    });
+
+    const { user } = renderPage();
+
+    expect(await screen.findByText('Data set title')).toBeInTheDocument();
+
+    const rows = within(screen.getByRole('table')).getAllByRole('row');
+    expect(rows).toHaveLength(3);
+    expect(within(rows[1]).getAllByRole('cell')[0]).toHaveTextContent('3.1');
+    expect(within(rows[2]).getAllByRole('cell')[0]).toHaveTextContent('3.0');
+
+    expect(
+      screen.getByRole('navigation', { name: 'Pagination' }),
+    ).toBeInTheDocument();
+
+    apiDataSetVersionService.listVersions.mockResolvedValueOnce({
+      results: [testVersions[2], testVersions[3]],
+      paging: { page: 2, pageSize: 2, totalPages: 2, totalResults: 4 },
+    });
+
+    await user.click(screen.getByRole('link', { name: 'Page 2' }));
+
+    await waitFor(() => {
+      expect(apiDataSetVersionService.listVersions).toHaveBeenCalledWith({
+        dataSetId: 'data-set-id',
+        page: 2,
+      });
+      expect(screen.queryByText('3.1')).not.toBeInTheDocument();
+    });
+
+    const updatedRows = within(screen.getByRole('table')).getAllByRole('row');
+    expect(updatedRows).toHaveLength(3);
+
+    expect(within(updatedRows[1]).getAllByRole('cell')[0]).toHaveTextContent(
+      '2.0',
+    );
+    expect(within(updatedRows[2]).getAllByRole('cell')[0]).toHaveTextContent(
+      '1.0',
+    );
+  });
+
+  function renderPage() {
+    return render(
+      <TestConfigContextProvider>
+        <ReleaseContextProvider release={testRelease}>
+          <MemoryRouter
+            initialEntries={[
+              generatePath<ReleaseDataSetRouteParams>(
+                releaseApiDataSetHistoryPageRoute.path,
+                {
+                  publicationId: testRelease.publicationId,
+                  releaseId: testRelease.id,
+                  dataSetId: 'data-set-id',
+                },
+              ),
+            ]}
+          >
+            <Route
+              component={ReleaseApiDataSetHistoryPage}
+              path={releaseApiDataSetHistoryPageRoute.path}
+            />
+          </MemoryRouter>
+        </ReleaseContextProvider>
+      </TestConfigContextProvider>,
+    );
+  }
+});

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DraftApiDataSetsTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DraftApiDataSetsTable.test.tsx
@@ -46,9 +46,17 @@ describe('DraftApiDataSetsTable', () => {
         type: 'Major',
       },
       latestLiveVersion: {
+        file: {
+          id: 'file-id',
+          title: 'file-title',
+        },
         published: '2024-02-01T09:30:00+00:00',
         id: 'version-3',
         version: '1.0',
+        releaseVersion: {
+          id: 'release-version-id',
+          title: 'Release Version',
+        },
         status: 'Published',
         type: 'Major',
       },
@@ -66,9 +74,17 @@ describe('DraftApiDataSetsTable', () => {
         type: 'Minor',
       },
       latestLiveVersion: {
+        file: {
+          id: 'file-id',
+          title: 'file-title',
+        },
         published: '2024-02-01T09:30:00+00:00',
         id: 'version-1',
         version: '1.0',
+        releaseVersion: {
+          id: 'release-version-id',
+          title: 'Release Version',
+        },
         status: 'Published',
         type: 'Major',
       },

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/LiveApiDataSetsTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/LiveApiDataSetsTable.test.tsx
@@ -25,9 +25,17 @@ describe('LiveApiDataSetsTable', () => {
       summary: 'Data set 2 summary',
       status: 'Published',
       latestLiveVersion: {
+        file: {
+          id: 'file-id',
+          title: 'file-title',
+        },
         published: '2024-02-01T09:30:00+00:00',
         id: 'version-2',
         version: '1.0',
+        releaseVersion: {
+          id: 'release-version-id',
+          title: 'Release Version',
+        },
         status: 'Published',
         type: 'Major',
       },
@@ -39,8 +47,16 @@ describe('LiveApiDataSetsTable', () => {
       summary: 'Data set 1 summary',
       status: 'Published',
       latestLiveVersion: {
+        file: {
+          id: 'file-id',
+          title: 'file-title',
+        },
         published: '2024-02-01T09:30:00+00:00',
         id: 'version-1',
+        releaseVersion: {
+          id: 'release-version-id',
+          title: 'Release Version',
+        },
         version: '2.0',
         status: 'Published',
         type: 'Major',
@@ -53,9 +69,17 @@ describe('LiveApiDataSetsTable', () => {
       summary: 'Data set 3 summary',
       status: 'Published',
       latestLiveVersion: {
+        file: {
+          id: 'file-id',
+          title: 'file-title',
+        },
         published: '2024-02-01T09:30:00+00:00',
         id: 'version-3',
         version: '1.2',
+        releaseVersion: {
+          id: 'release-version-id',
+          title: 'Release Version',
+        },
         status: 'Published',
         type: 'Minor',
       },

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseApiDataSetsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseApiDataSetsSection.test.tsx
@@ -65,7 +65,15 @@ describe('ReleaseApiDataSetsSection', () => {
       },
       latestLiveVersion: {
         id: 'version-3',
+        file: {
+          id: 'file-id',
+          title: 'file-title',
+        },
         version: '1.0',
+        releaseVersion: {
+          id: 'release-version-id',
+          title: 'Release Version',
+        },
         status: 'Published',
         type: 'Major',
         published: '2024-05-01T09:30:00+00:00',
@@ -79,7 +87,15 @@ describe('ReleaseApiDataSetsSection', () => {
       status: 'Published',
       latestLiveVersion: {
         id: 'version-4',
+        file: {
+          id: 'file-id',
+          title: 'file-title',
+        },
         version: '1.0',
+        releaseVersion: {
+          id: 'release-version-id',
+          title: 'Release Version',
+        },
         status: 'Published',
         type: 'Major',
         published: '2024-05-01T09:30:00+00:00',

--- a/src/explore-education-statistics-admin/src/queries/apiDataSetVersionQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/apiDataSetVersionQueries.ts
@@ -1,17 +1,27 @@
-import apiDataSetVersionService from '@admin/services/apiDataSetVersionService';
+import apiDataSetVersionService, {
+  ListVersionsParams,
+} from '@admin/services/apiDataSetVersionService';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 
 const apiDataSetVersionQueries = createQueryKeys('apiDataSetVersionQueries', {
-  getFiltersMapping(versionId: string) {
+  list(query: ListVersionsParams) {
     return {
-      queryKey: [versionId],
-      queryFn: () => apiDataSetVersionService.getFiltersMapping(versionId),
+      queryKey: [query],
+      queryFn: () => apiDataSetVersionService.listVersions(query),
     };
   },
-  getLocationsMapping(versionId: string) {
+  getFiltersMapping(dataSetVersionId: string) {
     return {
-      queryKey: [versionId],
-      queryFn: () => apiDataSetVersionService.getLocationsMapping(versionId),
+      queryKey: [dataSetVersionId],
+      queryFn: () =>
+        apiDataSetVersionService.getFiltersMapping(dataSetVersionId),
+    };
+  },
+  getLocationsMapping(dataSetVersionId: string) {
+    return {
+      queryKey: [dataSetVersionId],
+      queryFn: () =>
+        apiDataSetVersionService.getLocationsMapping(dataSetVersionId),
     };
   },
 });

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -5,6 +5,7 @@ import ReleaseApiDataSetLocationsMappingPage from '@admin/pages/release/data/Rel
 import ReleaseApiDataSetPreviewPage from '@admin/pages/release/data/ReleaseApiDataSetPreviewPage';
 import ReleaseApiDataSetPreviewTokenPage from '@admin/pages/release/data/ReleaseApiDataSetPreviewTokenPage';
 import ReleaseApiDataSetPreviewTokenLogPage from '@admin/pages/release/data/ReleaseApiDataSetPreviewTokenLogPage';
+import ReleaseApiDataSetHistoryPage from '@admin/pages/release/data/ReleaseApiDataSetHistoryPage';
 import ReleaseContentPage from '@admin/pages/release/content/ReleaseContentPage';
 import ReleaseDataFilePage from '@admin/pages/release/data/ReleaseDataFilePage';
 import ReleaseAncillaryFilePage from '@admin/pages/release/data/ReleaseAncillaryFilePage';
@@ -157,6 +158,13 @@ export const releaseApiDataSetPreviewTokenLogRoute: ReleaseRouteProps = {
   path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId/token-log',
   title: 'View API data set token log',
   component: ReleaseApiDataSetPreviewTokenLogPage,
+  protectionAction: permissions => permissions.isBauUser,
+};
+
+export const releaseApiDataSetHistoryPageRoute: ReleaseRouteProps = {
+  path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId/history',
+  title: 'API data set version history',
+  component: ReleaseApiDataSetHistoryPage,
   protectionAction: permissions => permissions.isBauUser,
 };
 

--- a/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
@@ -25,7 +25,9 @@ export interface ApiDataSetDraftVersionSummary
 }
 
 export interface ApiDataSetLiveVersionSummary extends ApiDataSetVersionSummary {
+  file: IdTitlePair;
   published: string;
+  releaseVersion: IdTitlePair;
   status: DataSetLiveVersionStatus;
 }
 

--- a/src/explore-education-statistics-admin/src/services/apiDataSetVersionService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetVersionService.ts
@@ -1,5 +1,9 @@
 import client from '@admin/services/utils/service';
-import { ApiDataSet } from '@admin/services/apiDataSetService';
+import {
+  ApiDataSet,
+  ApiDataSetLiveVersionSummary,
+} from '@admin/services/apiDataSetService';
+import { PaginatedList } from '@common/services/types/pagination';
 import { Dictionary } from '@common/types';
 import { LocationLevelKey } from '@common/utils/locationLevelsMap';
 
@@ -96,6 +100,12 @@ interface LocationsMappingUpdateResponse {
   }[];
 }
 
+export interface ListVersionsParams {
+  dataSetId: string;
+  page?: number;
+  pageSize?: number;
+}
+
 const apiDataSetVersionService = {
   createVersion(data: {
     dataSetId: string;
@@ -108,6 +118,13 @@ const apiDataSetVersionService = {
   },
   deleteVersion(dataSetVersionId: string): Promise<void> {
     return client.delete(`/public-data/data-set-versions/${dataSetVersionId}`);
+  },
+  listVersions(
+    params?: ListVersionsParams,
+  ): Promise<PaginatedList<ApiDataSetLiveVersionSummary>> {
+    return client.get(`/public-data/data-set-versions`, {
+      params,
+    });
   },
   getFiltersMapping(dataSetVersionId: string): Promise<FiltersMapping> {
     return client.get(


### PR DESCRIPTION
Adds the API data set history page in the admin. There are some TODOs pending a back end change (EES-5427).

The ticket doesn't mention pagination, but since the endpoint is paginated I thought I might as well add it in as it was quick to do.

![Screenshot 2024-08-19 170812](https://github.com/user-attachments/assets/a1494943-cce3-4669-bf87-c87b708b0eba)
