### PR TITLE
EES-5623 Temporarily scale up the Importer function app and the Stati…

### DIFF
--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -15,7 +15,7 @@
       "value": "S1 Standard"
     },
     "skuImporter": {
-      "value": "B1 Basic"
+      "value": "P1V2 PremiumV2"
     },
     "skuNotifier": {
       "value": "B1 Basic"
@@ -75,13 +75,13 @@
       "value": 10
     },
     "skuStatisticsDb": {
-      "value": "Standard"
+      "value": "GP_Gen5"
     },
     "tierStatisticsDb": {
-      "value": "Standard"
+      "value": "GeneralPurpose"
     },
     "capacityStatisticsDb": {
-      "value": 50
+      "value": 2
     },
     "maxContentDbSizeBytes": {
       "value": 1073741824


### PR DESCRIPTION
This PR is to reflect the manual change we made earlier today to temporarily scale up the Importer function app and the Statistics Azure SQL main and replica databases in the Test environment to allow importing of data for testing the Public API.

We will revert this change when the importing of data set files and also the reindexing of that data (by the Data Factory overnight task run) is completed for the Public API testing.