### PR TITLE
EES-5540 - additional changes to improve interoperability between --rerun-failed-suites and --rerun-attempts options

### DIFF
--- a/tests/robot-tests/args_and_variables.py
+++ b/tests/robot-tests/args_and_variables.py
@@ -221,7 +221,8 @@ def validate_environment_variables():
 # back slashes.
 def includes_data_changing_tests(arguments: argparse.Namespace):
     return (
-        arguments.tests == "tests/"
+        arguments.tests == "tests"
+        or arguments.tests == "tests/"
         or arguments.tests == f"tests{os.sep}"
         or f"{os.sep}admin" in arguments.tests
         or "/admin" in arguments.tests

--- a/tests/robot-tests/args_and_variables.py
+++ b/tests/robot-tests/args_and_variables.py
@@ -27,7 +27,11 @@ def create_argument_parser() -> argparse.ArgumentParser:
         help="interpreter to use to run the tests",
     )
     parser.add_argument(
-        "--processes", dest="processes", help="how many processes should be used when using the pabot interpreter"
+        "--processes",
+        dest="processes",
+        type=int,
+        default=4,
+        help="how many processes should be used when using the pabot interpreter"
     )
     parser.add_argument(
         "-e",
@@ -78,7 +82,12 @@ def create_argument_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="rerun failed test suites and merge results into original run results",
     )
-    parser.add_argument("--rerun-attempts", dest="rerun_attempts", type=int, default=0, help="Number of rerun attempts")
+    parser.add_argument(
+        "--rerun-attempts",
+        dest="rerun_attempts",
+        type=int,
+        default=0,
+        help="Number of rerun attempts")
     parser.add_argument(
         "--print-keywords",
         dest="print_keywords",

--- a/tests/robot-tests/reports.py
+++ b/tests/robot-tests/reports.py
@@ -1,6 +1,7 @@
 import os
 import glob
 import shutil
+import time
 from bs4 import BeautifulSoup
 from robot import rebot_cli as robot_rebot_cli
 from tests.libs.logger import get_logger
@@ -11,14 +12,16 @@ logger = get_logger(__name__)
 
 
 # Merge multiple Robot test reports and assets together into the main test results folder.
-def merge_robot_reports(number_of_test_runs: int):
+def merge_robot_reports(first_run_attempt_number: int, number_of_test_runs: int):
 
-    run_1_folder=f"{main_results_folder}{os.sep}run-1"
+    first_run_folder=f"{main_results_folder}{os.sep}run-{first_run_attempt_number}"
 
-    for file in os.listdir(run_1_folder):
-        _copy_to_destination_folder(run_1_folder, file, main_results_folder)
+    logger.info(f"Merging test run {first_run_attempt_number} results into full results")
+        
+    for file in os.listdir(first_run_folder):
+        _copy_to_destination_folder(first_run_folder, file, main_results_folder)
 
-    for test_run in range(2, number_of_test_runs + 1):
+    for test_run in range(first_run_attempt_number + 1, number_of_test_runs + 1):
         
         logger.info(f"Merging test run {test_run} results into full results")
         
@@ -90,6 +93,9 @@ def filter_out_passing_suites_from_report_file(path_to_original_report: str, pat
         suite_stats = report.find_all('stat', recursive=True)
         [suite_stat.extract() for suite_stat in suite_stats if suite_stat.get('id') in passing_suite_ids]
     
+        if os.path.exists(path_to_filtered_report):
+            os.remove(path_to_filtered_report)
+
         with open(path_to_filtered_report, "a") as filtered_file:
             filtered_file.write(report.prettify())
 

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -63,7 +63,7 @@ user opens ie
 user opens chrome headlessly
     [Arguments]    ${alias}=headless_chrome
     ${c_opts}=    Evaluate    sys.modules['selenium.webdriver'].ChromeOptions()    sys, selenium.webdriver
-    Call Method    ${c_opts}    add_argument    headless
+    Call Method    ${c_opts}    add_argument    headless\=old
     Call Method    ${c_opts}    add_argument    start-maximized
     Call Method    ${c_opts}    add_argument    disable-extensions
     Call Method    ${c_opts}    add_argument    disable-infobars


### PR DESCRIPTION
This PR:
- fixes issues in the Robot run scripts whereby certain combinations Pabot vs Robot runner, `--rerun-failed-suites` and `-rerun-attempts` options were not working as expected.
- also fixes an issue whereby the `--processes` Pabot option was not being passed to the Pabot executor.

Now all combinations of these parameters work fine together as expected, plus there is additional error checking prior to starting a rerun attempt using `--rerun-failed-suites` that there was indeed a previous report generated from which failed suites can be gathered.