### PR TITLE
EES-5518 Add server URL to OpenAPI docs

### DIFF
--- a/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
@@ -12,6 +12,9 @@ param containerAppEnvironmentId string
 @description('The tags of the Docker images to deploy.')
 param dockerImagesTag string
 
+@description('The URL of the Public API.')
+param publicApiUrl string
+
 @description('The URL of the Public site.')
 param publicSiteUrl string
 
@@ -93,6 +96,10 @@ module apiContainerAppModule '../../components/containerApp.bicep' = {
         // identity.
         name: 'AZURE_CLIENT_ID'
         value: apiContainerAppManagedIdentity.properties.clientId
+      }
+      {
+        name: 'AppSettings__HostUrl'
+        value: publicApiUrl
       }
       {
         name: 'ContentApi__Url'

--- a/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
@@ -102,6 +102,10 @@ module apiContainerAppModule '../../components/containerApp.bicep' = {
         value: publicApiUrl
       }
       {
+        name: 'AppInsights__ConnectionString'
+        value: appInsightsConnectionString
+      }
+      {
         name: 'ContentApi__Url'
         value: contentApiUrl
       }
@@ -120,10 +124,6 @@ module apiContainerAppModule '../../components/containerApp.bicep' = {
       {
         name: 'OpenIdConnect__ClientId'
         value: apiAppRegistrationClientId
-      }
-      {
-        name: 'ApplicationInsights__ConnectionString'
-        value: appInsightsConnectionString
       }
     ]
     entraIdAuthentication: {

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -97,10 +97,10 @@ var tagValues = union(resourceTags ?? {}, {
 // Define our resource prefix.
 //
 
-// The resource prefix for anything specific to the Public API. 
+// The resource prefix for anything specific to the Public API.
 var publicApiResourcePrefix = '${subscription}-ees-papi'
 
-// The resource prefix for anything not specific solely to the Public API but set up within Bicep. 
+// The resource prefix for anything not specific solely to the Public API but set up within Bicep.
 var commonResourcePrefix = '${subscription}-ees'
 
 // The resource prefix for resources created in the ARM template.
@@ -250,6 +250,7 @@ module apiAppModule 'application/public-api/publicApiApp.bicep' = if (deployCont
     apiAppRegistrationClientId: apiAppRegistrationClientId
     containerAppEnvironmentId: containerAppEnvironmentModule.outputs.containerAppEnvironmentId
     contentApiUrl: publicUrls.contentApi
+    publicApiUrl: publicUrls.publicApi
     publicSiteUrl: publicUrls.publicSite
     dockerImagesTag: dockerImagesTag
     appInsightsConnectionString: appInsightsModule.outputs.appInsightsConnectionString

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/RequestTimeoutTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/RequestTimeoutTests.cs
@@ -100,9 +100,7 @@ public class RequestTimeoutTests(TestApplicationFactory testApp) : IntegrationTe
             return NoContent();
         }
 
-        private readonly int _requestTimeout = requestTimeoutOptions.Value.TimeoutMilliseconds
-            ?? throw new Exception(
-                $"Must populate '{RequestTimeoutOptions.Section}:{nameof(RequestTimeoutOptions.TimeoutMilliseconds)}' in the integration test app settings.");
+        private readonly int _requestTimeout = requestTimeoutOptions.Value.TimeoutMilliseconds;
     }
 
     private WebApplicationFactory<Startup> BuildApp()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/appsettings.IntegrationTest.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/appsettings.IntegrationTest.json
@@ -5,14 +5,7 @@
   "ContentApi": {
     "Url": "http://localhost:5010"
   },
-  "MiniProfiler": {
-    "Enabled": false
-  },
   "DataFiles": {
     "BasePath": "Resources/DataFiles"
-  },
-  "OpenIdConnect": {
-    "ClientId": "00000000-0000-0000-0000-000000000000",
-    "TenantId": "00000000-0000-0000-0000-000000000000"
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/appsettings.IntegrationTest.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/appsettings.IntegrationTest.json
@@ -1,4 +1,7 @@
 {
+  "AppSettings": {
+    "HostUrl": "http://localhost:5050"
+  },
   "ContentApi": {
     "Url": "http://localhost:5010"
   },

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/AppInsightsOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/AppInsightsOptions.cs
@@ -1,8 +1,8 @@
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 
-public class ApplicationInsightsOptions
+public class AppInsightsOptions
 {
-    public const string Section = "ApplicationInsights";
+    public const string Section = "AppInsights";
 
     public string ConnectionString { get; init; } = string.Empty;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/AppSettingsOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/AppSettingsOptions.cs
@@ -1,0 +1,11 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
+
+public class AppSettingsOptions
+{
+    public const string Section = "AppSettings";
+
+    /// <summary>
+    /// The host URL of the public API.
+    /// </summary>
+    public string HostUrl { get; init; } = string.Empty;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/RequestTimeoutOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/RequestTimeoutOptions.cs
@@ -4,5 +4,5 @@ public class RequestTimeoutOptions
 {
     public const string Section = "RequestTimeout";
 
-    public int? TimeoutMilliseconds { get; init; }
+    public int TimeoutMilliseconds { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -173,6 +173,8 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
 
         // Options
 
+        services.AddOptions<AppSettingsOptions>()
+            .Bind(configuration.GetRequiredSection(AppSettingsOptions.Section));
         services.AddOptions<ContentApiOptions>()
             .Bind(configuration.GetRequiredSection(ContentApiOptions.Section));
         services.AddOptions<RequestTimeoutOptions>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -43,8 +43,8 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         configuration.GetRequiredSection(OpenIdConnectOptions.Section);
     private readonly IConfiguration _requestTimeoutConfig =
         configuration.GetSection(RequestTimeoutOptions.Section);
-    private readonly IConfiguration _applicationInsightsConfig =
-        configuration.GetSection(ApplicationInsightsOptions.Section);
+    private readonly IConfiguration _appInsightsConfig =
+        configuration.GetSection(AppInsightsOptions.Section);
 
     // This method gets called by the runtime. Use this method to add services to the container.
     public void ConfigureServices(IServiceCollection services)
@@ -57,7 +57,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
             .AddApplicationInsightsTelemetry(options =>
             {
                 options.ConnectionString =
-                    _applicationInsightsConfig.GetValue<string>(nameof(ApplicationInsightsOptions.ConnectionString));
+                    _appInsightsConfig.GetValue<string>(nameof(AppInsightsOptions.ConnectionString));
             })
             .AddApplicationInsightsTelemetryProcessor<SensitiveDataTelemetryProcessor>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -37,14 +37,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api;
 [ExcludeFromCodeCoverage]
 public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironment)
 {
-    private readonly IConfiguration _miniProfilerConfig =
-        configuration.GetRequiredSection(MiniProfilerOptions.Section);
-    private readonly IConfiguration _openIdConnectConfig =
-        configuration.GetRequiredSection(OpenIdConnectOptions.Section);
-    private readonly IConfiguration _requestTimeoutConfig =
-        configuration.GetSection(RequestTimeoutOptions.Section);
-    private readonly IConfiguration _appInsightsConfig =
-        configuration.GetSection(AppInsightsOptions.Section);
+    private readonly MiniProfilerOptions _miniProfilerOptions = configuration
+        .GetRequiredSection(MiniProfilerOptions.Section)
+        .Get<MiniProfilerOptions>()!;
+
+    private readonly OpenIdConnectOptions _openIdConnectOptions = configuration
+        .GetRequiredSection(OpenIdConnectOptions.Section)
+        .Get<OpenIdConnectOptions>()!;
+
+    private readonly RequestTimeoutOptions _requestTimeoutOptions = configuration
+        .GetSection(RequestTimeoutOptions.Section)
+        .Get<RequestTimeoutOptions>()!;
+
+    private readonly AppInsightsOptions _appInsightsOptions = configuration
+        .GetSection(AppInsightsOptions.Section)
+        .Get<AppInsightsOptions>()!;
 
     // This method gets called by the runtime. Use this method to add services to the container.
     public void ConfigureServices(IServiceCollection services)
@@ -56,16 +63,13 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         services
             .AddApplicationInsightsTelemetry(options =>
             {
-                options.ConnectionString =
-                    _appInsightsConfig.GetValue<string>(nameof(AppInsightsOptions.ConnectionString));
+                options.ConnectionString = _appInsightsOptions.ConnectionString;
             })
             .AddApplicationInsightsTelemetryProcessor<SensitiveDataTelemetryProcessor>();
 
         // Profiling
 
-        var isMiniProfilerEnabled = _miniProfilerConfig.GetValue<bool>(nameof(MiniProfilerOptions.Enabled));
-
-        if (isMiniProfilerEnabled)
+        if (_miniProfilerOptions.Enabled)
         {
             services
                 .AddMiniProfiler(options =>
@@ -87,8 +91,8 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
                 .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddJwtBearer(options =>
                 {
-                    var tenantId = _openIdConnectConfig.GetValue<Guid>(nameof(OpenIdConnectOptions.TenantId));
-                    var clientId = _openIdConnectConfig.GetValue<Guid>(nameof(OpenIdConnectOptions.ClientId));
+                    var tenantId = _openIdConnectOptions.TenantId;
+                    var clientId = _openIdConnectOptions.ClientId;
                     options.Authority = $"https://login.microsoftonline.com/{tenantId}";
                     options.Audience = $"api://{clientId}";
                 });
@@ -101,7 +105,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
             options.DefaultPolicy =
                 new RequestTimeoutPolicy
                 {
-                    Timeout = TimeSpan.FromMilliseconds(_requestTimeoutConfig.GetValue<int?>(nameof(RequestTimeoutOptions.TimeoutMilliseconds)) ?? 30000),
+                    Timeout = TimeSpan.FromMilliseconds(_requestTimeoutOptions.TimeoutMilliseconds),
                     TimeoutStatusCode = (int)HttpStatusCode.GatewayTimeout
                 };
         });
@@ -158,7 +162,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         // Configure Dapper to match CSV columns with underscores
         DefaultTypeMap.MatchNamesWithUnderscores = true;
 
-        services.AddScoped<IDuckDbConnection>(_ => isMiniProfilerEnabled
+        services.AddScoped<IDuckDbConnection>(_ => _miniProfilerOptions.Enabled
             ? new ProfiledDuckDbConnection()
             : new DuckDbConnection()
         );
@@ -171,18 +175,14 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
             options.EnableForHttps = true;
         });
 
-        // Options
+        // Options - only need to add ones that will be used in services
 
         services.AddOptions<AppSettingsOptions>()
             .Bind(configuration.GetRequiredSection(AppSettingsOptions.Section));
         services.AddOptions<ContentApiOptions>()
             .Bind(configuration.GetRequiredSection(ContentApiOptions.Section));
-        services.AddOptions<RequestTimeoutOptions>()
-            .Bind(configuration.GetSection(RequestTimeoutOptions.Section));
         services.AddOptions<DataFilesOptions>()
             .Bind(configuration.GetRequiredSection(DataFilesOptions.Section));
-        services.AddOptions<MiniProfilerOptions>()
-            .Bind(_miniProfilerConfig);
 
         // Services
 
@@ -198,7 +198,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         });
 
         services.AddSecurity();
-        
+
         services.AddScoped<IAuthorizationHandlerService, AuthorizationHandlerService>();
 
         services.AddScoped<IPreviewTokenService, PreviewTokenService>();
@@ -222,7 +222,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
     {
         UpdateDatabase(app);
 
-        if (_miniProfilerConfig.GetValue<bool>(nameof(MiniProfilerOptions.Enabled)))
+        if (_miniProfilerOptions.Enabled)
         {
             app.UseMiniProfiler();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerConfig.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerConfig.cs
@@ -2,13 +2,17 @@ using Asp.Versioning.ApiExplorer;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 
-public class SwaggerConfig(IApiVersionDescriptionProvider provider) : IConfigureOptions<SwaggerGenOptions>
+public class SwaggerConfig(
+    IApiVersionDescriptionProvider provider,
+    IOptions<AppSettingsOptions> appSettingsOptions)
+    : IConfigureOptions<SwaggerGenOptions>
 {
     public void Configure(SwaggerGenOptions options)
     {
@@ -64,6 +68,12 @@ public class SwaggerConfig(IApiVersionDescriptionProvider provider) : IConfigure
                 }
             );
         }
+
+        options.AddServer(new OpenApiServer
+        {
+            Description = "API server",
+            Url = appSettingsOptions.Value.HostUrl
+        });
     }
 
     private static string SchemaIdSelector(Type type)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.Development.json
@@ -14,9 +14,6 @@
   "AppSettings": {
     "HostUrl": "http://localhost:5050"
   },
-  "AppInsights": {
-    "ConnectionString": ""
-  },
   "ContentApi": {
     "Url": "http://localhost:5010"
   },
@@ -25,9 +22,5 @@
   },
   "DataFiles": {
     "BasePath": "data/public-api-data"
-  },
-  "OpenIdConnect": {
-    "ClientId": "00000000-0000-0000-0000-000000000000",
-    "TenantId": "00000000-0000-0000-0000-000000000000"
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.Development.json
@@ -14,6 +14,9 @@
   "AppSettings": {
     "HostUrl": "http://localhost:5050"
   },
+  "AppInsights": {
+    "ConnectionString": ""
+  },
   "ContentApi": {
     "Url": "http://localhost:5010"
   },
@@ -26,8 +29,5 @@
   "OpenIdConnect": {
     "ClientId": "00000000-0000-0000-0000-000000000000",
     "TenantId": "00000000-0000-0000-0000-000000000000"
-  },
-  "ApplicationInsights": {
-    "ConnectionString": ""
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.Development.json
@@ -11,6 +11,9 @@
       "MicroElements.Swashbuckle.FluentValidation": "Warning"
     }
   },
+  "AppSettings": {
+    "HostUrl": "http://localhost:5050"
+  },
   "ContentApi": {
     "Url": "http://localhost:5010"
   },

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.json
@@ -5,5 +5,18 @@
       "Microsoft": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AppInsights": {
+    "ConnectionString": ""
+  },
+  "MiniProfiler": {
+    "Enabled": false
+  },
+  "OpenIdConnect": {
+    "ClientId": "00000000-0000-0000-0000-000000000000",
+    "TenantId": "00000000-0000-0000-0000-000000000000"
+  },
+  "RequestTimeout": {
+    "TimeoutMilliseconds": 300000
+  }
 }


### PR DESCRIPTION
This PR adds the server URL to the OpenAPI docs so that it can be used independently of where it's hosted. The URL is passed into the docs via the `AppSettings.HostUrl` app setting.

## Other changes

- Simplified `ApplicationInsightsOptions` to `AppInsightsOptions`
- Refactored public API `Startup` to use typed options instead of getting values directly from `IConfiguration`.