### PR TITLE
EES-5573 Hide delete user button

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/bau/BauUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauUsersPage.tsx
@@ -1,26 +1,24 @@
 import Link from '@admin/components/Link';
 import Page from '@admin/components/Page';
 import userService from '@admin/services/userService';
-import ButtonText from '@common/components/ButtonText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
-import logger from '@common/services/logger';
 import React from 'react';
 import styles from './BauUsersPage.module.scss';
 
 const BauUsersPage = () => {
   const { value, isLoading } = useAsyncRetry(() => userService.getUsers());
 
-  const handleDeleteUser = async (userEmail: string) => {
-    await userService
-      .deleteUser(userEmail)
-      .then(() => {
-        window.location.reload();
-      })
-      .catch(error => {
-        logger.info(`Error encountered when deleting the user - ${error}`);
-      });
-  };
+  // const handleDeleteUser = async (userEmail: string) => { // EES-5573
+  //   await userService
+  //     .deleteUser(userEmail)
+  //     .then(() => {
+  //       window.location.reload();
+  //     })
+  //     .catch(error => {
+  //       logger.info(`Error encountered when deleting the user - ${error}`);
+  //     });
+  // };
 
   return (
     <Page
@@ -57,12 +55,13 @@ const BauUsersPage = () => {
                     >
                       Manage
                     </Link>
-                    <ButtonText
-                      onClick={() => handleDeleteUser(user.email)}
-                      className={styles.deleteUserButton}
-                    >
-                      Delete
-                    </ButtonText>
+                    {/* EES-5573 */}
+                    {/* <ButtonText */}
+                    {/*  onClick={() => handleDeleteUser(user.email)} */}
+                    {/*  className={styles.deleteUserButton} */}
+                    {/* > */}
+                    {/*  Delete */}
+                    {/* </ButtonText> */}
                   </td>
                 </tr>
               ))}

--- a/src/explore-education-statistics-admin/src/pages/bau/__tests__/BauUsersPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/__tests__/BauUsersPage.test.tsx
@@ -4,8 +4,7 @@ import _userService, {
 } from '@admin/services/userService';
 import { MemoryRouter } from 'react-router';
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 import BauUsersPage from '../BauUsersPage';
 
 jest.mock('@admin/services/userService');
@@ -31,9 +30,9 @@ describe('BauUsersPage', () => {
 
     renderPage();
 
-    await waitFor(() => {
-      expect(screen.getByText('Delete')).toBeInTheDocument();
-    });
+    // await waitFor(() => { // EES-5573
+    //   expect(screen.getByText('Delete')).toBeInTheDocument();
+    // });
   });
 
   test('calls user service when delete user button is clicked', async () => {
@@ -42,12 +41,12 @@ describe('BauUsersPage', () => {
 
     renderPage();
 
-    await waitFor(() => {
-      expect(screen.getByText('Delete')).toBeInTheDocument();
-    });
-    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
-
-    expect(userService.deleteUser).toHaveBeenCalled();
+    // await waitFor(() => { // EES-5573
+    //   expect(screen.getByText('Delete')).toBeInTheDocument();
+    // });
+    // await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    //
+    // expect(userService.deleteUser).toHaveBeenCalled();
   });
 
   function renderPage() {


### PR DESCRIPTION
This PR hides the delete user button we previously added to the BauUserPage.

We've done this as there is currently a bug with deleting a user due to the userId being references in many other table's CreatedById/UpdatedById/DeletedById/etc. columns.

We decided to just comment out the delete user button so that we could deploy current changes and give us more time to consider the best approach to solving this issue.