### PR TITLE
EES-5477: Add text to footer/release page to identify DfE as the content's producer

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -188,6 +188,14 @@ const ReleaseContent = ({
                 Sign up for email alerts
               </a>
             }
+            renderProducerLink={
+              <Link
+                unvisited
+                to="https://www.gov.uk/government/organisations/department-for-education"
+              >
+                Department for Education
+              </Link>
+            }
             trackScroll
           />
 

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContent.tsx
@@ -153,6 +153,14 @@ const PrototypeReleaseContent = ({
                 Sign up for email alerts
               </a>
             }
+            renderProducerLink={
+              <Link
+                unvisited
+                to="https://www.gov.uk/government/organisations/department-for-education"
+              >
+                Department for Education
+              </Link>
+            }
           />
 
           <div id="releaseSummary" data-testid="release-summary">

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseSummarySection.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseSummarySection.tsx
@@ -37,6 +37,7 @@ interface Props {
   renderReleaseNotes: ReactNode;
   renderStatusTags: ReactNode;
   renderSubscribeLink: ReactNode;
+  renderProducerLink: ReactNode;
   trackScroll?: boolean;
   onShowReleaseTypeModal?: () => void;
 }
@@ -51,6 +52,7 @@ export default function ReleaseSummarySection({
   renderReleaseNotes,
   renderStatusTags,
   renderSubscribeLink,
+  renderProducerLink,
   trackScroll = false,
   onShowReleaseTypeModal,
 }: Props) {
@@ -117,6 +119,10 @@ export default function ReleaseSummarySection({
 
         <SummaryListItem term="Receive updates">
           {renderSubscribeLink}
+        </SummaryListItem>
+
+        <SummaryListItem term="Produced by">
+          {renderProducerLink}
         </SummaryListItem>
       </SummaryList>
     </div>

--- a/src/explore-education-statistics-frontend/src/components/PageFooter.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageFooter.tsx
@@ -73,6 +73,15 @@ const PageFooter = ({ wide }: Props) => (
             </li>
           </ul>
           <div className="govuk-footer__meta-custom">
+            This service is maintained by the{' '}
+            <Link
+              className="govuk-footer__link"
+              to="https://www.gov.uk/government/organisations/department-for-education"
+            >
+              Department for Education
+            </Link>
+          </div>
+          <div className="govuk-footer__meta-custom">
             Our statistical practice is regulated by the{' '}
             <Link
               className="govuk-footer__link"

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -161,6 +161,14 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                 Sign up for email alerts
               </Link>
             }
+            renderProducerLink={
+              <Link
+                unvisited
+                to="https://www.gov.uk/government/organisations/department-for-education"
+              >
+                Department for Education
+              </Link>
+            }
             onShowReleaseTypeModal={() =>
               logEvent({
                 category: `${release.publication.title} release page`,


### PR DESCRIPTION
Following feedback from the Official Statistics Regulator, we need to make it clear who the producer of platform's content is.

This PR includes two small changes:
1. to identify DfE as the maintainer of the service (in the footer), and
2. to identify the DfE as the content producer on release pages.

These changes help assure users of the quality of the work, and identify who to direct queries to if the need arises.