### PR TITLE
EES-5254/5255/5075: Additionally order publications by latest release version type

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Extensions/OrderedQueryableExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Extensions/OrderedQueryableExtensionsTests.cs
@@ -1,0 +1,62 @@
+using AngleSharp.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Extensions;
+
+public class OrderedQueryableExtensionsTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    [Fact]
+    public void ThenByReleaseType_ReordersPublicationsByTheirReleaseType()
+    {
+        // Arrange
+        var publications = _dataFixture
+            .DefaultPublication()
+            .Generate(6);
+
+        var publicationsResult = new List<FreeTextValueResult<Publication>>();
+        var publishedDate = DateTime.UtcNow;
+
+        for (var i = 0; i < publications.Count(); i++)
+        {
+            var publication = publications.GetItemByIndex(i);
+            publication.LatestPublishedReleaseVersion = new()
+            {
+                Type = (ReleaseType)i,
+                Published = publishedDate
+            };
+
+            publicationsResult.Add(new()
+            {
+                Rank = i,
+                Value = publication
+            });
+        }
+
+        var orderedQueryable = publicationsResult
+            .AsQueryable()
+            .OrderBy(p => 1); // Initial nonsense ordering to convert to an IOrderedQueryable
+
+        // Act
+        var result = orderedQueryable
+            .ThenByReleaseType()!
+            .ToList();
+
+        // Assert
+        Assert.Equal(ReleaseType.AccreditedOfficialStatistics, result[0].Value.LatestPublishedReleaseVersion!.Type);
+        Assert.Equal(ReleaseType.OfficialStatistics, result[1].Value.LatestPublishedReleaseVersion!.Type);
+        Assert.Equal(ReleaseType.OfficialStatisticsInDevelopment, result[2].Value.LatestPublishedReleaseVersion!.Type);
+        Assert.Equal(ReleaseType.ExperimentalStatistics, result[3].Value.LatestPublishedReleaseVersion!.Type);
+        Assert.Equal(ReleaseType.AdHocStatistics, result[4].Value.LatestPublishedReleaseVersion!.Type);
+        Assert.Equal(ReleaseType.ManagementInformation, result[5].Value.LatestPublishedReleaseVersion!.Type);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
@@ -16,6 +12,10 @@ using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using MockQueryable.Moq;
 using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.SortDirection;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
@@ -1695,6 +1695,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     Published = new DateTime(2022, 1, 1)
                 };
 
+                // Two releases with the same published date should be ordered by Type
+                var releaseVersionD = new ReleaseVersion
+                {
+                    Type = AdHocStatistics,
+                    Published = new DateTime(2023, 1, 1)
+                };
+
+                var releaseVersionE = new ReleaseVersion
+                {
+                    Type = OfficialStatistics,
+                    Published = new DateTime(2023, 1, 1)
+                };
+
                 var publicationA = new Publication
                 {
                     Title = "Publication A",
@@ -1713,23 +1726,37 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     LatestPublishedReleaseVersion = releaseVersionC
                 };
 
+                var publicationD = new Publication
+                {
+                    Title = "Publication D",
+                    LatestPublishedReleaseVersion = releaseVersionD
+                };
+
+                var publicationE = new Publication
+                {
+                    Title = "Publication E",
+                    LatestPublishedReleaseVersion = releaseVersionE
+                };
+
                 var themes = new List<Theme>
             {
                 new()
                 {
                     Title = "Theme 1 title",
-                    Topics = new List<Topic>
-                    {
+                    Topics =
+                    [
                         new()
                         {
-                            Publications = new List<Publication>
-                            {
+                            Publications =
+                            [
                                 publicationB,
                                 publicationC,
-                                publicationA
-                            }
+                                publicationA,
+                                publicationD,
+                                publicationE
+                            ]
                         }
-                    }
+                    ]
                 }
             };
 
@@ -1750,18 +1777,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     )).AssertRight();
                     var results = pagedResult.Results;
 
-                    Assert.Equal(3, results.Count);
+                    Assert.Equal(5, results.Count);
 
                     // Expect results sorted by published date in descending order
 
-                    Assert.Equal(publicationC.Id, results[0].Id);
-                    Assert.Equal(new DateTime(2022, 1, 1), results[0].Published);
+                    Assert.Equal(publicationE.Id, results[0].Id);
+                    Assert.Equal(new DateTime(2023, 1, 1), results[0].Published);
 
-                    Assert.Equal(publicationB.Id, results[1].Id);
-                    Assert.Equal(new DateTime(2021, 1, 1), results[1].Published);
+                    Assert.Equal(publicationD.Id, results[1].Id);
+                    Assert.Equal(new DateTime(2023, 1, 1), results[1].Published);
 
-                    Assert.Equal(publicationA.Id, results[2].Id);
-                    Assert.Equal(new DateTime(2020, 1, 1), results[2].Published);
+                    Assert.Equal(publicationC.Id, results[2].Id);
+                    Assert.Equal(new DateTime(2022, 1, 1), results[2].Published);
+
+                    Assert.Equal(publicationB.Id, results[3].Id);
+                    Assert.Equal(new DateTime(2021, 1, 1), results[3].Published);
+
+                    Assert.Equal(publicationA.Id, results[4].Id);
+                    Assert.Equal(new DateTime(2020, 1, 1), results[4].Published);
+
+
                 }
             }
 
@@ -2043,7 +2078,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
                 var firstReleaseVersionPublishedDate = "2019-02-03T07:34:12";
                 var firstReleaseVersionUpdateDate = "2019-02-04T08:29:54";
-            
+
                 var publicationUpdatedDate = DateTime.Parse(publicationUpdated);
                 var firstReleaseVersionPublished = DateTime.Parse(firstReleaseVersionPublishedDate);
                 var firstReleaseVersionUpdated = DateTime.Parse(firstReleaseVersionUpdateDate);
@@ -2108,7 +2143,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     var item = Assert.Single(result);
                     Assert.Equal(publication.Slug, item.Slug);
                     Assert.Equal(publicationUpdatedDate, item.LastModified);
-                    
+
                     Assert.NotNull(item.Releases);
                     var nonDraftReleaseVersion = Assert.Single(item.Releases);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Extensions/OrderedQueryableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Extensions/OrderedQueryableExtensions.cs
@@ -1,0 +1,19 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using System.Linq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Extensions;
+
+public static class OrderedQueryableExtensions
+{
+    public static IOrderedQueryable<FreeTextValueResult<Publication>>? ThenByReleaseType(this IOrderedQueryable<FreeTextValueResult<Publication>>? orderedQueryable)
+    {
+        return orderedQueryable?.ThenBy(publication =>
+            publication.Value.LatestPublishedReleaseVersion!.Type == ReleaseType.AccreditedOfficialStatistics ? 0 :
+            publication.Value.LatestPublishedReleaseVersion!.Type == ReleaseType.OfficialStatistics ? 1 :
+            publication.Value.LatestPublishedReleaseVersion!.Type == ReleaseType.OfficialStatisticsInDevelopment ? 2 :
+            publication.Value.LatestPublishedReleaseVersion!.Type == ReleaseType.ExperimentalStatistics ? 3 :
+            publication.Value.LatestPublishedReleaseVersion!.Type == ReleaseType.AdHocStatistics ? 4 : 5);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Extensions/OrderedQueryableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Extensions/OrderedQueryableExtensions.cs
@@ -7,9 +7,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Extensions
 
 public static class OrderedQueryableExtensions
 {
-    public static IOrderedQueryable<FreeTextValueResult<Publication>>? ThenByReleaseType(this IOrderedQueryable<FreeTextValueResult<Publication>>? orderedQueryable)
+    public static IOrderedQueryable<FreeTextValueResult<Publication>> ThenByReleaseType(this IOrderedQueryable<FreeTextValueResult<Publication>> orderedQueryable)
     {
-        return orderedQueryable?.ThenBy(publication =>
+        return orderedQueryable.ThenBy(publication =>
             publication.Value.LatestPublishedReleaseVersion!.Type == ReleaseType.AccreditedOfficialStatistics ? 0 :
             publication.Value.LatestPublishedReleaseVersion!.Type == ReleaseType.OfficialStatistics ? 1 :
             publication.Value.LatestPublishedReleaseVersion!.Type == ReleaseType.OfficialStatisticsInDevelopment ? 2 :

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -1,9 +1,4 @@
 #nullable enable
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -12,10 +7,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Requests;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.SortDirection;
 using static GovUk.Education.ExploreEducationStatistics.Content.Requests.PublicationsSortBy;
 
@@ -197,8 +198,10 @@ public class PublicationService : IPublicationService
             _ => throw new ArgumentOutOfRangeException(nameof(sort), sort, message: null)
         };
 
-        // Then sort by publication id to provide a stable sort order
-        orderedQueryable = orderedQueryable.ThenBy(result => result.Value.Id);
+        // Order by release type, then publication ID to provide a stable sort order
+        orderedQueryable = orderedQueryable
+            .ThenByReleaseType()!
+            .ThenBy(result => result.Value.Id);
 
         // Get the total results count for the paginated response
         var totalResults = await orderedQueryable.CountAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -185,8 +185,8 @@ public class PublicationService : IPublicationService
         {
             Published =>
                 sortDirection == Asc
-                    ? queryable.OrderBy(result => result.Value.LatestPublishedReleaseVersion!.Published)
-                    : queryable.OrderByDescending(result => result.Value.LatestPublishedReleaseVersion!.Published),
+                    ? queryable.OrderBy(result => DateOnly.FromDateTime(result.Value.LatestPublishedReleaseVersion!.Published!.Value))
+                    : queryable.OrderByDescending(result => DateOnly.FromDateTime(result.Value.LatestPublishedReleaseVersion!.Published!.Value)),
             Relevance =>
                 sortDirection == Asc
                     ? queryable.OrderBy(result => result.Rank)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -185,8 +185,12 @@ public class PublicationService : IPublicationService
         {
             Published =>
                 sortDirection == Asc
-                    ? queryable.OrderBy(result => DateOnly.FromDateTime(result.Value.LatestPublishedReleaseVersion!.Published!.Value))
-                    : queryable.OrderByDescending(result => DateOnly.FromDateTime(result.Value.LatestPublishedReleaseVersion!.Published!.Value)),
+                    ? queryable
+                        .OrderBy(result => DateOnly.FromDateTime(result.Value.LatestPublishedReleaseVersion!.Published!.Value))
+                        .ThenByReleaseType()
+                    : queryable
+                        .OrderByDescending(result => DateOnly.FromDateTime(result.Value.LatestPublishedReleaseVersion!.Published!.Value))
+                        .ThenByReleaseType(),
             Relevance =>
                 sortDirection == Asc
                     ? queryable.OrderBy(result => result.Rank)
@@ -198,10 +202,8 @@ public class PublicationService : IPublicationService
             _ => throw new ArgumentOutOfRangeException(nameof(sort), sort, message: null)
         };
 
-        // Order by release type, then publication ID to provide a stable sort order
-        orderedQueryable = orderedQueryable
-            .ThenByReleaseType()!
-            .ThenBy(result => result.Value.Id);
+        // Then sort by publication id to provide a stable sort order
+        orderedQueryable = orderedQueryable.ThenBy(result => result.Value.Id);
 
         // Get the total results count for the paginated response
         var totalResults = await orderedQueryable.CountAsync();


### PR DESCRIPTION
**EES-5254/5075**: Apply a secondary ordering to publications (i.e. after date/alphabetic ordering has taken place), which orders by the release type of the latest release version, using a pre-defined and hardcoded ordering rule.

**EES-5255**: Remove the time element from published dates during query execution. This ensures that publications published on the same date are ordered using the release type, rather than being based on the minutes/hours which may make one publication "newer" than another.

These changes allow users to see results ordered by release type when they share the same date, so that they can see the most relevant statistics first when searching.