### PR TITLE
EES-5427 Add file info to data set version summaries in admin

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
@@ -337,6 +337,14 @@ public abstract class DataSetVersionsControllerTests(
             validationProblem.AssertHasNotEmptyError("dataSetId");
         }
 
+        [Fact]
+        public async Task DataSetDoesNotExist_Returns404()
+        {
+            var response = await ListLiveVersions(dataSetId: Guid.NewGuid());
+
+            response.AssertNotFound();
+        }
+
         private async Task<HttpResponseMessage> ListLiveVersions(
             Guid dataSetId,
             int? page = null,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetVersionsControllerTests.cs
@@ -122,8 +122,13 @@ public abstract class DataSetVersionsControllerTests(
             Assert.Equal(currentDataSetVersion.PublicVersion, liveVersion.Version);
             Assert.Equal(currentDataSetVersion.Status, liveVersion.Status);
             Assert.Equal(currentDataSetVersion.VersionType, liveVersion.Type);
+
             Assert.Equal(releaseFile.ReleaseVersion.Id, liveVersion.ReleaseVersion.Id);
             Assert.Equal(releaseFile.ReleaseVersion.Title, liveVersion.ReleaseVersion.Title);
+
+            Assert.Equal(releaseFile.File.DataSetFileId, liveVersion.File.Id);
+            Assert.Equal(releaseFile.Name, liveVersion.File.Title);
+
             liveVersion.Published.AssertEqual(currentDataSetVersion.Published!.Value);
         }
 
@@ -306,8 +311,13 @@ public abstract class DataSetVersionsControllerTests(
             Assert.Equal(targetDataSetVersion.PublicVersion, liveVersion.Version);
             Assert.Equal(targetDataSetVersion.Status, liveVersion.Status);
             Assert.Equal(targetDataSetVersion.VersionType, liveVersion.Type);
+
             Assert.Equal(targetReleaseFile.ReleaseVersion.Id, liveVersion.ReleaseVersion.Id);
             Assert.Equal(targetReleaseFile.ReleaseVersion.Title, liveVersion.ReleaseVersion.Title);
+
+            Assert.Equal(targetReleaseFile.File.DataSetFileId, liveVersion.File.Id);
+            Assert.Equal(targetReleaseFile.Name, liveVersion.File.Title);
+
             liveVersion.Published.AssertEqual(targetDataSetVersion.Published!.Value);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
@@ -18,16 +18,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Publi
 [Route("api/public-data/data-set-versions")]
 public class DataSetVersionsController(IDataSetVersionService dataSetVersionService) : ControllerBase
 {
-    [HttpGet("{dataSetId:guid}")]
+    [HttpGet]
     [Produces("application/json")]
-    public async Task<ActionResult<PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>>> ListLiveVersions(
+    public async Task<ActionResult<PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>>> ListVersions(
         [FromQuery] DataSetVersionListRequest request,
-        Guid dataSetId,
         CancellationToken cancellationToken)
     {
         return await dataSetVersionService
             .ListLiveVersions(
-                dataSetId: dataSetId,
+                dataSetId: request.DataSetId,
                 page: request.Page,
                 pageSize: request.PageSize,
                 cancellationToken: cancellationToken)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/DataSetVersionListRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/DataSetVersionListRequest.cs
@@ -1,3 +1,5 @@
+#nullable enable
+using System;
 using FluentValidation;
 using System.ComponentModel;
 
@@ -5,6 +7,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
 
 public record DataSetVersionListRequest
 {
+    public Guid DataSetId { get; init; }
+
     [DefaultValue(1)]
     public int Page { get; init; } = 1;
 
@@ -15,6 +19,8 @@ public record DataSetVersionListRequest
     {
         public Validator()
         {
+            RuleFor(request => request.DataSetId)
+                .NotEmpty();
             RuleFor(request => request.Page)
                 .GreaterThanOrEqualTo(1);
             RuleFor(request => request.PageSize)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
@@ -56,7 +56,7 @@ internal class DataSetService(
                     await GetDataSetReleaseVersions(dataSets, cancellationToken);
 
                 var results = dataSets
-                    .Select(ds => MapDataSetSummary(ds, dataSetReleaseVersions[ds.Id]))
+                    .Select(ds => MapDataSetSummary(ds, dataSetReleaseVersions[ds.Id].ReleaseFilesByDataSetVersionId))
                     .ToList();
 
                 return new PaginatedListViewModel<DataSetSummaryViewModel>(
@@ -94,10 +94,10 @@ internal class DataSetService(
 
     private DataSetSummaryViewModel MapDataSetSummary(
         DataSet dataSet,
-        DataSetReleaseVersions dataSetReleaseVersions)
+        IReadOnlyDictionary<Guid, ReleaseFile> releaseFilesByDataSetVersionId)
     {
-        var previousReleaseIds = dataSetReleaseVersions.ReleaseVersionsByDataSetVersionId
-            .Select(r => r.Value.ReleaseId)
+        var previousReleaseIds = releaseFilesByDataSetVersionId
+            .Select(r => r.Value.ReleaseVersion.ReleaseId)
             .ToList();
 
         return new DataSetSummaryViewModel
@@ -107,19 +107,15 @@ internal class DataSetService(
             Summary = dataSet.Summary,
             Status = dataSet.Status,
             SupersedingDataSetId = dataSet.SupersedingDataSetId,
-            DraftVersion = MapDraftSummaryVersion(
-                dataSet.LatestDraftVersion,
-                dataSetReleaseVersions.ReleaseVersionsByDataSetVersionId),
-            LatestLiveVersion = MapLiveSummaryVersion(
-                dataSet.LatestLiveVersion,
-                dataSetReleaseVersions.ReleaseVersionsByDataSetVersionId),
+            DraftVersion = MapDraftSummaryVersion(dataSet.LatestDraftVersion, releaseFilesByDataSetVersionId),
+            LatestLiveVersion = MapLiveSummaryVersion(dataSet.LatestLiveVersion, releaseFilesByDataSetVersionId),
             PreviousReleaseIds = previousReleaseIds
         };
     }
 
     private static DataSetVersionSummaryViewModel? MapDraftSummaryVersion(
         DataSetVersion? dataSetVersion,
-        IReadOnlyDictionary<Guid, ReleaseVersion> releaseVersionsByDataSetVersionId)
+        IReadOnlyDictionary<Guid, ReleaseFile> releaseFilesByDataSetVersionId)
     {
         return dataSetVersion != null
             ? new DataSetVersionSummaryViewModel
@@ -128,14 +124,15 @@ internal class DataSetService(
                 Version = dataSetVersion.PublicVersion,
                 Status = dataSetVersion.Status,
                 Type = dataSetVersion.VersionType,
-                ReleaseVersion = MapReleaseVersion(releaseVersionsByDataSetVersionId[dataSetVersion.Id])
+                ReleaseVersion = MapReleaseVersion(releaseFilesByDataSetVersionId[dataSetVersion.Id].ReleaseVersion),
+                File = MapVersionFile(releaseFilesByDataSetVersionId[dataSetVersion.Id])
             }
             : null;
     }
 
     private static DataSetLiveVersionSummaryViewModel? MapLiveSummaryVersion(
         DataSetVersion? dataSetVersion,
-        IReadOnlyDictionary<Guid, ReleaseVersion> releaseVersionsByDataSetVersionId)
+        IReadOnlyDictionary<Guid, ReleaseFile> releaseFilesByDataSetVersionId)
     {
         return dataSetVersion != null
             ? new DataSetLiveVersionSummaryViewModel
@@ -145,7 +142,8 @@ internal class DataSetService(
                 Published = dataSetVersion.Published!.Value,
                 Status = dataSetVersion.Status,
                 Type = dataSetVersion.VersionType,
-                ReleaseVersion = MapReleaseVersion(releaseVersionsByDataSetVersionId[dataSetVersion.Id])
+                ReleaseVersion = MapReleaseVersion(releaseFilesByDataSetVersionId[dataSetVersion.Id].ReleaseVersion),
+                File = MapVersionFile(releaseFilesByDataSetVersionId[dataSetVersion.Id])
             }
             : null;
     }
@@ -196,33 +194,26 @@ internal class DataSetService(
             .SelectMany(ds => ds.Versions)
             .ToDictionary(dsv => dsv.Release.ReleaseFileId, dsv => dsv.DataSet);
 
-        var releaseVersionsByReleaseFileId = await contentDbContext
+        var releaseFiles = await contentDbContext
             .ReleaseFiles
             .Include(rf => rf.ReleaseVersion)
-            .Where(releaseFile => dataSetsByPreviousReleaseFileId.Keys.Contains(releaseFile.Id))
-            .ToDictionaryAsync(
-                rf => rf.Id,
-                rf => rf.ReleaseVersion,
-                cancellationToken);
+            .Include(rf => rf.File)
+            .Where(rf => dataSetsByPreviousReleaseFileId.Keys.Contains(rf.Id))
+            .ToListAsync(cancellationToken);
 
-        return releaseVersionsByReleaseFileId
-            .Select(d => new
-            {
-                ReleaseFileId = d.Key,
-                ReleaseVersion = d.Value,
-                DataSet = dataSetsByPreviousReleaseFileId[d.Key]
-            })
-            .GroupBy(a => a.DataSet)
+        return releaseFiles
+            .GroupBy(rf => dataSetsByPreviousReleaseFileId[rf.Id])
             .ToDictionary(
-                g => g.Key.Id,
-                g => new DataSetReleaseVersions
+                group => group.Key.Id,
+                group => new DataSetReleaseVersions
                 {
-                    ReleaseVersionsByDataSetVersionId = g
+                    ReleaseFilesByDataSetVersionId = group
                         .ToDictionary(
-                            a => a.DataSet.Versions.Single(dsv => dsv.Release.ReleaseFileId == a.ReleaseFileId).Id,
-                            a => a.ReleaseVersion
+                            rf => group.Key.Versions.Single(v => v.Release.ReleaseFileId == rf.Id).Id,
+                            rf => rf
                         )
-                });
+                }
+            );
     }
 
     private async Task<IReadOnlyDictionary<Guid, ReleaseFile>> GetReleaseFilesByDataSetVersionId(
@@ -348,7 +339,7 @@ internal class DataSetService(
 
     private record DataSetReleaseVersions
     {
-        public IReadOnlyDictionary<Guid, ReleaseVersion> ReleaseVersionsByDataSetVersionId { get; init; } =
-            new Dictionary<Guid, ReleaseVersion>();
+        public IReadOnlyDictionary<Guid, ReleaseFile> ReleaseFilesByDataSetVersionId { get; init; }
+            = new Dictionary<Guid, ReleaseFile>();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
@@ -43,11 +43,14 @@ public class DataSetVersionService(
             CancellationToken cancellationToken = default)
     {
         return await userService.CheckIsBauUser()
-            .OnSuccess(async () =>
+            .OnSuccess(() => publicDataDbContext.DataSets
+                .AsNoTracking()
+                .SingleOrNotFoundAsync(ds => ds.Id == dataSetId, cancellationToken))
+            .OnSuccess(async dataSet =>
             {
                 var dataSetVersionsQueryable = publicDataDbContext.DataSetVersions
                     .AsNoTracking()
-                    .Where(ds => ds.DataSetId == dataSetId)
+                    .Where(ds => ds.DataSetId == dataSet.Id)
                     .WherePublicStatus();
 
                 var dataSetVersions = await dataSetVersionsQueryable

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
@@ -70,6 +70,8 @@ public record DataSetVersionSummaryViewModel
     public required DataSetVersionType Type { get; init; }
 
     public required IdTitleViewModel ReleaseVersion { get; init; }
+
+    public required IdTitleViewModel File { get; init; }
 }
 
 public record DataSetLiveVersionSummaryViewModel : DataSetVersionSummaryViewModel


### PR DESCRIPTION
This PR changes data set version summaries in the admin to return file info:

- `DataSetVersionSummary.File.Id` (mapped from `ReleaseFile.File.DataSetFileId`)
- `DataSetVersionSummary.File.Title` (mapped from `ReleaseFile.Name`)

This can then be used in the frontend to link through to the data set page in the public frontend.

## Relevant changes

- Updated `ListVersions` endpoint to use a `dataSetId` query parameter instead of the parameter being inside of the URL. This was previously inconsistent with other data set version endpoints.
- Fixed `ListVersions` endpoint not 404ing if the data set can't be found.