### PR TITLE
EES-5515 Reverting increase in number of provisioned vCores of Prod statistics databases made for EES-5339

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -84,7 +84,7 @@
       "value": "GeneralPurpose"
     },
     "capacityStatisticsDb": {
-      "value": 10
+      "value": 6
     },
     "tableBuilderMaxTableCellsAllowed": {
       "value": 1000000


### PR DESCRIPTION
This PR changes the statistics primary and replica databases in the Prod environment from provisioned 10 to 6 vCores. This is a code change to reflect the same change that's already been made to the databases manually on 19/09/24.

In EES-5339 we temporarily increased the scale of the Prod primary and replica statistics databases after slow running of the table tool was observed. That was found to be caused by long running table reindexing, and multiple days worth of scheduled reindexing runs overlapping.

In EES-5205 we aimed to prevent this by stopping further reindexing tasks from starting once a set time limit has been reached.

In EES-5368 we added logging for the reindexing so that we can observe which tasks ran to completion and their duration, and which tasks were skipped due to exceeding the allowed time limit.

We are reverting the Prod statistics database scale now and relying on the new logging to see if we need to increase the scale again in future.

