### PR TITLE
EES-5571 Remove heading level accessibility check for first heading of a text block

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/utils/__tests__/getInvalidContent.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/utils/__tests__/getInvalidContent.test.tsx
@@ -258,26 +258,27 @@ describe('getInvalidContent', () => {
     ]);
   });
 
-  test('returns an error when the first heading is higher than h3', () => {
-    const testContent: JsonElement[] = [
-      {
-        name: 'heading4',
-        children: [
-          {
-            data: 'heading 4',
-          },
-        ],
-      },
-    ];
+  it.each([
+    ['heading4', 'heading 4'],
+    ['heading5', 'heading 5'],
+  ])(
+    'returns no errors when the first heading is higher than h3',
+    (headingName, headingData) => {
+      const testContent: JsonElement[] = [
+        {
+          name: headingName,
+          children: [
+            {
+              data: headingData,
+            },
+          ],
+        },
+      ];
 
-    const result = getInvalidContent(testContent);
-    expect(result).toEqual([
-      {
-        type: 'skippedHeadingLevel',
-        message: 'h2 (section title) to h4 (heading 4)',
-      },
-    ]);
-  });
+      const result = getInvalidContent(testContent);
+      expect(result).toHaveLength(0);
+    },
+  );
 
   test('returns an error when there is repeated link text within the same page where the links are different', () => {
     const testContent: JsonElement[] = [

--- a/src/explore-education-statistics-admin/src/components/editable/utils/getInvalidContent.ts
+++ b/src/explore-education-statistics-admin/src/components/editable/utils/getInvalidContent.ts
@@ -56,21 +56,16 @@ export default function getInvalidContent(
     }
 
     const level = parseNumber(heading.name.split('heading')[1]);
-    const headingText = heading.children.map(child => child.data).join('');
 
     if (index === 0) {
-      if (level !== 3) {
-        errors.push({
-          type: 'skippedHeadingLevel',
-          message: `h2 (section title) to h${level} (${headingText})`,
-        });
-      }
       return;
     }
 
     const previousLevel = parseNumber(
       allHeadings[index - 1].name.split('heading')[1],
     );
+
+    const headingText = heading.children.map(child => child.data).join('');
 
     if (level && previousLevel && level > previousLevel + 1) {
       const previousHeadingText = allHeadings[index - 1].children


### PR DESCRIPTION
Removing the requirement for the first heading of a text block to be a level `<h3>` header. 

It will still check for the logical header ordering, taking the first heading level found within the text block as the starting heading level - i.e. you can still not 'jump' header levels from say `<h3>` to `<h5>`.