### PR TITLE
EES-5536 Fix styling and markup issues in data set file usage section

### DIFF
--- a/src/explore-education-statistics-common/src/components/CodeBlock.tsx
+++ b/src/explore-education-statistics-common/src/components/CodeBlock.tsx
@@ -20,7 +20,7 @@ export default function CodeBlock({
     const resetTimeout = setTimeout(toggleCopied.off, 5000);
 
     return () => {
-      if (copied === true) {
+      if (copied) {
         clearTimeout(resetTimeout);
       }
     };
@@ -35,7 +35,7 @@ export default function CodeBlock({
           toggleCopied.on();
         }}
       >
-        {copied ? <span aria-live="polite">Code copied</span> : 'Copy Code'}
+        {copied ? <span aria-live="polite">Code copied</span> : 'Copy code'}
       </Button>
       <SyntaxHighlighter
         className={styles.pre}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -216,7 +216,7 @@ export default function DataSetFilePage({
               }}
             />
 
-            <div className="govuk-grid-column-two-thirds">
+            <div className="govuk-grid-column-three-quarters">
               <DataSetFileDetails
                 dataSetFile={dataSetFile}
                 hasApiDataSet={!!apiDataSet}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileUsage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileUsage.tsx
@@ -62,38 +62,39 @@ export default function DataSetFileUsage({
             }
           />
         )}
-        <ChevronCard
-          link={<>Download this data using code</>}
-          cardSize="l"
-          description="Access this data using common programming languages"
-          descriptionAfter={
-            <>
-              <CopyTextButton
-                className="govuk-!-margin-top-5"
-                text={downloadLink}
-                labelHidden={false}
-              />
-              <h4>Example code</h4>
-              <Tabs id="dataSetUsage-code">
-                <TabsSection title="Python" headingTag="h4">
-                  <CodeBlock
-                    language="python"
-                    code={`import pandas as pd
-pd.read_csv("${downloadLink}")`}
-                  />
-                </TabsSection>
-                <TabsSection title="R" headingTag="h4">
-                  <CodeBlock
-                    language="r"
-                    code={`read.csv("${downloadLink}")`}
-                  />
-                </TabsSection>
-              </Tabs>
-            </>
-          }
-          noChevron
-        />
       </ChevronGrid>
+
+      <h3>Download this data using code</h3>
+
+      <p>
+        Access this data using common programming languages using the URL below.
+      </p>
+
+      <CopyTextButton
+        className="govuk-!-margin-top-5"
+        text={downloadLink}
+        labelHidden={false}
+      />
+
+      <h4>Example code</h4>
+
+      <Tabs id="dataSetUsage-code">
+        <TabsSection title="Python">
+          <h5 className="govuk-heading-s">Python</h5>
+
+          <CodeBlock
+            language="python"
+            code={`import pandas as pd
+            
+pd.read_csv("${downloadLink}")`}
+          />
+        </TabsSection>
+        <TabsSection title="R">
+          <h5 className="govuk-heading-s">R</h5>
+
+          <CodeBlock language="r" code={`read.csv("${downloadLink}")`} />
+        </TabsSection>
+      </Tabs>
     </DataSetFilePageSection>
   );
 }


### PR DESCRIPTION
This PR fixes:

- The main content column not taking the full 3/4th width (was 2/3rd)
- Incorrect use of `ChevronCard` wrapping the 'Download this data using code' section
- Incorrect heading markup for example code tabs
- Unneeded capitalisation of 'code' in 'Copy code'