### PR TITLE
EES-5572 Various tweaks to changelog page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
@@ -1141,12 +1141,12 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
             // Addition
             Assert.Null(minorChanges[0].PreviousState);
             Assert.NotNull(minorChanges[0].CurrentState);
-            Assert.Equal(GeographicLevel.Region, minorChanges[0].CurrentState!.Code);
+            Assert.Equal(GeographicLevel.LocalAuthority, minorChanges[0].CurrentState!.Code);
 
             // Addition
             Assert.Null(minorChanges[1].PreviousState);
             Assert.NotNull(minorChanges[1].CurrentState);
-            Assert.Equal(GeographicLevel.LocalAuthority, minorChanges[1].CurrentState!.Code);
+            Assert.Equal(GeographicLevel.Region, minorChanges[1].CurrentState!.Code);
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetVersionChangeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetVersionChangeService.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Extensions;
@@ -194,12 +195,14 @@ public class DataSetVersionChangeService(
         [
             ..currentLevels
                 .Where(level => !previousLevels.Contains(level))
+                .OrderBy(level => level.GetEnumLabel())
                 .Select(level => new GeographicLevelChangeViewModel
                 {
                     CurrentState = GeographicLevelViewModel.Create(level),
                 }),
             ..previousLevels
                 .Where(level => !currentLevels.Contains(level))
+                .OrderBy(level => level.GetEnumLabel())
                 .Select(level => new GeographicLevelChangeViewModel
                 {
                     PreviousState = GeographicLevelViewModel.Create(level),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionChangeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionChangeService.cs
@@ -363,7 +363,7 @@ internal class DataSetVersionChangeService(PublicDataDbContext publicDataDbConte
 
         foreach (var (indicatorPublicId, newIndicator) in newMetas)
         {
-            if (!oldMetas.TryGetValue(indicatorPublicId, out var oldIndicator))
+            if (!oldMetas.TryGetValue(indicatorPublicId, out _))
             {
                 // Indicator added
                 metaAdditions.Add(new IndicatorMetaChange
@@ -407,7 +407,7 @@ internal class DataSetVersionChangeService(PublicDataDbContext publicDataDbConte
 
         var timePeriodMetaDeletions = oldTimePeriodMetas
             .Except(newTimePeriodMetas, TimePeriodMeta.CodePeriodComparer)
-            .OrderBy(timePeriodMeta => timePeriodMeta.Period)
+            .NaturalOrderBy(timePeriodMeta => timePeriodMeta.Period)
             .ThenBy(timePeriodMeta => timePeriodMeta.Code)
             .Select(timePeriodMeta => new TimePeriodMetaChange
             {
@@ -419,7 +419,7 @@ internal class DataSetVersionChangeService(PublicDataDbContext publicDataDbConte
 
         var timePeriodMetaAdditions = newTimePeriodMetas
             .Except(oldTimePeriodMetas, TimePeriodMeta.CodePeriodComparer)
-            .OrderBy(timePeriodMeta => timePeriodMeta.Period)
+            .NaturalOrderBy(timePeriodMeta => timePeriodMeta.Period)
             .ThenBy(timePeriodMeta => timePeriodMeta.Code)
             .Select(timePeriodMeta => new TimePeriodMetaChange
             {
@@ -463,7 +463,7 @@ internal class DataSetVersionChangeService(PublicDataDbContext publicDataDbConte
             .SingleAsync(m => m.DataSetVersionId == dataSetVersionId, cancellationToken);
     }
 
-    private async Task<IReadOnlyDictionary<string, IndicatorMeta>> GetIndicatorMetas(
+    private async Task<Dictionary<string, IndicatorMeta>> GetIndicatorMetas(
         Guid dataSetVersionId,
         CancellationToken cancellationToken)
     {

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetChangelogPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetChangelogPage.test.tsx
@@ -71,14 +71,24 @@ describe('ReleaseApiDataSetChangelogPage', () => {
     majorChanges: {
       filters: [
         {
-          previousState: { id: 'filter-1', label: 'Filter 1', hint: '' },
+          previousState: {
+            id: 'filter-1',
+            column: 'filter_1',
+            label: 'Filter 1',
+            hint: '',
+          },
         },
       ],
     },
     minorChanges: {
       filters: [
         {
-          currentState: { id: 'filter-2', label: 'Filter 2', hint: '' },
+          currentState: {
+            id: 'filter-2',
+            column: 'filter_2',
+            label: 'Filter 2',
+            hint: '',
+          },
         },
       ],
     },
@@ -115,7 +125,7 @@ describe('ReleaseApiDataSetChangelogPage', () => {
     const minorChanges = within(screen.getByTestId('minor-changes'));
 
     expect(minorChanges.getByTestId('added-filters')).toHaveTextContent(
-      'Filter 2 (id: filter-2)',
+      'Filter 2 (id: filter-2, column: filter_2)',
     );
   });
 
@@ -142,7 +152,7 @@ describe('ReleaseApiDataSetChangelogPage', () => {
     const majorChanges = within(screen.getByTestId('major-changes'));
 
     expect(majorChanges.getByTestId('deleted-filters')).toHaveTextContent(
-      'Filter 1 (id: filter-1)',
+      'Filter 1 (id: filter-1, column: filter_1)',
     );
 
     expect(
@@ -152,7 +162,7 @@ describe('ReleaseApiDataSetChangelogPage', () => {
     const minorChanges = within(screen.getByTestId('minor-changes'));
 
     expect(minorChanges.getByTestId('added-filters')).toHaveTextContent(
-      'Filter 2 (id: filter-2)',
+      'Filter 2 (id: filter-2, column: filter_2)',
     );
   });
 

--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/ChangeSection.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/ChangeSection.tsx
@@ -1,7 +1,5 @@
 import ChangeList from '@common/modules/data-catalogue/components/ChangeList';
 import { ChangeSet } from '@common/services/types/apiDataSetChanges';
-import naturalOrderBy from '@common/utils/array/naturalOrderBy';
-import orderBy from 'lodash/orderBy';
 import React from 'react';
 
 interface Props {
@@ -9,57 +7,15 @@ interface Props {
 }
 
 export default function ChangeSection({ changes }: Props) {
-  const filters = naturalOrderBy(
-    changes.filters ?? [],
-    filter => filter.previousState?.label ?? filter.currentState?.label ?? '',
-  );
-
-  const filterOptions = naturalOrderBy(
-    changes.filterOptions ?? [],
-    group => group.filter.label,
-  );
-
-  const geographicLevels = orderBy(
-    changes.geographicLevels ?? [],
-    level => level.previousState?.label ?? level.currentState?.label,
-  );
-
-  const indicators = naturalOrderBy(
-    changes.indicators ?? [],
-    indicator =>
-      indicator.previousState?.label ?? indicator.currentState?.label ?? '',
-  );
-
-  const locationGroups = orderBy(
-    changes.locationGroups ?? [],
-    group =>
-      group.previousState?.level.label ?? group.currentState?.level.label,
-  );
-
-  const locationOptions = orderBy(
-    changes.locationOptions ?? [],
-    group => group.level.label,
-  );
-
-  const timePeriods = naturalOrderBy(
-    changes.timePeriods ?? [],
-    timePeriod =>
-      timePeriod.previousState?.label ?? timePeriod.currentState?.label ?? '',
-  );
-
   return (
     <>
-      <ChangeList changes={filters} metaType="filters" />
+      <ChangeList changes={changes.filters} metaType="filters" />
 
-      {filterOptions.map(group => {
+      {changes.filterOptions?.map(group => {
         return (
           <ChangeList
             key={group.filter.id}
-            changes={orderBy(
-              group.options,
-              option =>
-                option.previousState?.label ?? option?.currentState?.label,
-            )}
+            changes={group.options}
             metaType="filterOptions"
             metaTypeLabel={`${group.filter.label} filter options`}
             testId={`filterOptions-${group.filter.id}`}
@@ -67,21 +23,20 @@ export default function ChangeSection({ changes }: Props) {
         );
       })}
 
-      <ChangeList changes={geographicLevels} metaType="geographicLevels" />
+      <ChangeList
+        changes={changes.geographicLevels}
+        metaType="geographicLevels"
+      />
 
-      <ChangeList changes={indicators} metaType="indicators" />
+      <ChangeList changes={changes.indicators} metaType="indicators" />
 
-      <ChangeList changes={locationGroups} metaType="locationGroups" />
+      <ChangeList changes={changes.locationGroups} metaType="locationGroups" />
 
-      {locationOptions.map(group => {
+      {changes.locationOptions?.map(group => {
         return (
           <ChangeList
             key={group.level.code}
-            changes={orderBy(
-              group.options,
-              option =>
-                option.previousState?.label ?? option?.currentState?.label,
-            )}
+            changes={group.options}
             metaType="locationOptions"
             metaTypeLabel={`${group.level.label} location options`}
             testId={`locationOptions-${group.level.code}`}
@@ -89,7 +44,7 @@ export default function ChangeSection({ changes }: Props) {
         );
       })}
 
-      <ChangeList changes={timePeriods} metaType="timePeriods" />
+      <ChangeList changes={changes.timePeriods} metaType="timePeriods" />
     </>
   );
 }

--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/FilterChangeLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/FilterChangeLabel.tsx
@@ -13,7 +13,8 @@ export default function FilterChangeLabel({
   if (previousState && currentState) {
     return (
       <>
-        {previousState.label} (id: <code>{previousState.id}</code>):
+        {previousState.label} (id: <code>{previousState.id}</code>, column:{' '}
+        <code>{previousState.column}</code>):
         <ul>
           {previousState.label !== currentState.label && (
             <li>label changed to: {currentState.label}</li>
@@ -21,6 +22,11 @@ export default function FilterChangeLabel({
           {previousState.id !== currentState.id && (
             <li>
               id changed to: <code>{currentState.id}</code>
+            </li>
+          )}
+          {previousState.column !== currentState.column && (
+            <li>
+              column changed to: <code>{currentState.column}</code>
             </li>
           )}
           {previousState.hint !== currentState.hint && (
@@ -39,7 +45,8 @@ export default function FilterChangeLabel({
 
   return (
     <>
-      {state.label} (id: <code>{state.id}</code>)
+      {state.label} (id: <code>{state.id}</code>, column:{' '}
+      <code>{state.column}</code>)
     </>
   );
 }

--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/IndicatorChangeLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/IndicatorChangeLabel.tsx
@@ -13,7 +13,8 @@ export default function IndicatorChangeLabel({
   if (previousState && currentState) {
     return (
       <>
-        {previousState.label} (id: <code>{previousState.id}</code>):
+        {previousState.label} (id: <code>{previousState.id}</code>, column:{' '}
+        <code>{previousState.column}</code>):
         <ul>
           {previousState.label !== currentState.label && (
             <li>label changed to: {currentState.label}</li>
@@ -21,6 +22,11 @@ export default function IndicatorChangeLabel({
           {previousState.id !== currentState.id && (
             <li>
               id changed to: <code>{currentState.id}</code>
+            </li>
+          )}
+          {previousState.column !== currentState.column && (
+            <li>
+              column changed to: <code>{currentState.column}</code>
             </li>
           )}
           {previousState.unit !== currentState.unit && (

--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/__tests__/ApiDataSetChangelog.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/__tests__/ApiDataSetChangelog.test.tsx
@@ -9,7 +9,14 @@ describe('ApiDataSetChangelog', () => {
         version="2.0"
         majorChanges={{
           filters: [
-            { previousState: { id: 'filter-1', label: 'Filter 1', hint: '' } },
+            {
+              previousState: {
+                id: 'filter-1',
+                column: 'filter_1',
+                label: 'Filter 1',
+                hint: '',
+              },
+            },
           ],
         }}
         minorChanges={{}}
@@ -33,7 +40,9 @@ describe('ApiDataSetChangelog', () => {
     ).getAllByRole('listitem');
 
     expect(deletedFilters).toHaveLength(1);
-    expect(deletedFilters[0]).toHaveTextContent('Filter 1 (id: filter-1)');
+    expect(deletedFilters[0]).toHaveTextContent(
+      'Filter 1 (id: filter-1, column: filter_1)',
+    );
 
     // No minor changes
     expect(screen.queryByTestId('minor-changes')).not.toBeInTheDocument();
@@ -46,7 +55,14 @@ describe('ApiDataSetChangelog', () => {
         majorChanges={{}}
         minorChanges={{
           filters: [
-            { currentState: { id: 'filter-2', label: 'Filter 2', hint: '' } },
+            {
+              currentState: {
+                id: 'filter-2',
+                column: 'filter_2',
+                label: 'Filter 2',
+                hint: '',
+              },
+            },
           ],
         }}
       />,
@@ -73,7 +89,9 @@ describe('ApiDataSetChangelog', () => {
 
     expect(addedFilters).toHaveLength(1);
 
-    expect(addedFilters[0]).toHaveTextContent('Filter 2 (id: filter-2)');
+    expect(addedFilters[0]).toHaveTextContent(
+      'Filter 2 (id: filter-2, column: filter_2)',
+    );
   });
 
   test('renders major and minor changes', () => {
@@ -82,12 +100,26 @@ describe('ApiDataSetChangelog', () => {
         version="2.0"
         majorChanges={{
           filters: [
-            { previousState: { id: 'filter-1', label: 'Filter 1', hint: '' } },
+            {
+              previousState: {
+                id: 'filter-1',
+                column: 'filter_1',
+                label: 'Filter 1',
+                hint: '',
+              },
+            },
           ],
         }}
         minorChanges={{
           filters: [
-            { currentState: { id: 'filter-2', label: 'Filter 2', hint: '' } },
+            {
+              currentState: {
+                id: 'filter-2',
+                column: 'filter_2',
+                label: 'Filter 2',
+                hint: '',
+              },
+            },
           ],
         }}
       />,
@@ -110,7 +142,9 @@ describe('ApiDataSetChangelog', () => {
     ).getAllByRole('listitem');
 
     expect(deletedFilters).toHaveLength(1);
-    expect(deletedFilters[0]).toHaveTextContent('Filter 1 (id: filter-1)');
+    expect(deletedFilters[0]).toHaveTextContent(
+      'Filter 1 (id: filter-1, column: filter_1)',
+    );
 
     const minorChanges = within(screen.getByTestId('minor-changes'));
 
@@ -129,6 +163,8 @@ describe('ApiDataSetChangelog', () => {
     ).getAllByRole('listitem');
 
     expect(addedFilters).toHaveLength(1);
-    expect(addedFilters[0]).toHaveTextContent('Filter 2 (id: filter-2)');
+    expect(addedFilters[0]).toHaveTextContent(
+      'Filter 2 (id: filter-2, column: filter_2)',
+    );
   });
 });

--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/__tests__/ChangeSection.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/__tests__/ChangeSection.test.tsx
@@ -7,8 +7,12 @@ describe('ChangeSection', () => {
   test('renders filter changes only', () => {
     const testChanges: ChangeSet = {
       filters: [
-        { previousState: { id: 'filter-2', label: 'Filter 2', hint: '' } },
         { previousState: { id: 'filter-1', label: 'Filter 1', hint: '' } },
+        { previousState: { id: 'filter-2', label: 'Filter 2', hint: '' } },
+        {
+          previousState: { id: 'filter-3', label: 'Filter 3', hint: '' },
+          currentState: { id: 'filter-3-updated', label: 'Filter 3', hint: '' },
+        },
         {
           previousState: {
             id: 'filter-4',
@@ -21,12 +25,8 @@ describe('ChangeSection', () => {
             hint: 'Filter 4 hint updated',
           },
         },
-        {
-          previousState: { id: 'filter-3', label: 'Filter 3', hint: '' },
-          currentState: { id: 'filter-3-updated', label: 'Filter 3', hint: '' },
-        },
-        { currentState: { id: 'filter-6', label: 'Filter 6', hint: '' } },
         { currentState: { id: 'filter-5', label: 'Filter 5', hint: '' } },
+        { currentState: { id: 'filter-6', label: 'Filter 6', hint: '' } },
       ],
     };
 
@@ -71,8 +71,15 @@ describe('ChangeSection', () => {
         {
           filter: { id: 'filter-1', label: 'Filter 1', hint: '' },
           options: [
-            { previousState: { id: 'filter-opt-2', label: 'Filter option 2' } },
             { previousState: { id: 'filter-opt-1', label: 'Filter option 1' } },
+            { previousState: { id: 'filter-opt-2', label: 'Filter option 2' } },
+            {
+              previousState: { id: 'filter-opt-3', label: 'Filter option 3' },
+              currentState: {
+                id: 'filter-opt-3-updated',
+                label: 'Filter option 3',
+              },
+            },
             {
               previousState: { id: 'filter-opt-4', label: 'Filter option 4' },
               currentState: {
@@ -81,15 +88,8 @@ describe('ChangeSection', () => {
                 isAggregate: true,
               },
             },
-            {
-              previousState: { id: 'filter-opt-3', label: 'Filter option 3' },
-              currentState: {
-                id: 'filter-opt-3-updated',
-                label: 'Filter option 3',
-              },
-            },
-            { currentState: { id: 'filter-opt-6', label: 'Filter option 6' } },
             { currentState: { id: 'filter-opt-5', label: 'Filter option 5' } },
+            { currentState: { id: 'filter-opt-6', label: 'Filter option 6' } },
           ],
         },
         {
@@ -197,18 +197,18 @@ describe('ChangeSection', () => {
   test('renders geographic level changes only', () => {
     const testChanges: ChangeSet = {
       geographicLevels: [
-        { previousState: { code: 'WARD', label: 'Ward' } },
         { previousState: { code: 'NAT', label: 'National' } },
-        {
-          previousState: { code: 'OA', label: 'Opportunity area' },
-          currentState: { code: 'PA', label: 'Planning area' },
-        },
+        { previousState: { code: 'WARD', label: 'Ward' } },
         {
           previousState: { code: 'LA', label: 'Local authority' },
           currentState: { code: 'LAD', label: 'Local authority district' },
         },
-        { currentState: { code: 'REG', label: 'Regional' } },
+        {
+          previousState: { code: 'OA', label: 'Opportunity area' },
+          currentState: { code: 'PA', label: 'Planning area' },
+        },
         { currentState: { code: 'NAT', label: 'National' } },
+        { currentState: { code: 'REG', label: 'Regional' } },
       ],
     };
 
@@ -254,8 +254,8 @@ describe('ChangeSection', () => {
   test('renders indicators changes only', () => {
     const testChanges: ChangeSet = {
       indicators: [
-        { previousState: { id: 'indicator-2', label: 'Indicator 2' } },
         { previousState: { id: 'indicator-1', label: 'Indicator 1' } },
+        { previousState: { id: 'indicator-2', label: 'Indicator 2' } },
         {
           currentState: { id: 'indicator-4', label: 'Indicator 3' },
           previousState: { id: 'indicator-3', label: 'Indicator 3' },
@@ -268,8 +268,8 @@ describe('ChangeSection', () => {
           },
           previousState: { id: 'indicator-5', label: 'Indicator 5' },
         },
-        { currentState: { id: 'indicator-7', label: 'Indicator 7' } },
         { currentState: { id: 'indicator-6', label: 'Indicator 6' } },
+        { currentState: { id: 'indicator-7', label: 'Indicator 7' } },
       ],
     };
 
@@ -313,20 +313,20 @@ describe('ChangeSection', () => {
   test('renders location group changes only', () => {
     const testChanges: ChangeSet = {
       locationGroups: [
-        { previousState: { level: { code: 'WARD', label: 'Ward' } } },
         { previousState: { level: { code: 'INST', label: 'Institution' } } },
-        {
-          previousState: { level: { code: 'OA', label: 'Opportunity area' } },
-          currentState: { level: { code: 'PA', label: 'Planning area' } },
-        },
+        { previousState: { level: { code: 'WARD', label: 'Ward' } } },
         {
           previousState: { level: { code: 'LA', label: 'Local authority' } },
           currentState: {
             level: { code: 'LAD', label: 'Local authority district' },
           },
         },
-        { currentState: { level: { code: 'REG', label: 'Regional' } } },
+        {
+          previousState: { level: { code: 'OA', label: 'Opportunity area' } },
+          currentState: { level: { code: 'PA', label: 'Planning area' } },
+        },
         { currentState: { level: { code: 'NAT', label: 'National' } } },
+        { currentState: { level: { code: 'REG', label: 'Regional' } } },
       ],
     };
 
@@ -379,13 +379,6 @@ describe('ChangeSection', () => {
           options: [
             {
               previousState: {
-                id: 'location-2',
-                code: 'location-2-code',
-                label: 'Location 2',
-              },
-            },
-            {
-              previousState: {
                 id: 'location-1',
                 code: 'location-1-code',
                 label: 'Location 1',
@@ -393,14 +386,9 @@ describe('ChangeSection', () => {
             },
             {
               previousState: {
-                id: 'location-4',
-                label: 'Location 4',
-                ukprn: 'location-4-ukprn',
-              },
-              currentState: {
-                id: 'location-4',
-                label: 'Location 4 updated',
-                ukprn: 'location-4-ukprn-updated',
+                id: 'location-2',
+                code: 'location-2-code',
+                label: 'Location 2',
               },
             },
             {
@@ -415,6 +403,18 @@ describe('ChangeSection', () => {
                 label: 'Location 3',
                 code: 'location-3-code-updated',
                 oldCode: 'location-3-oldCode-updated',
+              },
+            },
+            {
+              previousState: {
+                id: 'location-4',
+                label: 'Location 4',
+                ukprn: 'location-4-ukprn',
+              },
+              currentState: {
+                id: 'location-4',
+                label: 'Location 4 updated',
+                ukprn: 'location-4-ukprn-updated',
               },
             },
             {
@@ -582,10 +582,10 @@ describe('ChangeSection', () => {
     const testChanges: ChangeSet = {
       timePeriods: [
         {
-          previousState: { code: 'AY', label: '2018/19', period: '2018/2019' },
+          previousState: { code: 'AY', label: '2017/18', period: '2017/2018' },
         },
         {
-          previousState: { code: 'AY', label: '2017/18', period: '2017/2018' },
+          previousState: { code: 'AY', label: '2018/19', period: '2018/2019' },
         },
         {
           previousState: { code: 'AY', label: '2019/20', period: '2019/2020' },

--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/__tests__/ChangeSection.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/__tests__/ChangeSection.test.tsx
@@ -7,26 +7,66 @@ describe('ChangeSection', () => {
   test('renders filter changes only', () => {
     const testChanges: ChangeSet = {
       filters: [
-        { previousState: { id: 'filter-1', label: 'Filter 1', hint: '' } },
-        { previousState: { id: 'filter-2', label: 'Filter 2', hint: '' } },
         {
-          previousState: { id: 'filter-3', label: 'Filter 3', hint: '' },
-          currentState: { id: 'filter-3-updated', label: 'Filter 3', hint: '' },
+          previousState: {
+            id: 'filter-1',
+            column: 'filter_1',
+            label: 'Filter 1',
+            hint: '',
+          },
+        },
+        {
+          previousState: {
+            id: 'filter-2',
+            column: 'filter_2',
+            label: 'Filter 2',
+            hint: '',
+          },
+        },
+        {
+          previousState: {
+            id: 'filter-3',
+            column: 'filter_3',
+            label: 'Filter 3',
+            hint: '',
+          },
+          currentState: {
+            id: 'filter-3-updated',
+            column: 'filter_3_updated',
+            label: 'Filter 3',
+            hint: '',
+          },
         },
         {
           previousState: {
             id: 'filter-4',
+            column: 'filter_4',
             label: 'Filter 4',
             hint: 'Filter 4 hint',
           },
           currentState: {
             id: 'filter-4',
+            column: 'filter_4',
             label: 'Filter 4 updated',
             hint: 'Filter 4 hint updated',
           },
         },
-        { currentState: { id: 'filter-5', label: 'Filter 5', hint: '' } },
-        { currentState: { id: 'filter-6', label: 'Filter 6', hint: '' } },
+        {
+          currentState: {
+            id: 'filter-5',
+            column: 'filter_5',
+            label: 'Filter 5',
+            hint: '',
+          },
+        },
+        {
+          currentState: {
+            id: 'filter-6',
+            column: 'filter_6',
+            label: 'Filter 6',
+            hint: '',
+          },
+        },
       ],
     };
 
@@ -41,35 +81,69 @@ describe('ChangeSection', () => {
     );
 
     expect(deleted).toHaveLength(2);
-    expect(deleted[0]).toHaveTextContent('Filter 1 (id: filter-1)');
-    expect(deleted[1]).toHaveTextContent('Filter 2 (id: filter-2)');
+    expect(deleted[0]).toHaveTextContent(
+      'Filter 1 (id: filter-1, column: filter_1)',
+    );
+    expect(deleted[1]).toHaveTextContent(
+      'Filter 2 (id: filter-2, column: filter_2)',
+    );
 
     const updated = within(
       screen.getByTestId('updated-filters'),
     ).getAllByTestId('updated-item');
 
     expect(updated).toHaveLength(2);
-    expect(updated[0]).toHaveTextContent('Filter 3 (id: filter-3)');
-    expect(updated[0]).toHaveTextContent('id changed to: filter-3-updated');
+    expect(updated[0]).toHaveTextContent(
+      'Filter 3 (id: filter-3, column: filter_3)',
+    );
 
-    expect(updated[1]).toHaveTextContent('Filter 4 (id: filter-4)');
-    expect(updated[1]).toHaveTextContent('label changed to: Filter 4 updated');
-    expect(updated[1]).toHaveTextContent('hint changed to: Filter 4 hint');
+    const updated1Changes = within(updated[0]).getAllByRole('listitem');
+
+    expect(updated1Changes).toHaveLength(2);
+    expect(updated1Changes[0]).toHaveTextContent(
+      'id changed to: filter-3-updated',
+    );
+    expect(updated1Changes[1]).toHaveTextContent(
+      'column changed to: filter_3_updated',
+    );
+
+    expect(updated[1]).toHaveTextContent(
+      'Filter 4 (id: filter-4, column: filter_4)',
+    );
+
+    const updated2Changes = within(updated[1]).getAllByRole('listitem');
+
+    expect(updated2Changes).toHaveLength(2);
+    expect(updated2Changes[0]).toHaveTextContent(
+      'label changed to: Filter 4 updated',
+    );
+    expect(updated2Changes[1]).toHaveTextContent(
+      'hint changed to: Filter 4 hint',
+    );
 
     const added = within(screen.getByTestId('added-filters')).getAllByRole(
       'listitem',
     );
 
     expect(added).toHaveLength(2);
-    expect(added[0]).toHaveTextContent('Filter 5 (id: filter-5)');
-    expect(added[1]).toHaveTextContent('Filter 6 (id: filter-6)');
+    expect(added[0]).toHaveTextContent(
+      'Filter 5 (id: filter-5, column: filter_5)',
+    );
+    expect(added[1]).toHaveTextContent(
+      'Filter 6 (id: filter-6, column: filter_6)',
+    );
   });
 
   test('renders filter option changes only', () => {
     const testChanges: ChangeSet = {
       filterOptions: [
         {
-          filter: { id: 'filter-1', label: 'Filter 1', hint: '' },
+          filter: {
+            id: 'filter-1',
+            column: 'filter_1',
+            label: 'Filter 1',
+            hint: '',
+          },
           options: [
             { previousState: { id: 'filter-opt-1', label: 'Filter option 1' } },
             { previousState: { id: 'filter-opt-2', label: 'Filter option 2' } },
@@ -93,7 +167,12 @@ describe('ChangeSection', () => {
           ],
         },
         {
-          filter: { id: 'filter-2', label: 'Filter 2', hint: '' },
+          filter: {
+            id: 'filter-2',
+            column: 'filter_2',
+            label: 'Filter 2',
+            hint: '',
+          },
           options: [
             { previousState: { id: 'filter-opt-7', label: 'Filter option 7' } },
             {
@@ -138,16 +217,29 @@ describe('ChangeSection', () => {
     expect(updatedFilter1Options[0]).toHaveTextContent(
       'Filter option 3 (id: filter-opt-3)',
     );
-    expect(updatedFilter1Options[0]).toHaveTextContent(
+
+    const updatedFilter1Option1Changes = within(
+      updatedFilter1Options[0],
+    ).getAllByRole('listitem');
+
+    expect(updatedFilter1Option1Changes).toHaveLength(1);
+    expect(updatedFilter1Option1Changes[0]).toHaveTextContent(
       'id changed to: filter-opt-3-updated',
     );
+
     expect(updatedFilter1Options[1]).toHaveTextContent(
       'Filter option 4 (id: filter-opt-4)',
     );
-    expect(updatedFilter1Options[1]).toHaveTextContent(
+
+    const updatedFilter1Option2Changes = within(
+      updatedFilter1Options[1],
+    ).getAllByRole('listitem');
+
+    expect(updatedFilter1Option2Changes).toHaveLength(2);
+    expect(updatedFilter1Option2Changes[0]).toHaveTextContent(
       'label changed to: Filter option 4 updated',
     );
-    expect(updatedFilter1Options[1]).toHaveTextContent(
+    expect(updatedFilter1Option2Changes[1]).toHaveTextContent(
       'changed to an aggregate',
     );
 
@@ -180,6 +272,12 @@ describe('ChangeSection', () => {
     expect(updatedFilter2Options[0]).toHaveTextContent(
       'Filter option 8 (id: filter-opt-8)',
     );
+
+    const updatedFilter2Option1Changes = within(
+      updatedFilter2Options[0],
+    ).getAllByRole('listitem');
+
+    expect(updatedFilter2Option1Changes).toHaveLength(1);
     expect(updatedFilter2Options[0]).toHaveTextContent(
       'no longer an aggregate',
     );
@@ -234,11 +332,20 @@ describe('ChangeSection', () => {
 
     expect(updated).toHaveLength(2);
     expect(updated[0]).toHaveTextContent('Local authority (code: LA)');
-    expect(updated[0]).toHaveTextContent(
+
+    const updated1Changes = within(updated[0]).getAllByRole('listitem');
+
+    expect(updated1Changes).toHaveLength(1);
+    expect(updated1Changes[0]).toHaveTextContent(
       'changed to: Local authority district (code: LAD)',
     );
+
     expect(updated[1]).toHaveTextContent('Opportunity area (code: OA)');
-    expect(updated[1]).toHaveTextContent(
+
+    const updated2Changes = within(updated[1]).getAllByRole('listitem');
+
+    expect(updated2Changes).toHaveLength(1);
+    expect(updated2Changes[0]).toHaveTextContent(
       'changed to: Planning area (code: PA)',
     );
 
@@ -254,22 +361,59 @@ describe('ChangeSection', () => {
   test('renders indicators changes only', () => {
     const testChanges: ChangeSet = {
       indicators: [
-        { previousState: { id: 'indicator-1', label: 'Indicator 1' } },
-        { previousState: { id: 'indicator-2', label: 'Indicator 2' } },
         {
-          currentState: { id: 'indicator-4', label: 'Indicator 3' },
-          previousState: { id: 'indicator-3', label: 'Indicator 3' },
+          previousState: {
+            id: 'indicator-1',
+            column: 'indicator_1',
+            label: 'Indicator 1',
+          },
+        },
+        {
+          previousState: {
+            id: 'indicator-2',
+            column: 'indicator_2',
+            label: 'Indicator 2',
+          },
         },
         {
           currentState: {
-            id: 'indicator-5',
-            label: 'Indicator 5 updated',
+            id: 'indicator-3-updated',
+            column: 'indicator_3_updated',
+            label: 'Indicator 3',
+          },
+          previousState: {
+            id: 'indicator-3',
+            column: 'indicator_3',
+            label: 'Indicator 3',
+          },
+        },
+        {
+          currentState: {
+            id: 'indicator-4',
+            column: 'indicator_4',
+            label: 'Indicator 4 updated',
             unit: '%',
           },
-          previousState: { id: 'indicator-5', label: 'Indicator 5' },
+          previousState: {
+            id: 'indicator-4',
+            column: 'indicator_4',
+            label: 'Indicator 4',
+          },
         },
-        { currentState: { id: 'indicator-6', label: 'Indicator 6' } },
-        { currentState: { id: 'indicator-7', label: 'Indicator 7' } },
+        {
+          currentState: {
+            id: 'indicator-6',
+            column: 'indicator_6',
+            label: 'Indicator 6',
+          },
+        },
+        {
+          currentState: {
+            id: 'indicator-7',
+            column: 'indicator_7',
+            label: 'Indicator 7',
+          },
+        },
       ],
     };
 
@@ -292,14 +436,31 @@ describe('ChangeSection', () => {
     ).getAllByTestId('updated-item');
 
     expect(updated).toHaveLength(2);
-    expect(updated[0]).toHaveTextContent('Indicator 3 (id: indicator-3)');
-    expect(updated[0]).toHaveTextContent('id changed to: indicator-4');
-
-    expect(updated[1]).toHaveTextContent('Indicator 5 (id: indicator-5)');
-    expect(updated[1]).toHaveTextContent(
-      'label changed to: Indicator 5 updated',
+    expect(updated[0]).toHaveTextContent(
+      'Indicator 3 (id: indicator-3, column: indicator_3)',
     );
-    expect(updated[1]).toHaveTextContent('unit changed to: %');
+
+    const updated1Changes = within(updated[0]).getAllByRole('listitem');
+
+    expect(updated1Changes).toHaveLength(2);
+    expect(updated1Changes[0]).toHaveTextContent(
+      'id changed to: indicator-3-updated',
+    );
+    expect(updated1Changes[1]).toHaveTextContent(
+      'column changed to: indicator_3_updated',
+    );
+
+    expect(updated[1]).toHaveTextContent(
+      'Indicator 4 (id: indicator-4, column: indicator_4)',
+    );
+
+    const updated2Changes = within(updated[1]).getAllByRole('listitem');
+
+    expect(updated2Changes).toHaveLength(2);
+    expect(updated2Changes[0]).toHaveTextContent(
+      'label changed to: Indicator 4 updated',
+    );
+    expect(updated2Changes[1]).toHaveTextContent('unit changed to: %');
 
     const added = within(screen.getByTestId('added-indicators')).getAllByRole(
       'listitem',
@@ -352,12 +513,20 @@ describe('ChangeSection', () => {
     expect(updated).toHaveLength(2);
 
     expect(updated[0]).toHaveTextContent('Local authority (code: LA)');
-    expect(updated[0]).toHaveTextContent(
+
+    const updated1Changes = within(updated[0]).getAllByRole('listitem');
+
+    expect(updated1Changes).toHaveLength(1);
+    expect(updated1Changes[0]).toHaveTextContent(
       'changed to: Local authority district (code: LAD)',
     );
 
     expect(updated[1]).toHaveTextContent('Opportunity area (code: OA)');
-    expect(updated[1]).toHaveTextContent(
+
+    const updated2Changes = within(updated[1]).getAllByRole('listitem');
+
+    expect(updated2Changes).toHaveLength(1);
+    expect(updated2Changes[0]).toHaveTextContent(
       'changed to: Planning area (code: PA)',
     );
 
@@ -499,24 +668,36 @@ describe('ChangeSection', () => {
     expect(updatedRegionOptions[0]).toHaveTextContent(
       'Location 3 (id: location-3, code: location-3-code, old code: location-3-oldCode)',
     );
-    expect(updatedRegionOptions[0]).toHaveTextContent(
+
+    const updatedRegionOption1Changes = within(
+      updatedRegionOptions[0],
+    ).getAllByRole('listitem');
+
+    expect(updatedRegionOption1Changes).toHaveLength(3);
+    expect(updatedRegionOption1Changes[0]).toHaveTextContent(
       'id changed to: location-3-updated',
     );
-    expect(updatedRegionOptions[0]).toHaveTextContent(
+    expect(updatedRegionOption1Changes[1]).toHaveTextContent(
       'code changed to: location-3-code-updated',
     );
-    expect(updatedRegionOptions[0]).toHaveTextContent(
+    expect(updatedRegionOption1Changes[2]).toHaveTextContent(
       'old code changed to: location-3-oldCode-updated',
     );
 
     expect(updatedRegionOptions[1]).toHaveTextContent(
       'Location 4 (id: location-4, UKPRN: location-4-ukprn)',
     );
-    expect(updatedRegionOptions[1]).toHaveTextContent(
+
+    const updatedRegionOption2Changes = within(
+      updatedRegionOptions[1],
+    ).getAllByRole('listitem');
+
+    expect(updatedRegionOption2Changes).toHaveLength(2);
+    expect(updatedRegionOption2Changes[0]).toHaveTextContent(
       'label changed to: Location 4 updated',
     );
-    expect(updatedRegionOptions[1]).toHaveTextContent(
-      'UKPRN changed to: location-4-ukprn',
+    expect(updatedRegionOption2Changes[1]).toHaveTextContent(
+      'UKPRN changed to: location-4-ukprn-updated',
     );
 
     const addedRegionOptions = within(
@@ -555,16 +736,22 @@ describe('ChangeSection', () => {
     expect(updatedSchoolOptions[0]).toHaveTextContent(
       'Location 8 (id: location-8, URN: location-8-urn, LAESTAB: location-8-laEstab)',
     );
-    expect(updatedSchoolOptions[0]).toHaveTextContent(
-      'id changed to: location-8-updated',
-    );
-    expect(updatedSchoolOptions[0]).toHaveTextContent(
+
+    const updatedSchoolOption1Changes = within(
+      updatedSchoolOptions[0],
+    ).getAllByRole('listitem');
+
+    expect(updatedSchoolOption1Changes).toHaveLength(4);
+    expect(updatedSchoolOption1Changes[0]).toHaveTextContent(
       'label changed to: Location 8 updated',
     );
-    expect(updatedSchoolOptions[0]).toHaveTextContent(
+    expect(updatedSchoolOption1Changes[1]).toHaveTextContent(
+      'id changed to: location-8-updated',
+    );
+    expect(updatedSchoolOption1Changes[2]).toHaveTextContent(
       'URN changed to: location-8-urn-updated',
     );
-    expect(updatedSchoolOptions[0]).toHaveTextContent(
+    expect(updatedSchoolOption1Changes[3]).toHaveTextContent(
       'LAESTAB changed to: location-8-laEstab-updated',
     );
 
@@ -640,13 +827,28 @@ describe('ChangeSection', () => {
     const testChanges: ChangeSet = {
       filters: [
         {
-          previousState: { id: 'filter-1', label: 'Filter 1', hint: '' },
-          currentState: { id: 'filter-1', label: 'Filter 1 updated', hint: '' },
+          previousState: {
+            id: 'filter-1',
+            column: 'filter_1',
+            label: 'Filter 1',
+            hint: '',
+          },
+          currentState: {
+            id: 'filter-1',
+            column: 'filter_1_updated',
+            label: 'Filter 1 updated',
+            hint: '',
+          },
         },
       ],
       filterOptions: [
         {
-          filter: { id: 'filter-1', label: 'Filter 1', hint: '' },
+          filter: {
+            id: 'filter-1',
+            column: 'filter_1',
+            label: 'Filter 1',
+            hint: '',
+          },
           options: [
             { previousState: { id: 'filter-opt-1', label: 'Filter option 1' } },
           ],
@@ -657,8 +859,16 @@ describe('ChangeSection', () => {
       ],
       indicators: [
         {
-          currentState: { id: 'indicator-1', label: 'Indicator 1 updated' },
-          previousState: { id: 'indicator-1', label: 'Indicator 1' },
+          currentState: {
+            id: 'indicator-1',
+            column: 'indicator_1_updated',
+            label: 'Indicator 1 updated',
+          },
+          previousState: {
+            id: 'indicator-1',
+            column: 'indicator_1',
+            label: 'Indicator 1',
+          },
         },
       ],
       locationGroups: [
@@ -697,9 +907,19 @@ describe('ChangeSection', () => {
 
     expect(updatedFilters).toHaveLength(1);
 
-    expect(updatedFilters[0]).toHaveTextContent('Filter 1 (id: filter-1)');
     expect(updatedFilters[0]).toHaveTextContent(
+      'Filter 1 (id: filter-1, column: filter_1)',
+    );
+
+    const updatedFilterChanges = within(updatedFilters[0]).getAllByRole(
+      'listitem',
+    );
+    expect(updatedFilterChanges).toHaveLength(2);
+    expect(updatedFilterChanges[0]).toHaveTextContent(
       'label changed to: Filter 1 updated',
+    );
+    expect(updatedFilterChanges[1]).toHaveTextContent(
+      'column changed to: filter_1_updated',
     );
 
     expect(
@@ -738,10 +958,18 @@ describe('ChangeSection', () => {
 
     expect(updatedIndicators).toHaveLength(1);
     expect(updatedIndicators[0]).toHaveTextContent(
-      'Indicator 1 (id: indicator-1)',
+      'Indicator 1 (id: indicator-1, column: indicator_1)',
     );
-    expect(updatedIndicators[0]).toHaveTextContent(
+
+    const updatedIndicatorChanges = within(updatedIndicators[0]).getAllByRole(
+      'listitem',
+    );
+    expect(updatedIndicatorChanges).toHaveLength(2);
+    expect(updatedIndicatorChanges[0]).toHaveTextContent(
       'label changed to: Indicator 1 updated',
+    );
+    expect(updatedIndicatorChanges[1]).toHaveTextContent(
+      'column changed to: indicator_1_updated',
     );
 
     expect(

--- a/src/explore-education-statistics-common/src/services/types/apiDataSetMeta.ts
+++ b/src/explore-education-statistics-common/src/services/types/apiDataSetMeta.ts
@@ -3,6 +3,7 @@ import { GeographicLevelCode } from '@common/utils/locationLevelsMap';
 export interface Filter {
   id: string;
   hint: string;
+  column: string;
   label: string;
 }
 
@@ -20,6 +21,7 @@ export interface GeographicLevel {
 export interface IndicatorOption {
   id: string;
   label: string;
+  column: string;
   unit?: string;
 }
 

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataSetFilePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataSetFilePage.test.tsx
@@ -10,6 +10,7 @@ import DataSetFilePage from '@frontend/modules/data-catalogue/DataSetFilePage';
 import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 
+jest.mock('@frontend/services/apiDataSetService');
 jest.mock('@common/services/downloadService');
 
 const downloadService = _downloadService as jest.Mocked<

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataSetFilePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataSetFilePage.test.tsx
@@ -308,7 +308,14 @@ describe('DataSetFilePage', () => {
       const testApiDataSetVersionChanges: ApiDataSetVersionChanges = {
         majorChanges: {
           filters: [
-            { previousState: { id: 'filter-1', label: 'Filter 1', hint: '' } },
+            {
+              previousState: {
+                id: 'filter-1',
+                column: 'filter_1',
+                label: 'Filter 1',
+                hint: '',
+              },
+            },
           ],
         },
         minorChanges: {},
@@ -376,7 +383,14 @@ describe('DataSetFilePage', () => {
       const testApiDataSetVersionChanges: ApiDataSetVersionChanges = {
         majorChanges: {
           filters: [
-            { previousState: { id: 'filter-1', label: 'Filter 1', hint: '' } },
+            {
+              previousState: {
+                id: 'filter-1',
+                column: 'filter_1',
+                label: 'Filter 1',
+                hint: '',
+              },
+            },
           ],
         },
         minorChanges: {},

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiChangelog.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiChangelog.test.tsx
@@ -9,14 +9,24 @@ describe('DataSetFileApiChangelog', () => {
           majorChanges: {
             filters: [
               {
-                previousState: { id: 'filter-1', label: 'Filter 1', hint: '' },
+                previousState: {
+                  id: 'filter-1',
+                  column: 'filter_1',
+                  label: 'Filter 1',
+                  hint: '',
+                },
               },
             ],
           },
           minorChanges: {
             filters: [
               {
-                currentState: { id: 'filter-2', label: 'Filter 2', hint: '' },
+                currentState: {
+                  id: 'filter-2',
+                  column: 'filter_2',
+                  label: 'Filter 2',
+                  hint: '',
+                },
               },
             ],
           },
@@ -41,13 +51,13 @@ describe('DataSetFileApiChangelog', () => {
     const majorChanges = within(screen.getByTestId('major-changes'));
 
     expect(majorChanges.getByTestId('deleted-filters')).toHaveTextContent(
-      'Filter 1 (id: filter-1)',
+      'Filter 1 (id: filter-1, column: filter_1)',
     );
 
     const minorChanges = within(screen.getByTestId('minor-changes'));
 
     expect(minorChanges.getByTestId('added-filters')).toHaveTextContent(
-      'Filter 2 (id: filter-2)',
+      'Filter 2 (id: filter-2, column: filter_2)',
     );
   });
 
@@ -58,7 +68,12 @@ describe('DataSetFileApiChangelog', () => {
           majorChanges: {
             filters: [
               {
-                previousState: { id: 'filter-1', label: 'Filter 1', hint: '' },
+                previousState: {
+                  id: 'filter-1',
+                  column: 'filter_1',
+                  label: 'Filter 1',
+                  hint: '',
+                },
               },
             ],
           },
@@ -72,7 +87,7 @@ describe('DataSetFileApiChangelog', () => {
     const majorChanges = within(screen.getByTestId('major-changes'));
 
     expect(majorChanges.getByTestId('deleted-filters')).toHaveTextContent(
-      'Filter 1 (id: filter-1)',
+      'Filter 1 (id: filter-1, column: filter_1)',
     );
 
     expect(screen.queryByTestId('minor-changes')).not.toBeInTheDocument();
@@ -86,7 +101,12 @@ describe('DataSetFileApiChangelog', () => {
           minorChanges: {
             filters: [
               {
-                currentState: { id: 'filter-2', label: 'Filter 2', hint: '' },
+                currentState: {
+                  id: 'filter-2',
+                  column: 'filter_2',
+                  label: 'Filter 2',
+                  hint: '',
+                },
               },
             ],
           },
@@ -101,7 +121,7 @@ describe('DataSetFileApiChangelog', () => {
     const minorChanges = within(screen.getByTestId('minor-changes'));
 
     expect(minorChanges.getByTestId('added-filters')).toHaveTextContent(
-      'Filter 2 (id: filter-2)',
+      'Filter 2 (id: filter-2, column: filter_2)',
     );
   });
 
@@ -113,7 +133,12 @@ describe('DataSetFileApiChangelog', () => {
           minorChanges: {
             filters: [
               {
-                currentState: { id: 'filter-2', label: 'Filter 2', hint: '' },
+                currentState: {
+                  id: 'filter-2',
+                  column: 'filter_2',
+                  label: 'Filter 2',
+                  hint: '',
+                },
               },
             ],
           },


### PR DESCRIPTION
This PR:

- Removes frontend ordering of changelog entries. This is now deferred to the backend when the changelog is initially generated.
- Adds filter and indicator column names to changelog
- Fixes time periods being naturally ordered in the changelog
- Adds explicit ordering of geographic levels by label in changelog
- Adds missing service mock to `DataSetFilePage` tests which was previously causing console errors due to real HTTP requests being attempted