### PR TITLE
Fix incorrect default request timeout for public API

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/RequestTimeoutTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/RequestTimeoutTests.cs
@@ -109,8 +109,8 @@ public class RequestTimeoutTests(TestApplicationFactory testApp) : IntegrationTe
             .WithWebHostBuilder(builder =>
             {
                 builder.WithAdditionalControllers(typeof(TestController));
-                builder.ConfigureAppConfiguration((hostContext, config) => 
-                    config.AddInMemoryCollection(new Dictionary<string, string?>()
+                builder.ConfigureAppConfiguration((_, config) =>
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
                     {
                         { $"{RequestTimeoutOptions.Section}:{nameof(RequestTimeoutOptions.TimeoutMilliseconds)}", "100" }
                     }));

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -183,6 +183,8 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
             .Bind(configuration.GetRequiredSection(ContentApiOptions.Section));
         services.AddOptions<DataFilesOptions>()
             .Bind(configuration.GetRequiredSection(DataFilesOptions.Section));
+        services.AddOptions<RequestTimeoutOptions>()
+            .Bind(configuration.GetRequiredSection(RequestTimeoutOptions.Section));
 
         // Services
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.json
@@ -17,6 +17,6 @@
     "TenantId": "00000000-0000-0000-0000-000000000000"
   },
   "RequestTimeout": {
-    "TimeoutMilliseconds": 300000
+    "TimeoutMilliseconds": 30000
   }
 }


### PR DESCRIPTION
This was accidentally set to 300 seconds instead of 30 seconds.