### PR TITLE
EES-5614 Disable Azure Web Application Firewall rule

### DIFF
--- a/infrastructure/templates/public-api/components/wafPolicy.bicep
+++ b/infrastructure/templates/public-api/components/wafPolicy.bicep
@@ -7,6 +7,18 @@ param name string
 @description('Specifies a set of tags with which to tag the resource in Azure')
 param tagValues object
 
+var owaspRuleGroupOverrides = [
+  {
+    ruleGroupName: 'REQUEST-913-SCANNER-DETECTION'
+    rules: [
+      {
+        ruleId: '913101'
+        state: 'Disabled'
+      }
+    ]
+  }
+]
+
 resource policy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2023-11-01' = {
   name: name
   location: location
@@ -26,6 +38,7 @@ resource policy 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolic
         {
           ruleSetType: 'OWASP'
           ruleSetVersion: '3.2'
+          ruleGroupOverrides: owaspRuleGroupOverrides
         }
         {
           ruleSetType: 'Microsoft_BotManagerRuleSet'


### PR DESCRIPTION
This PR disables an Azure Web Application Firewall (WAF) default rule set rule.

This change is being made after finding that Public API requests with certain `User-Agent` headers were being blocked with 403 Forbidden responses by the Azure Application Gateway.

Rule set group: `REQUEST-913-SCANNER-DETECTION`
Rule:  `913101 - 'Found User-Agent associated with scripting/generic HTTP client`