### PR TITLE
EES-5519 Wait for remove API data set modal to close

### DIFF
--- a/tests/robot-tests/tests/public_api/public_api_dataset_cancel_and_removal.robot
+++ b/tests/robot-tests/tests/public_api/public_api_dataset_cancel_and_removal.robot
@@ -120,6 +120,8 @@ Remove draft API dataset
     
     ${modal}=    user waits until modal is visible     Remove this draft API data set version
     user clicks button     Remove this API data set version
+
+    user waits until modal is not visible     Remove this draft API data set version
     user waits until h2 is visible    API data sets
 
 User creates 1st API dataset again


### PR DESCRIPTION
This is a speculative fix for a UI test failure we saw posted in Slack at 8:06am on 23rd September. 

The test run report had a couple of screenshots of the Remove API data set modal loading, so I've guessed that this test has failed on the pipeline because we're not waiting for that modal to disappear.