### PR TITLE
EES-5617 Add public API docs to App Gateway via `/docs` route

### DIFF
--- a/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
@@ -6,7 +6,7 @@ param resourceNames resourceNamesType
 @description('Specifies the location for all resources.')
 param location string
 
-@description('The id of the owning Container App Environment.')
+@description('The ID of the owning Container App Environment.')
 param containerAppEnvironmentId string
 
 @description('The IP address of the owning Container App Environment.')
@@ -148,4 +148,4 @@ module apiContainerAppModule '../../components/containerApp.bicep' = {
 
 output containerAppFqdn string = apiContainerAppModule.outputs.containerAppFqdn
 output containerAppName string = apiContainerAppModule.outputs.containerAppName
-output containerAppHealthProbeRelativeUrl string = '/health'
+output healthProbePath string = '/health'

--- a/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
@@ -6,8 +6,11 @@ param resourceNames resourceNamesType
 @description('Specifies the location for all resources.')
 param location string
 
-@description('Specifies the id of the Container App Environment in which to deploy this Container App.')
+@description('The id of the owning Container App Environment.')
 param containerAppEnvironmentId string
+
+@description('The IP address of the owning Container App Environment.')
+param containerAppEnvironmentIpAddress string
 
 @description('The tags of the Docker images to deploy.')
 param dockerImagesTag string
@@ -62,7 +65,9 @@ module apiContainerAppModule '../../components/containerApp.bicep' = {
     dockerPullManagedIdentityClientId: keyVault.getSecret('DOCKER-REGISTRY-SERVER-USERNAME')
     dockerPullManagedIdentitySecretValue: keyVault.getSecret('DOCKER-REGISTRY-SERVER-PASSWORD')
     userAssignedManagedIdentityId: apiContainerAppManagedIdentity.id
-    managedEnvironmentId: containerAppEnvironmentId
+    environmentId: containerAppEnvironmentId
+    environmentIpAddress: containerAppEnvironmentIpAddress
+    deployPrivateDns: true
     corsPolicy: {
       allowedOrigins: [
         publicSiteUrl
@@ -70,6 +75,7 @@ module apiContainerAppModule '../../components/containerApp.bicep' = {
         'http://127.0.0.1'
       ]
     }
+    vnetName: resourceNames.existingResources.vNet
     volumeMounts: [
       {
         volumeName: 'public-api-fileshare-mount'

--- a/infrastructure/templates/public-api/application/public-api/publicApiDocs.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiDocs.bicep
@@ -1,12 +1,12 @@
 import { resourceNamesType, staticWebAppSkuType } from '../../types.bicep'
 
-@description('Common resource naming variables.')
+@description('Common resource naming variables')
 param resourceNames resourceNamesType
 
-@description('Static Web App SKU to use.')
+@description('Static Web App SKU to use')
 param appSku staticWebAppSkuType = 'Free'
 
-@description('A set of tags for the resource.')
+@description('Tags for the resources')
 param tagValues object
 
 module publicApiDocsApp  '../../components/staticWebApp.bicep' = {
@@ -17,3 +17,6 @@ module publicApiDocsApp  '../../components/staticWebApp.bicep' = {
     sku: appSku
   }
 }
+
+output appFqdn string = publicApiDocsApp.outputs.fqdn
+output healthProbePath string = '/'

--- a/infrastructure/templates/public-api/application/shared/appGateway.bicep
+++ b/infrastructure/templates/public-api/application/shared/appGateway.bicep
@@ -1,15 +1,30 @@
-import { resourceNamesType, appGatewaySiteConfigType } from '../../types.bicep'
+import {
+  AppGatewayBackend
+  AppGatewayRewriteSet
+  AppGatewayRoute
+  AppGatewaySite
+  resourceNamesType
+} from '../../types.bicep'
 
-@description('Specifies common resource naming variables.')
+@description('Common resource naming variables')
 param resourceNames resourceNamesType
 
-@description('Specifies the location for all resources.')
+@description('The location to create resources in')
 param location string
 
-@description('Specifies the subnet id for the App Gateway to integrate with the VNet.')
-param publicApiContainerAppSettings appGatewaySiteConfigType
+@description('Sites that the App Gateway handles')
+param sites AppGatewaySite[]
 
-@description('Specifies a set of tags with which to tag the resource in Azure.')
+@description('Backend resources the App Gateway can direct traffic to')
+param backends AppGatewayBackend[]
+
+@description('Routes the App Gateway should direct traffic through')
+param routes AppGatewayRoute[]
+
+@description('Rules for how the App Gateway should rewrite URLs')
+param rewrites AppGatewayRewriteSet[]
+
+@description('Tags for the resources')
 param tagValues object
 
 resource vNet 'Microsoft.Network/virtualNetworks@2023-11-01' existing = {
@@ -29,9 +44,10 @@ module appGatewayModule '../../components/appGateway.bicep' = {
     managedIdentityName: resourceNames.sharedResources.appGatewayIdentity
     keyVaultName: resourceNames.existingResources.keyVault
     subnetId: subnet.id
-    sites: [
-      publicApiContainerAppSettings
-    ]
+    sites: sites
+    backends: backends
+    routes: routes
+    rewrites: rewrites
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/public-api/application/shared/appGateway.bicep
+++ b/infrastructure/templates/public-api/application/shared/appGateway.bicep
@@ -28,7 +28,6 @@ module appGatewayModule '../../components/appGateway.bicep' = {
     appGatewayName: resourceNames.sharedResources.appGateway
     managedIdentityName: resourceNames.sharedResources.appGatewayIdentity
     keyVaultName: resourceNames.existingResources.keyVault
-    vnetName: resourceNames.existingResources.vNet
     subnetId: subnet.id
     sites: [
       publicApiContainerAppSettings

--- a/infrastructure/templates/public-api/application/shared/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/shared/virtualNetwork.bicep
@@ -44,8 +44,11 @@ resource appGatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01'
   parent: vNet
 }
 
-@description('The fully qualified Azure resource ID of the Network.')
+@description('The fully qualified Azure resource ID of the virtual network')
 output vnetId string = resourceId('Microsoft.Network/VirtualNetworks', resourceNames.existingResources.vNet)
+
+@description('The name of the virtual network')
+output vnetName string = vNet.name
 
 @description('The fully qualified Azure resource ID of the Data Processor Function App Subnet.')
 output dataProcessorSubnetRef string = dataProcessorSubnet.id

--- a/infrastructure/templates/public-api/components/appGateway.bicep
+++ b/infrastructure/templates/public-api/components/appGateway.bicep
@@ -6,9 +6,6 @@ param keyVaultName string
 @description('Specifies the location for all resources')
 param location string
 
-@description('Specifies the VNet name that this App Gateway will be connected to')
-param vnetName string
-
 @description('Specifies the id of a dedicated subnet to which this App Gateway will be connected')
 param subnetId string
 
@@ -92,15 +89,6 @@ module wafPolicyModule 'wafPolicy.bicep' = {
     tagValues: tagValues
   }
 }
-
-module backendPrivateDnsConfigurationsModule './appGatewayBackendDns.bicep' = [for site in sites: {
-  name: site.backendDomainName
-  params: {
-    site: site
-    vnetName: vnetName
-    tagValues: tagValues
-  }
-}]
 
 // Create the App Gateway.
 resource appGateway 'Microsoft.Network/applicationGateways@2023-11-01' = {

--- a/infrastructure/templates/public-api/components/appGatewayPathRules.bicep
+++ b/infrastructure/templates/public-api/components/appGatewayPathRules.bicep
@@ -1,0 +1,28 @@
+import { AppGatewayPathRule } from '../types.bicep'
+
+@description('Name of the App Gateway')
+param appGatewayName string
+
+@description('Routes the App Gateway should direct traffic through')
+param pathRules AppGatewayPathRule[]
+
+var rules = [for rule in pathRules: {
+  name: rule.name
+  properties: {
+    paths: rule.paths
+    backendAddressPool: rule.type == 'backend' ? {
+      id: resourceId('Microsoft.Network/applicationGateways/backendAddressPools', appGatewayName, '${rule.backendName}-backend-pool')
+    } : null
+    backendHttpSettings: rule.type == 'backend' ? {
+      id: resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', appGatewayName, '${rule.backendName}-backend')
+    } : null
+    redirectConfiguration: rule.type == 'redirect' ? {
+      id: resourceId('Microsoft.Network/applicationGateways/redirectConfigurations', appGatewayName, rule.name)
+    } : null
+    rewriteRuleSet: rule.type == 'backend' && rule.rewriteSetName != null ? {
+      id: resourceId('Microsoft.Network/applicationGateways/rewriteRuleSets', appGatewayName, rule.rewriteSetName)
+    } : null
+  }
+}]
+
+output rules object[] = rules

--- a/infrastructure/templates/public-api/components/containerApp.bicep
+++ b/infrastructure/templates/public-api/components/containerApp.bicep
@@ -137,7 +137,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
         external: true
         targetPort: containerAppTargetPort
         allowInsecure: false
-        corsPolicy: corsPolicy
+        corsPolicy: any(corsPolicy)
         traffic: [
           {
             latestRevision: true

--- a/infrastructure/templates/public-api/components/containerApp.bicep
+++ b/infrastructure/templates/public-api/components/containerApp.bicep
@@ -75,8 +75,17 @@ param dockerPullManagedIdentityClientId string
 @secure()
 param dockerPullManagedIdentitySecretValue string
 
-@description('Id of the owning Container App Environment')
-param managedEnvironmentId string
+@description('The id of the owning Container App Environment')
+param environmentId string
+
+@description('The IP address of the Container App Environment')
+param environmentIpAddress string
+
+@description('Deploy private DNS zone and records so other resources can communicate with Container App over private network using FQDNs')
+param deployPrivateDns bool = true
+
+@description('The vnet that the Container App will be connected to')
+param vnetName string
 
 @description('Volumes to mount within Containers - used in conjunction with "volumeMounts"')
 param volumes {
@@ -114,7 +123,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
     }
   }
   properties: {
-    managedEnvironmentId: managedEnvironmentId
+    managedEnvironmentId: environmentId
     configuration: {
       secrets: [
         {
@@ -189,6 +198,18 @@ module azureAuthentication 'containerAppAzureAuthentication.bicep' = if (entraId
   }
 }
 
-output containerAppFqdn string = containerApp.properties.configuration.ingress.fqdn
+var containerAppFqdn = containerApp.properties.configuration.ingress.fqdn
+
+module privateDns 'containerAppPrivateDns.bicep' = if (deployPrivateDns) {
+  name: '${containerAppName}PrivateDns'
+  params: {
+    domain: substring(containerAppFqdn, indexOf(containerAppFqdn, '.') + 1)
+    ipAddress: environmentIpAddress
+    vnetName: vnetName
+    tagValues: tagValues
+  }
+}
+
+output containerAppFqdn string = containerAppFqdn
 output containerImage string = containerImageName
 output containerAppName string = containerApp.name

--- a/infrastructure/templates/public-api/components/containerAppEnvironment.bicep
+++ b/infrastructure/templates/public-api/components/containerAppEnvironment.bicep
@@ -60,7 +60,7 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-03-01' 
     workloadProfiles: workloadProfiles
   }
   tags: tagValues
-  
+
   resource azureFileStorage 'storages@2022-03-01' = [for storage in azureFileStorages: {
       name: storage.storageName
       properties: {

--- a/infrastructure/templates/public-api/components/containerAppPrivateDns.bicep
+++ b/infrastructure/templates/public-api/components/containerAppPrivateDns.bicep
@@ -1,31 +1,32 @@
-import { appGatewaySiteConfigType } from '../types.bicep'
-
-@description('Specifies the VNet name that the DNS records will be made available to')
+@description('Name of the vnet the private DNS zone should be connected to')
 param vnetName string
 
-@description('Specifies the Key Vault name that this App Gateway will be permitted to get and list certificates from')
-param site appGatewaySiteConfigType
+@description('Domain name to use in the DNS records')
+param domain string
 
-@description('Specifies a set of tags with which to tag the resource in Azure')
+@description('The IP address to use in the DNS A records')
+param ipAddress string
+
+@description('Tags to assign to resources')
 param tagValues object
 
 module privateDnsZoneModule './privateDnsZone.bicep' = {
-  name: '${site.backendDomainName}Deploy'
+  name: '${domain}Deploy'
   params: {
     vnetName: vnetName
     zoneType: 'custom'
-    customName: site.backendDomainName
+    customName: domain
     tagValues: tagValues
   }
 }
 
 resource dnsWildcardARecord 'Microsoft.Network/privateDnsZones/A@2024-06-01' = {
-  name: '${site.backendDomainName}/*'
+  name: '${domain}/*'
   properties: {
     ttl: 3600
     aRecords: [
       {
-        ipv4Address: site.backendIpAddress
+        ipv4Address: ipAddress
       }
     ]
   }
@@ -35,12 +36,12 @@ resource dnsWildcardARecord 'Microsoft.Network/privateDnsZones/A@2024-06-01' = {
 }
 
 resource dnsAtARecord 'Microsoft.Network/privateDnsZones/A@2024-06-01' = {
-  name: '${site.backendDomainName}/@'
+  name: '${domain}/@'
   properties: {
     ttl: 3600
     aRecords: [
       {
-        ipv4Address: site.backendIpAddress
+        ipv4Address: ipAddress
       }
     ]
   }
@@ -50,7 +51,7 @@ resource dnsAtARecord 'Microsoft.Network/privateDnsZones/A@2024-06-01' = {
 }
 
 resource dnsAtSoaRecord 'Microsoft.Network/privateDnsZones/SOA@2024-06-01' = {
-  name: '${site.backendDomainName}/@'
+  name: '${domain}/@'
   properties: {
     ttl: 3600
     soaRecord: {

--- a/infrastructure/templates/public-api/components/staticWebApp.bicep
+++ b/infrastructure/templates/public-api/components/staticWebApp.bicep
@@ -23,3 +23,5 @@ resource staticWebApp 'Microsoft.Web/staticSites@2023-12-01' = {
   }
   properties: {}
 }
+
+output fqdn string = staticWebApp.properties.defaultHostname

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -256,6 +256,7 @@ module apiAppModule 'application/public-api/publicApiApp.bicep' = if (deployCont
     resourceNames: resourceNames
     apiAppRegistrationClientId: apiAppRegistrationClientId
     containerAppEnvironmentId: containerAppEnvironmentModule.outputs.containerAppEnvironmentId
+    containerAppEnvironmentIpAddress: containerAppEnvironmentModule.outputs.containerAppEnvironmentIpAddress
     contentApiUrl: publicUrls.contentApi
     publicApiUrl: publicUrls.publicApi
     publicSiteUrl: publicUrls.publicSite

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -280,21 +280,82 @@ module docsModule 'application/public-api/publicApiDocs.bicep' = {
   }
 }
 
+var docsRewriteSetName = '${publicApiResourcePrefix}-docs-rewrites'
+
 // Create an Application Gateway to serve public traffic for the Public API Container App.
 module appGatewayModule 'application/shared/appGateway.bicep' = if (deployContainerApp) {
-  name: 'appGatewayApplicationModuleDeploy'
+  name: 'appGatewayModuleDeploy'
   params: {
     location: location
     resourceNames: resourceNames
-    publicApiContainerAppSettings: {
-      resourceName: apiAppModule.outputs.containerAppName
-      backendFqdn: apiAppModule.outputs.containerAppFqdn
-      backendDomainName: substring(apiAppModule.outputs.containerAppFqdn, indexOf(apiAppModule.outputs.containerAppFqdn, '.') + 1)
-      backendIpAddress: containerAppEnvironmentModule.outputs.containerAppEnvironmentIpAddress
-      publicFqdn: replace(publicUrls.publicApi, 'https://', '')
-      certificateName: '${apiAppModule.outputs.containerAppName}-certificate'
-      healthProbeRelativeUrl: apiAppModule.outputs.containerAppHealthProbeRelativeUrl
-    }
+    sites: [
+      {
+        name: publicApiResourcePrefix
+        certificateName: '${publicApiResourcePrefix}-certificate'
+        fqdn: replace(publicUrls.publicApi, 'https://', '')
+      }
+    ]
+    backends: [
+      {
+        name: resourceNames.publicApi.apiApp
+        fqdn: apiAppModule.outputs.containerAppFqdn
+        healthProbePath: apiAppModule.outputs.healthProbePath
+      }
+      {
+        name: resourceNames.publicApi.docsApp
+        fqdn: docsModule.outputs.appFqdn
+        healthProbePath: docsModule.outputs.healthProbePath
+      }
+    ]
+    routes: [
+      {
+        name: publicApiResourcePrefix
+        siteName: publicApiResourcePrefix
+        defaultBackendName: resourceNames.publicApi.apiApp
+        pathRules: [
+          {
+            name: 'docs-backend'
+            paths: ['/docs/*']
+            type: 'backend'
+            backendName: resourceNames.publicApi.docsApp
+            rewriteSetName: docsRewriteSetName
+          }
+          {
+            // Redirect non-rooted URL (has no trailing slash) to the
+            // rooted URL so that relative links in the docs site
+            // can resolve correctly.
+            name: 'docs-root-redirect'
+            paths: ['/docs']
+            type: 'redirect'
+            redirectUrl: '${publicUrls.publicApi}/docs/'
+            redirectType: 'Permanent'
+            includePath: false
+          }
+        ]
+      }
+    ]
+    rewrites: [
+      {
+        name: docsRewriteSetName
+        rules: [
+          {
+            name: 'trim-docs-path-prefix'
+            conditions: [
+              {
+                variable: 'var_uri_path'
+                pattern: '^/docs/(.*)'
+                ignoreCase: true
+              }
+            ]
+            actionSet: {
+              urlConfiguration: {
+                modifiedPath: '/{var_uri_path_1}'
+              }
+            }
+          }
+        ]
+      }
+    ]
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/public-api/types.bicep
+++ b/infrastructure/templates/public-api/types.bicep
@@ -64,14 +64,137 @@ type entraIdAuthenticationType = {
 }
 
 @export()
-type appGatewaySiteConfigType = {
-  resourceName: string
-  backendFqdn: string
-  backendDomainName: string
-  backendIpAddress: string
-  publicFqdn: string
+type AppGatewaySite = {
+  @description('Name of the site')
+  name: string
+
+  @description('Name of the certificate that applies for this site')
   certificateName: string
-  healthProbeRelativeUrl: string
+
+  @description('FQDN of the site')
+  fqdn: string
+}
+
+@export()
+type AppGatewayBackend = {
+  @description('Name of the backend')
+  name: string
+
+  @description('FQDN of the backend')
+  fqdn: string
+
+  @description('Path that the health probe should periodically ping e.g. /')
+  healthProbePath: string
+}
+
+@export()
+type AppGatewayRoute = {
+  @description('Name of the route')
+  name: string
+
+  @description('Name of the site that will receive incoming traffic for this route')
+  siteName: string
+
+  @description('Name of the backend that the route will direct traffic to by default if no path rule applies')
+  defaultBackendName: string
+
+  @description('A set of path rules to apply')
+  pathRules: AppGatewayPathRule[]
+}
+
+@export()
+@discriminator('type')
+type AppGatewayPathRule = AppGatewayBackendPathRule | AppGatewayRedirectPathRule
+
+@export()
+type AppGatewayBackendPathRule = {
+  type: 'backend'
+
+  @description('Name of the rule')
+  name: string
+
+  @description('Request paths that apply for this rule')
+  paths: string[]
+
+  @description('Name of the backend to direct traffic to')
+  backendName: string?
+
+  @description('The name of the rewrite set that applies for this path')
+  rewriteSetName: string?
+}
+
+@export()
+type AppGatewayRedirectPathRule = {
+  type: 'redirect'
+
+  @description('Name of the rule')
+  name: string
+
+  @description('Request paths that apply for this rule')
+  paths: string[]
+
+  @description('URL to redirect traffic to')
+  redirectUrl: string?
+
+  @description('Type of redirect')
+  redirectType: 'Temporary' | 'Permanent'
+
+  @description('Append the request path to the redirected URL. Defaults to true')
+  includePath: bool?
+}
+
+@export()
+type AppGatewayRewriteSet = {
+  @description('Name of the rewrite set')
+  name: string
+
+  @description('The rewrite rules in the rewrite set')
+  rules: AppGatewayRewriteRule[]
+}
+
+@export()
+type AppGatewayRewriteRule = {
+  @description('Name of the rewrite rule')
+  name: string
+
+  @description('Conditions that need to be met for rewrite rule to trigger')
+  conditions: AppGatewayRewriteCondition[]
+
+  @description(' that should be performed when the rewrite rule triggers')
+  actionSet: AppGatewayRewriteActionSet
+}
+
+@export()
+type AppGatewayRewriteCondition = {
+  @description('The server variable to check - see https://learn.microsoft.com/en-us/azure/application-gateway/rewrite-http-headers-url#server-variables')
+  variable: string
+
+  @description('A string or regex to compare with the variable')
+  pattern: string
+
+  @description('Negate the condition check. Defaults to false')
+  negate: bool?
+
+  @description('Ignore case when checking the variable. Defaults to true')
+  ignoreCase: bool?
+}
+
+@export()
+type AppGatewayRewriteActionSet = {
+  @description('Rewrite config for the URL')
+  urlConfiguration: AppGatewayRewriteUrlConfig
+}
+
+@export()
+type AppGatewayRewriteUrlConfig = {
+  @description('The path after it has been rewritten. Can contain variables from other parts of the request')
+  modifiedPath: string?
+
+  @description('The query string after it has been rewritten. Can contain variables from other parts of the request')
+  modifiedQueryString: string?
+
+  @description('Re-evaluate any associated URL path maps with the rewritten path. Defaults to false')
+  reroute: bool?
 }
 
 @export()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Program.cs
@@ -39,16 +39,16 @@ startup.Configure(app, app.Environment);
 
 app.UseSwagger(options =>
 {
-    options.RouteTemplate = "/docs/{documentName}/openapi.json";
+    options.RouteTemplate = "/swagger/{documentName}/openapi.json";
 });
 app.UseSwaggerUI(options =>
 {
-    options.RoutePrefix = "docs";
+    options.RoutePrefix = "swagger";
 
     foreach (var description in app.DescribeApiVersions())
     {
         options.SwaggerEndpoint(
-            url: $"/docs/{description.GroupName}/openapi.json",
+            url: $"/swagger/{description.GroupName}/openapi.json",
             name: $"v{description.GroupName}");
     }
 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Properties/launchSettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Properties/launchSettings.json
@@ -12,7 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "docs",
+      "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -21,7 +21,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "docs",
+      "launchUrl": "swagger",
       "applicationUrl": "https://0.0.0.0:5051;http://0.0.0.0:5050;https://[::1]:5051;http://[::1]:5050",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
This PR adds the public API docs app to the App Gateway via a `/docs` route.

To enable this, we've made significant modifications to the App Gateway to enable us to configure all the required parts i.e. path rules, rewrites and redirects.

We've also moved the private DNS zone (and records) out of the `appGateway` module and into the `containerApp` module. The private DNS configuration was previously necessary for Container Apps to make them accessible to the App Gateway without opening them to the public internet. However, a private DNS is not necessary (or possible) with a Static Web App, which is used for the public API docs, and did not fit the previous abstraction.

## Related changes

- Updated Swagger endpoints in public API to `/swagger` instead of `/docs` (which conflicts with the API docs app)
- Fixed `corsPolicy` type error in `containerApp` module

## Deployment

The new infrastructure changes will fail to deploy over the existing infrastructure due to existing resources that can't be automatically deleted.

To deploy the infrastructure changes, we need to manually the delete the following resources beforehand:

- App Gateway - `s101d01-ees-agw-01`
- Public IP - `s10dt01-ees-papi-ca-api-pip`