### PR TITLE
EES-4491 - fixing UI tests after changes in navigation controls

### DIFF
--- a/tests/robot-tests/tests/admin/analyst/manage_publication_as_publication_owner.robot
+++ b/tests/robot-tests/tests/admin/analyst/manage_publication_as_publication_owner.robot
@@ -77,7 +77,7 @@ Update publication details
     user waits until page contains element    id:publicationDetailsForm-summary
 
     # Only BAU should see theme
-    user checks page does not contain element    id:publicationDetailsForm-themeId
+    user checks page does not contain element    name:themeId
 
     # Only BAU users should see supersededById
     user checks page does not contain element    id:publicationDetailsForm-supersededById

--- a/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
+++ b/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
@@ -26,13 +26,13 @@ Go to Create publication page for "UI tests theme" theme
     user waits until h1 is visible    Create new publication
 
 Enters contact details
-    user enters text into element    id:publicationForm-teamName    Post-16 statistics team
-    user enters text into element    id:publicationForm-teamEmail    post16.statistics@education.gov.uk
-    user enters text into element    id:publicationForm-contactName    UI Tests Contact Name
-    user enters text into element    id:publicationForm-contactTelNo    0123456789
+    user enters text into element    name:teamName    Post-16 statistics team
+    user enters text into element    name:teamEmail    post16.statistics@education.gov.uk
+    user enters text into element    name:contactName    UI Tests Contact Name
+    user enters text into element    name:contactTelNo    0123456789
 
 Option to set superseding publication should not appear
-    user checks page does not contain element    id:publicationForm-supersede
+    user checks page does not contain element    name:supersede
 
 Error message appears when submitting and title is empty
     user checks element is not visible    id:publicationForm-title-error    %{WAIT_SMALL}
@@ -40,11 +40,11 @@ Error message appears when submitting and title is empty
     user waits until element is visible    id:publicationForm-title-error    %{WAIT_SMALL}
 
 Enter new publication title
-    user enters text into element    id:publicationForm-title    ${PUBLICATION_NAME} (created)
+    user enters text into element    name:title    ${PUBLICATION_NAME} (created)
     user checks element is not visible    id:publicationForm-title-error    %{WAIT_SMALL}
 
 Enter new publication summary
-    user enters text into element    id:publicationForm-summary    ${PUBLICATION_NAME} summary
+    user enters text into element    name:summary    ${PUBLICATION_NAME} summary
 
 User redirects to the dashboard after saving publication
     user clicks button    Save publication
@@ -76,9 +76,9 @@ Update publication's details
 
     user clicks button    Edit publication details
 
-    user enters text into element    id:publicationDetailsForm-title    ${PUBLICATION_NAME}
-    user enters text into element    id:publicationDetailsForm-summary    ${PUBLICATION_NAME} summary updated
-    user chooses select option    id:publicationDetailsForm-themeId    ${CREATED_THEME_NAME}
+    user enters text into element    name:title    ${PUBLICATION_NAME}
+    user enters text into element    name:summary    ${PUBLICATION_NAME} summary updated
+    user chooses select option    name:themeId    ${CREATED_THEME_NAME}
 
     user clicks button    Update publication details
 
@@ -98,10 +98,10 @@ Update publication's contact
 
     user clicks button    Edit contact details
 
-    user enters text into element    id:publicationContactForm-teamName    Special educational needs statistics team
-    user enters text into element    id:publicationContactForm-teamEmail    sen.statistics@education.gov.uk
-    user enters text into element    id:publicationContactForm-contactName    UI Tests Contact Name
-    user enters text into element    id:publicationContactForm-contactTelNo    0987654321
+    user enters text into element    name:teamName    Special educational needs statistics team
+    user enters text into element    name:teamEmail    sen.statistics@education.gov.uk
+    user enters text into element    name:contactName    UI Tests Contact Name
+    user enters text into element    name:contactTelNo    0987654321
 
     user clicks button    Update contact details
 
@@ -144,8 +144,8 @@ Create new release for publication
     user clicks link    Create new release
     user waits until h1 is visible    Create new release
 
-    user waits until page contains element    id:releaseSummaryForm-timePeriodCoverageCode
-    user waits until page contains element    id:releaseSummaryForm-timePeriodCoverageStartYear
+    user waits until page contains element    name:timePeriodCoverageCode
+    user waits until page contains element    name:timePeriodCoverageStartYear
 
 Verify Release type options
     user checks page contains radio    Accredited official statistics
@@ -155,8 +155,8 @@ Verify Release type options
     user checks page contains radio    Management information
 
 Create new release
-    user chooses select option    id:releaseSummaryForm-timePeriodCoverageCode    Spring term
-    user enters text into element    id:releaseSummaryForm-timePeriodCoverageStartYear    2025
+    user chooses select option    name:timePeriodCoverageCode    Spring term
+    user enters text into element    name:timePeriodCoverageStartYear    2025
     user clicks radio    Accredited official statistics
     user clicks button    Create new release
     user waits until page contains title caption    Edit release for Spring term 2025/26
@@ -172,9 +172,9 @@ Edit release summary
     user waits until page contains link    Edit release summary
     user clicks link    Edit release summary
     user waits until h2 is visible    Edit release summary
-    user waits until page contains element    id:releaseSummaryForm-timePeriodCoverageStartYear
-    user chooses select option    id:releaseSummaryForm-timePeriodCoverageCode    Summer term
-    user enters text into element    id:releaseSummaryForm-timePeriodCoverageStartYear    2026
+    user waits until page contains element    name:timePeriodCoverageStartYear
+    user chooses select option    name:timePeriodCoverageCode    Summer term
+    user enters text into element    name:timePeriodCoverageStartYear    2026
     user clicks radio    Official statistics
     user clicks button    Update release summary
 

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -94,7 +94,7 @@ user selects dashboard theme if possible
     user waits until page finishes loading
     ${dropdowns_exist}=    user checks dashboard theme dropdown exists
     IF    ${dropdowns_exist}
-        user chooses select option    id:publicationsReleases-theme-themeId    ${theme_name}
+        user chooses select option    name:themeId    ${theme_name}
         user waits until page contains    ${theme_name}
     END
 

--- a/tests/robot-tests/tests/libs/admin-utilities.py
+++ b/tests/robot-tests/tests/libs/admin-utilities.py
@@ -122,7 +122,7 @@ def user_waits_for_release_process_status_to_be(status, timeout):
 
 def user_checks_dashboard_theme_dropdown_exists():
     try:
-        sl().driver.find_element(By.ID, "publicationsReleases-theme-themeId")
+        sl().driver.find_element(By.ID, "publicationsReleases-theme")
     except NoSuchElementException:
         return False
 

--- a/tests/robot-tests/tests/public_api/public_api_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_preview_token.robot
@@ -278,7 +278,7 @@ User checks relevant headings exist on API data set details page
     user waits until h2 is visible    API data set version history
 
 User verifies 'Data set details' section
-    user checks summary list contains    Theme    Test theme    id:dataSetDetails
+    user checks summary list contains    Theme    %{TEST_THEME_NAME}    id:dataSetDetails
     user checks summary list contains    Publication    ${PUBLICATION_NAME}    id:dataSetDetails
     user checks summary list contains    Release    ${RELEASE_NAME}    id:dataSetDetails
     user checks summary list contains    Release type    Accredited official statistics    id:dataSetDetails


### PR DESCRIPTION
This PR fixes UI tests following the merging in of Topic deletion.

This includes:
- fixing selectors for the Theme selection dropdown.
- using the `TEST_THEME_NAME` variable in Robot tests now that a new Theme is created for every run.

I did also take a stab at changing `user selects dashboard theme if possible` to `user selects dashboard theme` and just not trying to interact with a non-existent Theme dropdown if the user under test was an analyst (by creating new navigational keywords that didn't expect to use the Theme dropdown) but this would cause an explosion of changes! 