### PR TITLE
Ees xxxx robot test improvements 2

### DIFF
--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -594,7 +594,6 @@ user waits until data upload displays importing
     user chooses file    id:dataFileUploadForm-metadataFile    ${FOLDER}${META_FILE}
     user clicks button    Upload data files
     user waits until page finishes loading
-    user waits for caches to expire
     user waits until h2 is visible    Uploaded data files    %{WAIT_LONG}
     user waits until page contains accordion section    ${SUBJECT_NAME}    %{WAIT_SMALL}
     user opens accordion section    ${SUBJECT_NAME}


### PR DESCRIPTION
This PR:
- removes an (I think) unnecessary cache expiry wait whilst looking for a file to enter "Importing" status.

Cache expiries don't affect this code so I don't believe it should be here.  In addition it was causing Robot tests (`release_status.robot`) to fail, as on my local machine the file finished "Importing" before the sleep finished, and so the test got stuck on this step. 