### PR TITLE
Remove references to deprecated / removed Docker Compose v1 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The service can be started against a set of non-existent database. If no pre-exi
 1. Start the SQL Server Docker container:
 
    ```
-   docker-compose up -d db
+   docker compose up -d db
    ```
 
 2. Create empty `content` and `statistics` databases.
@@ -252,7 +252,7 @@ The Azurite Docker container can be started by one of the following methods:
 3. Directly via Docker Compose
 
     ```bash
-    docker-compose up data-storage
+    docker compose up data-storage
     ```
 
 ### Setting up an Identity Provider (IdP)
@@ -284,7 +284,7 @@ The Keycloak Docker container can be started by one of the following methods:
 
    ```bash
    src
-   docker-compose up idp
+   docker compose up idp
    ```
 
 All the standard seed data users can be supported with Keycloak, and use their standard email addresses and the
@@ -316,7 +316,7 @@ To do this, you can run one of the following:
 pnpm start idp --rebuild-docker
 
 # Using Docker
-docker-compose up --build --force-recreate idp
+docker compose up --build --force-recreate idp
 ```
 
 #### Using a custom Identity Provider
@@ -735,7 +735,7 @@ blobs, queues and tables. This is typically done at the same time as resetting t
 To delete all data in Azurite simply delete the Azurite docker container, remove the Azurite volume and recreate it:
 
 ```bash
-docker-compose up data-storage
+docker compose up data-storage
 ```
 
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/README.md
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Scripts/README.md
@@ -24,7 +24,7 @@ Once you have done this, ensure the public API Docker database is running:
 
 ```bash
 # Via Docker Compose
-docker-compose up -d public-api-db
+docker compose up -d public-api-db
 
 # Via project start script
 pnpm start publicApiDb

--- a/tests/performance-tests/README.md
+++ b/tests/performance-tests/README.md
@@ -5,8 +5,8 @@ The performance test suite is built using [k6](https://k6.io/) and visualised us
 
 ## How it works
 
-* We run InfluxDB (for collecting data) and Grafana (for visualising the collected data) using docker-compose.
-* We run the K6 tests using docker-compose. We can choose specific tests to run from the CLI.
+* We run InfluxDB (for collecting data) and Grafana (for visualising the collected data) using Docker Compose.
+* We run the K6 tests using Docker Compose. We can choose specific tests to run from the CLI.
 * The K6 tests run and post data to InfluxDB.
 * Grafana is set up with a Dashboard that consumes and visualises data from the InfluxDB data source.
 

--- a/tests/performance-tests/package.json
+++ b/tests/performance-tests/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "scripts": {
     "webpack": "webpack",
-    "start": "docker-compose up -d influxdb grafana",
-    "stop": "docker-compose down",
-    "stop-and-clear-data": "docker-compose down -v",
-    "store-environment-details": "docker-compose run --rm --user \"$(id -u):$(id -g)\" node -r source-map-support/register dist/storeEnvironmentDetails.js ${npm_config_environment} ${npm_config_users}",
-    "test": "cross-env TEST_ENVIRONMENT=${npm_config_environment} docker-compose run --rm k6 run",
+    "start": "docker compose up -d influxdb grafana",
+    "stop": "docker compose down",
+    "stop-and-clear-data": "docker compose down -v",
+    "store-environment-details": "docker compose run --rm --user \"$(id -u):$(id -g)\" node -r source-map-support/register dist/storeEnvironmentDetails.js ${npm_config_environment} ${npm_config_users}",
+    "test": "cross-env TEST_ENVIRONMENT=${npm_config_environment} docker compose run --rm k6 run",
     "tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/useful-scripts/start.ts
+++ b/useful-scripts/start.ts
@@ -308,7 +308,7 @@ async function startDockerServices() {
     if (programOpts.restartDocker) {
       logInfo('Stopping Docker services...');
 
-      await $$`docker-compose stop ${[...dockerServicesToStart]}`;
+      await $$`docker compose stop ${[...dockerServicesToStart]}`;
     }
 
     logInfo('Starting Docker services...');
@@ -319,7 +319,7 @@ async function startDockerServices() {
       args.push('--build', '--force-recreate');
     }
 
-    await $$`docker-compose up ${[...args, ...dockerServicesToStart]}`;
+    await $$`docker compose up ${[...args, ...dockerServicesToStart]}`;
 
     await delay(1000);
   }
@@ -392,7 +392,7 @@ async function startService(service: ServiceName): Promise<void> {
       break;
     }
     case 'docker': {
-      command = 'docker-compose logs';
+      command = 'docker compose logs';
       args = ['-f', '--no-log-prefix'];
 
       if (programOpts.rebuildDocker) {


### PR DESCRIPTION
This PR removes any references to the deprecated / removed Docker Compose v1 commands in favour of the newer v2 commands across the project. This means that any `docker-compose` commands have been changed to `docker compose`.

This was mostly brought to my attention upon upgrading to Ubuntu 24.04 where it appears that Docker Compose v1 has been dropped completely (which broke the project `start` script for me). 

See [Compose v2 migration](https://docs.docker.com/compose/releases/migrate) for further reading.