### PR TITLE
EES-5541 Various fixes across boundary level and data groupings

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBoundaryLevelsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBoundaryLevelsConfiguration.tsx
@@ -2,63 +2,61 @@ import ChartBoundaryLevelsForm, {
   ChartBoundaryLevelsFormValues,
 } from '@admin/pages/release/datablocks/components/chart/ChartBoundaryLevelsForm';
 import { ChartOptions } from '@admin/pages/release/datablocks/components/chart/reducers/chartBuilderReducer';
-import {
-  AxisConfiguration,
-  MapConfig,
-} from '@common/modules/charts/types/chart';
-import { LegendConfiguration } from '@common/modules/charts/types/legend';
-import createDataSetCategories from '@common/modules/charts/util/createDataSetCategories';
-import expandDataSet from '@common/modules/charts/util/expandDataSet';
-import generateDataSetKey from '@common/modules/charts/util/generateDataSetKey';
-import getDataSetCategoryConfigs from '@common/modules/charts/util/getDataSetCategoryConfigs';
+import { MapBoundaryLevelConfig } from '@admin/pages/release/datablocks/components/chart/types/mapConfig';
+import { MapConfig } from '@common/modules/charts/types/chart';
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
-import { TableDataResult } from '@common/services/tableBuilderService';
 import parseNumber from '@common/utils/number/parseNumber';
-import { isEqual } from 'lodash';
 import React, { ReactNode, useCallback, useMemo } from 'react';
-import generateDataSetLabel from './utils/generateDataSetLabel';
 
 interface Props {
   buttons?: ReactNode;
-  axisMajor: AxisConfiguration;
-  data: TableDataResult[];
-  legend: LegendConfiguration;
-  map?: MapConfig;
+  // TODO: EES-5402 - Remove when all boundary level changes are done
+  hasDataSetBoundaryLevels?: boolean;
+  map: MapConfig;
   meta: FullTableMeta;
   options: ChartOptions;
-  onChange: (values: Partial<ChartBoundaryLevelsFormValues>) => void;
-  onSubmit: (values: ChartBoundaryLevelsFormValues) => void;
+  onChange: (values: MapBoundaryLevelConfig) => void;
+  onSubmit: (values: MapBoundaryLevelConfig) => void;
 }
 
 export default function ChartBoundaryLevelsConfiguration({
   buttons,
-  axisMajor,
-  data,
-  legend,
+  // TODO: EES-5402 - Remove when all boundary level changes are done
+  hasDataSetBoundaryLevels = false,
   map,
   meta,
   options,
   onChange,
   onSubmit,
 }: Props) {
+  const initialValues = useMemo<ChartBoundaryLevelsFormValues>(() => {
+    return {
+      boundaryLevel: options.boundaryLevel?.toString(),
+      dataSetConfigs:
+        map?.dataSetConfigs.map(dataSetConfig => {
+          return {
+            boundaryLevel: dataSetConfig.boundaryLevel?.toString(),
+          };
+        }) ?? [],
+    };
+  }, [options.boundaryLevel, map?.dataSetConfigs]);
+
   const normalizeValues = useCallback(
     (
       values: Partial<ChartBoundaryLevelsFormValues>,
-    ): ChartBoundaryLevelsFormValues => {
-      // Use `merge` as we want to avoid potential undefined
-      // values from overwriting existing values
+    ): MapBoundaryLevelConfig => {
       return {
-        boundaryLevel: values.boundaryLevel
-          ? parseNumber(values.boundaryLevel)
-          : undefined,
+        boundaryLevel: parseNumber(values.boundaryLevel),
         dataSetConfigs:
-          values.dataSetConfigs?.map(({ boundaryLevel, dataSet }) => ({
-            boundaryLevel: parseNumber(boundaryLevel),
-            dataSet,
-          })) ?? [],
+          values.dataSetConfigs?.map(({ boundaryLevel }, index) => {
+            return {
+              boundaryLevel: parseNumber(boundaryLevel),
+              dataSet: map.dataSetConfigs[index].dataSet,
+            };
+          }) ?? [],
       };
     },
-    [],
+    [map.dataSetConfigs],
   );
 
   const handleSubmit = useCallback(
@@ -67,6 +65,7 @@ export default function ChartBoundaryLevelsConfiguration({
     },
     [onSubmit, normalizeValues],
   );
+
   const handleChange = useCallback(
     (values: Partial<ChartBoundaryLevelsFormValues>) => {
       onChange(normalizeValues(values));
@@ -74,59 +73,13 @@ export default function ChartBoundaryLevelsConfiguration({
     [onChange, normalizeValues],
   );
 
-  const { dataSetConfigs, boundaryLevel } =
-    useMemo<ChartBoundaryLevelsFormValues>(() => {
-      const dataSetCategories = createDataSetCategories({
-        axisConfiguration: {
-          ...axisMajor,
-          groupBy: 'locations',
-        },
-        data,
-        meta,
-      });
-
-      const dataSetCategoryConfigs = getDataSetCategoryConfigs({
-        dataSetCategories,
-        legendItems: legend.items,
-        meta,
-        deprecatedDataClassification: options.dataClassification,
-        deprecatedDataGroups: options.dataGroups,
-      });
-
-      return {
-        boundaryLevel: options.boundaryLevel,
-        dataSetConfigs: dataSetCategoryConfigs.map(({ rawDataSet }) => ({
-          dataSet: rawDataSet,
-          boundaryLevel: map?.dataSetConfigs.find(config =>
-            isEqual(config.dataSet, rawDataSet),
-          )?.boundaryLevel,
-        })),
-      };
-    }, [axisMajor, data, meta, legend.items, map, options]);
-
-  const mappedDataSetConfigs = useMemo(() => {
-    return Object.values(dataSetConfigs).map(dataSetConfig => {
-      const expandedDataSet = expandDataSet(dataSetConfig.dataSet, meta);
-      const label = generateDataSetLabel(expandedDataSet);
-      const key = generateDataSetKey(dataSetConfig.dataSet);
-
-      return {
-        label,
-        key,
-      };
-    });
-  }, [meta, dataSetConfigs]);
-
   return (
     <ChartBoundaryLevelsForm
-      hasDataSetBoundaryLevels={false}
       buttons={buttons}
-      boundaryLevelOptions={meta.boundaryLevels.map(({ id, label }) => ({
-        label,
-        value: id,
-      }))}
-      dataSetRows={mappedDataSetConfigs}
-      initialValues={{ boundaryLevel, dataSetConfigs }}
+      dataSetConfigs={map.dataSetConfigs}
+      hasDataSetBoundaryLevels={hasDataSetBoundaryLevels}
+      initialValues={initialValues}
+      meta={meta}
       onChange={handleChange}
       onSubmit={handleSubmit}
     />

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataGroupingsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataGroupingsConfiguration.tsx
@@ -1,94 +1,46 @@
 import ChartBuilderSaveActions from '@admin/pages/release/datablocks/components/chart/ChartBuilderSaveActions';
 import ChartDataGroupingForm from '@admin/pages/release/datablocks/components/chart/ChartDataGroupingForm';
 import { useChartBuilderFormsContext } from '@admin/pages/release/datablocks/components/chart/contexts/ChartBuilderFormsContext';
+import { MapDataGroupingConfig } from '@admin/pages/release/datablocks/components/chart/types/mapConfig';
 import generateDataSetLabel from '@admin/pages/release/datablocks/components/chart/utils/generateDataSetLabel';
 import ButtonText from '@common/components/ButtonText';
 import Effect from '@common/components/Effect';
 import Modal from '@common/components/Modal';
 import {
-  AxisConfiguration,
+  dataGroupingTypes,
   MapConfig,
   MapDataSetConfig,
-  dataGroupingTypes,
 } from '@common/modules/charts/types/chart';
-import createDataSetCategories from '@common/modules/charts/util/createDataSetCategories';
 import expandDataSet from '@common/modules/charts/util/expandDataSet';
 import generateDataSetKey from '@common/modules/charts/util/generateDataSetKey';
-import getDataSetCategoryConfigs from '@common/modules/charts/util/getDataSetCategoryConfigs';
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
-import { TableDataResult } from '@common/services/tableBuilderService';
-import { LegendConfiguration } from '@common/modules/charts/types/legend';
 import isEqual from 'lodash/isEqual';
-import React, { ReactNode, useMemo, useState } from 'react';
-import { ChartOptions } from './reducers/chartBuilderReducer';
+import React, { ReactNode, useState } from 'react';
 
 const formId = 'chartDataGroupingsConfigurationForm';
 
-interface FormValues {
-  dataSetConfigs: MapDataSetConfig[];
-}
-
 interface Props {
-  axisMajor: AxisConfiguration;
   buttons?: ReactNode;
-  data: TableDataResult[];
-  legend: LegendConfiguration;
   map?: MapConfig;
   meta: FullTableMeta;
-  options: ChartOptions;
-  onChange: (dataSetConfigs: MapDataSetConfig[]) => void;
-  onSubmit: (dataSetConfigs: MapDataSetConfig[]) => void;
+  onChange: (values: MapDataGroupingConfig) => void;
+  onSubmit: (values: MapDataGroupingConfig) => void;
 }
 
-const ChartDataGroupingsConfiguration = ({
-  axisMajor,
+export default function ChartDataGroupingsConfiguration({
   buttons,
-  data,
-  legend,
   map,
   meta,
-  options,
   onChange,
   onSubmit,
-}: Props) => {
+}: Props) {
   const [editDataSetConfig, setEditDataSetConfig] = useState<{
     dataSetConfig: MapDataSetConfig;
     unit: string;
   }>();
   const { forms, updateForm, submitForms } = useChartBuilderFormsContext();
 
-  const initialValues = useMemo<FormValues>(() => {
-    const dataSetCategories = createDataSetCategories({
-      axisConfiguration: {
-        ...axisMajor,
-        groupBy: 'locations',
-      },
-      data,
-      meta,
-    });
-
-    const dataSetCategoryConfigs = getDataSetCategoryConfigs({
-      dataSetCategories,
-      legendItems: legend.items,
-      meta,
-      deprecatedDataClassification: options.dataClassification,
-      deprecatedDataGroups: options.dataGroups,
-    });
-
-    return {
-      dataSetConfigs: dataSetCategoryConfigs.map(
-        ({ rawDataSet, dataGrouping }) => ({
-          dataSet: rawDataSet,
-          dataGrouping:
-            map?.dataSetConfigs.find(config =>
-              isEqual(config.dataSet, rawDataSet),
-            )?.dataGrouping ?? dataGrouping,
-        }),
-      ),
-    };
-  }, [axisMajor, data, meta, legend.items, map, options]);
-
-  if (!initialValues.dataSetConfigs?.length) {
+  if (!map?.dataSetConfigs.length) {
     return <p>No data groupings to edit.</p>;
   }
 
@@ -112,7 +64,7 @@ const ChartDataGroupingsConfiguration = ({
           </tr>
         </thead>
         <tbody>
-          {initialValues.dataSetConfigs.map(dataSetConfig => {
+          {map.dataSetConfigs.map(dataSetConfig => {
             const expandedDataSet = expandDataSet(dataSetConfig.dataSet, meta);
             const label = generateDataSetLabel(expandedDataSet);
             const key = generateDataSetKey(dataSetConfig.dataSet);
@@ -153,18 +105,19 @@ const ChartDataGroupingsConfiguration = ({
         >
           <ChartDataGroupingForm
             dataSetConfig={editDataSetConfig.dataSetConfig}
-            dataSetConfigs={initialValues.dataSetConfigs}
+            dataSetConfigs={map.dataSetConfigs}
             meta={meta}
             unit={editDataSetConfig.unit}
             onCancel={() => setEditDataSetConfig(undefined)}
             onSubmit={values => {
-              const updated = initialValues.dataSetConfigs.map(config => {
-                if (isEqual(config.dataSet, values.dataSet)) {
-                  return values;
-                }
-                return config;
+              onChange({
+                dataSetConfigs: map.dataSetConfigs.map(config => {
+                  return isEqual(config.dataSet, values.dataSet)
+                    ? values
+                    : config;
+                }),
               });
-              onChange(updated);
+
               setEditDataSetConfig(undefined);
             }}
           />
@@ -181,7 +134,11 @@ const ChartDataGroupingsConfiguration = ({
               ? forms.dataGroupings.submitCount + 1
               : 1,
           });
-          onSubmit(initialValues.dataSetConfigs);
+
+          onSubmit({
+            dataSetConfigs: map.dataSetConfigs,
+          });
+
           await submitForms();
         }}
       >
@@ -189,6 +146,4 @@ const ChartDataGroupingsConfiguration = ({
       </ChartBuilderSaveActions>
     </>
   );
-};
-
-export default ChartDataGroupingsConfiguration;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/contexts/ChartBuilderFormsContext.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/contexts/ChartBuilderFormsContext.tsx
@@ -50,7 +50,7 @@ export interface ChartBuilderFormsContextValue {
   hasSubmitted: boolean;
   isSubmitting: boolean;
   isValid: boolean;
-  submitForms: () => void;
+  submitForms: () => Promise<void>;
   updateForm: (nextState: UpdateFormState) => void;
 }
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/chartBuilderReducer.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/chartBuilderReducer.ts
@@ -1,3 +1,7 @@
+import {
+  MapBoundaryLevelConfig,
+  MapDataGroupingConfig,
+} from '@admin/pages/release/datablocks/components/chart/types/mapConfig';
 import { useLoggedImmerReducer } from '@common/hooks/useLoggedReducer';
 import {
   AxesConfiguration,
@@ -12,13 +16,21 @@ import {
 } from '@common/modules/charts/types/chart';
 import { DataSet } from '@common/modules/charts/types/dataSet';
 import { LegendConfiguration } from '@common/modules/charts/types/legend';
+import createDataSetCategories from '@common/modules/charts/util/createDataSetCategories';
+import getMapDataSetCategoryConfigs from '@common/modules/charts/util/getMapDataSetCategoryConfigs';
+import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
+import { TableDataResult } from '@common/services/tableBuilderService';
 import { Chart } from '@common/services/types/blocks';
 import deepMerge from 'deepmerge';
-import { isEqual, merge } from 'lodash';
 import mapValues from 'lodash/mapValues';
-import { useCallback, useMemo } from 'react';
-import { Reducer } from 'use-immer';
-import { ChartBoundaryLevelsFormValues } from '../ChartBoundaryLevelsForm';
+import { Reducer, useCallback, useMemo } from 'react';
+
+export interface ChartBuilderReducerOptions {
+  chart?: Chart;
+  data: TableDataResult[];
+  meta: FullTableMeta;
+  tableTitle?: string;
+}
 
 export interface ChartOptions extends ChartDefinitionOptions {
   file?: File;
@@ -52,12 +64,12 @@ export type ChartBuilderActions =
       payload: LegendConfiguration;
     }
   | {
-      type: 'UPDATE_CHART_MAP_BOUNDARY_LEVELS';
-      payload: ChartBoundaryLevelsFormValues;
+      type: 'UPDATE_MAP_BOUNDARY_LEVELS';
+      payload: MapBoundaryLevelConfig;
     }
   | {
-      type: 'UPDATE_CHART_MAP_CONFIGURATION';
-      payload: MapDataSetConfig[];
+      type: 'UPDATE_MAP_DATA_GROUPINGS';
+      payload: MapDataGroupingConfig;
     }
   | {
       type: 'UPDATE_CHART_AXIS';
@@ -112,209 +124,313 @@ const updateAxis = (
       },
     ],
     {
-      arrayMerge: (target, source) => source,
+      arrayMerge: (_, source) => source,
     },
   );
 };
 
-const getInitialState = (
-  initialChart?: Chart,
-  tableTitle?: string,
-): ChartBuilderState => {
-  if (!initialChart) {
+const getInitialState = ({
+  chart,
+  data,
+  meta,
+  tableTitle,
+}: ChartBuilderReducerOptions): ChartBuilderState => {
+  if (!chart) {
     return {
       titleType: 'default',
       axes: {},
     };
   }
 
-  const { type, axes, legend, map, ...options } = initialChart;
+  const {
+    type,
+    axes: initialAxes,
+    legend: initialLegend,
+    map,
+    ...initialOptions
+  } = chart;
 
   const definition = chartDefinitions.find(
     chartDefinition => chartDefinition.type === type,
   );
 
+  if (!definition) {
+    throw new Error(`Could not find chart definition for type: ${type}`);
+  }
+
+  const options: ChartOptions = {
+    ...defaultOptions,
+    ...(definition?.options.defaults ?? {}),
+    ...initialOptions,
+    titleType: chart.title === tableTitle ? 'default' : 'alternative',
+  };
+
+  const axes: AxesConfiguration = mapValues(
+    definition?.axes ?? {},
+    (axisDefinition: ChartDefinitionAxis, axisType: AxisType) =>
+      updateAxis(
+        axisDefinition,
+        (initialAxes?.[axisType] ?? {}) as AxisConfiguration,
+      ),
+  );
+
+  const legend: LegendConfiguration = {
+    ...defaultLegend,
+    ...(initialLegend ?? {}),
+  };
+
   return {
     definition,
-    options: {
-      ...defaultOptions,
-      ...(definition?.options.defaults ?? {}),
-      ...options,
-      titleType: initialChart.title === tableTitle ? 'default' : 'alternative',
-    },
-    legend: {
-      ...defaultLegend,
-      ...(legend ?? {}),
-    },
-    axes: mapValues(
-      definition?.axes ?? {},
-      (axisDefinition: ChartDefinitionAxis, axisType: AxisType) =>
-        updateAxis(
-          axisDefinition,
-          (axes?.[axisType] ?? {}) as AxisConfiguration,
-        ),
-    ),
-    map,
+    options,
+    legend,
+    axes,
+    map: getInitialMapState({
+      axes,
+      data,
+      definition,
+      legend,
+      map,
+      meta,
+      options,
+    }),
   };
 };
 
-export const chartBuilderReducer: Reducer<
-  ChartBuilderState,
-  ChartBuilderActions
-> = (draft, action) => {
-  switch (action.type) {
-    case 'UPDATE_CHART_DEFINITION': {
-      draft.definition = action.payload;
-
-      draft.options = {
-        ...defaultOptions,
-        ...(action.payload.options.defaults ?? {}),
-        ...draft.options,
-        // Set height/width to definition defaults
-        // as this seems to surprise users the least.
-        height:
-          action.payload.options.defaults?.height ??
-          draft.options?.height ??
-          defaultOptions.height,
-        width: action.payload.options.defaults?.width ?? draft.options?.width,
-      };
-
-      if (action.payload.capabilities.hasLegend) {
-        draft.legend = {
-          ...defaultLegend,
-          ...(action.payload.legend.defaults ?? {}),
-          ...(draft.legend ?? {}),
-        };
-      } else {
-        draft.legend = undefined;
-      }
-
-      draft.axes = mapValues(
-        action.payload.axes,
-        (axisDefinition: ChartDefinitionAxis, type: AxisType) => {
-          return updateAxis(axisDefinition, draft.axes[type]);
-        },
-      );
-
-      break;
-    }
-    case 'UPDATE_CHART_AXIS': {
-      const axisDefinition = draft?.definition?.axes?.[action.payload.type];
-
-      if (!axisDefinition) {
-        throw new Error(
-          `Could not find chart axis definition for type '${action.payload.type}'`,
-        );
-      }
-
-      if (!draft.axes[action.payload.type]) {
-        throw new Error(
-          `Could not find axis configuration for type '${action.payload.type}'`,
-        );
-      }
-
-      draft.axes[action.payload.type] = updateAxis(
-        axisDefinition,
-        draft.axes[action.payload.type] as AxisConfiguration,
-        action.payload,
-      );
-
-      break;
-    }
-    case 'UPDATE_CHART_LEGEND': {
-      draft.legend = {
-        ...defaultLegend,
-        ...(draft?.definition?.legend.defaults ?? {}),
-        ...draft.legend,
-        ...action.payload,
-      };
-
-      break;
-    }
-    case 'UPDATE_CHART_MAP_BOUNDARY_LEVELS': {
-      draft.options = {
-        ...(draft.options as ChartOptions),
-        boundaryLevel: action.payload.boundaryLevel,
-      };
-
-      const existingDataSetConfigs = draft.map?.dataSetConfigs ?? [];
-      const dataSetConfigs = action.payload.dataSetConfigs.map(
-        // add existing dataGrouping to new MapDataSetConfigs
-        ({ dataSet, boundaryLevel }) => {
-          const { dataGrouping } =
-            existingDataSetConfigs.find(({ dataSet: existingDataSet }) =>
-              isEqual(existingDataSet, dataSet),
-            )! ?? {};
-
-          return merge({}, { dataSet, boundaryLevel, dataGrouping });
-        },
-      );
-
-      draft.map = {
-        ...draft.map,
-        dataSetConfigs,
-      };
-
-      break;
-    }
-    case 'UPDATE_CHART_MAP_CONFIGURATION': {
-      const existingDataSetConfigs = draft.map?.dataSetConfigs ?? [];
-      const dataSetConfigs = action.payload.map(
-        // add existing boundaryLevel to new MapDataSetConfigs
-        ({ dataSet, dataGrouping }) => {
-          const { boundaryLevel } = existingDataSetConfigs.find(
-            ({ dataSet: existingDataSet }) => isEqual(existingDataSet, dataSet),
-          )!;
-
-          return merge({}, { dataSet, boundaryLevel, dataGrouping });
-        },
-      );
-
-      draft.map = {
-        ...draft.map,
-        dataSetConfigs,
-      };
-
-      break;
-    }
-    case 'UPDATE_CHART_OPTIONS': {
-      draft.options = {
-        ...defaultOptions,
-        ...(draft?.definition?.options.defaults ?? {}),
-        ...draft.options,
-        ...action.payload,
-      };
-
-      break;
-    }
-    case 'UPDATE_DATA_SETS': {
-      if (draft.axes.major) {
-        draft.axes.major.dataSets = action.payload;
-      }
-
-      break;
-    }
-    case 'RESET':
-      return getInitialState();
-    default:
-      break;
+function getInitialMapState({
+  axes,
+  data,
+  definition,
+  legend,
+  map,
+  meta,
+  options,
+}: {
+  axes: AxesConfiguration;
+  data: TableDataResult[];
+  definition: ChartDefinition;
+  legend?: LegendConfiguration;
+  map?: MapConfig;
+  meta: FullTableMeta;
+  options: ChartOptions;
+}): MapConfig | undefined {
+  if (definition.type !== 'map' || !axes.major) {
+    return undefined;
   }
 
-  return draft;
-};
+  return {
+    dataSetConfigs: getMapDataSetConfigs({
+      axisMajor: axes.major,
+      data,
+      legend,
+      map,
+      meta,
+      options,
+    }),
+  };
+}
 
-export function useChartBuilderReducer(
-  initialChart?: Chart,
-  tableTitle?: string,
-) {
+function getMapDataSetConfigs({
+  axisMajor,
+  data,
+  legend,
+  map,
+  meta,
+  options,
+}: {
+  axisMajor: AxisConfiguration;
+  data: TableDataResult[];
+  legend?: LegendConfiguration;
+  map?: MapConfig;
+  meta: FullTableMeta;
+  options?: ChartOptions;
+}): MapDataSetConfig[] {
+  const dataSetCategories = createDataSetCategories({
+    axisConfiguration: {
+      ...axisMajor,
+      groupBy: 'locations',
+    },
+    data,
+    meta,
+  });
+
+  const dataSetCategoryConfigs = getMapDataSetCategoryConfigs({
+    dataSetCategories,
+    dataSetConfigs: map?.dataSetConfigs,
+    legendItems: legend?.items ?? [],
+    meta,
+    deprecatedDataClassification: options?.dataClassification,
+    deprecatedDataGroups: options?.dataGroups,
+  });
+
+  return dataSetCategoryConfigs.map(config => {
+    return {
+      boundaryLevel: config.boundaryLevel,
+      dataSet: config.rawDataSet,
+      dataGrouping: config.dataGrouping,
+    };
+  });
+}
+
+export function chartBuilderReducer(
+  reducerOptions: ChartBuilderReducerOptions,
+): Reducer<ChartBuilderState, ChartBuilderActions> {
+  const { data, meta } = reducerOptions;
+
+  return (draft, action) => {
+    switch (action.type) {
+      case 'UPDATE_CHART_DEFINITION': {
+        draft.definition = action.payload;
+
+        draft.options = {
+          ...defaultOptions,
+          ...(action.payload.options.defaults ?? {}),
+          ...draft.options,
+          // Set height/width to definition defaults
+          // as this seems to surprise users the least.
+          height:
+            action.payload.options.defaults?.height ??
+            draft.options?.height ??
+            defaultOptions.height,
+          width: action.payload.options.defaults?.width ?? draft.options?.width,
+        };
+
+        if (action.payload.capabilities.hasLegend) {
+          draft.legend = {
+            ...defaultLegend,
+            ...(action.payload.legend.defaults ?? {}),
+            ...(draft.legend ?? {}),
+          };
+        } else {
+          draft.legend = undefined;
+        }
+
+        draft.axes = mapValues(
+          action.payload.axes,
+          (axisDefinition: ChartDefinitionAxis, type: AxisType) => {
+            return updateAxis(axisDefinition, draft.axes[type]);
+          },
+        );
+
+        if (draft.definition.type === 'map' && !draft.map) {
+          draft.map = getInitialMapState({
+            axes: draft.axes,
+            data,
+            definition: action.payload,
+            legend: draft.legend,
+            map: draft.map,
+            meta,
+            options: draft.options,
+          });
+        }
+
+        break;
+      }
+      case 'UPDATE_CHART_AXIS': {
+        const axisDefinition = draft?.definition?.axes?.[action.payload.type];
+
+        if (!axisDefinition) {
+          throw new Error(
+            `Could not find chart axis definition for type '${action.payload.type}'`,
+          );
+        }
+
+        if (!draft.axes[action.payload.type]) {
+          throw new Error(
+            `Could not find axis configuration for type '${action.payload.type}'`,
+          );
+        }
+
+        draft.axes[action.payload.type] = updateAxis(
+          axisDefinition,
+          draft.axes[action.payload.type] as AxisConfiguration,
+          action.payload,
+        );
+
+        break;
+      }
+      case 'UPDATE_CHART_LEGEND': {
+        draft.legend = {
+          ...defaultLegend,
+          ...(draft?.definition?.legend.defaults ?? {}),
+          ...draft.legend,
+          ...action.payload,
+        };
+
+        break;
+      }
+      case 'UPDATE_MAP_BOUNDARY_LEVELS': {
+        if (!draft.map) {
+          throw new Error('Map config has not been initialised');
+        }
+
+        if (draft.options) {
+          draft.options.boundaryLevel = action.payload.boundaryLevel;
+        }
+
+        draft.map.dataSetConfigs.forEach((dataSetConfig, index) => {
+          // eslint-disable-next-line no-param-reassign
+          dataSetConfig.boundaryLevel =
+            action.payload.dataSetConfigs[index].boundaryLevel;
+        });
+
+        break;
+      }
+      case 'UPDATE_MAP_DATA_GROUPINGS': {
+        if (!draft.map) {
+          throw new Error('Map config has not been initialised');
+        }
+
+        draft.map.dataSetConfigs.forEach((dataSetConfig, index) => {
+          // eslint-disable-next-line no-param-reassign
+          dataSetConfig.dataGrouping =
+            action.payload.dataSetConfigs[index].dataGrouping;
+        });
+
+        break;
+      }
+      case 'UPDATE_CHART_OPTIONS': {
+        draft.options = {
+          ...defaultOptions,
+          ...(draft?.definition?.options.defaults ?? {}),
+          ...draft.options,
+          ...action.payload,
+        };
+
+        break;
+      }
+      case 'UPDATE_DATA_SETS': {
+        if (draft.axes.major) {
+          draft.axes.major.dataSets = action.payload;
+        }
+
+        if (draft.map && draft.axes.major) {
+          draft.map.dataSetConfigs = getMapDataSetConfigs({
+            axisMajor: draft.axes.major,
+            data,
+            legend: draft.legend,
+            map: draft.map,
+            meta,
+            options: draft.options,
+          });
+        }
+
+        break;
+      }
+      case 'RESET':
+        return getInitialState(reducerOptions);
+      default:
+        break;
+    }
+
+    return draft;
+  };
+}
+
+export function useChartBuilderReducer(options: ChartBuilderReducerOptions) {
   const [state, dispatch] = useLoggedImmerReducer<
     ChartBuilderState,
     ChartBuilderActions
-  >(
-    'Chart builder',
-    chartBuilderReducer,
-    getInitialState(initialChart, tableTitle),
-  );
+  >('Chart builder', chartBuilderReducer(options), getInitialState(options));
 
   const updateDataSets = useCallback(
     (dataSets: DataSet[]) => {
@@ -356,19 +472,20 @@ export function useChartBuilderReducer(
     [dispatch],
   );
 
-  const updateChartBoundaryLevels = useCallback(
-    (payload: ChartBoundaryLevelsFormValues) => {
+  const updateMapBoundaryLevels = useCallback(
+    (payload: MapBoundaryLevelConfig) => {
       dispatch({
-        type: 'UPDATE_CHART_MAP_BOUNDARY_LEVELS',
+        type: 'UPDATE_MAP_BOUNDARY_LEVELS',
         payload,
       });
     },
     [dispatch],
   );
-  const updateChartMapConfiguration = useCallback(
-    (dataSetConfigs: MapDataSetConfig[]) => {
+
+  const updateMapDataGroupings = useCallback(
+    (dataSetConfigs: MapDataGroupingConfig) => {
       dispatch({
-        type: 'UPDATE_CHART_MAP_CONFIGURATION',
+        type: 'UPDATE_MAP_DATA_GROUPINGS',
         payload: dataSetConfigs,
       });
     },
@@ -396,20 +513,20 @@ export function useChartBuilderReducer(
       updateDataSets,
       updateChartDefinition,
       updateChartLegend,
-      updateChartBoundaryLevels,
-      updateChartMapConfiguration,
+      updateMapBoundaryLevels,
+      updateMapDataGroupings,
       updateChartOptions,
       updateChartAxis,
       resetState,
     }),
     [
       updateDataSets,
-      updateChartAxis,
       updateChartDefinition,
       updateChartLegend,
-      updateChartBoundaryLevels,
-      updateChartMapConfiguration,
+      updateMapBoundaryLevels,
+      updateMapDataGroupings,
       updateChartOptions,
+      updateChartAxis,
       resetState,
     ],
   );

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/types/mapConfig.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/types/mapConfig.ts
@@ -1,0 +1,17 @@
+import { DataGroupingConfig } from '@common/modules/charts/types/chart';
+import { DataSet } from '@common/modules/charts/types/dataSet';
+
+export interface MapBoundaryLevelConfig {
+  boundaryLevel?: number;
+  dataSetConfigs: {
+    boundaryLevel?: number;
+    dataSet: DataSet;
+  }[];
+}
+
+export interface MapDataGroupingConfig {
+  dataSetConfigs: {
+    dataGrouping: DataGroupingConfig;
+    dataSet: DataSet;
+  }[];
+}

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
@@ -18,9 +18,9 @@ import {
 } from '@common/modules/charts/types/chart';
 import { DataSetCategory } from '@common/modules/charts/types/dataSet';
 import { LegendConfiguration } from '@common/modules/charts/types/legend';
-import getDataSetCategoryConfigs, {
-  DataSetCategoryConfig,
-} from '@common/modules/charts/util/getDataSetCategoryConfigs';
+import getMapDataSetCategoryConfigs, {
+  MapDataSetCategoryConfig,
+} from '@common/modules/charts/util/getMapDataSetCategoryConfigs';
 import { GeoJsonFeatureProperties } from '@common/services/tableBuilderService';
 import { Dictionary } from '@common/types';
 import naturalOrderBy from '@common/utils/array/naturalOrderBy';
@@ -136,14 +136,14 @@ export default function MapBlock({
     [axisMajor, data, meta],
   );
 
-  const dataSetCategoryConfigs = useMemo<Dictionary<DataSetCategoryConfig>>(
+  const dataSetCategoryConfigs = useMemo<Dictionary<MapDataSetCategoryConfig>>(
     () =>
       keyBy(
-        getDataSetCategoryConfigs({
+        getMapDataSetCategoryConfigs({
           dataSetCategories,
+          dataSetConfigs: map?.dataSetConfigs,
           legendItems: legend.items,
           meta,
-          dataSetConfigs: map?.dataSetConfigs,
           deprecatedDataGroups,
           deprecatedDataClassification,
         }),
@@ -151,9 +151,9 @@ export default function MapBlock({
       ),
     [
       dataSetCategories,
-      map?.dataSetConfigs,
-      legend,
+      legend.items,
       meta,
+      map,
       deprecatedDataGroups,
       deprecatedDataClassification,
     ],

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapGeoJSON.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapGeoJSON.tsx
@@ -1,13 +1,12 @@
 import useCallbackRef from '@common/hooks/useCallbackRef';
 import useIntersectionObserver from '@common/hooks/useIntersectionObserver';
 import styles from '@common/modules/charts/components/MapBlock.module.scss';
-import { DataSetCategoryConfig } from '@common/modules/charts/util/getDataSetCategoryConfigs';
 import {
   MapFeature,
   MapFeatureCollection,
   MapFeatureProperties,
 } from '@common/modules/charts/components/MapBlock';
-
+import { MapDataSetCategoryConfig } from '@common/modules/charts/util/getMapDataSetCategoryConfigs';
 import { Dictionary } from '@common/types';
 import formatPretty from '@common/utils/number/formatPretty';
 import { FeatureCollection } from 'geojson';
@@ -16,7 +15,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { GeoJSON, useMap } from 'react-leaflet';
 
 interface Props {
-  dataSetCategoryConfigs: Dictionary<DataSetCategoryConfig>;
+  dataSetCategoryConfigs: Dictionary<MapDataSetCategoryConfig>;
   features?: MapFeatureCollection;
   selectedFeature?: MapFeature;
   selectedDataSetKey: string;

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/generateFeaturesAndDataGroups.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/generateFeaturesAndDataGroups.ts
@@ -2,7 +2,7 @@ import { MapDataSetCategory } from '@common/modules/charts/components/utils/crea
 import generateLegendDataGroups, {
   LegendDataGroup,
 } from '@common/modules/charts/components/utils/generateLegendDataGroups';
-import { DataSetCategoryConfig } from '@common/modules/charts/util/getDataSetCategoryConfigs';
+import { MapDataSetCategoryConfig } from '@common/modules/charts/util/getMapDataSetCategoryConfigs';
 import generateHslColour from '@common/utils/colour/generateHslColour';
 import {
   MapFeature,
@@ -14,7 +14,7 @@ export default function generateFeaturesAndDataGroups({
   selectedDataSetConfig,
 }: {
   dataSetCategories: MapDataSetCategory[];
-  selectedDataSetConfig: DataSetCategoryConfig;
+  selectedDataSetConfig: MapDataSetCategoryConfig;
 }): {
   features: MapFeatureCollection;
   dataGroups: LegendDataGroup[];

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/getMapDataSetCategoryConfigs.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/getMapDataSetCategoryConfigs.test.ts
@@ -1,0 +1,3 @@
+describe('getMapDataSetCategoryConfigs', () => {
+  test.failing('TODO - Add tests', () => {});
+});

--- a/src/explore-education-statistics-common/src/modules/charts/util/getMapDataSetCategoryConfigs.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/getMapDataSetCategoryConfigs.ts
@@ -1,0 +1,77 @@
+import {
+  DataGroupingConfig,
+  DataGroupingType,
+  MapDataSetConfig,
+} from '@common/modules/charts/types/chart';
+import generateDataSetKey from '@common/modules/charts/util/generateDataSetKey';
+import getDataSetCategoryConfigs, {
+  DataSetCategoryConfig,
+  GetDataSetCategoryConfigsOptions,
+} from '@common/modules/charts/util/getDataSetCategoryConfigs';
+import keyBy from 'lodash/keyBy';
+
+const defaultDataGrouping: DataGroupingConfig = {
+  customGroups: [],
+  numberOfGroups: 5,
+  type: 'EqualIntervals',
+};
+
+export interface MapDataSetCategoryConfig extends DataSetCategoryConfig {
+  boundaryLevel?: number;
+  dataGrouping: DataGroupingConfig;
+}
+
+interface GetMapDataSetCategoryConfigsOptions
+  extends GetDataSetCategoryConfigsOptions {
+  dataSetConfigs?: MapDataSetConfig[];
+  defaultBoundaryLevel?: number;
+  /**
+   * Data classification and data groups are now in `dataSetConfigs`
+   * as they are per data set instead of for all data sets (EES-3858).
+   * The deprecated versions are to retain backwards compatibility
+   * with maps created before this change.
+   * @deprecated
+   */
+  deprecatedDataClassification?: DataGroupingType;
+  /**
+   * @deprecated
+   */
+  deprecatedDataGroups?: number;
+}
+
+export default function getMapDataSetCategoryConfigs({
+  dataSetConfigs = [],
+  defaultBoundaryLevel,
+  deprecatedDataClassification,
+  deprecatedDataGroups,
+  ...options
+}: GetMapDataSetCategoryConfigsOptions): MapDataSetCategoryConfig[] {
+  const dataSetConfigsByDataSet = keyBy(dataSetConfigs, item =>
+    generateDataSetKey(item.dataSet),
+  );
+
+  const deprecatedGrouping: DataGroupingConfig | undefined =
+    !dataSetConfigs?.length && deprecatedDataClassification
+      ? {
+          customGroups: [],
+          numberOfGroups:
+            deprecatedDataGroups ?? defaultDataGrouping.numberOfGroups,
+          type: deprecatedDataClassification,
+        }
+      : undefined;
+
+  const dataSetCategoryConfigs = getDataSetCategoryConfigs(options);
+
+  return dataSetCategoryConfigs.map(dataSetCategoryConfig => {
+    const dataSetConfig =
+      dataSetConfigsByDataSet[dataSetCategoryConfig.dataKey];
+
+    const dataGrouping = dataSetConfig?.dataGrouping ?? defaultDataGrouping;
+
+    return {
+      ...dataSetCategoryConfig,
+      boundaryLevel: defaultBoundaryLevel ?? dataSetConfig?.boundaryLevel,
+      dataGrouping: deprecatedGrouping ?? dataGrouping,
+    };
+  });
+}


### PR DESCRIPTION
- Hoists initialization of map `dataSetConfigs` into `chartBuilderReducer`
- Refactors form types for boundary level and data grouping tabs
- Fixes boundary level tab not showing invalid form errors for other tabs
- Refactors out new `getMapDataSetCategoryConfigs` function from `getDataSetCategoryConfigs`

## TODOs (Stu)

- Check if map state needs to be initialised in `UPDATE_CHART_DEFINITION` when map config already exists i.e. `if (draft.definition.type === 'map' && !draft.map)`
- Stop legend tab firing `UPDATE_CHART_LEGEND` seemingly more than necessary
- If you change data sets (on 'Data sets' tab) after setting some data set boundary levels, you can end up with stale state in 'Boundary levels' tab where some options will still be selected:

  1. Add data set
  2. Change boundary levels for some of those data sets
  3. Add a second data set
  4. Remove the first data set
  5. The second data set will appear to have the first data set's boundary levels, even though the first data set configs no longer exist - **maybe due to RHF?**