### PR TITLE
EES-5663 Tweaks to public API versioning

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2114,7 +2114,7 @@
         "NEXT_CONFIG_MODE": "server",
         "NODE_ENV": "production",
         "PUBLIC_URL": "[concat(variables('publicAppUrl'), '/')]",
-        "PUBLIC_API_BASE_URL": "[concat('https://', parameters('publicApiUrl'), '/api/v1')]",
+        "PUBLIC_API_BASE_URL": "[concat('https://', parameters('publicApiUrl'), '/v1')]",
         "PUBLIC_API_DOCS_URL": "[concat('https://', parameters('publicApiDocsUrl'))]",
         "WEBSITE_NODE_DEFAULT_VERSION": "20.16.0",
         "WEBSITES_PORT": 3000

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2114,7 +2114,7 @@
         "NEXT_CONFIG_MODE": "server",
         "NODE_ENV": "production",
         "PUBLIC_URL": "[concat(variables('publicAppUrl'), '/')]",
-        "PUBLIC_API_BASE_URL": "[concat('https://', parameters('publicApiUrl'),'/api/v1.0')]",
+        "PUBLIC_API_BASE_URL": "[concat('https://', parameters('publicApiUrl'), '/api/v1')]",
         "PUBLIC_API_DOCS_URL": "[concat('https://', parameters('publicApiDocsUrl'))]",
         "WEBSITE_NODE_DEFAULT_VERSION": "20.16.0",
         "WEBSITES_PORT": 3000

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient.cs
@@ -35,7 +35,7 @@ public class PublicDataApiClient(
     {
         return await SendRequest(
             () => httpClient.GetAsync(
-                $"api/v1/data-sets/{dataSetId}/versions/{dataSetVersion}/changes",
+                $"v1/data-sets/{dataSetId}/versions/{dataSetVersion}/changes",
                 cancellationToken
             ),
             cancellationToken

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
@@ -20,7 +20,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Contr
 
 public abstract class DataSetVersionsControllerTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
 {
-    private const string BaseUrl = "api/v1/data-sets";
+    private const string BaseUrl = "v1/data-sets";
 
     public class ListDataSetVersionsTests(TestApplicationFactory testApp) : DataSetVersionsControllerTests(testApp)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
@@ -23,7 +23,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Contr
 
 public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
 {
-    private const string BaseUrl = "api/v1/data-sets";
+    private const string BaseUrl = "v1/data-sets";
 
     private readonly TestDataSetVersionPathResolver _dataSetVersionPathResolver = new()
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
@@ -25,7 +25,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Contr
 
 public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
 {
-    private const string BaseUrl = "api/v1/data-sets";
+    private const string BaseUrl = "v1/data-sets";
 
     private readonly TestDataSetVersionPathResolver _dataSetVersionPathResolver = new()
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -25,7 +25,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Contr
 
 public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
 {
-    private const string BaseUrl = "api/v1/data-sets";
+    private const string BaseUrl = "v1/data-sets";
 
     public class GetDataSetTests(TestApplicationFactory testApp) : DataSetsControllerTests(testApp)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Contr
 
 public abstract class PublicationsControllerTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
 {
-    private const string BaseUrl = "api/v1/publications";
+    private const string BaseUrl = "v1/publications";
 
     public class ListPublicationsTests(TestApplicationFactory testApp) : PublicationsControllerTests(testApp)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/VersionedPathsDocumentFilterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Swagger/VersionedPathsDocumentFilterTests.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Swagger;
+
+public class VersionedPathsDocumentFilterTests
+{
+    [Fact]
+    public void VersionsInlinedIntoPaths()
+    {
+        var document = new OpenApiDocument
+        {
+            Info = new OpenApiInfo { Version = "1" },
+            Paths = new OpenApiPaths
+            {
+                {"/v{version}/endpoint-1", new OpenApiPathItem()},
+                {"/v{version}/endpoint-2/{id}", new OpenApiPathItem()}
+            }
+        };
+
+        var filter = new VersionedPathsDocumentFilter();
+        var context = CreateDocumentFilterContext();
+
+        filter.Apply(document, context);
+
+        Assert.Equal(2, document.Paths.Count);
+        Assert.Contains("/v1/endpoint-1", document.Paths.Keys);
+        Assert.Contains("/v1/endpoint-2/{id}", document.Paths.Keys);
+    }
+
+    [Fact]
+    public void VersionParametersRemoved()
+    {
+        var document = new OpenApiDocument
+        {
+            Info = new OpenApiInfo { Version = "1" },
+            Paths = new OpenApiPaths
+            {
+                {
+                    "/v{version}/endpoint-1",
+                    new OpenApiPathItem
+                    {
+                        Parameters =
+                        [
+                            new OpenApiParameter { Name = "version" }
+                        ],
+                        Operations =
+                        {
+                            {
+                                OperationType.Get,
+                                new OpenApiOperation
+                                {
+                                    Parameters =
+                                    [
+                                        new OpenApiParameter { Name = "version" }
+                                    ]
+                                }
+                            }
+
+                        }
+                    }
+                },
+                {
+                    "/v{version}/endpoint-2/{id}",
+                    new OpenApiPathItem
+                    {
+                        Parameters =
+                        [
+                            new OpenApiParameter { Name = "version" },
+                            new OpenApiParameter { Name = "id" }
+                        ],
+                        Operations =
+                        {
+                            {
+                                OperationType.Get,
+                                new OpenApiOperation
+                                {
+                                    Parameters =
+                                    [
+                                        new OpenApiParameter { Name = "version" },
+                                        new OpenApiParameter { Name = "id" }
+                                    ]
+                                }
+                            }
+
+                        }
+                    }
+                }
+            }
+        };
+
+        var filter = new VersionedPathsDocumentFilter();
+        var context = CreateDocumentFilterContext();
+
+        filter.Apply(document, context);
+
+        Assert.Equal(2, document.Paths.Count);
+
+        var endpoint1Paths = document.Paths["/v1/endpoint-1"];
+
+        Assert.Empty(endpoint1Paths.Parameters);
+        Assert.Empty(endpoint1Paths.Operations[OperationType.Get].Parameters);
+
+        var endpoint2Paths = document.Paths["/v1/endpoint-2/{id}"];
+
+        Assert.Single(endpoint2Paths.Parameters);
+        Assert.Equal("id", endpoint2Paths.Parameters[0].Name);
+
+        Assert.Single(endpoint2Paths.Operations[OperationType.Get].Parameters);
+        Assert.Equal("id", endpoint2Paths.Parameters[0].Name);
+    }
+
+    private static DocumentFilterContext CreateDocumentFilterContext()
+    {
+        var schemaGenerator = new SchemaGenerator(
+            new SchemaGeneratorOptions(),
+            new JsonSerializerDataContractResolver(
+                new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                }
+            )
+        );
+        var schemaRepository = new SchemaRepository();
+
+        return new DocumentFilterContext([], schemaGenerator, schemaRepository);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetVersionsController.cs
@@ -12,7 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Controllers
 
 [ApiVersion("1")]
 [ApiController]
-[Route("api/v{version:apiVersion}/data-sets/{dataSetId:guid}/versions")]
+[Route("v{version:apiVersion}/data-sets/{dataSetId:guid}/versions")]
 public class DataSetVersionsController(
     IDataSetService dataSetService,
     IDataSetVersionChangeService dataSetVersionChangeService)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetVersionsController.cs
@@ -10,7 +10,7 @@ using Swashbuckle.AspNetCore.Annotations;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Controllers;
 
-[ApiVersion(1.0)]
+[ApiVersion("1")]
 [ApiController]
 [Route("api/v{version:apiVersion}/data-sets/{dataSetId:guid}/versions")]
 public class DataSetVersionsController(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -13,7 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Controllers
 
 [ApiVersion("1")]
 [ApiController]
-[Route("api/v{version:apiVersion}/data-sets")]
+[Route("v{version:apiVersion}/data-sets")]
 public class DataSetsController(
     IDataSetService dataSetService,
     IDataSetQueryService dataSetQueryService)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -11,7 +11,7 @@ using System.Net.Mime;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Controllers;
 
-[ApiVersion(1.0)]
+[ApiVersion("1")]
 [ApiController]
 [Route("api/v{version:apiVersion}/data-sets")]
 public class DataSetsController(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/PublicationsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/PublicationsController.cs
@@ -12,7 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Controllers
 
 [ApiVersion("1")]
 [ApiController]
-[Route("api/v{version:apiVersion}/publications")]
+[Route("v{version:apiVersion}/publications")]
 public class PublicationsController(IPublicationService publicationService, IDataSetService dataSetService)
     : ControllerBase
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/PublicationsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/PublicationsController.cs
@@ -10,7 +10,7 @@ using Swashbuckle.AspNetCore.Annotations;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Controllers;
 
-[ApiVersion(1.0)]
+[ApiVersion("1")]
 [ApiController]
 [Route("api/v{version:apiVersion}/publications")]
 public class PublicationsController(IPublicationService publicationService, IDataSetService dataSetService)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Program.cs
@@ -39,7 +39,7 @@ startup.Configure(app, app.Environment);
 
 app.UseSwagger(options =>
 {
-    options.RouteTemplate = "/swagger/{documentName}/openapi.json";
+    options.RouteTemplate = "/swagger/v{documentName}/openapi.json";
 });
 app.UseSwaggerUI(options =>
 {
@@ -48,7 +48,7 @@ app.UseSwaggerUI(options =>
     foreach (var description in app.DescribeApiVersions())
     {
         options.SwaggerEndpoint(
-            url: $"/swagger/{description.GroupName}/openapi.json",
+            url: $"/swagger/v{description.GroupName}/openapi.json",
             name: $"v{description.GroupName}");
     }
 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerConfig.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerConfig.cs
@@ -16,8 +16,11 @@ public class SwaggerConfig(
 {
     public void Configure(SwaggerGenOptions options)
     {
+        options.DocumentFilter<VersionedPathsDocumentFilter>();
+
         options.OperationFilter<DefaultValuesOperationFilter>();
         options.OperationFilter<GeneralResponseOperationFilter>();
+
         options.SchemaFilter<JsonConverterSchemaFilter>();
         options.SchemaFilter<RequiredPropertySchemaFilter>();
         options.SchemaFilter<SwaggerEnumSchemaFilter>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/VersionedPathsDocumentFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/VersionedPathsDocumentFilter.cs
@@ -1,0 +1,32 @@
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
+
+public class VersionedPathsDocumentFilter : IDocumentFilter
+{
+    public void Apply(OpenApiDocument document, DocumentFilterContext context)
+    {
+        var newPaths = new OpenApiPaths();
+
+        foreach (var path in document.Paths)
+        {
+            var versionedPath = path.Key.Replace("{version}", document.Info.Version);
+
+            newPaths[versionedPath] = path.Value;
+
+            path.Value.Parameters = path.Value.Parameters
+                .Where(p => p.Name != "version")
+                .ToList();
+
+            foreach (var operation in path.Value.Operations.Values)
+            {
+                operation.Parameters = operation.Parameters
+                    .Where(p => p.Name != "version")
+                    .ToList();
+            }
+        }
+
+        document.Paths = newPaths;
+    }
+}

--- a/src/explore-education-statistics-frontend/.env
+++ b/src/explore-education-statistics-frontend/.env
@@ -1,6 +1,6 @@
 CONTENT_API_BASE_URL=http://localhost:5010/api
 DATA_API_BASE_URL=http://localhost:5000/api
-PUBLIC_API_BASE_URL=http://localhost:5050/api/v1
+PUBLIC_API_BASE_URL=http://localhost:5050/v1
 PUBLIC_API_DOCS_URL=https://dev.statistics.api.education.gov.uk/docs
 NOTIFICATION_API_BASE_URL=http://localhost:7073/api
 GA_TRACKING_ID=

--- a/src/explore-education-statistics-frontend/.env
+++ b/src/explore-education-statistics-frontend/.env
@@ -1,6 +1,6 @@
 CONTENT_API_BASE_URL=http://localhost:5010/api
 DATA_API_BASE_URL=http://localhost:5000/api
-PUBLIC_API_BASE_URL=http://localhost:5050/api/v1.0
+PUBLIC_API_BASE_URL=http://localhost:5050/api/v1
 PUBLIC_API_DOCS_URL=https://dev.statistics.api.education.gov.uk/docs
 NOTIFICATION_API_BASE_URL=http://localhost:7073/api
 GA_TRACKING_ID=


### PR DESCRIPTION
This PR makes the following tweaks to the versioning in the public API:

- Removes minor versions as they are unnecessary. We only need to communicate major changes to API consumers.
- Removes `version` path parameters from the generated OpenAPI documents. This was previously quite confusing as it would not enumerate or constrain what version number you should use.
- Prefixes generated OpenAPI document version paths with `v` e.g. `/swagger/v1/openapi.json`
- Removes `/api` prefix from routes as it's redundant to declare it in the path due to the app already being an API