### PR TITLE
EES-5601 Allow fixing of ContentBlock with "BoundaryLevel":null in Da…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
@@ -173,6 +173,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     .ContentBlocks
                     .Where(block => block.ReleaseVersionId == releaseVersionId)
                     .OfType<DataBlock>()
+                    .Select(db => new { db.Id, db.Query })
                     .ToListAsync()) // we need to materialise the list access `dataBlock.Query.SubjectId` as `Query` is json
                 .Where(dataBlock => publishedSubjectIds.Contains(dataBlock.Query.SubjectId))
                 .ToList();


### PR DESCRIPTION
This PR fixes a bug where the table tool page wasn't loading for a specific older release. See Jira ticket for more details.

After investigation, it turned out that this occurred because a Map associated with the release had `"BoundaryLevel":null` in the `DataBlock_Charts` column of the `ContentBlock` table. `MapChart` in `Charts.cs` doesn't allow `BoundaryLevel` to be nullable, and so the parsing of the `DataBlock_Charts` JSON failed.

There are three content blocks on Prod that have null boundary levels. Two of those content blocks aren't live. The final block is live, but only as a featured table, so even though it has associated chart json, that isn't ever needed/displayed.

So to fix this, since we don't need the `DataBlock_Charts` JSON when loading the table tool page, I've added a select so the database query only returns the required data, and so won't have to parse the `DataBlock_Charts` JSON.