### PR TITLE
EES-5617 Update custom Bicep type names to be PascalCased

### DIFF
--- a/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
@@ -1,7 +1,7 @@
-import { resourceNamesType } from '../../types.bicep'
+import { ResourceNames } from '../../types.bicep'
 
 @description('Specifies common resource naming variables.')
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 @description('Specifies the location for all resources.')
 param location string

--- a/infrastructure/templates/public-api/application/public-api/publicApiAppIdentity.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiAppIdentity.bicep
@@ -1,7 +1,7 @@
-import { resourceNamesType } from '../../types.bicep'
+import { ResourceNames } from '../../types.bicep'
 
 @description('Specifies common resource naming variables.')
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 @description('Specifies the location for all resources.')
 param location string

--- a/infrastructure/templates/public-api/application/public-api/publicApiAppInsights.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiAppInsights.bicep
@@ -1,7 +1,7 @@
-import { resourceNamesType } from '../../types.bicep'
+import { ResourceNames } from '../../types.bicep'
 
 @description('Specifies common resource naming variables.')
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 @description('Specifies the location for all resources.')
 param location string

--- a/infrastructure/templates/public-api/application/public-api/publicApiDataProcessor.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiDataProcessor.bicep
@@ -1,7 +1,7 @@
-import { resourceNamesType, firewallRuleType } from '../../types.bicep'
+import { ResourceNames, FirewallRule } from '../../types.bicep'
 
 @description('Specifies common resource naming variables.')
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 @description('Specifies the location for all resources.')
 param location string
@@ -19,7 +19,7 @@ param dataProcessorFunctionAppExists bool = false
 param dataProcessorAppRegistrationClientId string
 
 @description('Public API Storage : Firewall rules.')
-param storageFirewallRules firewallRuleType[] = []
+param storageFirewallRules FirewallRule[] = []
 
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object

--- a/infrastructure/templates/public-api/application/public-api/publicApiDocs.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiDocs.bicep
@@ -1,10 +1,10 @@
-import { resourceNamesType, staticWebAppSkuType } from '../../types.bicep'
+import { ResourceNames, StaticWebAppSku } from '../../types.bicep'
 
 @description('Common resource naming variables')
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 @description('Static Web App SKU to use')
-param appSku staticWebAppSkuType = 'Free'
+param appSku StaticWebAppSku = 'Free'
 
 @description('Tags for the resources')
 param tagValues object

--- a/infrastructure/templates/public-api/application/public-api/publicApiStorage.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiStorage.bicep
@@ -1,6 +1,6 @@
-import { resourceNamesType, firewallRuleType } from '../../types.bicep'
+import { ResourceNames, FirewallRule } from '../../types.bicep'
 
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 @description('Specifies the location for all resources.')
 param location string
@@ -9,7 +9,7 @@ param location string
 param publicApiDataFileShareQuota int = 1
 
 @description('Public API Storage : Firewall rules.')
-param storageFirewallRules firewallRuleType[] = []
+param storageFirewallRules FirewallRule[] = []
 
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object

--- a/infrastructure/templates/public-api/application/shared/appGateway.bicep
+++ b/infrastructure/templates/public-api/application/shared/appGateway.bicep
@@ -3,11 +3,11 @@ import {
   AppGatewayRewriteSet
   AppGatewayRoute
   AppGatewaySite
-  resourceNamesType
+  ResourceNames
 } from '../../types.bicep'
 
 @description('Common resource naming variables')
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 @description('The location to create resources in')
 param location string

--- a/infrastructure/templates/public-api/application/shared/containerAppEnvironment.bicep
+++ b/infrastructure/templates/public-api/application/shared/containerAppEnvironment.bicep
@@ -1,7 +1,7 @@
-import { resourceNamesType } from '../../types.bicep'
+import { ResourceNames } from '../../types.bicep'
 
 @description('Specifies common resource naming variables.')
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 @description('Specifies the location for all resources.')
 param location string

--- a/infrastructure/templates/public-api/application/shared/coreStorage.bicep
+++ b/infrastructure/templates/public-api/application/shared/coreStorage.bicep
@@ -1,7 +1,7 @@
-import { resourceNamesType } from '../../types.bicep'
+import { ResourceNames } from '../../types.bicep'
 
 @description('Specifies common resource naming variables.')
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 resource coreStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
   name: resourceNames.existingResources.coreStorageAccount

--- a/infrastructure/templates/public-api/application/shared/logAnalyticsWorkspace.bicep
+++ b/infrastructure/templates/public-api/application/shared/logAnalyticsWorkspace.bicep
@@ -1,7 +1,7 @@
-import { resourceNamesType } from '../../types.bicep'
+import { ResourceNames } from '../../types.bicep'
 
 @description('Specifies common resource naming variables.')
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 @description('Specifies the location for all resources.')
 param location string

--- a/infrastructure/templates/public-api/application/shared/postgreSqlFlexibleServer.bicep
+++ b/infrastructure/templates/public-api/application/shared/postgreSqlFlexibleServer.bicep
@@ -1,7 +1,7 @@
-import { resourceNamesType, firewallRuleType, principalNameAndIdType } from '../../types.bicep'
+import { ResourceNames, FirewallRule, PrincipalNameAndId } from '../../types.bicep'
 
 @description('Specifies common resource naming variables.')
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 @description('Specifies the location for all resources.')
 param location string
@@ -23,13 +23,13 @@ param storageSizeGB int = 32
 param autoGrowStatus string = 'Disabled'
 
 @description('Firewall rules.')
-param firewallRules firewallRuleType[] = []
+param firewallRules FirewallRule[] = []
 
 @description('Specifies the subnet id that the PostgreSQL private endpoint will be attached to.')
 param privateEndpointSubnetId string
 
 @description('An array of Entra ID admin principal names for this resource')
-param entraIdAdminPrincipals principalNameAndIdType[] = []
+param entraIdAdminPrincipals PrincipalNameAndId[] = []
 
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object

--- a/infrastructure/templates/public-api/application/shared/privateDnsZones.bicep
+++ b/infrastructure/templates/public-api/application/shared/privateDnsZones.bicep
@@ -1,7 +1,7 @@
-import { resourceNamesType } from '../../types.bicep'
+import { ResourceNames } from '../../types.bicep'
 
 @description('Specifies common resource naming variables.')
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object

--- a/infrastructure/templates/public-api/application/shared/virtualNetwork.bicep
+++ b/infrastructure/templates/public-api/application/shared/virtualNetwork.bicep
@@ -1,7 +1,7 @@
-import { resourceNamesType } from '../../types.bicep'
+import { ResourceNames } from '../../types.bicep'
 
 @description('Specifies common resource naming variables.')
-param resourceNames resourceNamesType
+param resourceNames ResourceNames
 
 var subnets = resourceNames.existingResources.subnets
 

--- a/infrastructure/templates/public-api/components/appServiceSlotConfig.bicep
+++ b/infrastructure/templates/public-api/components/appServiceSlotConfig.bicep
@@ -1,4 +1,4 @@
-import { azureFileshareMountType } from '../types.bicep'
+import { AzureFileshareMount } from '../types.bicep'
 
 @description('Specifies the Web / Function App name that these settings belong to')
 param appName string
@@ -25,7 +25,7 @@ param existingStagingAppSettings object
 param existingProductionAppSettings object
 
 @description('Specifies additional Azure Storage Accounts to make available to the staging slot')
-param azureFileShares azureFileshareMountType[] = []
+param azureFileShares AzureFileshareMount[] = []
 
 @description('Set specific appsettings to be slot specific values')
 resource functionSlotConfig 'Microsoft.Web/sites/config@2023-12-01' = {

--- a/infrastructure/templates/public-api/components/containerApp.bicep
+++ b/infrastructure/templates/public-api/components/containerApp.bicep
@@ -1,4 +1,4 @@
-import { entraIdAuthenticationType } from '../types.bicep'
+import { EntraIdAuthentication } from '../types.bicep'
 
 @description('Specifies the location for all resources.')
 param location string
@@ -106,7 +106,7 @@ param volumeMounts {
 }[] = []
 
 @description('An existing App Registration registered with Entra ID that will be used to control access to this Container App')
-param entraIdAuthentication entraIdAuthenticationType?
+param entraIdAuthentication EntraIdAuthentication?
 
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object

--- a/infrastructure/templates/public-api/components/containerRegistryRoleAssignment.bicep
+++ b/infrastructure/templates/public-api/components/containerRegistryRoleAssignment.bicep
@@ -1,4 +1,4 @@
-import { containerRegistryRoleType } from '../types.bicep'
+import { ContainerRegistryRole } from '../types.bicep'
 
 @description('Specifies the name of an existing Container Registry to be use as the scope of the role assignment')
 param containerRegistryName string
@@ -11,7 +11,7 @@ param principalIds string[]
 // roles to support here, in conjunction with the limited set of roles that the deploying service
 // principal is allowed to assign.
 @description('The Container Registry-specific role to assign')
-param role containerRegistryRoleType
+param role ContainerRegistryRole
 
 // See https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#containers for Container-specific built in role ids.
 var rolesToRoleIds = {

--- a/infrastructure/templates/public-api/components/functionApp.bicep
+++ b/infrastructure/templates/public-api/components/functionApp.bicep
@@ -1,4 +1,4 @@
-import { firewallRuleType, azureFileshareMountType, entraIdAuthenticationType } from '../types.bicep'
+import { FirewallRule, AzureFileshareMount, EntraIdAuthentication } from '../types.bicep'
 
 @description('Specifies the location for all resources.')
 param location string
@@ -47,7 +47,7 @@ param userAssignedManagedIdentityParams {
 }?
 
 @description('An existing App Registration registered with Entra ID that will be used to control access to this Function App')
-param entraIdAuthentication entraIdAuthenticationType?
+param entraIdAuthentication EntraIdAuthentication?
 
 @description('Specifies the SKU for the Function App hosting plan')
 param sku object
@@ -71,10 +71,10 @@ param healthCheck {
 }?
 
 @description('Specifies additional Azure Storage Accounts to make available to this Function App')
-param azureFileShares azureFileshareMountType[] = []
+param azureFileShares AzureFileshareMount[] = []
 
 @description('Specifies firewall rules for the various storage accounts in use by the Function App')
-param storageFirewallRules firewallRuleType[] = []
+param storageFirewallRules FirewallRule[] = []
 
 var reserved = appServicePlanOS == 'Linux'
 
@@ -182,10 +182,10 @@ var commonSiteProperties = {
   enabled: true
   httpsOnly: true
   serverFarmId: appServicePlan.id
-  
+
   // This property integrates the Function App into a VNet given the supplied subnet id.
   virtualNetworkSubnetId: subnetId
-  
+
   clientAffinityEnabled: true
   reserved: reserved
   siteConfig: {
@@ -396,7 +396,7 @@ module functionAppSlotSettings 'appServiceSlotConfig.bicep' = {
     stagingOnlySettings: {
       SLOT_NAME: 'staging'
       DurableManagementStorage: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=${slot1StorageAccountModule.outputs.connectionStringSecretName})'
-      
+
       // The following property tell the Function App slot that its deployment code file share (as identified by the WEBSITE_CONTENTSHARE setting)
       // resides in the specified Storage account.
       WEBSITE_CONTENTAZUREFILECONNECTIONSTRING: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=${slot1StorageAccountModule.outputs.connectionStringSecretName})'
@@ -404,7 +404,7 @@ module functionAppSlotSettings 'appServiceSlotConfig.bicep' = {
     prodOnlySettings: {
       SLOT_NAME: 'production'
       DurableManagementStorage: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=${slot2StorageAccountModule.outputs.connectionStringSecretName})'
-      
+
       // The following property tell the Function App slot that its deployment code file share (as identified by the WEBSITE_CONTENTSHARE setting)
       // resides in the specified Storage account.
       WEBSITE_CONTENTAZUREFILECONNECTIONSTRING: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=${slot2StorageAccountModule.outputs.connectionStringSecretName})'

--- a/infrastructure/templates/public-api/components/keyVaultRoleAssignment.bicep
+++ b/infrastructure/templates/public-api/components/keyVaultRoleAssignment.bicep
@@ -1,4 +1,4 @@
-import { keyVaultRoleType } from '../types.bicep'
+import { KeyVaultRole } from '../types.bicep'
 
 @description('Specifies the name of the Key Vault.')
 param keyVaultName string
@@ -11,7 +11,7 @@ param principalIds string[]
 // roles to support here, in conjunction with the limited set of roles that the deploying service
 // principal is allowed to assign.
 @description('Specifies the Key Vault role to assign to the service principals')
-param role keyVaultRoleType
+param role KeyVaultRole
 
 var rolesToRoleIds = {
   'Secrets User': '4633458b-17de-408a-b874-0445c86b69e6'

--- a/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
+++ b/infrastructure/templates/public-api/components/postgresqlDatabase.bicep
@@ -1,4 +1,4 @@
-import { firewallRuleType, principalNameAndIdType } from '../types.bicep'
+import { FirewallRule, PrincipalNameAndId } from '../types.bicep'
 
 @description('Specifies the location for all resources.')
 param location string
@@ -40,10 +40,10 @@ param geoRedundantBackup string = 'Disabled'
 param databaseNames string[]
 
 @description('An array of firewall rules containing IP address ranges')
-param firewallRules firewallRuleType[] = []
+param firewallRules FirewallRule[] = []
 
 @description('An array of Entra ID admin principal names for this resource')
-param entraIdAdminPrincipals principalNameAndIdType[] = []
+param entraIdAdminPrincipals PrincipalNameAndId[] = []
 
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object

--- a/infrastructure/templates/public-api/components/privateDnsZone.bicep
+++ b/infrastructure/templates/public-api/components/privateDnsZone.bicep
@@ -1,7 +1,7 @@
-import { privateDnsZoneType } from '../types.bicep'
+import { PrivateDnsZone } from '../types.bicep'
 
 @description('Specifies the type of zone to create')
-param zoneType privateDnsZoneType
+param zoneType PrivateDnsZone
 
 @description('Specifies an optional name for the zone, if "custom" zoneType was chosen')
 param customName string?

--- a/infrastructure/templates/public-api/components/privateEndpoint.bicep
+++ b/infrastructure/templates/public-api/components/privateEndpoint.bicep
@@ -1,4 +1,4 @@
-import { privateDnsZoneType } from '../types.bicep'
+import { PrivateDnsZone } from '../types.bicep'
 
 @description('Specifies the name of the service being connected via private endpoint')
 @minLength(0)
@@ -16,7 +16,7 @@ param subnetId string
 param location string
 
 @description('Specifies the type of service being attached to the private endpoint')
-param serviceType privateDnsZoneType
+param serviceType PrivateDnsZone
 
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object
@@ -34,8 +34,8 @@ var serviceTypeToGroupIds = {
 var privateEndpointName = '${serviceName}-pep'
 var privateDnsZoneName = serviceTypeToDnsZoneNames[serviceType]
 
-// A private endpoint that establishes a link between a VNet and an Azure service 
-// that supports Private Link. This takes the form of an IP address that is 
+// A private endpoint that establishes a link between a VNet and an Azure service
+// that supports Private Link. This takes the form of an IP address that is
 // resolvable by a private DNS zone.
 resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-01-01' = {
   name: privateEndpointName
@@ -67,7 +67,7 @@ resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' existing 
   name: privateDnsZoneName
 }
 
-// The private DNS zone group establishes a hard connection between the service being 
+// The private DNS zone group establishes a hard connection between the service being
 // connected and the DNS records in the private DNS zone. It handles updates to DNS
 // records automatically.
 resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-01-01' = {

--- a/infrastructure/templates/public-api/components/staticWebApp.bicep
+++ b/infrastructure/templates/public-api/components/staticWebApp.bicep
@@ -1,4 +1,4 @@
-import { staticWebAppSkuType } from '../types.bicep'
+import { StaticWebAppSku } from '../types.bicep'
 
 @description('Name of the resource.')
 param name string
@@ -8,7 +8,7 @@ param name string
 param location string = 'westeurope'
 
 @description('Static Web App SKU to use.')
-param sku staticWebAppSkuType = 'Free'
+param sku StaticWebAppSku = 'Free'
 
 @description('A set of tags for the resource.')
 param tagValues object

--- a/infrastructure/templates/public-api/components/storageAccount.bicep
+++ b/infrastructure/templates/public-api/components/storageAccount.bicep
@@ -1,4 +1,4 @@
-import { firewallRuleType } from '../types.bicep'
+import { FirewallRule } from '../types.bicep'
 
 @description('Specifies the location for all resources.')
 param location string
@@ -10,7 +10,7 @@ param storageAccountName string
 param allowedSubnetIds string[] = []
 
 @description('Storage Account Network Firewall Rules')
-param firewallRules firewallRuleType[] = []
+param firewallRules FirewallRule[] = []
 
 @description('Storage Account SKU')
 param skuStorageResource 'Standard_LRS' | 'Standard_GRS' | 'Standard_RAGRS' | 'Standard_ZRS' | 'Premium_LRS' | 'Premium_ZRS' | 'Standard_GZRS' | 'Standard_RAGZRS' = 'Standard_LRS'
@@ -60,7 +60,7 @@ module storeADOConnectionStringToKeyVault './keyVaultSecret.bicep' = {
   params: {
     keyVaultName: keyVaultName
     isEnabled: true
-    secretValue: storageAccountConnectionString 
+    secretValue: storageAccountConnectionString
     contentType: 'text/plain'
     secretName: connectionStringSecretName
   }

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -1,5 +1,5 @@
 import { abbreviations } from 'abbreviations.bicep'
-import { firewallRuleType, principalNameAndIdType, staticWebAppSkuType } from 'types.bicep'
+import { FirewallRule, PrincipalNameAndId, StaticWebAppSku } from 'types.bicep'
 
 @description('Environment : Subscription name e.g. s101d01. Used as a prefix for created resources.')
 param subscription string = ''
@@ -11,7 +11,7 @@ param location string = resourceGroup().location
 param publicApiDataFileShareQuota int = 1
 
 @description('Public API Storage : Firewall rules.')
-param storageFirewallRules firewallRuleType[] = []
+param storageFirewallRules FirewallRule[] = []
 
 @description('Database : administrator login name.')
 @minLength(0)
@@ -37,16 +37,16 @@ param postgreSqlStorageSizeGB int = 32
 param postgreSqlAutoGrowStatus string = 'Disabled'
 
 @description('Database : Firewall rules.')
-param postgreSqlFirewallRules firewallRuleType[] = []
+param postgreSqlFirewallRules FirewallRule[] = []
 
 @description('Database : Entra ID admin  principal names for this resource')
-param postgreSqlEntraIdAdminPrincipals principalNameAndIdType[] = []
+param postgreSqlEntraIdAdminPrincipals PrincipalNameAndId[] = []
 
 @description('ACR : Specifies the resource group in which the shared Container Registry lives.')
 param acrResourceGroupName string = ''
 
 @description('Public API docs app : SKU to use.')
-param docsAppSku staticWebAppSkuType = 'Free'
+param docsAppSku StaticWebAppSku = 'Free'
 
 @description('Tagging : Environment name e.g. Development. Used for tagging resources created by this infrastructure pipeline.')
 param environmentName string

--- a/infrastructure/templates/public-api/types.bicep
+++ b/infrastructure/templates/public-api/types.bicep
@@ -1,5 +1,5 @@
 @export()
-type resourceNamesType = {
+type ResourceNames = {
   existingResources: {
     adminApp: string
     publisherFunction: string
@@ -41,13 +41,13 @@ type resourceNamesType = {
 }
 
 @export()
-type firewallRuleType = {
+type FirewallRule = {
   name: string
   cidr: string
 }
 
 @export()
-type azureFileshareMountType = {
+type AzureFileshareMount = {
   storageName: string
   storageAccountKey: string
   storageAccountName: string
@@ -56,7 +56,7 @@ type azureFileshareMountType = {
 }
 
 @export()
-type entraIdAuthenticationType = {
+type EntraIdAuthentication = {
   appRegistrationClientId: string
   allowedClientIds: string[]
   allowedPrincipalIds: string[]
@@ -198,19 +198,19 @@ type AppGatewayRewriteUrlConfig = {
 }
 
 @export()
-type principalNameAndIdType = {
+type PrincipalNameAndId = {
   principalName: string
   objectId: string
 }
 
 @export()
-type privateDnsZoneType = 'sites' | 'postgres' | 'custom'
+type PrivateDnsZone = 'sites' | 'postgres' | 'custom'
 
 @export()
-type containerRegistryRoleType = 'AcrPull'
+type ContainerRegistryRole = 'AcrPull'
 
 @export()
-type keyVaultRoleType = 'Secrets User' | 'Certificate User'
+type KeyVaultRole = 'Secrets User' | 'Certificate User'
 
 @export()
-type staticWebAppSkuType = 'Free' | 'Standard'
+type StaticWebAppSku = 'Free' | 'Standard'


### PR DESCRIPTION
This PR updates our custom Bicep type names to be PascalCased to avoid confusion with variables. This also removes the unnecessary '*Type' suffix we were previously adding as well.