### PR TITLE
EES-5597 Ensuring that `mailto:` links DO NOT HAVE '(opens in new tab)' added to them

### DIFF
--- a/src/explore-education-statistics-common/src/components/ContentHtml.tsx
+++ b/src/explore-education-statistics-common/src/components/ContentHtml.tsx
@@ -87,7 +87,8 @@ export default function ContentHtml({
         return !url?.includes('explore-education-statistics.service.gov.uk') &&
           typeof node.attribs['data-featured-table'] === 'undefined' ? (
           <a href={url} target="_blank" rel="noopener noreferrer">
-            {text} (opens in a new tab)
+            {text}
+            {url.startsWith('mailto:') ? '' : ' (opens in a new tab)'}
           </a>
         ) : (
           <a href={url}>{text}</a>

--- a/src/explore-education-statistics-common/src/components/ContentHtml.tsx
+++ b/src/explore-education-statistics-common/src/components/ContentHtml.tsx
@@ -85,10 +85,10 @@ export default function ContentHtml({
         const text = domToReact(node.children);
 
         return !url?.includes('explore-education-statistics.service.gov.uk') &&
+          !url.startsWith('mailto:') &&
           typeof node.attribs['data-featured-table'] === 'undefined' ? (
           <a href={url} target="_blank" rel="noopener noreferrer">
-            {text}
-            {url.startsWith('mailto:') ? '' : ' (opens in a new tab)'}
+            {text} (opens in a new tab)
           </a>
         ) : (
           <a href={url}>{text}</a>

--- a/src/explore-education-statistics-common/src/components/__tests__/ContentHtml.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ContentHtml.test.tsx
@@ -305,5 +305,25 @@ describe('ContentHtml', () => {
       expect(externalLink).not.toHaveAttribute('target', '_blank');
       expect(externalLink).not.toHaveAttribute('rel', 'noopener noreferrer');
     });
+
+    test("appends '(opens in a new tab)' to the name for external links", () => {
+      render(
+        <ContentHtml html='<a href="https://gov.uk/">External link</a>' />,
+      );
+
+      const link = screen.getByRole('link');
+
+      expect(link.textContent).toBe('External link (opens in a new tab)');
+    });
+
+    test("does not append '(opens in a new tab)' to any 'mailto:' links", () => {
+      render(
+        <ContentHtml html='<a href="mailto:explore.statistics@education.gov.uk">Mailto link</a>' />,
+      );
+
+      const link = screen.getByRole('link');
+
+      expect(link.textContent).toBe('Mailto link');
+    });
   });
 });


### PR DESCRIPTION
We currently add '(opens in new tab) 'to any external links added in the admin system. However this is also treating `mailto:` links as external, and while that is partially true, it’s not technically true, and is not an expected behaviour for users.

This PR prevents `mailto:` links from having the '(opens in new tab)' text appended to them inside the release content.