### PR TITLE
EES-5497 Add API data set preview token guidance

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewPage.tsx
@@ -96,13 +96,13 @@ export default function ReleaseApiDataSetPreviewPage() {
             </p>
             <Modal
               open={modalOpen}
-              title="Generate API token"
+              title="Generate preview token"
               triggerButton={
                 <Button
                   className="govuk-!-margin-top-5"
                   onClick={toggleModalOpen.on}
                 >
-                  Generate token
+                  Generate preview token
                 </Button>
               }
             >

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenLogPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenLogPage.tsx
@@ -126,7 +126,7 @@ export default function ReleaseApiDataSetPreviewTokenLogPage() {
                             <VisuallyHidden> for {token.label}</VisuallyHidden>
                           </Link>
                           <ModalConfirm
-                            title="Revoke this token"
+                            title="Revoke preview token"
                             triggerButton={
                               <ButtonText className="govuk-!-margin-left-2">
                                 Revoke
@@ -135,7 +135,10 @@ export default function ReleaseApiDataSetPreviewTokenLogPage() {
                             }
                             onConfirm={() => handleRevoke(token.id)}
                           >
-                            <p>Are you sure you want to revoke this token?</p>
+                            <p>
+                              Are you sure you want to revoke this preview
+                              token?
+                            </p>
                           </ModalConfirm>
                         </>
                       )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
@@ -11,11 +11,14 @@ import previewTokenQueries from '@admin/queries/previewTokenQueries';
 import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
 import previewTokenService from '@admin/services/previewTokenService';
 import { useLastLocation } from '@admin/contexts/LastLocationContext';
+import CodeBlock from '@common/components/CodeBlock';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Button from '@common/components/Button';
 import CopyTextButton from '@common/components/CopyTextButton';
 import FormattedDate from '@common/components/FormattedDate';
 import ModalConfirm from '@common/components/ModalConfirm';
+import Tabs from '@common/components/Tabs';
+import TabsSection from '@common/components/TabsSection';
 import ApiDataSetQuickStart from '@common/modules/data-catalogue/components/ApiDataSetQuickStart';
 import { useQuery } from '@tanstack/react-query';
 import { generatePath, useHistory, useParams } from 'react-router-dom';
@@ -75,6 +78,8 @@ export default function ReleaseApiDataSetPreviewTokenPage() {
     );
   };
 
+  const tokenExampleUrl = `${publicApiUrl}/api/v1.0/data-sets/${dataSet?.draftVersion?.id}`;
+
   return (
     <>
       <Link
@@ -92,51 +97,98 @@ export default function ReleaseApiDataSetPreviewTokenPage() {
       </Link>
       <LoadingSpinner loading={isLoadingDataSet || isLoadingPreviewTokenId}>
         <div className="govuk-grid-row">
-          <div className="govuk-grid-column-three-quarters">
+          <div className="govuk-grid-column-three-quarters-from-desktop">
             <span className="govuk-caption-l">API data set preview token</span>
             <h2>{dataSet?.title}</h2>
 
             {previewToken?.status === 'Active' ? (
               <>
                 <p>
-                  Token expiry time:{' '}
+                  Reference: <strong>{previewToken.label}</strong>
+                </p>
+
+                <CopyTextButton
+                  buttonText="Copy preview token"
+                  className="govuk-!-margin-bottom-6"
+                  confirmMessage="Token copied to the clipboard"
+                  inlineButton={false}
+                  label="Preview token"
+                  text={previewToken.id}
+                />
+
+                <p>
+                  The token expires:{' '}
                   <strong>
                     <FormattedDate formatRelativeToNow>
                       {previewToken.expiry}
                     </FormattedDate>
                   </strong>
                 </p>
-                <h3>Using this token</h3>
-                <h4>Step 1</h4>
-                <p>TODO</p>
-                <h4>Step 2</h4>
-                <p>TODO else</p>
-                <h4>Final checks</h4>
-                <CopyTextButton
-                  buttonText="Copy preview token"
-                  className="govuk-!-margin-bottom-4"
-                  confirmMessage="Token copied to the clipboard"
-                  inlineButton={false}
-                  label="Preview token"
-                  text={previewToken.id}
-                />
+
+                <h3>Using the preview token</h3>
+
                 <p>
-                  Please revoke the token as soon as you have finished checking
-                  the API data set.
+                  To use the preview token, add it to your request using a{' '}
+                  <code>Preview-Token</code> header.
                 </p>
+                <p>
+                  The examples below illustrate how you can add the preview
+                  token header to your code.
+                </p>
+
+                <Tabs id="preview-token-examples">
+                  <TabsSection title="cURL" headingTitle="cURL" headingTag="h4">
+                    <CodeBlock language="bash">
+                      {`curl -X GET -H "Preview-Token: ${previewToken.id}" \\
+  ${tokenExampleUrl}`}
+                    </CodeBlock>
+                  </TabsSection>
+                  <TabsSection
+                    title="Python"
+                    headingTitle="Python"
+                    headingTag="h4"
+                  >
+                    <CodeBlock language="python">
+                      {`import requests
+
+url = "${tokenExampleUrl}"
+
+response = requests.get(url, headers={"Preview-Token": "${previewToken.id}"})`}
+                    </CodeBlock>
+                  </TabsSection>
+                  <TabsSection title="R" headingTitle="R" headingTag="h4">
+                    <CodeBlock language="r">{`library(httr)
+
+url <- "${tokenExampleUrl}"
+
+response <- GET(url, add_headers("Preview-Token" = "${previewToken.id}"))
+`}</CodeBlock>
+                  </TabsSection>
+                </Tabs>
+
+                <h3>Revoking the preview token</h3>
+
+                <p>
+                  Once you have checked the API data set, it is recommended that
+                  you revoke the preview token.
+                </p>
+
                 <ModalConfirm
-                  title="Revoke this token"
+                  title="Revoke preview token"
                   triggerButton={
-                    <Button variant="warning">Revoke this token</Button>
+                    <Button variant="warning">Revoke preview token</Button>
                   }
                   onConfirm={() => handleRevoke(previewToken.id)}
                 >
-                  <p>Are you sure you want to revoke this token?</p>
+                  <p>Are you sure you want to revoke the preview token?</p>
                 </ModalConfirm>
+
                 <p>
-                  <Link to={tokenLogPagePath}>View API data set token log</Link>
+                  <Link to={tokenLogPagePath}>View preview token log</Link>
                 </p>
+
                 <h3>API data set endpoints quick start</h3>
+
                 {dataSet?.draftVersion && (
                   <ApiDataSetQuickStart
                     publicApiBaseUrl={`${publicApiUrl}/api/v1.0`}

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
@@ -109,9 +109,8 @@ export default function ReleaseApiDataSetPreviewTokenPage() {
 
                 <CopyTextButton
                   buttonText="Copy preview token"
-                  className="govuk-!-margin-bottom-6"
-                  confirmMessage="Token copied to the clipboard"
-                  inlineButton={false}
+                  confirmText="Preview token copied"
+                  id="copy-preview-token"
                   label="Preview token"
                   text={previewToken.id}
                 />

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewPage.test.tsx
@@ -72,7 +72,7 @@ describe('ReleaseApiDataSetPreviewPage', () => {
       screen.getByRole('heading', { name: 'Data set title' }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Generate token' }),
+      screen.getByRole('button', { name: 'Generate preview token' }),
     ).toBeInTheDocument();
   });
 
@@ -87,7 +87,9 @@ describe('ReleaseApiDataSetPreviewPage', () => {
       await screen.findByText('Generate API data set preview token'),
     ).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Generate token' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Generate preview token' }),
+    );
 
     expect(await screen.findByText('Token name')).toBeInTheDocument();
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenLogPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenLogPage.test.tsx
@@ -197,7 +197,9 @@ describe('ReleaseApiDataSetPreviewTokenLogPage', () => {
     );
 
     expect(
-      await screen.findByText('Are you sure you want to revoke this token?'),
+      await screen.findByText(
+        'Are you sure you want to revoke this preview token?',
+      ),
     ).toBeInTheDocument();
 
     expect(previewTokenService.revokePreviewToken).not.toHaveBeenCalled();

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenPage.test.tsx
@@ -95,7 +95,7 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('link', { name: 'View API data set token log' }),
+      screen.getByRole('link', { name: 'View preview token log' }),
     ).toBeInTheDocument();
 
     expect(

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenPage.test.tsx
@@ -78,11 +78,11 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
       minute: '2-digit',
     })}`;
 
-    expect(screen.getByText('Token expiry time:')).toBeInTheDocument();
+    expect(screen.getByText('The token expires:')).toBeInTheDocument();
     expect(screen.getByText(expiry)).toBeInTheDocument();
 
     expect(
-      screen.getByRole('heading', { name: 'Using this token' }),
+      screen.getByRole('heading', { name: 'Using the preview token' }),
     ).toBeInTheDocument();
 
     expect(screen.getByLabelText('Preview token')).toHaveValue('token-id');
@@ -91,7 +91,7 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('button', { name: 'Revoke this token' }),
+      screen.getByRole('button', { name: 'Revoke preview token' }),
     ).toBeInTheDocument();
 
     expect(
@@ -143,10 +143,14 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
       await screen.findByText('API data set preview token'),
     ).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Revoke this token' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Revoke preview token' }),
+    );
 
     expect(
-      await screen.findByText('Are you sure you want to revoke this token?'),
+      await screen.findByText(
+        'Are you sure you want to revoke the preview token?',
+      ),
     ).toBeInTheDocument();
 
     expect(previewTokenService.revokePreviewToken).not.toHaveBeenCalled();

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetPreviewTokenCreateForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetPreviewTokenCreateForm.tsx
@@ -76,7 +76,7 @@ export default function ApiDataSetPreviewTokenCreateForm({
                 inline
                 loading={formState.isSubmitting}
                 size="sm"
-                text="Creating new API data set preview token"
+                text="Creating new preview token"
               />
             </ButtonGroup>
           </Form>

--- a/src/explore-education-statistics-common/src/components/CodeBlock.tsx
+++ b/src/explore-education-statistics-common/src/components/CodeBlock.tsx
@@ -1,17 +1,19 @@
 import styles from '@common/components/CodeBlock.module.scss';
 import useToggle from '@common/hooks/useToggle';
 import React, { useEffect } from 'react';
+import bashLang from 'react-syntax-highlighter/dist/cjs/languages/hljs/bash';
 import pythonLang from 'react-syntax-highlighter/dist/cjs/languages/hljs/python';
 import rLang from 'react-syntax-highlighter/dist/cjs/languages/hljs/r';
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light';
 import Button from './Button';
 
+SyntaxHighlighter.registerLanguage('bash', bashLang);
 SyntaxHighlighter.registerLanguage('r', rLang);
 SyntaxHighlighter.registerLanguage('python', pythonLang);
 
 export interface CodeBlockProps {
   children: string;
-  language: 'python' | 'r';
+  language: 'bash' | 'python' | 'r';
 }
 
 export default function CodeBlock({ children, language }: CodeBlockProps) {

--- a/src/explore-education-statistics-common/src/components/CodeBlock.tsx
+++ b/src/explore-education-statistics-common/src/components/CodeBlock.tsx
@@ -1,4 +1,5 @@
 import styles from '@common/components/CodeBlock.module.scss';
+import ScreenReaderMessage from '@common/components/ScreenReaderMessage';
 import useToggle from '@common/hooks/useToggle';
 import React, { useEffect } from 'react';
 import bashLang from 'react-syntax-highlighter/dist/cjs/languages/hljs/bash';
@@ -13,10 +14,17 @@ SyntaxHighlighter.registerLanguage('python', pythonLang);
 
 export interface CodeBlockProps {
   children: string;
+  copyConfirmText?: string;
+  copyText?: string;
   language: 'bash' | 'python' | 'r';
 }
 
-export default function CodeBlock({ children, language }: CodeBlockProps) {
+export default function CodeBlock({
+  children,
+  copyConfirmText = 'Code copied',
+  copyText = 'Copy code',
+  language,
+}: CodeBlockProps) {
   const [copied, toggleCopied] = useToggle(false);
 
   useEffect(() => {
@@ -38,8 +46,10 @@ export default function CodeBlock({ children, language }: CodeBlockProps) {
           toggleCopied.on();
         }}
       >
-        <span aria-live="polite">{copied ? 'Code copied' : 'Copy code'}</span>
+        {copied ? copyConfirmText : copyText}
       </Button>
+
+      <ScreenReaderMessage message={copied ? copyConfirmText : ''} />
 
       <SyntaxHighlighter
         className={styles.pre}

--- a/src/explore-education-statistics-common/src/components/CopyLinkModal.module.scss
+++ b/src/explore-education-statistics-common/src/components/CopyLinkModal.module.scss
@@ -1,0 +1,9 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.copyLink {
+  margin-bottom: govuk-spacing(4);
+
+  @include govuk-media-query($from: desktop) {
+    min-width: map-get($govuk-breakpoints, 'tablet');
+  }
+}

--- a/src/explore-education-statistics-common/src/components/CopyLinkModal.tsx
+++ b/src/explore-education-statistics-common/src/components/CopyLinkModal.tsx
@@ -4,6 +4,7 @@ import Modal from '@common/components/Modal';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import CopyTextButton from '@common/components/CopyTextButton';
 import React from 'react';
+import styles from './CopyLinkModal.module.scss';
 
 interface Props {
   buttonClassName?: string;
@@ -24,6 +25,7 @@ export default function CopyLinkModal({ buttonClassName, url }: Props) {
     >
       <CopyTextButton
         buttonText="Copy link"
+        className={styles.copyLink}
         confirmText="Link copied"
         id="copy-link-url"
         label="URL"

--- a/src/explore-education-statistics-common/src/components/CopyLinkModal.tsx
+++ b/src/explore-education-statistics-common/src/components/CopyLinkModal.tsx
@@ -2,24 +2,15 @@ import Button from '@common/components/Button';
 import LinkIcon from '@common/components/LinkIcon';
 import Modal from '@common/components/Modal';
 import VisuallyHidden from '@common/components/VisuallyHidden';
-import CopyTextButton, {
-  CopyTextButtonProps,
-} from '@common/components/CopyTextButton';
-import { OmitStrict } from '@common/types';
+import CopyTextButton from '@common/components/CopyTextButton';
 import React from 'react';
 
-interface Props extends OmitStrict<CopyTextButtonProps, 'text'> {
+interface Props {
   buttonClassName?: string;
   url: string;
 }
 
-export default function CopyLinkModal({
-  buttonClassName,
-  className,
-  confirmMessage = 'Link copied to the clipboard.',
-  inlineButton = true,
-  url,
-}: Props) {
+export default function CopyLinkModal({ buttonClassName, url }: Props) {
   return (
     <Modal
       showClose
@@ -32,9 +23,11 @@ export default function CopyLinkModal({
       }
     >
       <CopyTextButton
-        className={className}
-        confirmMessage={confirmMessage}
-        inlineButton={inlineButton}
+        buttonText="Copy link"
+        confirmText="Link copied"
+        id="copy-link-url"
+        label="URL"
+        labelHidden={false}
         text={url}
       />
     </Modal>

--- a/src/explore-education-statistics-common/src/components/CopyTextButton.module.scss
+++ b/src/explore-education-statistics-common/src/components/CopyTextButton.module.scss
@@ -1,13 +1,28 @@
 @import '~govuk-frontend/dist/govuk/base';
 
-.message {
-  height: 2rem;
-  margin: govuk-spacing(2) 0;
+.container {
+  margin-bottom: govuk-spacing(4);
+
+  @include govuk-media-query($until: tablet) {
+    display: block;
+  }
 }
 
-.container {
+.urlContainer {
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: govuk-spacing(2);
+  }
+}
+
+.button {
+  display: block;
+
   @include govuk-media-query($from: tablet) {
-    width: 500px;
-    max-width: 100%;
+    box-shadow: 0 0;
+    display: inline-block;
+    flex-shrink: 1;
+    margin-bottom: 0;
+    white-space: nowrap;
+    width: auto;
   }
 }

--- a/src/explore-education-statistics-common/src/components/CopyTextButton.tsx
+++ b/src/explore-education-statistics-common/src/components/CopyTextButton.tsx
@@ -1,16 +1,18 @@
 import Button from '@common/components/Button';
 import styles from '@common/components/CopyTextButton.module.scss';
+import ScreenReaderMessage from '@common/components/ScreenReaderMessage';
 import UrlContainer from '@common/components/UrlContainer';
 import useToggle from '@common/hooks/useToggle';
 import classNames from 'classnames';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 
 export interface CopyTextButtonProps {
   buttonText?: string | ReactNode;
   className?: string;
-  confirmMessage?: string;
-  inlineButton?: boolean;
-  label?: string;
+  confirmText?: string;
+  id: string;
+  inline?: boolean;
+  label: string;
   labelHidden?: boolean;
   text: string;
 }
@@ -18,74 +20,56 @@ export interface CopyTextButtonProps {
 export default function CopyTextButton({
   buttonText = 'Copy',
   className,
-  confirmMessage = 'Text copied to the clipboard.',
-  inlineButton = true,
+  confirmText = 'Copied',
+  id,
+  inline = true,
   label,
-  labelHidden = true,
+  labelHidden,
   text,
 }: CopyTextButtonProps) {
   const [copied, toggleCopied] = useToggle(false);
 
-  return (
-    <div className={className}>
-      <div
-        className={classNames(styles.container, {
-          'dfe-flex dfe-align-items-start': inlineButton,
-        })}
-      >
-        <UrlContainer
-          id="copy-link-url"
-          className={styles.urlContainer}
-          label={label}
-          labelHidden={labelHidden}
-          url={text}
-          widthLimited={false}
-        />
-        <div
-          className={classNames({
-            'dfe-flex dfe-align-items--center govuk-!-margin-top-2':
-              !inlineButton,
-          })}
-        >
-          <Button
-            className={classNames('govuk-!-margin-bottom-0', {
-              'govuk-!-margin-right-2': !inlineButton,
-            })}
-            onClick={async () => {
-              await navigator.clipboard.writeText(text);
-              toggleCopied.on();
-            }}
-          >
-            {buttonText}
-          </Button>
-          {!inlineButton && (
-            <Message copied={copied} confirmMessage={confirmMessage} />
-          )}
-        </div>
-      </div>
-      {inlineButton && (
-        <Message
-          className={styles.message}
-          copied={copied}
-          confirmMessage={confirmMessage}
-        />
-      )}
-    </div>
-  );
-}
+  useEffect(() => {
+    const resetTimeout = setTimeout(toggleCopied.off, 5000);
 
-function Message({
-  className,
-  copied,
-  confirmMessage,
-}: {
-  className?: string;
-  copied: boolean;
-  confirmMessage?: string;
-}) {
+    return () => {
+      if (copied) {
+        clearTimeout(resetTimeout);
+      }
+    };
+  }, [copied, toggleCopied]);
+
   return (
-    <div aria-live="polite" className={className}>
-      {copied && confirmMessage}
+    <div
+      className={classNames(className, styles.container, {
+        'dfe-flex dfe-align-items--start': inline,
+      })}
+    >
+      <UrlContainer
+        className={classNames(styles.urlContainer, {
+          'dfe-flex-grow--1': inline,
+          'govuk-!-margin-bottom-2': !inline,
+        })}
+        id={id}
+        inline={inline}
+        label={label}
+        labelHidden={labelHidden}
+        url={text}
+      />
+
+      <Button
+        className={classNames(styles.button, {
+          'govuk-!-margin-right-2': !inline,
+        })}
+        onClick={async () => {
+          await navigator.clipboard.writeText(text);
+          toggleCopied.on();
+        }}
+      >
+        {copied ? confirmText : buttonText}
+      </Button>
+
+      <ScreenReaderMessage message={copied ? confirmText : ''} />
     </div>
   );
 }

--- a/src/explore-education-statistics-common/src/components/UrlContainer.module.scss
+++ b/src/explore-education-statistics-common/src/components/UrlContainer.module.scss
@@ -1,11 +1,17 @@
 @import '~govuk-frontend/dist/govuk/base';
+@import '@common/styles/mixins/focus';
 
 .url {
   background: govuk-colour('light-grey');
   border: 0;
   display: inline-block;
-  flex: 1;
+  flex-grow: 1;
   padding: govuk-spacing(2) govuk-spacing(4);
+  text-overflow: ellipsis;
   user-select: all;
   white-space: pre-wrap;
+
+  &:focus {
+    @include focused-input;
+  }
 }

--- a/src/explore-education-statistics-common/src/components/UrlContainer.tsx
+++ b/src/explore-education-statistics-common/src/components/UrlContainer.tsx
@@ -5,9 +5,9 @@ import React, { ReactNode } from 'react';
 interface Props {
   className?: string;
   id: string;
+  inline?: boolean;
   label?: string | ReactNode;
   labelHidden?: boolean;
-  widthLimited?: boolean;
   testId?: string;
   url: string;
 }
@@ -15,17 +15,17 @@ interface Props {
 export default function UrlContainer({
   className,
   id,
+  inline = true,
   label = 'URL',
   labelHidden,
-  widthLimited,
   testId = id,
   url,
 }: Props) {
   return (
     <div
-      className={classNames(className, {
-        'dfe-flex dfe-align-items--center': !labelHidden,
-        'dfe-flex-grow--1': !widthLimited,
+      className={classNames(className, 'dfe-flex dfe-flex-wrap', {
+        'dfe-flex-direction--column': !inline,
+        'dfe-align-items--center': inline,
       })}
     >
       <label
@@ -33,18 +33,19 @@ export default function UrlContainer({
         className={classNames({
           'govuk-visually-hidden': labelHidden,
           'govuk-!-margin-right-2': !labelHidden,
+          'govuk-!-display-block govuk-!-margin-bottom-1': !inline,
         })}
       >
         {label}
       </label>
       <input
-        type="text"
-        value={url}
-        id={id}
         className={styles.url}
         data-testid={testId}
-        onFocus={e => e.target.select()}
+        id={id}
         readOnly
+        type="text"
+        value={url}
+        onFocus={e => e.target.select()}
       />
     </div>
   );

--- a/src/explore-education-statistics-common/src/components/__tests__/CopyLinkModal.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/CopyLinkModal.test.tsx
@@ -1,10 +1,10 @@
 import CopyLinkModal from '@common/components/CopyLinkModal';
 import render from '@common-test/render';
 import React from 'react';
-import { screen, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 
 describe('CopyLinkModal', () => {
-  const testUrl = 'http://test.com/1#test-heading';
+  const testUrl = 'https://test.com/1#test-heading';
 
   test('renders the copy link button', () => {
     render(<CopyLinkModal url={testUrl} />);
@@ -22,10 +22,33 @@ describe('CopyLinkModal', () => {
     );
 
     const modal = within(screen.getByRole('dialog'));
+
     expect(
       modal.getByRole('heading', { name: 'Copy link to the clipboard' }),
     ).toBeInTheDocument();
     expect(modal.getByLabelText('URL')).toHaveValue(testUrl);
-    expect(modal.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+    expect(
+      modal.getByRole('button', { name: 'Copy link' }),
+    ).toBeInTheDocument();
+  });
+
+  test('copies the text to the clipboard and shows a message when the button is clicked', async () => {
+    const { user } = render(<CopyLinkModal url={testUrl} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Copy link to the clipboard' }),
+    );
+
+    const modal = within(screen.getByRole('dialog'));
+
+    await user.click(modal.getByRole('button', { name: 'Copy link' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Link copied')).toBeInTheDocument();
+    });
+
+    const copiedText = await window.navigator.clipboard.readText();
+
+    expect(copiedText).toEqual(testUrl);
   });
 });

--- a/src/explore-education-statistics-common/src/components/__tests__/CopyTextButton.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/CopyTextButton.test.tsx
@@ -7,17 +7,18 @@ describe('CopyTextButton', () => {
   const testText = 'http://test.com/1#test-heading';
 
   test('copies the text to the clipboard and shows a message when the button is clicked', async () => {
-    const { user } = render(<CopyTextButton text={testText} />);
+    const { user } = render(
+      <CopyTextButton id="copy-text" label="Text" text={testText} />,
+    );
 
     await user.click(screen.getByRole('button', { name: 'Copy' }));
 
     await waitFor(() => {
-      expect(
-        screen.getByText('Text copied to the clipboard.'),
-      ).toBeInTheDocument();
+      expect(screen.getByText('Copied')).toBeInTheDocument();
     });
 
     const copiedText = await window.navigator.clipboard.readText();
+
     expect(copiedText).toEqual(testText);
   });
 });

--- a/src/explore-education-statistics-common/src/styles/utils/_flex.scss
+++ b/src/explore-education-statistics-common/src/styles/utils/_flex.scss
@@ -2,6 +2,14 @@
   display: flex;
 }
 
+.dfe-flex-direction--column {
+  flex-direction: column;
+}
+
+.dfe-flex-direction--row {
+  flex-direction: row;
+}
+
 .dfe-flex-wrap {
   flex-wrap: wrap;
 }

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileUsage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileUsage.tsx
@@ -24,7 +24,7 @@ export default function DataSetFileUsage({
   tableToolLink,
   onDownload,
 }: Props) {
-  const downloadLink = new URL(
+  const downloadUrl = new URL(
     `/data-catalogue/data-set/${dataSetFileId}/csv`,
     process.env.PUBLIC_URL,
   ).href;
@@ -71,8 +71,10 @@ export default function DataSetFileUsage({
       </p>
 
       <CopyTextButton
-        className="govuk-!-margin-top-5"
-        text={downloadLink}
+        className="govuk-!-margin-top-5 govuk-!-margin-bottom-5"
+        id="copy-download-url"
+        text={downloadUrl}
+        label="URL"
         labelHidden={false}
       />
 
@@ -85,13 +87,13 @@ export default function DataSetFileUsage({
           <CodeBlock language="python">
             {`import pandas as pd
 
-pd.read_csv("${downloadLink}")`}
+pd.read_csv("${downloadUrl}")`}
           </CodeBlock>
         </TabsSection>
         <TabsSection title="R">
           <h5 className="govuk-heading-s">R</h5>
 
-          <CodeBlock language="r">{`read.csv("${downloadLink}")`}</CodeBlock>
+          <CodeBlock language="r">{`read.csv("${downloadUrl}")`}</CodeBlock>
         </TabsSection>
       </Tabs>
     </DataSetFilePageSection>

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileUsage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileUsage.test.tsx
@@ -95,6 +95,6 @@ describe('DataSetFileUsage', () => {
       />,
     );
 
-    expect(screen.getByTestId('copy-link-url')).toBeInTheDocument();
+    expect(screen.getByTestId('copy-download-url')).toBeInTheDocument();
   });
 });

--- a/tests/robot-tests/tests/libs/public-api-common.robot
+++ b/tests/robot-tests/tests/libs/public-api-common.robot
@@ -46,19 +46,19 @@ verify status of API Datasets
     user waits for caches to expire
     ${status_value}=    get text    xpath:(//div[@data-testid="Status"]//dd[@data-testid="Status-value"]//strong)[2]
     should be equal as strings    ${status_value}    ${expected_status}
-    
+
 user checks status in Draft version table
     [Arguments]    ${text}    ${expected_status}
     user waits for caches to expire
     ${status_value}=    get text    xpath:(//div[@data-testid="Status"]//dd[@data-testid="${text}"]//strong)[2]
     should be equal as strings    ${status_value}    ${expected_status}
 
-user checks row headings within the api dataset section
+user checks row headings within the api data set section
     [Arguments]    ${text}        ${parent}=#dataSetDetails
     user waits until page contains element    css:${PARENT} [data-testid="${text}"] > dt
 
 user gets accordion header button element
-    [Arguments]    ${heading_text}    ${parent}=css:#dataSetDetails 
+    [Arguments]    ${heading_text}    ${parent}=css:#dataSetDetails
     ${button}=    get child element    ${parent}    css:.[data-testid="Release"] > dt
     [Return]    ${button}
 

--- a/tests/robot-tests/tests/public_api/public_api_cancel_and_removal.robot
+++ b/tests/robot-tests/tests/public_api/public_api_cancel_and_removal.robot
@@ -14,7 +14,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - public api cancel and removal %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    UI tests - Public API - cancel and removal %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Financial year 3000-01
 ${SUBJECT_NAME_1}=      UI test subject 1
 ${SUBJECT_NAME_2}=      UI test subject 2
@@ -117,7 +117,7 @@ Verify the contents inside the 'Draft API datasets' table
 
 Remove draft API dataset
     user clicks button in table cell    1    4    Remove draft    xpath://table[@data-testid='draft-api-data-sets']
-    
+
     ${modal}=    user waits until modal is visible     Remove this draft API data set version
     user clicks button     Remove this API data set version
 

--- a/tests/robot-tests/tests/public_api/public_api_dataset_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_dataset_preview_token.robot
@@ -11,17 +11,12 @@ Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
-
-
 *** Variables ***
 ${PUBLICATION_NAME}=    UI tests - Public API - Generate and Preview API token %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Academic year Q1
 ${ACADEMIC_YEAR}=       3000
 ${SUBJECT_NAME_1}=      UI test subject 1
 ${SUBJECT_NAME_2}=      UI test subject 2
-
-
-
 
 *** Test Cases ***
 Create publication and release
@@ -94,19 +89,16 @@ Verify the contents inside the 'Draft API datasets' table
     user clicks link    Back to API data sets
     user waits until h3 is visible    Draft API data sets
 
-
     user checks table column heading contains    1    1    Draft version    xpath://table[@data-testid='draft-api-data-sets']
     user checks table column heading contains    1    2    Name             xpath://table[@data-testid='draft-api-data-sets']
     user checks table column heading contains    1    3    Status           xpath://table[@data-testid='draft-api-data-sets']
     user checks table column heading contains    1    4    Actions          xpath://table[@data-testid='draft-api-data-sets']
-
 
     user checks table cell contains    1    1    v1.0    xpath://table[@data-testid='draft-api-data-sets']
     user checks table cell contains    1    3    Ready    xpath://table[@data-testid='draft-api-data-sets']
 
     user checks table cell contains    2    1    v1.0    xpath://table[@data-testid='draft-api-data-sets']
     user checks table cell contains    2    3    Ready    xpath://table[@data-testid='draft-api-data-sets']
-
 
 Click on 'View Details' link(First API dataset)
     user clicks link in table cell    1    4    View details    xpath://table[@data-testid='draft-api-data-sets']
@@ -120,7 +112,6 @@ User checks row data contents inside the 'Draft API datasets' summary table
     user checks contents inside the cell value    ${SUBJECT_NAME_1}                          xpath://div[@data-testid="Data set file"]//dd[@data-testid="Data set file-value"]
     user checks contents inside the cell value    National                                   xpath://div[@data-testid="Geographic levels"]//dd[@data-testid="Geographic levels-value"]
     user checks contents inside the cell value    2012/13                                    xpath://div[@data-testid="Time periods"]//dd[@data-testid="Time periods-value"]
-
 
     user checks contents inside the cell value    Lower quartile annualised earnings         xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[1]
     user checks contents inside the cell value    Median annualised earnings                 xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[2]
@@ -141,11 +132,9 @@ User checks row data contents inside the 'Draft API datasets' summary table
     user checks contents inside the cell value      Number of years after achievement of learning aim    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[6]
     user checks contents inside the cell value      Provision                                 xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[7]
 
-
     user checks contents inside the cell value      Preview API data set                      xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[1]/a
     user checks contents inside the cell value      View preview token log                    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[2]/a
     user checks contents inside the cell value      Remove draft version                      xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[3]/button
-
 
 User clicks on 'Preview API dataset' link
     user clicks link containing text    Preview API data set
@@ -165,11 +154,11 @@ User creates API token through 'Generate API token' modal window
     user waits until h2 is visible    ${SUBJECT_NAME_1}
 
 User revokes created API token
-    user clicks button    Revoke this token
-    ${modal}=    user waits until modal is visible    Revoke this token
+    user clicks button    Revoke preview token
+    ${modal}=    user waits until modal is visible    Revoke preview token
     user clicks button    Confirm
     user waits until page finishes loading
-    user waits until modal is not visible    Revoke this token    %{WAIT_LONG}
+    user waits until modal is not visible    Revoke preview token    %{WAIT_LONG}
     user waits until page contains    Generate API data set preview token
 
 User again clicks on 'Generate Token'
@@ -187,11 +176,11 @@ User creates API token through 'Generate API token' modal window
     user waits until h2 is visible    ${SUBJECT_NAME_1}
 
 User cancels to revoke created API token
-    user clicks button    Revoke this token
-    ${modal}=    user waits until modal is visible    Revoke this token
+    user clicks button    Revoke preview token
+    ${modal}=    user waits until modal is visible    Revoke preview token
     user clicks button    Cancel
     user waits until page finishes loading
-    user waits until modal is not visible    Revoke this token    %{WAIT_LONG}
+    user waits until modal is not visible    Revoke preview token    %{WAIT_LONG}
     user waits until page contains    API data set preview token
     user waits until h2 is visible    ${SUBJECT_NAME_1}
 
@@ -227,11 +216,11 @@ Verify the 'Active tokens' and 'Expired tokens' on preview token log page
     user checks table cell contains    2    4    Expired
 
     user clicks button in table cell    1    6    Revoke
-    ${modal}=    user waits until modal is visible    Revoke this token
+    ${modal}=    user waits until modal is visible    Revoke preview token
     user clicks button    Confirm    ${modal}
     user waits until page finishes loading
     user checks table cell contains    1    4    Expired
-    
+
 User verifies the relevant fields on the 'View Log Details' page for the Active API token.
     user clicks link    Generate preview token
     user clicks button    Generate token
@@ -249,17 +238,16 @@ User verifies the relevant fields on the 'View Log Details' page for the Active 
     ${current_time_tomorrow}=    get current datetime    %Y-%m-%dT%H:%M:%S    1    Europe/London
 
     ${time_with_leading_zero}=    format uk to local datetime    ${current_time_tomorrow}    %I:%M %p
-    
+
     ${time_end}=    format time without leading zero     ${time_with_leading_zero}
 
-    user checks page contains    
-    ...     Token expiry time: tomorrow at ${time_end}
+    user checks page contains
+    ...     The token expires: tomorrow at ${time_end}
 
     user checks page contains button    Copy preview token
-    user checks page contains button    Revoke this token
-    user checks page contains link    View API data set token log
+    user checks page contains button    Revoke preview token
+    user checks page contains link    View preview token log
     user checks page contains    API data set endpoints quick start
-
 
 Add headline text block to Content page
     user clicks link    Back to API data set details
@@ -290,7 +278,7 @@ Search with 1st API dataset
 User clicks on API dataset link
     user clicks link by index    ${SUBJECT_NAME_1}
     user waits until page finishes loading
-    
+
     user waits until h1 is visible    ${SUBJECT_NAME_1}
 
 User checks relevant headings exist on API dataset details page
@@ -314,25 +302,24 @@ User verifies the row headings and contents in 'Data set details' section
     user checks row headings within the api dataset section   Notifications
 
     user checks contents inside the cell value          Test theme                                                  css: #dataSetDetails [data-testid="Theme-value"]
-    user checks contents inside the cell value          ${PUBLICATION_NAME}                                         css:#dataSetDetails [data-testid="Publication-value"] 
+    user checks contents inside the cell value          ${PUBLICATION_NAME}                                         css:#dataSetDetails [data-testid="Publication-value"]
     user checks contents inside the cell value          Academic year Q1 3000/01                                    css:#dataSetDetails [data-testid="Release-value"]
     User checks contents inside the release type        Accredited official statistics                              css:#dataSetDetails [data-testid="Release type-value"] > button
     user checks contents inside the cell value          National                                                    css:#dataSetDetails [data-testid="Geographic levels-value"]
 
-
     user checks contents inside the cell value           Lower quartile annualised earnings                         css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(1)
     user checks contents inside the cell value           Median annualised earnings                                 css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(2)
     user checks contents inside the cell value           Number of learners with earnings                           css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(3)
-    
+
     user clicks button                                   Show 1 more indicator                                      css:#dataSetDetails [data-testid="Indicators-value"]
-    
+
     user checks contents inside the cell value           Upper quartile annualised earnings                         css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(4)
 
     user checks contents inside the cell value    	     Cheese                                                     css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(1)
     user checks contents inside the cell value    	     Colour                                                     css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(2)
     user checks contents inside the cell value    	     Ethnicity group                                            css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(3)
 
-    user clicks button                                   Show 4 more filters                                        css:#dataSetDetails [data-testid="Filters-value"] 
+    user clicks button                                   Show 4 more filters                                        css:#dataSetDetails [data-testid="Filters-value"]
 
     user checks contents inside the cell value    	     Gender                                                     css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(4)
     user checks contents inside the cell value    	     Level of learning                                          css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(5)
@@ -351,8 +338,6 @@ User verifies the headings and contents in 'API version history' section
     user checks table cell contains              1    1    1.0 (current)                xpath://section[@id="apiVersionHistory"]
     user checks table cell contains              1    2    Academic year Q1 3000/01     xpath://section[@id="apiVersionHistory"]
     user checks table cell contains              1    3    Published                    xpath://section[@id="apiVersionHistory"]
-
-
 
 *** Keywords ***
 User checks contents inside the release type

--- a/tests/robot-tests/tests/public_api/public_api_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_preview_token.robot
@@ -12,11 +12,12 @@ Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - Public API - Generate and Preview API token %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    UI tests - Public API - preview token %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Academic year Q1
 ${ACADEMIC_YEAR}=       3000
 ${SUBJECT_NAME_1}=      UI test subject 1
 ${SUBJECT_NAME_2}=      UI test subject 2
+${PREVIEW_TOKEN_NAME}=  Test token
 
 *** Test Cases ***
 Create publication and release
@@ -136,24 +137,24 @@ User checks row data contents inside the 'Draft API datasets' summary table
     user checks contents inside the cell value      View preview token log                    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[2]/a
     user checks contents inside the cell value      Remove draft version                      xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[3]/button
 
-User clicks on 'Preview API dataset' link
+User clicks on 'Preview API data set' link
     user clicks link containing text    Preview API data set
 
-User clicks on 'Generate Token'
-    user clicks button     Generate token
+User clicks on 'Generate preview token'
+    user clicks button     Generate preview token
 
-User creates API token through 'Generate API token' modal window
-    ${modal}=    user waits until modal is visible    Generate API token
-    user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    API Token
+User creates preview token through 'Generate preview token' modal window
+    ${modal}=    user waits until modal is visible    Generate preview token
+    user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
     user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Continue
 
     user waits until page finishes loading
-    user waits until modal is not visible    Generate API token    %{WAIT_LONG}
+    user waits until modal is not visible    Generate preview token    %{WAIT_LONG}
     user waits until page contains    API data set preview token
     user waits until h2 is visible    ${SUBJECT_NAME_1}
 
-User revokes created API token
+User revokes preview token
     user clicks button    Revoke preview token
     ${modal}=    user waits until modal is visible    Revoke preview token
     user clicks button    Confirm
@@ -161,21 +162,21 @@ User revokes created API token
     user waits until modal is not visible    Revoke preview token    %{WAIT_LONG}
     user waits until page contains    Generate API data set preview token
 
-User again clicks on 'Generate Token'
-    user clicks button     Generate token
+User again clicks on 'Generate preview token'
+    user clicks button     Generate preview token
 
-User creates API token through 'Generate API token' modal window
-    ${modal}=    user waits until modal is visible    Generate API token
-    user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    API Token
+User creates another preview token through 'Generate preview token' modal window
+    ${modal}=    user waits until modal is visible    Generate preview token
+    user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
     user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Continue
 
     user waits until page finishes loading
-    user waits until modal is not visible    Generate API token    %{WAIT_LONG}
+    user waits until modal is not visible    Generate preview token    %{WAIT_LONG}
     user waits until page contains    API data set preview token
     user waits until h2 is visible    ${SUBJECT_NAME_1}
 
-User cancels to revoke created API token
+User cancels revoking preview token
     user clicks button    Revoke preview token
     ${modal}=    user waits until modal is visible    Revoke preview token
     user clicks button    Cancel
@@ -184,18 +185,18 @@ User cancels to revoke created API token
     user waits until page contains    API data set preview token
     user waits until h2 is visible    ${SUBJECT_NAME_1}
 
-User cancels to create API token
+User cancels creating preview token
     user clicks link    Back to API data set details
     user clicks link containing text    Preview API data set
-    user clicks button     Generate token
+    user clicks button     Generate preview token
 
-    ${modal}=    user waits until modal is visible    Generate API token
-    user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    API Token
+    ${modal}=    user waits until modal is visible    Generate preview token
+    user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
     user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Cancel
 
     user waits until page finishes loading
-    user waits until modal is not visible    Generate API token    %{WAIT_LONG}
+    user waits until modal is not visible    Generate preview token    %{WAIT_LONG}
     user waits until page contains    Generate API data set preview token
     user waits until h2 is visible    ${SUBJECT_NAME_1}
 
@@ -221,19 +222,21 @@ Verify the 'Active tokens' and 'Expired tokens' on preview token log page
     user waits until page finishes loading
     user checks table cell contains    1    4    Expired
 
-User verifies the relevant fields on the 'View Log Details' page for the Active API token.
+User verifies the relevant fields on the active preview token page
     user clicks link    Generate preview token
-    user clicks button    Generate token
+    user clicks button    Generate preview token
 
-    ${modal}=    user waits until modal is visible    Generate API token
-    user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    API Token
+    ${modal}=    user waits until modal is visible    Generate preview token
+    user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
     user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Continue
 
     user waits until page finishes loading
-    user waits until modal is not visible    Generate API token    %{WAIT_LONG}
+    user waits until modal is not visible    Generate preview token    %{WAIT_LONG}
     user waits until page contains    API data set preview token
+
     user waits until h2 is visible    ${SUBJECT_NAME_1}
+    user checks page contains    Reference: ${PREVIEW_TOKEN_NAME}
 
     ${current_time_tomorrow}=    get current datetime    %Y-%m-%dT%H:%M:%S    1    Europe/London
 
@@ -265,7 +268,7 @@ Verify newly published release is on Find Statistics page
 User navigates to data catalogue page
     user navigates to data catalogue page on public frontend
 
-Search with 1st API dataset
+Search with 1st API data set
     user clicks element    id:searchForm-search
     user presses keys    ${PUBLICATION_NAME}
     user clicks radio    API data sets only
@@ -275,13 +278,13 @@ Search with 1st API dataset
     user checks page contains link    ${SUBJECT_NAME_1}
     user checks list item contains    testid:data-set-file-list    1    ${SUBJECT_NAME_1}
 
-User clicks on API dataset link
+User clicks on API data set link
     user clicks link by index    ${SUBJECT_NAME_1}
     user waits until page finishes loading
 
     user waits until h1 is visible    ${SUBJECT_NAME_1}
 
-User checks relevant headings exist on API dataset details page
+User checks relevant headings exist on API data set details page
     user waits until h2 is visible    Data set details
     user waits until h2 is visible    Data set preview
     user waits until h2 is visible    Variables in this data set
@@ -290,16 +293,16 @@ User checks relevant headings exist on API dataset details page
     user waits until h2 is visible    API data set version history
 
 User verifies the row headings and contents in 'Data set details' section
-    user checks row headings within the api dataset section    Theme
-    user checks row headings within the api dataset section    Publication
-    user checks row headings within the api dataset section    Release
-    user checks row headings within the api dataset section    Release type
-    user checks row headings within the api dataset section   Geographic levels
-    user checks row headings within the api dataset section   Indicators
-    user checks row headings within the api dataset section    Filters
-    user checks row headings within the api dataset section    Time period
+    user checks row headings within the api data set section    Theme
+    user checks row headings within the api data set section    Publication
+    user checks row headings within the api data set section    Release
+    user checks row headings within the api data set section    Release type
+    user checks row headings within the api data set section   Geographic levels
+    user checks row headings within the api data set section   Indicators
+    user checks row headings within the api data set section    Filters
+    user checks row headings within the api data set section    Time period
 
-    user checks row headings within the api dataset section   Notifications
+    user checks row headings within the api data set section   Notifications
 
     user checks contents inside the cell value          Test theme                                                  css: #dataSetDetails [data-testid="Theme-value"]
     user checks contents inside the cell value          ${PUBLICATION_NAME}                                         css:#dataSetDetails [data-testid="Publication-value"]

--- a/tests/robot-tests/tests/public_api/public_api_resolve_mapping_statuses.robot
+++ b/tests/robot-tests/tests/public_api/public_api_resolve_mapping_statuses.robot
@@ -14,7 +14,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - public api resolve mapping statuses %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    UI tests - Public API - resolve mapping statuses %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Financial year 3000-01
 ${SUBJECT_NAME_1}=      UI test subject 1
 ${SUBJECT_NAME_2}=      UI test subject 2
@@ -148,7 +148,7 @@ Validate the row headings and its contents in the 'Regions' section
 
     user checks table column heading contains    1    3    Type
     user checks table column heading contains   1    4    Actions
-    
+
     user checks table cell contains    1    1    Yorkshire and The Humber
     user checks table cell contains    1    2    Unmapped
     user checks table cell contains    1    3    N/A
@@ -241,7 +241,7 @@ Confirm finalization of this API data set version
 User navigates to 'changelog and guidance notes' page and update relevant details in it
     user clicks link by index    View changelog and guidance notes    1
     user waits until page contains     API data set changelog
-    
+
     user enters text into element    css:textarea[id="guidanceNotesForm-notes"]    public guidance notes
     user clicks button    Save public guidance notes
 

--- a/tests/robot-tests/tests/public_api/public_api_restricted.robot
+++ b/tests/robot-tests/tests/public_api/public_api_restricted.robot
@@ -14,7 +14,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - public api restricted %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    UI tests - Public API - restricted %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Financial year 3000-01
 ${SUBJECT_NAME_1}=      UI test subject 1
 ${SUBJECT_NAME_2}=      UI test subject 2
@@ -98,11 +98,11 @@ Verify the contents inside the 'Draft API datasets' table
     user checks table column heading contains    1    2    Name             xpath://table[@data-testid='draft-api-data-sets']
     user checks table column heading contains    1    3    Status           xpath://table[@data-testid='draft-api-data-sets']
     user checks table column heading contains    1    4    Actions          xpath://table[@data-testid='draft-api-data-sets']
-    
+
 
     user checks table cell contains    1    1    v1.0    xpath://table[@data-testid='draft-api-data-sets']
     user checks table cell contains    1    3    Ready    xpath://table[@data-testid='draft-api-data-sets']
-    
+
     user checks table cell contains    2    1    v1.0    xpath://table[@data-testid='draft-api-data-sets']
     user checks table cell contains    2    3    Ready    xpath://table[@data-testid='draft-api-data-sets']
 
@@ -119,7 +119,7 @@ User checks row data contents inside the 'Draft API datasets' summary table
     user checks contents inside the cell value    National                                   xpath://div[@data-testid="Geographic levels"]//dd[@data-testid="Geographic levels-value"]
     user checks contents inside the cell value    2012/13                                    xpath://div[@data-testid="Time periods"]//dd[@data-testid="Time periods-value"]
 
-    
+
     user checks contents inside the cell value    Lower quartile annualised earnings         xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[1]
     user checks contents inside the cell value    Median annualised earnings                 xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[2]
     user checks contents inside the cell value    Number of learners with earnings           xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[3]
@@ -131,7 +131,7 @@ User checks row data contents inside the 'Draft API datasets' summary table
     user checks contents inside the cell value    	Cheese                                   xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[1]
     user checks contents inside the cell value    	Colour                                   xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[2]
     user checks contents inside the cell value    	Ethnicity group                          xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[3]
-    
+
     user clicks button                              Show 4 more filters                      xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]
 
     user checks contents inside the cell value    	Gender                                    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[4]
@@ -156,7 +156,7 @@ Navigate to admin and create an amendment
     user navigates to admin dashboard    Bau1
     user creates amendment for release    ${PUBLICATION_NAME}    ${RELEASE_NAME}
 
-Upload third subject (which is invalid for Public API import) into the first amendment 
+Upload third subject (which is invalid for Public API import) into the first amendment
     user uploads subject and waits until complete
     ...    ${SUBJECT_NAME_3}
     ...    invalid-data-set.csv
@@ -206,7 +206,7 @@ Verify the contents inside the 'Live API datasets' table after the invalid impor
 
     user checks table cell contains    1    1    v1.0                       xpath://table[@data-testid='live-api-data-sets']
     user checks table cell contains    1    2    ${SUBJECT_NAME_1}          xpath://table[@data-testid='live-api-data-sets']
-    
+
     user checks table cell contains    2    1    v1.0                       xpath://table[@data-testid='live-api-data-sets']
     user checks table cell contains    2    2    ${SUBJECT_NAME_2}          xpath://table[@data-testid='live-api-data-sets']
 
@@ -258,7 +258,7 @@ Create a different version of an API dataset (minor version)
     user scrolls to the top of the page
     user clicks link    API data sets
     user waits until h2 is visible    API data sets
-    
+
     user waits until h3 is visible    Current live API data sets
 
     user checks table column heading contains    1    1    Version    xpath://table[@data-testid="live-api-data-sets"]


### PR DESCRIPTION
This PR adds the preview token guidance for API data sets. This looks like:

![image](https://github.com/user-attachments/assets/e488f41b-390c-4ce3-a007-8d196a3db53c)

## Other changes

- Fixed various issues with `UrlContainer` and `CopyTextButton`:
  - Makes `label` required for `UrlContainer` so that the copy input is labelled correctly by the consumer.
  - Allowes inline styling to be correctly toggled using the `inline` prop for `UrlContainer`.
  - Changes `UrlContainer` and `CopyTextButton` to fill the parent's space as much as possible instead of being limited to 500px.
  - Fixed incorrect flex styling causing the input in `CopyTextButton` to not take up the correct amount of space.
  - Adds the GOV.UK focus style to the `UrlContainer` input.
  - Improves how `CopyTextButton` responds at mobile / tablet.
  - Updates `CopyTextButton` to show the `confirmMessage` in the button itself rather than in a separate line. 
- Updated `CopyLinkModal` to be wider to show of the link