### PR TITLE
EES-5671 Fix methodology page not loading issue due to 'file://' link

### DIFF
--- a/src/explore-education-statistics-common/src/components/ContentHtml.tsx
+++ b/src/explore-education-statistics-common/src/components/ContentHtml.tsx
@@ -85,7 +85,7 @@ export default function ContentHtml({
         const text = domToReact(node.children);
 
         return !url?.includes('explore-education-statistics.service.gov.uk') &&
-          !url.startsWith('mailto:') &&
+          !url?.startsWith('mailto:') &&
           typeof node.attribs['data-featured-table'] === 'undefined' ? (
           <a href={url} target="_blank" rel="noopener noreferrer">
             {text} (opens in a new tab)


### PR DESCRIPTION
This PR fixes an issue where this methodology will not load: https://explore-education-statistics.service.gov.uk/methodology/technical-documentation-2022

This happens because the Content of that methodology version includes a link that starts "file://". These links previous didn't render, but now they prevent the page loading entirely. See Jira ticket for more details.
