### PR TITLE
EES-5307 fix table tool publication error link

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -192,7 +192,6 @@ const PublicationForm = ({
 
                 <div className={styles.publicationsList}>
                   <FormFieldRadioGroup<FormValues>
-                    id="publications"
                     legend={
                       <>
                         Select a publication


### PR DESCRIPTION
Fixes the link in the error message when you haven't selected a publication on the first step of the table tool (the id was overriding the expected one generated from the field name).