### PR TITLE
EES-5563 Fix not all meta deletions being considered as major version updates

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionMappingGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionMappingGeneratorExtensions.cs
@@ -40,6 +40,21 @@ public static class DataSetVersionMappingGeneratorExtensions
         FilterMappingPlan filterMappingPlan)
         => generator.ForInstance(s => s.SetFilterMappingPlan(filterMappingPlan));
 
+    public static Generator<DataSetVersionMapping> WithHasDeletedIndicators(
+        this Generator<DataSetVersionMapping> generator,
+        bool hasDeletedIndicators)
+        => generator.ForInstance(s => s.SetHasDeletedIndicators(hasDeletedIndicators));
+
+    public static Generator<DataSetVersionMapping> WithHasDeletedGeographicLevels(
+        this Generator<DataSetVersionMapping> generator,
+        bool hasDeletedGeographicLevels)
+        => generator.ForInstance(s => s.SetHasDeletedGeographicLevels(hasDeletedGeographicLevels));
+
+    public static Generator<DataSetVersionMapping> WithHasDeletedTimePeriods(
+        this Generator<DataSetVersionMapping> generator,
+        bool hasDeletedTimePeriods)
+        => generator.ForInstance(s => s.SetHasDeletedTimePeriods(hasDeletedTimePeriods));
+
     public static InstanceSetters<DataSetVersionMapping> SetDefaults(
         this InstanceSetters<DataSetVersionMapping> setters)
         => setters
@@ -76,12 +91,25 @@ public static class DataSetVersionMappingGeneratorExtensions
     public static InstanceSetters<DataSetVersionMapping> SetLocationMappingPlan(
         this InstanceSetters<DataSetVersionMapping> instanceSetter,
         LocationMappingPlan locationMappingPlan)
-        => instanceSetter
-            .Set(mapping => mapping.LocationMappingPlan, locationMappingPlan);
+        => instanceSetter.Set(mapping => mapping.LocationMappingPlan, locationMappingPlan);
 
     public static InstanceSetters<DataSetVersionMapping> SetFilterMappingPlan(
         this InstanceSetters<DataSetVersionMapping> instanceSetter,
         FilterMappingPlan filterMappingPlan)
-        => instanceSetter
-            .Set(mapping => mapping.FilterMappingPlan, filterMappingPlan);
+        => instanceSetter.Set(mapping => mapping.FilterMappingPlan, filterMappingPlan);
+
+    public static InstanceSetters<DataSetVersionMapping> SetHasDeletedIndicators(
+        this InstanceSetters<DataSetVersionMapping> instanceSetter,
+        bool hasDeletedIndicators)
+        => instanceSetter.Set(mapping => mapping.HasDeletedIndicators, hasDeletedIndicators);
+
+    public static InstanceSetters<DataSetVersionMapping> SetHasDeletedGeographicLevels(
+        this InstanceSetters<DataSetVersionMapping> instanceSetter,
+        bool hasDeletedGeographicLevels)
+        => instanceSetter.Set(mapping => mapping.HasDeletedGeographicLevels, hasDeletedGeographicLevels);
+
+    public static InstanceSetters<DataSetVersionMapping> SetHasDeletedTimePeriods(
+        this InstanceSetters<DataSetVersionMapping> instanceSetter,
+        bool hasDeletedTimePeriods)
+        => instanceSetter.Set(mapping => mapping.HasDeletedTimePeriods, hasDeletedTimePeriods);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionMapping.cs
@@ -28,6 +28,17 @@ public class DataSetVersionMapping : ICreatedUpdatedTimestamps<DateTimeOffset, D
 
     public bool FilterMappingsComplete { get; set; }
 
+    // Use boolean flags to describe meta types that have been deleted and cannot be
+    // changed via mapping currently. We can use this when calculating the version number.
+    // We've gone with this approach for simplicity and expedience, but we may need to
+    // migrate away from this approach later e.g. for indicator mappings.
+
+    public bool HasDeletedIndicators { get; set; }
+
+    public bool HasDeletedGeographicLevels { get; set; }
+
+    public bool HasDeletedTimePeriods { get; set; }
+
     public DateTimeOffset Created { get; set; }
 
     public DateTimeOffset? Updated { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20241013014815_EES5563_AddDeletedMetaFlagsToDataSetVersionMapping.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20241013014815_EES5563_AddDeletedMetaFlagsToDataSetVersionMapping.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
 {
     [DbContext(typeof(PublicDataDbContext))]
-    partial class PublicDataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241013014815_EES5563_AddDeletedMetaFlagsToDataSetVersionMapping")]
+    partial class EES5563_AddDeletedMetaFlagsToDataSetVersionMapping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20241013014815_EES5563_AddDeletedMetaFlagsToDataSetVersionMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20241013014815_EES5563_AddDeletedMetaFlagsToDataSetVersionMapping.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class EES5563_AddDeletedMetaFlagsToDataSetVersionMapping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "HasDeletedGeographicLevels",
+                table: "DataSetVersionMappings",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "HasDeletedIndicators",
+                table: "DataSetVersionMappings",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "HasDeletedTimePeriods",
+                table: "DataSetVersionMappings",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HasDeletedGeographicLevels",
+                table: "DataSetVersionMappings");
+
+            migrationBuilder.DropColumn(
+                name: "HasDeletedIndicators",
+                table: "DataSetVersionMappings");
+
+            migrationBuilder.DropColumn(
+                name: "HasDeletedTimePeriods",
+                table: "DataSetVersionMappings");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
@@ -197,6 +197,191 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
                 },
                 metaSummary.TimePeriodRange);
         }
+
+        [Fact]
+        public async Task Success_HasDeletedIndicators_True()
+        {
+            var initialVersionMeta = new DataSetVersionMeta
+            {
+                IndicatorMetas = DataFixture.DefaultIndicatorMeta().GenerateList(2),
+                GeographicLevelMeta = DataFixture.DefaultGeographicLevelMeta()
+                    .WithLevels(ProcessorTestData.AbsenceSchool.ExpectedGeographicLevels)
+            };
+
+            var (instanceId, _, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage(), initialVersionMeta);
+
+            await CreateMappings(instanceId);
+
+            var mapping = await GetDataSetVersionMapping(nextVersion);
+
+            Assert.True(mapping.HasDeletedIndicators);
+        }
+
+        [Fact]
+        public async Task Success_HasDeletedIndicators_SameIndicators_False()
+        {
+            var initialVersionMeta = new DataSetVersionMeta
+            {
+                IndicatorMetas = ProcessorTestData.AbsenceSchool.ExpectedIndicators,
+                GeographicLevelMeta = DataFixture.DefaultGeographicLevelMeta()
+                    .WithLevels(ProcessorTestData.AbsenceSchool.ExpectedGeographicLevels)
+            };
+
+            var (instanceId, _, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage(), initialVersionMeta);
+
+            await CreateMappings(instanceId);
+
+            var mapping = await GetDataSetVersionMapping(nextVersion);
+
+            Assert.False(mapping.HasDeletedIndicators);
+        }
+
+        [Fact]
+        public async Task Success_HasDeletedIndicators_NewIndicators_False()
+        {
+            var initialVersionMeta = new DataSetVersionMeta
+            {
+                IndicatorMetas = ProcessorTestData.AbsenceSchool.ExpectedIndicators[..2],
+                GeographicLevelMeta = DataFixture.DefaultGeographicLevelMeta()
+                    .WithLevels(ProcessorTestData.AbsenceSchool.ExpectedGeographicLevels)
+            };
+
+            var (instanceId, _, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage(), initialVersionMeta);
+
+            await CreateMappings(instanceId);
+
+            var mapping = await GetDataSetVersionMapping(nextVersion);
+
+            Assert.False(mapping.HasDeletedIndicators);
+        }
+
+        [Fact]
+        public async Task Success_HasDeletedGeographicLevels_True()
+        {
+            var initialVersionMeta = new DataSetVersionMeta
+            {
+                GeographicLevelMeta = DataFixture.DefaultGeographicLevelMeta()
+                    .WithLevels(
+                    [
+                        GeographicLevel.Country,
+                        GeographicLevel.Region,
+                        GeographicLevel.LocalAuthority,
+                        // Replaced by school in next version
+                        GeographicLevel.Institution
+                    ])
+            };
+
+            var (instanceId, _, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage(), initialVersionMeta);
+
+            await CreateMappings(instanceId);
+
+            var mapping = await GetDataSetVersionMapping(nextVersion);
+
+            Assert.True(mapping.HasDeletedGeographicLevels);
+        }
+
+        [Fact]
+        public async Task Success_HasDeletedGeographicLevels_SameGeographicLevels_False()
+        {
+            var initialVersionMeta = new DataSetVersionMeta
+            {
+                GeographicLevelMeta = DataFixture.DefaultGeographicLevelMeta()
+                    .WithLevels(ProcessorTestData.AbsenceSchool.ExpectedGeographicLevels)
+            };
+
+            var (instanceId, _, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage(), initialVersionMeta);
+
+            await CreateMappings(instanceId);
+
+            var mapping = await GetDataSetVersionMapping(nextVersion);
+
+            Assert.False(mapping.HasDeletedGeographicLevels);
+        }
+
+        [Fact]
+        public async Task Success_HasDeletedGeographicLevels_NewGeographicLevels_False()
+        {
+            var initialVersionMeta = new DataSetVersionMeta
+            {
+                GeographicLevelMeta = DataFixture.DefaultGeographicLevelMeta()
+                    .WithLevels(ProcessorTestData.AbsenceSchool.ExpectedGeographicLevels[..2])
+            };
+
+            var (instanceId, _, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage(), initialVersionMeta);
+
+            await CreateMappings(instanceId);
+
+            var mapping = await GetDataSetVersionMapping(nextVersion);
+
+            Assert.False(mapping.HasDeletedGeographicLevels);
+        }
+
+        [Fact]
+        public async Task Success_HasDeletedTimePeriods_True()
+        {
+            var initialVersionMeta = new DataSetVersionMeta
+            {
+                GeographicLevelMeta = DataFixture.DefaultGeographicLevelMeta()
+                    .WithLevels(ProcessorTestData.AbsenceSchool.ExpectedGeographicLevels),
+                TimePeriodMetas = DataFixture.DefaultTimePeriodMeta()
+                    .GenerateList(2)
+            };
+
+            var (instanceId, _, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage(), initialVersionMeta);
+
+            await CreateMappings(instanceId);
+
+            var mapping = await GetDataSetVersionMapping(nextVersion);
+
+            Assert.True(mapping.HasDeletedTimePeriods);
+        }
+
+        [Fact]
+        public async Task Success_HasDeletedTimePeriods_SameTimePeriods_False()
+        {
+            var initialVersionMeta = new DataSetVersionMeta
+            {
+                GeographicLevelMeta = DataFixture.DefaultGeographicLevelMeta()
+                    .WithLevels(ProcessorTestData.AbsenceSchool.ExpectedGeographicLevels),
+                TimePeriodMetas = ProcessorTestData.AbsenceSchool.ExpectedTimePeriods
+            };
+
+            var (instanceId, _, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage(), initialVersionMeta);
+
+            await CreateMappings(instanceId);
+
+            var mapping = await GetDataSetVersionMapping(nextVersion);
+
+            Assert.False(mapping.HasDeletedTimePeriods);
+        }
+
+        [Fact]
+        public async Task Success_HasDeletedTimePeriods_NewTimePeriods_False()
+        {
+            var initialVersionMeta = new DataSetVersionMeta
+            {
+                GeographicLevelMeta = DataFixture.DefaultGeographicLevelMeta()
+                    .WithLevels(ProcessorTestData.AbsenceSchool.ExpectedGeographicLevels),
+                TimePeriodMetas = ProcessorTestData.AbsenceSchool.ExpectedTimePeriods[..2]
+            };
+
+            var (instanceId, _, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage(), initialVersionMeta);
+
+            await CreateMappings(instanceId);
+
+            var mapping = await GetDataSetVersionMapping(nextVersion);
+
+            Assert.False(mapping.HasDeletedTimePeriods);
+        }
     }
 
     public class CreateMappingsLocationsTests(
@@ -1329,10 +1514,13 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
     }
 
     private async Task<(Guid instanceId, DataSetVersion initialVersion, DataSetVersion nextVersion)>
-        CreateNextDataSetVersionAndDataFiles(DataSetVersionImportStage importStage)
+        CreateNextDataSetVersionAndDataFiles(
+            DataSetVersionImportStage importStage,
+            DataSetVersionMeta? initialVersionMeta = null)
     {
         var (initialDataSetVersion, nextDataSetVersion, instanceId) =
             await CreateDataSetInitialAndNextVersion(
+                initialVersionMeta: initialVersionMeta ?? GetDefaultInitialDataSetVersionMeta(),
                 nextVersionImportStage: importStage,
                 nextVersionStatus: DataSetVersionStatus.Processing);
 
@@ -1363,6 +1551,15 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             .DataSetVersionMappings
             .Include(mapping => mapping.TargetDataSetVersion)
             .SingleAsync(mapping => mapping.TargetDataSetVersionId == nextVersion.Id);
+    }
+
+    private DataSetVersionMeta GetDefaultInitialDataSetVersionMeta()
+    {
+        return new DataSetVersionMeta
+        {
+            GeographicLevelMeta = DataFixture.DefaultGeographicLevelMeta()
+                .WithLevels(ProcessorTestData.AbsenceSchool.ExpectedGeographicLevels)
+        };
     }
 
     private async Task AssertCorrectDataSetVersionNumbers(DataSetVersionMapping mapping, string expectedVersion)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessNextDataSetVersionMappingsFunctionTests.cs
@@ -663,6 +663,69 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             Assert.Equal(Stage, savedImport.Stage);
             Assert.Equal(DataSetVersionStatus.Processing, savedImport.DataSetVersion.Status);
         }
+
+        [Fact]
+        public async Task Success_HasDeletedIndicators_MajorUpdate()
+        {
+            var (instanceId, originalVersion, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
+
+            DataSetVersionMapping mapping = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithHasDeletedIndicators(true);
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mapping));
+
+            await ApplyAutoMappings(instanceId);
+
+            var updatedMapping = await GetDataSetVersionMapping(nextVersion);
+
+            await AssertCorrectDataSetVersionNumbers(updatedMapping, "2.0.0");
+        }
+
+        [Fact]
+        public async Task Success_HasDeletedGeographicLevels_MajorUpdate()
+        {
+            var (instanceId, originalVersion, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
+
+            DataSetVersionMapping mapping = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithHasDeletedGeographicLevels(true);
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mapping));
+
+            await ApplyAutoMappings(instanceId);
+
+            var updatedMapping = await GetDataSetVersionMapping(nextVersion);
+
+            await AssertCorrectDataSetVersionNumbers(updatedMapping, "2.0.0");
+        }
+
+        [Fact]
+        public async Task Success_HasDeletedTimePeriods_MajorUpdate()
+        {
+            var (instanceId, originalVersion, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
+
+            DataSetVersionMapping mapping = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithHasDeletedTimePeriods(true);
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mapping));
+
+            await ApplyAutoMappings(instanceId);
+
+            var updatedMapping = await GetDataSetVersionMapping(nextVersion);
+
+            await AssertCorrectDataSetVersionNumbers(updatedMapping, "2.0.0");
+        }
     }
 
     public class ApplyAutoMappingsLocationsTests(
@@ -1087,6 +1150,120 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
             // All source options have auto-mapped candidates - minor version update.
             await AssertCorrectDataSetVersionNumbers(updatedMapping, "1.1.0");
         }
+
+        [Fact]
+        public async Task Complete_HasDeletedIndicators_MajorUpdate()
+        {
+            var (instanceId, originalVersion, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
+
+            DataSetVersionMapping mapping = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .DefaultLocationMappingPlan()
+                    .AddLevel(
+                        level: GeographicLevel.LocalAuthority,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping())
+                            .AddCandidate(
+                                targetKey: "location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())))
+                // Has deleted indicators that cannot be mapped
+                .WithHasDeletedIndicators(true);
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mapping));
+
+            await ApplyAutoMappings(instanceId);
+
+            var updatedMapping = await GetDataSetVersionMapping(nextVersion);
+
+            // Is an exact match but as there are deleted indicators so needs to be a major update.
+            await AssertCorrectDataSetVersionNumbers(updatedMapping, "2.0.0");
+        }
+
+        [Fact]
+        public async Task Complete_HasDeletedGeographicLevels_MajorUpdate()
+        {
+            var (instanceId, originalVersion, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
+
+            DataSetVersionMapping mapping = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .DefaultLocationMappingPlan()
+                    .AddLevel(
+                        level: GeographicLevel.LocalAuthority,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping())
+                            .AddCandidate(
+                                targetKey: "location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())))
+                // Has deleted geographic levels that cannot be mapped
+                .WithHasDeletedGeographicLevels(true);
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mapping));
+
+            await ApplyAutoMappings(instanceId);
+
+            var updatedMapping = await GetDataSetVersionMapping(nextVersion);
+
+            // Is an exact match but as there are deleted geographic levels so needs to be a major update.
+            await AssertCorrectDataSetVersionNumbers(updatedMapping, "2.0.0");
+        }
+
+        [Fact]
+        public async Task Complete_HasDeletedTimePeriods_MajorUpdate()
+        {
+            var (instanceId, originalVersion, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
+
+            DataSetVersionMapping mapping = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithLocationMappingPlan(DataFixture
+                    .DefaultLocationMappingPlan()
+                    .AddLevel(
+                        level: GeographicLevel.LocalAuthority,
+                        mappings: DataFixture
+                            .DefaultLocationLevelMappings()
+                            .AddMapping(
+                                sourceKey: "location-1-key",
+                                mapping: DataFixture
+                                    .DefaultLocationOptionMapping()
+                                    .WithSource(DataFixture.DefaultMappableLocationOption())
+                                    .WithNoMapping())
+                            .AddCandidate(
+                                targetKey: "location-1-key",
+                                candidate: DataFixture.DefaultMappableLocationOption())))
+                // Has deleted time periods that cannot be mapped
+                .WithHasDeletedTimePeriods(true);
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mapping));
+
+            await ApplyAutoMappings(instanceId);
+
+            var updatedMapping = await GetDataSetVersionMapping(nextVersion);
+
+            // Is an exact match but as there are deleted time periods so needs to be a major update.
+            await AssertCorrectDataSetVersionNumbers(updatedMapping, "2.0.0");
+        }
     }
 
     public class ApplyAutoMappingsFiltersTests(
@@ -1094,7 +1271,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
         : ApplyAutoMappingsTests(fixture)
     {
         [Fact]
-        public async Task PartiallyComplete()
+        public async Task PartiallyComplete_MajorUpdate()
         {
             var (instanceId, originalVersion, nextVersion) =
                 await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
@@ -1204,7 +1381,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
         }
 
         [Fact]
-        public async Task Complete_ExactMatch()
+        public async Task Complete_ExactMatch_MinorUpdate()
         {
             var (instanceId, originalVersion, nextVersion) =
                 await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
@@ -1312,7 +1489,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
         }
 
         [Fact]
-        public async Task Complete_AllSourcesMapped_OtherUnmappedCandidatesExist()
+        public async Task Complete_AllSourcesMapped_NewCandidatesExist_MinorUpdate()
         {
             var (instanceId, originalVersion, nextVersion) =
                 await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
@@ -1389,7 +1566,7 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
         // and their child filter options with mapping type of AutoNone should not count towards
         // the calculation of the FilterMappingsComplete flag.
         [Fact]
-        public async Task Complete_SomeFiltersAutoNone()
+        public async Task Complete_SomeFiltersAutoNone_MajorUpdate()
         {
             var (instanceId, originalVersion, nextVersion) =
                 await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
@@ -1474,6 +1651,111 @@ public abstract class ProcessNextDataSetVersionMappingsFunctionTests(
 
             // Some source filter options have no equivalent candidate to be mapped to, thus
             // resulting in a major version update.
+            await AssertCorrectDataSetVersionNumbers(updatedMapping, "2.0.0");
+        }
+
+        [Fact]
+        public async Task Complete_HasDeletedIndicators_MajorUpdate()
+        {
+            var (instanceId, originalVersion, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
+
+            DataSetVersionMapping mapping = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithNoMapping()
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping()))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())))
+                // Has deleted indicators that cannot be mapped
+                .WithHasDeletedIndicators(true);
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mapping));
+
+            await ApplyAutoMappings(instanceId);
+
+            var updatedMapping = await GetDataSetVersionMapping(nextVersion);
+
+            // Is an exact match but as there are deleted indicators so needs to be a major update.
+            await AssertCorrectDataSetVersionNumbers(updatedMapping, "2.0.0");
+        }
+
+        [Fact]
+        public async Task Complete_HasDeletedGeographicLevels_MajorUpdate()
+        {
+            var (instanceId, originalVersion, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
+
+            DataSetVersionMapping mapping = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithNoMapping()
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping()))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())))
+                // Has deleted geographic levels that cannot be mapped
+                .WithHasDeletedGeographicLevels(true);
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mapping));
+
+            await ApplyAutoMappings(instanceId);
+
+            var updatedMapping = await GetDataSetVersionMapping(nextVersion);
+
+            // Is an exact match but as there are deleted geographic levels so needs to be a major update.
+            await AssertCorrectDataSetVersionNumbers(updatedMapping, "2.0.0");
+        }
+
+        [Fact]
+        public async Task Complete_HasDeletedTimePeriods_MajorUpdate()
+        {
+            var (instanceId, originalVersion, nextVersion) =
+                await CreateNextDataSetVersionAndDataFiles(Stage.PreviousStage());
+
+            DataSetVersionMapping mapping = DataFixture
+                .DefaultDataSetVersionMapping()
+                .WithSourceDataSetVersionId(originalVersion.Id)
+                .WithTargetDataSetVersionId(nextVersion.Id)
+                .WithFilterMappingPlan(DataFixture
+                    .DefaultFilterMappingPlan()
+                    .AddFilterMapping("filter-1-key", DataFixture
+                        .DefaultFilterMapping()
+                        .WithNoMapping()
+                        .AddOptionMapping("filter-1-option-1-key", DataFixture
+                            .DefaultFilterOptionMapping()
+                            .WithNoMapping()))
+                    .AddFilterCandidate("filter-1-key", DataFixture
+                        .DefaultFilterMappingCandidate()
+                        .AddOptionCandidate("filter-1-option-1-key", DataFixture
+                            .DefaultMappableFilterOption())))
+                // Has deleted time periods that cannot be mapped
+                .WithHasDeletedTimePeriods(true);
+
+            await AddTestData<PublicDataDbContext>(context => context.DataSetVersionMappings.Add(mapping));
+
+            await ApplyAutoMappings(instanceId);
+
+            var updatedMapping = await GetDataSetVersionMapping(nextVersion);
+
+            // Is an exact match but as there are deleted time periods so needs to be a major update.
             await AssertCorrectDataSetVersionNumbers(updatedMapping, "2.0.0");
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Model/DataSertVersionMappingMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Model/DataSertVersionMappingMeta.cs
@@ -1,8 +1,0 @@
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
-
-namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Model;
-
-public record DataSetVersionMappingMeta(
-    IDictionary<FilterMeta, List<FilterOptionMeta>> Filters,
-    IDictionary<LocationMeta, List<LocationOptionMetaRow>> Locations,
-    DataSetVersionMetaSummary MetaSummary);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Models/DataSetVersionMappingMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Models/DataSetVersionMappingMeta.cs
@@ -1,0 +1,18 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Models;
+
+public record DataSetVersionMappingMeta
+{
+    public required IDictionary<FilterMeta, List<FilterOptionMeta>> Filters { get; init; }
+
+    public required IDictionary<LocationMeta, List<LocationOptionMetaRow>> Locations { get; init; }
+
+    public required DataSetVersionMetaSummary MetaSummary { get; init; }
+
+    public required IList<IndicatorMeta> Indicators { get; init; }
+
+    public required GeographicLevelMeta GeographicLevel { get; init; }
+
+    public required IList<TimePeriodMeta> TimePeriods { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/GeographicLevelMetaRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/GeographicLevelMetaRepository.cs
@@ -50,11 +50,10 @@ public class GeographicLevelMetaRepository(
             .OrderBy(EnumToEnumLabelConverter<GeographicLevel>.ToProvider)
             .ToList();
 
-        var meta = new GeographicLevelMeta
+        return new GeographicLevelMeta
         {
             DataSetVersionId = dataSetVersion.Id,
             Levels = geographicLevels
         };
-        return meta;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/Interfaces/IIndicatorMetaRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Repository/Interfaces/IIndicatorMetaRepository.cs
@@ -5,6 +5,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Repos
 
 public interface IIndicatorMetaRepository
 {
+    Task<IList<IndicatorMeta>> ReadIndicatorMetas(
+        IDuckDbConnection duckDbConnection,
+        DataSetVersion dataSetVersion,
+        IReadOnlySet<string> allowedColumns,
+        CancellationToken cancellationToken = default);
+
     Task CreateIndicatorMetas(
         IDuckDbConnection duckDbConnection,
         DataSetVersion dataSetVersion,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetMetaService.cs
@@ -3,7 +3,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Models;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Services.Interfaces;
@@ -27,7 +26,7 @@ public class DataSetMetaService(
     ITimePeriodsDuckDbRepository timePeriodsDuckDbRepository
 ) : IDataSetMetaService
 {
-    public async Task<DataSetVersionMappingMeta> ReadDataSetVersionMetaForMappings(
+    public async Task<DataSetVersionMappingMeta> ReadDataSetVersionMappingMeta(
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default)
     {
@@ -58,6 +57,12 @@ public class DataSetMetaService(
             dataSetVersion,
             cancellationToken);
 
+        var indicatorMetas = await indicatorMetaRepository.ReadIndicatorMetas(
+            duckDbConnection,
+            dataSetVersion,
+            allowedColumns,
+            cancellationToken);
+
         var locationMetas = await locationMetaRepository.ReadLocationMetas(
             duckDbConnection,
             dataSetVersion,
@@ -75,7 +80,15 @@ public class DataSetMetaService(
             allowedColumns,
             geographicLevelMeta);
 
-        return new DataSetVersionMappingMeta(filterMetas, locationMetas, metaSummary);
+        return new DataSetVersionMappingMeta
+        {
+            Filters = filterMetas,
+            Locations = locationMetas,
+            MetaSummary = metaSummary,
+            Indicators = indicatorMetas,
+            GeographicLevel = geographicLevelMeta,
+            TimePeriods = timePeriodMetas
+        };
     }
 
     public async Task CreateDataSetVersionMeta(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
@@ -101,17 +101,17 @@ internal class DataSetVersionMappingService(
         Guid nextDataSetVersionId,
         CancellationToken cancellationToken = default)
     {
-        var mappings = await publicDataDbContext
+        var mapping = await publicDataDbContext
             .DataSetVersionMappings
             .Include(mapping => mapping.TargetDataSetVersion)
             .SingleAsync(
                 mapping => mapping.TargetDataSetVersionId == nextDataSetVersionId,
                 cancellationToken);
 
-        AutoMapLocations(mappings.LocationMappingPlan);
-        AutoMapFilters(mappings.FilterMappingPlan);
+        AutoMapLocations(mapping.LocationMappingPlan);
+        AutoMapFilters(mapping.FilterMappingPlan);
 
-        mappings.LocationMappingsComplete = !mappings.LocationMappingPlan
+        mapping.LocationMappingsComplete = !mapping.LocationMappingPlan
             .Levels
             // Ignore any levels where candidates or mappings are empty as this means the level
             // has been added or deleted from the data set and is not a mappable change.
@@ -121,41 +121,62 @@ internal class DataSetVersionMappingService(
 
         // Note that currently within the UI there is no way to resolve unmapped filters, and therefore we
         // omit checking the status of filters that have a mapping of AutoNone.
-        mappings.FilterMappingsComplete = !mappings.FilterMappingPlan
+        mapping.FilterMappingsComplete = !mapping.FilterMappingPlan
             .Mappings
             .Where(filterMapping => filterMapping.Value.Type != MappingType.AutoNone)
             .SelectMany(filterMapping => filterMapping.Value.OptionMappings)
             .Any(optionMapping => IncompleteMappingTypes.Contains(optionMapping.Value.Type));
 
-        var hasMajorLocationChange =  mappings.LocationMappingPlan
-            .Levels
-            .Any(level => level.Value.Candidates.Count == 0
-                          || level.Value.Mappings
-                              .Any(optionMapping => NoMappingTypes.Contains(optionMapping.Value.Type)));
-
-        var hasMajorFilterUpdate = mappings.FilterMappingPlan
-            .Mappings
-            .SelectMany(filterMapping => filterMapping.Value.OptionMappings)
-            .Any(optionMapping => NoMappingTypes.Contains(optionMapping.Value.Type));
-
-        var isMajorVersionUpdate = hasMajorLocationChange || hasMajorFilterUpdate;
-
-        if (isMajorVersionUpdate)
+        if (IsMajorVersionUpdate(mapping))
         {
-            mappings.TargetDataSetVersion.VersionMajor += 1;
-            mappings.TargetDataSetVersion.VersionMinor = 0;
+            mapping.TargetDataSetVersion.VersionMajor += 1;
+            mapping.TargetDataSetVersion.VersionMinor = 0;
         }
 
-        publicDataDbContext.DataSetVersionMappings.Update(mappings);
+        publicDataDbContext.DataSetVersionMappings.Update(mapping);
         await publicDataDbContext.SaveChangesAsync(cancellationToken);
 
         var releaseFile = await contentDbContext.ReleaseFiles
-            .Where(rf => rf.Id == mappings.TargetDataSetVersion.Release.ReleaseFileId)
+            .Where(rf => rf.Id == mapping.TargetDataSetVersion.Release.ReleaseFileId)
             .SingleAsync(cancellationToken);
 
-        releaseFile.PublicApiDataSetVersion = mappings.TargetDataSetVersion.SemVersion();
+        releaseFile.PublicApiDataSetVersion = mapping.TargetDataSetVersion.SemVersion();
 
         await contentDbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static bool IsMajorVersionUpdate(DataSetVersionMapping mapping)
+    {
+        if (mapping.HasDeletedIndicators
+            || mapping.HasDeletedGeographicLevels
+            || mapping.HasDeletedTimePeriods)
+        {
+            return true;
+        }
+
+        var hasDeletedLocationLevels = mapping.LocationMappingPlan
+            .Levels
+            .Any(level => level.Value.Candidates.Count == 0);
+
+        if (hasDeletedLocationLevels)
+        {
+            return true;
+        }
+
+        var hasUnmappedLocationOptions =  mapping.LocationMappingPlan
+            .Levels
+            .Any(level => level.Value.Mappings
+                .Any(optionMapping => NoMappingTypes.Contains(optionMapping.Value.Type)));
+
+        if (hasUnmappedLocationOptions)
+        {
+            return true;
+        }
+
+        return mapping.FilterMappingPlan
+            .Mappings
+            .SelectMany(filterMapping => filterMapping.Value.OptionMappings)
+            .Any(optionMapping => NoMappingTypes.Contains(optionMapping.Value.Type));
     }
 
     public Task<Either<ActionResult, Tuple<DataSetVersion, DataSetVersionImport>>> GetManualMappingVersionAndImport(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/Interfaces/IDataSetMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/Interfaces/IDataSetMetaService.cs
@@ -1,10 +1,10 @@
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Models;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Services.Interfaces;
 
 public interface IDataSetMetaService
 {
-    Task<DataSetVersionMappingMeta> ReadDataSetVersionMetaForMappings(
+    Task<DataSetVersionMappingMeta> ReadDataSetVersionMappingMeta(
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
:warning: Depends on #5331

---

This PR primarily fixes deletions of indicator, geographic level and time periods previously not being considered by the data set's version number as a major update.

We have implemented this as new flag columns on `DataSetVersionMapping` in the form of:

- `HasDeletedIndicators`
- `HasDeletedGeographicLevels`
- `HasDeletedTimePeriods`

This is not necessarily an optimum way of implementing this as a better solution may be to structure this information in a similar to the mappings for filters and locations. Unfortunately, we're quite time constrained to get this working for private testing and have gone with this as a simpler solution for now.

In the future, we'll probably need to replace these columns if we want to implement things like indicator mappings.

## Related changes

- Fixed the read-only `FilterMetaRepository.ReadFilterMetas` method incorrectly incrementing the meta ID sequence in the database.