### PR TITLE
Ees 5526 fix timezone issues

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
@@ -1,5 +1,5 @@
 import Link from '@admin/components/Link';
-import { useConfig } from '@admin/contexts/ConfigContext';
+import {useConfig} from '@admin/contexts/ConfigContext';
 import {
   releaseApiDataSetDetailsRoute,
   releaseApiDataSetPreviewRoute,
@@ -10,7 +10,7 @@ import {
 import previewTokenQueries from '@admin/queries/previewTokenQueries';
 import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
 import previewTokenService from '@admin/services/previewTokenService';
-import { useLastLocation } from '@admin/contexts/LastLocationContext';
+import {useLastLocation} from '@admin/contexts/LastLocationContext';
 import CodeBlock from '@common/components/CodeBlock';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Button from '@common/components/Button';
@@ -20,24 +20,24 @@ import ModalConfirm from '@common/components/ModalConfirm';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
 import ApiDataSetQuickStart from '@common/modules/data-catalogue/components/ApiDataSetQuickStart';
-import { useQuery } from '@tanstack/react-query';
-import { generatePath, useHistory, useParams } from 'react-router-dom';
+import {useQuery} from '@tanstack/react-query';
+import {generatePath, useHistory, useParams} from 'react-router-dom';
 import React from 'react';
 
 export default function ReleaseApiDataSetPreviewTokenPage() {
   const history = useHistory();
   const lastLocation = useLastLocation();
 
-  const { publicApiUrl, publicApiDocsUrl } = useConfig();
+  const {publicApiUrl, publicApiDocsUrl} = useConfig();
 
-  const { dataSetId, previewTokenId, releaseId, publicationId } =
+  const {dataSetId, previewTokenId, releaseId, publicationId} =
     useParams<ReleaseDataSetPreviewTokenRouteParams>();
 
-  const { data: dataSet, isLoading: isLoadingDataSet } = useQuery(
+  const {data: dataSet, isLoading: isLoadingDataSet} = useQuery(
     apiDataSetQueries.get(dataSetId),
   );
 
-  const { data: previewToken, isLoading: isLoadingPreviewTokenId } = useQuery({
+  const {data: previewToken, isLoading: isLoadingPreviewTokenId} = useQuery({
     ...previewTokenQueries.get(previewTokenId),
   });
 
@@ -120,8 +120,8 @@ export default function ReleaseApiDataSetPreviewTokenPage() {
                   <strong>
                     <FormattedDate formatRelativeToNow>
                       {previewToken.expiry}
-                    </FormattedDate>{' '}
-                    (local time)
+                    </FormattedDate>
+                    {' '}(local time)
                   </strong>
                 </p>
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
@@ -1,5 +1,5 @@
 import Link from '@admin/components/Link';
-import {useConfig} from '@admin/contexts/ConfigContext';
+import { useConfig } from '@admin/contexts/ConfigContext';
 import {
   releaseApiDataSetDetailsRoute,
   releaseApiDataSetPreviewRoute,
@@ -10,7 +10,7 @@ import {
 import previewTokenQueries from '@admin/queries/previewTokenQueries';
 import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
 import previewTokenService from '@admin/services/previewTokenService';
-import {useLastLocation} from '@admin/contexts/LastLocationContext';
+import { useLastLocation } from '@admin/contexts/LastLocationContext';
 import CodeBlock from '@common/components/CodeBlock';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Button from '@common/components/Button';
@@ -20,24 +20,24 @@ import ModalConfirm from '@common/components/ModalConfirm';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
 import ApiDataSetQuickStart from '@common/modules/data-catalogue/components/ApiDataSetQuickStart';
-import {useQuery} from '@tanstack/react-query';
-import {generatePath, useHistory, useParams} from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { generatePath, useHistory, useParams } from 'react-router-dom';
 import React from 'react';
 
 export default function ReleaseApiDataSetPreviewTokenPage() {
   const history = useHistory();
   const lastLocation = useLastLocation();
 
-  const {publicApiUrl, publicApiDocsUrl} = useConfig();
+  const { publicApiUrl, publicApiDocsUrl } = useConfig();
 
-  const {dataSetId, previewTokenId, releaseId, publicationId} =
+  const { dataSetId, previewTokenId, releaseId, publicationId } =
     useParams<ReleaseDataSetPreviewTokenRouteParams>();
 
-  const {data: dataSet, isLoading: isLoadingDataSet} = useQuery(
+  const { data: dataSet, isLoading: isLoadingDataSet } = useQuery(
     apiDataSetQueries.get(dataSetId),
   );
 
-  const {data: previewToken, isLoading: isLoadingPreviewTokenId} = useQuery({
+  const { data: previewToken, isLoading: isLoadingPreviewTokenId } = useQuery({
     ...previewTokenQueries.get(previewTokenId),
   });
 
@@ -120,8 +120,8 @@ export default function ReleaseApiDataSetPreviewTokenPage() {
                   <strong>
                     <FormattedDate formatRelativeToNow>
                       {previewToken.expiry}
-                    </FormattedDate>
-                    {' '}(local time)
+                    </FormattedDate>{' '}
+                    (local time)
                   </strong>
                 </p>
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
@@ -120,7 +120,8 @@ export default function ReleaseApiDataSetPreviewTokenPage() {
                   <strong>
                     <FormattedDate formatRelativeToNow>
                       {previewToken.expiry}
-                    </FormattedDate>
+                    </FormattedDate>{' '}
+                    (local time)
                   </strong>
                 </p>
 

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -29,7 +29,8 @@ Upload subject
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
     ...    Calendar year 2000
 
-    user uploads subject and waits until complete    UI test subject    upload-file-test.csv    upload-file-test.meta.csv
+    user uploads subject and waits until complete    UI test subject    upload-file-test.csv
+    ...    upload-file-test.meta.csv
 
 Add metadata guidance
     user clicks link    Data guidance
@@ -141,11 +142,9 @@ Validate prerelease has not started
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
 
-    ${tomorrow}=    get current datetime    %Y-%m-%dT00:00:00    1    Europe/London
-    ${day_after_tomorrow}=    get current datetime    %Y-%m-%dT%H:%M:%S    2    Europe/London
+    ${time_start}=    get current london datetime    %-d %B %Y at 00:00    1
+    ${time_end}=    get current london datetime    %-d %B %Y    2
 
-    ${time_start}=    format uk to local datetime    ${tomorrow}    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${day_after_tomorrow}    %-d %B %Y
     user checks page contains
     ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 
@@ -248,11 +247,9 @@ Validate prerelease has not started for Analyst user
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
 
-    ${tomorrow}=    get current datetime    %Y-%m-%dT00:00:00    1
-    ${day_after_tomorrow}=    get current datetime    %Y-%m-%dT%H:%M:%S    2
+    ${time_start}=    get current london datetime    %-d %B %Y at 00:00    1
+    ${time_end}=    get current london datetime    %-d %B %Y    2
 
-    ${time_start}=    format uk to local datetime    ${tomorrow}    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${day_after_tomorrow}    %-d %B %Y
     user checks page contains
     ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -30,7 +30,8 @@ Upload subject
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
     ...    Calendar year 2000
 
-    user uploads subject and waits until complete    UI test subject    upload-file-test.csv    upload-file-test.meta.csv
+    user uploads subject and waits until complete    UI test subject    upload-file-test.csv
+    ...    upload-file-test.meta.csv
 
 Add metadata guidance
     user clicks link    Data guidance
@@ -238,11 +239,9 @@ Validate prerelease window is not yet open for Analyst user
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
 
-    ${tomorrow}=    get current datetime    %Y-%m-%dT00:00:00    1
-    ${day_after_tomorrow}=    get current datetime    %Y-%m-%dT%H:%M:%S    2
+    ${time_start}=    get current london datetime    %-d %B %Y at 00:00    1
+    ${time_end}=    get current london datetime    %-d %B %Y    2
 
-    ${time_start}=    format uk to local datetime    ${tomorrow}    %-d %B %Y at %H:%M
-    ${time_end}=    format uk to local datetime    ${day_after_tomorrow}    %-d %B %Y
     user checks page contains
     ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
 

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -3,20 +3,20 @@ import datetime
 import json
 import os
 import re
-import time
 from typing import Union
-from urllib.parse import urlparse, urlunparse
 
+import time
 import pytz
 import utilities_init
 import visual
 from robot.libraries.BuiltIn import BuiltIn
-from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
+from selenium.common.exceptions import NoSuchElementException
 from SeleniumLibrary.utils import is_noney
 from tests.libs.logger import get_logger
 from tests.libs.selenium_elements import element_finder, sl, waiting
+from urllib.parse import urlparse, urlunparse
 
 logger = get_logger(__name__)
 
@@ -99,13 +99,8 @@ def retry_or_fail_with_delay(func, retries=5, delay=1.0, *args, **kwargs):
 
 
 def user_waits_until_parent_contains_element(
-    parent_locator: object,
-    child_locator: str,
-    timeout: int = None,
-    error: str = None,
-    count: int = None,
-    retries: int = 5,
-    delay: float = 1.0,
+    parent_locator: object, child_locator: str, timeout: int = None, error: str = None, count: int = None,
+    retries: int = 5, delay: float = 1.0
 ):
     try:
         child_locator = _normalise_child_locator(child_locator)
@@ -293,7 +288,7 @@ def get_current_datetime(strf: str, offset_days: int = 0, timezone: str = "UTC")
 
 
 def get_current_london_datetime(strf: str, offset_days: int = 0) -> str:
-    return get_current_datetime(strf, offset_days, "Europe/London")
+    return get_current_datetime(strf, offset_days, 'Europe/London')
 
 
 def get_current_local_datetime(strf: str, offset_days: int = 0) -> str:
@@ -453,8 +448,7 @@ def remove_auth_from_url(publicUrl: str):
         netloc += f":{parsed_url.port}"
 
     modified_url_without_auth = urlunparse(
-        (parsed_url.scheme, netloc, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment)
-    )
+        (parsed_url.scheme, netloc, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment))
     return modified_url_without_auth
 
 
@@ -469,6 +463,5 @@ def get_child_element_with_retry(parent_locator: object, child_locator: str, max
             time.sleep(retry_delay)
     raise AssertionError(f"Failed to find child element after {max_retries} retries.")
 
-
 def _get_browser_timezone():
-    return sl().driver.execute_script("return Intl.DateTimeFormat().resolvedOptions().timeZone;")
+    return sl().driver.execute_script('return Intl.DateTimeFormat().resolvedOptions().timeZone;')

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -3,20 +3,20 @@ import datetime
 import json
 import os
 import re
-from typing import Union
-
 import time
+from typing import Union
+from urllib.parse import urlparse, urlunparse
+
 import pytz
 import utilities_init
 import visual
 from robot.libraries.BuiltIn import BuiltIn
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
-from selenium.common.exceptions import NoSuchElementException
 from SeleniumLibrary.utils import is_noney
 from tests.libs.logger import get_logger
 from tests.libs.selenium_elements import element_finder, sl, waiting
-from urllib.parse import urlparse, urlunparse
 
 logger = get_logger(__name__)
 
@@ -99,8 +99,13 @@ def retry_or_fail_with_delay(func, retries=5, delay=1.0, *args, **kwargs):
 
 
 def user_waits_until_parent_contains_element(
-    parent_locator: object, child_locator: str, timeout: int = None, error: str = None, count: int = None,
-    retries: int = 5, delay: float = 1.0
+    parent_locator: object,
+    child_locator: str,
+    timeout: int = None,
+    error: str = None,
+    count: int = None,
+    retries: int = 5,
+    delay: float = 1.0,
 ):
     try:
         child_locator = _normalise_child_locator(child_locator)
@@ -274,21 +279,12 @@ def set_cookie_from_json(cookie_json):
     sl().driver.add_cookie(cookie_dict)
 
 
-def format_uk_to_local_datetime(uk_local_datetime: str, strf: str) -> str:
-    if os.name == "nt":
-        strf = strf.replace("%-", "%#")
-
-    tz = pytz.timezone("Europe/London")
-
-    return tz.localize(datetime.datetime.fromisoformat(uk_local_datetime)).strftime(strf)
-
-
 def get_current_datetime(strf: str, offset_days: int = 0, timezone: str = "UTC") -> str:
     return format_datetime(datetime.datetime.now(pytz.timezone(timezone)) + datetime.timedelta(days=offset_days), strf)
 
 
 def get_current_london_datetime(strf: str, offset_days: int = 0) -> str:
-    return get_current_datetime(strf, offset_days, 'Europe/London')
+    return get_current_datetime(strf, offset_days, "Europe/London")
 
 
 def get_current_local_datetime(strf: str, offset_days: int = 0) -> str:
@@ -448,7 +444,8 @@ def remove_auth_from_url(publicUrl: str):
         netloc += f":{parsed_url.port}"
 
     modified_url_without_auth = urlunparse(
-        (parsed_url.scheme, netloc, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment))
+        (parsed_url.scheme, netloc, parsed_url.path, parsed_url.params, parsed_url.query, parsed_url.fragment)
+    )
     return modified_url_without_auth
 
 
@@ -463,5 +460,6 @@ def get_child_element_with_retry(parent_locator: object, child_locator: str, max
             time.sleep(retry_delay)
     raise AssertionError(f"Failed to find child element after {max_retries} retries.")
 
+
 def _get_browser_timezone():
-    return sl().driver.execute_script('return Intl.DateTimeFormat().resolvedOptions().timeZone;')
+    return sl().driver.execute_script("return Intl.DateTimeFormat().resolvedOptions().timeZone;")

--- a/tests/robot-tests/tests/public_api/public_api_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_preview_token.robot
@@ -11,13 +11,15 @@ Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
+
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - Public API - preview token %{RUN_IDENTIFIER}
-${RELEASE_NAME}=        Academic year Q1
-${ACADEMIC_YEAR}=       3000
-${SUBJECT_NAME_1}=      UI test subject 1
-${SUBJECT_NAME_2}=      UI test subject 2
-${PREVIEW_TOKEN_NAME}=  Test token
+${PUBLICATION_NAME}=        UI tests - Public API - preview token %{RUN_IDENTIFIER}
+${RELEASE_NAME}=            Academic year Q1
+${ACADEMIC_YEAR}=           3000
+${SUBJECT_NAME_1}=          UI test subject 1
+${SUBJECT_NAME_2}=          UI test subject 2
+${PREVIEW_TOKEN_NAME}=      Test token
+
 
 *** Test Cases ***
 Create publication and release
@@ -33,8 +35,10 @@ Verify release summary
     user verifies release summary    Academic year Q1    3000/01    Accredited official statistics
 
 Upload data files
-    user uploads subject and waits until complete    ${SUBJECT_NAME_1}    seven_filters.csv    seven_filters.meta.csv     ${PUBLIC_API_FILES_DIR}
-    user uploads subject and waits until complete    ${SUBJECT_NAME_2}    tiny-two-filters.csv    tiny-two-filters.meta.csv     ${PUBLIC_API_FILES_DIR}
+    user uploads subject and waits until complete    ${SUBJECT_NAME_1}    seven_filters.csv    seven_filters.meta.csv
+    ...    ${PUBLIC_API_FILES_DIR}
+    user uploads subject and waits until complete    ${SUBJECT_NAME_2}    tiny-two-filters.csv
+    ...    tiny-two-filters.meta.csv    ${PUBLIC_API_FILES_DIR}
 
 Add data guidance to subjects
     user clicks link    Data and files
@@ -62,7 +66,7 @@ Create 1st API dataset
 
     user clicks button    Create API data set
     ${modal}=    user waits until modal is visible    Create a new API data set
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_1}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_1}
     user clicks button    Confirm new API data set
 
     user waits until page finishes loading
@@ -76,7 +80,7 @@ Create 2nd API dataset
     user clicks link    Back to API data sets
     user clicks button    Create API data set
     ${modal}=    user waits until modal is visible    Create a new API data set
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_2}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_2}
     user clicks button    Confirm new API data set
 
     user waits until page finishes loading
@@ -90,10 +94,11 @@ Verify the contents inside the 'Draft API datasets' table
     user clicks link    Back to API data sets
     user waits until h3 is visible    Draft API data sets
 
-    user checks table column heading contains    1    1    Draft version    xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    2    Name             xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    3    Status           xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    4    Actions          xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    1    Draft version
+    ...    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    2    Name    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    3    Status    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    4    Actions    xpath://table[@data-testid='draft-api-data-sets']
 
     user checks table cell contains    1    1    v1.0    xpath://table[@data-testid='draft-api-data-sets']
     user checks table cell contains    1    3    Ready    xpath://table[@data-testid='draft-api-data-sets']
@@ -107,46 +112,67 @@ Click on 'View Details' link(First API dataset)
     user checks table headings for Draft version details table
 
 User checks row data contents inside the 'Draft API datasets' summary table
-    user checks contents inside the cell value    v1.0                                       xpath://dl[@data-testid="draft-version-summary"]/div/dd[@data-testid='Version-value']/strong
-    user checks contents inside the cell value    Ready                                      xpath:(//div[@data-testid="Status"]//dd[@data-testid="Status-value"]//strong)[2]
-    user checks contents inside the cell value    Academic year Q1 3000/01                    xpath:(//div[@data-testid="Release"]//dd[@data-testid="Release-value"]//a)[1]
-    user checks contents inside the cell value    ${SUBJECT_NAME_1}                          xpath://div[@data-testid="Data set file"]//dd[@data-testid="Data set file-value"]
-    user checks contents inside the cell value    National                                   xpath://div[@data-testid="Geographic levels"]//dd[@data-testid="Geographic levels-value"]
-    user checks contents inside the cell value    2012/13                                    xpath://div[@data-testid="Time periods"]//dd[@data-testid="Time periods-value"]
+    user checks contents inside the cell value    v1.0
+    ...    xpath://dl[@data-testid="draft-version-summary"]/div/dd[@data-testid='Version-value']/strong
+    user checks contents inside the cell value    Ready
+    ...    xpath:(//div[@data-testid="Status"]//dd[@data-testid="Status-value"]//strong)[2]
+    user checks contents inside the cell value    Academic year Q1 3000/01
+    ...    xpath:(//div[@data-testid="Release"]//dd[@data-testid="Release-value"]//a)[1]
+    user checks contents inside the cell value    ${SUBJECT_NAME_1}
+    ...    xpath://div[@data-testid="Data set file"]//dd[@data-testid="Data set file-value"]
+    user checks contents inside the cell value    National
+    ...    xpath://div[@data-testid="Geographic levels"]//dd[@data-testid="Geographic levels-value"]
+    user checks contents inside the cell value    2012/13
+    ...    xpath://div[@data-testid="Time periods"]//dd[@data-testid="Time periods-value"]
 
-    user checks contents inside the cell value    Lower quartile annualised earnings         xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[1]
-    user checks contents inside the cell value    Median annualised earnings                 xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[2]
-    user checks contents inside the cell value    Number of learners with earnings           xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[3]
+    user checks contents inside the cell value    Lower quartile annualised earnings
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[1]
+    user checks contents inside the cell value    Median annualised earnings
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[2]
+    user checks contents inside the cell value    Number of learners with earnings
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[3]
 
-    user clicks button                              Show 1 more indicator                    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]
+    user clicks button    Show 1 more indicator
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]
 
-    user checks contents inside the cell value      Upper quartile annualised earnings       xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[4]
+    user checks contents inside the cell value    Upper quartile annualised earnings
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[4]
 
-    user checks contents inside the cell value    	Cheese                                   xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[1]
-    user checks contents inside the cell value    	Colour                                   xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[2]
-    user checks contents inside the cell value    	Ethnicity group                          xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[3]
+    user checks contents inside the cell value    Cheese
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[1]
+    user checks contents inside the cell value    Colour
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[2]
+    user checks contents inside the cell value    Ethnicity group
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[3]
 
-    user clicks button                              Show 4 more filters                      xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]
+    user clicks button    Show 4 more filters    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]
 
-    user checks contents inside the cell value    	Gender                                    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[4]
-    user checks contents inside the cell value    	Level of learning                         xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[5]
-    user checks contents inside the cell value      Number of years after achievement of learning aim    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[6]
-    user checks contents inside the cell value      Provision                                 xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[7]
+    user checks contents inside the cell value    Gender
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[4]
+    user checks contents inside the cell value    Level of learning
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[5]
+    user checks contents inside the cell value    Number of years after achievement of learning aim
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[6]
+    user checks contents inside the cell value    Provision
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[7]
 
-    user checks contents inside the cell value      Preview API data set                      xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[1]/a
-    user checks contents inside the cell value      View preview token log                    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[2]/a
-    user checks contents inside the cell value      Remove draft version                      xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[3]/button
+    user checks contents inside the cell value    Preview API data set
+    ...    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[1]/a
+    user checks contents inside the cell value    View preview token log
+    ...    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[2]/a
+    user checks contents inside the cell value    Remove draft version
+    ...    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[3]/button
 
 User clicks on 'Preview API data set' link
     user clicks link containing text    Preview API data set
 
 User clicks on 'Generate preview token'
-    user clicks button     Generate preview token
+    user clicks button    Generate preview token
 
 User creates preview token through 'Generate preview token' modal window
     ${modal}=    user waits until modal is visible    Generate preview token
     user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
-    user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
+    user clicks checkbox by selector    css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Continue
 
     user waits until page finishes loading
@@ -163,12 +189,12 @@ User revokes preview token
     user waits until page contains    Generate API data set preview token
 
 User again clicks on 'Generate preview token'
-    user clicks button     Generate preview token
+    user clicks button    Generate preview token
 
 User creates another preview token through 'Generate preview token' modal window
     ${modal}=    user waits until modal is visible    Generate preview token
     user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
-    user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
+    user clicks checkbox by selector    css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Continue
 
     user waits until page finishes loading
@@ -188,11 +214,11 @@ User cancels revoking preview token
 User cancels creating preview token
     user clicks link    Back to API data set details
     user clicks link containing text    Preview API data set
-    user clicks button     Generate preview token
+    user clicks button    Generate preview token
 
     ${modal}=    user waits until modal is visible    Generate preview token
     user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
-    user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
+    user clicks checkbox by selector    css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Cancel
 
     user waits until page finishes loading
@@ -228,7 +254,7 @@ User verifies the relevant fields on the active preview token page
 
     ${modal}=    user waits until modal is visible    Generate preview token
     user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
-    user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
+    user clicks checkbox by selector    css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Continue
 
     user waits until page finishes loading
@@ -238,14 +264,9 @@ User verifies the relevant fields on the active preview token page
     user waits until h2 is visible    ${SUBJECT_NAME_1}
     user checks page contains    Reference: ${PREVIEW_TOKEN_NAME}
 
-    ${current_time_tomorrow}=    get current datetime    %Y-%m-%dT%H:%M:%S    1    Europe/London
-
-    ${time_with_leading_zero}=    format uk to local datetime    ${current_time_tomorrow}    %I:%M %p
-
-    ${time_end}=    format time without leading zero     ${time_with_leading_zero}
-
+    ${current_time_tomorrow}=    get current local datetime    %-I:%M %p    1
     user checks page contains
-    ...     The token expires: tomorrow at ${time_end}
+    ...    The token expires: tomorrow at ${current_time_tomorrow} (local time)
 
     user checks page contains button    Copy preview token
     user checks page contains button    Revoke preview token
@@ -297,55 +318,72 @@ User verifies the row headings and contents in 'Data set details' section
     user checks row headings within the api data set section    Publication
     user checks row headings within the api data set section    Release
     user checks row headings within the api data set section    Release type
-    user checks row headings within the api data set section   Geographic levels
-    user checks row headings within the api data set section   Indicators
+    user checks row headings within the api data set section    Geographic levels
+    user checks row headings within the api data set section    Indicators
     user checks row headings within the api data set section    Filters
     user checks row headings within the api data set section    Time period
 
-    user checks row headings within the api data set section   Notifications
+    user checks row headings within the api data set section    Notifications
 
-    user checks contents inside the cell value          Test theme                                                  css: #dataSetDetails [data-testid="Theme-value"]
-    user checks contents inside the cell value          ${PUBLICATION_NAME}                                         css:#dataSetDetails [data-testid="Publication-value"]
-    user checks contents inside the cell value          Academic year Q1 3000/01                                    css:#dataSetDetails [data-testid="Release-value"]
-    User checks contents inside the release type        Accredited official statistics                              css:#dataSetDetails [data-testid="Release type-value"] > button
-    user checks contents inside the cell value          National                                                    css:#dataSetDetails [data-testid="Geographic levels-value"]
+    user checks contents inside the cell value    Test theme    css: #dataSetDetails [data-testid="Theme-value"]
+    user checks contents inside the cell value    ${PUBLICATION_NAME}
+    ...    css:#dataSetDetails [data-testid="Publication-value"]
+    user checks contents inside the cell value    Academic year Q1 3000/01
+    ...    css:#dataSetDetails [data-testid="Release-value"]
+    User checks contents inside the release type    Accredited official statistics
+    ...    css:#dataSetDetails [data-testid="Release type-value"] > button
+    user checks contents inside the cell value    National
+    ...    css:#dataSetDetails [data-testid="Geographic levels-value"]
 
-    user checks contents inside the cell value           Lower quartile annualised earnings                         css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(1)
-    user checks contents inside the cell value           Median annualised earnings                                 css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(2)
-    user checks contents inside the cell value           Number of learners with earnings                           css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(3)
+    user checks contents inside the cell value    Lower quartile annualised earnings
+    ...    css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(1)
+    user checks contents inside the cell value    Median annualised earnings
+    ...    css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(2)
+    user checks contents inside the cell value    Number of learners with earnings
+    ...    css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(3)
 
-    user clicks button                                   Show 1 more indicator                                      css:#dataSetDetails [data-testid="Indicators-value"]
+    user clicks button    Show 1 more indicator    css:#dataSetDetails [data-testid="Indicators-value"]
 
-    user checks contents inside the cell value           Upper quartile annualised earnings                         css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(4)
+    user checks contents inside the cell value    Upper quartile annualised earnings
+    ...    css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(4)
 
-    user checks contents inside the cell value    	     Cheese                                                     css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(1)
-    user checks contents inside the cell value    	     Colour                                                     css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(2)
-    user checks contents inside the cell value    	     Ethnicity group                                            css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(3)
+    user checks contents inside the cell value    Cheese
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(1)
+    user checks contents inside the cell value    Colour
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(2)
+    user checks contents inside the cell value    Ethnicity group
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(3)
 
-    user clicks button                                   Show 4 more filters                                        css:#dataSetDetails [data-testid="Filters-value"]
+    user clicks button    Show 4 more filters    css:#dataSetDetails [data-testid="Filters-value"]
 
-    user checks contents inside the cell value    	     Gender                                                     css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(4)
-    user checks contents inside the cell value    	     Level of learning                                          css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(5)
-    user checks contents inside the cell value           Number of years after achievement of learning aim          css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(6)
-    user checks contents inside the cell value           Provision                                                  css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(7)
+    user checks contents inside the cell value    Gender
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(4)
+    user checks contents inside the cell value    Level of learning
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(5)
+    user checks contents inside the cell value    Number of years after achievement of learning aim
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(6)
+    user checks contents inside the cell value    Provision
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(7)
 
-    user checks contents inside the cell value           2012/13                                                    css:#dataSetDetails [data-testid="Time period-value"]
-    user checks contents inside the cell value           Get email updates about this API data set                  css:#dataSetDetails [data-testid="Notifications-value"] > a
+    user checks contents inside the cell value    2012/13    css:#dataSetDetails [data-testid="Time period-value"]
+    user checks contents inside the cell value    Get email updates about this API data set
+    ...    css:#dataSetDetails [data-testid="Notifications-value"] > a
 
 User verifies the headings and contents in 'API version history' section
     user checks table column heading contains    1    1    Version    css:section[id="apiVersionHistory"]
 
     user checks table column heading contains    1    2    Release    css:section[id="apiVersionHistory"]
-    user checks table column heading contains    1    3    Status     css:section[id="apiVersionHistory"]
+    user checks table column heading contains    1    3    Status    css:section[id="apiVersionHistory"]
 
-    user checks table cell contains              1    1    1.0 (current)                xpath://section[@id="apiVersionHistory"]
-    user checks table cell contains              1    2    Academic year Q1 3000/01     xpath://section[@id="apiVersionHistory"]
-    user checks table cell contains              1    3    Published                    xpath://section[@id="apiVersionHistory"]
+    user checks table cell contains    1    1    1.0 (current)    xpath://section[@id="apiVersionHistory"]
+    user checks table cell contains    1    2    Academic year Q1 3000/01    xpath://section[@id="apiVersionHistory"]
+    user checks table cell contains    1    3    Published    xpath://section[@id="apiVersionHistory"]
+
 
 *** Keywords ***
 User checks contents inside the release type
-    [Arguments]      ${expected_text}     ${locator}
-     ${full_text}=    get text    ${locator}
+    [Arguments]    ${expected_text}    ${locator}
+    ${full_text}=    get text    ${locator}
 
     # Split and remove the part after '?' and strip whitespace
     ${button_text}=    set variable    ${full_text.split('?')[0].strip()}

--- a/tests/robot-tests/tests/public_api/public_api_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_preview_token.robot
@@ -11,15 +11,13 @@ Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
-
 *** Variables ***
-${PUBLICATION_NAME}=        UI tests - Public API - preview token %{RUN_IDENTIFIER}
-${RELEASE_NAME}=            Academic year Q1
-${ACADEMIC_YEAR}=           3000
-${SUBJECT_NAME_1}=          UI test subject 1
-${SUBJECT_NAME_2}=          UI test subject 2
-${PREVIEW_TOKEN_NAME}=      Test token
-
+${PUBLICATION_NAME}=    UI tests - Public API - preview token %{RUN_IDENTIFIER}
+${RELEASE_NAME}=        Academic year Q1
+${ACADEMIC_YEAR}=       3000
+${SUBJECT_NAME_1}=      UI test subject 1
+${SUBJECT_NAME_2}=      UI test subject 2
+${PREVIEW_TOKEN_NAME}=  Test token
 
 *** Test Cases ***
 Create publication and release
@@ -35,10 +33,8 @@ Verify release summary
     user verifies release summary    Academic year Q1    3000/01    Accredited official statistics
 
 Upload data files
-    user uploads subject and waits until complete    ${SUBJECT_NAME_1}    seven_filters.csv    seven_filters.meta.csv
-    ...    ${PUBLIC_API_FILES_DIR}
-    user uploads subject and waits until complete    ${SUBJECT_NAME_2}    tiny-two-filters.csv
-    ...    tiny-two-filters.meta.csv    ${PUBLIC_API_FILES_DIR}
+    user uploads subject and waits until complete    ${SUBJECT_NAME_1}    seven_filters.csv    seven_filters.meta.csv     ${PUBLIC_API_FILES_DIR}
+    user uploads subject and waits until complete    ${SUBJECT_NAME_2}    tiny-two-filters.csv    tiny-two-filters.meta.csv     ${PUBLIC_API_FILES_DIR}
 
 Add data guidance to subjects
     user clicks link    Data and files
@@ -66,7 +62,7 @@ Create 1st API dataset
 
     user clicks button    Create API data set
     ${modal}=    user waits until modal is visible    Create a new API data set
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_1}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_1}
     user clicks button    Confirm new API data set
 
     user waits until page finishes loading
@@ -80,7 +76,7 @@ Create 2nd API dataset
     user clicks link    Back to API data sets
     user clicks button    Create API data set
     ${modal}=    user waits until modal is visible    Create a new API data set
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_2}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_2}
     user clicks button    Confirm new API data set
 
     user waits until page finishes loading
@@ -94,11 +90,10 @@ Verify the contents inside the 'Draft API datasets' table
     user clicks link    Back to API data sets
     user waits until h3 is visible    Draft API data sets
 
-    user checks table column heading contains    1    1    Draft version
-    ...    xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    2    Name    xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    3    Status    xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    4    Actions    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    1    Draft version    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    2    Name             xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    3    Status           xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    4    Actions          xpath://table[@data-testid='draft-api-data-sets']
 
     user checks table cell contains    1    1    v1.0    xpath://table[@data-testid='draft-api-data-sets']
     user checks table cell contains    1    3    Ready    xpath://table[@data-testid='draft-api-data-sets']
@@ -112,67 +107,46 @@ Click on 'View Details' link(First API dataset)
     user checks table headings for Draft version details table
 
 User checks row data contents inside the 'Draft API datasets' summary table
-    user checks contents inside the cell value    v1.0
-    ...    xpath://dl[@data-testid="draft-version-summary"]/div/dd[@data-testid='Version-value']/strong
-    user checks contents inside the cell value    Ready
-    ...    xpath:(//div[@data-testid="Status"]//dd[@data-testid="Status-value"]//strong)[2]
-    user checks contents inside the cell value    Academic year Q1 3000/01
-    ...    xpath:(//div[@data-testid="Release"]//dd[@data-testid="Release-value"]//a)[1]
-    user checks contents inside the cell value    ${SUBJECT_NAME_1}
-    ...    xpath://div[@data-testid="Data set file"]//dd[@data-testid="Data set file-value"]
-    user checks contents inside the cell value    National
-    ...    xpath://div[@data-testid="Geographic levels"]//dd[@data-testid="Geographic levels-value"]
-    user checks contents inside the cell value    2012/13
-    ...    xpath://div[@data-testid="Time periods"]//dd[@data-testid="Time periods-value"]
+    user checks contents inside the cell value    v1.0                                       xpath://dl[@data-testid="draft-version-summary"]/div/dd[@data-testid='Version-value']/strong
+    user checks contents inside the cell value    Ready                                      xpath:(//div[@data-testid="Status"]//dd[@data-testid="Status-value"]//strong)[2]
+    user checks contents inside the cell value    Academic year Q1 3000/01                    xpath:(//div[@data-testid="Release"]//dd[@data-testid="Release-value"]//a)[1]
+    user checks contents inside the cell value    ${SUBJECT_NAME_1}                          xpath://div[@data-testid="Data set file"]//dd[@data-testid="Data set file-value"]
+    user checks contents inside the cell value    National                                   xpath://div[@data-testid="Geographic levels"]//dd[@data-testid="Geographic levels-value"]
+    user checks contents inside the cell value    2012/13                                    xpath://div[@data-testid="Time periods"]//dd[@data-testid="Time periods-value"]
 
-    user checks contents inside the cell value    Lower quartile annualised earnings
-    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[1]
-    user checks contents inside the cell value    Median annualised earnings
-    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[2]
-    user checks contents inside the cell value    Number of learners with earnings
-    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[3]
+    user checks contents inside the cell value    Lower quartile annualised earnings         xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[1]
+    user checks contents inside the cell value    Median annualised earnings                 xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[2]
+    user checks contents inside the cell value    Number of learners with earnings           xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[3]
 
-    user clicks button    Show 1 more indicator
-    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]
+    user clicks button                              Show 1 more indicator                    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]
 
-    user checks contents inside the cell value    Upper quartile annualised earnings
-    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[4]
+    user checks contents inside the cell value      Upper quartile annualised earnings       xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[4]
 
-    user checks contents inside the cell value    Cheese
-    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[1]
-    user checks contents inside the cell value    Colour
-    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[2]
-    user checks contents inside the cell value    Ethnicity group
-    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[3]
+    user checks contents inside the cell value    	Cheese                                   xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[1]
+    user checks contents inside the cell value    	Colour                                   xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[2]
+    user checks contents inside the cell value    	Ethnicity group                          xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[3]
 
-    user clicks button    Show 4 more filters    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]
+    user clicks button                              Show 4 more filters                      xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]
 
-    user checks contents inside the cell value    Gender
-    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[4]
-    user checks contents inside the cell value    Level of learning
-    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[5]
-    user checks contents inside the cell value    Number of years after achievement of learning aim
-    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[6]
-    user checks contents inside the cell value    Provision
-    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[7]
+    user checks contents inside the cell value    	Gender                                    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[4]
+    user checks contents inside the cell value    	Level of learning                         xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[5]
+    user checks contents inside the cell value      Number of years after achievement of learning aim    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[6]
+    user checks contents inside the cell value      Provision                                 xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[7]
 
-    user checks contents inside the cell value    Preview API data set
-    ...    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[1]/a
-    user checks contents inside the cell value    View preview token log
-    ...    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[2]/a
-    user checks contents inside the cell value    Remove draft version
-    ...    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[3]/button
+    user checks contents inside the cell value      Preview API data set                      xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[1]/a
+    user checks contents inside the cell value      View preview token log                    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[2]/a
+    user checks contents inside the cell value      Remove draft version                      xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[3]/button
 
 User clicks on 'Preview API data set' link
     user clicks link containing text    Preview API data set
 
 User clicks on 'Generate preview token'
-    user clicks button    Generate preview token
+    user clicks button     Generate preview token
 
 User creates preview token through 'Generate preview token' modal window
     ${modal}=    user waits until modal is visible    Generate preview token
     user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
-    user clicks checkbox by selector    css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
+    user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Continue
 
     user waits until page finishes loading
@@ -189,12 +163,12 @@ User revokes preview token
     user waits until page contains    Generate API data set preview token
 
 User again clicks on 'Generate preview token'
-    user clicks button    Generate preview token
+    user clicks button     Generate preview token
 
 User creates another preview token through 'Generate preview token' modal window
     ${modal}=    user waits until modal is visible    Generate preview token
     user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
-    user clicks checkbox by selector    css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
+    user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Continue
 
     user waits until page finishes loading
@@ -214,11 +188,11 @@ User cancels revoking preview token
 User cancels creating preview token
     user clicks link    Back to API data set details
     user clicks link containing text    Preview API data set
-    user clicks button    Generate preview token
+    user clicks button     Generate preview token
 
     ${modal}=    user waits until modal is visible    Generate preview token
     user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
-    user clicks checkbox by selector    css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
+    user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Cancel
 
     user waits until page finishes loading
@@ -254,7 +228,7 @@ User verifies the relevant fields on the active preview token page
 
     ${modal}=    user waits until modal is visible    Generate preview token
     user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
-    user clicks checkbox by selector    css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
+    user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Continue
 
     user waits until page finishes loading
@@ -266,7 +240,7 @@ User verifies the relevant fields on the active preview token page
 
     ${current_time_tomorrow}=    get current local datetime    %-I:%M %p    1
     user checks page contains
-    ...    The token expires: tomorrow at ${current_time_tomorrow} (local time)
+    ...     The token expires: tomorrow at ${current_time_tomorrow} (local time)
 
     user checks page contains button    Copy preview token
     user checks page contains button    Revoke preview token
@@ -318,72 +292,55 @@ User verifies the row headings and contents in 'Data set details' section
     user checks row headings within the api data set section    Publication
     user checks row headings within the api data set section    Release
     user checks row headings within the api data set section    Release type
-    user checks row headings within the api data set section    Geographic levels
-    user checks row headings within the api data set section    Indicators
+    user checks row headings within the api data set section   Geographic levels
+    user checks row headings within the api data set section   Indicators
     user checks row headings within the api data set section    Filters
     user checks row headings within the api data set section    Time period
 
-    user checks row headings within the api data set section    Notifications
+    user checks row headings within the api data set section   Notifications
 
-    user checks contents inside the cell value    Test theme    css: #dataSetDetails [data-testid="Theme-value"]
-    user checks contents inside the cell value    ${PUBLICATION_NAME}
-    ...    css:#dataSetDetails [data-testid="Publication-value"]
-    user checks contents inside the cell value    Academic year Q1 3000/01
-    ...    css:#dataSetDetails [data-testid="Release-value"]
-    User checks contents inside the release type    Accredited official statistics
-    ...    css:#dataSetDetails [data-testid="Release type-value"] > button
-    user checks contents inside the cell value    National
-    ...    css:#dataSetDetails [data-testid="Geographic levels-value"]
+    user checks contents inside the cell value          Test theme                                                  css: #dataSetDetails [data-testid="Theme-value"]
+    user checks contents inside the cell value          ${PUBLICATION_NAME}                                         css:#dataSetDetails [data-testid="Publication-value"]
+    user checks contents inside the cell value          Academic year Q1 3000/01                                    css:#dataSetDetails [data-testid="Release-value"]
+    User checks contents inside the release type        Accredited official statistics                              css:#dataSetDetails [data-testid="Release type-value"] > button
+    user checks contents inside the cell value          National                                                    css:#dataSetDetails [data-testid="Geographic levels-value"]
 
-    user checks contents inside the cell value    Lower quartile annualised earnings
-    ...    css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(1)
-    user checks contents inside the cell value    Median annualised earnings
-    ...    css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(2)
-    user checks contents inside the cell value    Number of learners with earnings
-    ...    css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(3)
+    user checks contents inside the cell value           Lower quartile annualised earnings                         css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(1)
+    user checks contents inside the cell value           Median annualised earnings                                 css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(2)
+    user checks contents inside the cell value           Number of learners with earnings                           css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(3)
 
-    user clicks button    Show 1 more indicator    css:#dataSetDetails [data-testid="Indicators-value"]
+    user clicks button                                   Show 1 more indicator                                      css:#dataSetDetails [data-testid="Indicators-value"]
 
-    user checks contents inside the cell value    Upper quartile annualised earnings
-    ...    css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(4)
+    user checks contents inside the cell value           Upper quartile annualised earnings                         css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(4)
 
-    user checks contents inside the cell value    Cheese
-    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(1)
-    user checks contents inside the cell value    Colour
-    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(2)
-    user checks contents inside the cell value    Ethnicity group
-    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(3)
+    user checks contents inside the cell value    	     Cheese                                                     css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(1)
+    user checks contents inside the cell value    	     Colour                                                     css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(2)
+    user checks contents inside the cell value    	     Ethnicity group                                            css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(3)
 
-    user clicks button    Show 4 more filters    css:#dataSetDetails [data-testid="Filters-value"]
+    user clicks button                                   Show 4 more filters                                        css:#dataSetDetails [data-testid="Filters-value"]
 
-    user checks contents inside the cell value    Gender
-    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(4)
-    user checks contents inside the cell value    Level of learning
-    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(5)
-    user checks contents inside the cell value    Number of years after achievement of learning aim
-    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(6)
-    user checks contents inside the cell value    Provision
-    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(7)
+    user checks contents inside the cell value    	     Gender                                                     css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(4)
+    user checks contents inside the cell value    	     Level of learning                                          css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(5)
+    user checks contents inside the cell value           Number of years after achievement of learning aim          css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(6)
+    user checks contents inside the cell value           Provision                                                  css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(7)
 
-    user checks contents inside the cell value    2012/13    css:#dataSetDetails [data-testid="Time period-value"]
-    user checks contents inside the cell value    Get email updates about this API data set
-    ...    css:#dataSetDetails [data-testid="Notifications-value"] > a
+    user checks contents inside the cell value           2012/13                                                    css:#dataSetDetails [data-testid="Time period-value"]
+    user checks contents inside the cell value           Get email updates about this API data set                  css:#dataSetDetails [data-testid="Notifications-value"] > a
 
 User verifies the headings and contents in 'API version history' section
     user checks table column heading contains    1    1    Version    css:section[id="apiVersionHistory"]
 
     user checks table column heading contains    1    2    Release    css:section[id="apiVersionHistory"]
-    user checks table column heading contains    1    3    Status    css:section[id="apiVersionHistory"]
+    user checks table column heading contains    1    3    Status     css:section[id="apiVersionHistory"]
 
-    user checks table cell contains    1    1    1.0 (current)    xpath://section[@id="apiVersionHistory"]
-    user checks table cell contains    1    2    Academic year Q1 3000/01    xpath://section[@id="apiVersionHistory"]
-    user checks table cell contains    1    3    Published    xpath://section[@id="apiVersionHistory"]
-
+    user checks table cell contains              1    1    1.0 (current)                xpath://section[@id="apiVersionHistory"]
+    user checks table cell contains              1    2    Academic year Q1 3000/01     xpath://section[@id="apiVersionHistory"]
+    user checks table cell contains              1    3    Published                    xpath://section[@id="apiVersionHistory"]
 
 *** Keywords ***
 User checks contents inside the release type
-    [Arguments]    ${expected_text}    ${locator}
-    ${full_text}=    get text    ${locator}
+    [Arguments]      ${expected_text}     ${locator}
+     ${full_text}=    get text    ${locator}
 
     # Split and remove the part after '?' and strip whitespace
     ${button_text}=    set variable    ${full_text.split('?')[0].strip()}


### PR DESCRIPTION
This PR:
- fixes issues around the effects of timezones when displaying expiry times of preview tokens.
- removes unnecessary timezone-wangling code in Robot tests, opting for simpler approach.

## UI test run results

### Locally (BST)

![image](https://github.com/user-attachments/assets/9479d732-d202-42fe-8c3e-e660acf5067f)

### In the pipeline (UTC)

![image](https://github.com/user-attachments/assets/f1648005-ca61-44e3-92a8-f5b89cc9c68a)

## The problem

The React code that displays the expiry time is executed in the users' browsers and shows the time local to the browsers' timezones.  This has the effect of breaking tests in the pipeline where the Robot tests are run on a UTC runner, as the Robot tests were all geared towards asserting that the time was explicitly in the `Europe/London` timezone.

## Preview token expiry change

We are now explicitly deciding to show the expiry time in a user's local timezone, and so have additionally added the `(local time)` text to the expiry time as well to make this clear.  To ensure we're checking for the correct timezone for the user, we now have a new `get current local datetime` keyword that uses the timezone of the browser to determine which time we should be expecting to see based on the browser's own timezone.

Additionally there is also now a new `get current london datetime` keyword for explicitly getting a datetime in the `Europe/London` timezone.

Hopefully these 2 new keywords should make intentions much clearer as to what is being expected in any given usage in a Robot test.

## Removing timezone code

This PR also changes instances of test setup code like:

```
    ${tomorrow}=    get current datetime    %Y-%m-%dT00:00:00    1    Europe/London
    ${day_after_tomorrow}=    get current datetime    %Y-%m-%dT%H:%M:%S    2    Europe/London

    ${time_start}=    format uk to local datetime    ${tomorrow}    %-d %B %Y at %H:%M
    ${time_end}=    format uk to local datetime    ${day_after_tomorrow}    %-d %B %Y
```

to a simpler:

```
    ${time_start}=    get current london datetime    %-d %B %Y at 00:00    1
    ${time_end}=    get current london datetime    %-d %B %Y    2
```

which also allows us to remove the `format uk to local datetime` keyword.

## Miscellaneous changes

I also removed the `format_time_without_leading_zero` keyword, as the same behaviour can be achieved by changing the time format `%I` (12-hour clock's 2-digit hour value) to `%-I` (12-hour clock's hour value without leading zero).