### PR TITLE
EES-5657 Pause Playwright tests in azure-pipelines-ui-tests.yml

### DIFF
--- a/azure-pipelines-ui-tests.yml
+++ b/azure-pipelines-ui-tests.yml
@@ -273,200 +273,200 @@ jobs:
       path: tests/robot-tests/test-results/
       artifactName: test-results-admin-public-api
 
-- job: PublicPlaywrightUItest
-  displayName: Public suite - Playwright UI tests
-  timeoutInMinutes: 160
-  cancelTimeoutInMinutes: 10
-  condition: succeededOrFailed()
-  pool: ees-ubuntu2204-large
-  workspace:
-    clean: all
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
-    fetchTags: false
-
-  - task: NodeTool@0
-    displayName: Use Node 18
-    timeoutInMinutes: 5
-    inputs:
-      versionSpec: '18.18.2'
-
-  - script: |
-      node -v
-    displayName: Display node version
-
-  - script: |
-      npm ci
-    displayName: Clean and install NPM dependencies
-    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
-
-  - script: |
-      npx playwright install --with-deps
-    displayName: Install Playwright browsers
-    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
-
-  - script: |
-      npx playwright test --project "public"
-    displayName: Run Playwright tests
-    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
-    env:
-      CI: 'true'
-      PUBLIC_URL: $(PUBLIC_URL)
-      PROD_PUBLIC_URL: $(PROD_PUBLIC_URL)
-      PUBLIC_USERNAME: $(PUBLIC_AUTH_USER)
-      PUBLIC_PASSWORD: $(PUBLIC_AUTH_PASSWORD)
-      ADMIN_URL: $(ADMIN_URL)
-      ADMIN_EMAIL: $(ADMIN_EMAIL)
-
-    # this publishes the html report as an artifact that can then be downloaded
-  - task: PublishTestResults@2
-    displayName: Public Suite - Publish Playwright Test Results
-    inputs:
-      testResultsFiles: tests/playwright-tests/test-results/playwright-results.xml
-      failTaskOnFailedTests: true
-
-  - task: PublishPipelineArtifact@1
-    displayName: Public Suite - Publish Playwright Test Artifacts
-    condition: succeededOrFailed()
-    inputs:
-      path: tests/playwright-tests/test-results/
-      artifactName: test-results-playwright-public
-
-
-- job: AdminPlaywrightUITest
-  displayName: Admin suite - Playwright UI tests
-  timeoutInMinutes: 160
-  cancelTimeoutInMinutes: 10
-  condition: succeededOrFailed()
-  pool: ees-ubuntu2204-large
-  workspace:
-    clean: all
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
-    fetchTags: false
-
-  - task: NodeTool@0
-    displayName: Use Node 18
-    timeoutInMinutes: 5
-    inputs:
-      versionSpec: '18.18.2'
-
-  - task: AzureKeyVault@2
-    displayName: Azure Key Vault - s101d01-kv-ees-01
-    inputs:
-      azureSubscription: $(SPN_NAME)
-      KeyVaultName: s101d01-kv-ees-01
-      SecretsFilter: ees-test-ADMIN-PASSWORD
-      RunAsPreJob: true
-
-  - script: |
-      node -v
-    displayName: Display node version
-
-  - script: |
-      npm ci
-    displayName: 'Clean and install npm dependencies'
-    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
-
-  - script: |
-      npx playwright install --with-deps
-    displayName: 'Install Playwright browsers'
-    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
-
-  - script: |
-      npx playwright test --project "admin"
-    displayName: "Run Playwright tests"
-    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
-    env:
-      CI: 'true'
-      ADMIN_URL: $(ADMIN_URL)
-      ADMIN_EMAIL: $(ADMIN_EMAIL)
-      ADMIN_PASSWORD: $(ees-test-ADMIN-PASSWORD)
-
-    # this publishes the html report as an artifact that can then be downloaded
-  - task: PublishTestResults@2
-    displayName: Admin Suite - Publish Playwright Test Results
-    inputs:
-      testResultsFiles: tests/playwright-tests/test-results/playwright-results.xml
-      failTaskOnFailedTests: true
-
-  - task: PublishPipelineArtifact@1
-    displayName: Admin Suite - Publish Pipeline Artifact
-    condition: succeededOrFailed()
-    inputs:
-      path: tests/playwright-tests/test-results/
-      artifactName: test-results-playwright-admin
-
-- job: AdminAndPublicPlaywrightUItest
-  displayName: Admin and public suite - Playwright UI tests
-  timeoutInMinutes: 160
-  cancelTimeoutInMinutes: 10
-  condition: succeededOrFailed()
-  pool: ees-ubuntu2204-large
-  workspace:
-    clean: all
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
-    fetchTags: false
-
-  - task: NodeTool@0
-    displayName: Use Node 18
-    timeoutInMinutes: 5
-    inputs:
-      versionSpec: '18.18.2'
-
-  - task: AzureKeyVault@2
-    displayName: Azure Key Vault - s101d01-kv-ees-01
-    inputs:
-      azureSubscription: $(SPN_NAME)
-      KeyVaultName: s101d01-kv-ees-01
-      SecretsFilter: ees-test-ADMIN-PASSWORD
-      RunAsPreJob: true
-
-  - script: |
-      node -v
-    displayName: Display node version
-
-  - script: |
-      npm ci
-    displayName: Clean and install npm dependencies
-    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
-
-  - script: |
-      npx playwright install --with-deps
-    displayName: Install Playwright browsers
-    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
-
-  - script: |
-      npx playwright test --project "adminandpublic"  
-
-    displayName: Run Playwright tests
-    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
-    env:
-      CI: 'true'
-      PUBLIC_URL: $(PUBLIC_URL)
-      PUBLIC_USERNAME: $(PUBLIC_AUTH_USER)
-      PUBLIC_PASSWORD: $(PUBLIC_AUTH_PASSWORD)
-      ADMIN_URL: $(ADMIN_URL)
-      ADMIN_EMAIL: $(ADMIN_EMAIL)
-      ADMIN_PASSWORD: $(ees-test-ADMIN-PASSWORD)
-
-    # this publishes the html report as an artifact that can then be downloaded
-  - task: PublishTestResults@2
-    displayName: Admin And Public Suite - Publish Playwright Test Results
-    inputs:
-      testResultsFiles: tests/playwright-tests/test-results/playwright-results.xml
-      failTaskOnFailedTests: true
-
-  - task: PublishPipelineArtifact@1
-    displayName: Admin And Public Suite - Publish Playwright Test Artifacts
-    condition: succeededOrFailed()
-    inputs:
-      path: tests/playwright-tests/test-results/
-      artifactName: test-results-playwright-tests-admin-and-public
+        #- job: PublicPlaywrightUItest
+        #  displayName: Public suite - Playwright UI tests
+        #  timeoutInMinutes: 160
+        #  cancelTimeoutInMinutes: 10
+        #  condition: succeededOrFailed()
+        #  pool: ees-ubuntu2204-large
+        #  workspace:
+        #    clean: all
+        #  steps:
+        #  - checkout: self
+        #    clean: true
+        #    fetchDepth: 5
+        #    fetchTags: false
+        #
+        #  - task: NodeTool@0
+        #    displayName: Use Node 18
+        #    timeoutInMinutes: 5
+        #    inputs:
+        #      versionSpec: '18.18.2'
+        #
+        #  - script: |
+        #      node -v
+        #    displayName: Display node version
+        #
+        #  - script: |
+        #      npm ci
+        #    displayName: Clean and install NPM dependencies
+        #    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
+        #
+        #  - script: |
+        #      npx playwright install --with-deps
+        #    displayName: Install Playwright browsers
+        #    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
+        #
+        #  - script: |
+        #      npx playwright test --project "public"
+        #    displayName: Run Playwright tests
+        #    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
+        #    env:
+        #      CI: 'true'
+        #      PUBLIC_URL: $(PUBLIC_URL)
+        #      PROD_PUBLIC_URL: $(PROD_PUBLIC_URL)
+        #      PUBLIC_USERNAME: $(PUBLIC_AUTH_USER)
+        #      PUBLIC_PASSWORD: $(PUBLIC_AUTH_PASSWORD)
+        #      ADMIN_URL: $(ADMIN_URL)
+        #      ADMIN_EMAIL: $(ADMIN_EMAIL)
+        #
+        #    # this publishes the html report as an artifact that can then be downloaded
+        #  - task: PublishTestResults@2
+        #    displayName: Public Suite - Publish Playwright Test Results
+        #    inputs:
+        #      testResultsFiles: tests/playwright-tests/test-results/playwright-results.xml
+        #      failTaskOnFailedTests: true
+        #
+        #  - task: PublishPipelineArtifact@1
+        #    displayName: Public Suite - Publish Playwright Test Artifacts
+        #    condition: succeededOrFailed()
+        #    inputs:
+        #      path: tests/playwright-tests/test-results/
+        #      artifactName: test-results-playwright-public
+        #
+        #
+        #- job: AdminPlaywrightUITest
+        #  displayName: Admin suite - Playwright UI tests
+        #  timeoutInMinutes: 160
+        #  cancelTimeoutInMinutes: 10
+        #  condition: succeededOrFailed()
+        #  pool: ees-ubuntu2204-large
+        #  workspace:
+        #    clean: all
+        #  steps:
+        #  - checkout: self
+        #    clean: true
+        #    fetchDepth: 5
+        #    fetchTags: false
+        #
+        #  - task: NodeTool@0
+        #    displayName: Use Node 18
+        #    timeoutInMinutes: 5
+        #    inputs:
+        #      versionSpec: '18.18.2'
+        #
+        #  - task: AzureKeyVault@2
+        #    displayName: Azure Key Vault - s101d01-kv-ees-01
+        #    inputs:
+        #      azureSubscription: $(SPN_NAME)
+        #      KeyVaultName: s101d01-kv-ees-01
+        #      SecretsFilter: ees-test-ADMIN-PASSWORD
+        #      RunAsPreJob: true
+        #
+        #  - script: |
+        #      node -v
+        #    displayName: Display node version
+        #
+        #  - script: |
+        #      npm ci
+        #    displayName: 'Clean and install npm dependencies'
+        #    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
+        #
+        #  - script: |
+        #      npx playwright install --with-deps
+        #    displayName: 'Install Playwright browsers'
+        #    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
+        #
+        #  - script: |
+        #      npx playwright test --project "admin"
+        #    displayName: "Run Playwright tests"
+        #    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
+        #    env:
+        #      CI: 'true'
+        #      ADMIN_URL: $(ADMIN_URL)
+        #      ADMIN_EMAIL: $(ADMIN_EMAIL)
+        #      ADMIN_PASSWORD: $(ees-test-ADMIN-PASSWORD)
+        #
+        #    # this publishes the html report as an artifact that can then be downloaded
+        #  - task: PublishTestResults@2
+        #    displayName: Admin Suite - Publish Playwright Test Results
+        #    inputs:
+        #      testResultsFiles: tests/playwright-tests/test-results/playwright-results.xml
+        #      failTaskOnFailedTests: true
+        #
+        #  - task: PublishPipelineArtifact@1
+        #    displayName: Admin Suite - Publish Pipeline Artifact
+        #    condition: succeededOrFailed()
+        #    inputs:
+        #      path: tests/playwright-tests/test-results/
+        #      artifactName: test-results-playwright-admin
+        #
+        #- job: AdminAndPublicPlaywrightUItest
+        #  displayName: Admin and public suite - Playwright UI tests
+        #  timeoutInMinutes: 160
+        #  cancelTimeoutInMinutes: 10
+        #  condition: succeededOrFailed()
+        #  pool: ees-ubuntu2204-large
+        #  workspace:
+        #    clean: all
+        #  steps:
+        #  - checkout: self
+        #    clean: true
+        #    fetchDepth: 5
+        #    fetchTags: false
+        #
+        #  - task: NodeTool@0
+        #    displayName: Use Node 18
+        #    timeoutInMinutes: 5
+        #    inputs:
+        #      versionSpec: '18.18.2'
+        #
+        #  - task: AzureKeyVault@2
+        #    displayName: Azure Key Vault - s101d01-kv-ees-01
+        #    inputs:
+        #      azureSubscription: $(SPN_NAME)
+        #      KeyVaultName: s101d01-kv-ees-01
+        #      SecretsFilter: ees-test-ADMIN-PASSWORD
+        #      RunAsPreJob: true
+        #
+        #  - script: |
+        #      node -v
+        #    displayName: Display node version
+        #
+        #  - script: |
+        #      npm ci
+        #    displayName: Clean and install npm dependencies
+        #    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
+        #
+        #  - script: |
+        #      npx playwright install --with-deps
+        #    displayName: Install Playwright browsers
+        #    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
+        #
+        #  - script: |
+        #      npx playwright test --project "adminandpublic"
+        #
+        #    displayName: Run Playwright tests
+        #    workingDirectory: $(System.DefaultWorkingDirectory)/tests/playwright-tests/
+        #    env:
+        #      CI: 'true'
+        #      PUBLIC_URL: $(PUBLIC_URL)
+        #      PUBLIC_USERNAME: $(PUBLIC_AUTH_USER)
+        #      PUBLIC_PASSWORD: $(PUBLIC_AUTH_PASSWORD)
+        #      ADMIN_URL: $(ADMIN_URL)
+        #      ADMIN_EMAIL: $(ADMIN_EMAIL)
+        #      ADMIN_PASSWORD: $(ees-test-ADMIN-PASSWORD)
+        #
+        #    # this publishes the html report as an artifact that can then be downloaded
+        #  - task: PublishTestResults@2
+        #    displayName: Admin And Public Suite - Publish Playwright Test Results
+        #    inputs:
+        #      testResultsFiles: tests/playwright-tests/test-results/playwright-results.xml
+        #      failTaskOnFailedTests: true
+        #
+        #  - task: PublishPipelineArtifact@1
+        #    displayName: Admin And Public Suite - Publish Playwright Test Artifacts
+        #    condition: succeededOrFailed()
+        #    inputs:
+        #      path: tests/playwright-tests/test-results/
+        #      artifactName: test-results-playwright-tests-admin-and-public


### PR DESCRIPTION
Commented out all the Playwright tests from the yml file so that they do not run in pipelines.
These tests are not maintained anymore resulting in failures that reported as 'failed' on slack even though all other tests were passing.