### PR TITLE
EES-XXXX - Robot test improvements

### DIFF
--- a/tests/robot-tests/tests/libs/public-common.robot
+++ b/tests/robot-tests/tests/libs/public-common.robot
@@ -21,6 +21,12 @@ user checks release update
 user checks publication is on find statistics page
     [Arguments]    ${publication_name}
     user navigates to public find statistics page
+    user clicks element    id:searchForm-search
+    user presses keys    ${publication_name}
+    user clicks button    Search
+    user waits until page finishes loading
+    user clicks radio    Relevance
+    user waits until page finishes loading
     user waits until page contains link    ${publication_name}
 
 user waits until details dropdown contains publication

--- a/tests/robot-tests/tests/public_api/public_api_dataset_cancel_and_removal.robot
+++ b/tests/robot-tests/tests/public_api/public_api_dataset_cancel_and_removal.robot
@@ -9,6 +9,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 
 

--- a/tests/robot-tests/tests/public_api/public_api_dataset_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_dataset_preview_token.robot
@@ -9,6 +9,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 
 

--- a/tests/robot-tests/tests/public_api/public_api_restricted.robot
+++ b/tests/robot-tests/tests/public_api/public_api_restricted.robot
@@ -9,6 +9,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 
 


### PR DESCRIPTION
This PR:
- adds fail-fast behaviour to all Public API test suites
- adds more resilience to the Publication search on the Find Statistics page, so that we are guaranteed to find the correct Publication even if we end up with paginated results (due to lots of data piling up from multiple test runs with `--disable-teardown` enabled

Prior to this, the Publication search would not guarantee to bring up the correct Publication to the top of the search list if we did multiple runs while disabling teardown.  By adding "Relevance" to the search results, it'll then search by the closest matching name to the Publication title we're looking for.   