### PR TITLE
🐛 EES-5505 Allow modifying data in Public API `__EFMigrationsHistory` database table

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240902104511_InitialMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240902104511_InitialMigration.cs
@@ -33,11 +33,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migration
                 // is set. This also applies to running integration tests which identify as a Production environment
                 // if the enviroment is not set. Integration tests connect as the Postgres superuser without running
                 // the Docker script.
+
+                // A separate grant is needed for the __EFMigrationsHistory table, as it was created prior to this migration.
                 migrationBuilder.Sql(
                     $"""
                      DO $$
                      BEGIN
                          IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{PublicDataDbContext.PublicDataReadWriteRole}') THEN
+                             GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON "__EFMigrationsHistory" TO {PublicDataDbContext.PublicDataReadWriteRole};
                              ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON TABLES TO {PublicDataDbContext.PublicDataReadWriteRole};
                              ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, UPDATE ON SEQUENCES TO {PublicDataDbContext.PublicDataReadWriteRole};
                          END IF;


### PR DESCRIPTION
This PR is (another) bugfix for https://github.com/dfe-analytical-services/explore-education-statistics/pull/5044.

While testing the `public_data_read_write` role added by EES-5329 I found that we can't insert/update/delete data in the Public API `__EFMigrationsHistory` database table.

The `InitialMigration` has grants at the beginning which affect all tables created subsequently by that migration and further migrations, i.e. all of our tables, allowing us to modify data. However these grants don't cover existing tables. The `__EFMigrationsHistory` table is created prior to the `InitialMigration` being run.

This PR adds an explicit grant in `InitialMigration` for the `__EFMigrationsHistory` table.

# Testing

I was able to test this locally with the following steps to force the migration to run:

1. Stop the public-api-db and Public API docker service if they are already running.
2. Remove the public data docker database volume.
3. Delete the `data/01-public_data.sql` entrypoint script to stop the schema and test data being bootstrapped at the next startup.
4. Alter the `data/00-init.sh` entrypoint script to stop privileges being granted in the local environment prior to the Public API starting up for the first time (we will grant them using the code in `InitialMigration` as it would do in non-local environments by  forcing it to run in the next step). Remove lines: https://github.com/dfe-analytical-services/explore-education-statistics/blob/f63a362cb3bb2e8dcd07cda527a3e5cbce46477a/data/public-api-db/00-init.sh#L32-L33
5. Force the migration to run in the local environment by commenting out the line https://github.com/dfe-analytical-services/explore-education-statistics/blob/f63a362cb3bb2e8dcd07cda527a3e5cbce46477a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20240902104511_InitialMigration.cs#L19
6. Start the Public API which in turn starts the database and runs the `InitialMigration`.


I created a database user `test_user` with the `public_data_read_write` role for the testing:
```bash
psql -U postgres -d public_data <<-EOSQL
CREATE ROLE test_user WITH LOGIN PASSWORD 'password';
GRANT USAGE ON SCHEMA public TO test_user;
GRANT public_data_read_write TO test_user;
EOSQL
```

Before and after this change I ran the following to test inserting/updating/deleting:

```bash
psql -U test_user -d public_data <<-EOSQL
INSERT INTO public."__EFMigrationsHistory" ("MigrationId", "ProductVersion") VALUES ('1', '1');
UPDATE public."__EFMigrationsHistory" SET "ProductVersion" = '1-Updated' WHERE "MigrationId" = '1';
DELETE FROM public."__EFMigrationsHistory" WHERE "ProductVersion" = '1-Updated';
EOSQL
```

## 🔴Before

```
$ psql -U test_user -d public_data <<-EOSQL
    INSERT INTO public."__EFMigrationsHistory" ("MigrationId", "ProductVersion") VALUES ('1', '1');
    UPDATE public."__EFMigrationsHistory" SET "ProductVersion" = '1-Updated' WHERE "MigrationId" = '1';
    DELETE FROM public."__EFMigrationsHistory" WHERE "ProductVersion" = '1-Updated';
EOSQL
Password for user test_user:

ERROR:  permission denied for table __EFMigrationsHistory
ERROR:  permission denied for table __EFMigrationsHistory
ERROR:  permission denied for table __EFMigrationsHistory
```

## 🟢After

```
$ psql -U test_user -d public_data <<-EOSQL
    INSERT INTO public."__EFMigrationsHistory" ("MigrationId", "ProductVersion") VALUES ('1', '1');
    UPDATE public."__EFMigrationsHistory" SET "ProductVersion" = '1-Updated' WHERE "MigrationId" = '1';
    DELETE FROM public."__EFMigrationsHistory" WHERE "ProductVersion" = '1-Updated';
EOSQL
Password for user test_user:

INSERT 0 1
UPDATE 1
DELETE 1
```