### PR TITLE
EES-5520 Group public API data sets in root `data-sets` dir

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetFilenames.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetFilenames.cs
@@ -2,6 +2,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 
 public static class DataSetFilenames
 {
+    public const string DataSetsDirectory = "data-sets";
+
     public const string CsvDataFile = "data.csv.gz";
     public const string CsvMetadataFile = "metadata.csv";
     public const string DuckDbDatabaseFile = "data.db";

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/DeleteDataSetVersionFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/DeleteDataSetVersionFunctionTests.cs
@@ -83,7 +83,7 @@ public abstract class DeleteDataSetVersionFunctionTests(ProcessorFunctionsIntegr
             await using var contentDataDbContext = GetDbContext<ContentDbContext>();
 
             // Assert that the base directory containing all parquet data file entries has been emptied
-            var dataSetVersionBaseDirectoryEntries = Directory.GetFileSystemEntries(_dataSetVersionPathResolver.BasePath());
+            var dataSetVersionBaseDirectoryEntries = Directory.GetFileSystemEntries(_dataSetVersionPathResolver.DataSetsPath());
             Assert.Empty(dataSetVersionBaseDirectoryEntries);
 
             // Assert that the Data Set has been deleted

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/Commands/SeedDataCommand.cs
@@ -871,7 +871,7 @@ public class SeedDataCommand : ICommand
         private async Task OutputParquetFiles()
         {
             var projectRootPath = PathUtils.ProjectRootPath;
-            var dataDir = Path.Combine(projectRootPath, "data", "public-api-data");
+            var dataDir = Path.Combine(projectRootPath, "data", "public-api-data", DataSetFilenames.DataSetsDirectory);
 
             if (!Path.Exists(dataDir))
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/DataSetVersionPathResolverTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/DataSetVersionPathResolverTests.cs
@@ -38,18 +38,12 @@ public abstract class DataSetVersionPathResolverTests
 
     public class PathTests : DataSetVersionPathResolverTests
     {
-        public static IEnumerable<object[]> GetEnvironmentNames =>
-        [
-            [
-                Environments.Development
-            ],
-            [
-                HostEnvironmentExtensions.IntegrationTestEnvironment
-            ],
-            [
-                Environments.Production
-            ]
-        ];
+        public static readonly TheoryData<string> GetEnvironmentNames = new()
+        {
+            Environments.Development,
+            HostEnvironmentExtensions.IntegrationTestEnvironment,
+            Environments.Production
+        };
 
         [Fact]
         public void DevelopmentEnv_ValidBasePath()
@@ -116,10 +110,7 @@ public abstract class DataSetVersionPathResolverTests
             });
 
             Assert.Equal(
-                Path.Combine(
-                    "data",
-                    "data-files"
-                ),
+                Path.Combine("data", "data-files"),
                 resolver.BasePath());
         }
 
@@ -140,7 +131,7 @@ public abstract class DataSetVersionPathResolverTests
 
             Assert.Equal(
                 Path.Combine(
-                    resolver.BasePath(),
+                    resolver.DataSetsPath(),
                     version.DataSetId.ToString(),
                     "v1.0.0"
                 ),
@@ -164,7 +155,7 @@ public abstract class DataSetVersionPathResolverTests
 
             Assert.Equal(
                 Path.Combine(
-                    resolver.BasePath(),
+                    resolver.DataSetsPath(),
                     version.DataSetId.ToString(),
                     "v1.2.3"
                 ),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
@@ -37,7 +37,7 @@ public class DataSetVersionPathResolver : IDataSetVersionPathResolver
     public string DirectoryPath(DataSetVersion dataSetVersion, SemVersion? versionNumber = null)
     {
         return Path.Combine(
-            _basePath,
+            ((IDataSetVersionPathResolver) this).DataSetsPath(),
             dataSetVersion.DataSetId.ToString(),
             $"v{versionNumber ?? dataSetVersion.SemVersion()}");
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/Interfaces/IDataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/Interfaces/IDataSetVersionPathResolver.cs
@@ -8,6 +8,8 @@ public interface IDataSetVersionPathResolver
 {
     string BasePath();
 
+    string DataSetsPath() => Path.Combine(BasePath(), DataSetFilenames.DataSetsDirectory);
+
     string DirectoryPath(DataSetVersion dataSetVersion, SemVersion? versionNumber = null);
 
     string CsvDataPath(DataSetVersion dataSetVersion)


### PR DESCRIPTION
This PR updates public API file storage paths to group data set directories under a root `data-sets` directory.

This simplifies clearing down test data as we can just remove the `data-sets` directory in one go, rather than have to delete potentially hundreds (or thousands) of individual data set directories.