### PR TITLE
EES-5502: Replace WYSIWYG link text validation with pre-defined list of banned words.

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/InvalidContentDetails.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/InvalidContentDetails.tsx
@@ -10,8 +10,8 @@ export default function InvalidContentDetails({
 }: {
   errors: InvalidContentError[];
 }) {
-  const clickHereLinkTextErrors = errors.filter(
-    error => error.type === 'clickHereLinkText',
+  const badLinkTextErrors = errors.filter(
+    error => error.type === 'badLinkText',
   );
   const repeatedLinkTextErrors = errors.filter(
     error => error.type === 'repeatedLinkText',
@@ -19,9 +19,6 @@ export default function InvalidContentDetails({
   const filteredRepeatedLinkTextErrors = uniqBy(
     repeatedLinkTextErrors,
     'message',
-  );
-  const oneWordLinkTextErrors = errors.filter(
-    error => error.type === 'oneWordLinkText',
   );
   const urlLinkTextErrors = errors.filter(
     error => error.type === 'urlLinkText',
@@ -43,8 +40,11 @@ export default function InvalidContentDetails({
     <>
       <p>The following accessibility problems have been found:</p>
       <ul>
-        {!!clickHereLinkTextErrors.length && (
+        {!!badLinkTextErrors.length && (
           <ErrorItem
+            detailsList={badLinkTextErrors.map((error, index) => (
+              <li key={`error-${index.toString()}`}>{error.message}</li>
+            ))}
             modalContent={
               <>
                 <p>
@@ -53,15 +53,17 @@ export default function InvalidContentDetails({
                   descriptive and understandable on their own.
                 </p>
                 <p>
-                  Avoid using "click here" as link text as it does not describe
-                  where the link is to.
+                  Avoid using phrases such as "click here" as it does not
+                  describe where the link is to. Similarly, you should try to
+                  avoid short, or single word links because this limits how
+                  descriptive and user friendly it can be, and can also create
+                  problems for users with limited dexterity to click on a small
+                  area.
                 </p>
               </>
             }
-            modalTitle='"Click here" links'
-            text={`${clickHereLinkTextErrors.length} "click here" ${
-              clickHereLinkTextErrors.length === 1 ? 'link' : 'links'
-            }`}
+            modalTitle="Bad link text"
+            text={`${badLinkTextErrors.length} bad link text`}
           />
         )}
 
@@ -93,38 +95,6 @@ export default function InvalidContentDetails({
             }
             modalTitle="Repeated link text"
             text={`${repeatedLinkTextErrors.length} links have the same text with different URLs`}
-          />
-        )}
-
-        {!!oneWordLinkTextErrors.length && (
-          <ErrorItem
-            detailsList={oneWordLinkTextErrors.map((error, index) => (
-              <li key={`error-${index.toString()}`}>{error.message}</li>
-            ))}
-            modalContent={
-              <>
-                <p>
-                  Links are often viewed out of context and used to help
-                  navigate pages like headers, it is important that they are
-                  descriptive and understandable on their own.
-                </p>
-                <p>Avoid one word links because:</p>
-                <ul>
-                  <li>
-                    they can create problems for users with limited dexterity to
-                    click on a small area
-                  </li>
-                  <li>
-                    having a single word limits how descriptive and user
-                    friendly it can be
-                  </li>
-                </ul>
-              </>
-            }
-            modalTitle="One word link text"
-            text={`${oneWordLinkTextErrors.length} ${
-              oneWordLinkTextErrors.length === 1 ? 'link' : 'links'
-            } with one word link text`}
           />
         )}
 

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/InvalidContentDetails.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/InvalidContentDetails.test.tsx
@@ -3,20 +3,6 @@ import { InvalidContentError } from '@admin/components/editable/utils/getInvalid
 import { render, screen } from '@testing-library/react';
 
 describe('InvalidContentDetails', () => {
-  test('renders clickHereLink errors', () => {
-    const testErrors: InvalidContentError[] = [
-      {
-        type: 'clickHereLinkText',
-      },
-      {
-        type: 'clickHereLinkText',
-      },
-    ];
-    render(<InvalidContentDetails errors={testErrors} />);
-
-    expect(screen.getByRole('button', { name: /2 "click here" links/ }));
-  });
-
   test('renders repeatedLinkText errors', () => {
     const testErrors: InvalidContentError[] = [
       {
@@ -40,21 +26,21 @@ describe('InvalidContentDetails', () => {
     expect(screen.getByText('Repeated link text: url-1, url-2'));
   });
 
-  test('renders oneWordLinkText errors', () => {
+  test('renders badLinkText errors', () => {
     const testErrors: InvalidContentError[] = [
       {
-        type: 'oneWordLinkText',
-        message: 'word',
+        type: 'badLinkText',
+        message: 'learn more',
       },
     ];
     render(<InvalidContentDetails errors={testErrors} />);
 
     expect(
       screen.getByRole('button', {
-        name: /1 link with one word link text/,
+        name: /1 bad link text/,
       }),
     );
-    expect(screen.getByText('word'));
+    expect(screen.getByText('learn more'));
   });
 
   test('renders urlLinkText errors', () => {

--- a/src/explore-education-statistics-admin/src/components/editable/utils/__tests__/getInvalidContent.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/utils/__tests__/getInvalidContent.test.tsx
@@ -335,7 +335,7 @@ describe('getInvalidContent', () => {
     ]);
   });
 
-  test('returns an error when the link text is just one word', () => {
+  test('returns an error when the link text is an inaccessible word or phrase', () => {
     const testContent: JsonElement[] = [
       {
         name: 'paragraph',
@@ -366,39 +366,7 @@ describe('getInvalidContent', () => {
               linkHref: 'https://bbc.co.uk',
               linkOpenInNewTab: true,
             },
-            data: 'link',
-          },
-          {
-            data: ' words',
-          },
-        ],
-      },
-    ];
-
-    const result = getInvalidContent(testContent);
-
-    expect(result).toEqual([
-      {
-        type: 'oneWordLinkText',
-        message: 'link',
-      },
-    ]);
-  });
-
-  test('returns an error when the link text is "click here"', () => {
-    const testContent: JsonElement[] = [
-      {
-        name: 'paragraph',
-        children: [
-          {
-            data: 'words ',
-          },
-          {
-            attributes: {
-              linkHref: 'https://gov.uk',
-              linkOpenInNewTab: true,
-            },
-            data: 'link to something',
+            data: 'learn more',
           },
           {
             data: ' words',
@@ -416,7 +384,7 @@ describe('getInvalidContent', () => {
               linkHref: 'https://bbc.co.uk',
               linkOpenInNewTab: true,
             },
-            data: 'click here',
+            data: ' learn more ',
           },
           {
             data: ' words',
@@ -429,7 +397,12 @@ describe('getInvalidContent', () => {
 
     expect(result).toEqual([
       {
-        type: 'clickHereLinkText',
+        type: 'badLinkText',
+        message: 'learn more',
+      },
+      {
+        type: 'badLinkText',
+        message: ' learn more ',
       },
     ]);
   });

--- a/src/explore-education-statistics-admin/src/components/editable/utils/getInvalidContent.ts
+++ b/src/explore-education-statistics-admin/src/components/editable/utils/getInvalidContent.ts
@@ -3,9 +3,8 @@ import parseNumber from '@common/utils/number/parseNumber';
 
 export interface InvalidContentError {
   type:
-    | 'clickHereLinkText'
     | 'repeatedLinkText'
-    | 'oneWordLinkText'
+    | 'badLinkText'
     | 'urlLinkText'
     | 'skippedHeadingLevel'
     | 'missingTableHeaders'
@@ -95,13 +94,6 @@ export default function getInvalidContent(
     }, []);
 
   allLinks.forEach(link => {
-    if (link.data?.toLowerCase().trim() === 'click here') {
-      errors.push({
-        type: 'clickHereLinkText',
-      });
-      return;
-    }
-
     if (link.data === link.attributes?.linkHref) {
       errors.push({
         type: 'urlLinkText',
@@ -110,13 +102,67 @@ export default function getInvalidContent(
       return;
     }
 
-    // exclude glossary links
+    const badLinkTextWords = [
+      'click',
+      'csv',
+      'continue',
+      'dashboard',
+      'document',
+      'download',
+      'file',
+      'form',
+      'guidance',
+      'here',
+      'info',
+      'information',
+      'jpeg',
+      'jpg',
+      'learn',
+      'link',
+      'more',
+      'next',
+      'page',
+      'pdf',
+      'previous',
+      'read',
+      'site',
+      'svg',
+      'this',
+      'web',
+      'webpage',
+      'website',
+      'word',
+      'xslx',
+      'click here',
+      'click this link',
+      'download csv',
+      'download document',
+      'download file',
+      'download here',
+      'download jpg',
+      'download jpeg',
+      'download pdf',
+      'download png',
+      'download svg',
+      'download word',
+      'download xslx',
+      'further information',
+      'go here',
+      'learn more',
+      'link to',
+      'read more',
+      'this page',
+      'visit this',
+      'web page',
+      'web site',
+    ];
+
     if (
-      link.data?.split(' ').length === 1 &&
-      !link.attributes?.linkHref?.includes('/glossary')
+      link.data &&
+      badLinkTextWords.includes(link.data.trim().toLowerCase())
     ) {
       errors.push({
-        type: 'oneWordLinkText',
+        type: 'badLinkText',
         message: link.data,
       });
       return;


### PR DESCRIPTION
This PR updates the validation by removing the single-word rule, and updating the "click here" rule to instead check against a larger list of words which would be considered unacceptable from an accessibility standpoint.

![image](https://github.com/user-attachments/assets/fc1583d7-8eb9-4915-9801-67de928ab90e)
