### PR TITLE
EES-5600 Add download data set CSV URL to API guidance

### DIFF
--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/ApiDataSetQuickStart.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/ApiDataSetQuickStart.tsx
@@ -137,6 +137,26 @@ export default function ApiDataSetQuickStart({
           children: 'Guidance: Query data set (POST)',
         })}
       </p>
+
+      <Heading>Download data set as CSV</Heading>
+
+      <UrlContainer
+        className="govuk-!-margin-bottom-2"
+        id="data-set-download-csv-endpoint"
+        label={
+          <>
+            GET<VisuallyHidden> data set CSV URL</VisuallyHidden>
+          </>
+        }
+        labelHidden={false}
+        url={`${publicApiBaseUrl}/data-sets/${dataSetId}/csv?dataSetVersion=${dataSetVersion}`}
+      />
+      <p>
+        {renderLink({
+          to: `${publicApiDocsUrl}/endpoints/DownloadDataSetCsv`,
+          children: 'Guidance: Download data set as CSV',
+        })}
+      </p>
     </>
   );
 }

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiQuickStart.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiQuickStart.test.tsx
@@ -55,5 +55,8 @@ describe('DataSetFileApiQuickStart', () => {
     expect(screen.getByLabelText('POST data set query URL')).toHaveDisplayValue(
       /data-sets\/api-data-set-id\/query\?dataSetVersion=1.0/,
     );
+    expect(screen.getByLabelText('GET data set CSV URL')).toHaveDisplayValue(
+      /data-sets\/api-data-set-id\/csv\?dataSetVersion=1.0/,
+    );
   });
 });


### PR DESCRIPTION
This PR adds the URL for downloading a data set as CSV to the API guidance:

![image](https://github.com/user-attachments/assets/342efb98-8185-4fa2-aac9-911818d10f85)
