### PR TITLE
Ees 5526 part 2 - making date time handling code in Robot tests easier

### DIFF
--- a/azure-pipelines-ui-tests.dfe.yml
+++ b/azure-pipelines-ui-tests.dfe.yml
@@ -49,7 +49,7 @@ jobs:
     displayName: Public UI tests
     inputs:
       scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --noinvite-pass "test" --pendinginvite-pass "test" --env "dev" --file "tests/general_public/" --processes 4 --rerun-attempts 3
+      arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --noinvite-pass "test" --pendinginvite-pass "test" --env "dev" --file "tests/general_public" --processes 4 --rerun-attempts 3
       workingDirectory: tests/robot-tests
     env:
       SLACK_APP_TOKEN: $(ees-alerts-slackapptoken)

--- a/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
@@ -134,10 +134,10 @@ Put release back into draft
 
 Approve release for scheduled release
     ${days_until_release}=    set variable    2
-    ${publish_date_day}=    get current datetime    %-d    ${days_until_release}
-    ${publish_date_month}=    get current datetime    %-m    ${days_until_release}
-    ${publish_date_month_word}=    get current datetime    %B    ${days_until_release}
-    ${publish_date_year}=    get current datetime    %Y    ${days_until_release}
+    ${publish_date_day}=    get london day of month    offset_days=${days_until_release}
+    ${publish_date_month}=    get london month date    offset_days=${days_until_release}
+    ${publish_date_month_word}=    get london month word    offset_days=${days_until_release}
+    ${publish_date_year}=    get london year    offset_days=${days_until_release}
 
     user approves release for scheduled publication
     ...    ${publish_date_day}

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -103,8 +103,8 @@ Check publication owner can edit release status to "Ready for higher review"
 Validates Release status table is correct
     user waits until page contains element    css:table
     user checks element count is x    xpath://table/tbody/tr    1
-    ${datetime}    get current datetime    %-d %B %Y
-    table cell should contain    css:table    2    1    ${datetime}    # Date
+    ${date}    get london date
+    table cell should contain    css:table    2    1    ${date}    # Date
     table cell should contain    css:table    2    2    HigherLevelReview    # Status
     table cell should contain    css:table    2    3    ready for higher review (publication owner)    # Internal note
     table cell should contain    css:table    2    4    1    # Release version
@@ -116,10 +116,10 @@ Check publication owner can edit release status to "In draft"
 Validates Release status table is correct again
     user waits until page contains element    css:table
     user checks element count is x    xpath://table/tbody/tr    2
-    ${datetime}    get current datetime    %-d %B %Y
+    ${date}    get london date
 
     # New In draft row
-    table cell should contain    css:table    2    1    ${datetime}    # Date
+    table cell should contain    css:table    2    1    ${date}    # Date
     table cell should contain    css:table    2    2    Draft    # Status
     # Internal note
     table cell should contain    css:table    2    3    Moving back to Draft state (publication owner)
@@ -127,7 +127,7 @@ Validates Release status table is correct again
     table cell should contain    css:table    2    5    ees-test.analyst1@education.gov.uk    # By user
 
     # Higher review row
-    table cell should contain    css:table    3    1    ${datetime}    # Date
+    table cell should contain    css:table    3    1    ${date}    # Date
     table cell should contain    css:table    3    2    HigherLevelReview    # Status
     table cell should contain    css:table    3    3    ready for higher review (publication owner)    # Internal note
     table cell should contain    css:table    3    4    1    # Release version
@@ -224,7 +224,7 @@ Add a Footnote as a release approver
 Check release approver can create a release note
     user clicks link    Content
     user adds a release note    Test release note one
-    ${date}    get current datetime    %-d %B %Y
+    ${date}    get london date
     user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
     user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note one
 

--- a/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
+++ b/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
@@ -63,7 +63,7 @@ Adopt a published Methodology
     # List of adoptable methodologies shows latest published version, not latest version -
     # that's why this is approved and not the draft amendment
     user checks element should contain    ${selected_methodology_details}    Approved
-    ${methodology_published_date}=    get current datetime    %-d %B %Y
+    ${methodology_published_date}=    get london date
     user checks element should contain    ${selected_methodology_details}    ${methodology_published_date}
     user clicks button    Save
     user waits until h2 is visible    Manage methodologies
@@ -83,10 +83,10 @@ Set methodology to published alongside release
 Schedule release to be published tomorrow
     user navigates to draft release page from dashboard    ${ADOPTING_PUBLICATION_NAME}    ${RELEASE_NAME}
 
-    ${day}=    get current datetime    %-d    1
-    ${month}=    get current datetime    %-m    1
-    ${month_word}=    get current datetime    %B    1
-    ${year}=    get current datetime    %Y    1
+    ${day}=    get london day of month    offset_days=1
+    ${month}=    get london month date    offset_days=1
+    ${month_word}=    get london month word    offset_days=1
+    ${year}=    get london year    offset_days=1
 
     user clicks link    Sign off
     user clicks button    Edit release status

--- a/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
@@ -69,8 +69,8 @@ Create Methodology with some content and images
     user adds content to accordion section text block    Methodology annex section 2    2
     ...    Adding Methodology annex 2 text block 2    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
     user scrolls up    100
-    user adds image to accordion section text block with retry   Methodology annex section 2    2    test-infographic.png
-    ...    Alt text for the uploaded annex image 3    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
+    user adds image to accordion section text block with retry    Methodology annex section 2    2
+    ...    test-infographic.png    Alt text for the uploaded annex image 3    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
 
 Verify the editable content is as expected
     user checks accordion section contains x blocks    Methodology content section 1    1
@@ -106,7 +106,7 @@ Approve the Methodology
     user approves methodology for publication    ${PUBLICATION_NAME}    ${PUBLICATION_NAME} - first methodology version
 
 Verify the summary for the original Methodology is as expected
-    ${expected_published_date}=    get current datetime    %-d %B %Y
+    ${expected_published_date}=    get london date
     user navigates to methodologies on publication page
     ...    ${PUBLICATION_NAME}
 
@@ -213,7 +213,7 @@ Visit the approved Amendment and check that its summary is as expected
     user clicks element    xpath://*[text()="View"]    ${ROW}
     user waits until h2 is visible    Methodology summary
 
-    ${date}=    get current datetime    %-d %B %Y
+    ${date}=    get london date
     user verifies methodology summary details
     ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -105,10 +105,10 @@ Go to "Sign off" page
     user waits until page contains button    Edit release status
 
 Approve release and wait for it to be Scheduled
-    ${day}=    get current datetime    %-d    2
-    ${month}=    get current datetime    %-m    2
-    ${month_word}=    get current datetime    %B    2
-    ${year}=    get current datetime    %Y    2
+    ${day}=    get london day of month    offset_days=2
+    ${month}=    get london month date    offset_days=2
+    ${month_word}=    get london month word    offset_days=2
+    ${year}=    get london year    offset_days=2
 
     user clicks button    Edit release status
     user clicks radio    Approved for publication
@@ -142,11 +142,11 @@ Validate prerelease has not started
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
 
-    ${time_start}=    get current london datetime    %-d %B %Y at 00:00    1
-    ${time_end}=    get current london datetime    %-d %B %Y    2
+    ${start_date}=    get london date    offset_days=1
+    ${end_date}=    get london date    offset_days=2
 
     user checks page contains
-    ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
+    ...    Pre-release access will be available from ${start_date} at 00:00 until it is published on ${end_date}.
 
 Go to prerelease access page
     user navigates to admin frontend    ${RELEASE_URL}/prerelease-access
@@ -247,18 +247,18 @@ Validate prerelease has not started for Analyst user
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
 
-    ${time_start}=    get current london datetime    %-d %B %Y at 00:00    1
-    ${time_end}=    get current london datetime    %-d %B %Y    2
+    ${start_date}=    get london date    offset_days=1
+    ${end_date}=    get london date    offset_days=2
 
     user checks page contains
-    ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
+    ...    Pre-release access will be available from ${start_date} at 00:00 until it is published on ${end_date}.
 
 Start prerelease
     user changes to bau1
-    ${day}=    get current datetime    %-d    1
-    ${month}=    get current datetime    %-m    1
-    ${month_word}=    get current datetime    %B    1
-    ${year}=    get current datetime    %Y    1
+    ${day}=    get london day of month    offset_days=1
+    ${month}=    get london month date    offset_days=1
+    ${month_word}=    get london month word    offset_days=1
+    ${year}=    get london year    offset_days=1
     user navigates to admin frontend    ${RELEASE_URL}/status
     user clicks button    Edit release status
     user enters text into element    id:releaseStatusForm-publishScheduled-day    ${day}

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -148,7 +148,7 @@ Add release note to amendment
     user clicks button    Add note
     user enters text into element    id:create-release-note-form-reason    Test release note
     user clicks button    Save note
-    ${date}=    get current datetime    ${DATE_FORMAT_MEDIUM}
+    ${date}=    get london date
     user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
     user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note
 
@@ -205,10 +205,10 @@ Validate prerelease has not started for Analyst user during amendment as it is s
 
 Approve amendment for a scheduled release and check warning text
     user changes to bau1
-    ${day}=    get current datetime    %-d    2
-    ${month}=    get current datetime    %-m    2
-    ${month_word}=    get current datetime    %B    2
-    ${year}=    get current datetime    %Y    2
+    ${day}=    get london day of month    offset_days=2
+    ${month}=    get london month date    offset_days=2
+    ${month_word}=    get london month word    offset_days=2
+    ${year}=    get london year    offset_days=2
     user navigates to admin frontend    ${RELEASE_URL}/status
     user clicks button    Edit release status
     user clicks radio    Approved for publication
@@ -239,18 +239,18 @@ Validate prerelease window is not yet open for Analyst user
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
 
-    ${time_start}=    get current london datetime    %-d %B %Y at 00:00    1
-    ${time_end}=    get current london datetime    %-d %B %Y    2
+    ${start_date}=    get london date    offset_days=1
+    ${end_date}=    get london date    offset_days=2
 
     user checks page contains
-    ...    Pre-release access will be available from ${time_start} until it is published on ${time_end}.
+    ...    Pre-release access will be available from ${start_date} at 00:00 until it is published on ${end_date}.
 
 Start prerelease
     user changes to bau1
-    ${day}=    get current datetime    %-d    1
-    ${month}=    get current datetime    %-m    1
-    ${month_word}=    get current datetime    %B    1
-    ${year}=    get current datetime    %Y    1
+    ${day}=    get london day of month    offset_days=1
+    ${month}=    get london month date    offset_days=1
+    ${month_word}=    get london month word    offset_days=1
+    ${year}=    get london year    offset_days=1
     user navigates to admin frontend    ${RELEASE_URL}/status
     user clicks button    Edit release status
     user clicks radio    On a specific date

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -62,7 +62,7 @@ Add summary content to release
 
 Add release note to release
     user adds a release note    Test release note one
-    ${date}=    get current datetime    %-d %B %Y
+    ${date}=    get london date
     user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
     user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note one
 
@@ -81,9 +81,9 @@ Add secondary statistics
     ...    ${expected_select_options}
 
 Check secondary statistics are included correctly
-    user waits until element is visible    id:${SECONDARY_STATS_TABLE_TAB_ID}   %{WAIT_MEDIUM}
+    user waits until element is visible    id:${SECONDARY_STATS_TABLE_TAB_ID}    %{WAIT_MEDIUM}
     user scrolls to element    id:${SECONDARY_STATS_TABLE_TAB_ID}
-    user clicks element    id:${SECONDARY_STATS_TABLE_TAB_ID} 
+    user clicks element    id:${SECONDARY_STATS_TABLE_TAB_ID}
     user checks page contains    Data Block 1 title
     user checks page contains element    css:table
     user checks page contains button    Change secondary stats
@@ -249,8 +249,7 @@ Verify that validation prevents adding an invalid link
 
 
 *** Keywords ***
-
 User waits until secondary stats table tab is visible
     [Arguments]    ${SECONDARY_STATS_TABLE_TAB_ID}    ${timeout}= %{TIMEOUT}
-    wait until keyword succeeds     ${timeout}    5 sec    Element Should Be Visible    id=${SECONDARY_STATS_TABLE_TAB_ID}
-
+    wait until keyword succeeds    ${timeout}    5 sec    Element Should Be Visible
+    ...    id=${SECONDARY_STATS_TABLE_TAB_ID}

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -28,7 +28,8 @@ Verify release summary
     ...    Accredited official statistics
 
 Upload subject
-    user uploads subject and waits until complete    UI test subject    upload-file-test.csv    upload-file-test.meta.csv
+    user uploads subject and waits until complete    UI test subject    upload-file-test.csv
+    ...    upload-file-test.meta.csv
 
 Check release isn't publically visible
     user clicks link    Sign off
@@ -103,10 +104,10 @@ Go to "Sign off" page
     user waits until page contains button    Edit release status    %{WAIT_SMALL}
 
 Approve release and wait for it to be Scheduled
-    ${day}=    get current datetime    %-d    2
-    ${month}=    get current datetime    %-m    2
-    ${month_word}=    get current datetime    %B    2
-    ${year}=    get current datetime    %Y    2
+    ${day}=    get london day of month    offset_days=2
+    ${month}=    get london month date    offset_days=2
+    ${month_word}=    get london month word    offset_days=2
+    ${year}=    get london year    offset_days=2
 
     user clicks button    Edit release status
     user clicks radio    Approved for publication

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -151,8 +151,8 @@ Verify that the methodology 'Published' tag and datetime is shown
 
     ${ROW}=    user gets table row    ${PUBLICATION_NAME}
     user checks element contains    ${ROW}    Published
-    ${DATE}=    get current datetime    %-d %B %Y
-    user checks element contains    ${ROW}    ${DATE}
+    ${date}=    get london date
+    user checks element contains    ${ROW}    ${date}
 
 Verify that the methodology is visible on the public methodologies page with the expected URL
     user navigates to public methodologies page
@@ -198,7 +198,7 @@ Verify that the methodology displays a link to the publication
     ...    css:[aria-labelledby="related-information"]
 
 Verify that the methodology content is correct
-    ${date}=    get current datetime    %-d %B %Y
+    ${date}=    get london date
     user checks summary list contains    Published    ${date}
 
     user checks accordion is in position    Methodology content section 1    1    id:content
@@ -363,7 +363,7 @@ Verify that the amended methodology displays a link to the publication
     ...    css:[aria-labelledby="related-information"]
 
 Verify that the amended methodology content is correct
-    ${date}=    get current datetime    %-d %B %Y
+    ${date}=    get london date
     user checks summary list contains    Published    ${date}
     user checks summary list contains    Last updated    ${date}
 
@@ -400,7 +400,7 @@ Verify that the amended methodology content is correct
     user checks element contains    ${annexe_section_1}    Annexe 1
 
 Verify the list of notes
-    ${date}=    get current datetime    %-d %B %Y
+    ${date}=    get london date
     user opens details dropdown    See all notes (2)
     user waits until page contains element    css:[data-testid="notes"] li    limit=2
     user checks methodology note    1    ${date}    Latest note

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -152,10 +152,10 @@ Add public prerelease access list
 
 Approve release for scheduled publication
     ${days_until_release}=    set variable    0
-    ${publish_date_day}=    get current datetime    %-d    ${days_until_release}
-    ${publish_date_month}=    get current datetime    %-m    ${days_until_release}
-    ${publish_date_month_word}=    get current datetime    %B    ${days_until_release}
-    ${publish_date_year}=    get current datetime    %Y    ${days_until_release}
+    ${publish_date_day}=    get london day of month    offset_days=${days_until_release}
+    ${publish_date_month}=    get london month date    offset_days=${days_until_release}
+    ${publish_date_month_word}=    get london month word    offset_days=${days_until_release}
+    ${publish_date_year}=    get london year    offset_days=${days_until_release}
 
     user approves release for scheduled publication
     ...    ${publish_date_day}
@@ -170,9 +170,9 @@ Approve release for scheduled publication
 Publish the scheduled release
     user waits for scheduled release to be published immediately
 
-    ${publish_date_day}=    get current datetime    %-d
-    ${publish_date_month_word}=    get current datetime    %B
-    ${publish_date_year}=    get current datetime    %Y
+    ${publish_date_day}=    get london day of month
+    ${publish_date_month_word}=    get london month word
+    ${publish_date_year}=    get london year
     set suite variable    ${EXPECTED_PUBLISHED_DATE}
     ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -244,10 +244,10 @@ Add public prerelease access list
 
 Approve release for scheduled publication
     ${days_until_release}=    set variable    0
-    ${publish_date_day}=    get current datetime    %-d    ${days_until_release}
-    ${publish_date_month}=    get current datetime    %-m    ${days_until_release}
-    ${publish_date_month_word}=    get current datetime    %B    ${days_until_release}
-    ${publish_date_year}=    get current datetime    %Y    ${days_until_release}
+    ${publish_date_day}=    get london day of month    offset_days=${days_until_release}
+    ${publish_date_month}=    get london month date    offset_days=${days_until_release}
+    ${publish_date_month_word}=    get london month word    offset_days=${days_until_release}
+    ${publish_date_year}=    get london year    offset_days=${days_until_release}
 
     user approves release for scheduled publication
     ...    ${publish_date_day}
@@ -273,7 +273,7 @@ Get public release link
 Publish the scheduled release
     user waits for scheduled release to be published immediately
 
-    ${EXPECTED_PUBLISHED_DATE}=    get current datetime    ${DATE_FORMAT_MEDIUM}
+    ${EXPECTED_PUBLISHED_DATE}=    get london date
     set suite variable    ${EXPECTED_PUBLISHED_DATE}
 
 Verify newly published release is on Find Statistics page
@@ -724,7 +724,7 @@ Add release note to first amendment
     user clicks button    Add note
     user enters text into element    id:create-release-note-form-reason    Test release note one
     user clicks button    Save note
-    ${date}=    get current datetime    ${DATE_FORMAT_MEDIUM}
+    ${date}=    get london date
     user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
     user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note one
 
@@ -739,10 +739,10 @@ Update public prerelease access list
 
 Approve amendment for scheduled release
     ${days_until_release}=    set variable    1
-    ${publish_date_day}=    get current datetime    %-d    ${days_until_release}
-    ${publish_date_month}=    get current datetime    %-m    ${days_until_release}
-    ${publish_date_month_word}=    get current datetime    %B    ${days_until_release}
-    ${publish_date_year}=    get current datetime    %Y    ${days_until_release}
+    ${publish_date_day}=    get london day of month    offset_days=${days_until_release}
+    ${publish_date_month}=    get london month date    offset_days=${days_until_release}
+    ${publish_date_month_word}=    get london month word    offset_days=${days_until_release}
+    ${publish_date_year}=    get london year    offset_days=${days_until_release}
 
     user approves release for scheduled publication
     ...    ${publish_date_day}
@@ -753,7 +753,7 @@ Approve amendment for scheduled release
 
     user waits for scheduled release to be published immediately
 
-    ${EXPECTED_PUBLISHED_DATE}=    get current datetime    ${DATE_FORMAT_MEDIUM}
+    ${EXPECTED_PUBLISHED_DATE}=    get london date
     set suite variable    ${EXPECTED_PUBLISHED_DATE}
 
 Verify amendment is on Find Statistics page again
@@ -966,7 +966,7 @@ Override release published date to past date
     ${release_id}=    get release id from url
     ${published_override}=    Get Current Date    UTC    increment=-1000 days    result_format=datetime
     user updates release published date via api    ${release_id}    ${published_override}
-    ${EXPECTED_PUBLISHED_DATE}=    format datetime    ${published_override}    ${DATE_FORMAT_MEDIUM}
+    ${EXPECTED_PUBLISHED_DATE}=    get london date    offset_days=-1000
     set suite variable    ${EXPECTED_PUBLISHED_DATE}
 
 Verify published date on publication page is overriden with past date
@@ -1005,9 +1005,9 @@ Remove the content section that originally contained the deleted data block
 
 Approve release amendment for scheduled publication and update published date
     ${days_until_release}=    set variable    2
-    ${publish_date_day}=    get current datetime    %-d    ${days_until_release}
-    ${publish_date_month}=    get current datetime    %-m    ${days_until_release}
-    ${publish_date_year}=    get current datetime    %Y    ${days_until_release}
+    ${publish_date_day}=    get london day of month    offset_days=${days_until_release}
+    ${publish_date_month}=    get london month date    offset_days=${days_until_release}
+    ${publish_date_year}=    get london year    offset_days=${days_until_release}
     user approves release for scheduled publication
     ...    ${publish_date_day}
     ...    ${publish_date_month}
@@ -1016,7 +1016,7 @@ Approve release amendment for scheduled publication and update published date
     ...    next_release_year=4001
     ...    update_amendment_published_date=${True}
     user waits for scheduled release to be published immediately
-    ${EXPECTED_PUBLISHED_DATE}=    get current datetime    ${DATE_FORMAT_MEDIUM}
+    ${EXPECTED_PUBLISHED_DATE}=    get london date
     set suite variable    ${EXPECTED_PUBLISHED_DATE}
 
 Verify published date on publication page has been updated

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
@@ -33,7 +33,8 @@ Create new release
 
 Upload another subject (for deletion later)
     user waits until page contains element    id:dataFileUploadForm-subjectTitle
-    user uploads subject and waits until complete    ${SECOND_SUBJECT}    upload-file-test.csv    upload-file-test.meta.csv
+    user uploads subject and waits until complete    ${SECOND_SUBJECT}    upload-file-test.csv
+    ...    upload-file-test.meta.csv
 
 Add data guidance to subject
     user clicks link    Data guidance
@@ -292,7 +293,7 @@ Add release note to release amendment
     user clicks button    Add note
     user enters text into element    id:create-release-note-form-reason    Test release note one
     user clicks button    Save note
-    ${date}    get current datetime    %-d %B %Y
+    ${date}    get london date
     user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
     user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note one
 
@@ -303,8 +304,8 @@ Go to "Sign off" page
 Validate Release status table row is correct
     user waits until page contains element    css:table
     user checks element count is x    xpath://table/tbody/tr    1
-    ${datetime}    get current datetime    %-d %B %Y
-    table cell should contain    css:table    2    1    ${datetime}    # Date
+    ${date}    get london date
+    table cell should contain    css:table    2    1    ${date}    # Date
     table cell should contain    css:table    2    2    Approved    # Status
     table cell should contain    css:table    2    3    Approved by UI tests    # Internal note
     table cell should contain    css:table    2    4    1    # Release version
@@ -425,7 +426,7 @@ Update Seven filters footnote
 Add release note for new release amendment
     user clicks link    Content
     user adds a release note    Test release note two
-    ${date}    get current datetime    %-d %B %Y
+    ${date}    get london date
     user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
     user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note two
 

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -161,7 +161,7 @@ User validates permanent link works correctly
     ...    'Exclusions by geographic level' from '${EXCLUSIONS_PUBLICATION_TITLE}'
 
 User validates permalink contains correct date
-    ${date}=    get current datetime    %-d %B %Y
+    ${date}=    get london date
     user checks page contains element    xpath://*[@data-testid="created-date"]//strong//time[text()="${date}"]
 
 User validates permalink table headers

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -407,7 +407,7 @@ user adds note to methodology
     user clicks button    Add note
     user enters text into element    label:New methodology note    ${note}
     user clicks button    Save note
-    ${date}=    get current datetime    %-d %B %Y
+    ${date}=    get london date
     user waits until element contains    css:#methodologyNotes time    ${date}
     user waits until element contains    css:#methodologyNotes p    ${note}
 
@@ -569,11 +569,11 @@ user uploads subject and waits until complete
     ...    ${META_FILE}
     ...    ${FOLDER}=${FILES_DIR}
     user uploads subject
-        ...    ${SUBJECT_NAME}
-        ...    ${SUBJECT_FILE}
-        ...    ${META_FILE}
-        ...    Complete
-        ...    ${FOLDER}
+    ...    ${SUBJECT_NAME}
+    ...    ${SUBJECT_FILE}
+    ...    ${META_FILE}
+    ...    Complete
+    ...    ${FOLDER}
 
 user uploads subject and waits until importing
     [Arguments]
@@ -582,12 +582,12 @@ user uploads subject and waits until importing
     ...    ${META_FILE}
     ...    ${FOLDER}=${FILES_DIR}
     user uploads subject
-        ...    ${SUBJECT_NAME}
-        ...    ${SUBJECT_FILE}
-        ...    ${META_FILE}
-        ...    Importing
-        ...    ${FOLDER}
-    
+    ...    ${SUBJECT_NAME}
+    ...    ${SUBJECT_FILE}
+    ...    ${META_FILE}
+    ...    Importing
+    ...    ${FOLDER}
+
 user uploads subject
     [Arguments]
     ...    ${SUBJECT_NAME}
@@ -603,14 +603,14 @@ user uploads subject
     user clicks button    Upload data files
     user waits until h2 is visible    Uploaded data files    %{WAIT_LONG}
     user waits until page contains accordion section    ${SUBJECT_NAME}    %{WAIT_SMALL}
-    user scrolls to accordion section     ${SUBJECT_NAME}
+    user scrolls to accordion section    ${SUBJECT_NAME}
     user opens accordion section    ${SUBJECT_NAME}
     ${section}=    user gets accordion section content element    ${SUBJECT_NAME}
-    
+
     IF    "${IMPORT_STATUS}" != "Importing"
         user waits until page finishes loading
     END
-    
+
     user checks headed table body row contains    Status    ${IMPORT_STATUS}    ${section}    %{WAIT_DATA_FILE_IMPORT}
 
 user waits until data upload is completed
@@ -941,7 +941,8 @@ user updates free text key stat
     user enters text into element    xpath://*[@data-testid="keyStat"][${tile_num}]//input[@name="guidanceTitle"]
     ...    ${guidance_title}
 
-    user enters text into element    xpath://*[@data-testid="keyStat"][${tile_num}]//textarea[@name="guidanceText"]    ${guidance_text}
+    user enters text into element    xpath://*[@data-testid="keyStat"][${tile_num}]//textarea[@name="guidanceText"]
+    ...    ${guidance_text}
 
     user clicks button    Save
     user waits until page does not contain button    Save

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -2,9 +2,10 @@
 Library     SeleniumLibrary    timeout=%{TIMEOUT}    implicit_wait=%{IMPLICIT_WAIT}    run_on_failure=record test failure
 Library     OperatingSystem
 Library     Collections
+Library     dates_and_times.py
+Library     fail_fast.py
 Library     file_operations.py
 Library     utilities.py
-Library     fail_fast.py
 Library     visual.py
 Resource    ./tables-common.robot
 Resource    ./table_tool.robot
@@ -20,7 +21,6 @@ ${DOWNLOADS_DIR}=                       ${EXECDIR}${/}test-results${/}downloads$
 ${timeout}=                             %{TIMEOUT}
 ${implicit_wait}=                       %{IMPLICIT_WAIT}
 ${prompt_to_continue_on_failure}=       0
-${DATE_FORMAT_MEDIUM}=                  %-d %B %Y
 
 
 *** Keywords ***
@@ -454,7 +454,7 @@ user checks element should not contain
 user checks input field contains
     [Arguments]    ${element}    ${text}
     page should contain textfield    ${element}
-    textfield should contain     ${element}    ${text}
+    textfield should contain    ${element}    ${text}
 
 user checks page contains
     [Arguments]    ${text}
@@ -489,7 +489,7 @@ user clicks link by index
     [Arguments]    ${text}    ${index}=1    ${parent}=css:body
     ${xpath}=    set variable    (//a[text()='${text}'])[${index}]
     ${button}=    get webelement    ${xpath}
-    user clicks element   ${button}    ${parent}
+    user clicks element    ${button}    ${parent}
 
 user clicks link by visible text
     [Arguments]    ${text}    ${parent}=css:body
@@ -508,7 +508,7 @@ user clicks button by index
     [Arguments]    ${text}    ${index}=1    ${parent}=css:body
     ${xpath}=    set variable    (//button[text()='${text}'])[${index}]
     ${button}=    get webelement    ${xpath}
-    user clicks element   ${button}    ${parent}
+    user clicks element    ${button}    ${parent}
 
 user waits until button is clickable
     [Arguments]    ${button_text}
@@ -707,9 +707,9 @@ user checks url equals
 user checks url without auth equals
     [Arguments]    ${expected}
     ${current_url}=    get location
-    ${remove_auth_current_url}=    remove auth from url      ${current_url}
+    ${remove_auth_current_url}=    remove auth from url    ${current_url}
     set variable    ${remove_auth_current_url}
-    should contain    ${remove_auth_current_url}   ${expected}
+    should contain    ${remove_auth_current_url}    ${expected}
 
 user checks page contains link
     [Arguments]
@@ -832,7 +832,7 @@ user clicks checkbox
 
 user clicks checkbox by selector
     [Arguments]    ${locator}
-    user scrolls to element     ${locator}
+    user scrolls to element    ${locator}
     user clicks element    ${locator}
 
 user checks checkbox is checked
@@ -1019,35 +1019,29 @@ user waits for caches to expire
     sleep    %{WAIT_CACHE_EXPIRY}
 
 user wait for option to be available and select it
-    [Arguments]  ${dropdown_locator}  ${option_text}  ${timeout}=%{TIMEOUT}
-    wait until keyword succeeds  ${timeout}  1s  check option exist in dropdown  ${dropdown_locator}  ${option_text}
-    select from list by label  ${dropdown_locator}  ${option_text}
+    [Arguments]    ${dropdown_locator}    ${option_text}    ${timeout}=%{TIMEOUT}
+    wait until keyword succeeds    ${timeout}    1s    check option exist in dropdown    ${dropdown_locator}
+    ...    ${option_text}
+    select from list by label    ${dropdown_locator}    ${option_text}
 
 check option exist in dropdown
-    [Arguments]  ${dropdown_locator}  ${option_text}
-     ${options}=  get webelements    ${dropdown_locator} > option
-     ${all_texts}=  Create List
+    [Arguments]    ${dropdown_locator}    ${option_text}
+    ${options}=    get webelements    ${dropdown_locator} > option
+    ${all_texts}=    Create List
 
-     FOR    ${option}    IN    @{options}
-        ${text}=  get text  ${option}
-        Append To List  ${all_texts}  ${text}
-     END
-     # Adding logging to help catch intermittent test failures
-     Log to console  \n\tAll Texts: ${all_texts}
-     ${matched}=  Run Keyword And Return Status  Should Contain  ${all_texts}  ${option_text}
+    FOR    ${option}    IN    @{options}
+        ${text}=    get text    ${option}
+        Append To List    ${all_texts}    ${text}
+    END
+    # Adding logging to help catch intermittent test failures
+    Log to console    \n\tAll Texts: ${all_texts}
+    ${matched}=    Run Keyword And Return Status    Should Contain    ${all_texts}    ${option_text}
 
-     IF  ${matched}
+    IF    ${matched}
         # Adding logging to help catch intermittent test failures
-        Log to console  \n\tOption '${option_text}' found in the dropdown.
-     ELSE
-         # Adding logging to help catch intermittent test failures
-        Log to console  \n\tOption '${option_text}' not found in the dropdown.
-     END
-     Return From Keyword  ${matched}
-
-
-    
-    
-
-
-
+        Log to console    \n\tOption '${option_text}' found in the dropdown.
+    ELSE
+        # Adding logging to help catch intermittent test failures
+        Log to console    \n\tOption '${option_text}' not found in the dropdown.
+    END
+    Return From Keyword    ${matched}

--- a/tests/robot-tests/tests/libs/dates_and_times.py
+++ b/tests/robot-tests/tests/libs/dates_and_times.py
@@ -1,6 +1,5 @@
 import datetime
 import os
-
 import pytz
 from tests.libs.selenium_elements import sl
 

--- a/tests/robot-tests/tests/libs/dates_and_times.py
+++ b/tests/robot-tests/tests/libs/dates_and_times.py
@@ -1,0 +1,50 @@
+import datetime
+import os
+
+import pytz
+from tests.libs.selenium_elements import sl
+
+
+def get_london_date(offset_days: int = 0, format_string: str = "%-d %B %Y") -> str:
+    return _get_date_and_time(offset_days, format_string, "Europe/London")
+
+
+def get_london_date_and_time(offset_days: int = 0, format_string: str = "%-d %B %Y") -> str:
+    return _get_date_and_time(offset_days, format_string, "Europe/London")
+
+
+def get_local_browser_date_and_time(offset_days: int = 0, format_string: str = "%-d %B %Y") -> str:
+    return _get_date_and_time(offset_days, format_string, _get_browser_timezone())
+
+
+def get_london_day_of_month(offset_days: int = 0) -> str:
+    return get_london_date_and_time(offset_days, "%-d")
+
+
+def get_london_month_date(offset_days: int = 0) -> str:
+    return get_london_date_and_time(offset_days, "%-m")
+
+
+def get_london_month_word(offset_days: int = 0) -> str:
+    return get_london_date_and_time(offset_days, "%B")
+
+
+def get_london_year(offset_days: int = 0) -> str:
+    return get_london_date_and_time(offset_days, "%Y")
+
+
+def _get_browser_timezone():
+    return sl().driver.execute_script("return Intl.DateTimeFormat().resolvedOptions().timeZone;")
+
+
+def _get_date_and_time(offset_days: int, format_string: str, timezone: str) -> str:
+    return _format_datetime(
+        datetime.datetime.now(pytz.timezone(timezone)) + datetime.timedelta(days=offset_days), format_string
+    )
+
+
+def _format_datetime(datetime: datetime, format_string: str) -> str:
+    if os.name == "nt":
+        format_string = format_string.replace("%-", "%#")
+
+    return datetime.strftime(format_string)

--- a/tests/robot-tests/tests/libs/dates_and_times.py
+++ b/tests/robot-tests/tests/libs/dates_and_times.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+
 import pytz
 from tests.libs.selenium_elements import sl
 
@@ -17,19 +18,19 @@ def get_local_browser_date_and_time(offset_days: int = 0, format_string: str = "
 
 
 def get_london_day_of_month(offset_days: int = 0) -> str:
-    return get_london_date_and_time(offset_days, "%-d")
+    return _get_date_and_time(offset_days, "%-d", "Europe/London")
 
 
 def get_london_month_date(offset_days: int = 0) -> str:
-    return get_london_date_and_time(offset_days, "%-m")
+    return _get_date_and_time(offset_days, "%-m", "Europe/London")
 
 
 def get_london_month_word(offset_days: int = 0) -> str:
-    return get_london_date_and_time(offset_days, "%B")
+    return _get_date_and_time(offset_days, "%B", "Europe/London")
 
 
 def get_london_year(offset_days: int = 0) -> str:
-    return get_london_date_and_time(offset_days, "%Y")
+    return _get_date_and_time(offset_days, "%Y", "Europe/London")
 
 
 def _get_browser_timezone():

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -7,7 +7,6 @@ import time
 from typing import Union
 from urllib.parse import urlparse, urlunparse
 
-import pytz
 import utilities_init
 import visual
 from robot.libraries.BuiltIn import BuiltIn
@@ -280,25 +279,6 @@ def set_cookie_from_json(cookie_json):
     sl().driver.add_cookie(cookie_dict)
 
 
-def get_current_datetime(strf: str, offset_days: int = 0, timezone: str = "UTC") -> str:
-    return format_datetime(datetime.datetime.now(pytz.timezone(timezone)) + datetime.timedelta(days=offset_days), strf)
-
-
-def get_current_london_datetime(strf: str, offset_days: int = 0) -> str:
-    return get_current_datetime(strf, offset_days, "Europe/London")
-
-
-def get_current_local_datetime(strf: str, offset_days: int = 0) -> str:
-    return get_current_datetime(strf, offset_days, _get_browser_timezone())
-
-
-def format_datetime(datetime: datetime, strf: str) -> str:
-    if os.name == "nt":
-        strf = strf.replace("%-", "%#")
-
-    return datetime.strftime(strf)
-
-
 def user_should_be_at_top_of_page():
     (x, y) = sl().get_window_position()
     if y != 0:
@@ -438,7 +418,3 @@ def get_child_element_with_retry(parent_locator: object, child_locator: str, max
             logger.warn(f"Child element not found, after ({max_retries}) retries")
             time.sleep(retry_delay)
     raise AssertionError(f"Failed to find child element after {max_retries} retries.")
-
-
-def _get_browser_timezone():
-    return sl().driver.execute_script("return Intl.DateTimeFormat().resolvedOptions().timeZone;")

--- a/tests/robot-tests/tests/public_api/public_api_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_preview_token.robot
@@ -11,13 +11,15 @@ Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
+
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - Public API - preview token %{RUN_IDENTIFIER}
-${RELEASE_NAME}=        Academic year Q1
-${ACADEMIC_YEAR}=       3000
-${SUBJECT_NAME_1}=      UI test subject 1
-${SUBJECT_NAME_2}=      UI test subject 2
-${PREVIEW_TOKEN_NAME}=  Test token
+${PUBLICATION_NAME}=        UI tests - Public API - preview token %{RUN_IDENTIFIER}
+${RELEASE_NAME}=            Academic year Q1
+${ACADEMIC_YEAR}=           3000
+${SUBJECT_NAME_1}=          UI test subject 1
+${SUBJECT_NAME_2}=          UI test subject 2
+${PREVIEW_TOKEN_NAME}=      Test token
+
 
 *** Test Cases ***
 Create publication and release
@@ -33,8 +35,10 @@ Verify release summary
     user verifies release summary    Academic year Q1    3000/01    Accredited official statistics
 
 Upload data files
-    user uploads subject and waits until complete    ${SUBJECT_NAME_1}    seven_filters.csv    seven_filters.meta.csv     ${PUBLIC_API_FILES_DIR}
-    user uploads subject and waits until complete    ${SUBJECT_NAME_2}    tiny-two-filters.csv    tiny-two-filters.meta.csv     ${PUBLIC_API_FILES_DIR}
+    user uploads subject and waits until complete    ${SUBJECT_NAME_1}    seven_filters.csv    seven_filters.meta.csv
+    ...    ${PUBLIC_API_FILES_DIR}
+    user uploads subject and waits until complete    ${SUBJECT_NAME_2}    tiny-two-filters.csv
+    ...    tiny-two-filters.meta.csv    ${PUBLIC_API_FILES_DIR}
 
 Add data guidance to subjects
     user clicks link    Data and files
@@ -62,7 +66,7 @@ Create 1st API dataset
 
     user clicks button    Create API data set
     ${modal}=    user waits until modal is visible    Create a new API data set
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_1}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_1}
     user clicks button    Confirm new API data set
 
     user waits until page finishes loading
@@ -76,7 +80,7 @@ Create 2nd API dataset
     user clicks link    Back to API data sets
     user clicks button    Create API data set
     ${modal}=    user waits until modal is visible    Create a new API data set
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_2}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_2}
     user clicks button    Confirm new API data set
 
     user waits until page finishes loading
@@ -90,10 +94,11 @@ Verify the contents inside the 'Draft API datasets' table
     user clicks link    Back to API data sets
     user waits until h3 is visible    Draft API data sets
 
-    user checks table column heading contains    1    1    Draft version    xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    2    Name             xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    3    Status           xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    4    Actions          xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    1    Draft version
+    ...    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    2    Name    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    3    Status    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    4    Actions    xpath://table[@data-testid='draft-api-data-sets']
 
     user checks table cell contains    1    1    v1.0    xpath://table[@data-testid='draft-api-data-sets']
     user checks table cell contains    1    3    Ready    xpath://table[@data-testid='draft-api-data-sets']
@@ -107,46 +112,67 @@ Click on 'View Details' link(First API dataset)
     user checks table headings for Draft version details table
 
 User checks row data contents inside the 'Draft API datasets' summary table
-    user checks contents inside the cell value    v1.0                                       xpath://dl[@data-testid="draft-version-summary"]/div/dd[@data-testid='Version-value']/strong
-    user checks contents inside the cell value    Ready                                      xpath:(//div[@data-testid="Status"]//dd[@data-testid="Status-value"]//strong)[2]
-    user checks contents inside the cell value    Academic year Q1 3000/01                    xpath:(//div[@data-testid="Release"]//dd[@data-testid="Release-value"]//a)[1]
-    user checks contents inside the cell value    ${SUBJECT_NAME_1}                          xpath://div[@data-testid="Data set file"]//dd[@data-testid="Data set file-value"]
-    user checks contents inside the cell value    National                                   xpath://div[@data-testid="Geographic levels"]//dd[@data-testid="Geographic levels-value"]
-    user checks contents inside the cell value    2012/13                                    xpath://div[@data-testid="Time periods"]//dd[@data-testid="Time periods-value"]
+    user checks contents inside the cell value    v1.0
+    ...    xpath://dl[@data-testid="draft-version-summary"]/div/dd[@data-testid='Version-value']/strong
+    user checks contents inside the cell value    Ready
+    ...    xpath:(//div[@data-testid="Status"]//dd[@data-testid="Status-value"]//strong)[2]
+    user checks contents inside the cell value    Academic year Q1 3000/01
+    ...    xpath:(//div[@data-testid="Release"]//dd[@data-testid="Release-value"]//a)[1]
+    user checks contents inside the cell value    ${SUBJECT_NAME_1}
+    ...    xpath://div[@data-testid="Data set file"]//dd[@data-testid="Data set file-value"]
+    user checks contents inside the cell value    National
+    ...    xpath://div[@data-testid="Geographic levels"]//dd[@data-testid="Geographic levels-value"]
+    user checks contents inside the cell value    2012/13
+    ...    xpath://div[@data-testid="Time periods"]//dd[@data-testid="Time periods-value"]
 
-    user checks contents inside the cell value    Lower quartile annualised earnings         xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[1]
-    user checks contents inside the cell value    Median annualised earnings                 xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[2]
-    user checks contents inside the cell value    Number of learners with earnings           xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[3]
+    user checks contents inside the cell value    Lower quartile annualised earnings
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[1]
+    user checks contents inside the cell value    Median annualised earnings
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[2]
+    user checks contents inside the cell value    Number of learners with earnings
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[3]
 
-    user clicks button                              Show 1 more indicator                    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]
+    user clicks button    Show 1 more indicator
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]
 
-    user checks contents inside the cell value      Upper quartile annualised earnings       xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[4]
+    user checks contents inside the cell value    Upper quartile annualised earnings
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[4]
 
-    user checks contents inside the cell value    	Cheese                                   xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[1]
-    user checks contents inside the cell value    	Colour                                   xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[2]
-    user checks contents inside the cell value    	Ethnicity group                          xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[3]
+    user checks contents inside the cell value    Cheese
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[1]
+    user checks contents inside the cell value    Colour
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[2]
+    user checks contents inside the cell value    Ethnicity group
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[3]
 
-    user clicks button                              Show 4 more filters                      xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]
+    user clicks button    Show 4 more filters    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]
 
-    user checks contents inside the cell value    	Gender                                    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[4]
-    user checks contents inside the cell value    	Level of learning                         xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[5]
-    user checks contents inside the cell value      Number of years after achievement of learning aim    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[6]
-    user checks contents inside the cell value      Provision                                 xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[7]
+    user checks contents inside the cell value    Gender
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[4]
+    user checks contents inside the cell value    Level of learning
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[5]
+    user checks contents inside the cell value    Number of years after achievement of learning aim
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[6]
+    user checks contents inside the cell value    Provision
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[7]
 
-    user checks contents inside the cell value      Preview API data set                      xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[1]/a
-    user checks contents inside the cell value      View preview token log                    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[2]/a
-    user checks contents inside the cell value      Remove draft version                      xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[3]/button
+    user checks contents inside the cell value    Preview API data set
+    ...    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[1]/a
+    user checks contents inside the cell value    View preview token log
+    ...    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[2]/a
+    user checks contents inside the cell value    Remove draft version
+    ...    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[3]/button
 
 User clicks on 'Preview API data set' link
     user clicks link containing text    Preview API data set
 
 User clicks on 'Generate preview token'
-    user clicks button     Generate preview token
+    user clicks button    Generate preview token
 
 User creates preview token through 'Generate preview token' modal window
     ${modal}=    user waits until modal is visible    Generate preview token
     user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
-    user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
+    user clicks checkbox by selector    css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Continue
 
     user waits until page finishes loading
@@ -163,12 +189,12 @@ User revokes preview token
     user waits until page contains    Generate API data set preview token
 
 User again clicks on 'Generate preview token'
-    user clicks button     Generate preview token
+    user clicks button    Generate preview token
 
 User creates another preview token through 'Generate preview token' modal window
     ${modal}=    user waits until modal is visible    Generate preview token
     user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
-    user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
+    user clicks checkbox by selector    css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Continue
 
     user waits until page finishes loading
@@ -188,11 +214,11 @@ User cancels revoking preview token
 User cancels creating preview token
     user clicks link    Back to API data set details
     user clicks link containing text    Preview API data set
-    user clicks button     Generate preview token
+    user clicks button    Generate preview token
 
     ${modal}=    user waits until modal is visible    Generate preview token
     user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
-    user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
+    user clicks checkbox by selector    css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Cancel
 
     user waits until page finishes loading
@@ -228,7 +254,7 @@ User verifies the relevant fields on the active preview token page
 
     ${modal}=    user waits until modal is visible    Generate preview token
     user enters text into element    css:input[id="apiDataSetTokenCreateForm-label"]    ${PREVIEW_TOKEN_NAME}
-    user clicks checkbox by selector        css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
+    user clicks checkbox by selector    css:input[id="apiDataSetTokenCreateForm-agreeTerms"]
     user clicks button    Continue
 
     user waits until page finishes loading
@@ -238,9 +264,9 @@ User verifies the relevant fields on the active preview token page
     user waits until h2 is visible    ${SUBJECT_NAME_1}
     user checks page contains    Reference: ${PREVIEW_TOKEN_NAME}
 
-    ${current_time_tomorrow}=    get current local datetime    %-I:%M %p    1
+    ${current_time_tomorrow}=    get local browser date and time    offset_days=1    format_string=%-I:%M %p
     user checks page contains
-    ...     The token expires: tomorrow at ${time_end} (local time)
+    ...    The token expires: tomorrow at ${current_time_tomorrow} (local time)
 
     user checks page contains button    Copy preview token
     user checks page contains button    Revoke preview token
@@ -292,55 +318,72 @@ User verifies the row headings and contents in 'Data set details' section
     user checks row headings within the api data set section    Publication
     user checks row headings within the api data set section    Release
     user checks row headings within the api data set section    Release type
-    user checks row headings within the api data set section   Geographic levels
-    user checks row headings within the api data set section   Indicators
+    user checks row headings within the api data set section    Geographic levels
+    user checks row headings within the api data set section    Indicators
     user checks row headings within the api data set section    Filters
     user checks row headings within the api data set section    Time period
 
-    user checks row headings within the api data set section   Notifications
+    user checks row headings within the api data set section    Notifications
 
-    user checks contents inside the cell value          Test theme                                                  css: #dataSetDetails [data-testid="Theme-value"]
-    user checks contents inside the cell value          ${PUBLICATION_NAME}                                         css:#dataSetDetails [data-testid="Publication-value"]
-    user checks contents inside the cell value          Academic year Q1 3000/01                                    css:#dataSetDetails [data-testid="Release-value"]
-    User checks contents inside the release type        Accredited official statistics                              css:#dataSetDetails [data-testid="Release type-value"] > button
-    user checks contents inside the cell value          National                                                    css:#dataSetDetails [data-testid="Geographic levels-value"]
+    user checks contents inside the cell value    Test theme    css: #dataSetDetails [data-testid="Theme-value"]
+    user checks contents inside the cell value    ${PUBLICATION_NAME}
+    ...    css:#dataSetDetails [data-testid="Publication-value"]
+    user checks contents inside the cell value    Academic year Q1 3000/01
+    ...    css:#dataSetDetails [data-testid="Release-value"]
+    User checks contents inside the release type    Accredited official statistics
+    ...    css:#dataSetDetails [data-testid="Release type-value"] > button
+    user checks contents inside the cell value    National
+    ...    css:#dataSetDetails [data-testid="Geographic levels-value"]
 
-    user checks contents inside the cell value           Lower quartile annualised earnings                         css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(1)
-    user checks contents inside the cell value           Median annualised earnings                                 css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(2)
-    user checks contents inside the cell value           Number of learners with earnings                           css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(3)
+    user checks contents inside the cell value    Lower quartile annualised earnings
+    ...    css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(1)
+    user checks contents inside the cell value    Median annualised earnings
+    ...    css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(2)
+    user checks contents inside the cell value    Number of learners with earnings
+    ...    css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(3)
 
-    user clicks button                                   Show 1 more indicator                                      css:#dataSetDetails [data-testid="Indicators-value"]
+    user clicks button    Show 1 more indicator    css:#dataSetDetails [data-testid="Indicators-value"]
 
-    user checks contents inside the cell value           Upper quartile annualised earnings                         css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(4)
+    user checks contents inside the cell value    Upper quartile annualised earnings
+    ...    css:#dataSetDetails [data-testid="Indicators-value"] > ul > :nth-of-type(4)
 
-    user checks contents inside the cell value    	     Cheese                                                     css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(1)
-    user checks contents inside the cell value    	     Colour                                                     css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(2)
-    user checks contents inside the cell value    	     Ethnicity group                                            css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(3)
+    user checks contents inside the cell value    Cheese
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(1)
+    user checks contents inside the cell value    Colour
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(2)
+    user checks contents inside the cell value    Ethnicity group
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(3)
 
-    user clicks button                                   Show 4 more filters                                        css:#dataSetDetails [data-testid="Filters-value"]
+    user clicks button    Show 4 more filters    css:#dataSetDetails [data-testid="Filters-value"]
 
-    user checks contents inside the cell value    	     Gender                                                     css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(4)
-    user checks contents inside the cell value    	     Level of learning                                          css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(5)
-    user checks contents inside the cell value           Number of years after achievement of learning aim          css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(6)
-    user checks contents inside the cell value           Provision                                                  css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(7)
+    user checks contents inside the cell value    Gender
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(4)
+    user checks contents inside the cell value    Level of learning
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(5)
+    user checks contents inside the cell value    Number of years after achievement of learning aim
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(6)
+    user checks contents inside the cell value    Provision
+    ...    css:#dataSetDetails [data-testid="Filters-value"] > ul > :nth-of-type(7)
 
-    user checks contents inside the cell value           2012/13                                                    css:#dataSetDetails [data-testid="Time period-value"]
-    user checks contents inside the cell value           Get email updates about this API data set                  css:#dataSetDetails [data-testid="Notifications-value"] > a
+    user checks contents inside the cell value    2012/13    css:#dataSetDetails [data-testid="Time period-value"]
+    user checks contents inside the cell value    Get email updates about this API data set
+    ...    css:#dataSetDetails [data-testid="Notifications-value"] > a
 
 User verifies the headings and contents in 'API version history' section
     user checks table column heading contains    1    1    Version    css:section[id="apiVersionHistory"]
 
     user checks table column heading contains    1    2    Release    css:section[id="apiVersionHistory"]
-    user checks table column heading contains    1    3    Status     css:section[id="apiVersionHistory"]
+    user checks table column heading contains    1    3    Status    css:section[id="apiVersionHistory"]
 
-    user checks table cell contains              1    1    1.0 (current)                xpath://section[@id="apiVersionHistory"]
-    user checks table cell contains              1    2    Academic year Q1 3000/01     xpath://section[@id="apiVersionHistory"]
-    user checks table cell contains              1    3    Published                    xpath://section[@id="apiVersionHistory"]
+    user checks table cell contains    1    1    1.0 (current)    xpath://section[@id="apiVersionHistory"]
+    user checks table cell contains    1    2    Academic year Q1 3000/01    xpath://section[@id="apiVersionHistory"]
+    user checks table cell contains    1    3    Published    xpath://section[@id="apiVersionHistory"]
+
 
 *** Keywords ***
 User checks contents inside the release type
-    [Arguments]      ${expected_text}     ${locator}
-     ${full_text}=    get text    ${locator}
+    [Arguments]    ${expected_text}    ${locator}
+    ${full_text}=    get text    ${locator}
 
     # Split and remove the part after '?' and strip whitespace
     ${button_text}=    set variable    ${full_text.split('?')[0].strip()}

--- a/tests/robot-tests/tests/public_api/public_api_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_preview_token.robot
@@ -240,7 +240,7 @@ User verifies the relevant fields on the active preview token page
 
     ${current_time_tomorrow}=    get current local datetime    %-I:%M %p    1
     user checks page contains
-    ...     The token expires: tomorrow at ${current_time_tomorrow} (local time)
+    ...     The token expires: tomorrow at ${time_end} (local time)
 
     user checks page contains button    Copy preview token
     user checks page contains button    Revoke preview token

--- a/tests/robot-tests/tests/public_api/public_api_restricted.robot
+++ b/tests/robot-tests/tests/public_api/public_api_restricted.robot
@@ -1,4 +1,3 @@
-
 *** Settings ***
 Library             ../libs/admin_api.py
 Resource            ../libs/admin-common.robot
@@ -12,16 +11,14 @@ Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
 
-
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - Public API - restricted %{RUN_IDENTIFIER}
-${RELEASE_NAME}=        Financial year 3000-01
-${SUBJECT_NAME_1}=      UI test subject 1
-${SUBJECT_NAME_2}=      UI test subject 2
-${SUBJECT_NAME_3}=      UI test subject 3
-${SUBJECT_NAME_4}=      UI test subject 4
-${SUBJECT_NAME_5}=      UI test subject 5
-
+${PUBLICATION_NAME}     UI tests - Public API - restricted %{RUN_IDENTIFIER}
+${RELEASE_NAME}         Financial year 3000-01
+${SUBJECT_NAME_1}       UI test subject 1
+${SUBJECT_NAME_2}       UI test subject 2
+${SUBJECT_NAME_3}       UI test subject 3
+${SUBJECT_NAME_4}       UI test subject 4
+${SUBJECT_NAME_5}       UI test subject 5
 
 
 *** Test Cases ***
@@ -36,8 +33,10 @@ Verify release summary
     user verifies release summary    Financial year    3000-01    Accredited official statistics
 
 Upload data files
-    user uploads subject and waits until complete    ${SUBJECT_NAME_1}    seven_filters.csv    seven_filters.meta.csv    ${PUBLIC_API_FILES_DIR}
-    user uploads subject and waits until complete    ${SUBJECT_NAME_2}    tiny-two-filters.csv    tiny-two-filters.meta.csv    ${PUBLIC_API_FILES_DIR}
+    user uploads subject and waits until complete    ${SUBJECT_NAME_1}    seven_filters.csv    seven_filters.meta.csv
+    ...    ${PUBLIC_API_FILES_DIR}
+    user uploads subject and waits until complete    ${SUBJECT_NAME_2}    tiny-two-filters.csv
+    ...    tiny-two-filters.meta.csv    ${PUBLIC_API_FILES_DIR}
 
 Add data guidance to subjects
     user clicks link    Data and files
@@ -65,7 +64,7 @@ Create 1st API dataset
 
     user clicks button    Create API data set
     ${modal}=    user waits until modal is visible    Create a new API data set
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_1}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_1}
     user clicks button    Confirm new API data set
 
     user waits until page finishes loading
@@ -79,7 +78,7 @@ Create 2nd API dataset
     user clicks link    Back to API data sets
     user clicks button    Create API data set
     ${modal}=    user waits until modal is visible    Create a new API data set
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_2}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_2}
     user clicks button    Confirm new API data set
 
     user waits until page finishes loading
@@ -93,12 +92,11 @@ Verify the contents inside the 'Draft API datasets' table
     user clicks link    Back to API data sets
     user waits until h3 is visible    Draft API data sets
 
-
-    user checks table column heading contains    1    1    Draft version    xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    2    Name             xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    3    Status           xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    4    Actions          xpath://table[@data-testid='draft-api-data-sets']
-
+    user checks table column heading contains    1    1    Draft version
+    ...    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    2    Name    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    3    Status    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    4    Actions    xpath://table[@data-testid='draft-api-data-sets']
 
     user checks table cell contains    1    1    v1.0    xpath://table[@data-testid='draft-api-data-sets']
     user checks table cell contains    1    3    Ready    xpath://table[@data-testid='draft-api-data-sets']
@@ -112,36 +110,56 @@ Click on 'View Details' link
     user checks table headings for Draft version details table
 
 User checks row data contents inside the 'Draft API datasets' summary table
-    user checks contents inside the cell value    v1.0                                       xpath://dl[@data-testid="draft-version-summary"]/div/dd[@data-testid='Version-value']/strong
-    user checks contents inside the cell value    Ready                                      xpath:(//div[@data-testid="Status"]//dd[@data-testid="Status-value"]//strong)[2]
-    user checks contents inside the cell value    Financial year 3000-01                     xpath:(//div[@data-testid="Release"]//dd[@data-testid="Release-value"]//a)[1]
-    user checks contents inside the cell value    ${SUBJECT_NAME_1}                          xpath://div[@data-testid="Data set file"]//dd[@data-testid="Data set file-value"]
-    user checks contents inside the cell value    National                                   xpath://div[@data-testid="Geographic levels"]//dd[@data-testid="Geographic levels-value"]
-    user checks contents inside the cell value    2012/13                                    xpath://div[@data-testid="Time periods"]//dd[@data-testid="Time periods-value"]
+    user checks contents inside the cell value    v1.0
+    ...    xpath://dl[@data-testid="draft-version-summary"]/div/dd[@data-testid='Version-value']/strong
+    user checks contents inside the cell value    Ready
+    ...    xpath:(//div[@data-testid="Status"]//dd[@data-testid="Status-value"]//strong)[2]
+    user checks contents inside the cell value    Financial year 3000-01
+    ...    xpath:(//div[@data-testid="Release"]//dd[@data-testid="Release-value"]//a)[1]
+    user checks contents inside the cell value    ${SUBJECT_NAME_1}
+    ...    xpath://div[@data-testid="Data set file"]//dd[@data-testid="Data set file-value"]
+    user checks contents inside the cell value    National
+    ...    xpath://div[@data-testid="Geographic levels"]//dd[@data-testid="Geographic levels-value"]
+    user checks contents inside the cell value    2012/13
+    ...    xpath://div[@data-testid="Time periods"]//dd[@data-testid="Time periods-value"]
 
+    user checks contents inside the cell value    Lower quartile annualised earnings
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[1]
+    user checks contents inside the cell value    Median annualised earnings
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[2]
+    user checks contents inside the cell value    Number of learners with earnings
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[3]
 
-    user checks contents inside the cell value    Lower quartile annualised earnings         xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[1]
-    user checks contents inside the cell value    Median annualised earnings                 xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[2]
-    user checks contents inside the cell value    Number of learners with earnings           xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[3]
+    user clicks button    Show 1 more indicator
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]
 
-    user clicks button                              Show 1 more indicator                    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]
+    user checks contents inside the cell value    Upper quartile annualised earnings
+    ...    xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[4]
 
-    user checks contents inside the cell value      Upper quartile annualised earnings       xpath://div[@data-testid="Indicators"]//dd[@data-testid="Indicators-value"]/ul/li[4]
+    user checks contents inside the cell value    Cheese
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[1]
+    user checks contents inside the cell value    Colour
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[2]
+    user checks contents inside the cell value    Ethnicity group
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[3]
 
-    user checks contents inside the cell value    	Cheese                                   xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[1]
-    user checks contents inside the cell value    	Colour                                   xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[2]
-    user checks contents inside the cell value    	Ethnicity group                          xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[3]
+    user clicks button    Show 4 more filters    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]
 
-    user clicks button                              Show 4 more filters                      xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]
+    user checks contents inside the cell value    Gender
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[4]
+    user checks contents inside the cell value    Level of learning
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[5]
+    user checks contents inside the cell value    Number of years after achievement of learning aim
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[6]
+    user checks contents inside the cell value    Provision
+    ...    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[7]
 
-    user checks contents inside the cell value    	Gender                                    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[4]
-    user checks contents inside the cell value    	Level of learning                         xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[5]
-    user checks contents inside the cell value      Number of years after achievement of learning aim    xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[6]
-    user checks contents inside the cell value      Provision                                 xpath://div[@data-testid="Filters"]//dd[@data-testid="Filters-value"]/ul/li[7]
-
-    user checks contents inside the cell value      Preview API data set                      xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[1]/a
-    user checks contents inside the cell value      View preview token log                    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[2]/a
-    user checks contents inside the cell value      Remove draft version                      xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[3]/button
+    user checks contents inside the cell value    Preview API data set
+    ...    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[1]/a
+    user checks contents inside the cell value    View preview token log
+    ...    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[2]/a
+    user checks contents inside the cell value    Remove draft version
+    ...    xpath://div[@data-testid="Actions"]//dd[@data-testid="Actions-value"]/ul/li[3]/button
 
 Add headline text block to Content page
     user navigates to content page    ${PUBLICATION_NAME}
@@ -175,7 +193,7 @@ Create a new API dataset version through the first amendment using the invalid s
 
     user clicks button    Create API data set
     ${modal}=    user waits until modal is visible    Create a new API data set
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_3}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_3}
     user clicks button    Confirm new API data set
 
     user waits until page finishes loading
@@ -189,35 +207,33 @@ Verify the contents inside the 'Draft API datasets' table after the invalid impo
     user clicks link    Back to API data sets
     user waits until h3 is visible    Draft API data sets
 
-    user checks table column heading contains    1    1    Draft version    xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    2    Name             xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    3    Status           xpath://table[@data-testid='draft-api-data-sets']
-    user checks table column heading contains    1    4    Actions          xpath://table[@data-testid='draft-api-data-sets']
-
+    user checks table column heading contains    1    1    Draft version
+    ...    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    2    Name    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    3    Status    xpath://table[@data-testid='draft-api-data-sets']
+    user checks table column heading contains    1    4    Actions    xpath://table[@data-testid='draft-api-data-sets']
 
     user checks table cell contains    1    1    v1.0    xpath://table[@data-testid='draft-api-data-sets']
     user checks table cell contains    1    3    Failed    xpath://table[@data-testid='draft-api-data-sets']
 
 Verify the contents inside the 'Live API datasets' table after the invalid import fails
-    user checks table column heading contains    1    1    Version          xpath://table[@data-testid='live-api-data-sets']
-    user checks table column heading contains    1    2    Name             xpath://table[@data-testid='live-api-data-sets']
-    user checks table column heading contains    1    3    Actions          xpath://table[@data-testid='live-api-data-sets']
+    user checks table column heading contains    1    1    Version    xpath://table[@data-testid='live-api-data-sets']
+    user checks table column heading contains    1    2    Name    xpath://table[@data-testid='live-api-data-sets']
+    user checks table column heading contains    1    3    Actions    xpath://table[@data-testid='live-api-data-sets']
 
+    user checks table cell contains    1    1    v1.0    xpath://table[@data-testid='live-api-data-sets']
+    user checks table cell contains    1    2    ${SUBJECT_NAME_1}    xpath://table[@data-testid='live-api-data-sets']
 
-    user checks table cell contains    1    1    v1.0                       xpath://table[@data-testid='live-api-data-sets']
-    user checks table cell contains    1    2    ${SUBJECT_NAME_1}          xpath://table[@data-testid='live-api-data-sets']
-
-    user checks table cell contains    2    1    v1.0                       xpath://table[@data-testid='live-api-data-sets']
-    user checks table cell contains    2    2    ${SUBJECT_NAME_2}          xpath://table[@data-testid='live-api-data-sets']
+    user checks table cell contains    2    1    v1.0    xpath://table[@data-testid='live-api-data-sets']
+    user checks table cell contains    2    2    ${SUBJECT_NAME_2}    xpath://table[@data-testid='live-api-data-sets']
 
 Add release note for the first release amendment
     user clicks link    Content
     user adds a release note    Test release note two
 
-    ${date}    get current datetime    %-d %B %Y
+    ${date}=    get london date
     user waits until element contains    css:#release-notes li:nth-of-type(1) time    ${date}
     user waits until element contains    css:#release-notes li:nth-of-type(1) p    Test release note two
-
 
 # When processing large API datasets, the current EES system returns one of two errors depending on the processing speed.
 # Additionally, there's an active bug ticket (EES-5420) - large data files are failing to create API datasets.
@@ -236,7 +252,8 @@ Create a second draft release via api
     user creates release from publication page    ${PUBLICATION_NAME}    Academic year    3010
 
 Upload subject to second release
-    user uploads subject and waits until complete    ${SUBJECT_NAME_4}    seven_filters_minor_update.csv    seven_filters_minor_update.meta.csv    ${PUBLIC_API_FILES_DIR}
+    user uploads subject and waits until complete    ${SUBJECT_NAME_4}    seven_filters_minor_update.csv
+    ...    seven_filters_minor_update.meta.csv    ${PUBLIC_API_FILES_DIR}
 
 Add data guidance to second release
     user clicks link    Data and files
@@ -262,10 +279,11 @@ Create a different version of an API dataset (minor version)
     user waits until h3 is visible    Current live API data sets
 
     user checks table column heading contains    1    1    Version    xpath://table[@data-testid="live-api-data-sets"]
-    user clicks button in table cell    1    3    Create new version    xpath://table[@data-testid="live-api-data-sets"]
+    user clicks button in table cell    1    3    Create new version
+    ...    xpath://table[@data-testid="live-api-data-sets"]
 
     ${modal}=    user waits until modal is visible    Create a new API data set version
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_4}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_4}
     user clicks button    Confirm new data set version
 
     user waits until page finishes loading
@@ -273,8 +291,10 @@ Create a different version of an API dataset (minor version)
 
 Validate the summary contents inside the 'draft version details' table
     user waits until h3 is visible    Draft version details
-    user waits until element contains    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(1) > dt + dd     v1.1    %{WAIT_LONG}
-    user waits until element contains    css=dl[data-testid="draft-version-summary"] > div:nth-of-type(2) > dt + dd     Action required    %{WAIT_LONG}
+    user waits until element contains    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(1) > dt + dd
+    ...    v1.1    %{WAIT_LONG}
+    user waits until element contains    css=dl[data-testid="draft-version-summary"] > div:nth-of-type(2) > dt + dd
+    ...    Action required    %{WAIT_LONG}
     ${mapping_status}=    get text    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(2) > dt + dd
     should be equal as strings    ${mapping_status}    Action required
 
@@ -295,7 +315,8 @@ Create a third draft release via api
     user creates release from publication page    ${PUBLICATION_NAME}    Academic year    3020
 
 Upload subject to the third release
-    user uploads subject and waits until complete    ${SUBJECT_NAME_5}    institution_and_provider.csv    institution_and_provider.meta.csv    ${PUBLIC_API_FILES_DIR}
+    user uploads subject and waits until complete    ${SUBJECT_NAME_5}    institution_and_provider.csv
+    ...    institution_and_provider.meta.csv    ${PUBLIC_API_FILES_DIR}
 
 Add data guidance to the third release
     user clicks link    Data and files
@@ -321,21 +342,23 @@ Create a different version of API dataset (major version) for the third release
     user waits until h3 is visible    Current live API data sets
 
     user checks table column heading contains    1    1    Version    xpath://table[@data-testid="live-api-data-sets"]
-    user clicks button in table cell    1    3    Create new version    xpath://table[@data-testid="live-api-data-sets"]
+    user clicks button in table cell    1    3    Create new version
+    ...    xpath://table[@data-testid="live-api-data-sets"]
 
     ${modal}=    user waits until modal is visible    Create a new API data set version
 
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_5}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_5}
     user clicks button    Confirm new data set version
-
 
     user waits until page finishes loading
     user waits until modal is not visible    Create a new API data set version    %{WAIT_LONG}
 
 Validate the summary contents inside the 'draft version details' table for the third release
     user waits until h3 is visible    Draft version details
-    user waits until element contains    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(1) > dt + dd     v2.0    %{WAIT_LONG}
-    user waits until element contains    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(2) > dt + dd     Action required    %{WAIT_LONG}
+    user waits until element contains    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(1) > dt + dd
+    ...    v2.0    %{WAIT_LONG}
+    user waits until element contains    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(2) > dt + dd
+    ...    Action required    %{WAIT_LONG}
 
     ${mapping_status}=    get text    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(2) > dt + dd
     should be equal as strings    ${mapping_status}    Action required

--- a/tests/robot-tests/tests/seed_data/seed_data_common.robot
+++ b/tests/robot-tests/tests/seed_data/seed_data_common.robot
@@ -46,9 +46,9 @@ user creates a fully populated approved release
     ...    ${RELEASE_YEAR}
     ...    ${RELEASE_TYPE}
     ${days_until_release}=    set variable    10000
-    ${publish_date_day}=    get current datetime    %-d    ${days_until_release}
-    ${publish_date_month}=    get current datetime    %-m    ${days_until_release}
-    ${publish_date_year}=    get current datetime    %Y    ${days_until_release}
+    ${publish_date_day}=    get london day of month    offset_days=${days_until_release}
+    ${publish_date_month}=    get london month date    offset_days=${days_until_release}
+    ${publish_date_year}=    get london year    offset_days=${days_until_release}
     user approves release for scheduled publication
     ...    ${publish_date_day}
     ...    ${publish_date_month}


### PR DESCRIPTION
# UI test results

## Local run (BST)

![image](https://github.com/user-attachments/assets/14c49e1c-b066-46f9-a743-a02bdcb540f1)

## Pipeline run (UTC)

![image](https://github.com/user-attachments/assets/28c96534-d983-4eca-b154-446fce42c08f)

The "Public Suite" tests are failing for an unrelated reason, because the back button in the table tool in the public site isn't doing what is expected. 

# Overview

This PR:
- simplifies the datetime wrangling code that we use in the Robot tests, by offering more targeted keywords.
- moves the default timezone of dates and times that are used for checking dates and times shown in the browser to be Europe/London by default, as that is the default timezone that EES displays dates in.
- adds specific keywords for getting individual date portions e.g. day, month, month word, year.
- splits keywords into "get london" and "get local browser" keywords, depending on whether we expect them to be displayed in Europe/London time or in time that is local to the browser.
- removes the need to use datetimes in the Robot tests when all we're interested in getting is date parts.
- removes a trailing forward slash from the UI test pipeline yml that was causing the file download name of UI test report failures to be invalid in the pipeline.