### PR TITLE
EES-5284 add border to map legend colours

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.module.scss
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.module.scss
@@ -26,6 +26,7 @@
 }
 
 .legendIcon {
+  border: 1px solid govuk-colour('black');
   forced-color-adjust: none;
   height: 20px;
   margin-right: govuk-spacing(1);


### PR DESCRIPTION
Adds a border to map legend colours to make them more distinguishable for low vision users.

![Screenshot 2024-10-10 145933](https://github.com/user-attachments/assets/852871e0-98de-4db3-96fb-5d571e3e009d)
