### PR TITLE
EES-5660 - ensuring we correctly locate the draft DataSetVersions folder by version if the DSV is a major version

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -466,6 +466,41 @@ public class EnumerableExtensionsTests
         Assert.True(containsAll);
     }
 
+    public class CartesianTests
+    {
+        [Fact]
+        public void Cartesian()
+        {
+            List<int> list1 = [1, 2];
+            List<string> list2 = ["3", "4"];
+
+            List<Tuple<int, string>> expected =
+            [
+                new Tuple<int, string>(1, "3"),
+                new Tuple<int, string>(1, "4"),
+                new Tuple<int, string>(2, "3"),
+                new Tuple<int, string>(2, "4")
+            ];
+
+            var actual = list1.Cartesian(list2);
+            Assert.Equal(expected, actual);
+        }
+        
+        [Fact]
+        public void EmptyList()
+        {
+            List<int> list1 = [1, 2];
+            Assert.Empty(list1.Cartesian(new List<string>()));
+        }
+        
+        [Fact]
+        public void NullList()
+        {
+            List<int> list1 = [1, 2];
+            Assert.Empty(list1.Cartesian((List<string>?) null));
+        }
+    }
+
     private static async Task<Either<Unit, int>> GetSuccessfulEither(int value)
     {
         await Task.Delay(5);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -469,7 +469,7 @@ public class EnumerableExtensionsTests
     public class CartesianTests
     {
         [Fact]
-        public void Cartesian()
+        public void TwoLists_Cartesian()
         {
             List<int> list1 = [1, 2];
             List<string> list2 = ["3", "4"];
@@ -487,17 +487,72 @@ public class EnumerableExtensionsTests
         }
         
         [Fact]
-        public void EmptyList()
+        public void TwoLists_EmptyList()
         {
             List<int> list1 = [1, 2];
             Assert.Empty(list1.Cartesian(new List<string>()));
         }
         
         [Fact]
-        public void NullList()
+        public void TwoLists_NullList()
         {
             List<int> list1 = [1, 2];
             Assert.Empty(list1.Cartesian((List<string>?) null));
+        }
+        
+        [Fact]
+        public void ThreeLists_Cartesian()
+        {
+            List<int> list1 = [1, 2];
+            List<string> list2 = ["3", "4"];
+            List<char> list3 = ['5', '6'];
+
+            List<Tuple<int, string, char>> expected =
+            [
+                new Tuple<int, string, char>(1, "3", '5'),
+                new Tuple<int, string, char>(1, "3", '6'),
+                new Tuple<int, string, char>(1, "4", '5'),
+                new Tuple<int, string, char>(1, "4", '6'),
+                new Tuple<int, string, char>(2, "3", '5'),
+                new Tuple<int, string, char>(2, "3", '6'),
+                new Tuple<int, string, char>(2, "4", '5'),
+                new Tuple<int, string, char>(2, "4", '6'),
+            ];
+
+            var actual = list1.Cartesian(list2, list3);
+            Assert.Equal(expected, actual);
+        }
+        
+        [Fact]
+        public void ThreeLists_EmptyFirstList()
+        {
+            List<int> list1 = [1, 2];
+            List<char> list3 = ['5', '6'];
+            Assert.Empty(list1.Cartesian(new List<string>(), list3));
+        }
+        
+        [Fact]
+        public void ThreeLists_EmptySecondList()
+        {
+            List<int> list1 = [1, 2];
+            List<string> list2 = ["3", "4"];
+            Assert.Empty(list1.Cartesian(list2, new List<char>()));
+        }
+        
+        [Fact]
+        public void ThreeLists_NullFirstList()
+        {
+            List<int> list1 = [1, 2];
+            List<char> list3 = ['5', '6'];
+            Assert.Empty(list1.Cartesian((List<string>?) null, list3));
+        }
+        
+        [Fact]
+        public void ThreeLists_NullSecondList()
+        {
+            List<int> list1 = [1, 2];
+            List<string> list2 = ["3", "4"];
+            Assert.Empty(list1.Cartesian(list2, (List<char>?) null));
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -319,5 +319,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
         {
             return source.ThenBy(keySelector, comparison.WithNaturalSort());
         }
+
+        public static IEnumerable<Tuple<T1, T2>> Cartesian<T1, T2>(
+            this IEnumerable<T1> list1,
+            IEnumerable<T2>? list2)
+        {
+            return list2 == null 
+                ? [] 
+                : list1.Join(list2, _ => true, _ => true,(t1, t2) => new Tuple<T1, T2>(t1, t2));
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -328,5 +328,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
                 ? [] 
                 : list1.Join(list2, _ => true, _ => true,(t1, t2) => new Tuple<T1, T2>(t1, t2));
         }
+        
+        public static IEnumerable<Tuple<T1, T2, T3>> Cartesian<T1, T2, T3>(
+            this IEnumerable<T1> list1,
+            IEnumerable<T2>? list2,
+            IEnumerable<T3>? list3)
+        {
+            return list2 == null || list3 == null
+                ? [] 
+                : list1
+                    .Join(list2, _ => true, _ => true, (t1, t2) => new Tuple<T1, T2>(t1, t2))
+                    .Join(list3, _ => true, _ => true, (tuple, t3) => new Tuple<T1, T2, T3>(tuple.Item1, tuple.Item2, t3));
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/TheoryData/DataSetVersionStatusTheoryData.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/TheoryData/DataSetVersionStatusTheoryData.cs
@@ -5,7 +5,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests
 
 public static class DataSetVersionStatusTheoryData
 {
-    private static readonly List<DataSetVersionStatus> DeletableStatusList =
+    public static readonly List<DataSetVersionStatus> DeletableStatusList =
     [
         DataSetVersionStatus.Failed,
         DataSetVersionStatus.Mapping,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -297,11 +297,20 @@ internal class DataSetVersionService(
             .Select(dataSet => dataSet.LatestLiveVersion!)
             .SingleAsync(cancellationToken);
 
-        var originalPath = dataSetVersionPathResolver.DirectoryPath(
-            dataSetVersion: dataSetVersion,
-            versionNumber: currentLiveVersion.DefaultNextVersion());
+        var originalNextMinorVersion = currentLiveVersion.DefaultNextVersion();
         
-        DeleteDirectoryIfExists(originalPath);
+        var originalDraftFolderName = dataSetVersionPathResolver.DirectoryPath(
+            dataSetVersion: dataSetVersion,
+            versionNumber: originalNextMinorVersion);
+        
+        DeleteDirectoryIfExists(originalDraftFolderName);
+
+        var currentVersionFolderName = dataSetVersionPathResolver.DirectoryPath(dataSetVersion);
+
+        if (currentVersionFolderName != originalDraftFolderName)
+        {
+            DeleteDirectoryIfExists(currentVersionFolderName);
+        }
     }
 
     private string GetDataSetDirectory(DataSetVersion dataSetVersion)


### PR DESCRIPTION
This PR:
- fixes a bug whereby if a draft DataSetVersion is deleted when it is projected to be a major version update, it left behind its Fileshare folder which was still using a minor version as its path.

The work here now attempts to delete the folder by both the *original* draft folder name and the *current* version number of the DataSetVersion being deleted.  This covers both the case whereby the import of the new draft has not yet been completed (and so its folder name will definitely still be of the minor version value) and the case where the new draft mapping and import has been completed and so the original folder name may have been updated already to reflect its final version.

### Proposing an alternative solution longer-term

Although this solution now works, it does highlight that there's some complexity in this area which is how this bug was able to sneak in.  Specifically, by looking at the file system you'd not be able to tell for certain that a version-number-based folder path *actually* matched the version of the corresponding DSV in the database, which although is not the end of the world, does feel a little wrong, plus the version can flip again if further amendments are made to the DSV mappings and it switches between major and minor.

I'd propose an alternative approach, which is to have a draft DSV's files reside under a folder named `draft` instead, and only at the point that the DSV is published do we update the `draft` folder to instead match the final version of the DSV being published.  We're safe to do it then because we're 100% certain that this is the final version of the DSV.

Going with this approach:
- the logic for determining the folder path would be incorporated into `DataSetVersionPathResolver` to look for `draft` if the DSV is in Draft.
- the Publisher would be amended to correct the final folder name on publishing.
- the `ProcessCompletionOfNextDataSetVersionFunctions.UpdateFileStoragePath` Function would be removed.

We'd then need to do some folder migration for every draft DSV in an environment to rename its folder to `draft`. 
