### PR TITLE
EES-4489: Add endpoint to remove all themes created by UI tests

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
@@ -1,16 +1,17 @@
-using System;
-using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.Extensions.Configuration;
 using Moq;
+using System;
+using System.Threading.Tasks;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.PermissionTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
@@ -19,7 +20,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
     public class ThemeServicePermissionTests
     {
-        private readonly Theme _theme = new Theme
+        private readonly Theme _theme = new()
         {
             Id = Guid.NewGuid()
         };
@@ -224,14 +225,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 );
         }
 
-        private static Mock<IConfiguration> DefaultConfigurationMock()
+        [Fact]
+        public async Task DeleteUITestThemes()
         {
-            var mock = new Mock<IConfiguration>(MockBehavior.Strict);
-            mock
-                .Setup(x => x.GetSection(It.IsAny<String>()))
-                .Returns(new Mock<IConfigurationSection>().Object);
-            return mock;
+            await PolicyCheckBuilder()
+                .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
+                .AssertForbidden(
+                    async userService =>
+                    {
+                        var service = SetupThemeService(userService: userService.Object);
+
+                        return await service.DeleteUITestThemes();
+                    }
+                );
         }
+
+        private static Mock<IConfiguration> DefaultConfigurationMock()
+            => CreateMockConfiguration(CollectionUtils.TupleOf("enableThemeDeletion", "true"));
 
         private ThemeService SetupThemeService(
             ContentDbContext context = null,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -1,8 +1,4 @@
 #nullable enable
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
@@ -13,10 +9,14 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.EntityFrameworkCore;
 using Moq;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
@@ -180,8 +180,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Title = "Test theme",
                 Slug = "test-theme",
                 Summary = "Test summary",
-                Topics = new List<Topic>
-                {
+                Topics =
+                [
                     new()
                     {
                         Title = "Test topic 1",
@@ -192,7 +192,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Title = "Test topic 2",
                         Slug = "test-topic-2",
                     }
-                }
+                ]
             };
 
             // This topic should not be included with
@@ -223,11 +223,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test theme", viewModel.Title);
                 Assert.Equal("test-theme", viewModel.Slug);
                 Assert.Equal("Test summary", viewModel.Summary);
-                
+
                 Assert.Equal(2, theme.Topics.Count);
                 Assert.Equal("Test topic 1", theme.Topics[0].Title);
                 Assert.Equal("test-topic-1", theme.Topics[0].Slug);
-                
+
                 Assert.Equal("Test topic 2", theme.Topics[1].Title);
                 Assert.Equal("test-topic-2", theme.Topics[1].Slug);
             }
@@ -242,24 +242,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "Theme A",
                 Summary = "Test summary",
-                Topics = new List<Topic>
-                {
-                    new Topic
-                    {
+                Topics =
+                [
+                    new() {
                         Slug = "topic-b",
                         Title = "Topic B"
                     },
-                    new Topic
-                    {
+                    new() {
                         Slug = "topic-c",
                         Title = "Topic C"
                     },
-                    new Topic
-                    {
+                    new() {
                         Slug = "topic-a",
                         Title = "Topic A"
                     },
-                }
+                ]
             };
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -302,16 +299,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var theme = new Theme
             {
                 Title = "UI test theme",
-                Topics = AsList(new Topic
-                {
-                    Id = Guid.NewGuid(),
-                    Title = "UI test topic 1"
-                },
-                new Topic
-                {
-                    Id = Guid.NewGuid(),
-                    Title = "UI test topic 2"
-                })
+                Topics =
+                [
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Title = "UI test topic 1"
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Title = "UI test topic 2"
+                    }
+                ]
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -321,8 +321,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 context.Add(theme);
                 await context.SaveChangesAsync();
 
-                Assert.Equal(1, context.Themes.Count());
-                Assert.Equal(2, context.Topics.Count());
+                Assert.Equal(1, await context.Themes.CountAsync());
+                Assert.Equal(2, await context.Topics.CountAsync());
             }
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -342,7 +342,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 VerifyAllMocks(topicService);
 
                 result.AssertRight();
-                Assert.Equal(0, context.Themes.Count());
+                Assert.Equal(0, await context.Themes.CountAsync());
             }
         }
 
@@ -352,14 +352,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var theme = new Theme
             {
                 Title = "Non-conforming title",
-                Topics = AsList(new Topic
-                {
-                    Title = "UI test topic 1"
-                },
-                new Topic
-                {
-                    Title = "UI test topic 2"
-                })
+                Topics =
+                [
+                    new() { Title = "UI test topic 1" },
+                    new() { Title = "UI test topic 2" }
+                ]
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -379,7 +376,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 VerifyAllMocks(topicService);
                 result.AssertForbidden();
 
-                Assert.Equal(1, context.Themes.Count());
+                Assert.Equal(1, await context.Themes.CountAsync());
             }
         }
 
@@ -389,14 +386,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var theme = new Theme
             {
                 Title = "UI test theme",
-                Topics = AsList(new Topic
-                {
-                    Title = "UI test topic 1"
-                },
-                new Topic
-                {
-                    Title = "UI test topic 2"
-                })
+                Topics =
+                [
+                    new() { Title = "UI test topic 1" },
+                    new() { Title = "UI test topic 2" }
+                ]
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -420,7 +414,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 VerifyAllMocks(topicService);
                 result.AssertForbidden();
 
-                Assert.Equal(1, context.Themes.Count());
+                Assert.Equal(1, await context.Themes.CountAsync());
             }
         }
 
@@ -430,31 +424,37 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var theme = new Theme
             {
                 Title = "UI test theme",
-                Topics = AsList(new Topic
+                Topics =
+                [
+                    new()
                     {
                         Id = Guid.NewGuid(),
                         Title = "UI test topic 1"
                     },
-                    new Topic
+                    new()
                     {
                         Id = Guid.NewGuid(),
                         Title = "UI test topic 2"
-                    })
+                    }
+                ]
             };
 
             var otherTheme = new Theme
             {
                 Title = "UI test theme",
-                Topics = AsList(new Topic
+                Topics =
+                [
+                    new()
                     {
                         Id = Guid.NewGuid(),
                         Title = "UI test topic 1"
                     },
-                    new Topic
+                    new()
                     {
                         Id = Guid.NewGuid(),
                         Title = "UI test topic 2"
-                    })
+                    }
+                ]
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -464,8 +464,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.AddRangeAsync(theme, otherTheme);
                 await context.SaveChangesAsync();
 
-                Assert.Equal(2, context.Themes.Count());
-                Assert.Equal(4, context.Topics.Count());
+                Assert.Equal(2, await context.Themes.CountAsync());
+                Assert.Equal(4, await context.Topics.CountAsync());
             }
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -485,7 +485,109 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 VerifyAllMocks(topicService);
 
                 result.AssertRight();
-                Assert.Equal(otherTheme.Id, context.Themes.AsQueryable().Select(t => t.Id).Single());
+                Assert.Equal(otherTheme.Id, await context.Themes.AsQueryable().Select(t => t.Id).SingleAsync());
+            }
+        }
+
+        [Fact]
+        public async Task DeleteUITestThemes()
+        {
+            // Arrange
+            var uiTestTheme1Id = Guid.NewGuid();
+            var standardTitleThemeId = Guid.NewGuid();
+
+            var uiTestThemeTopic = new Topic
+            {
+                ThemeId = uiTestTheme1Id,
+                Title = "UI test theme topic",
+            };
+
+            var standardTitleThemeTopic = new Topic
+            {
+                ThemeId = standardTitleThemeId,
+                Title = "Standard title theme topic",
+            };
+
+            var uiTestTheme = new Theme
+            {
+                Id = uiTestTheme1Id,
+                Title = "UI test theme",
+                Topics = [uiTestThemeTopic]
+            };
+
+            var standardTitleTheme = new Theme
+            {
+                Id = standardTitleThemeId,
+                Title = "Standard title",
+                Topics = [standardTitleThemeTopic]
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+            {
+                await context.AddRangeAsync(uiTestTheme, standardTitleTheme);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var topicService = new Mock<ITopicService>(Strict);
+
+                topicService
+                    .Setup(s => s.DeleteTopic(uiTestTheme.Topics[0].Id))
+                    .ReturnsAsync(Unit.Instance);
+
+                var service = SetupThemeService(context, topicService: topicService.Object);
+
+                // Act
+                await service.DeleteUITestThemes();
+
+                // Assert
+                var themesResult = await context.Themes.ToListAsync();
+                var topicsResult = await context.Topics.ToListAsync();
+
+                Assert.Single(themesResult);
+                Assert.Single(topicsResult);
+                Assert.DoesNotContain(themesResult, theme => theme.Title is "UI test theme");
+            }
+        }
+
+        [Fact]
+        public async Task DeleteUITestThemes_DisallowedByConfiguration()
+        {
+            var theme = new Theme
+            {
+                Title = "UI test theme",
+                Topics =
+                [
+                    new() { Title = "UI test topic 1" },
+                    new() { Title = "UI test topic 2" }
+                ]
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                context.Add(theme);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var topicService = new Mock<ITopicService>(Strict);
+
+                var service = SetupThemeService(
+                    context,
+                    topicService: topicService.Object,
+                    enableThemeDeletion: false);
+
+                var result = await service.DeleteUITestThemes();
+                VerifyAllMocks(topicService);
+                result.AssertForbidden();
+
+                Assert.Equal(1, await context.Themes.CountAsync());
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ThemeController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ThemeController.cs
@@ -1,32 +1,25 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
 {
-    // TODO rename to Themes once the current Crud theme controller is removed
     [Route("api")]
     [Authorize]
     [ApiController]
-    public class ThemeController : ControllerBase
+    public class ThemeController(IThemeService themeService) : ControllerBase
     {
-        private readonly IThemeService _themeService;
-
-        public ThemeController(IThemeService themeService)
-        {
-            _themeService = themeService;
-        }
-
         [HttpPost("themes")]
         public async Task<ActionResult<ThemeViewModel>> CreateTheme(ThemeSaveViewModel theme)
         {
-            return await _themeService
+            return await themeService
                 .CreateTheme(theme)
                 .HandleFailuresOrOk();
         }
@@ -36,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             [Required] Guid themeId,
             ThemeSaveViewModel theme)
         {
-            return await _themeService
+            return await themeService
                 .UpdateTheme(themeId, theme)
                 .HandleFailuresOrOk();
         }
@@ -45,7 +38,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [HttpGet("themes/{themeId:guid}")]
         public async Task<ActionResult<ThemeViewModel>> GetTheme([Required] Guid themeId)
         {
-            return await _themeService
+            return await themeService
                 .GetTheme(themeId)
                 .HandleFailuresOrOk();
         }
@@ -53,7 +46,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [HttpGet("themes")]
         public async Task<ActionResult<List<ThemeViewModel>>> GetThemes()
         {
-            return await _themeService
+            return await themeService
                 .GetThemes()
                 .HandleFailuresOrOk();
         }
@@ -61,8 +54,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [HttpDelete("themes/{themeId:guid}")]
         public async Task<ActionResult> DeleteTheme([Required] Guid themeId)
         {
-            return await _themeService
+            return await themeService
                 .DeleteTheme(themeId)
+                .HandleFailuresOrNoContent();
+        }
+
+        [HttpDelete("themes")]
+        public async Task<ActionResult> DeleteUITestThemes(CancellationToken cancellationToken)
+        {
+            return await themeService
+                .DeleteUITestThemes(cancellationToken)
                 .HandleFailuresOrNoContent();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IThemeService.cs
@@ -1,9 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
@@ -18,5 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, List<ThemeViewModel>>> GetThemes();
 
         Task<Either<ActionResult, Unit>> DeleteTheme(Guid themeId);
+
+        Task<Either<ActionResult, Unit>> DeleteUITestThemes(CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
Robot UI tests generate themes and topics as part of their process, which are then removed during the teardown phase. This phase uses an existing endpoint which accepts an ID to target the removal of an individual resource.

UI test execution occasionally fails, or is cancelled prematurely, meaning that the teardown phase isn't triggered. This results in test resources remaining in the system and causing bloat.

This PR adds an endpoint which removes all themes and associated topics created during UI tests in one go, using the same logic to identify tests as is used for individual removal. The intended use for this endpoint is as part of a manual clean-up process when a notification is received regarding test execution failure, or eventually implemented into an automated process.

_The PR also includes a few minor recommended code style amendments._