### PR TITLE
EES-5546: Allow bulk imports to start replacements

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataArchiveValidationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataArchiveValidationServiceTests.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
@@ -36,8 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseVersionId,
                     It.IsAny<ArchiveDataSetFile>(),
                     It.IsAny<Stream>(),
-                    It.IsAny<Stream>(),
-                    null))
+                    It.IsAny<Stream>()))
                 .ReturnsAsync([]);
 
             fileTypeService
@@ -128,8 +128,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseVersionId,
                     It.IsAny<ArchiveDataSetFile>(),
                     It.IsAny<Stream>(),
-                    It.IsAny<Stream>(),
-                    null))
+                    It.IsAny<Stream>()))
                 .ReturnsAsync([]);
 
             fileTypeService
@@ -338,8 +337,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseVersionId,
                     It.IsAny<ArchiveDataSetFile>(),
                     It.IsAny<Stream>(),
-                    It.IsAny<Stream>(),
-                    null))
+                    It.IsAny<Stream>()))
                 .ReturnsAsync([]);
 
             fileTypeService
@@ -382,11 +380,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         private static DataArchiveValidationService SetupDataArchiveValidationService(
+            ContentDbContext? contentDbContext = null,
             IFileTypeService? fileTypeService = null,
             IFileUploadsValidatorService? fileUploadsValidatorService = null)
         {
             return new DataArchiveValidationService(
-                fileTypeService ?? Mock.Of<IFileTypeService>(Strict),
+                contentDbContext ?? Mock.Of<ContentDbContext>(Strict),
+            fileTypeService ?? Mock.Of<IFileTypeService>(Strict),
                 fileUploadsValidatorService ?? Mock.Of<IFileUploadsValidatorService>(Strict)
             );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataArchiveValidationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataArchiveValidationServiceTests.cs
@@ -10,11 +10,13 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
+using File = System.IO.File;
 using ValidationMessages = GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationMessages;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
@@ -25,13 +27,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task ValidateDataArchiveFile_Success()
         {
             var releaseVersionId = Guid.NewGuid();
+            var archive = CreateFormFileFromResource("data-zip-valid.zip");
+
             var fileUploadsValidatorService = new Mock<IFileUploadsValidatorService>(Strict);
             var fileTypeService = new Mock<IFileTypeService>(Strict);
-
-            var service = SetupDataArchiveValidationService(
-                fileTypeService: fileTypeService.Object,
-                fileUploadsValidatorService: fileUploadsValidatorService.Object);
-            var archive = CreateFormFileFromResource("data-zip-valid.zip");
 
             fileUploadsValidatorService.Setup(mock => mock.ValidateDataSetFilesForUpload(
                     releaseVersionId,
@@ -44,12 +43,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Setup(s => s.IsValidZipFile(archive))
                 .ReturnsAsync(true);
 
-            var result = await service.ValidateDataArchiveFile(
-                releaseVersionId,
-                "Data set title",
-                archive);
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupDataArchiveValidationService(
+                    contentDbContext: contentDbContext,
+                    fileTypeService: fileTypeService.Object,
+                    fileUploadsValidatorService: fileUploadsValidatorService.Object);
 
-            Assert.True(result.IsRight);
+                var result = await service.ValidateDataArchiveFile(
+                    releaseVersionId,
+                    "Data set title",
+                    archive);
+
+                Assert.True(result.IsRight);
+            }
 
             VerifyAllMocks(fileUploadsValidatorService, fileTypeService);
         }
@@ -58,7 +66,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task ValidateDataArchiveFile_ZipFilenameTooLong_DoesNotEndInDotZip()
         {
             var fileTypeService = new Mock<IFileTypeService>(Strict);
-            var service = SetupDataArchiveValidationService(fileTypeService: fileTypeService.Object);
 
             var fileName =
                 "LoremipsumdolorsitametconsecteturadipiscingelitInsitametelitaccumsanbibendumlacusutmattismaurisCrasvehiculaaccumsaneratidelementumaugueposuereatNuncege.zipp";
@@ -68,19 +75,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Setup(s => s.IsValidZipFile(archive))
                 .ReturnsAsync(() => true);
 
-            var result = await service.ValidateDataArchiveFile(
-                Guid.NewGuid(),
-                "Data set title",
-                archive);
-            VerifyAllMocks(fileTypeService);
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupDataArchiveValidationService(
+                    contentDbContext: contentDbContext,
+                    fileTypeService: fileTypeService.Object);
 
-            result
-                .AssertLeft()
-                .AssertBadRequestWithValidationErrors([
-                    ValidationMessages.GenerateErrorFilenameTooLong(
-                        fileName, DataArchiveValidationService.MaxFilenameSize),
-                    ValidationMessages.GenerateErrorZipFilenameMustEndDotZip(fileName),
-            ]);
+                var result = await service.ValidateDataArchiveFile(
+                    Guid.NewGuid(),
+                    "Data set title",
+                    archive);
+
+                result
+                    .AssertLeft()
+                    .AssertBadRequestWithValidationErrors([
+                        ValidationMessages.GenerateErrorFilenameTooLong(
+                            fileName, DataArchiveValidationService.MaxFilenameSize),
+                        ValidationMessages.GenerateErrorZipFilenameMustEndDotZip(fileName),
+                    ]);
+            }
+
+            VerifyAllMocks(fileTypeService);
         }
 
         [Fact]
@@ -88,58 +104,164 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var fileTypeService = new Mock<IFileTypeService>(Strict);
 
-            var service = SetupDataArchiveValidationService(fileTypeService: fileTypeService.Object);
             var archive = CreateFormFileFromResource("data-zip-invalid.zip");
 
             fileTypeService
                 .Setup(s => s.IsValidZipFile(archive))
                 .ReturnsAsync(() => true);
 
-            var result = await service.ValidateDataArchiveFile(
-                Guid.NewGuid(),
-                "Data set title",
-                archive);
-            VerifyAllMocks(fileTypeService);
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupDataArchiveValidationService(
+                    contentDbContext: contentDbContext,
+                    fileTypeService: fileTypeService.Object);
 
-            result
-                .AssertLeft()
-                .AssertBadRequestWithValidationErrors([
-                    new ErrorViewModel
-                    {
-                        Code = ValidationMessages.DataZipShouldContainTwoFiles.Code,
-                        Message = ValidationMessages.DataZipShouldContainTwoFiles.Message,
-                    }
-            ]);
+                var result = await service.ValidateDataArchiveFile(
+                    Guid.NewGuid(),
+                    "Data set title",
+                    archive);
+
+                result
+                    .AssertLeft()
+                    .AssertBadRequestWithValidationErrors([
+                        new ErrorViewModel
+                        {
+                            Code = ValidationMessages.DataZipShouldContainTwoFiles.Code,
+                            Message = ValidationMessages.DataZipShouldContainTwoFiles.Message,
+                        }
+                    ]);
+            }
+
+            VerifyAllMocks(fileTypeService);
         }
 
         [Fact]
         public async Task ValidateBulkDataArchiveFile_Success()
         {
             var releaseVersionId = Guid.NewGuid();
+            var archive = CreateFormFileFromResource("bulk-data-zip-valid.zip");
+
             var fileUploadsValidatorService = new Mock<IFileUploadsValidatorService>(Strict);
             var fileTypeService = new Mock<IFileTypeService>(Strict);
 
-            var service = SetupDataArchiveValidationService(
-                fileTypeService: fileTypeService.Object,
-                fileUploadsValidatorService: fileUploadsValidatorService.Object);
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupDataArchiveValidationService(
+                    contentDbContext: contentDbContext,
+                    fileTypeService: fileTypeService.Object,
+                    fileUploadsValidatorService: fileUploadsValidatorService.Object);
+
+                fileUploadsValidatorService.Setup(mock => mock.ValidateDataSetFilesForUpload(
+                        releaseVersionId,
+                        It.IsAny<ArchiveDataSetFile>(),
+                        It.IsAny<Stream>(),
+                        It.IsAny<Stream>()))
+                    .ReturnsAsync([]);
+
+                fileTypeService
+                    .Setup(s => s.IsValidZipFile(archive))
+                    .ReturnsAsync(true);
+
+                var result = await service.ValidateBulkDataArchiveFile(
+                    releaseVersionId,
+                    archive);
+
+                var archiveDataSets = result.AssertRight();
+
+                Assert.Equal(2, archiveDataSets.Count);
+
+                Assert.Equal("First data set", archiveDataSets[0].Title);
+                Assert.Equal("one.csv", archiveDataSets[0].DataFilename);
+                Assert.Equal("one.meta.csv", archiveDataSets[0].MetaFilename);
+                Assert.Equal(696, archiveDataSets[0].DataFileSize);
+                Assert.Equal(210, archiveDataSets[0].MetaFileSize);
+                Assert.Null(archiveDataSets[0].ReplacingFile);
+
+                Assert.Equal("Second data set", archiveDataSets[1].Title);
+                Assert.Equal("two.csv", archiveDataSets[1].DataFilename);
+                Assert.Equal("two.meta.csv", archiveDataSets[1].MetaFilename);
+                Assert.Equal(2085, archiveDataSets[1].DataFileSize);
+                Assert.Equal(318, archiveDataSets[1].MetaFileSize);
+                Assert.Null(archiveDataSets[1].ReplacingFile);
+            }
+
+            VerifyAllMocks(fileUploadsValidatorService, fileTypeService);
+        }
+
+        [Fact]
+        public async Task ValidateBulkDataArchiveFile_Replacement_Success()
+        {
+            var releaseVersionId = Guid.NewGuid();
             var archive = CreateFormFileFromResource("bulk-data-zip-valid.zip");
 
-            fileUploadsValidatorService.Setup(mock => mock.ValidateDataSetFilesForUpload(
+            var fileUploadsValidatorService = new Mock<IFileUploadsValidatorService>(Strict);
+            var fileTypeService = new Mock<IFileTypeService>(Strict);
+
+            var releaseFile = new ReleaseFile
+            {
+                Name = "First data set",
+                ReleaseVersion = new ReleaseVersion
+                {
+                    Id = releaseVersionId,
+                },
+                File = new Content.Model.File
+                {
+                    Type = FileType.Data,
+                    SubjectId = Guid.NewGuid(),
+                    Filename = "one.csv",
+                    ContentLength = 1024,
+                },
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                contentDbContext.ReleaseFiles.Add(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupDataArchiveValidationService(
+                    contentDbContext: contentDbContext,
+                    fileTypeService: fileTypeService.Object,
+                    fileUploadsValidatorService: fileUploadsValidatorService.Object);
+
+                fileUploadsValidatorService.Setup(mock => mock.ValidateDataSetFilesForUpload(
+                        releaseVersionId,
+                        It.IsAny<ArchiveDataSetFile>(),
+                        It.IsAny<Stream>(),
+                        It.IsAny<Stream>()))
+                    .ReturnsAsync([]);
+
+                fileTypeService
+                    .Setup(s => s.IsValidZipFile(archive))
+                    .ReturnsAsync(true);
+
+                var result = await service.ValidateBulkDataArchiveFile(
                     releaseVersionId,
-                    It.IsAny<ArchiveDataSetFile>(),
-                    It.IsAny<Stream>(),
-                    It.IsAny<Stream>()))
-                .ReturnsAsync([]);
+                    archive);
 
-            fileTypeService
-                .Setup(s => s.IsValidZipFile(archive))
-                .ReturnsAsync(true);
+                var archiveDataSets = result.AssertRight();
 
-            var result = await service.ValidateBulkDataArchiveFile(
-                releaseVersionId,
-                archive);
+                Assert.Equal(2, archiveDataSets.Count);
 
-            Assert.True(result.IsRight);
+                Assert.Equal("First data set", archiveDataSets[0].Title);
+                Assert.Equal("one.csv", archiveDataSets[0].DataFilename);
+                Assert.Equal("one.meta.csv", archiveDataSets[0].MetaFilename);
+                Assert.Equal(696, archiveDataSets[0].DataFileSize);
+                Assert.Equal(210, archiveDataSets[0].MetaFileSize);
+                Assert.Equal(releaseFile.FileId, archiveDataSets[0].ReplacingFile!.Id);
+
+                Assert.Equal("Second data set", archiveDataSets[1].Title);
+                Assert.Equal("two.csv", archiveDataSets[1].DataFilename);
+                Assert.Equal("two.meta.csv", archiveDataSets[1].MetaFilename);
+                Assert.Equal(2085, archiveDataSets[1].DataFileSize);
+                Assert.Equal(318, archiveDataSets[1].MetaFileSize);
+                Assert.Null(archiveDataSets[1].ReplacingFile);
+            }
 
             VerifyAllMocks(fileUploadsValidatorService, fileTypeService);
         }
@@ -150,8 +272,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var releaseVersionId = Guid.NewGuid();
             var fileTypeService = new Mock<IFileTypeService>(Strict);
 
-            var service = SetupDataArchiveValidationService(
-                fileTypeService: fileTypeService.Object);
             var longFilename =
                 "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongfilename.csv";
             var archive = CreateFormFileFromResource("test-data.csv", longFilename);
@@ -160,18 +280,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Setup(s => s.IsValidZipFile(archive))
                 .ReturnsAsync(false);
 
-            var result = await service.ValidateBulkDataArchiveFile(
-                releaseVersionId,
-                archive);
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupDataArchiveValidationService(
+                    contentDbContext: contentDbContext,
+                    fileTypeService: fileTypeService.Object);
 
-            result
-                .AssertLeft()
-                .AssertBadRequestWithValidationErrors([
-                    ValidationMessages.GenerateErrorFilenameTooLong(longFilename,
-                        FileUploadsValidatorService.MaxFilenameSize),
-                    ValidationMessages.GenerateErrorZipFilenameMustEndDotZip(longFilename),
-                    ValidationMessages.GenerateErrorMustBeZipFile(longFilename),
-                ]);
+                var result = await service.ValidateBulkDataArchiveFile(
+                    releaseVersionId,
+                    archive);
+
+                result
+                    .AssertLeft()
+                    .AssertBadRequestWithValidationErrors([
+                        ValidationMessages.GenerateErrorFilenameTooLong(longFilename,
+                            FileUploadsValidatorService.MaxFilenameSize),
+                        ValidationMessages.GenerateErrorZipFilenameMustEndDotZip(longFilename),
+                        ValidationMessages.GenerateErrorMustBeZipFile(longFilename),
+                    ]);
+            }
 
             VerifyAllMocks(fileTypeService);
         }
@@ -180,29 +308,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task ValidateBulkDataArchiveFile_Fail_NoDatasetNamesCsv()
         {
             var releaseVersionId = Guid.NewGuid();
-            var fileTypeService = new Mock<IFileTypeService>(Strict);
-
-            var service = SetupDataArchiveValidationService(
-                fileTypeService: fileTypeService.Object);
             var archive = CreateFormFileFromResource("bulk-data-zip-invalid-no-datasetnames-csv.zip");
+
+            var fileTypeService = new Mock<IFileTypeService>(Strict);
 
             fileTypeService
                 .Setup(s => s.IsValidZipFile(archive))
                 .ReturnsAsync(true);
 
-            var result = await service.ValidateBulkDataArchiveFile(
-                releaseVersionId,
-                archive);
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupDataArchiveValidationService(
+                    contentDbContext: contentDbContext,
+                    fileTypeService: fileTypeService.Object);
 
-            result
-                .AssertLeft()
-                .AssertBadRequestWithValidationErrors([
-                    new ErrorViewModel
-                    {
-                        Code = ValidationMessages.BulkDataZipMustContainDatasetNamesCsv.Code,
-                        Message = ValidationMessages.BulkDataZipMustContainDatasetNamesCsv.Message,
-                    }
-                ]);
+                var result = await service.ValidateBulkDataArchiveFile(
+                    releaseVersionId,
+                    archive);
+
+                result
+                    .AssertLeft()
+                    .AssertBadRequestWithValidationErrors([
+                        new ErrorViewModel
+                        {
+                            Code = ValidationMessages.BulkDataZipMustContainDatasetNamesCsv.Code,
+                            Message = ValidationMessages.BulkDataZipMustContainDatasetNamesCsv.Message,
+                        }
+                    ]);
+            }
 
             VerifyAllMocks(fileTypeService);
         }
@@ -213,27 +347,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var releaseVersionId = Guid.NewGuid();
             var fileTypeService = new Mock<IFileTypeService>(Strict);
 
-            var service = SetupDataArchiveValidationService(
-                fileTypeService: fileTypeService.Object);
             var archive = CreateFormFileFromResource("bulk-data-zip-invalid-datasetnames-headers.zip");
 
             fileTypeService
                 .Setup(s => s.IsValidZipFile(archive))
                 .ReturnsAsync(true);
 
-            var result = await service.ValidateBulkDataArchiveFile(
-                releaseVersionId,
-                archive);
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupDataArchiveValidationService(
+                    contentDbContext: contentDbContext,
+                    fileTypeService: fileTypeService.Object);
 
-            result
-                .AssertLeft()
-                .AssertBadRequestWithValidationErrors([
-                    new ErrorViewModel
-                    {
-                        Code = ValidationMessages.DatasetNamesCsvIncorrectHeaders.Code,
-                        Message = ValidationMessages.DatasetNamesCsvIncorrectHeaders.Message,
-                    },
-                ]);
+                var result = await service.ValidateBulkDataArchiveFile(
+                    releaseVersionId,
+                    archive);
+
+                result
+                    .AssertLeft()
+                    .AssertBadRequestWithValidationErrors([
+                        new ErrorViewModel
+                        {
+                            Code = ValidationMessages.DatasetNamesCsvIncorrectHeaders.Code,
+                            Message = ValidationMessages.DatasetNamesCsvIncorrectHeaders.Message,
+                        },
+                    ]);
+            }
 
             VerifyAllMocks(fileTypeService);
         }
@@ -242,26 +382,32 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task ValidateBulkDataArchiveFile_Fail_FilesNotFoundInZip()
         {
             var releaseVersionId = Guid.NewGuid();
-            var fileTypeService = new Mock<IFileTypeService>(Strict);
-
-            var service = SetupDataArchiveValidationService(
-                fileTypeService: fileTypeService.Object);
             var archive = CreateFormFileFromResource("bulk-data-zip-invalid-files-not-found.zip");
+
+            var fileTypeService = new Mock<IFileTypeService>(Strict);
 
             fileTypeService
                 .Setup(s => s.IsValidZipFile(archive))
                 .ReturnsAsync(true);
 
-            var result = await service.ValidateBulkDataArchiveFile(
-                releaseVersionId,
-                archive);
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupDataArchiveValidationService(
+                    contentDbContext: contentDbContext,
+                    fileTypeService: fileTypeService.Object);
 
-            result
-                .AssertLeft()
-                .AssertBadRequestWithValidationErrors([
-                    ValidationMessages.GenerateErrorFileNotFoundInZip("one.meta.csv", FileType.Metadata),
-                    ValidationMessages.GenerateErrorFileNotFoundInZip("two.csv", FileType.Data),
-                ]);
+                var result = await service.ValidateBulkDataArchiveFile(
+                    releaseVersionId,
+                    archive);
+
+                result
+                    .AssertLeft()
+                    .AssertBadRequestWithValidationErrors([
+                        ValidationMessages.GenerateErrorFileNotFoundInZip("one.meta.csv", FileType.Metadata),
+                        ValidationMessages.GenerateErrorFileNotFoundInZip("two.csv", FileType.Data),
+                    ]);
+            }
 
             VerifyAllMocks(fileTypeService);
         }
@@ -270,26 +416,32 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task ValidateBulkDataArchiveFile_Fail_DuplicateDataSetTitlesAndFilenames()
         {
             var releaseVersionId = Guid.NewGuid();
-            var fileTypeService = new Mock<IFileTypeService>(Strict);
-
-            var service = SetupDataArchiveValidationService(
-                fileTypeService: fileTypeService.Object);
             var archive = CreateFormFileFromResource("bulk-data-zip-invalid-duplicate-names.zip");
+
+            var fileTypeService = new Mock<IFileTypeService>(Strict);
 
             fileTypeService
                 .Setup(s => s.IsValidZipFile(archive))
                 .ReturnsAsync(true);
 
-            var result = await service.ValidateBulkDataArchiveFile(
-                releaseVersionId,
-                archive);
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupDataArchiveValidationService(
+                    contentDbContext: contentDbContext,
+                    fileTypeService: fileTypeService.Object);
 
-            result
-                .AssertLeft()
-                .AssertBadRequestWithValidationErrors([
-                    ValidationMessages.GenerateErrorDataSetTitleShouldBeUnique("Duplicate title"),
-                    ValidationMessages.GenerateErrorDatasetNamesCsvFilenamesShouldBeUnique("one"),
-                ]);
+                var result = await service.ValidateBulkDataArchiveFile(
+                    releaseVersionId,
+                    archive);
+
+                result
+                    .AssertLeft()
+                    .AssertBadRequestWithValidationErrors([
+                        ValidationMessages.GenerateErrorDataSetTitleShouldBeUnique("Duplicate title"),
+                        ValidationMessages.GenerateErrorDatasetNamesCsvFilenamesShouldBeUnique("one"),
+                    ]);
+            }
 
             VerifyAllMocks(fileTypeService);
         }
@@ -300,23 +452,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var releaseVersionId = Guid.NewGuid();
             var fileTypeService = new Mock<IFileTypeService>(Strict);
 
-            var service = SetupDataArchiveValidationService(
-                fileTypeService: fileTypeService.Object);
             var archive = CreateFormFileFromResource("bulk-data-zip-invalid-filename-contains-extension.zip");
 
             fileTypeService
                 .Setup(s => s.IsValidZipFile(archive))
                 .ReturnsAsync(true);
 
-            var result = await service.ValidateBulkDataArchiveFile(
-                releaseVersionId,
-                archive);
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupDataArchiveValidationService(
+                    contentDbContext: contentDbContext,
+                    fileTypeService: fileTypeService.Object);
+                var result = await service.ValidateBulkDataArchiveFile(
+                    releaseVersionId,
+                    archive);
 
-            result
-                .AssertLeft()
-                .AssertBadRequestWithValidationErrors([
-                    ValidationMessages.GenerateErrorDatasetNamesCsvFilenamesShouldNotEndDotCsv("one.csv")
-                ]);
+                result
+                    .AssertLeft()
+                    .AssertBadRequestWithValidationErrors([
+                        ValidationMessages.GenerateErrorDatasetNamesCsvFilenamesShouldNotEndDotCsv("one.csv")
+                    ]);
+            }
 
             VerifyAllMocks(fileTypeService);
         }
@@ -325,13 +482,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task ValidateBulkDataArchiveFile_Fail_UnusedFilesInZip()
         {
             var releaseVersionId = Guid.NewGuid();
+            var archive = CreateFormFileFromResource("bulk-data-zip-invalid-unused-files.zip");
+
             var fileUploadsValidatorService = new Mock<IFileUploadsValidatorService>(Strict);
             var fileTypeService = new Mock<IFileTypeService>(Strict);
-
-            var service = SetupDataArchiveValidationService(
-                fileTypeService: fileTypeService.Object,
-                fileUploadsValidatorService: fileUploadsValidatorService.Object);
-            var archive = CreateFormFileFromResource("bulk-data-zip-invalid-unused-files.zip");
 
             fileUploadsValidatorService.Setup(mock => mock.ValidateDataSetFilesForUpload(
                     releaseVersionId,
@@ -344,15 +498,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Setup(s => s.IsValidZipFile(archive))
                 .ReturnsAsync(true);
 
-            var result = await service.ValidateBulkDataArchiveFile(
-                releaseVersionId,
-                archive);
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupDataArchiveValidationService(
+                    contentDbContext: contentDbContext,
+                    fileTypeService: fileTypeService.Object,
+                    fileUploadsValidatorService: fileUploadsValidatorService.Object);
 
-            result
-                .AssertLeft()
-                .AssertBadRequestWithValidationErrors([
-                    ValidationMessages.GenerateErrorZipContainsUnusedFiles(["two.csv", "two.meta.csv"]),
-                ]);
+                var result = await service.ValidateBulkDataArchiveFile(
+                    releaseVersionId,
+                    archive);
+
+                result
+                    .AssertLeft()
+                    .AssertBadRequestWithValidationErrors([
+                        ValidationMessages.GenerateErrorZipContainsUnusedFiles(["two.csv", "two.meta.csv"]),
+                    ]);
+            }
 
             VerifyAllMocks(fileUploadsValidatorService, fileTypeService);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/ArchiveDataSetFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/ArchiveDataSetFile.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Models;
 
 public record ArchiveDataSetFile(
@@ -6,4 +8,5 @@ public record ArchiveDataSetFile(
     string DataFilename,
     string MetaFilename,
     long DataFileSize = 1048576,
-    long MetaFileSize = 1024);
+    long MetaFileSize = 1024,
+    File? ReplacingFile = null);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
@@ -50,11 +50,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             File? replacingFile = null)
         {
             List<ErrorViewModel> errors = [];
+            var isReplacement = replacingFile != null;
 
             errors.AddRange(ValidateDataSetTitle(
                 releaseVersionId,
                 dataSetTitle,
-                isReplacement: replacingFile != null));
+                isReplacement));
 
             errors.AddRange(ValidateDataFileNames(
                 releaseVersionId,
@@ -73,6 +74,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 dataFileStream,
                 metaFileName,
                 metaFileStream));
+
+            if (isReplacement)
+            {
+                var releaseFileWithApiDataSet = _context.ReleaseFiles
+                    .SingleOrDefault(rf =>
+                        rf.ReleaseVersionId == releaseVersionId
+                        && rf.Name == dataSetTitle
+                        && rf.PublicApiDataSetId != null);
+                if (releaseFileWithApiDataSet != null)
+                {
+                    errors.Add(ValidationMessages.GenerateErrorCannotReplaceDataSetWithApiDataSet(dataSetTitle));
+                }
+            }
 
             return errors;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
@@ -103,8 +103,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             Guid releaseVersionId,
             ArchiveDataSetFile archiveDataSet,
             Stream dataFileStream,
-            Stream metaFileStream,
-            File? replacingFile = null)
+            Stream metaFileStream)
         {
             return await ValidateDataSetFilesForUpload(
                 releaseVersionId: releaseVersionId,
@@ -115,7 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 metaFileName: archiveDataSet.MetaFilename,
                 metaFileLength: archiveDataSet.MetaFileSize,
                 metaFileStream: metaFileStream,
-                replacingFile: replacingFile);
+                replacingFile: archiveDataSet.ReplacingFile);
         }
 
         public async Task<Either<ActionResult, Unit>> ValidateFileForUpload(IFormFile file, FileType type)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileUploadsValidatorService.cs
@@ -36,8 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             Guid releaseVersionId,
             ArchiveDataSetFile archiveDataSet,
             Stream dataFileStream,
-            Stream metaFileStream,
-            File? replacingFile = null);
+            Stream metaFileStream);
 
         Task<Either<ActionResult, Unit>> ValidateFileForUpload(IFormFile file, FileType type);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
@@ -461,7 +461,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             var subjectId = await _releaseVersionRepository
                                 .CreateStatisticsDbReleaseAndSubjectHierarchy(releaseVersionId);
 
-                            var releaseDataFileOrder = await GetNextDataFileOrder(releaseVersionId);
+                            var releaseDataFileOrder = await GetNextDataFileOrder(
+                                releaseVersionId, archiveFile.ReplacingFile);
 
                             var dataFile = await _releaseDataFileRepository.Create(
                                 releaseVersionId: releaseVersionId,
@@ -471,6 +472,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                 type: FileType.Data,
                                 createdById: _userService.GetUserId(),
                                 name: archiveFile.Title,
+                                replacingDataFile: archiveFile.ReplacingFile,
                                 source: bulkZipFile,
                                 order: releaseDataFileOrder);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -308,6 +308,20 @@ public static class ValidationMessages
         };
     }
 
+    public static readonly LocalizableMessage CannotReplaceDataSetWithApiDataSet = new(
+        Code: nameof(CannotReplaceDataSetWithApiDataSet),
+        Message: "Data set with title '{0}' cannot be replaced as it has an API data set."
+    );
+
+    public static ErrorViewModel GenerateErrorCannotReplaceDataSetWithApiDataSet(string title)
+    {
+        return new ErrorViewModel
+        {
+            Code = CannotReplaceDataSetWithApiDataSet.Code,
+            Message = string.Format(CannotReplaceDataSetWithApiDataSet.Message, title),
+        };
+    }
+
     public static readonly LocalizableMessage PreviewTokenExpired = new(
         Code: nameof(PreviewTokenExpired),
         Message: "The preview token is expired."

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
@@ -17,7 +17,7 @@ public class ReleaseFile
 
     public Guid FileId { get; set; }
 
-    public string? Name { get; set; }
+    public string? Name { get; set; } // otherwise referred to as "title" to avoid confusion with filename
 
     public string? Summary { get; set; }
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -32,6 +32,7 @@ import DataUploadCancelButton from '@admin/pages/release/data/components/DataUpl
 import React, { useCallback, useEffect, useState } from 'react';
 import { generatePath } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
+import { reverse, uniqBy } from 'lodash';
 
 interface Props {
   publicationId: string;
@@ -151,7 +152,10 @@ const ReleaseDataUploadsSection = ({
           break;
       }
       setActiveFileIds(newFiles.map(file => file.id));
-      setDataFiles(currentDataFiles => [...currentDataFiles, ...newFiles]);
+      setDataFiles(currentDataFiles =>
+        // double reverse keeps *new* files as uniq item and at the end of the list
+        reverse(uniqBy(reverse([...currentDataFiles, ...newFiles]), 'title')),
+      );
     },
     [releaseId],
   );


### PR DESCRIPTION
> PR raised on behalf of @mmyoungman in his absence

Currently, a bulk import will fail if one the data sets contained in the zip has the same title as an already-imported data set. These changes allow users to initiate a data replacement for those data sets that have the same title as an existing data set.