### PR TITLE
Ees 5560 adding public guidance notes to public page

### DIFF
--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/ApiDataSetChangelog.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/ApiDataSetChangelog.tsx
@@ -31,7 +31,7 @@ export default function ApiDataSetChangelog({
             this version.
           </p>
 
-          <p>Note that the following are considered breaking changes:</p>
+          <p>The following are examples of breaking changes:</p>
           <ul>
             <li>options were deleted</li>
             <li>ids were changed</li>

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -259,8 +259,9 @@ export default function DataSetFilePage({
 
                   {apiDataSetVersionChanges && (
                     <DataSetFileApiChangelog
-                      version={apiDataSetVersion.version}
                       changes={apiDataSetVersionChanges}
+                      publicGuidanceNotes={apiDataSetVersion.notes}
+                      version={apiDataSetVersion.version}
                     />
                   )}
                 </>

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -260,7 +260,7 @@ export default function DataSetFilePage({
                   {apiDataSetVersionChanges && (
                     <DataSetFileApiChangelog
                       changes={apiDataSetVersionChanges}
-                      publicGuidanceNotes={apiDataSetVersion.notes}
+                      guidanceNotes={apiDataSetVersion.notes}
                       version={apiDataSetVersion.version}
                     />
                   )}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileApiChangelog.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileApiChangelog.tsx
@@ -6,13 +6,13 @@ import React from 'react';
 
 interface Props {
   changes: ApiDataSetVersionChanges;
-  publicGuidanceNotes?: string;
+  guidanceNotes: string;
   version: string;
 }
 
 export default function DataSetFileApiChangelog({
   changes,
-  publicGuidanceNotes,
+  guidanceNotes,
   version,
 }: Props) {
   const { majorChanges, minorChanges } = changes;
@@ -26,8 +26,8 @@ export default function DataSetFileApiChangelog({
       heading={pageSections.apiChangelog}
       id="apiChangelog"
     >
-      {publicGuidanceNotes && (
-        <p data-testid="public-guidance-notes">{publicGuidanceNotes}</p>
+      {guidanceNotes.length && (
+        <p data-testid="public-guidance-notes">{guidanceNotes}</p>
       )}
       <ApiDataSetChangelog
         majorChanges={changes.majorChanges}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileApiChangelog.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileApiChangelog.tsx
@@ -6,10 +6,15 @@ import React from 'react';
 
 interface Props {
   changes: ApiDataSetVersionChanges;
+  publicGuidanceNotes?: string;
   version: string;
 }
 
-export default function DataSetFileApiChangelog({ changes, version }: Props) {
+export default function DataSetFileApiChangelog({
+  changes,
+  publicGuidanceNotes,
+  version,
+}: Props) {
   const { majorChanges, minorChanges } = changes;
 
   if (!Object.keys(majorChanges).length && !Object.keys(minorChanges).length) {
@@ -21,6 +26,9 @@ export default function DataSetFileApiChangelog({ changes, version }: Props) {
       heading={pageSections.apiChangelog}
       id="apiChangelog"
     >
+      {publicGuidanceNotes && (
+        <p data-testid="public-guidance-notes">{publicGuidanceNotes}</p>
+      )}
       <ApiDataSetChangelog
         majorChanges={changes.majorChanges}
         minorChanges={changes.minorChanges}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiChangelog.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiChangelog.test.tsx
@@ -2,7 +2,7 @@ import DataSetFileApiChangelog from '@frontend/modules/data-catalogue/components
 import { render, screen, within } from '@testing-library/react';
 
 describe('DataSetFileApiChangelog', () => {
-  test('renders correctly with major and minor changes', () => {
+  test('renders correctly with major and minor changes and public guidance notes', () => {
     render(
       <DataSetFileApiChangelog
         changes={{
@@ -21,6 +21,7 @@ describe('DataSetFileApiChangelog', () => {
             ],
           },
         }}
+        publicGuidanceNotes={'Guidance notes.\nMultiline content.'}
         version="2.0"
       />,
     );
@@ -28,6 +29,10 @@ describe('DataSetFileApiChangelog', () => {
     expect(
       screen.getByRole('heading', { name: 'API data set changelog' }),
     ).toBeInTheDocument();
+
+    expect(screen.getByTestId('public-guidance-notes')).toHaveTextContent(
+      'Guidance notes. Multiline content.',
+    );
 
     expect(
       screen.getByRole('heading', { name: 'Major changes for version 2.0' }),
@@ -98,6 +103,26 @@ describe('DataSetFileApiChangelog', () => {
     );
   });
 
+  test('renders correctly with no public data guidance', () => {
+    render(
+      <DataSetFileApiChangelog
+        changes={{
+          majorChanges: {},
+          minorChanges: {
+            filters: [
+              {
+                currentState: { id: 'filter-2', label: 'Filter 2', hint: '' },
+              },
+            ],
+          },
+        }}
+        version="2.0"
+      />,
+    );
+
+    expect(screen.queryByTestId('data-guidance-notes')).not.toBeInTheDocument();
+  });
+
   test('does not render if empty changes', () => {
     render(
       <DataSetFileApiChangelog
@@ -111,6 +136,10 @@ describe('DataSetFileApiChangelog', () => {
 
     expect(
       screen.queryByRole('heading', { name: 'API data set changelog' }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByTestId('public-guidance-notes'),
     ).not.toBeInTheDocument();
 
     expect(

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiChangelog.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiChangelog.test.tsx
@@ -21,7 +21,7 @@ describe('DataSetFileApiChangelog', () => {
             ],
           },
         }}
-        publicGuidanceNotes={'Guidance notes.\nMultiline content.'}
+        guidanceNotes={'Guidance notes.\nMultiline content.'}
         version="2.0"
       />,
     );
@@ -64,6 +64,7 @@ describe('DataSetFileApiChangelog', () => {
           },
           minorChanges: {},
         }}
+        guidanceNotes=""
         version="2.0"
       />,
     );
@@ -90,6 +91,7 @@ describe('DataSetFileApiChangelog', () => {
             ],
           },
         }}
+        guidanceNotes=""
         version="2.0"
       />,
     );
@@ -116,6 +118,7 @@ describe('DataSetFileApiChangelog', () => {
             ],
           },
         }}
+        guidanceNotes=""
         version="2.0"
       />,
     );
@@ -130,6 +133,7 @@ describe('DataSetFileApiChangelog', () => {
           majorChanges: {},
           minorChanges: {},
         }}
+        guidanceNotes=""
         version="2.0"
       />,
     );

--- a/src/explore-education-statistics-frontend/src/services/apiDataSetService.ts
+++ b/src/explore-education-statistics-frontend/src/services/apiDataSetService.ts
@@ -33,7 +33,7 @@ export interface ApiDataSetVersion {
   status: ApiDataSetStatus;
   published: string;
   withdrawn?: Date;
-  notes?: string;
+  notes: string;
   totalResults: number;
   file: ApiDataSetVersionFile;
   release: ApiDataSetVersionRelease;

--- a/src/explore-education-statistics-frontend/src/services/apiDataSetService.ts
+++ b/src/explore-education-statistics-frontend/src/services/apiDataSetService.ts
@@ -33,7 +33,7 @@ export interface ApiDataSetVersion {
   status: ApiDataSetStatus;
   published: string;
   withdrawn?: Date;
-  notes: string;
+  notes?: string;
   totalResults: number;
   file: ApiDataSetVersionFile;
   release: ApiDataSetVersionRelease;

--- a/tests/robot-tests/args_and_variables.py
+++ b/tests/robot-tests/args_and_variables.py
@@ -31,7 +31,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
         dest="processes",
         type=int,
         default=4,
-        help="how many processes should be used when using the pabot interpreter"
+        help="how many processes should be used when using the pabot interpreter",
     )
     parser.add_argument(
         "-e",
@@ -82,12 +82,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="rerun failed test suites and merge results into original run results",
     )
-    parser.add_argument(
-        "--rerun-attempts",
-        dest="rerun_attempts",
-        type=int,
-        default=0,
-        help="Number of rerun attempts")
+    parser.add_argument("--rerun-attempts", dest="rerun_attempts", type=int, default=0, help="Number of rerun attempts")
     parser.add_argument(
         "--print-keywords",
         dest="print_keywords",

--- a/tests/robot-tests/reports.py
+++ b/tests/robot-tests/reports.py
@@ -1,7 +1,7 @@
-import os
 import glob
+import os
 import shutil
-import time
+
 from bs4 import BeautifulSoup
 from robot import rebot_cli as robot_rebot_cli
 from tests.libs.logger import get_logger
@@ -13,21 +13,19 @@ logger = get_logger(__name__)
 
 # Merge multiple Robot test reports and assets together into the main test results folder.
 def merge_robot_reports(first_run_attempt_number: int, number_of_test_runs: int):
-
-    first_run_folder=f"{main_results_folder}{os.sep}run-{first_run_attempt_number}"
+    first_run_folder = f"{main_results_folder}{os.sep}run-{first_run_attempt_number}"
 
     logger.info(f"Merging test run {first_run_attempt_number} results into full results")
-        
+
     for file in os.listdir(first_run_folder):
         _copy_to_destination_folder(first_run_folder, file, main_results_folder)
 
     for test_run in range(first_run_attempt_number + 1, number_of_test_runs + 1):
-        
         logger.info(f"Merging test run {test_run} results into full results")
-        
+
         test_run_foldername = f"{main_results_folder}{os.sep}run-{test_run}"
         _merge_test_reports(test_run_foldername)
-        
+
         for file in glob.glob(rf"{test_run_foldername}{os.sep}*screenshot*"):
             _copy_to_destination_folder(test_run_foldername, file.split(os.sep)[-1], main_results_folder)
 
@@ -35,11 +33,39 @@ def merge_robot_reports(first_run_attempt_number: int, number_of_test_runs: int)
             _copy_to_destination_folder(test_run_foldername, file.split(os.sep)[-1], main_results_folder)
 
 
-def log_report_results(number_of_test_runs: int, failing_suites: []):
+def get_failing_test_suite_sources(path_to_report_file: str) -> []:
+    with open(path_to_report_file, "rb") as report_file:
+        report_contents = report_file.read()
+        report = BeautifulSoup(report_contents, features="xml")
+
+        failing_suite_ids = _get_failing_leaf_suite_ids_from_report(report)
+        suite_elements = report.find_all("suite", recursive=True)
+        return [
+            suite_element.get("source")
+            for suite_element in suite_elements
+            if suite_element.get("id") in failing_suite_ids
+        ]
+
+
+def log_report_results(number_of_test_runs: int, reran_failing_suites: bool, failing_suites: []):
+    logger.info("*************************************")
+    logger.info("FINAL REPORT")
     logger.info(f"Log available at: file://{os.getcwd()}{os.sep}{main_results_folder}{os.sep}log.html")
     logger.info(f"Report available at: file://{os.getcwd()}{os.sep}{main_results_folder}{os.sep}report.html")
-    logger.info(f"Number of test runs: {number_of_test_runs}")
+    logger.info("*************************************\n")
 
+    if reran_failing_suites:
+        logger.info("*************************************")
+        logger.info("LAST RUN ATTEMPT REPORT")
+        logger.info(
+            f"Log available at: file://{os.getcwd()}{os.sep}{main_results_folder}{os.sep}run-{number_of_test_runs}{os.sep}log.html"
+        )
+        logger.info(
+            f"Report available at: file://{os.getcwd()}{os.sep}{main_results_folder}{os.sep}run-{number_of_test_runs}{os.sep}report.html"
+        )
+        logger.info("*************************************\n")
+
+    logger.info(f"Number of test run attempts: {number_of_test_runs}")
     if failing_suites:
         logger.info(f"Number of failing suites: {len(failing_suites)}")
         logger.info(f"Failing suites:")
@@ -56,7 +82,7 @@ def create_report_from_output_xml(test_results_folder: str):
         "output.xml",
         "--xunit",
         "xunit.xml",
-        f"{test_results_folder}/output.xml"
+        f"{test_results_folder}/output.xml",
     ]
     robot_rebot_cli(create_args, exit=False)
 
@@ -79,36 +105,48 @@ def _merge_test_reports(test_results_folder):
 
 
 def filter_out_passing_suites_from_report_file(path_to_original_report: str, path_to_filtered_report: str):
-    
-    with open(path_to_original_report, "rb") as report:
-        
-        report_contents = report.read()
+    with open(path_to_original_report, "rb") as report_file:
+        report_contents = report_file.read()
         report = BeautifulSoup(report_contents, features="xml")
-        
+
         passing_suite_ids = _get_passing_suite_ids_from_report(report)
-        
-        suite_elements = report.find_all('suite', recursive=True)
-        [suite_element.extract() for suite_element in suite_elements if suite_element.get('id') in passing_suite_ids]
-        
-        suite_stats = report.find_all('stat', recursive=True)
-        [suite_stat.extract() for suite_stat in suite_stats if suite_stat.get('id') in passing_suite_ids]
-    
+
+        suite_elements = report.find_all("suite", recursive=True)
+        [suite_element.extract() for suite_element in suite_elements if suite_element.get("id") in passing_suite_ids]
+
+        suite_stats = report.find_all("stat", recursive=True)
+        [suite_stat.extract() for suite_stat in suite_stats if suite_stat.get("id") in passing_suite_ids]
+
         if os.path.exists(path_to_filtered_report):
             os.remove(path_to_filtered_report)
 
         with open(path_to_filtered_report, "a") as filtered_file:
             filtered_file.write(report.prettify())
 
-        
-def _get_passing_suite_ids_from_report(report: BeautifulSoup) -> []: 
-    suite_results = report.find('statistics').find('suite').find_all('stat')
-    passing_suite_results = [suite_result for suite_result in suite_results if int(suite_result.get('fail')) == 0]
-    return [passing_suite.get('id') for passing_suite in passing_suite_results]
+
+def _get_passing_suite_ids_from_report(report: BeautifulSoup) -> []:
+    suite_results = report.find("statistics").find("suite").find_all("stat")
+    passing_suite_results = [suite_result for suite_result in suite_results if int(suite_result.get("fail")) == 0]
+    return [passing_suite.get("id") for passing_suite in passing_suite_results]
+
+
+def _get_failing_leaf_suite_ids_from_report(report: BeautifulSoup) -> []:
+    suite_results = report.find("statistics").find("suite").find_all("stat")
+    failing_suite_results = [suite_result for suite_result in suite_results if int(suite_result.get("fail")) > 0]
+    suite_ids = [failing_suite.get("id") for failing_suite in failing_suite_results]
+    leaf_suite_ids = []
+    for suite_id in suite_ids:
+        other_suite_ids_containing_suite_id = [
+            other_suite_id for other_suite_id in suite_ids if other_suite_id != suite_id and suite_id in other_suite_id
+        ]
+        if len(other_suite_ids_containing_suite_id) == 0:
+            leaf_suite_ids += [suite_id]
+    return leaf_suite_ids
 
 
 def _copy_to_destination_folder(source_folder: str, source_file: str, destination_folder: str):
-    source_file_path=f"{source_folder}{os.sep}{source_file}"
-    destination_file_path=f"{destination_folder}{os.sep}{source_file}"
+    source_file_path = f"{source_folder}{os.sep}{source_file}"
+    destination_file_path = f"{destination_folder}{os.sep}{source_file}"
     if os.path.isfile(source_file_path):
         shutil.copy(source_file_path, destination_file_path)
     else:

--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -11,8 +11,7 @@ from selenium import webdriver
 from selenium.common import NoSuchElementException
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support.ui import Select
+from selenium.webdriver.support.ui import Select, WebDriverWait
 from slack_sdk.webhook import WebhookClient
 
 """

--- a/tests/robot-tests/test_runners.py
+++ b/tests/robot-tests/test_runners.py
@@ -1,7 +1,8 @@
-import os
-import reports
 import argparse
+import os
+
 import pabot.pabot as pabot
+import reports
 import robot
 from tests.libs.logger import get_logger
 
@@ -19,9 +20,9 @@ def create_robot_arguments(arguments: argparse.Namespace, test_run_folder: str) 
     ]
 
     robot_args += _create_include_and_exclude_args(arguments)
-    
+
     robot_args += ["-v", f"timeout:{os.getenv('TIMEOUT')}", "-v", f"implicit_wait:{os.getenv('IMPLICIT_WAIT')}"]
-    
+
     if arguments.fail_fast:
         robot_args += ["--exitonfailure"]
     if arguments.print_keywords:
@@ -30,7 +31,7 @@ def create_robot_arguments(arguments: argparse.Namespace, test_run_folder: str) 
         # NOTE(mark): Ensure secrets aren't visible in CI logs/reports
         robot_args += ["--removekeywords", "name:operatingsystem.environment variable should be set"]
         robot_args += ["--removekeywords", "name:common.user goes to url"]  # To hide basic auth credentials
-    
+
     if arguments.visual:
         robot_args += ["-v", "headless:0"]
     else:
@@ -72,7 +73,6 @@ def _create_include_and_exclude_args(arguments: argparse.Namespace) -> []:
 
 
 def execute_tests(arguments: argparse.Namespace, test_run_folder: str, path_to_previous_report_file: str):
-    
     robot_args = create_robot_arguments(arguments, test_run_folder)
 
     if arguments.interp == "robot":
@@ -80,23 +80,25 @@ def execute_tests(arguments: argparse.Namespace, test_run_folder: str, path_to_p
             robot_args += ["--rerunfailedsuites", path_to_previous_report_file]
 
         robot_args += [arguments.tests]
-        
-        logger.info(f'Performing test run with Robot')
+
+        logger.info(f"Performing test run with Robot")
         robot.run_cli(robot_args, exit=False)
 
     elif arguments.interp == "pabot":
-
-        robot_args = ['--processes', arguments.processes] + robot_args
+        robot_args = ["--processes", arguments.processes] + robot_args
 
         if path_to_previous_report_file is not None:
-        
-            path_to_filtered_report_file = '_filtered.xml'.join(path_to_previous_report_file.rsplit('.xml', 1))
-            reports.filter_out_passing_suites_from_report_file(path_to_previous_report_file, path_to_filtered_report_file)
-            
-            logger.info(f'Generated filtered report file containing only failing suites at {path_to_filtered_report_file}')
-            robot_args = ['--suitesfrom', path_to_filtered_report_file] + robot_args
+            path_to_filtered_report_file = "_filtered.xml".join(path_to_previous_report_file.rsplit(".xml", 1))
+            reports.filter_out_passing_suites_from_report_file(
+                path_to_previous_report_file, path_to_filtered_report_file
+            )
+
+            logger.info(
+                f"Generated filtered report file containing only failing suites at {path_to_filtered_report_file}"
+            )
+            robot_args = ["--suitesfrom", path_to_filtered_report_file] + robot_args
 
         robot_args += [arguments.tests]
 
-        logger.info(f'Performing test run with Pabot ({arguments.processes} processes)')
+        logger.info(f"Performing test run with Pabot ({arguments.processes} processes)")
         pabot.main_program(robot_args)

--- a/tests/robot-tests/tests/admin/analyst/manage_approvals_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/manage_approvals_as_publication_approver.robot
@@ -67,7 +67,7 @@ Validate if Your approvals tab is correct
 
 Check that release link takes user to the correct release
     ${RELEASE_ROW}=    get webelement    testid:release-${RELEASE_NAME}
-    user clicks link by visible text    Review this page    ${RELEASE_ROW}
+    user clicks link containing text    Review this page    ${RELEASE_ROW}
 
     user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_MEDIUM}
     user waits until page contains title caption    Edit release for Academic year 2026/27
@@ -80,7 +80,7 @@ Check that Your approvals tab methodology link takes user to the correct methodo
     user waits until h2 is visible    Your approvals
 
     ${METHODOLOGY_ROW}=    get webelement    testid:methodology-${PUBLICATION_NAME} - ${PUBLICATION_NAME}
-    user clicks link by visible text    Review this page    ${METHODOLOGY_ROW}
+    user clicks link containing text    Review this page    ${METHODOLOGY_ROW}
 
     user waits until h1 is visible    ${PUBLICATION_NAME}
     user waits until page contains title caption    Edit methodology

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -29,7 +29,8 @@ Create test publication and release via API
 Upload subject
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
     ...    Academic year 2025/26
-    user uploads subject and waits until complete    UI test subject    upload-file-test.csv    upload-file-test.meta.csv
+    user uploads subject and waits until complete    UI test subject    upload-file-test.csv
+    ...    upload-file-test.meta.csv
 
 Navigate to 'Footnotes' page
     user waits until page finishes loading
@@ -206,7 +207,6 @@ Validate data block is in list
     user checks table column heading contains    1    3    In content    testid:dataBlocks
     user checks table column heading contains    1    4    Created date    testid:dataBlocks
     user checks table column heading contains    1    5    Actions    testid:dataBlocks
-
 
     user checks table body has x rows    1    testid:dataBlocks
     user checks table cell contains    1    1    ${DATABLOCK_NAME}    testid:dataBlocks
@@ -488,7 +488,7 @@ Add reference line
     user clicks button    Add new line
     user chooses select option    id:chartAxisConfiguration-major-referenceLines-position    2005
     user enters text into element    id:chartAxisConfiguration-major-referenceLines-label    Reference line 1
-    user clicks button    Add
+    user clicks button    Add    exact_match=${TRUE}
 
 Validate basic line chart preview
     user waits until element contains line chart    id:chartBuilderPreview
@@ -551,7 +551,6 @@ Save chart and validate marked as 'Has chart' in data blocks list
     user waits until table is visible
     user checks table column heading contains    1    1    Name    testid:dataBlocks
     user checks table column heading contains    1    2    Has chart    testid:dataBlocks
-
 
     user checks table body has x rows    1
     user checks table cell contains    1    1    ${DATABLOCK_NAME}    testid:dataBlocks

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
@@ -48,7 +48,8 @@ Add text block with link to absence glossary entry to accordion section
     ${block}=    user starts editing accordion section text block    Test section    1
     ...    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
     ${toolbar}=    get editor toolbar    ${block}
-    ${insert}=    user gets button element    Insert    ${toolbar}
+    ${insert}=    get child element    parent_locator=${toolbar}
+    ...    child_locator=xpath://button[@data-cke-tooltip-text="Insert"]
     user clicks element    ${insert}
     ${button}=    user gets button element    Insert glossary link    ${toolbar}
     user clicks element    ${button}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -72,8 +72,10 @@ Verify new release summary
     user checks summary list contains    Release type    Accredited official statistics
 
 Upload subjects to release
-    user uploads subject and waits until complete    ${SUBJECT_1_NAME}    tiny-two-filters.csv    tiny-two-filters.meta.csv
-    user uploads subject and waits until complete    ${SUBJECT_2_NAME}    upload-file-test.csv    upload-file-test-with-filter.meta.csv
+    user uploads subject and waits until complete    ${SUBJECT_1_NAME}    tiny-two-filters.csv
+    ...    tiny-two-filters.meta.csv
+    user uploads subject and waits until complete    ${SUBJECT_2_NAME}    upload-file-test.csv
+    ...    upload-file-test-with-filter.meta.csv
 
 Navigate to Footnotes page
     user clicks link    Footnotes
@@ -502,7 +504,8 @@ Add text block with link to a featured table to accordion section
     ${block}=    user starts editing accordion section text block    Test section    1
     ...    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
     ${toolbar}=    get editor toolbar    ${block}
-    ${insert}=    user gets button element    Insert    ${toolbar}
+    ${insert}=    get child element    parent_locator=${toolbar}
+    ...    child_locator=xpath://button[@data-cke-tooltip-text="Insert"]
     user clicks element    ${insert}
     ${button}=    user gets button element    Insert featured table link    ${toolbar}
     user clicks element    ${button}

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -451,7 +451,7 @@ Verify that the Dates data block accordion is unchanged
     user checks chart title contains    ${section}    Dates table title
     user checks infographic chart contains alt    ${section}    Sample alt text
 
-    user clicks link by visible text    Table    ${section}
+    user clicks link containing text    Table    ${section}
     user waits until parent contains element    ${section}
     ...    xpath:.//*[@data-testid="dataTableCaption" and text()="Dates table title"]
     user waits until parent contains element    ${section}    xpath:.//*[.="Source: Dates source"]

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -232,7 +232,7 @@ Verify data block is updated correctly
     ${datablock}=    set variable    testid:Data block - ${DATABLOCK_NAME}
 
     user checks chart title contains    ${datablock}    Updated dates table title
-    user clicks link by visible text    Table    ${datablock}
+    user clicks link containing text    Table    ${datablock}
     user waits until parent contains element    ${datablock}
     ...    xpath:.//*[@data-testid="dataTableCaption" and text()="Updated dates table title"]
     user waits until parent contains element    ${datablock}    xpath:.//*[.="Source: Updated dates source"]
@@ -407,7 +407,7 @@ Verify Dates data block accordion section
     user checks chart title contains    ${section}    Updated dates table title
     user checks infographic chart contains alt    ${section}    Sample alt text
 
-    user clicks link by visible text    Table    ${section}
+    user clicks link containing text    Table    ${section}
     user waits until parent contains element    ${section}
     ...    xpath:.//*[@data-testid="dataTableCaption" and text()="Updated dates table title"]
     user waits until parent contains element    ${section}    xpath:.//*[.="Source: Updated dates source"]
@@ -434,7 +434,7 @@ Verify Dates data block table has footnotes
 Verify Dates data block Fast Track page
     ${release_url}=    user gets url
 
-    user clicks link by visible text    Explore data    testid:Data block - Dates data block name-table-tab
+    user clicks link containing text    Explore data    testid:Data block - Dates data block name-table-tab
 
     user waits until page contains title    Create your own tables
     user waits until page contains    This is the latest data
@@ -882,7 +882,7 @@ Verify amendment Dates data block accordion section
     user checks chart title contains    ${section}    Amended sample title
     user checks infographic chart contains alt    ${section}    Amended sample alt text
 
-    user clicks link by visible text    Table    ${section}
+    user clicks link containing text    Table    ${section}
     user waits until parent contains element    ${section}
     ...    xpath:.//*[@data-testid="dataTableCaption" and text()="Amended dates table title"]
     user waits until parent contains element    ${section}    xpath:.//*[.="Source: Amended dates source"]
@@ -915,7 +915,7 @@ Verify amendment Dates data block table has footnotes
 Verify amendment Dates data block Fast Track page
     ${release_url}=    user gets url
 
-    user clicks link by visible text    Explore data    testid:Data block - Dates data block name-table-tab
+    user clicks link containing text    Explore data    testid:Data block - Dates data block name-table-tab
 
     user waits until page contains title    Create your own tables
     user waits until page contains    This is the latest data

--- a/tests/robot-tests/tests/general_public/fast_track.robot
+++ b/tests/robot-tests/tests/general_public/fast_track.robot
@@ -20,7 +20,7 @@ Click fast track link for 'Pupil absence rates' data block
     user scrolls to accordion section    Pupil absence rates    id:content
     user scrolls to element    testid:Data block - Generic data block - National
     user waits until h3 is visible    Explore and edit this data online
-    user clicks link by visible text    Explore data    testid:Data block - Generic data block - National
+    user clicks link containing text    Explore data    testid:Data block - Generic data block - National
 
 Validate Publication selected step option
     user waits until h1 is visible    Create your own tables    %{WAIT_SMALL}

--- a/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
@@ -137,8 +137,8 @@ Reorder Gender to be column group
     user clicks button    Move and reorder table headers
     # Column group needs to be inside the viewport
     user scrolls to element    xpath://button[text()="Update and view reordered table"]
-    user clicks button    Move    testId:rowGroups-0
-    user clicks button    Move    testId:rowGroups-0
+    user clicks button    Move    testId:rowGroups-0    exact_match=${TRUE}
+    user clicks button    Move Characteristic to columns    testId:rowGroups-0
     user clicks button    Done    testId:columnGroups-1
 
 Move Gender to be first column group

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -119,7 +119,7 @@ user navigates to release page from dashboard
     ${ROW}=    user gets table row    ${RELEASE_NAME}    testid:${RELEASE_TABLE_TESTID}
     user scrolls to element    ${ROW}
 
-    user clicks link by visible text    ${LINK_TEXT}    ${ROW}
+    user clicks link containing text    ${LINK_TEXT}    ${ROW}
     user waits until h2 is visible    Release summary    %{WAIT_SMALL}
 
 user navigates to draft release page from dashboard

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -186,9 +186,9 @@ user chooses and embeds data block
     [Arguments]
     ...    ${datablock_name}
     user chooses select option    css:select[name="selectedDataBlock"]    ${datablock_name}
-    user waits until button is enabled    Embed    %{WAIT_SMALL}
-    user clicks button    Embed
-    user waits until page does not contain button    Embed    %{WAIT_MEDIUM}
+    user waits until button is enabled    Embed    %{WAIT_SMALL}    exact_match=${TRUE}
+    user clicks button    Embed    exact_match=${TRUE}
+    user waits until page does not contain button    Embed    %{WAIT_MEDIUM}    exact_match=${TRUE}
     user waits until page finishes loading
 
 user opens nth editable accordion section
@@ -468,12 +468,14 @@ user adds image to accordion section text block with retry
     ...    ${FILES_DIR}${filename}
 
     user scrolls up    300
-    wait until keyword succeeds     ${timeout}    %{WAIT_SMALL} sec    user clicks button    Change image text alternative
+    wait until keyword succeeds    ${timeout}    %{WAIT_SMALL} sec    user clicks button
+    ...    Change image text alternative
     user enters text into element    label:Text alternative    ${alt_text}
     user clicks element    css:button.ck-button-save
     sleep    5
     user scrolls up    100
-    wait until keyword succeeds     ${timeout}    %{WAIT_SMALL} sec    user clicks element    xpath://div[@title="Insert paragraph after block"]
+    wait until keyword succeeds    ${timeout}    %{WAIT_SMALL} sec    user clicks element
+    ...    xpath://div[@title="Insert paragraph after block"]
 
     # wait for the API to save the image and for the src attribute to be updated before continuing
     user waits until parent contains element    ${block}
@@ -566,7 +568,7 @@ user adds link to accordion section text block
     ${button}=    user gets button element    Link    ${toolbar}
     user clicks element    ${button}
     user enters text into element    label:Link URL    ${url}
-    
+
     # Save
     user presses keys    TAB
     user presses keys    ENTER

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -251,7 +251,7 @@ user checks accordion is in position
 user waits until accordion section contains text
     [Arguments]    ${section_text}    ${text}    ${wait}=${timeout}
     ${section}=    user gets accordion section content element    ${section_text}
-    user waits until parent contains element    ${section}    xpath:.//*[text()="${text}"]    timeout=${wait}
+    user waits until parent contains element    ${section}    xpath:.//*[contains(., "${text}")]    timeout=${wait}
 
 user gets accordion header button element
     [Arguments]    ${heading_text}    ${parent}=css:[data-testid="accordion"]
@@ -344,7 +344,7 @@ user checks page does not contain testid
 
 user checks testid element contains
     [Arguments]    ${id}    ${text}
-    user waits until element contains    css:[data-testid="${id}"]    ${text}
+    user waits until element contains    testid:${id}    ${text}
 
 user gets testid element
     [Arguments]    ${id}    ${wait}=${timeout}    ${parent}=css:body
@@ -361,6 +361,8 @@ user checks element contains child element
     ...    ${element}
     ...    ${child_element}
     user waits until parent contains element    ${element}    ${child_element}
+    ${child}=    get child element    ${element}    ${child_element}
+    RETURN    ${child}
 
 user checks element does not contain child element
     [Arguments]
@@ -493,7 +495,7 @@ user clicks link by index
 
 user clicks link by visible text
     [Arguments]    ${text}    ${parent}=css:body
-    user clicks element    xpath:.//a[text()="${text}"]    ${parent}
+    user clicks element    xpath:.//a[contains(., "${text}")]    ${parent}
 
 user clicks link containing text
     [Arguments]    ${text}    ${parent}=css:body
@@ -523,34 +525,36 @@ user clicks button containing text
 
 user waits until page contains button
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until page contains element    xpath://button[text()="${text}" or .//*[text()="${text}"]]    ${wait}
+    user waits until page contains element    xpath://button[contains(., "${text}") or .//*[contains(., "${text}")]]
+    ...    ${wait}
 
 user checks page contains button
     [Arguments]    ${text}
-    user checks page contains element    xpath://button[text()="${text}" or .//*[text()="${text}"]]
+    user checks page contains element    xpath://button[contains(., "${text}") or .//*[contains(., "${text}")]]
 
 user checks page does not contain button
     [Arguments]    ${text}
-    user checks page does not contain element    xpath://button[text()="${text}" or .//*[text()="${text}"]]
+    user checks page does not contain element    xpath://button[contains(., "${text}") or .//*[contains(., "${text}")]]
 
 user waits until page does not contain button
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until page does not contain element    xpath://button[text()="${text}" or .//*[text()="${text}"]]
-    ...    ${wait}
+    user waits until page does not contain element
+    ...    xpath://button[contains(., "${text}") or .//*[contains(., "${text}")]]    ${wait}
 
 user waits until button is enabled
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is enabled    xpath://button[text()="${text}" or .//*[text()="${text}"]]    ${wait}
+    user waits until element is enabled    xpath://button[contains(., "${text}") or .//*[contains(., "${text}")]]
+    ...    ${wait}
 
 user waits until parent contains button
     [Arguments]    ${parent}    ${text}    ${wait}=${timeout}
     user waits until parent contains element    ${parent}
-    ...    xpath:.//button[text()="${text}" or .//*[text()="${text}"]]    ${wait}
+    ...    xpath:.//button[contains(., "${text}") or .//*[contains(., "${text}")]]    ${wait}
 
 user waits until parent does not contain button
     [Arguments]    ${parent}    ${text}    ${wait}=${timeout}
     user waits until parent does not contain element    ${parent}
-    ...    xpath:.//button[text()="${text}" or .//*[text()="${text}"]]    ${wait}
+    ...    xpath:.//button[contains(., "${text}") or .//*[contains(., "${text}")]]    ${wait}
 
 user waits until parent does not contain
     [Arguments]    ${parent}    ${text}    ${wait}=${timeout}
@@ -560,49 +564,51 @@ user waits until parent does not contain
 user gets button element
     [Arguments]    ${text}    ${parent}=css:body
     user waits until parent contains button    ${parent}    ${text}
-    ${button}=    get child element    ${parent}    xpath:.//button[text()="${text}" or .//*[text()="${text}"]]
+    ${button}=    get child element    ${parent}
+    ...    xpath:.//button[contains(., "${text}") or .//*[contains(., "${text}")]]
     [Return]    ${button}
 
 user checks page contains tag
     [Arguments]    ${text}
-    user checks page contains element    xpath://*[contains(@class, "govuk-tag")][text()="${text}"]
+    user checks page contains element    xpath://*[contains(@class, "govuk-tag")][contains(., "${text}")]
 
 user waits until h1 is visible
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is visible    xpath://h1[text()="${text}"]    ${wait}
+    user waits until element is visible    xpath://h1[contains(., "${text}")]    ${wait}
 
 user waits until h1 is not visible
     [Arguments]    ${text}    ${wait}=%{WAIT_SMALL}
-    user waits until element is not visible    xpath://h1[text()="${text}"]    ${wait}
+    user waits until element is not visible    xpath://h1[contains(., "${text}")]    ${wait}
 
 user waits until h2 is visible
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is visible    xpath://h2[text()="${text}"]    ${wait}
+    user waits until element is visible    xpath://h2[contains(., "${text}")]    ${wait}
 
 user waits until h2 is not visible
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is not visible    xpath://h2[text()="${text}"]    ${wait}
+    user waits until element is not visible    xpath://h2[contains(., "${text}")]    ${wait}
 
 user waits until h3 is visible
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is visible    xpath://h3[text()="${text}"]    ${wait}
+    user waits until element is visible    xpath://h3[contains(., "${text}")]    ${wait}
 
 user waits until h3 is not visible
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is not visible    xpath://h3[text()="${text}"]    ${wait}
+    user waits until element is not visible    xpath://h3[contains(., "${text}")]    ${wait}
 
 user waits until legend is visible
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is visible    xpath://legend[text()="${text}"]    ${wait}
+    user waits until element is visible    xpath://legend[contains(., "${text}")]    ${wait}
 
 user waits until page contains title
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until page contains element    xpath://h1[@data-testid="page-title" and text()="${text}"]    ${wait}
+    user waits until page contains element    xpath://h1[@data-testid="page-title" and contains(., "${text}")]
+    ...    ${wait}
 
 user waits until page contains title caption
     [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until page contains element    xpath://span[@data-testid="page-title-caption" and text()="${text}"]
-    ...    ${wait}
+    user waits until page contains element
+    ...    xpath://span[@data-testid="page-title-caption" and contains(., "${text}")]    ${wait}
 
 user selects newly opened window
     switch window    locator=NEW

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -509,11 +509,6 @@ user clicks link by index
     ${button}=    get webelement    ${xpath}
     user clicks element    ${button}    ${parent}
 
-user clicks link by visible text
-    [Arguments]    ${text}    ${parent}=css:body    ${exact_match}=${FALSE}
-    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
-    user clicks element    xpath:.//a[${text_matcher}]    ${parent}
-
 user clicks link containing text
     [Arguments]    ${text}    ${parent}=css:body    ${exact_match}=${FALSE}
     ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
@@ -1037,7 +1032,7 @@ user gets data block from parent
 user gets data block table from parent
     [Arguments]    ${data_block_name}    ${parent}
     ${data_block}=    user gets data block from parent    ${data_block_name}    ${parent}
-    user clicks link by visible text    Table    ${data_block}
+    user clicks link containing text    Table    ${data_block}
     ${data_block_id}=    get element attribute    ${data_block}    id
     ${data_block_table}=    get child element    ${data_block}    id:${data_block_id}-tables
     [Return]    ${data_block_table}
@@ -1045,7 +1040,7 @@ user gets data block table from parent
 user gets data block chart from parent
     [Arguments]    ${data_block_name}    ${parent}
     ${data_block}=    user gets data block from parent    ${data_block_name}    ${parent}
-    user clicks link by visible text    Chart    ${data_block}
+    user clicks link containing text    Chart    ${data_block}
     ${data_block_id}=    get element attribute    ${data_block}    id
     ${data_block_chart}=    get child element    ${data_block}    id:${data_block_id}-chart
     [Return]    ${data_block_chart}

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -12,15 +12,15 @@ Resource    ./table_tool.robot
 
 
 *** Variables ***
-${browser}=                             chrome
-${headless}=                            1
-${FILES_DIR}=                           ${EXECDIR}${/}tests${/}files${/}
-${PUBLIC_API_FILES_DIR}=                ${EXECDIR}${/}tests${/}files${/}public-api-data-files${/}
-${UNZIPPED_FILES_DIR}=                  ${EXECDIR}${/}tests${/}files${/}.unzipped-seed-data-files${/}
-${DOWNLOADS_DIR}=                       ${EXECDIR}${/}test-results${/}downloads${/}
-${timeout}=                             %{TIMEOUT}
-${implicit_wait}=                       %{IMPLICIT_WAIT}
-${prompt_to_continue_on_failure}=       0
+${browser}                          chrome
+${headless}                         1
+${FILES_DIR}                        ${EXECDIR}${/}tests${/}files${/}
+${PUBLIC_API_FILES_DIR}             ${EXECDIR}${/}tests${/}files${/}public-api-data-files${/}
+${UNZIPPED_FILES_DIR}               ${EXECDIR}${/}tests${/}files${/}.unzipped-seed-data-files${/}
+${DOWNLOADS_DIR}                    ${EXECDIR}${/}test-results${/}downloads${/}
+${timeout}                          %{TIMEOUT}
+${implicit_wait}                    %{IMPLICIT_WAIT}
+${prompt_to_continue_on_failure}    0
 
 
 *** Keywords ***
@@ -220,50 +220,59 @@ user waits until element contains testid
     user waits until parent contains element    ${element}    css:[data-testid="${testid}"]    timeout=${wait}
 
 user waits until page contains accordion section
-    [Arguments]    ${section_title}    ${wait}=${timeout}
+    [Arguments]    ${section_title}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${section_title}    ${exact_match}
     user waits until page contains element
-    ...    xpath://button[@class='govuk-accordion__section-button'][.//span[text()="${section_title}"]]    ${wait}
+    ...    xpath://button[@class='govuk-accordion__section-button'][.//span[${text_matcher}]]    ${wait}
 
 user waits until page does not contain accordion section
-    [Arguments]    ${section_title}    ${wait}=${timeout}
+    [Arguments]    ${section_title}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${section_title}    ${exact_match}
     user waits until page does not contain element
-    ...    xpath://button[@class='govuk-accordion__section-button'][.//span[text()="${section_title}"]]    ${wait}
+    ...    xpath://button[@class='govuk-accordion__section-button'][.//span[${text_matcher}]]    ${wait}
 
 user verifies accordion is open
-    [Arguments]    ${section_text}
+    [Arguments]    ${section_text}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${section_text}    ${exact_match}
     user waits until page contains element
-    ...    xpath://button[@class='govuk-accordion__section-button'][.//span[text()="${section_text}"] and @aria-expanded="true"]
+    ...    xpath://button[@class='govuk-accordion__section-button'][.//span[${text_matcher}] and @aria-expanded="true"]
 
 user verifies accordion is closed
-    [Arguments]    ${section_text}
+    [Arguments]    ${section_text}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${section_text}    ${exact_match}
     user waits until page contains element
-    ...    xpath://button[@class='govuk-accordion__section-button'][.//span[text()="${section_text}"] and @aria-expanded="false"]
+    ...    xpath://button[@class='govuk-accordion__section-button'][.//span[${text_matcher}] and @aria-expanded="false"]
 
 user checks there are x accordion sections
     [Arguments]    ${count}    ${parent}=css:body
     user waits until parent contains element    ${parent}    css:[data-testid="accordionSection"]    count=${count}
 
 user checks accordion is in position
-    [Arguments]    ${section_text}    ${position}    ${parent}=css:[data-testid="accordion"]
+    [Arguments]    ${section_text}    ${position}    ${parent}=css:[data-testid="accordion"]    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${section_text}    ${exact_match}
     user waits until parent contains element    ${parent}
-    ...    xpath:(.//*[@data-testid="accordionSection"])[${position}]//span[starts-with(text(), "${section_text}")]
+    ...    xpath:(.//*[@data-testid="accordionSection"])[${position}]//span[${text_matcher}]
 
 user waits until accordion section contains text
-    [Arguments]    ${section_text}    ${text}    ${wait}=${timeout}
+    [Arguments]    ${section_text}    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
     ${section}=    user gets accordion section content element    ${section_text}
-    user waits until parent contains element    ${section}    xpath:.//*[contains(., "${text}")]    timeout=${wait}
+    user waits until parent contains element    ${section}    xpath:.//*[${text_matcher}]    timeout=${wait}
 
 user gets accordion header button element
-    [Arguments]    ${heading_text}    ${parent}=css:[data-testid="accordion"]
-    ${button}=    get child element    ${parent}    xpath:.//button[@aria-expanded and contains(., "${heading_text}")]
+    [Arguments]    ${heading_text}    ${parent}=css:[data-testid="accordion"]    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${heading_text}    ${exact_match}
+    ${button}=    get child element    ${parent}    xpath:.//button[@aria-expanded and ${text_matcher}]
     [Return]    ${button}
 
 user opens accordion section
     [Arguments]
     ...    ${heading_text}
     ...    ${parent}=css:[data-testid="accordion"]
+    ...    ${exact_match}=${FALSE}
 
     ${header_button}=    user gets accordion header button element    ${heading_text}    ${parent}
+    ...    exact_match=${exact_match}
     ${accordion}=    user opens accordion section with accordion header    ${header_button}    ${parent}
     [Return]    ${accordion}
 
@@ -290,22 +299,25 @@ user opens accordion section with accordion header
     [Return]    ${accordion}
 
 user closes accordion section
-    [Arguments]    ${heading_text}    ${parent}=css:[data-testid="accordion"]
+    [Arguments]    ${heading_text}    ${parent}=css:[data-testid="accordion"]    ${exact_match}=${FALSE}
     ${header_button}=    user gets accordion header button element    ${heading_text}    ${parent}
-    user closes accordion section with accordion header    ${header_button}    ${parent}
+    ...    exact_match=${exact_match}
+    user closes accordion section with accordion header    ${header_button}    ${parent}    exact_match=${exact_match}
 
 user closes accordion section with id
     [Arguments]
     ...    ${id}
     ...    ${parent}=css:[data-testid="accordion"]
+    ...    ${exact_match}=${FALSE}
 
     ${header_button}=    get child element    ${parent}    id:${id}-heading
-    user closes accordion section with accordion header    ${header_button}    ${parent}
+    user closes accordion section with accordion header    ${header_button}    ${parent}    exact_match=${exact_match}
 
 user closes accordion section with accordion header
     [Arguments]
     ...    ${header_button}
     ...    ${parent}=css:[data-testid="accordion"]
+    ...    ${exact_match}=${FALSE}
 
     ${is_expanded}=    get element attribute    ${header_button}    aria-expanded
     IF    '${is_expanded}' != 'false'
@@ -314,8 +326,9 @@ user closes accordion section with accordion header
     user checks element attribute value should be    ${header_button}    aria-expanded    false
 
 user gets accordion section content element
-    [Arguments]    ${heading_text}    ${parent}=css:[data-testid="accordion"]
+    [Arguments]    ${heading_text}    ${parent}=css:[data-testid="accordion"]    ${exact_match}=${FALSE}
     ${header_button}=    user gets accordion header button element    ${heading_text}    ${parent}
+    ...    exact_match=${exact_match}
     ${content_id}=    get element attribute    ${header_button}    aria-controls
     ${content}=    get child element    ${parent}    css:[id="${content_id}"]
     [Return]    ${content}
@@ -327,9 +340,11 @@ user gets accordion section content element from heading element
     [Return]    ${content}
 
 user scrolls to accordion section
-    [Arguments]    ${heading_text}    ${parent}=css:[data-testid="accordion"]
+    [Arguments]    ${heading_text}    ${parent}=css:[data-testid="accordion"]    ${exact_match}=${FALSE}
     ${header_button}=    user gets accordion header button element    ${heading_text}    ${parent}
+    ...    exact_match=${exact_match}
     ${content}=    user gets accordion section content element    ${heading_text}    ${parent}
+    ...    exact_match=${exact_match}
     user scrolls to element    ${header_button}
     # Workaround to get lazy loaded data blocks to render
     user scrolls down    1
@@ -371,8 +386,9 @@ user checks element does not contain child element
     user waits until parent does not contain element    ${element}    ${child_element}
 
 user checks element contains
-    [Arguments]    ${element}    ${text}
-    user waits until parent contains element    ${element}    xpath://*[contains(.,"${text}")]
+    [Arguments]    ${element}    ${text}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until parent contains element    ${element}    xpath://*[${text_matcher}]
 
 user checks element contains button
     [Arguments]
@@ -494,21 +510,24 @@ user clicks link by index
     user clicks element    ${button}    ${parent}
 
 user clicks link by visible text
-    [Arguments]    ${text}    ${parent}=css:body
-    user clicks element    xpath:.//a[contains(., "${text}")]    ${parent}
+    [Arguments]    ${text}    ${parent}=css:body    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user clicks element    xpath:.//a[${text_matcher}]    ${parent}
 
 user clicks link containing text
-    [Arguments]    ${text}    ${parent}=css:body
-    user clicks element    xpath:.//a[contains(text(), "${text}")]    ${parent}
+    [Arguments]    ${text}    ${parent}=css:body    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user clicks element    xpath:.//a[${text_matcher}]    ${parent}
 
 user clicks button
-    [Arguments]    ${text}    ${parent}=css:body
-    ${button}=    user gets button element    ${text}    ${parent}
+    [Arguments]    ${text}    ${parent}=css:body    ${exact_match}=${FALSE}
+    ${button}=    user gets button element    ${text}    ${parent}    exact_match=${exact_match}
     user clicks element    ${button}
 
 user clicks button by index
-    [Arguments]    ${text}    ${index}=1    ${parent}=css:body
-    ${xpath}=    set variable    (//button[text()='${text}'])[${index}]
+    [Arguments]    ${text}    ${index}=1    ${parent}=css:body    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    ${xpath}=    set variable    (//button[${text_matcher}])[${index}]
     ${button}=    get webelement    ${xpath}
     user clicks element    ${button}    ${parent}
 
@@ -520,95 +539,124 @@ user waits until button is clickable
     element should be enabled    xpath=//button[text()="${button_text}"]
 
 user clicks button containing text
-    [Arguments]    ${text}    ${parent}=css:body
-    user clicks element    xpath://button[contains(text(), "${text}")]    ${parent}
+    [Arguments]    ${text}    ${parent}=css:body    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user clicks element    xpath://button[${text_matcher}]    ${parent}
 
 user waits until page contains button
-    [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until page contains element    xpath://button[contains(., "${text}") or .//*[contains(., "${text}")]]
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until page contains element    xpath://button[${text_matcher}]
     ...    ${wait}
 
 user checks page contains button
-    [Arguments]    ${text}
-    user checks page contains element    xpath://button[contains(., "${text}") or .//*[contains(., "${text}")]]
+    [Arguments]    ${text}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user checks page contains element    xpath://button[${text_matcher}]
 
 user checks page does not contain button
-    [Arguments]    ${text}
-    user checks page does not contain element    xpath://button[contains(., "${text}") or .//*[contains(., "${text}")]]
+    [Arguments]    ${text}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user checks page does not contain element    xpath://button[${text_matcher}]
 
 user waits until page does not contain button
-    [Arguments]    ${text}    ${wait}=${timeout}
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
     user waits until page does not contain element
-    ...    xpath://button[contains(., "${text}") or .//*[contains(., "${text}")]]    ${wait}
+    ...    xpath://button[${text_matcher}]    ${wait}
 
 user waits until button is enabled
-    [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is enabled    xpath://button[contains(., "${text}") or .//*[contains(., "${text}")]]
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until element is enabled    xpath://button[${text_matcher}]
     ...    ${wait}
 
 user waits until parent contains button
-    [Arguments]    ${parent}    ${text}    ${wait}=${timeout}
+    [Arguments]    ${parent}    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
     user waits until parent contains element    ${parent}
-    ...    xpath:.//button[contains(., "${text}") or .//*[contains(., "${text}")]]    ${wait}
+    ...    xpath://button[${text_matcher}]    ${wait}
 
 user waits until parent does not contain button
-    [Arguments]    ${parent}    ${text}    ${wait}=${timeout}
+    [Arguments]    ${parent}    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
     user waits until parent does not contain element    ${parent}
-    ...    xpath:.//button[contains(., "${text}") or .//*[contains(., "${text}")]]    ${wait}
+    ...    xpath://button[${text_matcher}]    ${wait}
 
 user waits until parent does not contain
-    [Arguments]    ${parent}    ${text}    ${wait}=${timeout}
+    [Arguments]    ${parent}    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
     user waits until parent does not contain element    ${parent}
-    ...    .//*[contains(text(),"${text}")]    ${wait}
+    ...    //button[${text_matcher}]    ${wait}
 
 user gets button element
-    [Arguments]    ${text}    ${parent}=css:body
+    [Arguments]    ${text}    ${parent}=css:body    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
     user waits until parent contains button    ${parent}    ${text}
-    ${button}=    get child element    ${parent}
-    ...    xpath:.//button[contains(., "${text}") or .//*[contains(., "${text}")]]
+    ${button}=    get child element    ${parent}    xpath://button[${text_matcher}]
     [Return]    ${button}
 
+get xpath text matcher
+    [Arguments]    ${text}    ${exact_match}=${FALSE}
+    IF    "${exact_match}" == "${TRUE}"
+        ${expression}=    Set Variable    text()="${text}"
+    ELSE
+        ${expression}=    Set Variable    contains(., "${text}")
+    END
+    RETURN    ${expression}
+
 user checks page contains tag
-    [Arguments]    ${text}
-    user checks page contains element    xpath://*[contains(@class, "govuk-tag")][contains(., "${text}")]
+    [Arguments]    ${text}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user checks page contains element    xpath://*[contains(@class, "govuk-tag")][${text_matcher}]
 
 user waits until h1 is visible
-    [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is visible    xpath://h1[contains(., "${text}")]    ${wait}
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until element is visible    xpath://h1[${text_matcher}]    ${wait}
 
 user waits until h1 is not visible
-    [Arguments]    ${text}    ${wait}=%{WAIT_SMALL}
-    user waits until element is not visible    xpath://h1[contains(., "${text}")]    ${wait}
+    [Arguments]    ${text}    ${wait}=%{WAIT_SMALL}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until element is not visible    xpath://h1[${text_matcher}]    ${wait}
 
 user waits until h2 is visible
-    [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is visible    xpath://h2[contains(., "${text}")]    ${wait}
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until element is visible    xpath://h2[${text_matcher}]    ${wait}
 
 user waits until h2 is not visible
-    [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is not visible    xpath://h2[contains(., "${text}")]    ${wait}
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until element is not visible    xpath://h2[${text_matcher}]    ${wait}
 
 user waits until h3 is visible
-    [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is visible    xpath://h3[contains(., "${text}")]    ${wait}
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until element is visible    xpath://h3[${text_matcher}]    ${wait}
 
 user waits until h3 is not visible
-    [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is not visible    xpath://h3[contains(., "${text}")]    ${wait}
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until element is not visible    xpath://h3[${text_matcher}]    ${wait}
 
 user waits until legend is visible
-    [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until element is visible    xpath://legend[contains(., "${text}")]    ${wait}
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until element is visible    xpath://legend[${text_matcher}]    ${wait}
 
 user waits until page contains title
-    [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until page contains element    xpath://h1[@data-testid="page-title" and contains(., "${text}")]
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until page contains element    xpath://h1[@data-testid="page-title" and ${text_matcher}]
     ...    ${wait}
 
 user waits until page contains title caption
-    [Arguments]    ${text}    ${wait}=${timeout}
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
     user waits until page contains element
-    ...    xpath://span[@data-testid="page-title-caption" and contains(., "${text}")]    ${wait}
+    ...    xpath://span[@data-testid="page-title-caption" and ${text_matcher}]    ${wait}
 
 user selects newly opened window
     switch window    locator=NEW
@@ -721,23 +769,28 @@ user checks page contains link
     [Arguments]
     ...    ${text}
     ...    ${parent}=css:body
+    ...    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
     user waits until parent contains element    ${parent}
-    ...    xpath:.//a[contains(text(), "${text}")]
+    ...    xpath:.//a[${text_matcher}]
 
 user checks page contains link with text and url
     [Arguments]
     ...    ${text}
     ...    ${href}
     ...    ${parent}=css:body
+    ...    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
     user waits until parent contains element    ${parent}
-    ...    xpath:.//a[@href="${href}" and contains(text(), "${text}")]
+    ...    xpath:.//a[@href="${href}" and ${text_matcher}]
 
 user opens details dropdown
-    [Arguments]    ${text}    ${parent}=css:body
+    [Arguments]    ${text}    ${parent}=css:body    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
     user waits until parent contains element    ${parent}
-    ...    xpath:.//details/summary[contains(., "${text}") and @aria-expanded]    %{WAIT_SMALL}
-    ${details}=    get child element    ${parent}    xpath:.//details[summary[contains(., "${text}")]]
-    ${summary}=    get child element    ${parent}    xpath:.//details/summary[contains(., "${text}")]
+    ...    xpath:.//details/summary[${text_matcher} and @aria-expanded]    %{WAIT_SMALL}
+    ${details}=    get child element    ${parent}    xpath:.//details[summary[${text_matcher}]]
+    ${summary}=    get child element    ${parent}    xpath:.//details/summary[${text_matcher}]
     user waits until element is visible    ${summary}    %{WAIT_SMALL}
     ${is_expanded}=    get element attribute    ${summary}    aria-expanded
     IF    '${is_expanded}' != 'true'
@@ -747,10 +800,11 @@ user opens details dropdown
     [Return]    ${details}
 
 user closes details dropdown
-    [Arguments]    ${text}    ${parent}=css:body
+    [Arguments]    ${text}    ${parent}=css:body    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
     user waits until parent contains element    ${parent}
     ...    xpath:.//details/summary[contains(., "${text}") and @aria-expanded]
-    ${summary}=    get child element    ${parent}    xpath:.//details/summary[contains(., "${text}")]
+    ${summary}=    get child element    ${parent}    xpath:.//details/summary[${text_matcher}]
     user waits until element is visible    ${summary}
     ${is_expanded}=    get element attribute    ${summary}    aria-expanded
     IF    '${is_expanded}' != 'false'
@@ -759,25 +813,29 @@ user closes details dropdown
     user checks element attribute value should be    ${summary}    aria-expanded    false
 
 user gets details content element
-    [Arguments]    ${text}    ${parent}=css:body    ${wait}=${timeout}
-    user waits until parent contains element    ${parent}    xpath:.//details/summary[contains(., "${text}")]
+    [Arguments]    ${text}    ${parent}=css:body    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until parent contains element    ${parent}    xpath:.//details/summary[${text_matcher}]
     ...    timeout=${wait}
-    ${summary}=    get child element    ${parent}    xpath:.//details/summary[contains(., "${text}")]
+    ${summary}=    get child element    ${parent}    xpath:.//details/summary[${text_matcher}]
     ${content_id}=    get element attribute    ${summary}    aria-controls
     ${content}=    get child element    ${parent}    id:${content_id}
     [Return]    ${content}
 
 user waits until page contains details dropdown
-    [Arguments]    ${text}    ${wait}=${timeout}
-    user waits until page contains element    xpath:.//details/summary[contains(., "${text}")]    ${wait}
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user waits until page contains element    xpath:.//details/summary[${text_matcher}]    ${wait}
 
 user checks page for details dropdown
-    [Arguments]    ${text}
-    user checks page contains element    xpath:.//details/summary[contains(., "${text}")]
+    [Arguments]    ${text}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user checks page contains element    xpath:.//details/summary[${text_matcher}]
 
 user scrolls to details dropdown
-    [Arguments]    ${text}    ${wait}=${timeout}
-    user scrolls to element    xpath:.//details/summary[contains(., "${text}")]
+    [Arguments]    ${text}    ${wait}=${timeout}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${text}    ${exact_match}
+    user scrolls to element    xpath:.//details/summary[${text_matcher}]
 
 user checks publication bullet contains link
     [Arguments]    ${publication}    ${link}
@@ -827,14 +885,16 @@ user checks radio is checked
     user checks page contains element    xpath://label[text()="${label}"]/../input[@type="radio" and @checked]
 
 user checks radio in position has label
-    [Arguments]    ${position}    ${label}
+    [Arguments]    ${position}    ${label}    ${exact_match}=${FALSE}
+    ${text_matcher}=    get xpath text matcher    ${label}    ${exact_match}
     user checks page contains element
-    ...    xpath://*[contains(@data-testid, "Radio item for ")][${position}]//label[contains(text(), "${label}")]
+    ...    xpath://*[contains(@data-testid, "Radio item for ")][${position}]//label[${text_matcher}]
 
 user clicks checkbox
-    [Arguments]    ${label}
-    user scrolls to element    xpath://label[text()="${label}" or strong[text()="${label}"]]/../input[@type="checkbox"]
-    user clicks element    xpath://label[text()="${label}" or strong[text()="${label}"]]/../input[@type="checkbox"]
+    [Arguments]    ${label}    ${exact_match}=${TRUE}
+    ${text_matcher}=    get xpath text matcher    ${label}    ${exact_match}
+    user scrolls to element    xpath://label[${text_matcher} or strong[${text_matcher}]]/../input[@type="checkbox"]
+    user clicks element    xpath://label[${text_matcher} or strong[${text_matcher}]]/../input[@type="checkbox"]
 
 user clicks checkbox by selector
     [Arguments]    ${locator}
@@ -842,14 +902,16 @@ user clicks checkbox by selector
     user clicks element    ${locator}
 
 user checks checkbox is checked
-    [Arguments]    ${label}
+    [Arguments]    ${label}    ${exact_match}=${TRUE}
+    ${text_matcher}=    get xpath text matcher    ${label}    ${exact_match}
     user checks checkbox input is checked
-    ...    xpath://label[text()="${label}" or strong[text()="${label}"]]/../input[@type="checkbox"]
+    ...    xpath://label[${text_matcher} or strong[${text_matcher}]]/../input[@type="checkbox"]
 
 user checks checkbox is not checked
-    [Arguments]    ${label}
+    [Arguments]    ${label}    ${exact_match}=${TRUE}
+    ${text_matcher}=    get xpath text matcher    ${label}    ${exact_match}
     user checks checkbox input is not checked
-    ...    xpath://label[text()="${label}" or strong[text()="${label}"]]/../input[@type="checkbox"]
+    ...    xpath://label[${text_matcher} or strong[${text_matcher}]]/../input[@type="checkbox"]
 
 user checks checkbox input is checked
     [Arguments]    ${selector}
@@ -862,9 +924,10 @@ user checks checkbox input is not checked
     checkbox should not be selected    ${selector}
 
 user checks checkbox in position has label
-    [Arguments]    ${position}    ${label}
+    [Arguments]    ${position}    ${label}    ${exact_match}=${TRUE}
+    ${text_matcher}=    get xpath text matcher    ${label}    ${exact_match}
     user checks page contains element
-    ...    xpath://*[contains(@data-testid,"Checkbox item for ")][${position}]//label[contains(text(), "${label}")]
+    ...    xpath://*[contains(@data-testid,"Checkbox item for ")][${position}]//label[${text_matcher}]
 
 user checks list has x items
     [Arguments]    ${locator}    ${count}    ${parent}=css:body

--- a/tests/robot-tests/tests/libs/fail_fast.py
+++ b/tests/robot-tests/tests/libs/fail_fast.py
@@ -6,19 +6,20 @@ should continue to run or if they should fail immediately and therefore fail the
 """
 
 import datetime
-import os.path
 import os
+import os.path
 import threading
 
-from robot.libraries.BuiltIn import BuiltIn
+import tests.libs.visual as visual
 from robot.api import SkipExecution
+from robot.libraries.BuiltIn import BuiltIn
 from tests.libs.logger import get_logger
 from tests.libs.selenium_elements import sl
-import tests.libs.visual as visual
 
 failing_suites_filename = ".failing_suites"
 
 logger = get_logger(__name__)
+
 
 def record_test_failure():
     if not current_test_suite_failing_fast():
@@ -26,8 +27,8 @@ def record_test_failure():
         visual.capture_screenshot()
         visual.capture_large_screenshot()
         _capture_html()
-        
-    if BuiltIn().get_variable_value("${prompt_to_continue_on_failure}") == '1':
+
+    if BuiltIn().get_variable_value("${prompt_to_continue_on_failure}") == "1":
         _prompt_to_continue()
 
 
@@ -47,13 +48,13 @@ file_lock = threading.Lock()
 def record_failing_test_suite():
     if current_test_suite_failing_fast():
         return
-        
+
     test_suite = _get_current_test_suite()
-    
+
     logger.info(
         f"Recording test suite '{test_suite}' as failing - subsequent tests will automatically fail in this suite"
     )
-    
+
     with file_lock:
         try:
             with open(failing_suites_filename, "a") as file_write:
@@ -64,7 +65,7 @@ def record_failing_test_suite():
 
 def fail_test_fast_if_required():
     if current_test_suite_failing_fast():
-        raise SkipExecution(f"Test suite {_get_current_test_suite()} is already failing.  Skipping this test.")
+        raise SkipExecution("")
 
 
 def get_failing_test_suites() -> []:
@@ -82,7 +83,7 @@ def get_failing_test_suites() -> []:
 def _capture_html():
     html = sl().get_source()
     current_time_millis = round(datetime.datetime.timestamp(datetime.datetime.now()) * 1000)
-    output_dir = BuiltIn().get_variable_value('${OUTPUT DIR}')
+    output_dir = BuiltIn().get_variable_value("${OUTPUT DIR}")
     html_file = open(f"{output_dir}{os.sep}captured-html-{current_time_millis}.html", "w", encoding="utf-8")
     html_file.write(html)
     html_file.close()
@@ -93,8 +94,8 @@ def _prompt_to_continue():
     logger.warn("Continue? (Y/n)")
     choice = input()
     if choice.lower().startswith("n"):
-        raise_assertion_error("Tests stopped!")
-        
+        _raise_assertion_error("Tests stopped!")
+
 
 def _raise_assertion_error(err_msg):
     sl().failure_occurred()

--- a/tests/robot-tests/tests/public_api/public_api_resolve_mapping_statuses.robot
+++ b/tests/robot-tests/tests/public_api/public_api_resolve_mapping_statuses.robot
@@ -305,6 +305,7 @@ Search with 2nd API dataset
     user checks list item contains    testid:data-set-file-list    1    ${SUBJECT_NAME_2}
 
 User clicks on 2nd API dataset link
+    capture large screenshot
     user clicks link by index    ${SUBJECT_NAME_2}
     user waits until page finishes loading
 

--- a/tests/robot-tests/tests/public_api/public_api_resolve_mapping_statuses.robot
+++ b/tests/robot-tests/tests/public_api/public_api_resolve_mapping_statuses.robot
@@ -12,7 +12,6 @@ Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
 
-
 *** Variables ***
 ${PUBLICATION_NAME}=    UI tests - Public API - resolve mapping statuses %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Financial year 3000-01
@@ -20,10 +19,9 @@ ${SUBJECT_NAME_1}=      UI test subject 1
 ${SUBJECT_NAME_2}=      UI test subject 2
 
 
-
 *** Test Cases ***
 Create publication and release
-   ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
+    ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
     user creates test release via api    ${PUBLICATION_ID}    FY    3000
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
     ...    ${RELEASE_NAME}
@@ -33,7 +31,8 @@ Verify release summary
     user verifies release summary    Financial year    3000-01    Accredited official statistics
 
 Upload datafile
-    user uploads subject and waits until complete    ${SUBJECT_NAME_1}    absence_school.csv    absence_school.meta.csv    ${PUBLIC_API_FILES_DIR}
+    user uploads subject and waits until complete    ${SUBJECT_NAME_1}    absence_school.csv    absence_school.meta.csv
+    ...    ${PUBLIC_API_FILES_DIR}
 
 Add data guidance to subjects
     user clicks link    Data and files
@@ -58,7 +57,7 @@ Create 1st API dataset
 
     user clicks button    Create API data set
     ${modal}=    user waits until modal is visible    Create a new API data set
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_1}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_1}
     user clicks button    Confirm new API data set
 
     user waits until page finishes loading
@@ -83,7 +82,8 @@ Create a second draft release via api
     user creates release from publication page    ${PUBLICATION_NAME}    Academic year    3010
 
 Upload subject to second release
-   user uploads subject and waits until complete    ${SUBJECT_NAME_2}    absence_school_major_manual.csv    absence_school_major_manual.meta.csv    ${PUBLIC_API_FILES_DIR}
+    user uploads subject and waits until complete    ${SUBJECT_NAME_2}    absence_school_major_manual.csv
+    ...    absence_school_major_manual.meta.csv    ${PUBLIC_API_FILES_DIR}
 
 Add data guidance to second release
     user clicks link    Data and files
@@ -109,10 +109,11 @@ Create a different version of an API dataset(Major version)
     user waits until h3 is visible    Current live API data sets
 
     user checks table column heading contains    1    1    Version    xpath://table[@data-testid="live-api-data-sets"]
-    user clicks button in table cell    1    3    Create new version    xpath://table[@data-testid="live-api-data-sets"]
+    user clicks button in table cell    1    3    Create new version
+    ...    xpath://table[@data-testid="live-api-data-sets"]
 
     ${modal}=    user waits until modal is visible    Create a new API data set version
-    user chooses select option    id:apiDataSetCreateForm-releaseFileId   ${SUBJECT_NAME_2}
+    user chooses select option    id:apiDataSetCreateForm-releaseFileId    ${SUBJECT_NAME_2}
     user clicks button    Confirm new data set version
 
     user waits until page finishes loading
@@ -120,23 +121,32 @@ Create a different version of an API dataset(Major version)
 
 Validate the summary contents inside the 'draft version details' table
     user waits until h3 is visible    Draft version details
-    user waits until element contains    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(1) > dt + dd     v2.0    %{WAIT_LONG}
-    user waits until element contains    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(2) > dt + dd     Action required    %{WAIT_LONG}
+    user waits until element contains    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(1) > dt + dd
+    ...    v2.0    %{WAIT_LONG}
+    user waits until element contains    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(2) > dt + dd
+    ...    Action required    %{WAIT_LONG}
     ${mapping_status}=    get text    css:dl[data-testid="draft-version-summary"] > div:nth-of-type(2) > dt + dd
     should be equal as strings    ${mapping_status}    Action required
 
 Validate the version task statuses inside the 'Draft version task' section
     user waits until h3 is visible    Draft version tasks
-    user waits until element contains    css:div[data-testid="draft-version-tasks"] li:nth-child(1) a    Map locations    %{WAIT_LONG}
-    user waits until element contains    css:div[data-testid="draft-version-tasks"] li:nth-child(2) a    Map filters    %{WAIT_LONG}
+    user waits until element contains    css:div[data-testid="draft-version-tasks"] li:nth-child(1) a    Map locations
+    ...    %{WAIT_LONG}
+    user waits until element contains    css:div[data-testid="draft-version-tasks"] li:nth-child(2) a    Map filters
+    ...    %{WAIT_LONG}
 
-    user waits until element contains    css:div[data-testid="draft-version-tasks"] li:nth-child(1) div[id="map-locations-task-status"]    Incomplete    %{WAIT_LONG}
-    user waits until element contains    css:div[data-testid="draft-version-tasks"] li:nth-child(2) div[id="map-filters-task-status"]    Incomplete    %{WAIT_LONG}
+    user waits until element contains
+    ...    css:div[data-testid="draft-version-tasks"] li:nth-child(1) div[id="map-locations-task-status"]    Incomplete
+    ...    %{WAIT_LONG}
+    user waits until element contains
+    ...    css:div[data-testid="draft-version-tasks"] li:nth-child(2) div[id="map-filters-task-status"]    Incomplete
+    ...    %{WAIT_LONG}
 
 User clicks on Map locations link
     user clicks link    Map locations
-    user waits until h3 is visible        Locations not found in new data set
-    user waits until element contains     xpath://table[@data-testid='mappable-table-region']/caption//strong[1]    1 unmapped location     %{WAIT_LONG}
+    user waits until h3 is visible    Locations not found in new data set
+    user waits until element contains    xpath://table[@data-testid='mappable-table-region']/caption//strong[1]
+    ...    1 unmapped location    %{WAIT_LONG}
 
 Validate the 'unmapped location' notification banner
     user waits until h2 is visible    Action required
@@ -147,31 +157,31 @@ Validate the row headings and its contents in the 'Regions' section
     user checks table column heading contains    1    2    New data set
 
     user checks table column heading contains    1    3    Type
-    user checks table column heading contains   1    4    Actions
+    user checks table column heading contains    1    4    Actions
 
     user checks table cell contains    1    1    Yorkshire and The Humber
     user checks table cell contains    1    2    Unmapped
     user checks table cell contains    1    3    N/A
 
 User edits location mapping
-    user clicks button in table cell     1    4    Edit
+    user clicks button in table cell    1    4    Edit
 
     ${modal}=    user waits until modal is visible    Map existing location
-    user clicks radio        Yorkshire
+    user clicks radio    Yorkshire
     user clicks button    Update location mapping
     user waits until modal is not visible    Map existing location
 
 Verify mapping changes
-    user waits until element contains    xpath://table[@data-testid='mappable-table-region']/caption//strong[1]    1 mapped location     %{WAIT_LONG}
+    user waits until element contains    xpath://table[@data-testid='mappable-table-region']/caption//strong[1]
+    ...    1 mapped location    %{WAIT_LONG}
 
 Validate the row headings and its contents in the 'Regions' section(after mapping)
-
     user waits until h3 is visible    Locations not found in new data set
     user checks table column heading contains    1    1    Current data set
     user checks table column heading contains    1    2    New data set
 
     user checks table column heading contains    1    3    Type
-    user checks table column heading contains   1    4    Actions
+    user checks table column heading contains    1    4    Actions
 
     user checks table cell contains    1    1    Yorkshire and The Humber
     user checks table cell contains    1    2    Yorkshire
@@ -182,15 +192,20 @@ Validate the row headings and its contents in the 'Regions' section(after mappin
 Validate the version status of location task
     user waits until h3 is visible    Draft version tasks
 
-    user waits until element contains    css:div[data-testid="draft-version-tasks"] li:nth-child(1) a    Map locations    %{WAIT_LONG}
-    user waits until element contains    css:div[data-testid="draft-version-tasks"] li:nth-child(2) a    Map filters    %{WAIT_LONG}
+    user waits until element contains    css:div[data-testid="draft-version-tasks"] li:nth-child(1) a    Map locations
+    ...    %{WAIT_LONG}
+    user waits until element contains    css:div[data-testid="draft-version-tasks"] li:nth-child(2) a    Map filters
+    ...    %{WAIT_LONG}
 
-    user waits until element contains    css:div[data-testid="draft-version-tasks"] li:nth-child(1) div[id="map-locations-task-status"]    Complete    %{WAIT_LONG}
+    user waits until element contains
+    ...    css:div[data-testid="draft-version-tasks"] li:nth-child(1) div[id="map-locations-task-status"]    Complete
+    ...    %{WAIT_LONG}
 
 User clicks on Map filters link
     user clicks link    Map filters
-    user waits until h3 is visible        Filter options not found in new data set
-    user waits until element contains     xpath://table[@data-testid='mappable-table-school_type']/caption//strong[1]    1 unmapped filter option     %{WAIT_LONG}
+    user waits until h3 is visible    Filter options not found in new data set
+    user waits until element contains    xpath://table[@data-testid='mappable-table-school_type']/caption//strong[1]
+    ...    1 unmapped filter option    %{WAIT_LONG}
 
 Validate the 'unmapped filter option' notification banner
     user waits until h2 is visible    Action required
@@ -201,22 +216,23 @@ Validate the row headings and its contents in the 'filter options' section
     user checks table column heading contains    1    2    New data set
 
     user checks table column heading contains    1    3    Type
-    user checks table column heading contains   1    4    Actions
+    user checks table column heading contains    1    4    Actions
 
     user checks table cell contains    1    1    Total
     user checks table cell contains    1    2    Unmapped
     user checks table cell contains    1    3    N/A
 
 User edits filter mapping
-    user clicks button in table cell     1    4    Edit
+    user clicks button in table cell    1    4    Edit
 
     ${modal}=    user waits until modal is visible    Map existing filter option
-    user clicks radio        State-funded primary and secondary
+    user clicks radio    State-funded primary and secondary
     user clicks button    Update filter option mapping
     user waits until modal is not visible    Map existing location
 
 Verify mapping changes
-    user waits until element contains    xpath://table[@data-testid='mappable-table-school_type']/caption//strong[1]    1 mapped filter option     %{WAIT_LONG}
+    user waits until element contains    xpath://table[@data-testid='mappable-table-school_type']/caption//strong[1]
+    ...    1 mapped filter option    %{WAIT_LONG}
 
 Validate the row headings and its contents in the 'filters options' section(after mapping)
     user waits until h3 is visible    Filter options not found in new data set
@@ -224,7 +240,7 @@ Validate the row headings and its contents in the 'filters options' section(afte
     user checks table column heading contains    1    2    New data set
 
     user checks table column heading contains    1    3    Type
-    user checks table column heading contains   1    4    Actions
+    user checks table column heading contains    1    4    Actions
 
     user checks table cell contains    1    1    Total
     user checks table cell contains    1    2    State-funded primary and secondary
@@ -240,21 +256,22 @@ Confirm finalization of this API data set version
 
 User navigates to 'changelog and guidance notes' page and update relevant details in it
     user clicks link by index    View changelog and guidance notes    1
-    user waits until page contains     API data set changelog
+    user waits until page contains    API data set changelog
 
-    user enters text into element    css:textarea[id="guidanceNotesForm-notes"]    public guidance notes
+    user enters text into element    css:textarea[id="guidanceNotesForm-notes"]
+    ...    Content for the public guidance notes
     user clicks button    Save public guidance notes
 
-    user waits until page contains    public guidance notes
+    user waits until page contains    Content for the public guidance notes
     user clicks link    Back to API data set details
 
 User clicks on 'View preview token log' link inside the 'Draft version details' section
     user clicks link by index    View changelog and guidance notes    2
 
 Validate the contents in the 'API dataset changelog' page.
-    user waits until page contains     API data set changelog
+    user waits until page contains    API data set changelog
 
-    user waits until page contains    public guidance notes
+    user waits until page contains    Content for the public guidance notes
     user clicks link    Back to API data set details
 
 Add headline text block to Content page
@@ -280,8 +297,9 @@ Search with 2nd API dataset
     user waits until page finishes loading
     user clicks radio    Newest
 
-    ${API_DATASET_STATUS_VALUE}=  set variable  li[data-testid="data-set-file-summary-UI test subject 2"]:nth-of-type(1) [data-testid="Status-value"] strong:nth-of-type(1)
-    user checks contents inside the cell value     This is the latest data     css:${API_DATASET_STATUS_VALUE}
+    ${API_DATASET_STATUS_VALUE}=    set variable
+    ...    li[data-testid="data-set-file-summary-UI test subject 2"]:nth-of-type(1) [data-testid="Status-value"] strong:nth-of-type(1)
+    user checks contents inside the cell value    This is the latest data    css:${API_DATASET_STATUS_VALUE}
     user checks page contains link    ${SUBJECT_NAME_2}
 
     user checks list item contains    testid:data-set-file-list    1    ${SUBJECT_NAME_2}
@@ -299,16 +317,20 @@ User checks relevant headings exist on API dataset details page
     user waits until h2 is visible    Using this data
     user waits until h2 is visible    API data set quick start
     user waits until h2 is visible    API data set version history
+    user waits until h2 is visible    API data set changelog
 
-User verifies the headings and contents in 'API version history' section
-    user checks table column heading contains    1    1    Version    css:section[id="apiVersionHistory"]
-    user checks table column heading contains    1    2    Release    css:section[id="apiVersionHistory"]
-    user checks table column heading contains    1    3    Status     css:section[id="apiVersionHistory"]
+User verifies the public data guidance in the 'API data set changelog' section
+    user waits until element contains    testid:public-guidance-notes    Content for the public guidance notes
 
-    user checks table cell contains              1    1    1.1 (current)                xpath://section[@id="apiVersionHistory"]
-    user checks table cell contains              1    2    Academic year 3010/11        xpath://section[@id="apiVersionHistory"]
-    user checks table cell contains              1    3    Published                    xpath://section[@id="apiVersionHistory"]
-
-    user checks table cell contains              2    1    1.0                          xpath://section[@id="apiVersionHistory"]
-    user checks table cell contains              2    2    Financial year 3000-01       xpath://section[@id="apiVersionHistory"]
-    user checks table cell contains              2    3    Published                    xpath://section[@id="apiVersionHistory"]
+## EES-5560 - commented out any further testing until EES-5559 is resolved.
+## User verifies the major changes in the 'API data set changelog' section
+##    user waits until h3 is visible    Major changes for version 1.1
+##    ${major_changes_section}=    get child element    id:apiChangelog    testid:major-changes
+##    user checks element contains    ${major_changes_section}    This version introduces major breaking changes
+##    ${deleted_indicators_section}=    user checks element contains child element    ${major_changes_section}
+##    ...    testid:deleted-indicators
+##    user checks element contains    ${deleted_indicators_section}    Enrolments
+##    user checks element contains    ${deleted_indicators_section}    Number of authorised sessions
+##    user checks element contains    ${deleted_indicators_section}    Number of possible sessions
+##    user checks element contains    ${deleted_indicators_section}    Number of unauthorised sessions
+##    user checks element contains    ${deleted_indicators_section}    Percentage of unauthorised sessions

--- a/tests/robot-tests/tests/visual_testing/tables_and_charts.robot
+++ b/tests/robot-tests/tests/visual_testing/tables_and_charts.robot
@@ -92,7 +92,7 @@ Check Content Block Table
         ${tables_tab}=    set variable    dataBlock-${content_block.content_block_id}-tables
         user waits until parent contains element    ${data_block}    id:${tables_tab}
         user waits until element is enabled    id:${tables_tab}
-        user clicks link by visible text    Table    ${data_block}
+        user clicks link containing text    Table    ${data_block}
     ELSE
         ${tables_tab}=    set variable    dataBlock-${content_block.content_block_id}
         user scrolls to element    ${data_block}


### PR DESCRIPTION
# UI test results

![image](https://github.com/user-attachments/assets/7ec3ef23-a639-4aea-a1ed-25272c70a29b)

# Overview

This PR:
- adds the public guidance notes for the changelog into the public dataset landing page in the changelog section.
- reworks a lot of the xpath text selectors in `common.robot` to be either exact or fuzzy based on `exact_match` argument.
- amends run_tests.py to report failing suites based on final `output.xml` rather than our own `.failing-suites` file.

## Reworking text selectors

During my aborted UI test writing for the public Changelog section (waiting for EES-5559 to go in), I ran into issues around not having a fuzzy text selector for some elements.  I needed `text()="Blah"` xpath to instead be `contains(., "Blah")` instead. On changing this though, this broke a whole lot of other scenarios instead of course!

I saw that we had a right old mix of styles in the common keywords and so I added an argument to allow the caller to specify the desired behaviour instead, which produces either a `text()="Blah"` or `contains(., "Blah")` depending on the choice.

I defaulted the behaviour almost entirely to be fuzzy, with the exception of checkboxes where we tend to be able to rely on exact text with little to no decoration (happy to be pushed back on this but it would mean a lot of checkbox assertions would need updating in the tests and would make them a bit more verbose).

## run_tests.py updates to use output.xml

During my battle with the text selector changes, I broke the Robot code a few times but noticed that misconfigured keywords and errors within our own keyword code didn't cause our tests to fail fast (nothing new, as the `run_on_failure` that we use to trigger failures only kicks in within SeleniumLibrary's own keywords as has always been the case).  This would mean that some suites ultimately failed but didn't get recorded by our fail-fast mechanism.

They were however captured in output.xml and so I changed the code up to use this as the ultimate source of truth instead, should we accidentally introduce keyword changes that break them but don't get caught by our fail-fast mechanism.

Ultimately to fix the fail-fast issue we could do with setting `run_on_failure=None` to prevent Selenium-only keywords failing suites fast, and instead in each test suite specify `Test Teardown    Run Keyword On Test Failure    Record failing suite` - the only issue here being that it doesn't catch failures in `Suite Setup`, so we'd need another mechanism for that, potentially with listeners.
 
 