### PR TITLE
EES-5449 Hide changelog link for v1 draft API data set versions

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -34,7 +34,7 @@ import {
   releaseApiDataSetPreviewRoute,
   releaseApiDataSetPreviewTokenRoute,
   releaseApiDataSetPreviewTokenLogRoute,
-  releaseApiDataSetHistoryPageRoute,
+  releaseApiDataSetVersionHistoryRoute,
   releaseApiDataSetChangelogRoute,
 } from '@admin/routes/releaseRoutes';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -69,7 +69,7 @@ const routes = [
   releaseApiDataSetPreviewRoute,
   releaseApiDataSetPreviewTokenRoute,
   releaseApiDataSetPreviewTokenLogRoute,
-  releaseApiDataSetHistoryPageRoute,
+  releaseApiDataSetVersionHistoryRoute,
   releaseApiDataSetChangelogRoute,
   releaseSummaryEditRoute,
   releaseFootnotesCreateRoute,

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -9,7 +9,7 @@ import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
 import {
   releaseApiDataSetChangelogRoute,
   releaseApiDataSetFiltersMappingRoute,
-  releaseApiDataSetHistoryPageRoute,
+  releaseApiDataSetVersionHistoryRoute,
   releaseApiDataSetLocationsMappingRoute,
   releaseApiDataSetPreviewRoute,
   releaseApiDataSetPreviewTokenLogRoute,
@@ -209,7 +209,7 @@ export default function ReleaseApiDataSetDetailsPage() {
             <li>
               <Link
                 to={generatePath<ReleaseDataSetRouteParams>(
-                  releaseApiDataSetHistoryPageRoute.path,
+                  releaseApiDataSetVersionHistoryRoute.path,
                   {
                     publicationId: release.publicationId,
                     releaseId: dataSet.latestLiveVersion.releaseVersion.id,

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenLogPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenLogPage.tsx
@@ -1,6 +1,8 @@
+import ButtonLink from '@admin/components/ButtonLink';
 import Link from '@admin/components/Link';
 import {
   releaseApiDataSetDetailsRoute,
+  releaseApiDataSetPreviewRoute,
   releaseApiDataSetPreviewTokenRoute,
   ReleaseDataSetPreviewTokenRouteParams,
   ReleaseDataSetRouteParams,
@@ -59,7 +61,9 @@ export default function ReleaseApiDataSetPreviewTokenLogPage() {
       <LoadingSpinner loading={isLoadingDataSet || isLoadingPreviewTokens}>
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-three-quarters">
-            <span className="govuk-caption-l">API preview token log</span>
+            <span className="govuk-caption-l">
+              API data set preview token log
+            </span>
             <h2>{dataSet?.title}</h2>
           </div>
         </div>
@@ -142,8 +146,21 @@ export default function ReleaseApiDataSetPreviewTokenLogPage() {
             </tbody>
           </table>
         ) : (
-          <p>No tokens have been created.</p>
+          <p>No preview tokens have been created.</p>
         )}
+
+        <ButtonLink
+          to={generatePath<ReleaseDataSetRouteParams>(
+            releaseApiDataSetPreviewRoute.path,
+            {
+              publicationId,
+              releaseId,
+              dataSetId,
+            },
+          )}
+        >
+          Generate preview token
+        </ButtonLink>
       </LoadingSpinner>
     </>
   );

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetVersionHistoryPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetVersionHistoryPage.tsx
@@ -20,7 +20,7 @@ import { useQuery } from '@tanstack/react-query';
 import { generatePath, useParams } from 'react-router-dom';
 import React, { useState } from 'react';
 
-export default function ReleaseApiDataSetHistoryPage() {
+export default function ReleaseApiDataSetVersionHistoryPage() {
   const { publicAppUrl } = useConfig();
   const { page } = useQueryParams<{ page: string }>();
   const [currentPage, setCurrentPage] = useState<number>(

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -210,7 +210,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       summary.getByRole('link', { name: 'View preview token log' }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/token-log',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/preview-tokens',
     );
     expect(
       summary.getByRole('button', { name: 'Remove draft version' }),
@@ -268,7 +268,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       summary.getByRole('link', { name: 'View version history' }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-1-id/api-data-sets/data-set-id/history',
+      '/publication/publication-1/release/release-1-id/api-data-sets/data-set-id/versions',
     );
 
     // Draft version sections not rendered
@@ -366,7 +366,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       draftSummary.getByRole('link', { name: 'View preview token log' }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/token-log',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/preview-tokens',
     );
     expect(
       draftSummary.getByRole('button', { name: 'Remove draft version' }),
@@ -409,7 +409,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       liveSummary.getByRole('link', { name: 'View version history' }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-1-id/api-data-sets/data-set-id/history',
+      '/publication/publication-1/release/release-1-id/api-data-sets/data-set-id/versions',
     );
   });
 
@@ -440,7 +440,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       summary.getByRole('link', { name: 'View preview token log' }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/token-log',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/preview-tokens',
     );
     expect(
       summary.getByRole('button', { name: 'Remove draft version' }),
@@ -539,7 +539,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       summary.getByRole('link', { name: 'View version history' }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-1-id/api-data-sets/data-set-id/history',
+      '/publication/publication-1/release/release-1-id/api-data-sets/data-set-id/versions',
     );
   });
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -1,5 +1,5 @@
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
-import { testRelease } from '@admin/pages/release/__data__/testRelease';
+import { testRelease as testBaseRelease } from '@admin/pages/release/__data__/testRelease';
 import ReleaseApiDataSetDetailsPage from '@admin/pages/release/data/ReleaseApiDataSetDetailsPage';
 import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
 import {
@@ -25,6 +25,18 @@ const apiDataSetService = jest.mocked(_apiDataSetService);
 const apiDataSetVersionService = jest.mocked(_apiDataSetVersionService);
 
 describe('ReleaseApiDataSetDetailsPage', () => {
+  const testLiveRelease: Release = {
+    ...testBaseRelease,
+    id: 'release-1-id',
+    title: 'Release 1',
+  };
+
+  const testDraftRelease: Release = {
+    ...testBaseRelease,
+    id: 'release-2-id',
+    title: 'Release 2',
+  };
+
   const testDataSet: ApiDataSet = {
     id: 'data-set-id',
     title: 'Data set title',
@@ -35,14 +47,14 @@ describe('ReleaseApiDataSetDetailsPage', () => {
 
   const testLiveVersion: ApiDataSetLiveVersion = {
     id: 'live-version-id',
-    version: '1.0',
+    version: '1.1',
     type: 'Minor',
     status: 'Published',
     totalResults: 10_000,
     published: '2024-03-01T09:30:00+00:00',
     releaseVersion: {
-      id: 'release-1-id',
-      title: 'Test release 1',
+      id: testLiveRelease.id,
+      title: testLiveRelease.title,
     },
     file: {
       id: 'live-file-id',
@@ -64,8 +76,8 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     type: 'Minor',
     totalResults: 0,
     releaseVersion: {
-      id: 'release-2-id',
-      title: 'Test release 2',
+      id: testDraftRelease.id,
+      title: testDraftRelease.title,
     },
     file: {
       id: 'processing-file-id',
@@ -80,8 +92,8 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     type: 'Major',
     totalResults: 20_000,
     releaseVersion: {
-      id: 'release-2-id',
-      title: 'Test release 2',
+      id: testDraftRelease.id,
+      title: testDraftRelease.title,
     },
     file: {
       id: 'draft-file-id',
@@ -120,6 +132,8 @@ describe('ReleaseApiDataSetDetailsPage', () => {
 
     renderPage();
 
+    expect(screen.queryByTestId('draft-version-tasks')).not.toBeInTheDocument();
+
     expect(
       await screen.findByText('Draft version details'),
     ).toBeInTheDocument();
@@ -137,16 +151,11 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     expect(summary.queryByTestId('Geographic levels')).not.toBeInTheDocument();
     expect(summary.queryByTestId('Indicators')).not.toBeInTheDocument();
     expect(summary.queryByTestId('Filters')).not.toBeInTheDocument();
+    expect(summary.queryByTestId('Actions')).not.toBeInTheDocument();
 
     expect(
-      screen.queryByRole('heading', { name: 'Latest live version details' }),
+      screen.queryByTestId('live-version-summary'),
     ).not.toBeInTheDocument();
-
-    expect(
-      screen.queryByRole('heading', { name: 'Draft version tasks' }),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByTestId('map-locations-task')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('map-filters-task')).not.toBeInTheDocument();
   });
 
   test('renders correctly with processed draft version only', async () => {
@@ -156,6 +165,8 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     });
 
     renderPage();
+
+    expect(screen.queryByTestId('draft-version-tasks')).not.toBeInTheDocument();
 
     expect(
       await screen.findByText('Draft version details'),
@@ -182,18 +193,34 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       'Test draft filter',
     );
     expect(
-      screen.getByRole('button', { name: 'Remove draft version' }),
+      summary.getByRole('link', {
+        name: 'View changelog and guidance notes',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/changelog/draft-version-id',
+    );
+    expect(
+      summary.getByRole('link', { name: 'Preview API data set' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/preview',
+    );
+    expect(
+      summary.getByRole('link', { name: 'View preview token log' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/token-log',
+    );
+    expect(
+      summary.getByRole('button', { name: 'Remove draft version' }),
     ).toBeInTheDocument();
 
-    expect(
-      screen.queryByRole('heading', { name: 'Latest live version details' }),
-    ).not.toBeInTheDocument();
+    // Latest live version sections not rendered
 
     expect(
-      screen.queryByRole('heading', { name: 'Draft version tasks' }),
+      screen.queryByTestId('live-version-summary'),
     ).not.toBeInTheDocument();
-    expect(screen.queryByTestId('map-locations-task')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('map-filters-task')).not.toBeInTheDocument();
   });
 
   test('renders correctly with latest live version only', async () => {
@@ -214,7 +241,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
 
     const summary = within(screen.getByTestId('live-version-summary'));
 
-    expect(summary.getByTestId('Version')).toHaveTextContent('v1.0');
+    expect(summary.getByTestId('Version')).toHaveTextContent('v1.1');
     expect(summary.getByTestId('Status')).toHaveTextContent('Published');
     expect(summary.getByTestId('Time periods')).toHaveTextContent(
       '2018 to 2023',
@@ -226,27 +253,35 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       'Test live filter',
     );
     expect(
-      within(summary.getByTestId('Actions')).getByRole('link', {
-        name: /View live data set/,
-      }),
+      summary.getByRole('link', { name: /View live data set/ }),
     ).toHaveAttribute(
       'href',
       'http://localhost/data-catalogue/data-set/live-file-id',
     );
-
     expect(
-      screen.queryByRole('button', { name: 'Remove draft version' }),
-    ).not.toBeInTheDocument();
+      summary.getByRole('link', { name: 'View changelog and guidance notes' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1-id/api-data-sets/data-set-id/changelog/live-version-id',
+    );
+    expect(
+      summary.getByRole('link', { name: 'View version history' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1-id/api-data-sets/data-set-id/history',
+    );
+
+    // Draft version sections not rendered
+
+    expect(screen.queryByTestId('draft-version-tasks')).not.toBeInTheDocument();
 
     expect(
       screen.queryByRole('heading', { name: 'Draft version details' }),
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByRole('heading', { name: 'Draft version tasks' }),
+      screen.queryByTestId('draft-version-summary'),
     ).not.toBeInTheDocument();
-    expect(screen.queryByTestId('map-locations-task')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('map-filters-task')).not.toBeInTheDocument();
   });
 
   test('renders correctly with draft and latest live version', async () => {
@@ -272,20 +307,22 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     ).toBeInTheDocument();
 
     const mapLocationsTask = within(screen.getByTestId('map-locations-task'));
+
     expect(
       mapLocationsTask.getByRole('link', { name: 'Map locations' }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-1/api-data-sets/data-set-id/locations-mapping',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/locations-mapping',
     );
     expect(mapLocationsTask.getByText('Incomplete')).toBeInTheDocument();
 
     const mapFiltersTask = within(screen.getByTestId('map-filters-task'));
+
     expect(
       mapFiltersTask.getByRole('link', { name: 'Map filters' }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-1/api-data-sets/data-set-id/filters-mapping',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/filters-mapping',
     );
     expect(mapFiltersTask.getByText('Incomplete')).toBeInTheDocument();
 
@@ -312,6 +349,26 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       'Test draft filter',
     );
     expect(
+      draftSummary.getByRole('link', {
+        name: 'View changelog and guidance notes',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/changelog/draft-version-id',
+    );
+    expect(
+      draftSummary.getByRole('link', { name: 'Preview API data set' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/preview',
+    );
+    expect(
+      draftSummary.getByRole('link', { name: 'View preview token log' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/token-log',
+    );
+    expect(
       draftSummary.getByRole('button', { name: 'Remove draft version' }),
     ).toBeInTheDocument();
 
@@ -323,7 +380,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
 
     const liveSummary = within(screen.getByTestId('live-version-summary'));
 
-    expect(liveSummary.getByTestId('Version')).toHaveTextContent('v1.0');
+    expect(liveSummary.getByTestId('Version')).toHaveTextContent('v1.1');
     expect(liveSummary.getByTestId('Status')).toHaveTextContent('Published');
     expect(liveSummary.getByTestId('Time periods')).toHaveTextContent(
       '2018 to 2023',
@@ -335,35 +392,158 @@ describe('ReleaseApiDataSetDetailsPage', () => {
       'Test live filter',
     );
     expect(
-      within(liveSummary.getByTestId('Actions')).getByRole('link', {
-        name: /View live data set/,
-      }),
+      liveSummary.getByRole('link', { name: /View live data set/ }),
     ).toHaveAttribute(
       'href',
       'http://localhost/data-catalogue/data-set/live-file-id',
     );
+    expect(
+      liveSummary.getByRole('link', {
+        name: 'View changelog and guidance notes',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1-id/api-data-sets/data-set-id/changelog/live-version-id',
+    );
+    expect(
+      liveSummary.getByRole('link', { name: 'View version history' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1-id/api-data-sets/data-set-id/history',
+    );
   });
 
-  test('does not render the Remove draft version button when cannot update the release', async () => {
+  test('renders the correct draft version (v1) actions', async () => {
     apiDataSetService.getDataSet.mockResolvedValue({
       ...testDataSet,
-      draftVersion: testDraftVersion,
-      latestLiveVersion: testLiveVersion,
+      draftVersion: {
+        ...testDraftVersion,
+        version: '1.0',
+      },
     });
 
-    renderPage({ release: { ...testRelease, approvalStatus: 'Approved' } });
+    renderPage();
 
     expect(
       await screen.findByText('Draft version details'),
     ).toBeInTheDocument();
 
-    const draftSummary = within(screen.getByTestId('draft-version-summary'));
+    const summary = within(screen.getByTestId('draft-version-summary'));
+
     expect(
-      draftSummary.queryByRole('button', { name: 'Remove draft version' }),
+      summary.getByRole('link', { name: 'Preview API data set' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/preview',
+    );
+    expect(
+      summary.getByRole('link', { name: 'View preview token log' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-2-id/api-data-sets/data-set-id/token-log',
+    );
+    expect(
+      summary.getByRole('button', { name: 'Remove draft version' }),
+    ).toBeInTheDocument();
+    expect(
+      summary.queryByRole('link', {
+        name: 'View changelog and guidance notes',
+      }),
     ).not.toBeInTheDocument();
   });
 
-  test('renders the create new version button when release can be updated and there is no draft version', async () => {
+  test('does not render the `Remove draft version` button when release cannot be updated', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      draftVersion: testDraftVersion,
+    });
+
+    renderPage({
+      release: { ...testDraftRelease, approvalStatus: 'Approved' },
+    });
+
+    expect(
+      await screen.findByText('Draft version details'),
+    ).toBeInTheDocument();
+
+    const summary = within(screen.getByTestId('draft-version-summary'));
+
+    expect(
+      summary.queryByRole('button', { name: 'Remove draft version' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correct latest live version (v1) actions', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      latestLiveVersion: {
+        ...testLiveVersion,
+        version: '1.0',
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('Latest live version details'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: 'Latest live version details' }),
+    ).toBeInTheDocument();
+
+    const summary = within(screen.getByTestId('live-version-summary'));
+
+    // Not rendered for v1
+    expect(
+      summary.queryByRole('link', {
+        name: 'View changelog and guidance notes',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      summary.queryByRole('link', { name: 'View version history' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correct latest live version (non-v1) actions when release cannot be updated', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      latestLiveVersion: testLiveVersion,
+    });
+
+    renderPage({
+      release: { ...testDraftRelease, approvalStatus: 'Approved' },
+    });
+
+    expect(
+      await screen.findByText('Latest live version details'),
+    ).toBeInTheDocument();
+
+    const summary = within(screen.getByTestId('live-version-summary'));
+
+    expect(
+      summary.getByRole('link', { name: /View live data set/ }),
+    ).toHaveAttribute(
+      'href',
+      'http://localhost/data-catalogue/data-set/live-file-id',
+    );
+    expect(
+      summary.getByRole('link', {
+        name: 'View changelog and guidance notes',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1-id/api-data-sets/data-set-id/changelog/live-version-id',
+    );
+    expect(
+      summary.getByRole('link', { name: 'View version history' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1-id/api-data-sets/data-set-id/history',
+    );
+  });
+
+  test('renders the `Create new version` button when release can be updated and no draft version', async () => {
     apiDataSetService.getDataSet.mockResolvedValue({
       ...testDataSet,
       latestLiveVersion: testLiveVersion,
@@ -382,13 +562,15 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     ).toBeInTheDocument();
   });
 
-  test('does not render the create new version button when cannot update the release', async () => {
+  test('does not render the `Create new version` button when release cannot be updated', async () => {
     apiDataSetService.getDataSet.mockResolvedValue({
       ...testDataSet,
       latestLiveVersion: testLiveVersion,
     });
 
-    renderPage({ release: { ...testRelease, approvalStatus: 'Approved' } });
+    renderPage({
+      release: { ...testDraftRelease, approvalStatus: 'Approved' },
+    });
 
     expect(
       await screen.findByText('Latest live version details'),
@@ -401,7 +583,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('does not render the create new version button when there is a draft version', async () => {
+  test('does not render the `Create new version` button when there is a draft version', async () => {
     apiDataSetService.getDataSet.mockResolvedValue({
       ...testDataSet,
       draftVersion: testDraftVersion,
@@ -421,7 +603,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('does not render the create new version button when release series includes a previous version of this data set', async () => {
+  test('does not render the `Create new version` button when release series includes a previous version of this data set', async () => {
     apiDataSetService.getDataSet.mockResolvedValue({
       ...testDataSet,
       latestLiveVersion: testLiveVersion,
@@ -429,7 +611,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
 
     renderPage({
       release: {
-        ...testRelease,
+        ...testDraftRelease,
         releaseId: testDataSet.previousReleaseIds[0],
       },
     });
@@ -664,7 +846,8 @@ describe('ReleaseApiDataSetDetailsPage', () => {
   });
 
   function renderPage(options?: { release?: Release; dataSetId?: string }) {
-    const { release = testRelease, dataSetId = 'data-set-id' } = options ?? {};
+    const { release = testDraftRelease, dataSetId = 'data-set-id' } =
+      options ?? {};
 
     return render(
       <TestConfigContextProvider>

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewPage.test.tsx
@@ -111,7 +111,7 @@ describe('ReleaseApiDataSetPreviewPage', () => {
 
     await waitFor(() => {
       expect(history.location.pathname).toBe(
-        '/publication/publication-1/release/release-1/api-data-sets/data-set-id/preview/token-id',
+        '/publication/publication-1/release/release-1/api-data-sets/data-set-id/preview-tokens/token-id',
       );
     });
   });

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenLogPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenLogPage.test.tsx
@@ -23,7 +23,7 @@ jest.mock('@admin/services/previewTokenService');
 const apiDataSetService = jest.mocked(_apiDataSetService);
 const previewTokenService = jest.mocked(_previewTokenService);
 
-describe('ReleaseApiDataSetPreviewTokenPage', () => {
+describe('ReleaseApiDataSetPreviewTokenLogPage', () => {
   const testDataSet: ApiDataSet = {
     id: 'data-set-id',
     title: 'Data set title',
@@ -99,7 +99,7 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
       }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-1/api-data-sets/data-set-id/preview/token-id-1',
+      '/publication/publication-1/release/release-1/api-data-sets/data-set-id/preview-tokens/token-id-1',
     );
     expect(
       within(row1Cells[5]).getByRole('button', { name: 'Revoke Test label 1' }),
@@ -134,7 +134,7 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
       }),
     ).toHaveAttribute(
       'href',
-      '/publication/publication-1/release/release-1/api-data-sets/data-set-id/preview/token-id-3',
+      '/publication/publication-1/release/release-1/api-data-sets/data-set-id/preview-tokens/token-id-3',
     );
     expect(
       within(row3Cells[5]).getByRole('button', { name: 'Revoke Test label 3' }),

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenLogPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenLogPage.test.tsx
@@ -76,7 +76,7 @@ describe('ReleaseApiDataSetPreviewTokenLogPage', () => {
     },
   ];
 
-  test('renders the table correctly', async () => {
+  test('renders correctly with tokens', async () => {
     apiDataSetService.getDataSet.mockResolvedValue(testDataSet);
     previewTokenService.listPreviewTokens.mockResolvedValue(testTokens);
 
@@ -139,6 +139,39 @@ describe('ReleaseApiDataSetPreviewTokenLogPage', () => {
     expect(
       within(row3Cells[5]).getByRole('button', { name: 'Revoke Test label 3' }),
     ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText('No preview tokens have been created.'),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', { name: 'Generate preview token' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/api-data-sets/data-set-id/preview',
+    );
+  });
+
+  test('renders correctly with no tokens', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue(testDataSet);
+    previewTokenService.listPreviewTokens.mockResolvedValue([]);
+
+    renderPage();
+
+    expect(await screen.findByText('Data set title')).toBeInTheDocument();
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText('No preview tokens have been created.'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', { name: 'Generate preview token' }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/api-data-sets/data-set-id/preview',
+    );
   });
 
   test('revoking a token', async () => {

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenPage.test.tsx
@@ -1,25 +1,24 @@
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
 import { testRelease } from '@admin/pages/release/__data__/testRelease';
-import ReleaseApiDataSetPreviewTokenPage from '@admin/pages/release/data/ReleaseApiDataSetPreviewTokenPage';
 import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
+import ReleaseApiDataSetPreviewTokenPage from '@admin/pages/release/data/ReleaseApiDataSetPreviewTokenPage';
 import {
-  releaseApiDataSetPreviewRoute,
   releaseApiDataSetPreviewTokenRoute,
   ReleaseDataSetPreviewTokenRouteParams,
 } from '@admin/routes/releaseRoutes';
 import _apiDataSetService, {
   ApiDataSet,
 } from '@admin/services/apiDataSetService';
-import { Release } from '@admin/services/releaseService';
 import _previewTokenService, {
   PreviewToken,
 } from '@admin/services/previewTokenService';
+import { Release } from '@admin/services/releaseService';
 import render from '@common-test/render';
 import { screen, waitFor, within } from '@testing-library/react';
+import addHours from 'date-fns/addHours';
+import { createMemoryHistory, MemoryHistory } from 'history';
 import React from 'react';
 import { generatePath, Route, Router } from 'react-router-dom';
-import { createMemoryHistory, MemoryHistory } from 'history';
-import addHours from 'date-fns/addHours';
 
 jest.mock('@admin/services/apiDataSetService');
 jest.mock('@admin/services/previewTokenService');
@@ -133,9 +132,10 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
   });
 
   test('shows a modal and calls the `onRevoke` handler on confirm when the revoke button is clicked', async () => {
-    const history = createMemoryHistory();
     apiDataSetService.getDataSet.mockResolvedValue(testDataSet);
     previewTokenService.getPreviewToken.mockResolvedValue(testToken);
+
+    const history = createMemoryHistory();
 
     const { user } = renderPage({ history });
 
@@ -228,7 +228,7 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
           <Router history={history}>
             <Route
               component={ReleaseApiDataSetPreviewTokenPage}
-              path={releaseApiDataSetPreviewRoute.path}
+              path={releaseApiDataSetPreviewTokenRoute.path}
             />
           </Router>
         </ReleaseContextProvider>

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetVersionHistoryPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetVersionHistoryPage.test.tsx
@@ -1,9 +1,9 @@
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
 import { testRelease } from '@admin/pages/release/__data__/testRelease';
-import ReleaseApiDataSetHistoryPage from '@admin/pages/release/data/ReleaseApiDataSetHistoryPage';
+import ReleaseApiDataSetVersionHistoryPage from '@admin/pages/release/data/ReleaseApiDataSetVersionHistoryPage';
 import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
 import {
-  releaseApiDataSetHistoryPageRoute,
+  releaseApiDataSetVersionHistoryRoute,
   ReleaseDataSetRouteParams,
 } from '@admin/routes/releaseRoutes';
 import _apiDataSetService, {
@@ -22,7 +22,7 @@ jest.mock('@admin/services/apiDataSetVersionService');
 const apiDataSetService = jest.mocked(_apiDataSetService);
 const apiDataSetVersionService = jest.mocked(_apiDataSetVersionService);
 
-describe('ReleaseApiDataSetPreviewTokenPage', () => {
+describe('ReleaseApiDataSetVersionHistoryPage', () => {
   const testDataSet: ApiDataSet = {
     id: 'data-set-id',
     title: 'Data set title',
@@ -247,7 +247,7 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
           <MemoryRouter
             initialEntries={[
               generatePath<ReleaseDataSetRouteParams>(
-                releaseApiDataSetHistoryPageRoute.path,
+                releaseApiDataSetVersionHistoryRoute.path,
                 {
                   publicationId: testRelease.publicationId,
                   releaseId: testRelease.id,
@@ -257,8 +257,8 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
             ]}
           >
             <Route
-              component={ReleaseApiDataSetHistoryPage}
-              path={releaseApiDataSetHistoryPageRoute.path}
+              component={ReleaseApiDataSetVersionHistoryPage}
+              path={releaseApiDataSetVersionHistoryRoute.path}
             />
           </MemoryRouter>
         </ReleaseContextProvider>

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -5,7 +5,7 @@ import ReleaseApiDataSetLocationsMappingPage from '@admin/pages/release/data/Rel
 import ReleaseApiDataSetPreviewPage from '@admin/pages/release/data/ReleaseApiDataSetPreviewPage';
 import ReleaseApiDataSetPreviewTokenPage from '@admin/pages/release/data/ReleaseApiDataSetPreviewTokenPage';
 import ReleaseApiDataSetPreviewTokenLogPage from '@admin/pages/release/data/ReleaseApiDataSetPreviewTokenLogPage';
-import ReleaseApiDataSetHistoryPage from '@admin/pages/release/data/ReleaseApiDataSetHistoryPage';
+import ReleaseApiDataSetVersionHistoryPage from '@admin/pages/release/data/ReleaseApiDataSetVersionHistoryPage';
 import ReleaseApiDataSetChangelogPage from '@admin/pages/release/data/ReleaseApiDataSetChangelogPage';
 import ReleaseContentPage from '@admin/pages/release/content/ReleaseContentPage';
 import ReleaseDataFilePage from '@admin/pages/release/data/ReleaseDataFilePage';
@@ -153,23 +153,23 @@ export const releaseApiDataSetPreviewRoute: ReleaseRouteProps = {
 };
 
 export const releaseApiDataSetPreviewTokenRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId/preview/:previewTokenId',
+  path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId/preview-tokens/:previewTokenId',
   title: 'API data set preview token',
   component: ReleaseApiDataSetPreviewTokenPage,
   protectionAction: permissions => permissions.isBauUser,
 };
 
 export const releaseApiDataSetPreviewTokenLogRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId/token-log',
+  path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId/preview-tokens',
   title: 'View API data set token log',
   component: ReleaseApiDataSetPreviewTokenLogPage,
   protectionAction: permissions => permissions.isBauUser,
 };
 
-export const releaseApiDataSetHistoryPageRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId/history',
+export const releaseApiDataSetVersionHistoryRoute: ReleaseRouteProps = {
+  path: '/publication/:publicationId/release/:releaseId/api-data-sets/:dataSetId/versions',
   title: 'API data set version history',
-  component: ReleaseApiDataSetHistoryPage,
+  component: ReleaseApiDataSetVersionHistoryPage,
   protectionAction: permissions => permissions.isBauUser,
 };
 


### PR DESCRIPTION
This PR hides the 'View changelog and guidance notes' button from v1 draft API data set versions.

## Other changes

- Hides draft data set version actions whilst a version is processing.
- Tidies up routes and naming for preview tokens and version history pages.
- Added 'Generate preview token' link button to preview token log page for convenience.