### PR TITLE
EES-5631 Adding `ReleaseRedirects` table to the Content DB

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241112114310_EES5631_CreateReleaseRedirectsTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241112114310_EES5631_CreateReleaseRedirectsTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241112114310_EES5631_CreateReleaseRedirectsTable")]
+    partial class EES5631_CreateReleaseRedirectsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241112114310_EES5631_CreateReleaseRedirectsTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241112114310_EES5631_CreateReleaseRedirectsTable.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES5631_CreateReleaseRedirectsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ReleaseRedirects",
+                columns: table => new
+                {
+                    Slug = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ReleaseId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Created = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReleaseRedirects", x => new { x.ReleaseId, x.Slug });
+                    table.ForeignKey(
+                        name: "FK_ReleaseRedirects_Releases_ReleaseId",
+                        column: x => x.ReleaseId,
+                        principalTable: "Releases",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ReleaseRedirects");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -75,6 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
         public virtual DbSet<Contact> Contacts { get; set; }
         public virtual DbSet<Update> Update { get; set; }
         public virtual DbSet<PublicationRedirect> PublicationRedirects { get; set; }
+        public virtual DbSet<ReleaseRedirect> ReleaseRedirects { get; set; }
         public virtual DbSet<MethodologyRedirect> MethodologyRedirects { get; set; }
         public virtual DbSet<User> Users { get; set; }
         public virtual DbSet<UserPublicationRole> UserPublicationRoles { get; set; }
@@ -635,6 +636,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
         {
             modelBuilder.Entity<PublicationRedirect>()
                 .HasKey(pr => new { pr.PublicationId, pr.Slug });
+
+            modelBuilder.Entity<ReleaseRedirect>()
+                .HasKey(rr => new { rr.ReleaseId, rr.Slug });
 
             modelBuilder.Entity<MethodologyRedirect>()
                 .HasKey(mr => new { mr.MethodologyVersionId, mr.Slug });

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseRedirect.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseRedirect.cs
@@ -1,0 +1,16 @@
+#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+public class ReleaseRedirect : ICreatedTimestamp<DateTime>
+{
+    public string Slug { get; init; } = null!;
+
+    public Guid ReleaseId { get; init; }
+
+    public Release Release { get; init; } = null!;
+
+    public DateTime Created { get; set; }
+}


### PR DESCRIPTION
This PR adds a `ReleaseRedirects` table to the Content DB.

With the introduction of a new `Label` concept in [EES-5626](https://dfedigital.atlassian.net/jira/software/c/projects/EES/boards/105?selectedIssue=EES-5626), and the ability to edit that `Label` in [EES-5637](https://dfedigital.atlassian.net/jira/software/c/projects/EES/boards/105?selectedIssue=EES-5637), we will now be introducing the ability to change the `Slug` for a Release, which necessitates the introduction of Release Redirects.

The `ReleaseRedirects` schema is as the following:
- `Slug` - the previous slug of the Release
- `ReleaseId` - a foreign key to the `Id` primary key of the `Releases` table. Used to redirect to the **new** `Slug`
- `Created` - timestamp of when this redirect was created

We follow the same pattern as for the existing Publication and Methodology redirects.