### PR TITLE
EES-5297 add visually hidden text to map control labels

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
@@ -120,6 +120,7 @@ export default function MapBlock({
   width,
   height,
   axes,
+  title,
 }: MapBlockProps) {
   const axisMajor = useMemo<AxisConfiguration>(
     () => ({
@@ -221,6 +222,7 @@ export default function MapBlock({
         id={id}
         selectedDataSetKey={selectedDataSetKey}
         selectedLocation={selectedFeature?.id?.toString()}
+        title={title}
         onChangeDataSet={setSelectedDataSetKey}
         onChangeLocation={value => {
           const feature = features?.features.find(feat => feat.id === value);

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapControls.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapControls.tsx
@@ -1,5 +1,6 @@
 import { FormGroup, FormSelect } from '@common/components/form';
 import { SelectOption } from '@common/components/form/FormSelect';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 import { MapDataSetCategory } from '@common/modules/charts/components/utils/createMapDataSetCategories';
 import { Dictionary } from '@common/types';
 import locationLevelsMap, {
@@ -15,6 +16,7 @@ interface Props {
   id: string;
   selectedDataSetKey: string;
   selectedLocation?: string;
+  title?: string;
   onChangeDataSet: (value: string) => void;
   onChangeLocation: (value: string) => void;
 }
@@ -25,6 +27,7 @@ export default function MapControls({
   id,
   selectedDataSetKey,
   selectedLocation,
+  title,
   onChangeDataSet,
   onChangeLocation,
 }: Props) {
@@ -92,7 +95,12 @@ export default function MapControls({
             name="selectedDataSet"
             id={`${id}-selectedDataSet`}
             className="govuk-!-width-full"
-            label="1. Select data to view"
+            label={
+              <>
+                1. Select data to view
+                {title && <VisuallyHidden>{` for ${title}`}</VisuallyHidden>}
+              </>
+            }
             value={selectedDataSetKey}
             onChange={e => onChangeDataSet(e.currentTarget.value)}
             options={dataSetOptions}
@@ -104,7 +112,12 @@ export default function MapControls({
           <FormSelect
             name="selectedLocation"
             id={`${id}-selectedLocation`}
-            label={`2. Select ${locationType.prefix} ${locationType.label}`}
+            label={
+              <>
+                {`2. Select ${locationType.prefix} ${locationType.label}`}
+                {title && <VisuallyHidden>{` for ${title}`}</VisuallyHidden>}
+              </>
+            }
             value={selectedLocation}
             options={locationOptions}
             optGroups={groupedLocationOptions}


### PR DESCRIPTION
Adds the chart title as visually hidden text to the map control dropdowns so that it is clear to screen reader users what the dropdowns refer to.