### PR TITLE
EES-2468 Added Ability To Delete User

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/UserManagement/UserManagementControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/UserManagement/UserManagementControllerTests.cs
@@ -13,7 +13,7 @@ public class UserManagementControllerTests(TestApplicationFactory testApp) : Int
     public class DeleteUserTests(TestApplicationFactory testApp) : UserManagementControllerTests(testApp)
     {
         [Theory]
-        [InlineData("BAU User", true)]
+        [InlineData("BAU User", false)]
         [InlineData("Analyst", false)]
         [InlineData("Prerelease User", false)]
         public async Task PermissionCheck(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
@@ -131,36 +131,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             public async Task Success()
             {
                 await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupCheck(CanManageUsersOnSystem)
                     .AssertSuccess(async userService =>
                         {
                             var service = SetupUserManagementService(
-                                userService: userService.Object,
-                                enableDeletion: true);
+                                userService: userService.Object);
                             return await service.DeleteUser("ees-test.user@education.gov.uk");
-                        }
-                    );
-            }
-
-            [Fact]
-            public async Task Forbidden_EnvironmentConfiguration()
-            {
-                await PolicyCheckBuilder<SecurityPolicies>()
-                    .AssertForbidden(async userService =>
-                        {
-                            var service = SetupUserManagementService(userService: userService.Object);
-                            return await service.DeleteUser("ees.test-user@education.gov.uk");
-                        }
-                    );
-            }
-
-            [Fact]
-            public async Task Forbidden_InvalidEmailAddressFormat()
-            {
-                await PolicyCheckBuilder<SecurityPolicies>()
-                    .AssertForbidden(async userService =>
-                        {
-                            var service = SetupUserManagementService(userService: userService.Object);
-                            return await service.DeleteUser("invalid-email-to-delete@education.gov.uk");
                         }
                     );
             }
@@ -194,8 +170,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 userInviteRepository ?? new UserInviteRepository(usersAndRolesDbContext),
                 userReleaseInviteRepository ?? new UserReleaseInviteRepository(contentDbContext),
                 userPublicationInviteRepository ?? new UserPublicationInviteRepository(contentDbContext),
-                userManager ?? MockUserManager().Object,
-                new AppOptions { EnableThemeDeletion = enableDeletion }.ToOptionsWrapper()
+                userManager ?? MockUserManager().Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServiceTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Database;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
-using GovUk.Education.ExploreEducationStatistics.Admin.Options;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
@@ -17,7 +16,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Configuration;
 using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Utils.AdminMockUtils;
@@ -1030,8 +1028,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IUserInviteRepository? userInviteRepository = null,
             IUserReleaseInviteRepository? userReleaseInviteRepository = null,
             IUserPublicationInviteRepository? userPublicationInviteRepository = null,
-            UserManager<ApplicationUser>? userManager = null,
-            IConfiguration? configuration = null)
+            UserManager<ApplicationUser>? userManager = null)
         {
             contentDbContext ??= InMemoryApplicationDbContext();
             usersAndRolesDbContext ??= InMemoryUserAndRolesDbContext();
@@ -1047,8 +1044,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 userInviteRepository ?? new UserInviteRepository(usersAndRolesDbContext),
                 userReleaseInviteRepository ?? new UserReleaseInviteRepository(contentDbContext),
                 userPublicationInviteRepository ?? new UserPublicationInviteRepository(contentDbContext),
-                userManager ?? MockUserManager().Object,
-                new AppOptions { EnableThemeDeletion = true }.ToOptionsWrapper()
+                userManager ?? MockUserManager().Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Database/UsersAndRolesDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Database/UsersAndRolesDbContext.cs
@@ -47,6 +47,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Database
             base.OnModelCreating(modelBuilder);
 
             modelBuilder.Entity<UserInvite>()
+                .HasOne(c => c.CreatedBy)
+                .WithMany()
+                .HasForeignKey("CreatedById")
+                .OnDelete(DeleteBehavior.SetNull);
+
+                modelBuilder.Entity<UserInvite>()
                 .Property(invite => invite.Created)
                 .HasConversion(
                     v => v,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/UsersAndRolesMigrations/20240924102651_EES2468_AddSetNullToUserInviteCreatedById.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/UsersAndRolesMigrations/20240924102651_EES2468_AddSetNullToUserInviteCreatedById.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.UsersAndRolesMigrations
 {
     [DbContext(typeof(UsersAndRolesDbContext))]
-    partial class UsersAndRolesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240924102651_EES2468_AddSetNullToUserInviteCreatedById")]
+    partial class EES2468_AddSetNullToUserInviteCreatedById
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/UsersAndRolesMigrations/20240924102651_EES2468_AddSetNullToUserInviteCreatedById.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/UsersAndRolesMigrations/20240924102651_EES2468_AddSetNullToUserInviteCreatedById.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.UsersAndRolesMigrations
+{
+    /// <inheritdoc />
+    public partial class EES2468_AddSetNullToUserInviteCreatedById : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserInvites_AspNetUsers_CreatedById",
+                table: "UserInvites");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserInvites_AspNetUsers_CreatedById",
+                table: "UserInvites",
+                column: "CreatedById",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserInvites_AspNetUsers_CreatedById",
+                table: "UserInvites");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserInvites_AspNetUsers_CreatedById",
+                table: "UserInvites",
+                column: "CreatedById",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/src/explore-education-statistics-admin/src/pages/bau/BauUsersPage.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauUsersPage.module.scss
@@ -1,0 +1,9 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.manageUserLink {
+  margin-right: govuk-spacing(2);
+}
+
+.deleteUserButton {
+  color: govuk-colour('red');
+}

--- a/src/explore-education-statistics-admin/src/pages/bau/BauUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauUsersPage.tsx
@@ -1,12 +1,26 @@
 import Link from '@admin/components/Link';
 import Page from '@admin/components/Page';
 import userService from '@admin/services/userService';
+import ButtonText from '@common/components/ButtonText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import logger from '@common/services/logger';
 import React from 'react';
+import styles from './BauUsersPage.module.scss';
 
 const BauUsersPage = () => {
   const { value, isLoading } = useAsyncRetry(() => userService.getUsers());
+
+  const handleDeleteUser = async (userEmail: string) => {
+    await userService
+      .deleteUser(userEmail)
+      .then(() => {
+        window.location.reload();
+      })
+      .catch(error => {
+        logger.info(`Error encountered when deleting the user - ${error}`);
+      });
+  };
 
   return (
     <Page
@@ -37,7 +51,18 @@ const BauUsersPage = () => {
                   <td>{user.email}</td>
                   <td>{user.role ?? 'No role'}</td>
                   <td>
-                    <Link to={`/administration/users/${user.id}`}>Manage</Link>
+                    <Link
+                      className={styles.manageUserLink}
+                      to={`/administration/users/${user.id}`}
+                    >
+                      Manage
+                    </Link>
+                    <ButtonText
+                      onClick={() => handleDeleteUser(user.email)}
+                      className={styles.deleteUserButton}
+                    >
+                      Delete
+                    </ButtonText>
                   </td>
                 </tr>
               ))}

--- a/src/explore-education-statistics-admin/src/pages/bau/__tests__/BauUsersPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/__tests__/BauUsersPage.test.tsx
@@ -1,0 +1,62 @@
+import _userService, {
+  RemoveUser,
+  UserStatus,
+} from '@admin/services/userService';
+import { MemoryRouter } from 'react-router';
+import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BauUsersPage from '../BauUsersPage';
+
+jest.mock('@admin/services/userService');
+
+const userService = _userService as jest.Mocked<typeof _userService>;
+
+const user: UserStatus[] = [
+  {
+    id: '1',
+    name: 'TestUser1',
+    email: 'test@hotmail.com',
+    role: 'test',
+  },
+];
+
+const removedUser: RemoveUser = {
+  userId: '1',
+};
+
+describe('BauUsersPage', () => {
+  test('renders delete action when user a user is present', async () => {
+    userService.getUsers.mockResolvedValue(user);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete')).toBeInTheDocument();
+    });
+  });
+
+  test('calls user service when delete user button is clicked', async () => {
+    userService.getUsers.mockResolvedValue(user);
+    userService.deleteUser.mockResolvedValue(Promise.resolve(removedUser));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete')).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(userService.deleteUser).toHaveBeenCalled();
+  });
+
+  function renderPage() {
+    return render(
+      <MemoryRouter>
+        <TestConfigContextProvider>
+          <BauUsersPage />
+        </TestConfigContextProvider>
+      </MemoryRouter>,
+    );
+  }
+});

--- a/src/explore-education-statistics-admin/src/services/userService.ts
+++ b/src/explore-education-statistics-admin/src/services/userService.ts
@@ -72,11 +72,16 @@ export interface ResourceRoles {
   Release?: string[];
 }
 
+export interface RemoveUser {
+  userId: string;
+}
+
 export interface UsersService {
   getRoles(): Promise<Role[]>;
   getReleases(): Promise<IdTitlePair[]>;
   getResourceRoles(): Promise<ResourceRoles>;
   getUser(userId: string): Promise<User>;
+  deleteUser(email: string): Promise<RemoveUser>;
   addUserReleaseRole: (
     userId: string,
     userReleaseRole: UserReleaseRoleSubmission,
@@ -128,6 +133,9 @@ const userService: UsersService = {
   },
   updateUser(userId: string, update: UserUpdate): Promise<boolean> {
     return client.put(`/user-management/users/${userId}`, update);
+  },
+  deleteUser(email: string): Promise<RemoveUser> {
+    return client.delete(`/user-management/user/${email}`);
   },
 
   addUserReleaseRole(


### PR DESCRIPTION
PR changes:
- Added ability to delete user on user management page
- Added frontend tests to BAU User Page (backend tests were already implemented for deleting a user)
- Updated `CreatedById` column in UserInvites table to set to null on deletion

![delete user screenshot](https://github.com/user-attachments/assets/f69d1aff-fb29-4b9c-b57a-eefee8f96707)