### PR TITLE
EES-4863 accessible reorderable list component

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationReleaseSeriesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationReleaseSeriesPage.test.tsx
@@ -112,8 +112,6 @@ describe('PublicationReleaseSeriesPage', () => {
       const modal = within(screen.getByRole('dialog'));
       await user.click(modal.getByRole('button', { name: 'OK' }));
 
-      expect(await screen.findByText('Sort')).toBeInTheDocument();
-
       expect(
         screen.getByRole('button', { name: 'Confirm order' }),
       ).toBeInTheDocument();

--- a/src/explore-education-statistics-admin/src/pages/publication/components/ReleaseSeriesTable.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/ReleaseSeriesTable.module.scss
@@ -1,6 +1,0 @@
-@import '~govuk-frontend/dist/govuk/base';
-
-.dragHandle {
-  text-align: center;
-  width: 1.6rem;
-}

--- a/src/explore-education-statistics-admin/src/pages/publication/components/ReleaseSeriesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/ReleaseSeriesTable.tsx
@@ -1,24 +1,19 @@
-import DraggableItem from '@admin/components/DraggableItem';
-import DroppableArea from '@admin/components/DroppableArea';
 import Link from '@admin/components/Link';
 import {
   publicationEditReleaseSeriesLegacyLinkRoute,
   PublicationEditReleaseSeriesLegacyLinkRouteParams,
 } from '@admin/routes/publicationRoutes';
 import { ReleaseSeriesTableEntry } from '@admin/services/publicationService';
-import Button from '@common/components/Button';
+import ReorderableList from '@common/components/ReorderableList';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ModalConfirm from '@common/components/ModalConfirm';
 import WarningMessage from '@common/components/WarningMessage';
 import reorder from '@common/utils/reorder';
-import styles from '@admin/pages/publication/components/ReleaseSeriesTable.module.scss';
 import ButtonText from '@common/components/ButtonText';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import { useConfig } from '@admin/contexts/ConfigContext';
 import Tag from '@common/components/Tag';
-import classNames from 'classnames';
 import React, { useEffect, useState } from 'react';
-import { DragDropContext, Droppable } from '@hello-pangea/dnd';
 import { generatePath } from 'react-router';
 import { useHistory } from 'react-router-dom';
 
@@ -51,189 +46,149 @@ export default function ReleaseSeriesTable({
 
   const config = useConfig();
 
-  return (
-    <>
-      <DragDropContext
-        onDragEnd={seriesItem => {
-          if (!seriesItem.destination) {
-            return;
-          }
-
-          const nextReleaseSeries = reorder(
-            releaseSeries,
-            seriesItem.source.index,
-            seriesItem.destination.index,
-          );
-
-          setReleaseSeries(nextReleaseSeries);
+  if (isReordering) {
+    return (
+      <ReorderableList
+        heading="Reorder releases"
+        id="releaseSeries"
+        list={releaseSeries.map(seriesItem => ({
+          id: seriesItem.id,
+          label: seriesItem.description,
+        }))}
+        onCancel={() => {
+          setReleaseSeries(initialReleaseSeries);
+          onCancelReordering();
         }}
-      >
-        <Droppable droppableId="droppable" isDropDisabled={!isReordering}>
-          {(droppableProvided, droppableSnapshot) => (
-            <table
-              ref={droppableProvided.innerRef}
-              className={classNames({
-                [styles.tableDraggingOver]: droppableSnapshot.isDraggingOver,
-              })}
-            >
-              <thead>
-                <tr>
-                  {isReordering && <th>Sort</th>}
-                  <th>Description</th>
-                  <th className="govuk-!-width-one-half">URL</th>
-                  <th>Status</th>
-                  {canManageReleaseSeries && !isReordering && <th>Actions</th>}
-                </tr>
-              </thead>
-              <DroppableArea
-                droppableProvided={droppableProvided}
-                droppableSnapshot={droppableSnapshot}
-                tag="tbody"
-              >
-                {releaseSeries.map((seriesItem, index) => (
-                  <DraggableItem
-                    hideDragHandle
-                    id={seriesItem.id}
-                    index={index}
-                    isReordering={isReordering}
-                    key={seriesItem.id}
-                    tag="tr"
-                  >
-                    {isReordering && <td className={styles.dragHandle}>⬍</td>}
+        onConfirm={() => onConfirmReordering(releaseSeries)}
+        onMoveItem={({ prevIndex, nextIndex }) => {
+          const reordered = reorder(releaseSeries, prevIndex, nextIndex);
+          setReleaseSeries(reordered);
+        }}
+        onReverse={() => {
+          setReleaseSeries(releaseSeries.toReversed());
+        }}
+      />
+    );
+  }
 
-                    <td>
-                      <span className="govuk-!-display-block">
-                        {seriesItem.description}
-                      </span>
-                    </td>
-                    <td className="govuk-!-width-one-half">
-                      {seriesItem.isLegacyLink && (
-                        <a
-                          className="govuk-link--no-visited-state"
-                          href={seriesItem.legacyLinkUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          tabIndex={isReordering ? -1 : undefined}
-                        >
-                          {seriesItem.legacyLinkUrl}
-                        </a>
-                      )}
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Description</th>
+          <th className="govuk-!-width-one-half">URL</th>
+          <th>Status</th>
+          {canManageReleaseSeries && <th>Actions</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {releaseSeries.map(seriesItem => (
+          <tr key={seriesItem.id}>
+            <td>
+              <span className="govuk-!-display-block">
+                {seriesItem.description}
+              </span>
+            </td>
+            <td className="govuk-!-width-one-half">
+              {seriesItem.isLegacyLink && (
+                <a
+                  className="govuk-link--no-visited-state"
+                  href={seriesItem.legacyLinkUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {seriesItem.legacyLinkUrl}
+                </a>
+              )}
 
-                      {!seriesItem.isLegacyLink && seriesItem.isPublished && (
-                        <Link
-                          to={`${config.publicAppUrl}/find-statistics/${publicationSlug}/${seriesItem.releaseSlug}`}
-                          className="govuk-link--no-visited-state"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          tabIndex={isReordering ? -1 : undefined}
-                        >
-                          {`${config.publicAppUrl}/find-statistics/${publicationSlug}/${seriesItem.releaseSlug}`}
-                        </Link>
-                      )}
-                      {!seriesItem.isLegacyLink &&
-                        !seriesItem.isPublished &&
-                        `${config.publicAppUrl}/find-statistics/${publicationSlug}/${seriesItem.releaseSlug}`}
-                    </td>
+              {!seriesItem.isLegacyLink && seriesItem.isPublished && (
+                <Link
+                  to={`${config.publicAppUrl}/find-statistics/${publicationSlug}/${seriesItem.releaseSlug}`}
+                  className="govuk-link--no-visited-state"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {`${config.publicAppUrl}/find-statistics/${publicationSlug}/${seriesItem.releaseSlug}`}
+                </Link>
+              )}
+              {!seriesItem.isLegacyLink &&
+                !seriesItem.isPublished &&
+                `${config.publicAppUrl}/find-statistics/${publicationSlug}/${seriesItem.releaseSlug}`}
+            </td>
 
-                    <td>
-                      {seriesItem.isLegacyLink ? (
-                        <Tag colour="grey">Legacy release</Tag>
-                      ) : (
-                        <>
-                          {seriesItem.isLatest && <Tag>Latest release</Tag>}
-                          {!seriesItem.isPublished && <Tag>Unpublished</Tag>}
-                        </>
-                      )}
-                    </td>
+            <td>
+              {seriesItem.isLegacyLink ? (
+                <Tag colour="grey">Legacy release</Tag>
+              ) : (
+                <>
+                  {seriesItem.isLatest && <Tag>Latest release</Tag>}
+                  {!seriesItem.isPublished && <Tag>Unpublished</Tag>}
+                </>
+              )}
+            </td>
 
-                    {canManageReleaseSeries && !isReordering && (
-                      <td>
-                        {seriesItem.isLegacyLink && (
-                          <ButtonGroup className="govuk-!-margin-bottom-0">
-                            <ModalConfirm
-                              confirmText="OK"
-                              title="Edit legacy release"
-                              triggerButton={
-                                <ButtonText>
-                                  Edit
-                                  <VisuallyHidden>
-                                    {` ${seriesItem.description}`}
-                                  </VisuallyHidden>
-                                </ButtonText>
-                              }
-                              onConfirm={() => {
-                                history.push(
-                                  generatePath<PublicationEditReleaseSeriesLegacyLinkRouteParams>(
-                                    publicationEditReleaseSeriesLegacyLinkRoute.path,
-                                    {
-                                      publicationId,
-                                      releaseSeriesItemId: seriesItem.id,
-                                    },
-                                  ),
-                                );
-                              }}
-                            >
-                              <WarningMessage>
-                                All changes made to legacy releases appear
-                                immediately on the public website.
-                              </WarningMessage>
-                            </ModalConfirm>
+            {canManageReleaseSeries && (
+              <td>
+                {seriesItem.isLegacyLink && (
+                  <ButtonGroup className="govuk-!-margin-bottom-0">
+                    <ModalConfirm
+                      confirmText="OK"
+                      title="Edit legacy release"
+                      triggerButton={
+                        <ButtonText>
+                          Edit
+                          <VisuallyHidden>
+                            {` ${seriesItem.description}`}
+                          </VisuallyHidden>
+                        </ButtonText>
+                      }
+                      onConfirm={() => {
+                        history.push(
+                          generatePath<PublicationEditReleaseSeriesLegacyLinkRouteParams>(
+                            publicationEditReleaseSeriesLegacyLinkRoute.path,
+                            {
+                              publicationId,
+                              releaseSeriesItemId: seriesItem.id,
+                            },
+                          ),
+                        );
+                      }}
+                    >
+                      <WarningMessage>
+                        All changes made to legacy releases appear immediately
+                        on the public website.
+                      </WarningMessage>
+                    </ModalConfirm>
 
-                            <ModalConfirm
-                              title="Delete legacy release"
-                              triggerButton={
-                                <ButtonText variant="warning">
-                                  Delete
-                                  <VisuallyHidden>
-                                    {` ${seriesItem.description}`}
-                                  </VisuallyHidden>
-                                </ButtonText>
-                              }
-                              onConfirm={async () => {
-                                await onDelete(seriesItem.id);
-                              }}
-                            >
-                              <p>
-                                Are you sure you want to delete this legacy
-                                release?
-                              </p>
-                              <p>
-                                All changes made to legacy releases appear
-                                immediately on the public website.
-                              </p>
-                            </ModalConfirm>
-                          </ButtonGroup>
-                        )}
-                      </td>
-                    )}
-                  </DraggableItem>
-                ))}
-              </DroppableArea>
-            </table>
-          )}
-        </Droppable>
-      </DragDropContext>
-
-      {isReordering && (
-        <ButtonGroup>
-          <Button
-            onClick={() => {
-              onConfirmReordering(releaseSeries);
-            }}
-          >
-            Confirm order
-          </Button>
-          <Button
-            variant="secondary"
-            onClick={() => {
-              setReleaseSeries(initialReleaseSeries);
-              onCancelReordering();
-            }}
-          >
-            Cancel reordering
-          </Button>
-        </ButtonGroup>
-      )}
-    </>
+                    <ModalConfirm
+                      title="Delete legacy release"
+                      triggerButton={
+                        <ButtonText variant="warning">
+                          Delete
+                          <VisuallyHidden>
+                            {` ${seriesItem.description}`}
+                          </VisuallyHidden>
+                        </ButtonText>
+                      }
+                      onConfirm={async () => {
+                        await onDelete(seriesItem.id);
+                      }}
+                    >
+                      <p>
+                        Are you sure you want to delete this legacy release?
+                      </p>
+                      <p>
+                        All changes made to legacy releases appear immediately
+                        on the public website.
+                      </p>
+                    </ModalConfirm>
+                  </ButtonGroup>
+                )}
+              </td>
+            )}
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/ReleaseFootnotesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/ReleaseFootnotesPage.tsx
@@ -104,18 +104,13 @@ const ReleaseFootnotesPage = ({
               </ButtonLink>
             )}
 
-            {footnotes.length > 1 && (
+            {footnotes.length > 1 && !isReordering && (
               <Button
                 className="govuk-!-margin-left-auto"
-                variant={!isReordering ? 'secondary' : undefined}
-                onClick={async () => {
-                  if (isReordering) {
-                    await handleSaveOrder();
-                  }
-                  toggleIsReordering();
-                }}
+                variant="secondary"
+                onClick={toggleIsReordering.on}
               >
-                {isReordering ? 'Save order' : 'Reorder footnotes'}
+                Reorder footnotes
               </Button>
             )}
           </div>
@@ -128,6 +123,10 @@ const ReleaseFootnotesPage = ({
           footnoteMeta={footnoteMeta}
           canUpdateRelease={canUpdateRelease}
           isReordering={isReordering}
+          onConfirmReordering={async () => {
+            await handleSaveOrder();
+            toggleIsReordering();
+          }}
           onDelete={async footnote => {
             await footnoteService.deleteFootnote(releaseId, footnote.id);
             setFootnotes({

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/__tests__/ReleaseFootnotesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/__tests__/ReleaseFootnotesPage.test.tsx
@@ -120,7 +120,7 @@ describe('ReleaseFootnotesPage', () => {
       });
 
       expect(
-        screen.queryByRole('button', { name: 'Save order' }),
+        screen.queryByRole('button', { name: 'Confirm order' }),
       ).not.toBeInTheDocument();
       expect(
         screen.getByRole('link', { name: 'Create footnote' }),
@@ -131,7 +131,7 @@ describe('ReleaseFootnotesPage', () => {
       );
 
       expect(
-        screen.getByRole('button', { name: 'Save order' }),
+        screen.getByRole('button', { name: 'Confirm order' }),
       ).toBeInTheDocument();
       expect(
         screen.queryByRole('button', { name: 'Reorder footnotes' }),
@@ -150,18 +150,20 @@ describe('ReleaseFootnotesPage', () => {
         screen.queryByRole('button', { name: 'See matching criteria' }),
       ).not.toBeInTheDocument();
 
-      expect(screen.getByTestId('Footnote - Footnote 1 content')).toBe(
+      const reorderableItems = screen.getAllByTestId('reorderable-item');
+
+      expect(reorderableItems[0]).toBe(
         screen.getByRole('button', { name: 'Footnote 1 content' }),
       );
-      expect(screen.getByTestId('Footnote - Footnote 3 content')).toBe(
-        screen.getByRole('button', { name: 'Footnote 3 content' }),
+      expect(reorderableItems[1]).toBe(
+        screen.getByRole('button', { name: 'Footnote 2 content' }),
       );
-      expect(screen.getByTestId('Footnote - Footnote 3 content')).toBe(
+      expect(reorderableItems[2]).toBe(
         screen.getByRole('button', { name: 'Footnote 3 content' }),
       );
     });
 
-    test('calls the footnotes service when save order is clicked', async () => {
+    test('calls the footnotes service when confirm order is clicked', async () => {
       permissionService.canUpdateRelease.mockResolvedValue(true);
       footnoteService.getFootnoteMeta.mockResolvedValue(testFootnoteMeta);
       footnoteService.getFootnotes.mockResolvedValue(testFootnotes);
@@ -175,9 +177,11 @@ describe('ReleaseFootnotesPage', () => {
         screen.getByRole('button', { name: 'Reorder footnotes' }),
       );
       await waitFor(() => {
-        expect(screen.getByText('Save order')).toBeInTheDocument();
+        expect(screen.getByText('Confirm order')).toBeInTheDocument();
       });
-      await userEvent.click(screen.getByRole('button', { name: 'Save order' }));
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Confirm order' }),
+      );
 
       expect(footnoteService.updateFootnotesOrder).toHaveBeenCalledWith(
         'release-1',

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnotesList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnotesList.tsx
@@ -1,5 +1,3 @@
-import DroppableArea from '@admin/components/DroppableArea';
-import DraggableItem from '@admin/components/DraggableItem';
 import Link from '@admin/components/Link';
 import generateFootnoteMetaMap from '@admin/pages/release/footnotes/utils/generateFootnoteMetaMap';
 import styles from '@admin/pages/release/footnotes/components/FootnotesList.module.scss';
@@ -9,17 +7,17 @@ import {
   releaseFootnotesEditRoute,
 } from '@admin/routes/releaseRoutes';
 import { Footnote, FootnoteMeta } from '@admin/services/footnoteService';
+import ReorderableList from '@common/components/ReorderableList';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
 import Details from '@common/components/Details';
 import InsetText from '@common/components/InsetText';
 import ModalConfirm from '@common/components/ModalConfirm';
+import ContentHtml from '@common/components/ContentHtml';
+import sanitizeHtml from '@common/utils/sanitizeHtml';
 import reorder from '@common/utils/reorder';
-import classNames from 'classnames';
 import React, { useMemo } from 'react';
 import { generatePath } from 'react-router';
-import { DragDropContext, Droppable } from '@hello-pangea/dnd';
-import ContentHtml from '@common/components/ContentHtml';
 
 interface Props {
   publicationId: string;
@@ -29,6 +27,7 @@ interface Props {
   canUpdateRelease: boolean;
   isReordering: boolean;
   onDelete: (footnote: Footnote) => void;
+  onConfirmReordering: () => void;
   onReorder: (footnotes: Footnote[]) => void;
 }
 
@@ -39,6 +38,7 @@ const FootnotesList = ({
   footnoteMeta,
   canUpdateRelease,
   isReordering,
+  onConfirmReordering,
   onDelete,
   onReorder,
 }: Props) => {
@@ -50,116 +50,108 @@ const FootnotesList = ({
     return <InsetText>No footnotes have been created.</InsetText>;
   }
 
+  if (isReordering) {
+    return (
+      <ReorderableList
+        heading="Reorder footnotes"
+        id="footnotes"
+        list={footnotes.map(footnote => ({
+          id: footnote.id,
+          label: sanitizeHtml(footnote.content, { allowedTags: [] }),
+        }))}
+        onConfirm={onConfirmReordering}
+        onMoveItem={({ prevIndex, nextIndex }) => {
+          const reordered = reorder(footnotes, prevIndex, nextIndex);
+          onReorder(reordered);
+        }}
+        onReverse={() => {
+          onReorder(footnotes.toReversed());
+        }}
+      />
+    );
+  }
+
   return (
-    <DragDropContext
-      onDragEnd={result => {
-        if (!result.destination) {
-          return;
-        }
-        const reorderedFootnotes = reorder(
-          footnotes,
-          result.source.index,
-          result.destination.index,
-        );
-        onReorder(reorderedFootnotes);
-      }}
-    >
-      <Droppable droppableId="footnotes" isDropDisabled={!isReordering}>
-        {(droppableProvided, droppableSnapshot) => (
-          <DroppableArea
-            droppableProvided={droppableProvided}
-            droppableSnapshot={droppableSnapshot}
+    <>
+      {footnotes.map(footnote => {
+        const { id, content } = footnote;
+
+        return (
+          <div
+            className={styles.itemContainer}
+            id={id}
+            key={id}
+            data-testid={`Footnote - ${content}`}
           >
-            {footnotes.map((footnote, index) => {
-              const { id, content } = footnote;
+            <div className={styles.row}>
+              <ContentHtml className={styles.rowContent} html={content} />
 
-              return (
-                <DraggableItem
-                  className={classNames({
-                    [styles.itemContainer]: !isReordering,
-                  })}
-                  id={id}
-                  index={index}
-                  isReordering={isReordering}
-                  key={id}
-                  testId={`Footnote - ${content}`}
-                >
-                  <div className={styles.row}>
-                    <ContentHtml className={styles.rowContent} html={content} />
-
-                    {!isReordering && canUpdateRelease && (
-                      <ButtonGroup className={styles.rowActions}>
-                        <Link
-                          to={generatePath<ReleaseFootnoteRouteParams>(
-                            releaseFootnotesEditRoute.path,
-                            {
-                              publicationId,
-                              releaseId,
-                              footnoteId: id,
-                            },
-                          )}
-                        >
-                          Edit footnote
-                        </Link>
-
-                        <ModalConfirm
-                          title="Delete footnote"
-                          triggerButton={
-                            <ButtonText variant="warning">
-                              Delete footnote
-                            </ButtonText>
-                          }
-                          onConfirm={async () => {
-                            await onDelete(footnote);
-                          }}
-                        >
-                          <p>
-                            Are you sure you want to delete the following
-                            footnote:
-                          </p>
-
-                          <InsetText>
-                            <p>{footnote.content}</p>
-                          </InsetText>
-                        </ModalConfirm>
-                      </ButtonGroup>
+              {canUpdateRelease && (
+                <ButtonGroup className={styles.rowActions}>
+                  <Link
+                    to={generatePath<ReleaseFootnoteRouteParams>(
+                      releaseFootnotesEditRoute.path,
+                      {
+                        publicationId,
+                        releaseId,
+                        footnoteId: id,
+                      },
                     )}
-                  </div>
-                  {!isReordering && (
-                    <Details
-                      summary="See matching criteria"
-                      className="govuk-!-margin-0"
-                    >
-                      <table className={styles.footnoteSelectionTable}>
-                        <thead>
-                          <tr>
-                            <th>Subjects</th>
-                            <th>Indicators</th>
-                            <th>Filters</th>
-                          </tr>
-                        </thead>
-                        <tbody className="govuk-body-s">
-                          {Object.entries(footnote.subjects).map(
-                            ([subjectId, selection]) => (
-                              <FootnoteSubjectSelection
-                                key={subjectId}
-                                subjectId={subjectId}
-                                subject={selection}
-                                footnoteMetaGetters={footnoteMetaGetters}
-                              />
-                            ),
-                          )}
-                        </tbody>
-                      </table>
-                    </Details>
+                  >
+                    Edit footnote
+                  </Link>
+
+                  <ModalConfirm
+                    title="Delete footnote"
+                    triggerButton={
+                      <ButtonText variant="warning">Delete footnote</ButtonText>
+                    }
+                    onConfirm={async () => {
+                      await onDelete(footnote);
+                    }}
+                  >
+                    <p>
+                      Are you sure you want to delete the following footnote:
+                    </p>
+
+                    <InsetText>
+                      <p>{footnote.content}</p>
+                    </InsetText>
+                  </ModalConfirm>
+                </ButtonGroup>
+              )}
+            </div>
+
+            <Details
+              summary="See matching criteria"
+              className="govuk-!-margin-0"
+            >
+              <table className={styles.footnoteSelectionTable}>
+                <thead>
+                  <tr>
+                    <th>Subjects</th>
+                    <th>Indicators</th>
+                    <th>Filters</th>
+                  </tr>
+                </thead>
+                <tbody className="govuk-body-s">
+                  {Object.entries(footnote.subjects).map(
+                    ([subjectId, selection]) => (
+                      <FootnoteSubjectSelection
+                        key={subjectId}
+                        subjectId={subjectId}
+                        subject={selection}
+                        footnoteMetaGetters={footnoteMetaGetters}
+                      />
+                    ),
                   )}
-                </DraggableItem>
-              );
-            })}
-          </DroppableArea>
-        )}
-      </Droppable>
-    </DragDropContext>
+                </tbody>
+              </table>
+            </Details>
+          </div>
+        );
+      })}
+    </>
   );
 };
 

--- a/src/explore-education-statistics-common/src/components/ReorderableItem.module.scss
+++ b/src/explore-education-statistics-common/src/components/ReorderableItem.module.scss
@@ -1,0 +1,59 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.container {
+  position: relative;
+}
+
+.draggable {
+  align-items: center;
+  background: govuk-colour('white');
+  border-bottom: 1px solid govuk-colour('mid-grey');
+  display: flex;
+  justify-content: space-between;
+  min-height: 60px;
+  padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+
+  &:hover {
+    background: govuk-colour('light-grey');
+  }
+
+  &:focus {
+    @include govuk-focused-text;
+    z-index: 1;
+  }
+
+  &.notDragging:focus {
+    background: govuk-colour('white');
+  }
+}
+
+.isDragging {
+  @include govuk-focused-text;
+  z-index: 1;
+}
+
+.isDraggedOutside {
+  opacity: 0.7;
+}
+
+.arrow {
+  transform: rotate(90deg);
+}
+
+.controls {
+  position: absolute;
+  right: 5px;
+  top: govuk-spacing(2);
+}
+
+.itemLabel {
+  align-items: center;
+  display: flex;
+  padding: 0 90px 0 govuk-spacing(1); // Leave space for the controls.
+  word-break: break-word;
+}
+
+.dragIcon {
+  flex-shrink: 0;
+  margin-right: govuk-spacing(2);
+}

--- a/src/explore-education-statistics-common/src/components/ReorderableItem.tsx
+++ b/src/explore-education-statistics-common/src/components/ReorderableItem.tsx
@@ -1,0 +1,103 @@
+import DragIcon from '@common/components/DragIcon';
+import styles from '@common/components/ReorderableItem.module.scss';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import { ArrowLeft, ArrowRight } from '@common/components/ArrowIcons';
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import { mergeRefs } from '@common/utils/mergeRefs';
+import classNames from 'classnames';
+import React, { ReactNode, useEffect, useRef } from 'react';
+import { DraggableProvided, DraggableStateSnapshot } from '@hello-pangea/dnd';
+
+export interface ReorderableListItem {
+  id: string;
+  label: ReactNode | string;
+}
+
+interface Props {
+  draggableProvided: DraggableProvided;
+  draggableSnapshot: DraggableStateSnapshot;
+  dropAreaActive: boolean;
+  focusItem: boolean;
+  index: number;
+  isLastItem: boolean;
+  item: ReorderableListItem;
+  onMoveItem: ({
+    prevIndex,
+    nextIndex,
+  }: {
+    prevIndex: number;
+    nextIndex: number;
+  }) => void;
+}
+
+export default function ReorderableItem({
+  draggableProvided,
+  draggableSnapshot,
+  dropAreaActive,
+  focusItem = false,
+  index,
+  isLastItem,
+  item,
+  onMoveItem,
+}: Props) {
+  const itemRef = useRef<HTMLLIElement>(null);
+  useEffect(() => {
+    if (focusItem) {
+      itemRef.current?.focus();
+    }
+  });
+
+  return (
+    <li className={classNames(styles.container, 'govuk-!-margin-bottom-0')}>
+      <div
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...draggableProvided.draggableProps}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...draggableProvided.dragHandleProps}
+        className={classNames('govuk-!-margin-bottom-0', styles.draggable, {
+          [styles.isDragging]: draggableSnapshot.isDragging,
+          [styles.isDraggedOutside]:
+            draggableSnapshot.isDragging && !draggableSnapshot.draggingOver,
+          [styles.notDragging]: dropAreaActive && !draggableSnapshot.isDragging,
+        })}
+        ref={mergeRefs(draggableProvided.innerRef, itemRef)}
+        style={draggableProvided.draggableProps.style}
+        data-testid="reorderable-item"
+      >
+        <div className={styles.itemLabel}>
+          <DragIcon className={styles.dragIcon} />
+          <span>{item.label}</span>
+        </div>
+      </div>
+      {!dropAreaActive && !draggableSnapshot.isDragging && (
+        <ButtonGroup className={styles.controls}>
+          {index !== 0 && (
+            <Button
+              className="govuk-!-margin-bottom-0"
+              variant="secondary"
+              onClick={() => {
+                onMoveItem({ prevIndex: index, nextIndex: index - 1 });
+              }}
+            >
+              <ArrowLeft className={styles.arrow} />
+              <VisuallyHidden>Move {item.label} up</VisuallyHidden>
+            </Button>
+          )}
+          {!isLastItem && (
+            <Button
+              className="govuk-!-margin-bottom-0"
+              variant="secondary"
+              onClick={() => {
+                onMoveItem({ prevIndex: index, nextIndex: index + 1 });
+              }}
+            >
+              <ArrowRight className={styles.arrow} />
+              <VisuallyHidden>Move {item.label} down</VisuallyHidden>
+            </Button>
+          )}
+        </ButtonGroup>
+      )}
+    </li>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/ReorderableList.module.scss
+++ b/src/explore-education-statistics-common/src/components/ReorderableList.module.scss
@@ -1,0 +1,12 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.dropArea {
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+  }
+}
+
+.dropAreaActive {
+  background: govuk-colour('light-grey');
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+}

--- a/src/explore-education-statistics-common/src/components/ReorderableList.tsx
+++ b/src/explore-education-statistics-common/src/components/ReorderableList.tsx
@@ -1,0 +1,109 @@
+import styles from '@common/components/ReorderableList.module.scss';
+import ReorderableItem, {
+  ReorderableListItem,
+} from '@common/components/ReorderableItem';
+import ButtonGroup from '@common/components/ButtonGroup';
+import Button from '@common/components/Button';
+import classNames from 'classnames';
+import React, { useState } from 'react';
+import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
+
+interface Props {
+  heading?: string;
+  id: string;
+  list: ReorderableListItem[];
+  testId?: string;
+  onCancel?: () => void;
+  onConfirm: () => void;
+  onMoveItem: ({
+    prevIndex,
+    nextIndex,
+  }: {
+    prevIndex: number;
+    nextIndex: number;
+  }) => void;
+  onReverse?: () => void;
+}
+
+export default function ReorderableList({
+  heading,
+  id,
+  list,
+  testId,
+  onCancel,
+  onConfirm,
+  onMoveItem,
+  onReverse,
+}: Props) {
+  const [focusItem, setFocusItem] = useState<number>(0);
+
+  return (
+    <>
+      {heading && <h3>{heading}</h3>}
+      <DragDropContext
+        onDragEnd={result => {
+          if (!result.destination) {
+            return;
+          }
+
+          onMoveItem({
+            prevIndex: result.source.index,
+            nextIndex: result.destination.index,
+          });
+          setFocusItem(result.destination.index);
+        }}
+      >
+        <Droppable droppableId={id}>
+          {(droppableProvided, droppableSnapshot) => (
+            <ol
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...droppableProvided.droppableProps}
+              className={classNames('govuk-list', styles.dropArea, {
+                [styles.dropAreaActive]: droppableSnapshot.isDraggingOver,
+              })}
+              data-testid={testId}
+              ref={droppableProvided.innerRef}
+            >
+              {list.map((item, index) => {
+                return (
+                  <Draggable draggableId={item.id} key={item.id} index={index}>
+                    {(draggableProvided, draggableSnapshot) => (
+                      <ReorderableItem
+                        draggableProvided={draggableProvided}
+                        draggableSnapshot={draggableSnapshot}
+                        dropAreaActive={droppableSnapshot.isDraggingOver}
+                        focusItem={focusItem === index}
+                        key={item.id}
+                        index={index}
+                        isLastItem={index === list.length - 1}
+                        item={item}
+                        onMoveItem={({ prevIndex, nextIndex }) => {
+                          onMoveItem({ prevIndex, nextIndex });
+                          setFocusItem(nextIndex);
+                        }}
+                      />
+                    )}
+                  </Draggable>
+                );
+              })}
+              {droppableProvided.placeholder}
+            </ol>
+          )}
+        </Droppable>
+      </DragDropContext>
+      <ButtonGroup>
+        <Button onClick={onConfirm}>Confirm order</Button>
+        {onReverse && (
+          <Button variant="secondary" onClick={onReverse}>
+            Reverse order
+          </Button>
+        )}
+        {onCancel && (
+          <Button variant="secondary" onClick={onCancel}>
+            Cancel reordering
+          </Button>
+        )}
+      </ButtonGroup>
+    </>
+  );
+}

--- a/src/explore-education-statistics-common/src/components/__tests__/ReorderableList.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ReorderableList.test.tsx
@@ -1,0 +1,136 @@
+import ReorderableList from '@common/components/ReorderableList';
+import { ReorderableListItem } from '@common/components/ReorderableItem';
+import React from 'react';
+import { screen, within } from '@testing-library/react';
+import noop from 'lodash/noop';
+import render from '@common-test/render';
+
+describe('ReorderableList', () => {
+  const testList: ReorderableListItem[] = [
+    { id: 'item-1', label: 'Item 1' },
+    { id: 'item-2', label: 'Item 2' },
+    { id: 'item-3', label: 'Item 3' },
+  ];
+
+  test('renders the list', () => {
+    render(
+      <ReorderableList
+        id="test"
+        list={testList}
+        onConfirm={noop}
+        onMoveItem={noop}
+      />,
+    );
+
+    const listItems = screen.getAllByRole('listitem');
+    expect(listItems).toHaveLength(3);
+
+    const listItem1 = within(listItems[0]);
+    expect(
+      listItem1.getByRole('button', { name: 'Item 1' }),
+    ).toBeInTheDocument();
+    expect(
+      listItem1.queryByRole('button', { name: 'Move Item 1 up' }),
+    ).not.toBeInTheDocument();
+    expect(
+      listItem1.getByRole('button', { name: 'Move Item 1 down' }),
+    ).toBeInTheDocument();
+
+    const listItem2 = within(listItems[1]);
+    expect(
+      listItem2.getByRole('button', { name: 'Item 2' }),
+    ).toBeInTheDocument();
+    expect(
+      listItem2.getByRole('button', { name: 'Move Item 2 up' }),
+    ).toBeInTheDocument();
+    expect(
+      listItem2.getByRole('button', { name: 'Move Item 2 down' }),
+    ).toBeInTheDocument();
+
+    const listItem3 = within(listItems[2]);
+    expect(
+      listItem3.getByRole('button', { name: 'Item 3' }),
+    ).toBeInTheDocument();
+    expect(
+      listItem3.getByRole('button', { name: 'Move Item 3 up' }),
+    ).toBeInTheDocument();
+    expect(
+      listItem3.queryByRole('button', { name: 'Move Item 3 down' }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Confirm order' }),
+    ).toBeInTheDocument();
+  });
+
+  test('calls onConfirm when the confirm button is clicked', async () => {
+    const handleConfirm = jest.fn();
+    const { user } = render(
+      <ReorderableList
+        id="test"
+        list={testList}
+        onConfirm={handleConfirm}
+        onMoveItem={noop}
+      />,
+    );
+
+    expect(handleConfirm).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Confirm order' }));
+    expect(handleConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onMoveItem when the move buttons are clicked', async () => {
+    const handleMoveItem = jest.fn();
+    const { user } = render(
+      <ReorderableList
+        id="test"
+        list={testList}
+        onConfirm={noop}
+        onMoveItem={handleMoveItem}
+      />,
+    );
+
+    expect(handleMoveItem).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Move Item 1 down' }));
+    expect(handleMoveItem).toHaveBeenCalledTimes(1);
+    expect(handleMoveItem).toHaveBeenCalledWith({ prevIndex: 0, nextIndex: 1 });
+
+    await user.click(screen.getByRole('button', { name: 'Move Item 3 up' }));
+    expect(handleMoveItem).toHaveBeenCalledTimes(2);
+    expect(handleMoveItem).toHaveBeenCalledWith({ prevIndex: 2, nextIndex: 1 });
+  });
+
+  test('calls onReverse when the reverse button is clicked', async () => {
+    const handleReverse = jest.fn();
+    const { user } = render(
+      <ReorderableList
+        id="test"
+        list={testList}
+        onConfirm={noop}
+        onMoveItem={noop}
+        onReverse={handleReverse}
+      />,
+    );
+
+    expect(handleReverse).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Reverse order' }));
+    expect(handleReverse).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onCancel when the cancel button is clicked', async () => {
+    const handleCancel = jest.fn();
+    const { user } = render(
+      <ReorderableList
+        id="test"
+        list={testList}
+        onConfirm={noop}
+        onMoveItem={noop}
+        onCancel={handleCancel}
+      />,
+    );
+
+    expect(handleCancel).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Cancel reordering' }));
+    expect(handleCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/robot-tests/tests/admin_and_public/bau/legacy_releases_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/legacy_releases_reordering.robot
@@ -17,7 +17,7 @@ ${PUBLICATION_NAME}=                    ui-tests-legacy-releases-%{RUN_IDENTIFIE
 ${PUBLIC_PUBLICATION_URL_ENDING}=       /find-statistics/${PUBLICATION_NAME}
 ${DESCRIPTION}=                         legacy release description
 ${UPDATED_DESCRIPTION}=                 updated legacy release description
-${PUBLIC_URL_WITHOUT_AUTH}           ${EMPTY}
+${PUBLIC_URL_WITHOUT_AUTH}              ${EMPTY}
 
 
 *** Test Cases ***
@@ -131,7 +131,6 @@ Reorder the legacy releases
     user clicks button    OK
     user waits until modal is not visible    Reorder legacy releases
     user waits until page contains button    Confirm order
-    user sets focus to element    css:tbody tr:first-child
     user presses keys    ${SPACE}
     user presses keys    ARROW_DOWN
     user presses keys    ARROW_DOWN

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -430,11 +430,10 @@ Check data blocks are shown in the featured tables table
 
 Reorder featured tables
     user clicks button    Reorder featured tables
-    user sets focus to element    css:tbody tr:first-child
     user presses keys    ${SPACE}
     user presses keys    ARROW_DOWN
     user presses keys    ${SPACE}
-    user clicks button    Save order
+    user clicks button    Confirm order
 
 Check featured tables were reordered
     user checks table cell contains    1    1    UI Test data block name 2    testid:featuredTables
@@ -473,11 +472,10 @@ Reorder footnotes
     user clicks link    Footnotes
     user waits until h2 is visible    Footnotes
     user clicks button    Reorder footnotes
-    user sets focus to element    testid:Footnote - ${FOOTNOTE_ALL}
     user presses keys    ${SPACE}
     user presses keys    ARROW_DOWN
     user presses keys    ${SPACE}
-    user clicks button    Save order
+    user clicks button    Confirm order
 
 Check footnotes were reordered on data block
     user sets focus to element    link:Data blocks    xpath://*[@aria-label="Release"]


### PR DESCRIPTION
Adds a new reusable `ReorderableList` component for accessible reordering that renders a simplified ordered list. 
- includes move up and down buttons to satisfy the new WCAG requirement (note that these can't be nested in the draggable because it has the button role).
- moves focus to the first item when start reordering and keeps focus on the item you've moved.
- moves the confirm button to be consistently under the reorderable list.
- instead of updating the existing table / list / whatever to make it reorderable I'm replacing it with the new ReorderableList component when reordering is enabled. This is to make it simpler to use, plus it should help keep the reordering UIs more consistent.

I've implemented this new component for reordering:
- footnotes 
- releases (in the legacy releases tab)
- featured tables