### PR TITLE
Move snapshots back to UTC for winter

### DIFF
--- a/.github/workflows/validate-snapshots.yml
+++ b/.github/workflows/validate-snapshots.yml
@@ -5,9 +5,12 @@ on:
     # Actions are scheduled in UTC
     # Until Actions supports timezones, we need to update this cron
     # twice a year (at the start and end of daylight saving time) 
-    # to account for daylight saving time in the UK
+    # to account for daylight saving time in the UK.
+    # Set a new reminder in the slack channel for next time to 
+    # change this
     # This action is intended to run at 9:35AM, 12:35PM & 4:35PM
-    - cron: '35 8,11,15 * * 1-5'
+    # March to October - cron: '35 8,11,15 * * 1-5'
+    - cron: '35 9,12,16 * * 1-5'
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Quick one to shift the snapshots workflow back to UTC for winter. Just edited directly in GitHub as shouldn't affect anything else.

## Screenshots
Reminder that went off
![image](https://github.com/user-attachments/assets/2a091175-b7c7-479c-8583-d834ed1c3d70)

New reminder set for March to move to daylight savings time
![image](https://github.com/user-attachments/assets/0924d34e-375f-4f95-b8a5-42547188ed20)
![image](https://github.com/user-attachments/assets/491db55e-7606-434b-b490-30c0746b3f51)
