### PR TITLE
EES-5537 EES-5500 Notifier ContentDB connection and archived subscriptions fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The service can be started against a set of non-existent database. If no pre-exi
    CREATE LOGIN [adminapp] WITH PASSWORD = 'Your_Password123';
    CREATE LOGIN [importer] WITH PASSWORD = 'Your_Password123';
    CREATE LOGIN [publisher] WITH PASSWORD = 'Your_Password123';
+   CREATE LOGIN [notifier] WITH PASSWORD = 'Your_Password123';
    CREATE LOGIN [content] WITH PASSWORD = 'Your_Password123';
    CREATE LOGIN [data] WITH PASSWORD = 'Your_Password123';
    CREATE LOGIN [public_data_processor] WITH PASSWORD = 'Your_Password123';

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -236,13 +236,25 @@
     "sqlImporterUser": {
       "type": "string",
       "metadata": {
-        "description": "The username of the publisher for the private SQL Server"
+        "description": "The username of the importer for the private SQL Server"
       }
     },
     "sqlImporterUserPassword": {
       "type": "securestring",
       "metadata": {
         "description": "The password of the importer user for the private SQL Server"
+      }
+    },
+    "sqlNotifierUser": {
+      "type": "string",
+      "metadata": {
+        "description": "The username of the notifier for the private SQL Server"
+      }
+    },
+    "sqlNotifierUserPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password of the notifier user for the private SQL Server"
       }
     },
     "sqlAdminUser": {
@@ -1151,6 +1163,7 @@
     "ees-sql-password-data": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-sql-password-data')]",
     "ees-sql-password-importer": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-sql-password-importer')]",
     "ees-sql-password-publisher": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-sql-password-publisher')]",
+    "ees-sql-password-notifier": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-sql-password-notifier')]",
     "ees-sql-user-admin": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-sql-user-admin')]",
     "ees-sql-user-data": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-sql-user-data')]",
     "ees-sql-user-importer": "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'ees-sql-user-importer')]",
@@ -2903,7 +2916,14 @@
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]"
             ]
-          }
+          },
+          "connectionStrings": [
+            {
+              "name": "ContentDb",
+              "type": "SQLAzure",
+              "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('coreSqlServerName'))).fullyQualifiedDomainName, ',1433;Initial Catalog=', variables('contentDbName'), ';User Id=', parameters('sqlNotifierUser'), '@', reference(concat('Microsoft.Sql/servers/', variables('coreSqlServerName'))).fullyQualifiedDomainName, ';Password=', parameters('sqlNotifierUserPassword'), ';')]"
+            }
+          ]
         }
       }
     },

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240927152418_EES5537_CreateNotifierUserAndGrantPermissions.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240927152418_EES5537_CreateNotifierUserAndGrantPermissions.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240927152418_EES5537_CreateNotifierUserAndGrantPermissions")]
+    partial class EES5537_CreateNotifierUserAndGrantPermissions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240927152418_EES5537_CreateNotifierUserAndGrantPermissions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240927152418_EES5537_CreateNotifierUserAndGrantPermissions.cs
@@ -14,6 +14,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                                  CREATE USER [notifier] FROM LOGIN [notifier];
                                  
                                  GRANT SELECT ON [dbo].[Publications] TO [notifier];
+                                 GRANT SELECT ON [dbo].[ExternalMethodology] TO [notifier];
                                  """);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240927152418_EES5537_CreateNotifierUserAndGrantPermissions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20240927152418_EES5537_CreateNotifierUserAndGrantPermissions.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES5537_CreateNotifierUserAndGrantPermissions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                                 CREATE USER [notifier] FROM LOGIN [notifier];
+                                 
+                                 GRANT SELECT ON [dbo].[Publications] TO [notifier];
+                                 """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP USER [notifier];");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ReleaseNotificationMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/ReleaseNotificationMessage.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model
 {
@@ -15,7 +13,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model
 
         public bool Amendment { get; init; }
         public string UpdateNote { get; init; } = string.Empty;
-
-        public List<IdTitleViewModel> SupersededPublications { get; set; } = new();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/GovUk.Education.ExploreEducationStatistics.Notifier.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/GovUk.Education.ExploreEducationStatistics.Notifier.Tests.csproj
@@ -25,6 +25,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common.Tests\GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj" />
+      <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model.Tests\GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj" />
       <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Notifier\GovUk.Education.ExploreEducationStatistics.Notifier.csproj" />
     </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model\GovUk.Education.ExploreEducationStatistics.Content.Model.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Notifier.Model\GovUk.Education.ExploreEducationStatistics.Notifier.Model.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/NotifierHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/NotifierHostBuilder.cs
@@ -1,12 +1,16 @@
 using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Notifier.Options;
+using GovUk.Education.ExploreEducationStatistics.Common.Functions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Options;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Repositories;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Repositories.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Services;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -39,6 +43,14 @@ public static class NotifierHostBuilder
                 services
                     .AddApplicationInsightsTelemetryWorkerService()
                     .ConfigureFunctionsApplicationInsights()
+                    // @MarkFix Create migration with CREATE USER and GRANTs for access required
+                    // @MarkFix add sqlNotifierUser to release infra deploy validate/deploy steps
+                    // @MarkFix add sqlNotifierUserPassword to release infra deploy validate/deploy steps
+                    .AddDbContext<ContentDbContext>(options =>
+                        options.UseSqlServer(
+                            ConnectionUtils.GetAzureSqlConnectionString("ContentDb"),
+                            providerOptions =>
+                                SqlServerDbContextOptionsBuilderExtensions.EnableCustomRetryOnFailure(providerOptions)))
                     .AddFluentValidation()
                     .AddValidatorsFromAssembly(
                         typeof(ApiNotificationMessage.Validator).Assembly) // Adds *all* validators from Notifier.Model

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/NotifierHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/NotifierHostBuilder.cs
@@ -43,9 +43,6 @@ public static class NotifierHostBuilder
                 services
                     .AddApplicationInsightsTelemetryWorkerService()
                     .ConfigureFunctionsApplicationInsights()
-                    // @MarkFix Create migration with CREATE USER and GRANTs for access required
-                    // @MarkFix add sqlNotifierUser to release infra deploy validate/deploy steps
-                    // @MarkFix add sqlNotifierUserPassword to release infra deploy validate/deploy steps
                     .AddDbContext<ContentDbContext>(options =>
                         options.UseSqlServer(
                             ConnectionUtils.GetAzureSqlConnectionString("ContentDb"),

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/local.settings.json
@@ -5,6 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
   },
   "ConnectionStrings": {
+    "ContentDb": "Server=db;Database=content;User=notifier;Password=Your_Password123;TrustServerCertificate=True;"
   },
   "Host": {
     "LocalHttpPort": 7073,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/NotificationsServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/NotificationsServiceTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
-using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
@@ -167,8 +167,8 @@ public static class PublisherHostBuilderExtensions
                     }
                 }
 
-                StartupUtils.AddPersistenceHelper<ContentDbContext>(services); // @MarkFix Can be removed?
-                StartupUtils.AddPersistenceHelper<StatisticsDbContext>(services); // @MarkFix Can be removed?
+                StartupUtils.AddPersistenceHelper<ContentDbContext>(services);
+                StartupUtils.AddPersistenceHelper<StatisticsDbContext>(services);
             });
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
@@ -167,8 +167,8 @@ public static class PublisherHostBuilderExtensions
                     }
                 }
 
-                StartupUtils.AddPersistenceHelper<ContentDbContext>(services);
-                StartupUtils.AddPersistenceHelper<StatisticsDbContext>(services);
+                StartupUtils.AddPersistenceHelper<ContentDbContext>(services); // @MarkFix Can be removed?
+                StartupUtils.AddPersistenceHelper<StatisticsDbContext>(services); // @MarkFix Can be removed?
             });
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/NotificationsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/NotificationsService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
@@ -59,15 +58,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 latestUpdateNoteReason = latestUpdateNote.Reason;
             }
 
-            var supersededPublications = await context.Publications
-                .Where(p => p.SupersededById == releaseVersion.PublicationId)
-                .Select(p => new
-                {
-                    p.Id,
-                    p.Title
-                })
-                .ToListAsync();
-
             return new ReleaseNotificationMessage
             {
                 PublicationId = releaseVersion.Publication.Id,
@@ -77,8 +67,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 ReleaseSlug = releaseVersion.Slug,
                 Amendment = releaseVersion.Version > 0,
                 UpdateNote = latestUpdateNoteReason,
-                SupersededPublications = supersededPublications.Select(p =>
-                    new IdTitleViewModel(p.Id, p.Title)).ToList(),
             };
         }
     }


### PR DESCRIPTION
This PR does three things
- Allows the Notifier to connect to the Content DB
- When unsubscribing a user, we now also remove any subscriptions from associated archived subscriptions.
- Fixes the unsubscribe link for subscribers to archived publications

Details for why we decided to create the DB connection for Notifier are in the comments in EES-5500. The TLDR is that we consider it better to open a Content DB connection for Notifier than continue to pass everything Notifier needs in requests. And now we have a Content DB connection in Notifier, this opens up the possibility for other simplifications, as Notifier can now fetch the data it needs itself.

:rotating_light: This PR requires faffy deploy steps detailed in EES-5537 :rotating_light: 