### PR TITLE
EES-5582 Fix snapshots script and update snapshots

### DIFF
--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -75,8 +75,13 @@ class SnapshotService:
         print(f"Validating snapshot: {name}")
         create_snapshot_func = self._get_create_snapshot_func(name)
         path_to_file = os.path.join(os.getcwd(), "tests/snapshots", name)
-        with open(path_to_file, "r") as file:
-            snapshot = file.read()
+
+        try:
+            with open(path_to_file, "r") as file:
+                snapshot = file.read()
+        except FileNotFoundError:
+            return False
+
         return snapshot == create_snapshot_func()
 
     def _write_snapshot_to_file(self, name: str) -> None:
@@ -167,7 +172,7 @@ class SnapshotService:
             theme_label.click()
             theme = {"theme_heading": theme_label.text, "publications": []}
 
-            publication_labels = driver.find_elements(By.CSS_SELECTOR, 'label[for^="publicationForm-publications-"]')
+            publication_labels = driver.find_elements(By.CSS_SELECTOR, 'label[for^="publicationForm-publicationId-"]')
 
             for publication_label in publication_labels:
                 theme["publications"].append(publication_label.text)

--- a/tests/robot-tests/tests/snapshots/data_catalogue_snapshot.json
+++ b/tests/robot-tests/tests/snapshots/data_catalogue_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "num_datasets": "954 data sets",
+  "num_datasets": "960 data sets",
   "themes": [
     {
       "publications": [

--- a/tests/robot-tests/tests/snapshots/find_statistics_snapshot.json
+++ b/tests/robot-tests/tests/snapshots/find_statistics_snapshot.json
@@ -219,7 +219,7 @@
   {
     "publication_summary": "Management information on eligibility codes for the extended childcare entitlement for working parents.",
     "publication_title": "Expansion to early childcare entitlements: eligibility codes issued and validated",
-    "published": "7 May 2024",
+    "published": "17 Oct 2024",
     "release_type": "Management information",
     "theme": "Early years"
   },
@@ -527,7 +527,7 @@
   {
     "publication_summary": "Pupil absence, including overall, authorised and unauthorised absence and persistent absence by reason and pupil characteristics for the full academic year.",
     "publication_title": "Pupil absence in schools in England",
-    "published": "16 May 2024",
+    "published": "17 Oct 2024",
     "release_type": "Accredited official statistics",
     "theme": "Pupils and schools"
   },


### PR DESCRIPTION
This PR fixes an issue where the snapshots for the table tool was returning no publications. This was fixed by updating a CSS selector.

I also fixed an issue where if a snapshot file didn't exist, the script would fail. I've changed it so now the script will generate a snapshot file if none exists.

I also updated the snapshots.