### PR TITLE
EES-5617 Update public API docs URLs in public frontend and admin

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -59,6 +59,9 @@
     "publicApiUrl": {
       "value": "dev.statistics.api.education.gov.uk"
     },
+    "publicApiDocsUrl": {
+      "value": "dev.statistics.api.education.gov.uk/docs"
+    },
     "detailedErrors": {
       "value": true
     },

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -50,6 +50,9 @@
     "publicApiUrl": {
       "value": "pre-production.statistics.api.education.gov.uk"
     },
+    "publicApiDocsUrl": {
+      "value": "pre-production.statistics.api.education.gov.uk/docs"
+    },
     "publicAppGATrackingId": {
       "value": "G-8FSLWXTV2W"
     },

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -53,6 +53,9 @@
     "publicApiUrl": {
       "value": "statistics.api.education.gov.uk"
     },
+    "publicApiDocsUrl": {
+      "value": "statistics.api.education.gov.uk/docs"
+    },
     "publicAppGATrackingId": {
       "value": "G-9YG8ESXR5Y"
     },

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -50,6 +50,9 @@
     "publicApiUrl": {
       "value": "test.statistics.api.education.gov.uk"
     },
+    "publicApiDocsUrl": {
+      "value": "test.statistics.api.education.gov.uk/docs"
+    },
     "detailedErrors": {
       "value": true
     },

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -15,8 +15,7 @@
       "type": "string"
     },
     "publicApiDocsUrl": {
-      "type": "string",
-      "defaultValue": "dfe-analytical-services.github.io/explore-education-statistics-api-docs"
+      "type": "string"
     },
     "subscription": {
       "type": "string",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ConfigControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ConfigControllerTests.cs
@@ -60,7 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             Assert.Equal("http://localhost:3000", viewModel.PublicAppUrl);
             Assert.Equal("http://localhost:5050", viewModel.PublicApiUrl);
             Assert.Equal(
-                "https://dfe-analytical-services.github.io/explore-education-statistics-api-docs",
+                "https://dev.statistics.api.education.gov.uk/docs",
                 viewModel.PublicApiDocsUrl
             );
             Assert.Equal(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -48,7 +48,7 @@
   "PublicDataDbExists": false,
   "PublicDataApi": {
     "Url": "http://localhost:5050",
-    "DocsUrl": "https://dfe-analytical-services.github.io/explore-education-statistics-api-docs"
+    "DocsUrl": "https://dev.statistics.api.education.gov.uk/docs"
   },
   "PublicDataProcessor": {
     "Url": "http://localhost:7074"

--- a/src/explore-education-statistics-frontend/.env
+++ b/src/explore-education-statistics-frontend/.env
@@ -1,7 +1,7 @@
 CONTENT_API_BASE_URL=http://localhost:5010/api
 DATA_API_BASE_URL=http://localhost:5000/api
 PUBLIC_API_BASE_URL=http://localhost:5050/api/v1.0
-PUBLIC_API_DOCS_URL=https://dfe-analytical-services.github.io/explore-education-statistics-api-docs
+PUBLIC_API_DOCS_URL=https://dev.statistics.api.education.gov.uk/docs
 NOTIFICATION_API_BASE_URL=http://localhost:7073/api
 GA_TRACKING_ID=
 PUBLIC_URL=http://localhost:3000/

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileUsage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileUsage.test.tsx
@@ -60,7 +60,7 @@ describe('DataSetFileUsage', () => {
       }),
     ).toHaveAttribute(
       'href',
-      'https://dfe-analytical-services.github.io/explore-education-statistics-api-docs',
+      'https://dev.statistics.api.education.gov.uk/docs',
     );
   });
 


### PR DESCRIPTION
This PR updates the public API docs URLs in the public frontend and admin to our App Gateway URLs - `https://*.statistics.api.education.gov.uk/docs`.
