### PR TITLE
Ees 5408 automate private endpoint creation for data procesor

### DIFF
--- a/infrastructure/templates/public-api/application/privateDnsZones.bicep
+++ b/infrastructure/templates/public-api/application/privateDnsZones.bicep
@@ -1,13 +1,13 @@
-@description('Specifies the resource id of the VNet that the DNS Zones will be attached to')
+@description('Specifies the name of the VNet that the DNS Zones will be attached to')
 @minLength(0)
-param vnetId string
+param vnetName string
 
 // Set up a Private DNS zone for handling private endpoints for PostgreSQL resources.
 module postgreSqlPrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
   name: 'postgresPrivateDnsZoneDeploy'
   params: {
     zoneType: 'postgres'
-    vnetId: vnetId
+    vnetName: vnetName
   }
 }
 
@@ -17,7 +17,7 @@ module sitesPrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
   name: 'sitesPrivateDnsZoneDeploy'
   params: {
     zoneType: 'sites'
-    vnetId: vnetId
+    vnetName: vnetName
   }
 }
 

--- a/infrastructure/templates/public-api/application/privateDnsZones.bicep
+++ b/infrastructure/templates/public-api/application/privateDnsZones.bicep
@@ -2,16 +2,17 @@
 @minLength(0)
 param vnetId string
 
-@description('Private DNS zone for handling private endpoints for PostgreSQL resources.')
+// Set up a Private DNS zone for handling private endpoints for PostgreSQL resources.
 module postgreSqlPrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
   name: 'postgresPrivateDnsZoneDeploy'
   params: {
-    zoneType: 'postgresqlServer'
+    zoneType: 'postgres'
     vnetId: vnetId
   }
 }
 
-@description('Private DNS zone for handling private endpoints for site resources (e.g. App Services, Function Apps, Container Apps).')
+// Set up a Private DNS zone for handling private endpoints for site resources
+// (e.g. App Services, Function Apps, Container Apps).
 module sitesPrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
   name: 'sitesPrivateDnsZoneDeploy'
   params: {

--- a/infrastructure/templates/public-api/application/privateDnsZones.bicep
+++ b/infrastructure/templates/public-api/application/privateDnsZones.bicep
@@ -1,0 +1,27 @@
+@description('Specifies the resource id of the VNet that the DNS Zones will be attached to')
+@minLength(0)
+param vnetId string
+
+@description('Private DNS zone for handling private endpoints for PostgreSQL resources.')
+module postgreSqlPrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
+  name: 'postgresPrivateDnsZoneDeploy'
+  params: {
+    zoneType: 'postgresqlServer'
+    vnetId: vnetId
+  }
+}
+
+@description('Private DNS zone for handling private endpoints for site resources (e.g. App Services, Function Apps, Container Apps).')
+module sitesPrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
+  name: 'sitesPrivateDnsZoneDeploy'
+  params: {
+    zoneType: 'sites'
+    vnetId: vnetId
+  }
+}
+
+output postgreSqlPrivateDnsZoneId string = postgreSqlPrivateDnsZoneModule.outputs.privateDnsZoneId
+output postgreSqlPrivateDnsZoneName string = postgreSqlPrivateDnsZoneModule.outputs.privateDnsZoneName
+
+output sitesPrivateDnsZoneId string = sitesPrivateDnsZoneModule.outputs.privateDnsZoneId
+output sitesPrivateDnsZoneName string = sitesPrivateDnsZoneModule.outputs.privateDnsZoneName

--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -48,7 +48,7 @@ resource appGatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01'
 }
 
 @description('The fully qualified Azure resource ID of the Network.')
-output vNetRef string = resourceId('Microsoft.Network/VirtualNetworks', vNetName)
+output vnetId string = resourceId('Microsoft.Network/VirtualNetworks', vNetName)
 
 @description('The fully qualified Azure resource ID of the Data Processor Function App Subnet.')
 output dataProcessorSubnetRef string = dataProcessorSubnet.id

--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -32,6 +32,11 @@ resource dataProcessorSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-
   parent: vNet
 }
 
+resource dataProcessorPrivateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
+  name: '${resourcePrefix}-snet-fa-${dataProcessorFunctionAppNameSuffix}-plink'
+  parent: vNet
+}
+
 resource containerAppEnvironmentSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
   name: '${subscription}-ees-snet-cae-${containerAppEnvironmentNameSuffix}'
   parent: vNet
@@ -58,6 +63,15 @@ output dataProcessorSubnetStartIpAddress string = parseCidr(dataProcessorSubnet.
 
 @description('The last usable IP address for the Data Processor Function App Subnet.')
 output dataProcessorSubnetEndIpAddress string = parseCidr(dataProcessorSubnet.properties.addressPrefix).lastUsable
+
+@description('The fully qualified Azure resource ID of the Data Processor Function App Private Endpoint Subnet.')
+output dataProcessorPrivateEndpointSubnetRef string = dataProcessorPrivateEndpointSubnet.id
+
+@description('The first usable IP address for the Data Processor Function App Private Endpoint Subnet.')
+output dataProcessorPrivateEndpointSubnetStartIpAddress string = parseCidr(dataProcessorPrivateEndpointSubnet.properties.addressPrefix).firstUsable
+
+@description('The last usable IP address for the Data Processor Function App Private Endpoint Subnet.')
+output dataProcessorPrivateEndpointSubnetEndIpAddress string = parseCidr(dataProcessorPrivateEndpointSubnet.properties.addressPrefix).lastUsable
 
 @description('The fully qualified Azure resource ID of the API Container App Subnet.')
 output containerAppEnvironmentSubnetRef string = containerAppEnvironmentSubnet.id

--- a/infrastructure/templates/public-api/application/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/virtualNetwork.bicep
@@ -33,7 +33,7 @@ resource dataProcessorSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-
 }
 
 resource dataProcessorPrivateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
-  name: '${resourcePrefix}-snet-fa-${dataProcessorFunctionAppNameSuffix}-plink'
+  name: '${resourcePrefix}-snet-fa-${dataProcessorFunctionAppNameSuffix}-pep'
   parent: vNet
 }
 

--- a/infrastructure/templates/public-api/components/appGateway.bicep
+++ b/infrastructure/templates/public-api/components/appGateway.bicep
@@ -101,7 +101,7 @@ resource publicIPAddresses 'Microsoft.Network/publicIPAddresses@2024-01-01' = [f
 module wafPolicyModule 'wafPolicy.bicep' = {
   name: 'wafPolicy'
   params: {
-    name: '${appGatewayFullName}-waf-policy'
+    name: '${appGatewayFullName}-afwp'
     location: location
     tagValues: tagValues
   }

--- a/infrastructure/templates/public-api/components/functionApp.bicep
+++ b/infrastructure/templates/public-api/components/functionApp.bicep
@@ -36,8 +36,11 @@ param tagValues object
 @description('The Application Insights key that is associated with this resource')
 param applicationInsightsKey string
 
-@description('Specifies the subnet id')
+@description('Specifies the subnet id for the function app outbound traffic across the VNet')
 param subnetId string
+
+@description('Specifies the optional subnet id for function app inbound traffic from the VNet')
+param privateEndpointSubnetId string?
 
 @description('Specifies whether this Function App is accessible from the public internet')
 param publicNetworkAccessEnabled bool = false
@@ -435,6 +438,17 @@ module functionAppSlotSettings 'appServiceSlotConfig.bicep' = {
     slot1FileShare
     slot2FileShare
   ]
+}
+
+module privateEndpointModule 'privateEndpoint.bicep' = if (privateEndpointSubnetId != null) {
+  name: '${functionAppName}PrivateEndpointDeploy'
+  params: {
+    serviceId: functionApp.id
+    serviceName: functionApp.name
+    serviceType: 'sites'
+    subnetId: privateEndpointSubnetId!
+    tagValues: tagValues
+  }
 }
 
 output functionAppName string = functionApp.name

--- a/infrastructure/templates/public-api/components/functionApp.bicep
+++ b/infrastructure/templates/public-api/components/functionApp.bicep
@@ -447,6 +447,7 @@ module privateEndpointModule 'privateEndpoint.bicep' = if (privateEndpointSubnet
     serviceName: functionApp.name
     serviceType: 'sites'
     subnetId: privateEndpointSubnetId!
+    location: location
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
+++ b/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
@@ -133,8 +133,9 @@ module privateEndpointModule 'privateEndpoint.bicep' = {
   params: {
     serviceId: postgreSQLDatabase.id
     serviceName: postgreSQLDatabase.name
-    serviceType: 'postgresqlServer'
+    serviceType: 'postgres'
     subnetId: subnetId
+    location: location
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/public-api/components/privateDnsZone.bicep
+++ b/infrastructure/templates/public-api/components/privateDnsZone.bicep
@@ -5,8 +5,8 @@
 ])
 param zoneType string
 
-@description('Specifies the resource id of the VNet that this DNS Zone will be attached to')
-param vnetId string
+@description('Specifies the name of the VNet that this DNS Zone will be attached to')
+param vnetName string
 
 var zoneTypeToNames = {
   sites: 'privatelink.azurewebsites.net'
@@ -14,6 +14,10 @@ var zoneTypeToNames = {
 }
 
 var zoneName = zoneTypeToNames[zoneType]
+
+resource vnet 'Microsoft.Network/virtualNetworks@2023-11-01' existing = {
+  name: vnetName
+}
 
 // A DNS zone in which internal DNS records can be managed.
 resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
@@ -25,12 +29,12 @@ resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
 // A link which makes the internal DNS records within the DNS zone available to other resources on the VNet.
 resource privateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
   parent: privateDnsZone
-  name: '${zoneName}-link'
+  name: '${vnet.name}-${zoneName}-vnetlink'
   location: 'global'
   properties: {
     registrationEnabled: false
     virtualNetwork: {
-      id: vnetId
+      id: vnet.id
     }
   }
 }

--- a/infrastructure/templates/public-api/components/privateDnsZone.bicep
+++ b/infrastructure/templates/public-api/components/privateDnsZone.bicep
@@ -1,0 +1,43 @@
+@description('Specifies the type of zone to create')
+@allowed([
+  'sites'
+  'postgresqlServer'
+])
+param zoneType string
+
+@description('Specifies the resource id of the VNet that this DNS Zone will be attached to')
+@minLength(0)
+param vnetId string
+
+var zoneTypeToNames = {
+  sites: 'privatelink.azurewebsites.net'
+  postgresqlServer: 'privatelink.postgres.database.azure.com'
+}
+
+var privateLinkDnsZoneName = zoneTypeToNames[zoneType]
+
+@description('A DNS zone in which internal DNS records can be managed.')
+resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: privateLinkDnsZoneName
+  location: 'global'
+  properties: {}
+}
+
+@description('A link which makes the internal DNS records within the DNS zone available to other resources on the VNet.')
+resource privateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: privateDnsZone
+  name: '${privateLinkDnsZoneName}-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnetId
+    }
+  }
+}
+
+output privateDnsZoneId string = privateDnsZone.id
+output privateDnsZoneName string = privateDnsZone.name
+
+output privateDnsZoneLinkId string = privateDnsZoneLink.id
+output privateDnsZoneLinkName string = privateDnsZoneLink.name

--- a/infrastructure/templates/public-api/components/privateDnsZone.bicep
+++ b/infrastructure/templates/public-api/components/privateDnsZone.bicep
@@ -1,32 +1,31 @@
 @description('Specifies the type of zone to create')
 @allowed([
   'sites'
-  'postgresqlServer'
+  'postgres'
 ])
 param zoneType string
 
 @description('Specifies the resource id of the VNet that this DNS Zone will be attached to')
-@minLength(0)
 param vnetId string
 
 var zoneTypeToNames = {
   sites: 'privatelink.azurewebsites.net'
-  postgresqlServer: 'privatelink.postgres.database.azure.com'
+  postgres: 'privatelink.postgres.database.azure.com'
 }
 
-var privateLinkDnsZoneName = zoneTypeToNames[zoneType]
+var zoneName = zoneTypeToNames[zoneType]
 
-@description('A DNS zone in which internal DNS records can be managed.')
+// A DNS zone in which internal DNS records can be managed.
 resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
-  name: privateLinkDnsZoneName
+  name: zoneName
   location: 'global'
   properties: {}
 }
 
-@description('A link which makes the internal DNS records within the DNS zone available to other resources on the VNet.')
+// A link which makes the internal DNS records within the DNS zone available to other resources on the VNet.
 resource privateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
   parent: privateDnsZone
-  name: '${privateLinkDnsZoneName}-link'
+  name: '${zoneName}-link'
   location: 'global'
   properties: {
     registrationEnabled: false

--- a/infrastructure/templates/public-api/components/privateEndpoint.bicep
+++ b/infrastructure/templates/public-api/components/privateEndpoint.bicep
@@ -1,0 +1,76 @@
+@description('Specifies the name of the service being connected via private endpoint')
+@minLength(0)
+param serviceName string
+
+@description('Specifies the resource id of the service being connected via private endpoint')
+@minLength(0)
+param serviceId string
+
+@description('Specifies the resource id of the subnet with which the service will be attached to the VNet')
+@minLength(0)
+param subnetId string
+
+@description('Specifies the type of service being attached to the private endpoint')
+@allowed([
+  'sites'
+  'postgresqlServer'
+])
+param serviceType string
+
+@description('A set of tags with which to tag the resource in Azure')
+param tagValues object
+
+var zoneTypeToNames = {
+  sites: 'privatelink.azurewebsites.net'
+  postgresqlServer: 'privatelink.postgres.database.azure.com'
+}
+
+var privateEndpointName = '${serviceName}-plink'
+var privateDnsZoneName = zoneTypeToNames[serviceType]
+
+@description('A private endpoint that establishes a link between a VNet and an Azure service that supports Private Link. This takes the form of an IP address that is resolvable by a private DNS zone.')
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-01-01' = {
+  name: privateEndpointName
+  location: 'westeurope'
+  tags: tagValues
+  properties: {
+    privateLinkServiceConnections: [
+      {
+        name: privateEndpointName
+        properties: {
+          privateLinkServiceId: serviceId
+          groupIds: [
+            serviceType
+          ]
+          privateLinkServiceConnectionState: {
+            status: 'Approved'
+            actionsRequired: 'None'
+          }
+        }
+      }
+    ]
+    subnet: {
+      id: subnetId
+    }
+  }
+}
+
+resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' existing = {
+  name: privateDnsZoneName
+}
+
+@description('The private DNS zone group establishes a hard connection between the service being connected and the DNS records in the private DNS zone. It handles updates to DNS records automatically.')
+resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-01-01' = {
+  name: 'default'
+  parent: privateEndpoint
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: replace(privateDnsZoneName, '.', '-')
+        properties: {
+          privateDnsZoneId: privateDnsZone.id
+        }
+      }
+    ]
+  }
+}

--- a/infrastructure/templates/public-api/components/privateEndpoint.bicep
+++ b/infrastructure/templates/public-api/components/privateEndpoint.bicep
@@ -23,13 +23,18 @@ param serviceType string
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object
 
-var zoneTypeToNames = {
+var serviceTypeToDnsZoneNames = {
   sites: 'privatelink.azurewebsites.net'
   postgres: 'privatelink.postgres.database.azure.com'
 }
 
+var serviceTypeToGroupIds = {
+  sites: 'sites'
+  postgres: 'postgresqlServer'
+}
+
 var privateEndpointName = '${serviceName}-pep'
-var privateDnsZoneName = zoneTypeToNames[serviceType]
+var privateDnsZoneName = serviceTypeToDnsZoneNames[serviceType]
 
 // A private endpoint that establishes a link between a VNet and an Azure service 
 // that supports Private Link. This takes the form of an IP address that is 
@@ -45,7 +50,7 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-01-01' = {
         properties: {
           privateLinkServiceId: serviceId
           groupIds: [
-            serviceType
+            serviceTypeToGroupIds[serviceType]
           ]
           privateLinkServiceConnectionState: {
             status: 'Approved'

--- a/infrastructure/templates/public-api/components/privateEndpoint.bicep
+++ b/infrastructure/templates/public-api/components/privateEndpoint.bicep
@@ -10,10 +10,13 @@ param serviceId string
 @minLength(0)
 param subnetId string
 
+@description('Specifies the location for this resource.')
+param location string
+
 @description('Specifies the type of service being attached to the private endpoint')
 @allowed([
   'sites'
-  'postgresqlServer'
+  'postgres'
 ])
 param serviceType string
 
@@ -22,16 +25,18 @@ param tagValues object
 
 var zoneTypeToNames = {
   sites: 'privatelink.azurewebsites.net'
-  postgresqlServer: 'privatelink.postgres.database.azure.com'
+  postgres: 'privatelink.postgres.database.azure.com'
 }
 
-var privateEndpointName = '${serviceName}-plink'
+var privateEndpointName = '${serviceName}-pep'
 var privateDnsZoneName = zoneTypeToNames[serviceType]
 
-@description('A private endpoint that establishes a link between a VNet and an Azure service that supports Private Link. This takes the form of an IP address that is resolvable by a private DNS zone.')
+// A private endpoint that establishes a link between a VNet and an Azure service 
+// that supports Private Link. This takes the form of an IP address that is 
+// resolvable by a private DNS zone.
 resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-01-01' = {
   name: privateEndpointName
-  location: 'westeurope'
+  location: location
   tags: tagValues
   properties: {
     privateLinkServiceConnections: [
@@ -59,7 +64,9 @@ resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' existing 
   name: privateDnsZoneName
 }
 
-@description('The private DNS zone group establishes a hard connection between the service being connected and the DNS records in the private DNS zone. It handles updates to DNS records automatically.')
+// The private DNS zone group establishes a hard connection between the service being 
+// connected and the DNS records in the private DNS zone. It handles updates to DNS
+// records automatically.
 resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-01-01' = {
   name: 'default'
   parent: privateEndpoint

--- a/infrastructure/templates/public-api/components/storageAccount.bicep
+++ b/infrastructure/templates/public-api/components/storageAccount.bicep
@@ -7,6 +7,9 @@ param storageAccountName string
 @description('Storage Account Network Rules')
 param allowedSubnetIds string[] = []
 
+@description('Optional subnet id for allowing inbound traffic over the VNet via a private endpoint')
+param privateEndpointSubnetId string?
+
 @description('Storage Account Network Firewall Rules')
 param firewallRules {
   name: string
@@ -87,6 +90,17 @@ module storeAccessKeyToKeyVault './keyVaultSecret.bicep' = {
     secretValue: key
     contentType: 'text/plain'
     secretName: accessKeySecretName
+  }
+}
+
+module privateEndpointModule 'privateEndpoint.bicep' = if (privateEndpointSubnetId != null) {
+  name: '${storageAccountName}PrivateEndpointDeploy'
+  params: {
+    serviceId: storageAccount.id
+    serviceName: storageAccount.name
+    serviceType: 'sites'
+    subnetId: privateEndpointSubnetId!
+    tagValues: tagValues
   }
 }
 

--- a/infrastructure/templates/public-api/components/storageAccount.bicep
+++ b/infrastructure/templates/public-api/components/storageAccount.bicep
@@ -7,9 +7,6 @@ param storageAccountName string
 @description('Storage Account Network Rules')
 param allowedSubnetIds string[] = []
 
-@description('Optional subnet id for allowing inbound traffic over the VNet via a private endpoint')
-param privateEndpointSubnetId string?
-
 @description('Storage Account Network Firewall Rules')
 param firewallRules {
   name: string
@@ -90,17 +87,6 @@ module storeAccessKeyToKeyVault './keyVaultSecret.bicep' = {
     secretValue: key
     contentType: 'text/plain'
     secretName: accessKeySecretName
-  }
-}
-
-module privateEndpointModule 'privateEndpoint.bicep' = if (privateEndpointSubnetId != null) {
-  name: '${storageAccountName}PrivateEndpointDeploy'
-  params: {
-    serviceId: storageAccount.id
-    serviceName: storageAccount.name
-    serviceType: 'sites'
-    subnetId: privateEndpointSubnetId!
-    tagValues: tagValues
   }
 }
 

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -137,7 +137,7 @@ module vNetModule 'application/virtualNetwork.bicep' = {
 module privateDnsZonesModule 'application/privateDnsZones.bicep' = {
   name: 'privateDnsZonesDeploy'
   params: {
-    vnetId: vNetModule.outputs.vnetId
+    vnetName: vNetName
   }
 }
 

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -134,6 +134,13 @@ module vNetModule 'application/virtualNetwork.bicep' = {
   }
 }
 
+module privateDnsZonesModule 'application/privateDnsZones.bicep' = {
+  name: 'privateDnsZonesDeploy'
+  params: {
+    vnetId: vNetModule.outputs.vnetId
+  }
+}
+
 // TODO EES-5128 - add private endpoints to allow VNet traffic to go directly to Storage Account over the VNet.
 // Currently supported by subnet whitelisting and Storage service endpoints being enabled on the whitelisted subnets.
 module publicApiStorageAccountModule 'components/storageAccount.bicep' = {
@@ -221,9 +228,11 @@ module postgreSqlServerModule 'components/postgresqlDatabase.bicep' = if (update
     tagValues: tagValues
     firewallRules: formattedPostgreSqlFirewallRules
     databaseNames: ['public_data']
-    vnetId: vNetModule.outputs.vNetRef
     subnetId: vNetModule.outputs.psqlFlexibleServerSubnetRef
   }
+  dependsOn: [
+    privateDnsZonesModule
+  ]
 }
 
 var psqlManagedIdentityConnectionStringTemplate = 'Server=${psqlServerFullName}.postgres.database.azure.com;Database=[database_name];Port=5432;User Id=[managed_identity_name]'

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -386,6 +386,7 @@ module dataProcessorFunctionAppModule 'components/functionApp.bicep' = {
     location: location
     applicationInsightsKey: applicationInsightsModule.outputs.applicationInsightsKey
     subnetId: vNetModule.outputs.dataProcessorSubnetRef
+    privateEndpointSubnetId: vNetModule.outputs.dataProcessorPrivateEndpointSubnetRef
     publicNetworkAccessEnabled: false
     entraIdAuthentication: {
       appRegistrationClientId: dataProcessorAppRegistrationClientId
@@ -428,6 +429,9 @@ module dataProcessorFunctionAppModule 'components/functionApp.bicep' = {
     storageFirewallRules: storageFirewallRules
     tagValues: tagValues
   }
+  dependsOn: [
+    privateDnsZonesModule
+  ]
 }
 
 // Create an Application Gateway to serve public traffic for the Public API Container App.

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1077,7 +1077,7 @@
     "dataSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('dataSubnetName'))]",
     "publicApiDataProcessorSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-papi-snet-fa-processor')]",
     "publicApiDataProcessorSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('publicApiDataProcessorSubnetName'))]",
-    "publicApiDataProcessorPlinkSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-papi-snet-fa-processor-plink')]",
+    "publicApiDataProcessorPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-papi-snet-fa-processor-pep')]",
     "containerAppEnvironmentSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-cae-01')]",
     "applicationGatewaySubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-agw-01')]",
     "psqlFlexibleServerSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-psql-flexibleserver')]",
@@ -3559,7 +3559,7 @@
             }
           },
           {
-            "name": "[variables('publicApiDataProcessorPlinkSubnetName')]",
+            "name": "[variables('publicApiDataProcessorPrivateEndpointsSubnetName')]",
             "properties": {
               "addressPrefix": "10.0.7.0/24"
             }


### PR DESCRIPTION
This PR:
- creates and maintains a private endpoint to allow inbound traffic to the data processor from the VNet.

This replaces a manually created one that we created when it turned out that simply linking the function app to the VNet via a subnet wasn't enough to allow inbound requests from Admin.

We now have new modules for setting up DNS zones and private endpoints.

This PR also sets up ahead of time a couple of special private DNS zones which are used to resolve IP addresses for private link services of different kinds.  They are specially-named zones as per this guide (and currently only support sites and PostgreSQL in out templates):

https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns

Previously, a lot of Bicep code resided in the `postgresqlDatabase.bicep` file to do with setting up the DB's private endpoint.  This is now extracted as well.