### PR TITLE
EES-5512 - correcting Container App CORS policy to include public site URL rather than Public API url!

### DIFF
--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -21,7 +21,7 @@ resources:
 variables:
   - group: Public API Infrastructure - common
   - name: isDev
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/EES-5479-modularise-bicep')]
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
   - name: isTest
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/test')]
   - name: isMaster

--- a/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
@@ -12,8 +12,8 @@ param containerAppEnvironmentId string
 @description('The tags of the Docker images to deploy.')
 param dockerImagesTag string
 
-@description('The URL of the Public API.')
-param publicApiUrl string
+@description('The URL of the Public site.')
+param publicSiteUrl string
 
 @description('The URL of the Content API.')
 param contentApiUrl string
@@ -62,7 +62,7 @@ module apiContainerAppModule '../../components/containerApp.bicep' = {
     managedEnvironmentId: containerAppEnvironmentId
     corsPolicy: {
       allowedOrigins: [
-        publicApiUrl
+        publicSiteUrl
         'http://localhost:3000'
         'http://127.0.0.1'
       ]

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -250,7 +250,7 @@ module apiAppModule 'application/public-api/publicApiApp.bicep' = if (deployCont
     apiAppRegistrationClientId: apiAppRegistrationClientId
     containerAppEnvironmentId: containerAppEnvironmentModule.outputs.containerAppEnvironmentId
     contentApiUrl: publicUrls.contentApi
-    publicApiUrl: publicUrls.publicApi
+    publicSiteUrl: publicUrls.publicSite
     dockerImagesTag: dockerImagesTag
     appInsightsConnectionString: appInsightsModule.outputs.appInsightsConnectionString
     tagValues: tagValues


### PR DESCRIPTION
This corrects a bug introduced in the modularisation of the Bicep templates whereby the Public API URL was accidentally substituted in in place of the Public Site URL, leading to results in the Public Site not being allowed to include results from the Public API URL.

This also fixes the `isDev` branch test in `api-infrastructure-pipeline.yml` which had been accidentally left at the old Bicep modularisation branch whilst being tested off-branch.