### PR TITLE
EES-5241 - allow Public API deploys to occur into the Dev or Test env from any branch

### DIFF
--- a/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
+++ b/infrastructure/templates/public-api/api-infrastructure-pipeline.yml
@@ -7,6 +7,14 @@ parameters:
   - name: updatePsqlFlexibleServer
     displayName: Does the PostgreSQL Flexible Server require any updates? False by default to avoid unnecessarily lengthy deploys.
     default: false
+  - name: forceDeployToEnvironment
+    displayName: Set to either dev or test to force a deploy to that environment from the chosen branch.
+    type: string
+    values:
+      - none
+      - dev
+      - test
+    default: 'none'
 
 resources:
   pipelines:
@@ -20,10 +28,12 @@ resources:
 
 variables:
   - group: Public API Infrastructure - common
+  - name: forceDeployToEnvironment
+    value: ${{parameters.forceDeployToEnvironment}}
   - name: isDev
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
+    value: $[or(eq(variables['forceDeployToEnvironment'], 'dev'), eq(variables['Build.SourceBranch'], 'refs/heads/dev'))]
   - name: isTest
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/test')]
+    value: $[or(eq(variables['forceDeployToEnvironment'], 'test'), eq(variables['Build.SourceBranch'], 'refs/heads/test'))]
   - name: isMaster
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   - name: vmImageName


### PR DESCRIPTION
This PR:
- provides a way to force a deploy of the Public API pipeline to the Dev or Test environment from any branch.

A new radiofield will be available when manually running the Pipeline in DevOps - by default it will be "none" meaning that the environment selection will be base on the branch being run from, but alternatively this can be set to "dev" to deploy the pipeline from any branch to Dev, and the same for Test.

Note that "Resources" still need to be selected during a manual pipeline run so that the pipeline has some code to deploy.  We would go to Resources -> EESMainBuildPipeline -> and then search for "dev" in the search field to pull up the latest build pipeline artifacts with which to run the pipeline (if deploying to the Dev environment, that is).  This selects the ZIP files and Docker images that were built by the chosen run of the build pipeline as the deployment candidates for the Public API pipeline run. 