### PR TITLE
EES-5559 Fix filters and indicators not re-using public IDs for new versions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/CloneExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/CloneExtensionsTests.cs
@@ -1,0 +1,113 @@
+#nullable enable
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class CloneExtensionsTests
+{
+    public class ShallowCloneTests
+    {
+        [Theory]
+        [InlineData(123)]
+        [InlineData(1.1)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NonStringPrimitives(object value)
+        {
+            Assert.Equal(value, value.ShallowClone());
+        }
+
+        [Fact]
+        public void String()
+        {
+            const string value = "test";
+
+            // Need to be able to specify the type is
+            // a string to shallow clone it correctly.
+            Assert.Equal(value, value.ShallowClone());
+        }
+
+        [Fact]
+        public void Object()
+        {
+            var obj = new TestPerson
+            {
+                Name = "Test person",
+                Age = 123,
+                Addresses =
+                [
+                    new TestAddress { Line1 = "123 High Street" },
+                    new TestAddress { Line1 = "456 Low Street" },
+                ]
+            };
+
+            var clone = obj.ShallowClone();
+
+            Assert.Equal(obj.Name, clone.Name);
+            Assert.Equal(obj.Age, clone.Age);
+
+            Assert.Same(obj.Addresses, clone.Addresses);
+            Assert.Same(obj.Addresses[0], clone.Addresses[0]);
+            Assert.Same(obj.Addresses[1], clone.Addresses[1]);
+        }
+    }
+
+    public class DeepCloneTests
+    {
+        [Theory]
+        [InlineData(123)]
+        [InlineData(1.1)]
+        [InlineData(true)]
+        [InlineData(false)]
+        [InlineData("test")]
+        public void Primitives(object value)
+        {
+            Assert.Equal(value, value.DeepClone());
+        }
+
+        [Fact]
+        public void Object()
+        {
+            var obj = new TestPerson
+            {
+                Name = "Test person",
+                Age = 123,
+                Addresses =
+                [
+                    new TestAddress { Line1 = "123 High Street" },
+                    new TestAddress { Line1 = "456 Low Street" },
+                ]
+            };
+
+            var clone = obj.DeepClone();
+
+            Assert.Equal(obj.Name, clone.Name);
+            Assert.Equal(obj.Age, clone.Age);
+
+            Assert.NotSame(obj.Addresses, clone.Addresses);
+            Assert.Equal(obj.Addresses.Count, clone.Addresses.Count);
+
+            Assert.NotSame(obj.Addresses[0], clone.Addresses[0]);
+            Assert.Equal(obj.Addresses[0].Line1, clone.Addresses[0].Line1);
+
+            Assert.NotSame(obj.Addresses[1], clone.Addresses[1]);
+            Assert.Equal(obj.Addresses[1].Line1, clone.Addresses[1].Line1);
+        }
+    }
+
+    private class TestPerson
+    {
+        public required string Name { get; init; }
+
+        public required int Age { get; init; }
+
+        public List<TestAddress> Addresses { get; init; } = [];
+    }
+
+    private class TestAddress
+    {
+        public required string Line1 { get; init; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/CloneExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/CloneExtensions.cs
@@ -1,0 +1,15 @@
+#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+public static class CloneExtensions
+{
+    public static T ShallowClone<T>(this T obj)
+    {
+        return ObjectCloner.ObjectCloner.ShallowClone(obj);
+    }
+
+    public static T DeepClone<T>(this T obj)
+    {
+        return ObjectCloner.ObjectCloner.DeepClone(obj);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -41,6 +41,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
         <PackageReference Include="Azure.Storage.Queues" Version="12.19.0" />
+        <PackageReference Include="ObjectCloner" Version="2.2.2" />
         <PackageReference Include="Semver" Version="2.3.0" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
         <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionMapping.cs
@@ -125,7 +125,7 @@ public enum MappingType
 /// </summary>
 public abstract record MappableElement
 {
-    public required string Label { get; init; }
+    public required string Label { get; set; }
 }
 
 public abstract record MappableElementWithOptions<TMappableOption>
@@ -146,7 +146,7 @@ public abstract record Mapping<TMappableElement>
 {
     public required TMappableElement Source { get; init; }
 
-    public required string PublicId { get; init; }
+    public required string PublicId { get; set; }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]
     [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorTestData.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/ProcessorTestData.cs
@@ -218,16 +218,41 @@ public record ProcessorTestData
                 [
                     new FilterOptionMeta
                     {
+                        Id = 1,
                         Label = "Primary sponsor led academy",
                     },
                     new FilterOptionMeta
                     {
+                        Id = 2,
                         Label = "Secondary free school",
                     },
                     new FilterOptionMeta
                     {
+                        Id = 3,
                         Label = "Secondary sponsor led academy",
                     },
+                ],
+                OptionLinks =
+                [
+                    new FilterOptionMetaLink
+                    {
+                        MetaId = 1,
+                        OptionId = 1,
+                        PublicId = SqidEncoder.Encode(1),
+                    },
+                    new FilterOptionMetaLink
+                    {
+                        MetaId = 1,
+                        OptionId = 2,
+                        PublicId = SqidEncoder.Encode(2),
+                    },
+                    new FilterOptionMetaLink
+                    {
+
+                        MetaId = 1,
+                        OptionId = 3,
+                        PublicId = SqidEncoder.Encode(3),
+                    }
                 ],
             },
             new FilterMeta
@@ -242,20 +267,52 @@ public record ProcessorTestData
                 [
                     new FilterOptionMeta
                     {
+                        Id = 4,
                         Label = "Year 10",
                     },
                     new FilterOptionMeta
                     {
+                        Id = 5,
                         Label = "Year 4",
                     },
                     new FilterOptionMeta
                     {
+                        Id = 6,
                         Label = "Year 6",
                     },
                     new FilterOptionMeta
                     {
+                        Id = 7,
                         Label = "Year 8",
                     },
+                ],
+                OptionLinks =
+                [
+                    new FilterOptionMetaLink
+                    {
+                        MetaId = 2,
+                        OptionId = 4,
+                        PublicId = SqidEncoder.Encode(4),
+                    },
+                    new FilterOptionMetaLink
+                    {
+                        MetaId = 2,
+                        OptionId = 5,
+                        PublicId = SqidEncoder.Encode(5),
+                    },
+                    new FilterOptionMetaLink
+                    {
+
+                        MetaId = 2,
+                        OptionId = 6,
+                        PublicId = SqidEncoder.Encode(6),
+                    },
+                    new FilterOptionMetaLink
+                    {
+                        MetaId = 2,
+                        OptionId = 7,
+                        PublicId = SqidEncoder.Encode(7),
+                    }
                 ],
             },
             new FilterMeta
@@ -270,18 +327,42 @@ public record ProcessorTestData
                 [
                     new FilterOptionMeta
                     {
+                        Id = 8,
                         Label = "State-funded primary",
                     },
                     new FilterOptionMeta
                     {
+                        Id = 9,
                         Label = "State-funded secondary",
                     },
                     new FilterOptionMeta
                     {
+                        Id = 10,
                         Label = "Total",
                         IsAggregate = true
                     },
                 ],
+                OptionLinks =
+                [
+                    new FilterOptionMetaLink
+                    {
+                        MetaId = 3,
+                        OptionId = 8,
+                        PublicId = SqidEncoder.Encode(8),
+                    },
+                    new FilterOptionMetaLink
+                    {
+                        MetaId = 3,
+                        OptionId = 9,
+                        PublicId = SqidEncoder.Encode(9),
+                    },
+                    new FilterOptionMetaLink
+                    {
+                        MetaId = 3,
+                        OptionId = 10,
+                        PublicId = SqidEncoder.Encode(10),
+                    }
+                ]
             },
         ],
         ExpectedIndicators =


### PR DESCRIPTION
This PR fixes filters and indicators not re-using the public IDs of existing filters / indicators  when preparing new API data set versions. This was due to the `ImportMetadataFunction` code only really handling public ID mappings for filter options and location options.

As the public IDs were not being re-used, this was leading to the changelog reporting that _all_ filters and indicators were being deleted and re-added. By re-using the public IDs correctly, we now no longer see this.

We've importantly added a lot more tests for `ImportaMetadataFunction`, however, we still need to cover the other meta types more comprehensively. In the interest of time, this will be handled in a subsequent ticket - EES-5560.

## Relevant change

- Added `CloneExtensions` for shallow / deep clone extension methods. This uses [ObjectCloner](https://github.com/marcelltoth/ObjectCloner) internally.