### PR TITLE
EES-5453 Fix list styling for breadcrumbs and footer items

### DIFF
--- a/src/explore-education-statistics-common/src/styles/_typography.scss
+++ b/src/explore-education-statistics-common/src/styles/_typography.scss
@@ -1,3 +1,4 @@
+@import '~govuk-frontend/dist/govuk/base';
 @import '~govuk-frontend/dist/govuk/core/lists';
 @import '~govuk-frontend/dist/govuk/core/section-break';
 @import '~govuk-frontend/dist/govuk/core/typography';
@@ -26,11 +27,21 @@ small {
 }
 
 ul {
-  @extend %govuk-list, %govuk-list--bullet;
+  @extend %govuk-list--bullet;
+  @include govuk-responsive-margin(4, 'bottom');
 }
 
 ol {
-  @extend %govuk-list, %govuk-list--number;
+  @extend %govuk-list--number;
+  @include govuk-responsive-margin(4, 'bottom');
+}
+
+ol,
+ul {
+  ul,
+  ol {
+    margin-top: govuk-spacing(2);
+  }
 }
 
 dt {


### PR DESCRIPTION
This PR fixes a regression in list styling (caused by #5135) causing breadcrumb and footer items being too big.

We had attempted to apply `govuk-list` styling globally to `ul` and `ol` elements to provide better support for nested lists, but unfortunately, this set a default font size that would require additional component-level styles to fix.

Instead, we've now opted to bring in the specific `govuk-list` styles needed for nested lists (the original intention) and removed applying all the styles globally.