### PR TITLE
Ees 5479 modularise bicep to test env

### DIFF
--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -99,7 +99,7 @@
       "value": true
     },
     "publicDataDbExists": {
-      "value": false
+      "value": true
     }
   }
 }

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -23,7 +23,7 @@ variables:
   - name: isDev
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
   - name: isTest
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/test')]
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/EES-5479-modularise-bicep-to-test-env')]
   - name: isMaster
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   - name: vmImageName
@@ -53,23 +53,23 @@ pool:
   vmImage: $(vmImageName)
 
 stages:
-- template: validate-stage-template.yml
-  parameters:
-    stageName: 'Validate_Against_Development'
-    condition: eq(variables.isDev, true)
-    environment: 'Development'
-    serviceConnection: $(serviceConnectionDevelopment)
-    parameterFile: $(devParamFile)
+# - template: validate-stage-template.yml
+#   parameters:
+#     stageName: 'Validate_Against_Development'
+#     condition: eq(variables.isDev, true)
+#     environment: 'Development'
+#     serviceConnection: $(serviceConnectionDevelopment)
+#     parameterFile: $(devParamFile)
 
-- template: deploy-stage-template.yml
-  parameters:
-    stageName: 'Deploy_to_Development'
-    condition: and(succeeded(), eq(variables.isDev, true))
-    dependsOn: 'Validate_Against_Development'
-    environment: 'Development'
-    serviceConnection: $(serviceConnectionDevelopment)
-    subscription: $(subscription)
-    parameterFile: $(devParamFile)
+# - template: deploy-stage-template.yml
+#   parameters:
+#     stageName: 'Deploy_to_Development'
+#     condition: and(succeeded(), eq(variables.isDev, true))
+#     dependsOn: 'Validate_Against_Development'
+#     environment: 'Development'
+#     serviceConnection: $(serviceConnectionDevelopment)
+#     subscription: $(subscription)
+#     parameterFile: $(devParamFile)
 
 - template: validate-stage-template.yml
   parameters:

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -4,9 +4,6 @@ parameters:
   - name: deployContainerApp
     displayName: Can we deploy the Container App yet? This is dependent on the PostgreSQL Flexible Server being set up and having users manually added.
     default: true
-  - name: updatePsqlFlexibleServer
-    displayName: Does the PostgreSQL Flexible Server require any updates? False by default to avoid unnecessarily lengthy deploys.
-    default: false
 
 resources:
   pipelines:
@@ -46,8 +43,6 @@ variables:
     value: $(resources.pipeline.EESBuildPipeline.runName)
   - name: deployContainerApp
     value: ${{parameters.deployContainerApp}}
-  - name: updatePsqlFlexibleServer
-    value: ${{parameters.updatePsqlFlexibleServer}}
 
 pool:
   vmImage: $(vmImageName)

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -53,23 +53,23 @@ pool:
   vmImage: $(vmImageName)
 
 stages:
-  # - template: validate-stage-template.yml
-  #   parameters:
-  #     stageName: 'Validate_Against_Development'
-  #     condition: eq(variables.isDev, true)
-  #     environment: 'Development'
-  #     serviceConnection: $(serviceConnectionDevelopment)
-  #     parameterFile: $(devParamFile)
+  - template: validate-stage-template.yml
+    parameters:
+      stageName: 'Validate_Against_Development'
+      condition: eq(variables.isDev, true)
+      environment: 'Development'
+      serviceConnection: $(serviceConnectionDevelopment)
+      parameterFile: $(devParamFile)
   
-  # - template: deploy-stage-template.yml
-  #   parameters:
-  #     stageName: 'Deploy_to_Development'
-  #     condition: and(succeeded(), eq(variables.isDev, true))
-  #     dependsOn: 'Validate_Against_Development'
-  #     environment: 'Development'
-  #     serviceConnection: $(serviceConnectionDevelopment)
-  #     subscription: $(subscription)
-  #     parameterFile: $(devParamFile)
+  - template: deploy-stage-template.yml
+    parameters:
+      stageName: 'Deploy_to_Development'
+      condition: and(not(or(failed(), canceled())), eq(variables.isDev, true))
+      dependsOn: 'Validate_Against_Development'
+      environment: 'Development'
+      serviceConnection: $(serviceConnectionDevelopment)
+      subscription: $(subscription)
+      parameterFile: $(devParamFile)
 
   - template: validate-stage-template.yml
     parameters:
@@ -83,7 +83,7 @@ stages:
     parameters:
       stageName: 'Deploy_to_Test'
       dependsOn: 'Validate_Against_Test'
-      condition: and(succeeded(), eq(variables.isTest, true))
+      condition: and(not(or(failed(), canceled())), eq(variables.isTest, true))
       environment: 'Test'
       serviceConnection: $(serviceConnectionTest)
       subscription: $(subscription)
@@ -100,7 +100,7 @@ stages:
 #  - template: deploy-stage-template.yml
 #    parameters:
 #      stageName: 'Deploy_to_PreProduction'
-#      condition: and(succeeded(), eq(variables.isMaster, true))
+#      condition: and(not(or(failed('Validate_Against_PreProduction'), canceled('Validate_Against_PreProduction')), eq(variables.isMaster, true))
 #      dependsOn: 'Validate_Against_PreProduction'
 #      environment: 'Pre-production'
 #      serviceConnection: $(serviceConnectionPreProduction)
@@ -110,7 +110,7 @@ stages:
 #  - template: validate-stage-template.yml
 #    parameters:
 #      stageName: 'Validate_Against_Production'
-#      condition: and(succeeded(), eq(variables.isMaster, true))
+#      condition: and(not(or(failed('Deploy_to_PreProduction'), canceled('Deploy_to_PreProduction')), eq(variables.isMaster, true))
 #      environment: 'Production'
 #      serviceConnection: $(serviceConnectionProduction)
 #      parameterFile: $(prodParamFile)
@@ -118,7 +118,7 @@ stages:
 #  - template: deploy-stage-template.yml
 #    parameters:
 #      stageName: 'Deploy_to_Production'
-#      condition: and(succeeded(), eq(variables.isMaster, true))
+#      condition: and(not(or(failed('Validate_Against_Production'), canceled('Validate_Against_Production')), eq(variables.isMaster, true))
 #      dependsOn: 'Validate_Against_Production'
 #      environment: 'Production'
 #      serviceConnection: $(serviceConnectionProduction)

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -4,6 +4,9 @@ parameters:
   - name: deployContainerApp
     displayName: Can we deploy the Container App yet? This is dependent on the PostgreSQL Flexible Server being set up and having users manually added.
     default: true
+  - name: updatePsqlFlexibleServer
+    displayName: Does the PostgreSQL Flexible Server require any updates? False by default to avoid unnecessarily lengthy deploys.
+    default: false
 
 resources:
   pipelines:
@@ -43,46 +46,48 @@ variables:
     value: $(resources.pipeline.EESBuildPipeline.runName)
   - name: deployContainerApp
     value: ${{parameters.deployContainerApp}}
+  - name: updatePsqlFlexibleServer
+    value: ${{parameters.updatePsqlFlexibleServer}}
 
 pool:
   vmImage: $(vmImageName)
 
 stages:
-# - template: validate-stage-template.yml
-#   parameters:
-#     stageName: 'Validate_Against_Development'
-#     condition: eq(variables.isDev, true)
-#     environment: 'Development'
-#     serviceConnection: $(serviceConnectionDevelopment)
-#     parameterFile: $(devParamFile)
+  # - template: validate-stage-template.yml
+  #   parameters:
+  #     stageName: 'Validate_Against_Development'
+  #     condition: eq(variables.isDev, true)
+  #     environment: 'Development'
+  #     serviceConnection: $(serviceConnectionDevelopment)
+  #     parameterFile: $(devParamFile)
+  
+  # - template: deploy-stage-template.yml
+  #   parameters:
+  #     stageName: 'Deploy_to_Development'
+  #     condition: and(succeeded(), eq(variables.isDev, true))
+  #     dependsOn: 'Validate_Against_Development'
+  #     environment: 'Development'
+  #     serviceConnection: $(serviceConnectionDevelopment)
+  #     subscription: $(subscription)
+  #     parameterFile: $(devParamFile)
 
-# - template: deploy-stage-template.yml
-#   parameters:
-#     stageName: 'Deploy_to_Development'
-#     condition: and(succeeded(), eq(variables.isDev, true))
-#     dependsOn: 'Validate_Against_Development'
-#     environment: 'Development'
-#     serviceConnection: $(serviceConnectionDevelopment)
-#     subscription: $(subscription)
-#     parameterFile: $(devParamFile)
+  - template: validate-stage-template.yml
+    parameters:
+      stageName: 'Validate_Against_Test'
+      condition: eq(variables.isTest, true)
+      environment: 'Test'
+      serviceConnection: $(serviceConnectionTest)
+      parameterFile: $(testParamFile)
 
-- template: validate-stage-template.yml
-  parameters:
-    stageName: 'Validate_Against_Test'
-    condition: eq(variables.isTest, true)
-    environment: 'Test'
-    serviceConnection: $(serviceConnectionTest)
-    parameterFile: $(testParamFile)
-
-- template: deploy-stage-template.yml
-  parameters:
-    stageName: 'Deploy_to_Test'
-    dependsOn: 'Validate_Against_Test'
-    condition: and(succeeded(), eq(variables.isTest, true))
-    environment: 'Test'
-    serviceConnection: $(serviceConnectionTest)
-    subscription: $(subscription)
-    parameterFile: $(testParamFile)
+  - template: deploy-stage-template.yml
+    parameters:
+      stageName: 'Deploy_to_Test'
+      dependsOn: 'Validate_Against_Test'
+      condition: and(succeeded(), eq(variables.isTest, true))
+      environment: 'Test'
+      serviceConnection: $(serviceConnectionTest)
+      subscription: $(subscription)
+      parameterFile: $(testParamFile)
 
 #  - template: validate-stage-template.yml
 #    parameters:

--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -23,7 +23,7 @@ variables:
   - name: isDev
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
   - name: isTest
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/EES-5479-modularise-bicep-to-test-env')]
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/test')]
   - name: isMaster
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   - name: vmImageName

--- a/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
@@ -53,9 +53,9 @@ module apiContainerAppModule '../../components/containerApp.bicep' = {
     containerAppName: resourceNames.publicApi.apiApp
     acrLoginServer: keyVault.getSecret('DOCKER-REGISTRY-SERVER-DOMAIN')
     containerAppImageName: 'ees-public-api/api:${dockerImagesTag}'
-    userAssignedManagedIdentityId: apiContainerAppManagedIdentity.id
     dockerPullManagedIdentityClientId: keyVault.getSecret('DOCKER-REGISTRY-SERVER-USERNAME')
     dockerPullManagedIdentitySecretValue: keyVault.getSecret('DOCKER-REGISTRY-SERVER-PASSWORD')
+    userAssignedManagedIdentityId: apiContainerAppManagedIdentity.id
     managedEnvironmentId: containerAppEnvironmentId
     corsPolicy: {
       allowedOrigins: [

--- a/infrastructure/templates/public-api/application/public-api/publicApiAppIdentity.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiAppIdentity.bicep
@@ -15,12 +15,13 @@ resource apiContainerAppManagedIdentity 'Microsoft.ManagedIdentity/userAssignedI
   tags: tagValues
 }
 
-module apiContainerAppAcrPullRoleAssignmentModule '../../components/containerRegistryRoleAssignment.bicep' = {
-  name: '${resourceNames.publicApi.apiAppIdentity}AcrPullRoleAssignmentDeploy'
-  scope: resourceGroup(resourceNames.existingResources.acrResourceGroup)
-  params: {
-    role: 'AcrPull'
-    containerRegistryName: resourceNames.existingResources.acr
-    principalIds: [apiContainerAppManagedIdentity.properties.principalId]
-  }
-}
+// TODO - commenting out for now, as 
+// module apiContainerAppAcrPullRoleAssignmentModule '../../components/containerRegistryRoleAssignment.bicep' = {
+//   name: '${resourceNames.publicApi.apiAppIdentity}AcrPullRoleAssignmentDeploy'
+//   scope: resourceGroup(resourceNames.existingResources.acrResourceGroup)
+//   params: {
+//     role: 'AcrPull'
+//     containerRegistryName: resourceNames.existingResources.acr
+//     principalIds: [apiContainerAppManagedIdentity.properties.principalId]
+//   }
+// }

--- a/infrastructure/templates/public-api/application/public-api/publicApiAppIdentity.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiAppIdentity.bicep
@@ -15,7 +15,9 @@ resource apiContainerAppManagedIdentity 'Microsoft.ManagedIdentity/userAssignedI
   tags: tagValues
 }
 
-// TODO - commenting out for now, as 
+// TODO - commenting out for now, as we can't apply roles to Container Registries in other Resource Groups.
+// When we have a shared Resource Group for our ACR with special privileges, we can start to use the Container App
+// Identity again to pull Docker images, but for now we continue to use our shared SPN.
 // module apiContainerAppAcrPullRoleAssignmentModule '../../components/containerRegistryRoleAssignment.bicep' = {
 //   name: '${resourceNames.publicApi.apiAppIdentity}AcrPullRoleAssignmentDeploy'
 //   scope: resourceGroup(resourceNames.existingResources.acrResourceGroup)

--- a/infrastructure/templates/public-api/application/public-api/publicApiAppIdentity.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiAppIdentity.bicep
@@ -1,0 +1,26 @@
+import { resourceNamesType } from '../../types.bicep'
+
+@description('Specifies common resource naming variables.')
+param resourceNames resourceNamesType
+
+@description('Specifies the location for all resources.')
+param location string
+
+@description('Specifies a set of tags with which to tag the resource in Azure.')
+param tagValues object
+
+resource apiContainerAppManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: resourceNames.publicApi.apiAppIdentity
+  location: location
+  tags: tagValues
+}
+
+module apiContainerAppAcrPullRoleAssignmentModule '../../components/containerRegistryRoleAssignment.bicep' = {
+  name: '${resourceNames.publicApi.apiAppIdentity}AcrPullRoleAssignmentDeploy'
+  scope: resourceGroup(resourceNames.existingResources.acrResourceGroup)
+  params: {
+    role: 'AcrPull'
+    containerRegistryName: resourceNames.existingResources.acr
+    principalIds: [apiContainerAppManagedIdentity.properties.principalId]
+  }
+}

--- a/infrastructure/templates/public-api/application/shared/appGateway.bicep
+++ b/infrastructure/templates/public-api/application/shared/appGateway.bicep
@@ -28,15 +28,10 @@ module appGatewayModule '../../components/appGateway.bicep' = {
     appGatewayName: resourceNames.sharedResources.appGateway
     managedIdentityName: resourceNames.sharedResources.appGatewayIdentity
     keyVaultName: resourceNames.existingResources.keyVault
+    vnetName: resourceNames.existingResources.vNet
     subnetId: subnet.id
     sites: [
-      {
-        resourceName: publicApiContainerAppSettings.resourceName
-        backendFqdn: publicApiContainerAppSettings.backendFqdn
-        publicFqdn: publicApiContainerAppSettings.publicFqdn
-        certificateName: publicApiContainerAppSettings.certificateName
-        healthProbeRelativeUrl: publicApiContainerAppSettings.healthProbeRelativeUrl
-      }
+      publicApiContainerAppSettings
     ]
     tagValues: tagValues
   }

--- a/infrastructure/templates/public-api/application/shared/containerAppEnvironment.bicep
+++ b/infrastructure/templates/public-api/application/shared/containerAppEnvironment.bicep
@@ -47,3 +47,4 @@ module containerAppEnvironmentModule '../../components/containerAppEnvironment.b
 }
 
 output containerAppEnvironmentId string = containerAppEnvironmentModule.outputs.containerAppEnvironmentId
+output containerAppEnvironmentIpAddress string = containerAppEnvironmentModule.outputs.containerAppEnvironmentIpAddress

--- a/infrastructure/templates/public-api/application/shared/postgreSqlFlexibleServer.bicep
+++ b/infrastructure/templates/public-api/application/shared/postgreSqlFlexibleServer.bicep
@@ -28,6 +28,9 @@ param firewallRules firewallRuleType[] = []
 @description('Specifies the subnet id that the PostgreSQL private endpoint will be attached to.')
 param privateEndpointSubnetId string
 
+@description('An array of Entra ID admin principal names for this resource')
+param entraIdAdminPrincipalNames string[] = []
+
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
@@ -44,6 +47,7 @@ module postgreSqlServerModule '../../components/postgresqlDatabase.bicep' = {
     createMode: 'Default'
     adminName: adminName
     adminPassword: adminPassword
+    entraIdAdminPrincipalNames: entraIdAdminPrincipalNames
     dbSkuName: sku
     dbStorageSizeGB: storageSizeGB
     dbAutoGrowStatus: autoGrowStatus

--- a/infrastructure/templates/public-api/application/shared/postgreSqlFlexibleServer.bicep
+++ b/infrastructure/templates/public-api/application/shared/postgreSqlFlexibleServer.bicep
@@ -1,4 +1,4 @@
-import { resourceNamesType, firewallRuleType } from '../../types.bicep'
+import { resourceNamesType, firewallRuleType, principalNameAndIdType } from '../../types.bicep'
 
 @description('Specifies common resource naming variables.')
 param resourceNames resourceNamesType
@@ -29,7 +29,7 @@ param firewallRules firewallRuleType[] = []
 param privateEndpointSubnetId string
 
 @description('An array of Entra ID admin principal names for this resource')
-param entraIdAdminPrincipalNames string[] = []
+param entraIdAdminPrincipals principalNameAndIdType[] = []
 
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
@@ -47,7 +47,7 @@ module postgreSqlServerModule '../../components/postgresqlDatabase.bicep' = {
     createMode: 'Default'
     adminName: adminName
     adminPassword: adminPassword
-    entraIdAdminPrincipalNames: entraIdAdminPrincipalNames
+    entraIdAdminPrincipals: entraIdAdminPrincipals
     dbSkuName: sku
     dbStorageSizeGB: storageSizeGB
     dbAutoGrowStatus: autoGrowStatus

--- a/infrastructure/templates/public-api/application/shared/privateDnsZones.bicep
+++ b/infrastructure/templates/public-api/application/shared/privateDnsZones.bicep
@@ -3,12 +3,16 @@ import { resourceNamesType } from '../../types.bicep'
 @description('Specifies common resource naming variables.')
 param resourceNames resourceNamesType
 
+@description('Specifies a set of tags with which to tag the resource in Azure.')
+param tagValues object
+
 // Set up a Private DNS zone for handling private endpoints for PostgreSQL resources.
 module postgreSqlPrivateDnsZoneModule '../../components/privateDnsZone.bicep' = {
   name: 'postgresPrivateDnsZoneDeploy'
   params: {
     zoneType: 'postgres'
     vnetName: resourceNames.existingResources.vNet
+    tagValues: tagValues
   }
 }
 
@@ -19,6 +23,7 @@ module sitesPrivateDnsZoneModule '../../components/privateDnsZone.bicep' = {
   params: {
     zoneType: 'sites'
     vnetName: resourceNames.existingResources.vNet
+    tagValues: tagValues
   }
 }
 

--- a/infrastructure/templates/public-api/components/appGateway.bicep
+++ b/infrastructure/templates/public-api/components/appGateway.bicep
@@ -6,6 +6,9 @@ param keyVaultName string
 @description('Specifies the location for all resources')
 param location string
 
+@description('Specifies the VNet name that this App Gateway will be connected to')
+param vnetName string
+
 @description('Specifies the id of a dedicated subnet to which this App Gateway will be connected')
 param subnetId string
 
@@ -89,6 +92,15 @@ module wafPolicyModule 'wafPolicy.bicep' = {
     tagValues: tagValues
   }
 }
+
+module backendPrivateDnsConfigurationsModule './appGatewayBackendDns.bicep' = [for site in sites: {
+  name: site.backendDomainName
+  params: {
+    site: site
+    vnetName: vnetName
+    tagValues: tagValues
+  }
+}]
 
 // Create the App Gateway.
 resource appGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {

--- a/infrastructure/templates/public-api/components/appGatewayBackendDns.bicep
+++ b/infrastructure/templates/public-api/components/appGatewayBackendDns.bicep
@@ -1,0 +1,69 @@
+import { appGatewaySiteConfigType } from '../types.bicep'
+
+@description('Specifies the VNet name that the DNS records will be made available to')
+param vnetName string
+
+@description('Specifies the Key Vault name that this App Gateway will be permitted to get and list certificates from')
+param site appGatewaySiteConfigType
+
+@description('Specifies a set of tags with which to tag the resource in Azure')
+param tagValues object
+
+module privateDnsZoneModule './privateDnsZone.bicep' = {
+  name: '${site.backendDomainName}Deploy'
+  params: {
+    vnetName: vnetName
+    zoneType: 'custom'
+    customName: site.backendDomainName
+    tagValues: tagValues
+  }
+}
+
+resource dnsWildcardARecord 'Microsoft.Network/privateDnsZones/A@2024-06-01' = {
+  name: '${site.backendDomainName}/*'
+  properties: {
+    ttl: 3600
+    aRecords: [
+      {
+        ipv4Address: site.backendIpAddress
+      }
+    ]
+  }
+  dependsOn: [
+    privateDnsZoneModule
+  ]
+}
+
+resource dnsAtARecord 'Microsoft.Network/privateDnsZones/A@2024-06-01' = {
+  name: '${site.backendDomainName}/@'
+  properties: {
+    ttl: 3600
+    aRecords: [
+      {
+        ipv4Address: site.backendIpAddress
+      }
+    ]
+  }
+  dependsOn: [
+    privateDnsZoneModule
+  ]
+}
+
+resource dnsAtSoaRecord 'Microsoft.Network/privateDnsZones/SOA@2024-06-01' = {
+  name: '${site.backendDomainName}/@'
+  properties: {
+    ttl: 3600
+    soaRecord: {
+      email: 'azureprivatedns-host.microsoft.com'
+      expireTime: 2419200
+      host: 'azureprivatedns.net'
+      minimumTtl: 10
+      refreshTime: 3600
+      retryTime: 300
+      serialNumber: 1
+    }
+  }
+  dependsOn: [
+    privateDnsZoneModule
+  ]
+}

--- a/infrastructure/templates/public-api/components/containerAppEnvironment.bicep
+++ b/infrastructure/templates/public-api/components/containerAppEnvironment.bicep
@@ -76,3 +76,4 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-03-01' 
 
 output containerAppEnvironmentName string = containerAppEnvironmentName
 output containerAppEnvironmentId string = containerAppEnvironment.id
+output containerAppEnvironmentIpAddress string = containerAppEnvironment.properties.staticIp

--- a/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
+++ b/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
@@ -1,4 +1,4 @@
-import { firewallRuleType } from '../types.bicep'
+import { firewallRuleType, principalNameAndIdType } from '../types.bicep'
 
 @description('Specifies the location for all resources.')
 param location string
@@ -43,7 +43,7 @@ param databaseNames string[]
 param firewallRules firewallRuleType[] = []
 
 @description('An array of Entra ID admin principal names for this resource')
-param entraIdAdminPrincipalNames string[] = []
+param entraIdAdminPrincipals principalNameAndIdType[] = []
 
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object
@@ -123,12 +123,12 @@ module privateEndpointModule 'privateEndpoint.bicep' = {
 }
 
 @batchSize(1)
-resource adminRoleAssignments 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2022-12-01' = [for adminPrincipalName in entraIdAdminPrincipalNames: {
-  name: guid(postgreSQLDatabase.id, adminPrincipalName)
+resource adminRoleAssignments 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2022-12-01' = [for adminPrincipal in entraIdAdminPrincipals: {
+  name: adminPrincipal.objectId
   parent: postgreSQLDatabase
   properties: {
     tenantId: tenant().tenantId
-    principalName: adminPrincipalName
+    principalName: adminPrincipal.principalName
     principalType: 'USER'
   }
   dependsOn: [

--- a/infrastructure/templates/public-api/components/privateDnsZone.bicep
+++ b/infrastructure/templates/public-api/components/privateDnsZone.bicep
@@ -3,15 +3,21 @@ import { privateDnsZoneType } from '../types.bicep'
 @description('Specifies the type of zone to create')
 param zoneType privateDnsZoneType
 
+@description('Specifies an optional name for the zone, if "custom" zoneType was chosen')
+param customName string?
+
 @description('Specifies the name of the VNet that this DNS Zone will be attached to')
 param vnetName string
+
+@description('Specifies a set of tags with which to tag the resource in Azure')
+param tagValues object
 
 var zoneTypeToNames = {
   sites: 'privatelink.azurewebsites.net'
   postgres: 'privatelink.postgres.database.azure.com'
 }
 
-var zoneName = zoneTypeToNames[zoneType]
+var zoneName = zoneType == 'custom' ? customName : zoneTypeToNames[zoneType]
 
 resource vnet 'Microsoft.Network/virtualNetworks@2023-11-01' existing = {
   name: vnetName
@@ -22,6 +28,7 @@ resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
   name: zoneName
   location: 'global'
   properties: {}
+  tags: tagValues
 }
 
 // A link which makes the internal DNS records within the DNS zone available to other resources on the VNet.
@@ -35,6 +42,7 @@ resource privateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
       id: vnet.id
     }
   }
+  tags: tagValues
 }
 
 output privateDnsZoneId string = privateDnsZone.id

--- a/infrastructure/templates/public-api/deploy-stage-template.yml
+++ b/infrastructure/templates/public-api/deploy-stage-template.yml
@@ -19,198 +19,199 @@ parameters:
     type: string
 
 stages:
-- stage: ${{parameters.stageName}}
-  displayName: 'Deploy ${{parameters.environment}} Infrastructure and Applications'
-  # Prevent this stage from running in parallel with the same deploy stage in other ongoing runs of this pipeline.
-  # Instead, multiple executions of this stage will be queued and run sequentially in the order that their pipelines
-  # were triggered.
-  lockBehavior: sequential
-  condition: ${{parameters.condition}}
-  variables:
-    - group: Public API Infrastructure - ${{parameters.environment}}
-    - group: Public API Infrastructure - ${{parameters.environment}} secrets
-  ${{ if not(eq(parameters.dependsOn, '')) }}:
-    dependsOn: ${{parameters.dependsOn}}
-  jobs:
-  - deployment: Deploy
-    displayName: 'Deploy ${{parameters.environment}} Infrastructure Bicep template and applications'
-    environment: '${{parameters.environment}}'
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-          - task: Bash@3
-            displayName: 'Set additional pipeline variables'
-            inputs:
-              targetType: 'inline'
-              script: |
-                echo "##vso[task.setvariable variable=dataProcessorFunctionAppName;]$(subscription)-ees-papi-fa-processor"
+  - stage: ${{parameters.stageName}}
+    displayName: 'Deploy ${{parameters.environment}} Infrastructure and Applications'
+    # Prevent this stage from running in parallel with the same deploy stage in other ongoing runs of this pipeline.
+    # Instead, multiple executions of this stage will be queued and run sequentially in the order that their pipelines
+    # were triggered.
+    lockBehavior: sequential
+    condition: ${{parameters.condition}}
+    variables:
+      - group: Public API Infrastructure - ${{parameters.environment}}
+      - group: Public API Infrastructure - ${{parameters.environment}} secrets
+    ${{ if not(eq(parameters.dependsOn, '')) }}:
+      dependsOn: ${{parameters.dependsOn}}
+    jobs:
+      - deployment: Deploy
+        displayName: 'Deploy ${{parameters.environment}} Infrastructure Bicep template and applications'
+        environment: '${{parameters.environment}}'
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - task: Bash@3
+                  displayName: 'Set additional pipeline variables'
+                  inputs:
+                    targetType: 'inline'
+                    script: |
+                      echo "##vso[task.setvariable variable=dataProcessorFunctionAppName;]$(subscription)-ees-papi-fa-processor"
 
-          - download: EESBuildPipeline
-            displayName: 'Download Data Processor Function App ZIP file'
-            artifact: 'public-api-data-processor-$(upstreamPipelineBuildNumber)'
+                - download: EESBuildPipeline
+                  displayName: 'Download Data Processor Function App ZIP file'
+                  artifact: 'public-api-data-processor-$(upstreamPipelineBuildNumber)'
 
-          - checkout: self
+                - checkout: self
 
-          - task: AzureCLI@2
-            displayName: 'Deploy bicep template to Azure'
-            inputs:
-              azureSubscription: ${{parameters.serviceConnection}}
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                set -e
-                dataProcessorExists=`az functionapp list --resource-group $(resourceGroupName) --query "[?name=='$(dataProcessorFunctionAppName)']" | jq '. != []'`
+                - task: AzureCLI@2
+                  displayName: 'Deploy bicep template to Azure'
+                  inputs:
+                    azureSubscription: ${{parameters.serviceConnection}}
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      set -e
+                      dataProcessorExists=`az functionapp list --resource-group $(resourceGroupName) --query "[?name=='$(dataProcessorFunctionAppName)']" | jq '. != []'`
+                      
+                      if [[ "$dataProcessorExists" == "true" ]]; then
+                        echo "Data Processor Function App exists - combining existing appsettings with new ones"
+                      fi
+                      
+                      az deployment group create \
+                        --name 'DeployPublicApiInfrastructure$(upstreamPipelineBuildNumber)' \
+                        --resource-group $(resourceGroupName) \
+                        --template-file $(templateFile) \
+                        --parameters ${{parameters.parameterFile}} \
+                        --parameters \
+                            subscription='$(subscription)' \
+                            resourceTags='$(resourceTags)' \
+                            postgreSqlAdminName='$(postgreSqlAdminName)' \
+                            postgreSqlAdminPassword='$(postgreSqlAdminPassword)' \
+                            postgreSqlFirewallRules='$(maintenanceFirewallRules)' \
+                            postgreSqlEntraIdAdminPrincipals='$(postgreSqlEntraIdAdminPrincipals)' \
+                            storageFirewallRules='$(maintenanceFirewallRules)' \
+                            acrResourceGroupName='$(acrResourceGroupName)' \
+                            dockerImagesTag='$(upstreamPipelineBuildNumber)' \
+                            deployContainerApp=$(deployContainerApp) \
+                            updatePsqlFlexibleServer=$(updatePsqlFlexibleServer) \
+                            dataProcessorFunctionAppExists=$dataProcessorExists \
+                            dataProcessorAppRegistrationClientId='$(dataProcessorAppRegistrationClientId)' \
+                            apiAppRegistrationClientId='$(apiAppRegistrationClientId)'
+
+                - template: pipeline-variables-from-bicep-outputs-template.yml
+                  parameters:
+                    serviceConnection: ${{parameters.serviceConnection}}
                 
-                if [[ "$dataProcessorExists" == "true" ]]; then
-                  echo "Data Processor Function App exists - combining existing appsettings with new ones"
-                fi
+                # We handle the non-infrastructure appsetting and connection string configuration here rather than directly
+                # in the Bicep files so that we can implement slot swapping.
+                # Configuration changes are firstly deployed to the staging slot and combined with a fresh code deploy prior
+                # to being swapped into production.
+                - task: AzureCLI@2
+                  displayName: 'Deploy Data Processor Function App - update staging slot app settings'
+                  retryCountOnTaskFailure: 1
+                  inputs:
+                    azureSubscription: ${{parameters.serviceConnection}}
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      set -e
+                      
+                      az functionapp config appsettings set \
+                        --name $(dataProcessorFunctionAppName) \
+                        --resource-group $(resourceGroupName) \
+                        --slot staging \
+                        --settings \
+                          "AppSettings__PrivateStorageConnectionString=@Microsoft.KeyVault(VaultName=$(keyVaultName); SecretName=$(coreStorageConnectionStringSecretKey))" \
+                          "AZURE_CLIENT_ID=$(dataProcessorFunctionAppManagedIdentityClientId)" \
+                          "DataFiles__BasePath=$(dataProcessorPublicApiDataFileShareMountPath)"
+                      
+                      az webapp config connection-string set \
+                        --name $(dataProcessorFunctionAppName) \
+                        --resource-group $(resourceGroupName) \
+                        --connection-string-type SQLAzure \
+                        --slot staging \
+                        --settings \
+                          "ContentDb=@Microsoft.KeyVault(VaultName=$(keyVaultName); SecretName=$(dataProcessorContentDbConnectionStringSecretKey))"
+                      
+                      az webapp config connection-string set \
+                        --name $(dataProcessorFunctionAppName) \
+                        --resource-group $(resourceGroupName) \
+                        --connection-string-type PostgreSQL \
+                        --slot staging \
+                        --settings \
+                          "PublicDataDb=@Microsoft.KeyVault(VaultName=$(keyVaultName); SecretName=$(dataProcessorPsqlConnectionStringSecretKey))"
                 
-                az deployment group create \
-                  --name 'DeployPublicApiInfrastructure$(upstreamPipelineBuildNumber)' \
-                  --resource-group $(resourceGroupName) \
-                  --template-file $(templateFile) \
-                  --parameters ${{parameters.parameterFile}} \
-                  --parameters \
-                      subscription='$(subscription)' \
-                      resourceTags='$(resourceTags)' \
-                      postgreSqlAdminName='$(postgreSqlAdminName)' \
-                      postgreSqlAdminPassword='$(postgreSqlAdminPassword)' \
-                      postgreSqlFirewallRules='$(maintenanceFirewallRules)' \
-                      postgreSqlEntraIdAdminPrincipalNames='$(postgreSqlEntraIdAdminPrincipalNames)' \
-                      storageFirewallRules='$(maintenanceFirewallRules)' \
-                      acrResourceGroupName='$(acrResourceGroupName)' \
-                      dockerImagesTag='$(upstreamPipelineBuildNumber)' \
-                      deployContainerApp=$(deployContainerApp) \
-                      dataProcessorFunctionAppExists=$dataProcessorExists \
-                      dataProcessorAppRegistrationClientId='$(dataProcessorAppRegistrationClientId)' \
-                      apiAppRegistrationClientId='$(apiAppRegistrationClientId)'
-
-          - template: pipeline-variables-from-bicep-outputs-template.yml
-            parameters:
-              serviceConnection: ${{parameters.serviceConnection}}
-
-          # We handle the non-infrastructure appsetting and connection string configuration here rather than directly
-          # in the Bicep files so that we can implement slot swapping.
-          # Configuration changes are firstly deployed to the staging slot and combined with a fresh code deploy prior
-          # to being swapped into production.
-          - task: AzureCLI@2
-            displayName: 'Deploy Data Processor Function App - update staging slot app settings'
-            retryCountOnTaskFailure: 1
-            inputs:
-              azureSubscription: ${{parameters.serviceConnection}}
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                set -e
-
-                az functionapp config appsettings set \
-                  --name $(dataProcessorFunctionAppName) \
-                  --resource-group $(resourceGroupName) \
-                  --slot staging \
-                  --settings \
-                    "AppSettings__PrivateStorageConnectionString=@Microsoft.KeyVault(VaultName=$(keyVaultName); SecretName=$(coreStorageConnectionStringSecretKey))" \
-                    "AZURE_CLIENT_ID=$(dataProcessorFunctionAppManagedIdentityClientId)" \
-                    "DataFiles__BasePath=$(dataProcessorPublicApiDataFileShareMountPath)"
-
-                az webapp config connection-string set \
-                  --name $(dataProcessorFunctionAppName) \
-                  --resource-group $(resourceGroupName) \
-                  --connection-string-type SQLAzure \
-                  --slot staging \
-                  --settings \
-                    "ContentDb=@Microsoft.KeyVault(VaultName=$(keyVaultName); SecretName=$(dataProcessorContentDbConnectionStringSecretKey))"
-
-                az webapp config connection-string set \
-                  --name $(dataProcessorFunctionAppName) \
-                  --resource-group $(resourceGroupName) \
-                  --connection-string-type PostgreSQL \
-                  --slot staging \
-                  --settings \
-                    "PublicDataDb=@Microsoft.KeyVault(VaultName=$(keyVaultName); SecretName=$(dataProcessorPsqlConnectionStringSecretKey))"
-
-          # TODO EES-5128 - add Private Endpoint to Data Processor Function App into the VMSS VNet to allow DevOps to
-          # deploy the Data Processor Function App without having to temporarily make it publicly accessible.
-          - task: AzureCLI@2
-            displayName: 'Deploy Data Processor Function App - temporarily enable public network access before deploy'
-            retryCountOnTaskFailure: 1
-            inputs:
-              azureSubscription: ${{parameters.serviceConnection}}
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                set -e
+                # TODO EES-5128 - add Private Endpoint to Data Processor Function App into the VMSS VNet to allow DevOps to
+                # deploy the Data Processor Function App without having to temporarily make it publicly accessible.
+                - task: AzureCLI@2
+                  displayName: 'Deploy Data Processor Function App - temporarily enable public network access before deploy'
+                  retryCountOnTaskFailure: 1
+                  inputs:
+                    azureSubscription: ${{parameters.serviceConnection}}
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      set -e
+                      
+                      az functionapp update \
+                        --name $(dataProcessorFunctionAppName) \
+                        --resource-group $(resourceGroupName) \
+                        --slot staging \
+                        --set \
+                          publicNetworkAccess=Enabled \
+                          siteConfig.publicNetworkAccess=Enabled
                 
-                az functionapp update \
-                  --name $(dataProcessorFunctionAppName) \
-                  --resource-group $(resourceGroupName) \
-                  --slot staging \
-                  --set \
-                    publicNetworkAccess=Enabled \
-                    siteConfig.publicNetworkAccess=Enabled
-
-          # TODO EES-5128 - we will try several attempts to deploy the Function App in order to allow the staging
-          # slot the time to fully restart after appsettings and network visibility settings have been updated prior to
-          # attempting the deploy. Deploying prematurely results in a 500 from the deployment endpoint until the
-          # endpoint is ready to accept the deployment request. In the future it would be preferable to have a health
-          # check Function that we could call to establish that the site is ready, but this will require adding the
-          # Service Principal to allowed Client IDs / Identities that can access the Function App. The Service Principal
-          # that is performing the deploy can be accessed by using the "addSpnToEnvironment" config option in the task
-          # definition and using the $(servicePrincipalId) variable.
-          - task: AzureCLI@2
-            displayName: 'Deploy Data Processor Function App - deploy to staging slot'
-            retryCountOnTaskFailure: 10
-            inputs:
-              azureSubscription: ${{parameters.serviceConnection}}
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                set -e
-                az functionapp deployment source config-zip \
-                  --src '$(Pipeline.Workspace)/EESBuildPipeline/public-api-data-processor-$(upstreamPipelineBuildNumber)/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.zip' \
-                  --name $(dataProcessorFunctionAppName) \
-                  --resource-group $(resourceGroupName) \
-                  --slot staging
-
-          # TODO EES-5128 - add Private Endpoint to Data Processor Function App into the VMSS VNet to allow DevOps to
-          # deploy the Data Processor Function App without having to temporarily make it publicly accessible.
-          - task: AzureCLI@2
-            displayName: 'Deploy Data Processor Function App - disable public network access after deploy'
-            retryCountOnTaskFailure: 1
-            condition: always()
-            inputs:
-              azureSubscription: ${{parameters.serviceConnection}}
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                set -e
+                # TODO EES-5128 - we will try several attempts to deploy the Function App in order to allow the staging
+                # slot the time to fully restart after appsettings and network visibility settings have been updated prior to
+                # attempting the deploy. Deploying prematurely results in a 500 from the deployment endpoint until the
+                # endpoint is ready to accept the deployment request. In the future it would be preferable to have a health
+                # check Function that we could call to establish that the site is ready, but this will require adding the
+                # Service Principal to allowed Client IDs / Identities that can access the Function App. The Service Principal
+                # that is performing the deploy can be accessed by using the "addSpnToEnvironment" config option in the task
+                # definition and using the $(servicePrincipalId) variable.
+                - task: AzureCLI@2
+                  displayName: 'Deploy Data Processor Function App - deploy to staging slot'
+                  retryCountOnTaskFailure: 10
+                  inputs:
+                    azureSubscription: ${{parameters.serviceConnection}}
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      set -e
+                      az functionapp deployment source config-zip \
+                        --src '$(Pipeline.Workspace)/EESBuildPipeline/public-api-data-processor-$(upstreamPipelineBuildNumber)/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.zip' \
+                        --name $(dataProcessorFunctionAppName) \
+                        --resource-group $(resourceGroupName) \
+                        --slot staging
                 
-                az functionapp update \
-                  --name $(dataProcessorFunctionAppName) \
-                  --resource-group $(resourceGroupName) \
-                  --slot staging \
-                  --set \
-                    publicNetworkAccess=Disabled \
-                    siteConfig.publicNetworkAccess=Disabled
+                # TODO EES-5128 - add Private Endpoint to Data Processor Function App into the VMSS VNet to allow DevOps to
+                # deploy the Data Processor Function App without having to temporarily make it publicly accessible.
+                - task: AzureCLI@2
+                  displayName: 'Deploy Data Processor Function App - disable public network access after deploy'
+                  retryCountOnTaskFailure: 1
+                  condition: always()
+                  inputs:
+                    azureSubscription: ${{parameters.serviceConnection}}
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      set -e
+                      
+                      az functionapp update \
+                        --name $(dataProcessorFunctionAppName) \
+                        --resource-group $(resourceGroupName) \
+                        --slot staging \
+                        --set \
+                          publicNetworkAccess=Disabled \
+                          siteConfig.publicNetworkAccess=Disabled
 
-          - task: AzureCLI@2
-            displayName: 'Deploy Data Processor Function App - swap slots'
-            retryCountOnTaskFailure: 1
-            inputs:
-              azureSubscription: ${{parameters.serviceConnection}}
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                set -e
-                az functionapp deployment slot swap \
-                  --name $(dataProcessorFunctionAppName) \
-                  --resource-group $(resourceGroupName) \
-                  --slot staging \
-                  --target-slot production
-
-          # - template: assign-app-role-to-service-principal-template.yml
-          #   parameters:
-          #     serviceConnection: ${{parameters.serviceConnection}}
-          #     appRoleName: Admin.Access
-          #     protectedResourceAppRegName: ${{parameters.subscription}}-ees-papi-ca-api-appreg
-          #     servicePrincipalName: ${{parameters.subscription}}-as-ees-admin
+                - task: AzureCLI@2
+                  displayName: 'Deploy Data Processor Function App - swap slots'
+                  retryCountOnTaskFailure: 1
+                  inputs:
+                    azureSubscription: ${{parameters.serviceConnection}}
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      set -e
+                      az functionapp deployment slot swap \
+                        --name $(dataProcessorFunctionAppName) \
+                        --resource-group $(resourceGroupName) \
+                        --slot staging \
+                        --target-slot production
+              
+              # - template: assign-app-role-to-service-principal-template.yml
+              #   parameters:
+              #     serviceConnection: ${{parameters.serviceConnection}}
+              #     appRoleName: Admin.Access
+              #     protectedResourceAppRegName: ${{parameters.subscription}}-ees-papi-ca-api-appreg
+              #     servicePrincipalName: ${{parameters.subscription}}-as-ees-admin

--- a/infrastructure/templates/public-api/deploy-stage-template.yml
+++ b/infrastructure/templates/public-api/deploy-stage-template.yml
@@ -77,10 +77,11 @@ stages:
                       postgreSqlAdminName='$(postgreSqlAdminName)' \
                       postgreSqlAdminPassword='$(postgreSqlAdminPassword)' \
                       postgreSqlFirewallRules='$(maintenanceFirewallRules)' \
+                      postgreSqlEntraIdAdminPrincipalNames='$(postgreSqlEntraIdAdminPrincipalNames)' \
                       storageFirewallRules='$(maintenanceFirewallRules)' \
+                      acrResourceGroupName='$(acrResourceGroupName)' \
                       dockerImagesTag='$(upstreamPipelineBuildNumber)' \
                       deployContainerApp=$(deployContainerApp) \
-                      updatePsqlFlexibleServer=$(updatePsqlFlexibleServer) \
                       dataProcessorFunctionAppExists=$dataProcessorExists \
                       dataProcessorAppRegistrationClientId='$(dataProcessorAppRegistrationClientId)' \
                       apiAppRegistrationClientId='$(apiAppRegistrationClientId)'

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -166,6 +166,7 @@ module privateDnsZonesModule 'application/shared/privateDnsZones.bicep' = {
   name: 'privateDnsZonesApplicationModuleDeploy'
   params: {
     resourceNames: resourceNames
+    tagValues: tagValues
   }
 }
 
@@ -269,6 +270,8 @@ module appGatewayModule 'application/shared/appGateway.bicep' = if (deployContai
     publicApiContainerAppSettings: {
       resourceName: apiAppModule.outputs.containerAppName
       backendFqdn: apiAppModule.outputs.containerAppFqdn
+      backendDomainName: substring(apiAppModule.outputs.containerAppFqdn, indexOf(apiAppModule.outputs.containerAppFqdn, '.') + 1)
+      backendIpAddress: containerAppEnvironmentModule.outputs.containerAppEnvironmentIpAddress
       publicFqdn: replace(publicUrls.publicApi, 'https://', '')
       certificateName: '${apiAppModule.outputs.containerAppName}-certificate'
       healthProbeRelativeUrl: apiAppModule.outputs.containerAppHealthProbeRelativeUrl

--- a/infrastructure/templates/public-api/types.bicep
+++ b/infrastructure/templates/public-api/types.bicep
@@ -66,6 +66,8 @@ type entraIdAuthenticationType = {
 type appGatewaySiteConfigType = {
   resourceName: string
   backendFqdn: string
+  backendDomainName: string
+  backendIpAddress: string
   publicFqdn: string
   certificateName: string
   healthProbeRelativeUrl: string
@@ -78,7 +80,7 @@ type principalNameAndIdType = {
 }
 
 @export()
-type privateDnsZoneType = 'sites' | 'postgres'
+type privateDnsZoneType = 'sites' | 'postgres' | 'custom'
 
 @export()
 type containerRegistryRoleType = 'AcrPull'

--- a/infrastructure/templates/public-api/types.bicep
+++ b/infrastructure/templates/public-api/types.bicep
@@ -7,6 +7,7 @@ type resourceNamesType = {
     vNet: string
     alertsGroup: string
     acr: string
+    acrResourceGroup: string
     coreStorageAccount: string
     subnets: {
       dataProcessor: string

--- a/infrastructure/templates/public-api/types.bicep
+++ b/infrastructure/templates/public-api/types.bicep
@@ -72,6 +72,12 @@ type appGatewaySiteConfigType = {
 }
 
 @export()
+type principalNameAndIdType = {
+  principalName: string
+  objectId: string
+}
+
+@export()
 type privateDnsZoneType = 'sites' | 'postgres'
 
 @export()

--- a/infrastructure/templates/public-api/validate-stage-template.yml
+++ b/infrastructure/templates/public-api/validate-stage-template.yml
@@ -55,10 +55,11 @@ stages:
                     postgreSqlAdminName='$(postgreSqlAdminName)' \
                     postgreSqlAdminPassword='$(postgreSqlAdminPassword)' \
                     postgreSqlFirewallRules='$(maintenanceFirewallRules)' \
+                    postgreSqlEntraIdAdminPrincipalNames='$(postgreSqlEntraIdAdminPrincipalNames)' \
                     storageFirewallRules='$(maintenanceFirewallRules)' \
+                    acrResourceGroupName='$(acrResourceGroupName)' \
                     dockerImagesTag='$(upstreamPipelineBuildNumber)' \
                     deployContainerApp=true \
-                    updatePsqlFlexibleServer=true \
                     dataProcessorFunctionAppExists=true \
                     dataProcessorAppRegistrationClientId='$(dataProcessorAppRegistrationClientId)' \
                     apiAppRegistrationClientId='$(apiAppRegistrationClientId)'

--- a/infrastructure/templates/public-api/validate-stage-template.yml
+++ b/infrastructure/templates/public-api/validate-stage-template.yml
@@ -55,11 +55,12 @@ stages:
                     postgreSqlAdminName='$(postgreSqlAdminName)' \
                     postgreSqlAdminPassword='$(postgreSqlAdminPassword)' \
                     postgreSqlFirewallRules='$(maintenanceFirewallRules)' \
-                    postgreSqlEntraIdAdminPrincipalNames='$(postgreSqlEntraIdAdminPrincipalNames)' \
+                    postgreSqlEntraIdAdminPrincipals='$(postgreSqlEntraIdAdminPrincipals)' \
                     storageFirewallRules='$(maintenanceFirewallRules)' \
                     acrResourceGroupName='$(acrResourceGroupName)' \
                     dockerImagesTag='$(upstreamPipelineBuildNumber)' \
                     deployContainerApp=true \
+                    updatePsqlFlexibleServer=true \
                     dataProcessorFunctionAppExists=true \
                     dataProcessorAppRegistrationClientId='$(dataProcessorAppRegistrationClientId)' \
                     apiAppRegistrationClientId='$(apiAppRegistrationClientId)'


### PR DESCRIPTION
This PR:
- contains all of the additional tweaks that were necessary to get the Public API infrastructure rollout successfully to the Test Resource Group, which prior to this did not have any Public API rollout attempts done to it.

Notable changes:
- The conditions evaluated to determine which stages to run in the pipeline have been updated to no longer rely on `succeeded()`, as this fails when a prior stage has been skipped.  Instead we explicitly check for `not(failed(), canceled())` instead.
- The Container App Docker Image pull credentials use the same shared SPN as we currently use for the Public Site.  This is in lieu of creating a shared Resource Group with an ACR instance in that all RGs can pull from.
-  A missing piece in the automation was a Private DNS Zone that links the Container App Environment's domain name up with its static IP address, which the App Gateway uses to look up the IP address of the Container App so it can route traffic through.  Now, a "custom" type of Private DNS zone is supported, and the App Gateway module uses this type to support its backend pool name resolutions.
- We can now automate the creation of our PSQL Entra ID admins.  These are drawn from the Resource Group-specific Variable Group.