### PR TITLE
EES-5434 fix footnotes heading level on permalinks

### DIFF
--- a/src/explore-education-statistics-common/src/components/FigureFootnotes.tsx
+++ b/src/explore-education-statistics-common/src/components/FigureFootnotes.tsx
@@ -2,23 +2,36 @@ import CollapsibleList from '@common/components/CollapsibleList';
 import ContentHtml from '@common/components/ContentHtml';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import { Footnote } from '@common/services/types/footnotes';
-import React from 'react';
+import React, { createElement } from 'react';
 
 interface Props {
   footnotes: Footnote[];
   headingHiddenText?: string;
+  headingTag?: 'h2' | 'h3';
   id: string;
 }
 
-const FigureFootnotes = ({ footnotes, headingHiddenText, id }: Props) => {
+const FigureFootnotes = ({
+  footnotes,
+  headingHiddenText,
+  headingTag = 'h3',
+  id,
+}: Props) => {
   return footnotes.length > 0 ? (
     <>
-      <h3 className="govuk-heading-m">
-        Footnotes
-        {headingHiddenText && (
-          <VisuallyHidden>{` ${headingHiddenText}`}</VisuallyHidden>
-        )}
-      </h3>
+      {createElement(
+        headingTag,
+        {
+          className: `govuk-heading-m`,
+        },
+        <>
+          Footnotes
+          {headingHiddenText && (
+            <VisuallyHidden>{` ${headingHiddenText}`}</VisuallyHidden>
+          )}
+        </>,
+      )}
+
       <CollapsibleList
         listStyle="number"
         collapseAfter={2}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
@@ -13,6 +13,7 @@ interface Props extends OmitStrict<MultiHeaderTableProps, 'ariaLabelledBy'> {
   innerRef?: Ref<HTMLElement>;
   footnotes?: FullTableMeta['footnotes'];
   footnotesClassName?: string;
+  footnotesHeadingTag?: 'h2' | 'h3';
   footnotesId: string;
   source?: string;
   footnotesHeadingHiddenText?: string;
@@ -25,6 +26,7 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
       captionId,
       footnotes = [],
       footnotesClassName,
+      footnotesHeadingTag,
       footnotesId,
       source,
       footnotesHeadingHiddenText,
@@ -116,6 +118,7 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
           <FigureFootnotes
             footnotes={footnotes}
             headingHiddenText={footnotesHeadingHiddenText}
+            headingTag={footnotesHeadingTag}
             id={footnotesId}
           />
         </div>

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -87,6 +87,7 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
           captionId={captionId}
           footnotes={footnotes}
           footnotesClassName="govuk-!-width-two-thirds"
+          footnotesHeadingTag="h2"
           footnotesId={footnotesId}
           source={`${publicationTitle}, ${dataSetTitle}`}
           tableJson={json}


### PR DESCRIPTION
Fixes a skipped heading level on permalink pages when footnotes are present - it was skipping from h1 to h3, now the footnotes heading is h2.