### PR TITLE
Ees 5382 hotfix remove devops spn from key vault role assignment disable rbac switch

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -3840,8 +3840,8 @@
               ]
             }
           }
-        ],
-        "enableRbacAuthorization": true
+        ]//,
+        //"enableRbacAuthorization": true
       },
       "resources": [
         {


### PR DESCRIPTION
This PR:
- reverts the change to KV permission model until it has been manually switched