### PR TITLE
EES 5632 - Return the Release redirects from the `api/redirects` endpoint

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyApprovalServiceTests.cs
@@ -680,7 +680,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         new List<AllMethodologiesThemeViewModel>()));
 
             redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                .ReturnsAsync(new RedirectsViewModel(new List<RedirectViewModel>(), new List<RedirectViewModel>()));
+                .ReturnsAsync(new RedirectsViewModel(
+                    Publications: [], 
+                    Methodologies: [], 
+                    Releases: []));
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -3599,7 +3599,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var redirectsCacheService = new Mock<IRedirectsCacheService>(MockBehavior.Strict);
                 redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                    .ReturnsAsync(new RedirectsViewModel(new List<RedirectViewModel>(), new List<RedirectViewModel>()));
+                    .ReturnsAsync(new RedirectsViewModel(
+                        Publications: [],
+                        Methodologies: [],
+                        Releases: []));
 
                 var service = SetupMethodologyService(contentDbContext,
                     redirectsCacheService: redirectsCacheService.Object);
@@ -3658,7 +3661,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var redirectsCacheService = new Mock<IRedirectsCacheService>(MockBehavior.Strict);
                 redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                    .ReturnsAsync(new RedirectsViewModel(new List<RedirectViewModel>(), new List<RedirectViewModel>()));
+                    .ReturnsAsync(new RedirectsViewModel(
+                        Publications: [],
+                        Methodologies: [],
+                        Releases: []));
 
                 var service = SetupMethodologyService(contentDbContext,
                     redirectsCacheService: redirectsCacheService.Object);
@@ -3738,7 +3744,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var redirectsCacheService = new Mock<IRedirectsCacheService>(MockBehavior.Strict);
                 redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                    .ReturnsAsync(new RedirectsViewModel(new List<RedirectViewModel>(), new List<RedirectViewModel>()));
+                    .ReturnsAsync(new RedirectsViewModel(
+                        Publications: [],
+                        Methodologies: [],
+                        Releases: []));
 
                 var service = SetupMethodologyService(contentDbContext,
                     redirectsCacheService: redirectsCacheService.Object);
@@ -3837,7 +3846,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var redirectsCacheService = new Mock<IRedirectsCacheService>(MockBehavior.Strict);
                 redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                    .ReturnsAsync(new RedirectsViewModel(new List<RedirectViewModel>(), new List<RedirectViewModel>()));
+                    .ReturnsAsync(new RedirectsViewModel(
+                        Publications: [],
+                        Methodologies: [],
+                        Releases: []));
 
                 var service = SetupMethodologyService(contentDbContext,
                     redirectsCacheService: redirectsCacheService.Object);
@@ -3904,7 +3916,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var redirectsCacheService = new Mock<IRedirectsCacheService>(MockBehavior.Strict);
                 redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                    .ReturnsAsync(new RedirectsViewModel(new List<RedirectViewModel>(), new List<RedirectViewModel>()));
+                    .ReturnsAsync(new RedirectsViewModel(
+                        Publications: [],
+                        Methodologies: [],
+                        Releases: []));
 
                 var service = SetupMethodologyService(contentDbContext,
                     redirectsCacheService: redirectsCacheService.Object);
@@ -3988,7 +4003,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var redirectsCacheService = new Mock<IRedirectsCacheService>(MockBehavior.Strict);
                 redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                    .ReturnsAsync(new RedirectsViewModel(new List<RedirectViewModel>(), new List<RedirectViewModel>()));
+                    .ReturnsAsync(new RedirectsViewModel(
+                        Publications: [],
+                        Methodologies: [],
+                        Releases: []));
 
                 var service = SetupMethodologyService(contentDbContext,
                     redirectsCacheService: redirectsCacheService.Object);
@@ -4091,7 +4109,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var redirectsCacheService = new Mock<IRedirectsCacheService>(MockBehavior.Strict);
                 redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                    .ReturnsAsync(new RedirectsViewModel(new List<RedirectViewModel>(), new List<RedirectViewModel>()));
+                    .ReturnsAsync(new RedirectsViewModel(
+                        Publications: [],
+                        Methodologies: [],
+                        Releases: []));
 
                 var service = SetupMethodologyService(contentDbContext,
                     redirectsCacheService: redirectsCacheService.Object);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -1127,7 +1127,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 redirectsCacheService.Setup(mock => mock.UpdateRedirects())
                     .ReturnsAsync(new RedirectsViewModel(
-                        new List<RedirectViewModel>(), new List<RedirectViewModel>()));
+                        Publications: [],
+                        Methodologies: [],
+                        Releases: []));
 
                 var publicationService = BuildPublicationService(context,
                     methodologyService: methodologyService.Object,
@@ -1270,7 +1272,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 redirectsCacheService.Setup(mock => mock.UpdateRedirects())
                     .ReturnsAsync(new RedirectsViewModel(
-                        new List<RedirectViewModel>(), new List<RedirectViewModel>()));
+                        Publications: [],
+                        Methodologies: [],
+                        Releases: []));
 
                 var publicationService = BuildPublicationService(context,
                     methodologyService: methodologyService.Object,
@@ -1575,7 +1579,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
                 redirectsCacheService.Setup(mock => mock.UpdateRedirects())
                     .ReturnsAsync(new RedirectsViewModel(
-                        new List<RedirectViewModel>(), new List<RedirectViewModel>()));
+                        Publications: [],
+                        Methodologies: [],
+                        Releases: []));
 
                 var publicationService = BuildPublicationService(context,
                     methodologyService: methodologyService.Object,
@@ -1672,7 +1678,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
                 redirectsCacheService.Setup(mock => mock.UpdateRedirects())
                     .ReturnsAsync(new RedirectsViewModel(
-                        new List<RedirectViewModel>(), new List<RedirectViewModel>()));
+                        Publications: [],
+                        Methodologies: [],
+                        Releases: []));
 
                 var publicationService = BuildPublicationService(context,
                     methodologyService: methodologyService.Object,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/RedirectsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/RedirectsControllerTests.cs
@@ -1,0 +1,252 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
+using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using MockQueryable.Moq;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers;
+
+public abstract class RedirectsControllerTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+{
+    public class ListTests(TestApplicationFactory testApp) : RedirectsControllerTests(testApp)
+    {
+        public override async Task InitializeAsync() => await TestApp.StartAzurite();
+
+        [Fact]
+        public async Task RedirectsExist_Returns200WithRedirects()
+        {
+            var publicationRedirects = DataFixture.DefaultPublicationRedirect()
+                .WithPublication(DataFixture.DefaultPublication())
+                .GenerateList(3);
+
+            var releaseRedirects = DataFixture.DefaultReleaseRedirect()
+                .WithRelease(DataFixture.DefaultRelease())
+                .GenerateList(3);
+
+            var methodologyVersions = DataFixture.DefaultMethodologyVersion()
+                .ForIndex(3, s => s.SetPublished(DateTime.UtcNow))
+                .GenerateList(4);
+
+            Methodology methodology = DataFixture.DefaultMethodology()
+                .WithMethodologyVersions(methodologyVersions)
+                .WithLatestPublishedVersion(methodologyVersions.Last());
+
+            var methodologyRedirects = DataFixture.DefaultMethodologyRedirect()
+                .ForIndex(0, s => s.SetMethodologyVersion(methodologyVersions[0]))
+                .ForIndex(1, s => s.SetMethodologyVersion(methodologyVersions[1]))
+                .ForIndex(2, s => s.SetMethodologyVersion(methodologyVersions[2]))
+                .GenerateList(3);
+
+            var contentDbContext = ContentDbContextMock(
+                publicationRedirects: publicationRedirects,
+                releaseRedirects: releaseRedirects,
+                methodologiesRedirects: methodologyRedirects);
+
+            var client = BuildApp(contentDbContext.Object).CreateClient();
+
+            var response = await ListRedirects(client);
+
+            var viewModel = response.AssertOk<RedirectsViewModel>();
+
+            Assert.All(
+                publicationRedirects,
+                pr => Assert.Contains(
+                    viewModel.Publications, 
+                    rvm => pr.Slug == rvm.FromSlug && pr.Publication.Slug == rvm.ToSlug));
+            Assert.All(
+                releaseRedirects,
+                rr => Assert.Contains(
+                    viewModel.Releases,
+                    rvm => rr.Slug == rvm.FromSlug && rr.Release.Slug == rvm.ToSlug));
+            Assert.All(
+                methodologyRedirects,
+                mr => Assert.Contains(
+                    viewModel.Methodologies,
+                    rvm => mr.Slug == rvm.FromSlug && mr.MethodologyVersion.Methodology.OwningPublicationSlug == rvm.ToSlug));
+        }
+
+        [Fact]
+        public async Task RedirectsExist_RedirectsAreCached()
+        {
+            var publicationRedirects = DataFixture.DefaultPublicationRedirect()
+                .WithPublication(DataFixture.DefaultPublication())
+                .GenerateList(3);
+
+            var releaseRedirects = DataFixture.DefaultReleaseRedirect()
+                .WithRelease(DataFixture.DefaultRelease())
+                .GenerateList(3);
+
+            var methodologyVersions = DataFixture.DefaultMethodologyVersion()
+                .ForIndex(3, s => s.SetPublished(DateTime.UtcNow))
+                .GenerateList(4);
+
+            Methodology methodology = DataFixture.DefaultMethodology()
+                .WithMethodologyVersions(methodologyVersions)
+                .WithLatestPublishedVersion(methodologyVersions.Last());
+
+            var methodologyRedirects = DataFixture.DefaultMethodologyRedirect()
+                .ForIndex(0, s => s.SetMethodologyVersion(methodologyVersions[0]))
+                .ForIndex(1, s => s.SetMethodologyVersion(methodologyVersions[1]))
+                .ForIndex(2, s => s.SetMethodologyVersion(methodologyVersions[2]))
+                .GenerateList(3);
+
+            var contentDbContext = ContentDbContextMock(
+                publicationRedirects: publicationRedirects,
+                releaseRedirects: releaseRedirects,
+                methodologiesRedirects: methodologyRedirects);
+
+            var app = BuildApp(contentDbContext.Object);
+            var client = app.CreateClient();
+
+            await ListRedirects(client);
+
+            var blobCacheService = app.Services.GetRequiredService<IBlobCacheService>();
+
+            var cachedValue = await blobCacheService.GetItemAsync(new RedirectsCacheKey(), typeof(RedirectsViewModel));
+            var cachedRedirectsViewModel = Assert.IsType<RedirectsViewModel>(cachedValue);
+
+            Assert.All(
+                publicationRedirects,
+                pr => Assert.Contains(
+                    cachedRedirectsViewModel.Publications,
+                    rvm => pr.Slug == rvm.FromSlug && pr.Publication.Slug == rvm.ToSlug));
+            Assert.All(
+                releaseRedirects,
+                rr => Assert.Contains(
+                    cachedRedirectsViewModel.Releases,
+                    rvm => rr.Slug == rvm.FromSlug && rr.Release.Slug == rvm.ToSlug));
+            Assert.All(
+                methodologyRedirects,
+                mr => Assert.Contains(
+                    cachedRedirectsViewModel.Methodologies,
+                    rvm => mr.Slug == rvm.FromSlug && mr.MethodologyVersion.Methodology.OwningPublicationSlug == rvm.ToSlug));
+        }
+
+        [Fact]
+        public async Task RedirectsExistInCache_Returns200WithRedirects()
+        {
+            var app = BuildApp();
+            var client = app.CreateClient();
+
+            var blobCacheService = app.Services.GetRequiredService<IBlobCacheService>();
+
+            var cachedPublicationRedirects = new List<RedirectViewModel>()
+            {
+                new(FromSlug: "publication_fromSlug_1", ToSlug: "publication_toSlug_1"),
+                new(FromSlug: "publication_fromSlug_2", ToSlug: "publication_toSlug_2"),
+                new(FromSlug: "publication_fromSlug_3", ToSlug: "publication_toSlug_3")
+            };
+
+            var cachedReleaseRedirects = new List<RedirectViewModel>()
+            {
+                new(FromSlug: "release_fromSlug_1", ToSlug: "release_toSlug_1"),
+                new(FromSlug: "release_fromSlug_2", ToSlug: "release_toSlug_2"),
+                new(FromSlug: "release_fromSlug_3", ToSlug: "release_toSlug_3")
+            };
+
+            var cachedMethodologyRedirects = new List<RedirectViewModel>()
+            {
+                new(FromSlug: "methodology_fromSlug_1", ToSlug: "methodology_toSlug_1"),
+                new(FromSlug: "methodology_fromSlug_2", ToSlug: "methodology_toSlug_2"),
+                new(FromSlug: "methodology_fromSlug_3", ToSlug: "methodology_toSlug_3")
+            };
+
+            var cachedViewModel = new RedirectsViewModel(
+                Publications: cachedPublicationRedirects,
+                Releases: cachedReleaseRedirects,
+                Methodologies: cachedMethodologyRedirects);
+
+            await blobCacheService.SetItemAsync(new RedirectsCacheKey(), cachedViewModel);
+
+            var response = await ListRedirects(client);
+
+            var viewModel = response.AssertOk<RedirectsViewModel>();
+
+            Assert.All(
+                cachedPublicationRedirects,
+                cpr => Assert.Contains(
+                    viewModel.Publications,
+                    rvm => cpr.FromSlug == rvm.FromSlug && cpr.ToSlug == rvm.ToSlug));
+            Assert.All(
+                cachedReleaseRedirects,
+                crr => Assert.Contains(
+                    viewModel.Releases,
+                    rvm => crr.FromSlug == rvm.FromSlug && crr.ToSlug == rvm.ToSlug));
+            Assert.All(
+                cachedMethodologyRedirects,
+                cmr => Assert.Contains(
+                    viewModel.Methodologies,
+                    rvm => cmr.FromSlug == rvm.FromSlug && cmr.ToSlug == rvm.ToSlug));
+        }
+
+        [Fact]
+        public async Task NoRedirectsExist_Returns200WithNoRedirects()
+        {
+            var contentDbContext = ContentDbContextMock();
+
+            var client = BuildApp(contentDbContext.Object).CreateClient();
+
+            var response = await ListRedirects(client);
+
+            var viewModel = response.AssertOk<RedirectsViewModel>();
+
+            Assert.Empty(viewModel.Publications);
+            Assert.Empty(viewModel.Releases);
+            Assert.Empty(viewModel.Methodologies);
+        }
+
+        private static Mock<ContentDbContext> ContentDbContextMock(
+            IEnumerable<PublicationRedirect>? publicationRedirects = null,
+            IEnumerable<ReleaseRedirect>? releaseRedirects = null,
+            IEnumerable<MethodologyRedirect>? methodologiesRedirects = null)
+        {
+            var contentDbContext = new Mock<ContentDbContext>();
+
+            contentDbContext.Setup(context => context.PublicationRedirects)
+                .Returns((publicationRedirects ?? Array.Empty<PublicationRedirect>()).AsQueryable().BuildMockDbSet().Object);
+
+            contentDbContext.Setup(context => context.ReleaseRedirects)
+                .Returns((releaseRedirects ?? Array.Empty<ReleaseRedirect>()).AsQueryable().BuildMockDbSet().Object);
+
+            contentDbContext.Setup(context => context.MethodologyRedirects)
+                .Returns((methodologiesRedirects ?? Array.Empty<MethodologyRedirect>()).AsQueryable().BuildMockDbSet().Object);
+
+            return contentDbContext;
+        }
+
+        private async Task<HttpResponseMessage> ListRedirects(
+            HttpClient? client = null)
+        {
+            client ??= BuildApp().CreateClient();
+
+            return await client.GetAsync("/api/redirects");
+        }
+    }
+
+    private WebApplicationFactory<Startup> BuildApp(ContentDbContext? contentDbContext = null)
+    {
+        return TestApp
+            .WithAzurite(enabled: true)
+            .ConfigureServices(services =>
+            {
+                if (contentDbContext is not null)
+                {
+                    services.ReplaceService(contentDbContext);
+                }
+            });
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/MethodologyGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/MethodologyGeneratorExtensions.cs
@@ -18,32 +18,42 @@ public static class MethodologyGeneratorExtensions
             .SetDefault(m => m.Id)
             .SetDefault(m => m.OwningPublicationTitle)
             .SetDefault(m => m.OwningPublicationSlug);
-    
+
     public static Generator<Methodology> WithOwningPublication(
         this Generator<Methodology> generator,
         Publication publication)
         => generator.ForInstance(s => s.SetOwningPublication(publication));
-    
+
     public static Generator<Methodology> WithAdoptingPublication(
         this Generator<Methodology> generator,
         Publication publication)
         => generator.ForInstance(s => s.SetAdoptingPublication(publication));
-    
+
     public static Generator<Methodology> WithMethodologyVersions(
         this Generator<Methodology> generator,
         IEnumerable<MethodologyVersion> methodologyVersions)
         => generator.ForInstance(s => s.SetMethodologyVersions(methodologyVersions));
-    
+
     public static Generator<Methodology> WithMethodologyVersions(
         this Generator<Methodology> generator,
         Func<SetterContext, IEnumerable<MethodologyVersion>> methodologyVersions)
         => generator.ForInstance(s => s.SetMethodologyVersions(methodologyVersions.Invoke));
-    
+
+    public static Generator<Methodology> WithLatestPublishedVersion(
+        this Generator<Methodology> generator,
+        MethodologyVersion latestPublishedVersion)
+        => generator.ForInstance(s => s.SetLatestPublishedVersion(latestPublishedVersion));
+
+    public static Generator<Methodology> WithLatestPublishedVersionId(
+        this Generator<Methodology> generator,
+        Guid latestPublishedVersionId)
+        => generator.ForInstance(s => s.SetLatestPublishedVersionId(latestPublishedVersionId));
+
     public static InstanceSetters<Methodology> SetMethodologyVersions(
         this InstanceSetters<Methodology> setters,
-        IEnumerable<MethodologyVersion> methodologyVersions) 
+        IEnumerable<MethodologyVersion> methodologyVersions)
         => setters.SetMethodologyVersions(_ => methodologyVersions);
-    
+
     private static InstanceSetters<Methodology> SetMethodologyVersions(
         this InstanceSetters<Methodology> setters,
         Func<SetterContext, IEnumerable<MethodologyVersion>> methodologyVersions)
@@ -59,16 +69,35 @@ public static class MethodologyGeneratorExtensions
             }
         );
 
+    private static InstanceSetters<Methodology> SetLatestPublishedVersion(
+        this InstanceSetters<Methodology> setters,
+        MethodologyVersion latestPublishedVersion)
+        => setters.Set(
+            m => m.LatestPublishedVersion,
+            (_, methodology) =>
+            {
+                latestPublishedVersion.Methodology = methodology;
+
+                return latestPublishedVersion;
+            }
+        )
+        .SetLatestPublishedVersionId(latestPublishedVersion.Id);
+
+    private static InstanceSetters<Methodology> SetLatestPublishedVersionId(
+        this InstanceSetters<Methodology> setters,
+        Guid latestPublishedVersionId)
+        => setters.Set(m => m.LatestPublishedVersionId, latestPublishedVersionId);
+
     public static InstanceSetters<Methodology> SetOwningPublication(
         this InstanceSetters<Methodology> setters,
-        Publication publication) 
+        Publication publication)
         => setters.SetPublication(_ => publication, owner: true);
 
     public static InstanceSetters<Methodology> SetAdoptingPublication(
         this InstanceSetters<Methodology> setters,
-        Publication publication) 
+        Publication publication)
         => setters.SetPublication(_ => publication, owner: false);
-    
+
     private static InstanceSetters<Methodology> SetPublication(
         this InstanceSetters<Methodology> setters,
         Func<SetterContext, Publication> publication,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/MethodologyRedirectGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/MethodologyRedirectGeneratorExtensions.cs
@@ -16,6 +16,11 @@ public static class MethodologyRedirectGeneratorExtensions
             .SetDefault(p => p.Slug)
             .SetDefault(p => p.Created);
 
+    public static Generator<MethodologyRedirect> WithSlug(
+        this Generator<MethodologyRedirect> generator,
+        string slug)
+        => generator.ForInstance(s => s.SetSlug(slug));
+
     public static Generator<MethodologyRedirect> WithMethodologyVersion(
         this Generator<MethodologyRedirect> generator,
         MethodologyVersion methodologyVersion)
@@ -25,6 +30,11 @@ public static class MethodologyRedirectGeneratorExtensions
         this Generator<MethodologyRedirect> generator,
         Guid methodologyVersionId)
         => generator.ForInstance(s => s.SetMethodologyVersionId(methodologyVersionId));
+
+    public static InstanceSetters<MethodologyRedirect> SetSlug(
+        this InstanceSetters<MethodologyRedirect> setters,
+        string slug)
+        => setters.Set(mr => mr.Slug, slug);
 
     public static InstanceSetters<MethodologyRedirect> SetMethodologyVersion(
         this InstanceSetters<MethodologyRedirect> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/MethodologyRedirectGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/MethodologyRedirectGeneratorExtensions.cs
@@ -1,0 +1,39 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+
+public static class MethodologyRedirectGeneratorExtensions
+{
+    public static Generator<MethodologyRedirect> DefaultMethodologyRedirect(this DataFixture fixture)
+        => fixture.Generator<MethodologyRedirect>().WithDefaults();
+
+    public static Generator<MethodologyRedirect> WithDefaults(this Generator<MethodologyRedirect> generator)
+        => generator.ForInstance(d => d.SetDefaults());
+
+    public static InstanceSetters<MethodologyRedirect> SetDefaults(this InstanceSetters<MethodologyRedirect> setters)
+        => setters
+            .SetDefault(p => p.Slug)
+            .SetDefault(p => p.Created);
+
+    public static Generator<MethodologyRedirect> WithMethodologyVersion(
+        this Generator<MethodologyRedirect> generator,
+        MethodologyVersion methodologyVersion)
+        => generator.ForInstance(s => s.SetMethodologyVersion(methodologyVersion));
+
+    public static Generator<MethodologyRedirect> WithMethodologyVersionId(
+        this Generator<MethodologyRedirect> generator,
+        Guid methodologyVersionId)
+        => generator.ForInstance(s => s.SetMethodologyVersionId(methodologyVersionId));
+
+    public static InstanceSetters<MethodologyRedirect> SetMethodologyVersion(
+        this InstanceSetters<MethodologyRedirect> setters,
+        MethodologyVersion methodologyVersion)
+        => setters.Set(mr => mr.MethodologyVersion, methodologyVersion)
+            .SetMethodologyVersionId(methodologyVersion.Id);
+
+    public static InstanceSetters<MethodologyRedirect> SetMethodologyVersionId(
+        this InstanceSetters<MethodologyRedirect> setters,
+        Guid methodologyVersionId)
+        => setters.Set(mr => mr.MethodologyVersionId, methodologyVersionId);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/MethodologyVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/MethodologyVersionGeneratorExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
@@ -32,6 +33,11 @@ public static class MethodologyVersionGeneratorExtensions
         return generator;
     }
 
+    public static Generator<MethodologyVersion> WithPublished(
+        this Generator<MethodologyVersion> generator,
+        DateTime published)
+        => generator.ForInstance(d => d.SetPublished(published));
+
     public static InstanceSetters<MethodologyVersion> SetDefaults(this InstanceSetters<MethodologyVersion> setters)
         => setters
             .SetDefault(p => p.Id)
@@ -49,4 +55,9 @@ public static class MethodologyVersionGeneratorExtensions
         this InstanceSetters<MethodologyVersion> setters,
         MethodologyApprovalStatus approvalStatus)
         => setters.Set(mv => mv.Status, approvalStatus);
+
+    public static InstanceSetters<MethodologyVersion> SetPublished(
+        this InstanceSetters<MethodologyVersion> setters,
+        DateTime published)
+        => setters.Set(mv => mv.Published, published);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationRedirectGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationRedirectGeneratorExtensions.cs
@@ -1,0 +1,39 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+
+public static class PublicationRedirectGeneratorExtensions
+{
+    public static Generator<PublicationRedirect> DefaultPublicationRedirect(this DataFixture fixture)
+        => fixture.Generator<PublicationRedirect>().WithDefaults();
+
+    public static Generator<PublicationRedirect> WithDefaults(this Generator<PublicationRedirect> generator)
+        => generator.ForInstance(d => d.SetDefaults());
+
+    public static InstanceSetters<PublicationRedirect> SetDefaults(this InstanceSetters<PublicationRedirect> setters)
+        => setters
+            .SetDefault(p => p.Slug)
+            .SetDefault(p => p.Created);
+
+    public static Generator<PublicationRedirect> WithPublication(
+        this Generator<PublicationRedirect> generator,
+        Publication publication)
+        => generator.ForInstance(s => s.SetPublication(publication));
+
+    public static Generator<PublicationRedirect> WithPublicationId(
+        this Generator<PublicationRedirect> generator,
+        Guid publicationId)
+        => generator.ForInstance(s => s.SetPublicationId(publicationId));
+
+    public static InstanceSetters<PublicationRedirect> SetPublication(
+        this InstanceSetters<PublicationRedirect> setters,
+        Publication publication)
+        => setters.Set(pr => pr.Publication, publication)
+            .SetPublicationId(publication.Id);
+
+    public static InstanceSetters<PublicationRedirect> SetPublicationId(
+        this InstanceSetters<PublicationRedirect> setters,
+        Guid publicationId)
+        => setters.Set(rr => rr.PublicationId, publicationId);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationRedirectGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationRedirectGeneratorExtensions.cs
@@ -16,6 +16,11 @@ public static class PublicationRedirectGeneratorExtensions
             .SetDefault(p => p.Slug)
             .SetDefault(p => p.Created);
 
+    public static Generator<PublicationRedirect> WithSlug(
+        this Generator<PublicationRedirect> generator,
+        string slug)
+        => generator.ForInstance(s => s.SetSlug(slug));
+
     public static Generator<PublicationRedirect> WithPublication(
         this Generator<PublicationRedirect> generator,
         Publication publication)
@@ -26,6 +31,11 @@ public static class PublicationRedirectGeneratorExtensions
         Guid publicationId)
         => generator.ForInstance(s => s.SetPublicationId(publicationId));
 
+    public static InstanceSetters<PublicationRedirect> SetSlug(
+        this InstanceSetters<PublicationRedirect> setters,
+        string slug)
+        => setters.Set(pr => pr.Slug, slug);
+
     public static InstanceSetters<PublicationRedirect> SetPublication(
         this InstanceSetters<PublicationRedirect> setters,
         Publication publication)
@@ -35,5 +45,5 @@ public static class PublicationRedirectGeneratorExtensions
     public static InstanceSetters<PublicationRedirect> SetPublicationId(
         this InstanceSetters<PublicationRedirect> setters,
         Guid publicationId)
-        => setters.Set(rr => rr.PublicationId, publicationId);
+        => setters.Set(pr => pr.PublicationId, publicationId);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseRedirectGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseRedirectGeneratorExtensions.cs
@@ -1,0 +1,39 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+
+public static class ReleaseRedirectGeneratorExtensions
+{
+    public static Generator<ReleaseRedirect> DefaultReleaseRedirect(this DataFixture fixture)
+        => fixture.Generator<ReleaseRedirect>().WithDefaults();
+
+    public static Generator<ReleaseRedirect> WithDefaults(this Generator<ReleaseRedirect> generator)
+        => generator.ForInstance(d => d.SetDefaults());
+
+    public static InstanceSetters<ReleaseRedirect> SetDefaults(this InstanceSetters<ReleaseRedirect> setters)
+        => setters
+            .SetDefault(p => p.Slug)
+            .SetDefault(p => p.Created);
+
+    public static Generator<ReleaseRedirect> WithRelease(
+        this Generator<ReleaseRedirect> generator,
+        Release release)
+        => generator.ForInstance(s => s.SetRelease(release));
+
+    public static Generator<ReleaseRedirect> WithReleaseId(
+        this Generator<ReleaseRedirect> generator,
+        Guid releaseId)
+        => generator.ForInstance(s => s.SetReleaseId(releaseId));
+
+    public static InstanceSetters<ReleaseRedirect> SetRelease(
+        this InstanceSetters<ReleaseRedirect> setters,
+        Release release)
+        => setters.Set(rr => rr.Release, release)
+            .SetReleaseId(release.Id);
+
+    public static InstanceSetters<ReleaseRedirect> SetReleaseId(
+        this InstanceSetters<ReleaseRedirect> setters,
+        Guid releaseId)
+        => setters.Set(rr => rr.ReleaseId, releaseId);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseRedirectGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseRedirectGeneratorExtensions.cs
@@ -16,6 +16,11 @@ public static class ReleaseRedirectGeneratorExtensions
             .SetDefault(p => p.Slug)
             .SetDefault(p => p.Created);
 
+    public static Generator<ReleaseRedirect> WithSlug(
+        this Generator<ReleaseRedirect> generator,
+        string slug)
+        => generator.ForInstance(s => s.SetSlug(slug));
+
     public static Generator<ReleaseRedirect> WithRelease(
         this Generator<ReleaseRedirect> generator,
         Release release)
@@ -25,6 +30,11 @@ public static class ReleaseRedirectGeneratorExtensions
         this Generator<ReleaseRedirect> generator,
         Guid releaseId)
         => generator.ForInstance(s => s.SetReleaseId(releaseId));
+
+    public static InstanceSetters<ReleaseRedirect> SetSlug(
+        this InstanceSetters<ReleaseRedirect> setters,
+        string slug)
+        => setters.Set(rr => rr.Slug, slug);
 
     public static InstanceSetters<ReleaseRedirect> SetRelease(
         this InstanceSetters<ReleaseRedirect> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/RedirectsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/RedirectsService.cs
@@ -64,8 +64,18 @@ public class RedirectsService : IRedirectsService
             .Distinct()
             .ToList();
 
+        var releaseRedirectViewModels = await _contentDbContext.ReleaseRedirects
+            .Where(rr => rr.Slug != rr.Release.Slug) // don't use redirects to the current live slug
+            .Distinct()
+            .Select(rr => new RedirectViewModel(
+                rr.Slug,
+                rr.Release.Slug
+            ))
+            .ToListAsync();
+
         return new RedirectsViewModel(
             publicationRedirectViewModels,
-            methodologyRedirectViewModels);
+            methodologyRedirectViewModels,
+            releaseRedirectViewModels);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/RedirectViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/RedirectViewModels.cs
@@ -2,7 +2,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 
 public record RedirectsViewModel(
     List<RedirectViewModel> Publications,
-    List<RedirectViewModel> Methodologies);
+    List<RedirectViewModel> Methodologies,
+    List<RedirectViewModel> Releases);
 
 public record RedirectViewModel(
     string FromSlug,


### PR DESCRIPTION
⚠️ This PR depends on https://github.com/dfe-analytical-services/explore-education-statistics/pull/5409 ⚠️ 

In this PR we add the release redirects to the `RedirectsViewModel`, to be returned in the Content API's `GET api/redirects` endpoint.

We also add some integration tests for the `api/redirects` endpoint - testing all types of redirects and the caching. No tests previously existed.

We have **TEMPORARILY** added a `Slug` field to the `Release` model as a necessity so that we can create the release redirect view models. This **IS** where the `Slug` field belongs, but is actually going to be introduced as part of [EES-5625](https://dfedigital.atlassian.net/jira/software/c/projects/EES/boards/105?selectedIssue=EES-5625). So, this PR **IS BLOCKED** by EES-5625, and the `Slug` has only been added to the `Release` here as a temporary measure to make the code compile and the tests succeed _[the migration has been purposefully excluded]_.

Once EES-5625 is merged, then we should rebase this branch and resolve any conflicts with that `Slug` field.