### PR TITLE
EES-5537 Give Notifier subnet access to ContentDB

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1116,6 +1116,10 @@
         "id": "[variables('dataSubnetRef')]"
       },
       {
+        "name": "notifier",
+        "id": "[variables('notifySubnetRef')]"
+      },
+      {
         "name": "publicApiDataProcessor",
         "id": "[variables('publicApiDataProcessorSubnetRef')]"
       }


### PR DESCRIPTION
Notifier was unable to access the ContentDB and was throwing an exception.

This PR should fix this by giving the Notifier subnet access to the database.