### PR TITLE
EES-5506 fix data-catalogue footnotes rendering html as plain text

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileFootnotes.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileFootnotes.tsx
@@ -1,3 +1,4 @@
+import ContentHtml from '@common/components/ContentHtml';
 import DataSetFilePageSection from '@frontend/modules/data-catalogue/components/DataSetFilePageSection';
 import { pageSections } from '@frontend/modules/data-catalogue/DataSetFilePage';
 import { DataSetFootnote } from '@frontend/services/dataSetFileService';
@@ -14,7 +15,9 @@ export default function DataSetFileFootnotes({ footnotes }: Props) {
     <DataSetFilePageSection heading={pageSections[sectionId]} id={sectionId}>
       <ol>
         {footnotes.map(footnote => (
-          <li key={footnote.id}>{footnote.label}</li>
+          <li key={footnote.id}>
+            <ContentHtml html={footnote.label} />
+          </li>
         ))}
       </ol>
     </DataSetFilePageSection>


### PR DESCRIPTION
Fixes Footnotes rendering html as plain text in data catalogue pages.  
Implementation now follows suit with  other footnote rendering using `<ContentHtml / >` to render footnote labels