### PR TITLE
EES-5382 hotfix remove devops spn from key vault role assignment

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -3840,8 +3840,8 @@
               ]
             }
           }
-        ]
-        // "enableRbacAuthorization": true
+        ],
+        "enableRbacAuthorization": true
       },
       "resources": [
         {
@@ -3905,17 +3905,6 @@
       "properties": {
         "roleDefinitionId": "[variables('keyVaultSecretsUserRoleDefinitionId')]",
         "principalId": "[reference(variables('keyVaultSecretsUserPrincipalRefs')[copyIndex()], '2022-09-01', 'Full').identity.principalId]",
-        "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
-        "principalType": "ServicePrincipal"
-      }
-    },
-    {
-      "type": "Microsoft.KeyVault/vaults/providers/roleAssignments",
-      "apiVersion": "2022-04-01",
-      "name": "[concat(variables('keyVaultName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.KeyVault/vaults',  variables('keyVaultName')), variables('keyVaultSecretsUserRoleDefinitionId'), parameters('devopsSPN')))]",
-      "properties": {
-        "roleDefinitionId": "[variables('keyVaultSecretsUserRoleDefinitionId')]",
-        "principalId": "[parameters('devopsSPN')]",
         "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
         "principalType": "ServicePrincipal"
       }


### PR DESCRIPTION
This PR:
- removes the Key Vault Secrets User assignment from the DevOps SPN deploy user, as they must have this role at least prior to being able to start a successful inf deploy.

It would not necessarily have been a problem to keep it if the role assignments our code produces resulted in the same GUID-based name for the assignment that manual assignment produced, but they don't and as a result it would otherwise cause a "RoleASssignmentAlreadyExists" error.