### PR TITLE
EES-5557 Hotfix: Revert decrease in number of provisioned vCores of Stats DB made for EES-5515

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -78,7 +78,7 @@
       "value": "GeneralPurpose"
     },
     "capacityStatisticsDb": {
-      "value": 6
+      "value": 10
     },
     "tableBuilderMaxTableCellsAllowed": {
       "value": 1000000


### PR DESCRIPTION
This PR increases the number of provisions vCores of the Stats DB for Production. We're doing this to hopefully help the database reindexing.

This is a hotfix to master.