### PR TITLE
EES-5442 - updating file storage path to reflect updates to a next DataSetVersion's version number

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -77,6 +77,8 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
 
     public SemVersion SemVersion() => new(major: VersionMajor, minor: VersionMinor, patch: VersionPatch);
 
+    public SemVersion DefaultNextVersion() => SemVersion().WithMinor(VersionMinor + 1);
+
     public bool IsFirstVersion => VersionMajor == 1 && VersionMinor == 0 && VersionPatch == 0;
 
     public DataSetVersionType VersionType
@@ -143,7 +145,13 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
                         .IsUnique();
                 });
 
-            builder.HasIndex(dsv => new { dsv.DataSetId, dsv.VersionMajor, dsv.VersionMinor, dsv.VersionPatch })
+            builder.HasIndex(dsv => new
+                {
+                    dsv.DataSetId,
+                    dsv.VersionMajor,
+                    dsv.VersionMinor,
+                    dsv.VersionPatch
+                })
                 .HasDatabaseName("IX_DataSetVersions_DataSetId_VersionNumber")
                 .IsUnique();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ActivityNames.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ActivityNames.cs
@@ -8,14 +8,16 @@ internal static class ActivityNames
     public const string WriteDataFiles = nameof(WriteDataFilesFunction.WriteDataFiles);
     public const string HandleProcessingFailure = nameof(HandleProcessingFailureFunction.HandleProcessingFailure);
 
-    public const string CompleteInitialDataSetVersionProcessing = 
+    public const string CompleteInitialDataSetVersionProcessing =
         nameof(ProcessInitialDataSetVersionFunction.CompleteInitialDataSetVersionProcessing);
 
     public const string CreateMappings = nameof(ProcessNextDataSetVersionMappingsFunction.CreateMappings);
     public const string ApplyAutoMappings = nameof(ProcessNextDataSetVersionMappingsFunction.ApplyAutoMappings);
-    public const string CompleteNextDataSetVersionMappingProcessing = 
+    public const string CompleteNextDataSetVersionMappingProcessing =
         nameof(ProcessNextDataSetVersionMappingsFunction.CompleteNextDataSetVersionMappingProcessing);
-    
-    public const string CompleteNextDataSetVersionImportProcessing = 
+
+    public const string UpdateFileStoragePath =
+        nameof(ProcessCompletionOfNextDataSetVersionFunction.UpdateFileStoragePath);
+    public const string CompleteNextDataSetVersionImportProcessing =
         nameof(ProcessCompletionOfNextDataSetVersionFunction.CompleteNextDataSetVersionImportProcessing);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -13,6 +13,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Services.
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Semver;
 using Release = GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Release;
 using ValidationMessages =
     GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests.Validators.ValidationMessages;
@@ -447,6 +448,9 @@ internal class DataSetVersionService(
         ReleaseFile releaseFile,
         CancellationToken cancellationToken)
     {
+        var nextVersion = dataSet.LatestLiveVersion?.DefaultNextVersion()
+                          ?? new SemVersion(major: 1, minor: 0, patch: 0);
+
         var dataSetVersion = new DataSetVersion
         {
             DataSetId = dataSet.Id,
@@ -460,8 +464,9 @@ internal class DataSetVersionService(
                 Title = releaseFile.ReleaseVersion.Title
             },
             Notes = "",
-            VersionMajor = dataSet.LatestLiveVersion?.VersionMajor ?? 1,
-            VersionMinor = dataSet.LatestLiveVersion?.VersionMinor + 1 ?? 0
+            VersionMajor = nextVersion.Major,
+            VersionMinor = nextVersion.Minor,
+            VersionPatch = nextVersion.Patch
         };
 
         dataSet.Versions.Add(dataSetVersion);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/DataSetVersionPathResolverTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/DataSetVersionPathResolverTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Moq;
+using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests;
 
@@ -144,6 +145,30 @@ public abstract class DataSetVersionPathResolverTests
                     "v1.0.0"
                 ),
                 resolver.DirectoryPath(version));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetEnvironmentNames))]
+        public void ValidDirectoryPath_OptionalVersionArgument(string environmentName)
+        {
+            DataSetVersion version = _dataFixture.DefaultDataSetVersion();
+
+            _webHostEnvironmentMock
+                .SetupGet(s => s.EnvironmentName)
+                .Returns(environmentName);
+
+            var resolver = BuildService(options: new DataFilesOptions
+            {
+                BasePath = Path.Combine("data", "data-files")
+            });
+
+            Assert.Equal(
+                Path.Combine(
+                    resolver.BasePath(),
+                    version.DataSetId.ToString(),
+                    "v1.2.3"
+                ),
+                resolver.DirectoryPath(version, new SemVersion(major: 1, minor: 2, patch: 3)));
         }
 
         [Theory]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/TestDataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/TestDataSetVersionPathResolver.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
+using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests;
 
@@ -17,5 +18,8 @@ public class TestDataSetVersionPathResolver : IDataSetVersionPathResolver
 
     public string Directory { get; set; } = string.Empty;
 
-    public string DirectoryPath(DataSetVersion dataSetVersion) => Path.Combine(_basePath, Directory);
+    public string DirectoryPath(DataSetVersion dataSetVersion, SemVersion? versionNumber = null)
+    {
+        return Path.Combine(_basePath, Directory);
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Options;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Services;
 
@@ -33,8 +34,13 @@ public class DataSetVersionPathResolver : IDataSetVersionPathResolver
 
     public string BasePath() => _basePath;
 
-    public string DirectoryPath(DataSetVersion dataSetVersion)
-        => Path.Combine(_basePath, dataSetVersion.DataSetId.ToString(), $"v{dataSetVersion.SemVersion()}");
+    public string DirectoryPath(DataSetVersion dataSetVersion, SemVersion? versionNumber = null)
+    {
+        return Path.Combine(
+            _basePath,
+            dataSetVersion.DataSetId.ToString(),
+            $"v{versionNumber ?? dataSetVersion.SemVersion()}");
+    }
 
     private string GetBasePath()
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/Interfaces/IDataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/Interfaces/IDataSetVersionPathResolver.cs
@@ -1,5 +1,6 @@
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
+using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 
@@ -7,7 +8,7 @@ public interface IDataSetVersionPathResolver
 {
     string BasePath();
 
-    string DirectoryPath(DataSetVersion dataSetVersion);
+    string DirectoryPath(DataSetVersion dataSetVersion, SemVersion? versionNumber = null);
 
     string CsvDataPath(DataSetVersion dataSetVersion)
         => Path.Combine(DirectoryPath(dataSetVersion), DataSetFilenames.CsvDataFile);


### PR DESCRIPTION
This PR:
- adds an additional stage to the final import orchestration of a next DataSetVersion, in which the storage directory path is updated to reflect any changes in the DataSetVersion's version number during its mapping phase.
- if the version number is unchanged from the default version number originally assigned when the next DataSetVersion was created, no path update is necessary.

Thereafter, the import process should continue as usual, using the now-updated file storage path.

I've added a convenience `DataSetVersion.DefautlNextVersion()" method which will give us the expected next version number of a DataSetVersion (using the existing implementation of updating the minor version).  We can then use this method to assign a default version number to a brand new next DataSetVersion, plus use it again to get the default file storage path that may or may not need updating prior to completing the import process. 