### PR TITLE
EES-XXXX - amending run_tests.py to detect failed suites from output.xml

### DIFF
--- a/tests/robot-tests/args_and_variables.py
+++ b/tests/robot-tests/args_and_variables.py
@@ -31,7 +31,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
         dest="processes",
         type=int,
         default=4,
-        help="how many processes should be used when using the pabot interpreter"
+        help="how many processes should be used when using the pabot interpreter",
     )
     parser.add_argument(
         "-e",
@@ -82,12 +82,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="rerun failed test suites and merge results into original run results",
     )
-    parser.add_argument(
-        "--rerun-attempts",
-        dest="rerun_attempts",
-        type=int,
-        default=0,
-        help="Number of rerun attempts")
+    parser.add_argument("--rerun-attempts", dest="rerun_attempts", type=int, default=0, help="Number of rerun attempts")
     parser.add_argument(
         "--print-keywords",
         dest="print_keywords",

--- a/tests/robot-tests/reports.py
+++ b/tests/robot-tests/reports.py
@@ -1,7 +1,7 @@
-import os
 import glob
+import os
 import shutil
-import time
+
 from bs4 import BeautifulSoup
 from robot import rebot_cli as robot_rebot_cli
 from tests.libs.logger import get_logger
@@ -13,21 +13,19 @@ logger = get_logger(__name__)
 
 # Merge multiple Robot test reports and assets together into the main test results folder.
 def merge_robot_reports(first_run_attempt_number: int, number_of_test_runs: int):
-
-    first_run_folder=f"{main_results_folder}{os.sep}run-{first_run_attempt_number}"
+    first_run_folder = f"{main_results_folder}{os.sep}run-{first_run_attempt_number}"
 
     logger.info(f"Merging test run {first_run_attempt_number} results into full results")
-        
+
     for file in os.listdir(first_run_folder):
         _copy_to_destination_folder(first_run_folder, file, main_results_folder)
 
     for test_run in range(first_run_attempt_number + 1, number_of_test_runs + 1):
-        
         logger.info(f"Merging test run {test_run} results into full results")
-        
+
         test_run_foldername = f"{main_results_folder}{os.sep}run-{test_run}"
         _merge_test_reports(test_run_foldername)
-        
+
         for file in glob.glob(rf"{test_run_foldername}{os.sep}*screenshot*"):
             _copy_to_destination_folder(test_run_foldername, file.split(os.sep)[-1], main_results_folder)
 
@@ -35,11 +33,39 @@ def merge_robot_reports(first_run_attempt_number: int, number_of_test_runs: int)
             _copy_to_destination_folder(test_run_foldername, file.split(os.sep)[-1], main_results_folder)
 
 
-def log_report_results(number_of_test_runs: int, failing_suites: []):
+def get_failing_test_suite_sources(path_to_report_file: str) -> []:
+    with open(path_to_report_file, "rb") as report_file:
+        report_contents = report_file.read()
+        report = BeautifulSoup(report_contents, features="xml")
+
+        failing_suite_ids = _get_failing_leaf_suite_ids_from_report(report)
+        suite_elements = report.find_all("suite", recursive=True)
+        return [
+            suite_element.get("source")
+            for suite_element in suite_elements
+            if suite_element.get("id") in failing_suite_ids
+        ]
+
+
+def log_report_results(number_of_test_runs: int, reran_failing_suites: bool, failing_suites: []):
+    logger.info("*************************************")
+    logger.info("FINAL REPORT")
     logger.info(f"Log available at: file://{os.getcwd()}{os.sep}{main_results_folder}{os.sep}log.html")
     logger.info(f"Report available at: file://{os.getcwd()}{os.sep}{main_results_folder}{os.sep}report.html")
-    logger.info(f"Number of test runs: {number_of_test_runs}")
+    logger.info("*************************************\n")
 
+    if reran_failing_suites:
+        logger.info("*************************************")
+        logger.info("LAST RUN ATTEMPT REPORT")
+        logger.info(
+            f"Log available at: file://{os.getcwd()}{os.sep}{main_results_folder}{os.sep}run-{number_of_test_runs}{os.sep}log.html"
+        )
+        logger.info(
+            f"Report available at: file://{os.getcwd()}{os.sep}{main_results_folder}{os.sep}run-{number_of_test_runs}{os.sep}report.html"
+        )
+        logger.info("*************************************\n")
+
+    logger.info(f"Number of test run attempts: {number_of_test_runs}")
     if failing_suites:
         logger.info(f"Number of failing suites: {len(failing_suites)}")
         logger.info(f"Failing suites:")
@@ -56,7 +82,7 @@ def create_report_from_output_xml(test_results_folder: str):
         "output.xml",
         "--xunit",
         "xunit.xml",
-        f"{test_results_folder}/output.xml"
+        f"{test_results_folder}/output.xml",
     ]
     robot_rebot_cli(create_args, exit=False)
 
@@ -79,36 +105,48 @@ def _merge_test_reports(test_results_folder):
 
 
 def filter_out_passing_suites_from_report_file(path_to_original_report: str, path_to_filtered_report: str):
-    
-    with open(path_to_original_report, "rb") as report:
-        
-        report_contents = report.read()
+    with open(path_to_original_report, "rb") as report_file:
+        report_contents = report_file.read()
         report = BeautifulSoup(report_contents, features="xml")
-        
+
         passing_suite_ids = _get_passing_suite_ids_from_report(report)
-        
-        suite_elements = report.find_all('suite', recursive=True)
-        [suite_element.extract() for suite_element in suite_elements if suite_element.get('id') in passing_suite_ids]
-        
-        suite_stats = report.find_all('stat', recursive=True)
-        [suite_stat.extract() for suite_stat in suite_stats if suite_stat.get('id') in passing_suite_ids]
-    
+
+        suite_elements = report.find_all("suite", recursive=True)
+        [suite_element.extract() for suite_element in suite_elements if suite_element.get("id") in passing_suite_ids]
+
+        suite_stats = report.find_all("stat", recursive=True)
+        [suite_stat.extract() for suite_stat in suite_stats if suite_stat.get("id") in passing_suite_ids]
+
         if os.path.exists(path_to_filtered_report):
             os.remove(path_to_filtered_report)
 
         with open(path_to_filtered_report, "a") as filtered_file:
             filtered_file.write(report.prettify())
 
-        
-def _get_passing_suite_ids_from_report(report: BeautifulSoup) -> []: 
-    suite_results = report.find('statistics').find('suite').find_all('stat')
-    passing_suite_results = [suite_result for suite_result in suite_results if int(suite_result.get('fail')) == 0]
-    return [passing_suite.get('id') for passing_suite in passing_suite_results]
+
+def _get_passing_suite_ids_from_report(report: BeautifulSoup) -> []:
+    suite_results = report.find("statistics").find("suite").find_all("stat")
+    passing_suite_results = [suite_result for suite_result in suite_results if int(suite_result.get("fail")) == 0]
+    return [passing_suite.get("id") for passing_suite in passing_suite_results]
+
+
+def _get_failing_leaf_suite_ids_from_report(report: BeautifulSoup) -> []:
+    suite_results = report.find("statistics").find("suite").find_all("stat")
+    failing_suite_results = [suite_result for suite_result in suite_results if int(suite_result.get("fail")) > 0]
+    suite_ids = [failing_suite.get("id") for failing_suite in failing_suite_results]
+    leaf_suite_ids = []
+    for suite_id in suite_ids:
+        other_suite_ids_containing_suite_id = [
+            other_suite_id for other_suite_id in suite_ids if other_suite_id != suite_id and suite_id in other_suite_id
+        ]
+        if len(other_suite_ids_containing_suite_id) == 0:
+            leaf_suite_ids += [suite_id]
+    return leaf_suite_ids
 
 
 def _copy_to_destination_folder(source_folder: str, source_file: str, destination_folder: str):
-    source_file_path=f"{source_folder}{os.sep}{source_file}"
-    destination_file_path=f"{destination_folder}{os.sep}{source_file}"
+    source_file_path = f"{source_folder}{os.sep}{source_file}"
+    destination_file_path = f"{destination_folder}{os.sep}{source_file}"
     if os.path.isfile(source_file_path):
         shutil.copy(source_file_path, destination_file_path)
     else:

--- a/tests/robot-tests/reports.py
+++ b/tests/robot-tests/reports.py
@@ -131,6 +131,12 @@ def _get_passing_suite_ids_from_report(report: BeautifulSoup) -> []:
 
 
 def _get_failing_leaf_suite_ids_from_report(report: BeautifulSoup) -> []:
+    """Get the ids of failing suites from output.xml, filtering out ids from parent levels in the suite hierarchy.
+
+    Given an example suite folder structure of "Top-level folder:Sub-folder:Leaf suite", the report contains stats
+    for each level, with ids like "s1", "s1-1" and "s1-1-1". This code returns only the leaf ids, so "s1-1-1" in this
+    example.
+    """
     suite_results = report.find("statistics").find("suite").find_all("stat")
     failing_suite_results = [suite_result for suite_result in suite_results if int(suite_result.get("fail")) > 0]
     suite_ids = [failing_suite.get("id") for failing_suite in failing_suite_results]

--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -11,8 +11,7 @@ from selenium import webdriver
 from selenium.common import NoSuchElementException
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support.ui import Select
+from selenium.webdriver.support.ui import Select, WebDriverWait
 from slack_sdk.webhook import WebhookClient
 
 """

--- a/tests/robot-tests/test_runners.py
+++ b/tests/robot-tests/test_runners.py
@@ -1,7 +1,8 @@
-import os
-import reports
 import argparse
+import os
+
 import pabot.pabot as pabot
+import reports
 import robot
 from tests.libs.logger import get_logger
 
@@ -19,9 +20,9 @@ def create_robot_arguments(arguments: argparse.Namespace, test_run_folder: str) 
     ]
 
     robot_args += _create_include_and_exclude_args(arguments)
-    
+
     robot_args += ["-v", f"timeout:{os.getenv('TIMEOUT')}", "-v", f"implicit_wait:{os.getenv('IMPLICIT_WAIT')}"]
-    
+
     if arguments.fail_fast:
         robot_args += ["--exitonfailure"]
     if arguments.print_keywords:
@@ -30,7 +31,7 @@ def create_robot_arguments(arguments: argparse.Namespace, test_run_folder: str) 
         # NOTE(mark): Ensure secrets aren't visible in CI logs/reports
         robot_args += ["--removekeywords", "name:operatingsystem.environment variable should be set"]
         robot_args += ["--removekeywords", "name:common.user goes to url"]  # To hide basic auth credentials
-    
+
     if arguments.visual:
         robot_args += ["-v", "headless:0"]
     else:
@@ -72,7 +73,6 @@ def _create_include_and_exclude_args(arguments: argparse.Namespace) -> []:
 
 
 def execute_tests(arguments: argparse.Namespace, test_run_folder: str, path_to_previous_report_file: str):
-    
     robot_args = create_robot_arguments(arguments, test_run_folder)
 
     if arguments.interp == "robot":
@@ -80,23 +80,25 @@ def execute_tests(arguments: argparse.Namespace, test_run_folder: str, path_to_p
             robot_args += ["--rerunfailedsuites", path_to_previous_report_file]
 
         robot_args += [arguments.tests]
-        
-        logger.info(f'Performing test run with Robot')
+
+        logger.info(f"Performing test run with Robot")
         robot.run_cli(robot_args, exit=False)
 
     elif arguments.interp == "pabot":
-
-        robot_args = ['--processes', arguments.processes] + robot_args
+        robot_args = ["--processes", arguments.processes] + robot_args
 
         if path_to_previous_report_file is not None:
-        
-            path_to_filtered_report_file = '_filtered.xml'.join(path_to_previous_report_file.rsplit('.xml', 1))
-            reports.filter_out_passing_suites_from_report_file(path_to_previous_report_file, path_to_filtered_report_file)
-            
-            logger.info(f'Generated filtered report file containing only failing suites at {path_to_filtered_report_file}')
-            robot_args = ['--suitesfrom', path_to_filtered_report_file] + robot_args
+            path_to_filtered_report_file = "_filtered.xml".join(path_to_previous_report_file.rsplit(".xml", 1))
+            reports.filter_out_passing_suites_from_report_file(
+                path_to_previous_report_file, path_to_filtered_report_file
+            )
+
+            logger.info(
+                f"Generated filtered report file containing only failing suites at {path_to_filtered_report_file}"
+            )
+            robot_args = ["--suitesfrom", path_to_filtered_report_file] + robot_args
 
         robot_args += [arguments.tests]
 
-        logger.info(f'Performing test run with Pabot ({arguments.processes} processes)')
+        logger.info(f"Performing test run with Pabot ({arguments.processes} processes)")
         pabot.main_program(robot_args)

--- a/tests/robot-tests/tests/libs/fail_fast.py
+++ b/tests/robot-tests/tests/libs/fail_fast.py
@@ -6,19 +6,20 @@ should continue to run or if they should fail immediately and therefore fail the
 """
 
 import datetime
-import os.path
 import os
+import os.path
 import threading
 
-from robot.libraries.BuiltIn import BuiltIn
+import tests.libs.visual as visual
 from robot.api import SkipExecution
+from robot.libraries.BuiltIn import BuiltIn
 from tests.libs.logger import get_logger
 from tests.libs.selenium_elements import sl
-import tests.libs.visual as visual
 
 failing_suites_filename = ".failing_suites"
 
 logger = get_logger(__name__)
+
 
 def record_test_failure():
     if not current_test_suite_failing_fast():
@@ -26,8 +27,8 @@ def record_test_failure():
         visual.capture_screenshot()
         visual.capture_large_screenshot()
         _capture_html()
-        
-    if BuiltIn().get_variable_value("${prompt_to_continue_on_failure}") == '1':
+
+    if BuiltIn().get_variable_value("${prompt_to_continue_on_failure}") == "1":
         _prompt_to_continue()
 
 
@@ -47,13 +48,13 @@ file_lock = threading.Lock()
 def record_failing_test_suite():
     if current_test_suite_failing_fast():
         return
-        
+
     test_suite = _get_current_test_suite()
-    
+
     logger.info(
         f"Recording test suite '{test_suite}' as failing - subsequent tests will automatically fail in this suite"
     )
-    
+
     with file_lock:
         try:
             with open(failing_suites_filename, "a") as file_write:
@@ -64,7 +65,7 @@ def record_failing_test_suite():
 
 def fail_test_fast_if_required():
     if current_test_suite_failing_fast():
-        raise SkipExecution(f"Test suite {_get_current_test_suite()} is already failing.  Skipping this test.")
+        raise SkipExecution("")
 
 
 def get_failing_test_suites() -> []:
@@ -82,7 +83,7 @@ def get_failing_test_suites() -> []:
 def _capture_html():
     html = sl().get_source()
     current_time_millis = round(datetime.datetime.timestamp(datetime.datetime.now()) * 1000)
-    output_dir = BuiltIn().get_variable_value('${OUTPUT DIR}')
+    output_dir = BuiltIn().get_variable_value("${OUTPUT DIR}")
     html_file = open(f"{output_dir}{os.sep}captured-html-{current_time_millis}.html", "w", encoding="utf-8")
     html_file.write(html)
     html_file.close()
@@ -93,8 +94,8 @@ def _prompt_to_continue():
     logger.warn("Continue? (Y/n)")
     choice = input()
     if choice.lower().startswith("n"):
-        raise_assertion_error("Tests stopped!")
-        
+        _raise_assertion_error("Tests stopped!")
+
 
 def _raise_assertion_error(err_msg):
     sl().failure_occurred()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7b0e9827-b818-417f-af92-ecbb7b1296e1)

During some battles with text selector changes, I broke the Robot code a few times but noticed that misconfigured keywords and errors within our own keyword code didn't cause our tests to fail fast (nothing new, as the `run_on_failure` that we use to trigger failures only kicks in within SeleniumLibrary's own keywords as has always been the case). This would mean that some suites ultimately failed but didn't get recorded by our fail-fast mechanism.

They were however captured in output.xml and so I changed the code up to use this as the ultimate source of truth instead, should we accidentally introduce keyword changes that break them but don't get caught by our fail-fast mechanism.

Ultimately to fix the fail-fast issue we could do with setting `run_on_failure=None` to prevent Selenium-only keywords failing suites fast, and instead in each test suite specify `Test Teardown    Run Keyword On Test Failure    Record failing suite` - the only issue here being that it doesn't catch failures in `Suite Setup`, so we'd need another mechanism for that, potentially with listeners.

## Additional console logging details

There is now a direct link to the last run attempt's report `log.html` as well as the merged report, meaning you can jump to the final run's failures without all the noise of the full test suite results.

```
2024-10-10 14:20:40,753: *************************************
2024-10-10 14:20:40,753: FINAL REPORT
2024-10-10 14:20:40,753: Log available at: file:///home/dwatson/development/projects/dfe/explore-education-statistics/tests/robot-tests/test-results/log.html
2024-10-10 14:20:40,753: Report available at: file:///home/dwatson/development/projects/dfe/explore-education-statistics/tests/robot-tests/test-results/report.html
2024-10-10 14:20:40,753: *************************************

2024-10-10 14:20:40,753: *************************************
2024-10-10 14:20:40,753: LAST RUN ATTEMPT REPORT
2024-10-10 14:20:40,753: Log available at: file:///home/dwatson/development/projects/dfe/explore-education-statistics/tests/robot-tests/test-results/run-1/log.html
2024-10-10 14:20:40,753: Report available at: file:///home/dwatson/development/projects/dfe/explore-education-statistics/tests/robot-tests/test-results/run-1/report.html
2024-10-10 14:20:40,753: *************************************

2024-10-10 14:20:40,753: Number of test run attempts: 1
2024-10-10 14:20:40,753: 
All tests passed!
```