### PR TITLE
EES-5565 Fix UI test failure due to existence of other prerelease users

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/PrereleaseUsersController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/PrereleaseUsersController.cs
@@ -25,14 +25,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.UserM
         [ProducesResponseType(404)]
         public async Task<ActionResult<List<UserViewModel>>> GetPreReleaseUserList()
         {
-            var users = await _userManagementService.ListPreReleaseUsersAsync();
-
-            if (users.Any())
-            {
-                return Ok(users);
-            }
-
-            return NotFound();
+            return await _userManagementService.ListPreReleaseUsersAsync();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Database;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
-using GovUk.Education.ExploreEducationStatistics.Admin.Options;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;

--- a/tests/robot-tests/tests/libs/admin_api.py
+++ b/tests/robot-tests/tests/libs/admin_api.py
@@ -2,7 +2,6 @@ import os
 from datetime import datetime
 
 import requests
-from robot.libraries.BuiltIn import BuiltIn
 from tests.libs import local_storage_helper
 
 # To prevent InsecureRequestWarning
@@ -166,20 +165,17 @@ def user_resets_user_roles_via_api_if_required(user_emails: list) -> None:
 
     for user_email in user_emails:
         if user_email not in allowed_users:
-            raise AssertionError(f"`User emails` must contain only allowed users: {allowed_users}")
-        try:
-            user_ids = [_get_prerelease_user_details_via_api(user_email)["id"]]
-            _ = [user_removes_all_release_and_publication_roles_from_user(user_id) for user_id in user_ids]
-            BuiltIn().log(f"All userReleaseRoles & userPublicationRoles reset for user: {user_email}")
-        except TypeError or IndexError:
-            BuiltIn().log(f"User with email {user_email} does not exist in pre-release user list", "WARN")
+            raise AssertionError(
+                f"Not allowed to reset roles for {user_email}. Can only reset user roles for following users: {allowed_users}"
+            )
 
-            try:
-                user_ids = [_get_user_details_via_api(user_email)["id"]]
-                _ = [user_removes_all_release_and_publication_roles_from_user(user_id) for user_id in user_ids]
-                BuiltIn().log(f"All userReleaseRoles & userPublicationRoles reset for user: {user_email}")
-            except TypeError or IndexError:
-                BuiltIn().log(f"User with email {user_email} does not exist in user list", "WARN")
+        user = _get_user_details_via_api(user_email)
+
+        if not user:
+            user = _get_prerelease_user_details_via_api(user_email)
+            assert user, f"Failed to find user with email {user_email}"
+
+        user_removes_all_release_and_publication_roles_from_user(user["id"])
 
 
 def user_creates_test_release_via_api(
@@ -219,21 +215,35 @@ def delete_test_user(email: str):
 
 
 def _get_user_details_via_api(user_email: str):
-    users = admin_client.get("/api/user-management/users").json()
+    response = admin_client.get("/api/user-management/users")
+
+    assert response.status_code == 200, "Error when fetching users via api"
+
+    users = response.json()
 
     matching_users = list(filter(lambda user: user["email"] == user_email, users))
 
-    assert matching_users, f"Could not find user with email {user_email}"
+    if len(matching_users) == 0:
+        return None
+
+    assert len(matching_users) == 1, f"Should only have found one user with email {user_email}"
 
     return matching_users[0]
 
 
 def _get_prerelease_user_details_via_api(user_email: str):
-    users = admin_client.get("/api/user-management/pre-release").json()
+    response = admin_client.get("/api/user-management/pre-release")
+
+    assert response.status_code == 200, "Error when fetching prerelease users via api"
+
+    users = response.json()
 
     matching_users = list(filter(lambda user: user["email"] == user_email, users))
 
-    assert matching_users, f"Could not find user with email {user_email}"
+    if len(matching_users) == 0:
+        return None
+
+    assert len(matching_users) == 1, f"Should only have found one prerelease user with email {user_email}"
 
     return matching_users[0]
 


### PR DESCRIPTION
This PR fixes a UI test failure we were seeing due to an additional prerelease user being created on an environment alongside `ees-prerelease1` and `ees-prerelease2`.

Previously the tests passed as this would happen:

- `user_resets_user_roles_via_api_if_required` is called. This removes the global prerelease role for both ees-prerelease1 and ees-prerelease2. This means both users no longer appear in the list of prerelease users, but in the list of all other users.

- `_get_prerelease_user_details_via_api` is called. This results in `admin_client.get("/api/user-management/pre-release")` returning a 404 (as they are no other prerelease users) and so it throws an exception when `.json()` is called on the response.

- This 404 is caught and in the `except` block we go on to call `_get_user_details_via_api`, the prerelease users are found and the UI test continues as expected

However, if `user-management/pre-release` returned a 200 - because another prerelease user existed -  the response would be successfully parsed into json, resulting in us triggering `assert matching_users, f"Could not find user with email {user_email}"`.

I've removed the checks for exceptions and instead rely on checking the response status code directly to see if the user has been found amongst prerelease users or general users.

I also changed the backend so the user-management/pre-release endpoint no longer returns a 404 if there are no pre-release users. It now returns an JSON empty list.
