### PR TITLE
Ees 5660 replace versioned draft folder with static folder

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1197,7 +1197,10 @@
       "[concat('Microsoft.Web/sites/', variables('importerAppName'))]",
       "[concat('Microsoft.Web/sites/', variables('contentAppName'))]",
       "[concat('Microsoft.Web/sites/', variables('dataAppName'))]"
-    ]
+    ],
+    "publicDataFileshareMountPath": "/data/public-api-data",
+    "publicDataFileshareName": "[concat(parameters('subscription'), '-ees-papi-fs-data')]",
+    "publicDataStorageAccountName": "[concat(parameters('subscription'), 'eespapisa')]"
   },
   "resources": [
     {
@@ -3283,7 +3286,30 @@
         "App:NotifierStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-notifications')).secretUriWithVersion, ')')]",
         "App:PublicStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-public')).secretUriWithVersion, ')')]",
         "App:PublisherStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher')).secretUriWithVersion, ')')]",
+        "DataFiles:BasePath": "[parameters('publicDataFileshareMountPath')]",
         "PublicDataDbExists": "[parameters('publicDataDbExists')]"
+      }
+    },
+    {
+      "condition": "[parameters('publicDataDbExists')]",
+      "name": "[concat(variables('publisherAppName'), '/azurestorageaccounts')]",
+      "type": "Microsoft.Web/sites/config",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2019-08-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', variables('publisherAppName'))]",
+        "[variables('publicDataFileshareMountPath')]",
+        "[variables('publicDataFileshareName')]",
+        "[variables('publicDataStorageAccountName')]"
+      ],
+      "properties": {
+        "[variables('publicDataFileshareName')]": {
+          "type": "AzureFiles",
+          "accountName": "[variables('publicDataStorageAccountName')]",
+          "shareName": "[variables('publicDataFileshareName')]",
+          "mountPath": "[variables('publicDataFileshareMountPath')]",
+          "protocol": "Smb"
+        }
       }
     },
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/Custom/ICustomMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/Custom/ICustomMigration.cs
@@ -1,7 +1,0 @@
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.Custom
-{
-    public interface ICustomMigration
-    {
-        void Apply();
-    }
-}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -783,7 +783,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                     context.Database.Migrate();
                 }
 
-                ApplyCustomMigrations(app);
+                if (!env.IsIntegrationTest())
+                {
+                    ApplyCustomMigrations(app);
+                }
             }
 
             if (env.IsDevelopment())

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -3,7 +3,6 @@ using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Admin.Database;
 using GovUk.Education.ExploreEducationStatistics.Admin.Hubs;
 using GovUk.Education.ExploreEducationStatistics.Admin.Hubs.Filters;
-using GovUk.Education.ExploreEducationStatistics.Admin.Migrations.Custom;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Options;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data;
@@ -782,9 +781,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                 {
                     context.Database.SetCommandTimeout(int.MaxValue);
                     context.Database.Migrate();
-
-                    ApplyCustomMigrations();
                 }
+
+                ApplyCustomMigrations(app);
             }
 
             if (env.IsDevelopment())
@@ -798,8 +797,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             }
         }
 
-        private static void ApplyCustomMigrations(params ICustomMigration[] migrations)
+        private static void ApplyCustomMigrations(IApplicationBuilder app)
         {
+            using var serviceScope = app.ApplicationServices
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope();
+
+            var migrations = serviceScope.ServiceProvider.GetServices<ICustomMigration>();
+
             foreach (var migration in migrations)
             {
                 migration.Apply();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -466,6 +466,96 @@ public class EnumerableExtensionsTests
         Assert.True(containsAll);
     }
 
+    public class CartesianTests
+    {
+        [Fact]
+        public void TwoLists_Cartesian()
+        {
+            List<int> list1 = [1, 2];
+            List<string> list2 = ["3", "4"];
+
+            List<Tuple<int, string>> expected =
+            [
+                new Tuple<int, string>(1, "3"),
+                new Tuple<int, string>(1, "4"),
+                new Tuple<int, string>(2, "3"),
+                new Tuple<int, string>(2, "4")
+            ];
+
+            var actual = list1.Cartesian(list2);
+            Assert.Equal(expected, actual);
+        }
+        
+        [Fact]
+        public void TwoLists_EmptyList()
+        {
+            List<int> list1 = [1, 2];
+            Assert.Empty(list1.Cartesian(new List<string>()));
+        }
+        
+        [Fact]
+        public void TwoLists_NullList()
+        {
+            List<int> list1 = [1, 2];
+            Assert.Empty(list1.Cartesian((List<string>?) null));
+        }
+        
+        [Fact]
+        public void ThreeLists_Cartesian()
+        {
+            List<int> list1 = [1, 2];
+            List<string> list2 = ["3", "4"];
+            List<char> list3 = ['5', '6'];
+
+            List<Tuple<int, string, char>> expected =
+            [
+                new Tuple<int, string, char>(1, "3", '5'),
+                new Tuple<int, string, char>(1, "3", '6'),
+                new Tuple<int, string, char>(1, "4", '5'),
+                new Tuple<int, string, char>(1, "4", '6'),
+                new Tuple<int, string, char>(2, "3", '5'),
+                new Tuple<int, string, char>(2, "3", '6'),
+                new Tuple<int, string, char>(2, "4", '5'),
+                new Tuple<int, string, char>(2, "4", '6'),
+            ];
+
+            var actual = list1.Cartesian(list2, list3);
+            Assert.Equal(expected, actual);
+        }
+        
+        [Fact]
+        public void ThreeLists_EmptyFirstList()
+        {
+            List<int> list1 = [1, 2];
+            List<char> list3 = ['5', '6'];
+            Assert.Empty(list1.Cartesian(new List<string>(), list3));
+        }
+        
+        [Fact]
+        public void ThreeLists_EmptySecondList()
+        {
+            List<int> list1 = [1, 2];
+            List<string> list2 = ["3", "4"];
+            Assert.Empty(list1.Cartesian(list2, new List<char>()));
+        }
+        
+        [Fact]
+        public void ThreeLists_NullFirstList()
+        {
+            List<int> list1 = [1, 2];
+            List<char> list3 = ['5', '6'];
+            Assert.Empty(list1.Cartesian((List<string>?) null, list3));
+        }
+        
+        [Fact]
+        public void ThreeLists_NullSecondList()
+        {
+            List<int> list1 = [1, 2];
+            List<string> list2 = ["3", "4"];
+            Assert.Empty(list1.Cartesian(list2, (List<char>?) null));
+        }
+    }
+
     private static async Task<Either<Unit, int>> GetSuccessfulEither(int value)
     {
         await Task.Delay(5);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -474,12 +474,12 @@ public class EnumerableExtensionsTests
             List<int> list1 = [1, 2];
             List<string> list2 = ["3", "4"];
 
-            List<Tuple<int, string>> expected =
+            List<(int, string)> expected =
             [
-                new Tuple<int, string>(1, "3"),
-                new Tuple<int, string>(1, "4"),
-                new Tuple<int, string>(2, "3"),
-                new Tuple<int, string>(2, "4")
+                new(1, "3"),
+                new(1, "4"),
+                new(2, "3"),
+                new(2, "4")
             ];
 
             var actual = list1.Cartesian(list2);
@@ -507,16 +507,16 @@ public class EnumerableExtensionsTests
             List<string> list2 = ["3", "4"];
             List<char> list3 = ['5', '6'];
 
-            List<Tuple<int, string, char>> expected =
+            List<(int, string, char)> expected =
             [
-                new Tuple<int, string, char>(1, "3", '5'),
-                new Tuple<int, string, char>(1, "3", '6'),
-                new Tuple<int, string, char>(1, "4", '5'),
-                new Tuple<int, string, char>(1, "4", '6'),
-                new Tuple<int, string, char>(2, "3", '5'),
-                new Tuple<int, string, char>(2, "3", '6'),
-                new Tuple<int, string, char>(2, "4", '5'),
-                new Tuple<int, string, char>(2, "4", '6'),
+                new(1, "3", '5'),
+                new(1, "3", '6'),
+                new(1, "4", '5'),
+                new(1, "4", '6'),
+                new(2, "3", '5'),
+                new(2, "3", '6'),
+                new(2, "4", '5'),
+                new(2, "4", '6'),
             ];
 
             var actual = list1.Cartesian(list2, list3);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Database/ICustomMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Database/ICustomMigration.cs
@@ -1,0 +1,6 @@
+namespace GovUk.Education.ExploreEducationStatistics.Common.Database;
+
+public interface ICustomMigration
+{
+    void Apply();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Database/ICustomMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Database/ICustomMigration.cs
@@ -1,5 +1,12 @@
 namespace GovUk.Education.ExploreEducationStatistics.Common.Database;
 
+/// <summary>
+/// Custom migrations that run on deployment / startup.
+/// These differ in use from EF database migrations in that they are not limited
+/// to running against a single database / DbContext. These can be simple
+/// standalone implementations or can use dependency injection if registered
+/// with a DI container.
+/// </summary>
 public interface ICustomMigration
 {
     void Apply();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -320,18 +320,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return source.ThenBy(keySelector, comparison.WithNaturalSort());
         }
 
-        public static List<Tuple<T1, T2>> Cartesian<T1, T2>(
+        public static List<(T1, T2)> Cartesian<T1, T2>(
             this IEnumerable<T1> list1,
             IEnumerable<T2>? list2)
         {
             return list2 == null
                 ? []
                 : list1
-                    .Join(list2, _ => true, _ => true, (t1, t2) => new Tuple<T1, T2>(t1, t2))
+                    .Join(list2, _ => true, _ => true, (t1, t2) => (t1, t2))
                     .ToList();
         }
 
-        public static List<Tuple<T1, T2, T3>> Cartesian<T1, T2, T3>(
+        public static List<(T1, T2, T3)> Cartesian<T1, T2, T3>(
             this IEnumerable<T1> list1,
             IEnumerable<T2>? list2,
             IEnumerable<T3>? list3)
@@ -339,9 +339,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return list2 == null || list3 == null
                 ? []
                 : list1
-                    .Join(list2, _ => true, _ => true, (t1, t2) => new Tuple<T1, T2>(t1, t2))
+                    .Join(list2, _ => true, _ => true, (t1, t2) => (t1, t2))
                     .Join(list3, _ => true, _ => true,
-                        (tuple, t3) => new Tuple<T1, T2, T3>(tuple.Item1, tuple.Item2, t3))
+                        (tuple, t3) => (tuple.t1, tuple.t2, t3))
                     .ToList();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -221,7 +221,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
         }
 
         public static IAsyncEnumerable<T> WhereNotNull<T>(this IAsyncEnumerable<T?> source)
-            where T: class
+            where T : class
         {
             return source.Where(item => item is not null)!;
         }
@@ -264,7 +264,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 
             return !(firstNotInSecond.Any() || secondNotInFirst.Any());
         }
-        
+
         public static Tuple<T, T> ToTuple2<T>(this IEnumerable<T> collection)
             where T : class
         {
@@ -275,10 +275,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
                 throw new ArgumentException(
                     $"Expected 2 list items when constructing a 2-tuple, but found {list.Count}");
             }
-            
+
             return new Tuple<T, T>(list[0], list[1]);
         }
-        
+
         public static Tuple<T, T, T> ToTuple3<T>(this IEnumerable<T> collection)
             where T : class
         {
@@ -289,7 +289,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
                 throw new ArgumentException(
                     $"Expected 3 list items when constructing a 3-tuple, but found {list.Count}");
             }
-            
+
             return new Tuple<T, T, T>(list[0], list[1], list[2]);
         }
 
@@ -297,7 +297,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
         {
             return values.All(id => source.Contains(id));
         }
-        
+
         /// <summary>
         /// Order some objects, according to a string key, in natural order for humans to read.
         /// </summary>
@@ -320,25 +320,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return source.ThenBy(keySelector, comparison.WithNaturalSort());
         }
 
-        public static IEnumerable<Tuple<T1, T2>> Cartesian<T1, T2>(
+        public static List<Tuple<T1, T2>> Cartesian<T1, T2>(
             this IEnumerable<T1> list1,
             IEnumerable<T2>? list2)
         {
-            return list2 == null 
-                ? [] 
-                : list1.Join(list2, _ => true, _ => true,(t1, t2) => new Tuple<T1, T2>(t1, t2));
+            return list2 == null
+                ? []
+                : list1
+                    .Join(list2, _ => true, _ => true, (t1, t2) => new Tuple<T1, T2>(t1, t2))
+                    .ToList();
         }
-        
-        public static IEnumerable<Tuple<T1, T2, T3>> Cartesian<T1, T2, T3>(
+
+        public static List<Tuple<T1, T2, T3>> Cartesian<T1, T2, T3>(
             this IEnumerable<T1> list1,
             IEnumerable<T2>? list2,
             IEnumerable<T3>? list3)
         {
             return list2 == null || list3 == null
-                ? [] 
+                ? []
                 : list1
                     .Join(list2, _ => true, _ => true, (t1, t2) => new Tuple<T1, T2>(t1, t2))
-                    .Join(list3, _ => true, _ => true, (tuple, t3) => new Tuple<T1, T2, T3>(tuple.Item1, tuple.Item2, t3));
+                    .Join(list3, _ => true, _ => true,
+                        (tuple, t3) => new Tuple<T1, T2, T3>(tuple.Item1, tuple.Item2, t3))
+                    .ToList();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -319,5 +319,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
         {
             return source.ThenBy(keySelector, comparison.WithNaturalSort());
         }
+
+        public static IEnumerable<Tuple<T1, T2>> Cartesian<T1, T2>(
+            this IEnumerable<T1> list1,
+            IEnumerable<T2>? list2)
+        {
+            return list2 == null 
+                ? [] 
+                : list1.Join(list2, _ => true, _ => true,(t1, t2) => new Tuple<T1, T2>(t1, t2));
+        }
+        
+        public static IEnumerable<Tuple<T1, T2, T3>> Cartesian<T1, T2, T3>(
+            this IEnumerable<T1> list1,
+            IEnumerable<T2>? list2,
+            IEnumerable<T3>? list3)
+        {
+            return list2 == null || list3 == null
+                ? [] 
+                : list1
+                    .Join(list2, _ => true, _ => true, (t1, t2) => new Tuple<T1, T2>(t1, t2))
+                    .Join(list3, _ => true, _ => true, (tuple, t3) => new Tuple<T1, T2, T3>(tuple.Item1, tuple.Item2, t3));
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Migrations/EES5660_MigrateDraftDataSetVersionFolderNamesTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Migrations/EES5660_MigrateDraftDataSetVersionFolderNamesTests.cs
@@ -6,22 +6,24 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Fixture;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.TheoryData;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Migrations;
 
+// TODO EES-5660 - remove this migration after it has been run against each Public API-enabled environment.
 public class EES5660_MigrateDraftDataSetVersionFolderNamesTests(TestApplicationFactory testApp) 
     : IntegrationTestFixture(testApp)
 {
     public static readonly TheoryData<Tuple<DataSetVersionStatus, DataSetVersionType>>
-        PrivateDataSetVersionStatusAndTypes = new(DataSetVersionStatusConstants
+        PrivateDataSetVersionStatusAndTypes = new(DataSetVersionAuthExtensions
             .PrivateStatuses
             .Cartesian(EnumUtil.GetEnums<DataSetVersionType>()));
     
     public static readonly TheoryData<Tuple<DataSetVersionStatus, DataSetVersionType>>
-        PublicDataSetVersionStatusAndTypes = new(DataSetVersionStatusConstants
+        PublicDataSetVersionStatusAndTypes = new(DataSetVersionAuthExtensions
             .PublicStatuses
             .Cartesian(EnumUtil.GetEnums<DataSetVersionType>()));
     

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Migrations/EES5660_MigrateDraftDataSetVersionFolderNamesTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Migrations/EES5660_MigrateDraftDataSetVersionFolderNamesTests.cs
@@ -1,0 +1,174 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Migrations;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Fixture;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.TheoryData;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Migrations;
+
+public class EES5660_MigrateDraftDataSetVersionFolderNamesTests(TestApplicationFactory testApp) 
+    : IntegrationTestFixture(testApp)
+{
+    public static readonly TheoryData<Tuple<DataSetVersionStatus, DataSetVersionType>>
+        PrivateDataSetVersionStatusAndTypes = new(DataSetVersionStatusConstants
+            .PrivateStatuses
+            .Cartesian(EnumUtil.GetEnums<DataSetVersionType>()));
+    
+    public static readonly TheoryData<Tuple<DataSetVersionStatus, DataSetVersionType>>
+        PublicDataSetVersionStatusAndTypes = new(DataSetVersionStatusConstants
+            .PublicStatuses
+            .Cartesian(EnumUtil.GetEnums<DataSetVersionType>()));
+    
+    [Theory]
+    [MemberData(nameof(PrivateDataSetVersionStatusAndTypes))]
+    public async Task Success_NonMigratedDraft(Tuple<DataSetVersionStatus, DataSetVersionType> statusAndType)
+    {
+        var (status, type) = statusAndType;
+
+        DataSetVersion dataSetVersion = DataFixture
+            .DefaultDataSetVersion()
+            .WithId(Guid.NewGuid())
+            .WithDataSet(DataFixture
+                .DefaultDataSet())
+            .WithStatus(status)
+            .WithVersionNumber(
+                major: type == DataSetVersionType.Major ? 2 : 1,
+                minor: type == DataSetVersionType.Major ? 0 : 1);
+        
+        await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
+
+        var pathResolver = TestApp.Services.GetRequiredService<IDataSetVersionPathResolver>();
+
+        var versionedFolder = pathResolver.DirectoryPath(dataSetVersion, dataSetVersion.SemVersion());
+        Directory.CreateDirectory(versionedFolder);
+        File.Create(Path.Combine(versionedFolder, "test.txt"));
+        
+        var migration = TestApp.Services.GetRequiredService<EES5660_MigrateDraftDataSetVersionFolderNames>();
+
+        migration.Apply();
+
+        // Assert that the original folder that used the draft's version in its name no longer exists.
+        Assert.False(Directory.Exists(versionedFolder));
+
+        // Assert that the original folder has moved to use the new special "draft" folder.
+        var expectedDraftFolder = pathResolver.DirectoryPath(dataSetVersion);
+        Assert.True(Directory.Exists(expectedDraftFolder));
+        Assert.True(File.Exists(Path.Combine(expectedDraftFolder, "test.txt")));
+    }
+    
+    [Theory]
+    [MemberData(nameof(PrivateDataSetVersionStatusAndTypes))]
+    public async Task Success_AlreadyMigratedDraft(Tuple<DataSetVersionStatus, DataSetVersionType> statusAndType)
+    {
+        var (status, type) = statusAndType;
+        
+        DataSetVersion dataSetVersion = DataFixture
+            .DefaultDataSetVersion()
+            .WithId(Guid.NewGuid())
+            .WithDataSet(DataFixture
+                .DefaultDataSet()
+                .WithId(Guid.NewGuid()))
+            .WithStatus(status)
+            .WithVersionNumber(
+                major: type == DataSetVersionType.Major ? 2 : 1,
+                minor: type == DataSetVersionType.Major ? 0 : 1);
+        
+        await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
+
+        var pathResolver = TestApp.Services.GetRequiredService<IDataSetVersionPathResolver>();
+
+        var draftFolder = pathResolver.DirectoryPath(dataSetVersion);
+        Directory.CreateDirectory(draftFolder);
+        File.Create(Path.Combine(draftFolder, "test.txt"));
+        
+        var migration = TestApp.Services.GetRequiredService<EES5660_MigrateDraftDataSetVersionFolderNames>();
+
+        migration.Apply();
+
+        // Assert that the existing draft folder is left untouched.
+        Assert.True(Directory.Exists(draftFolder));
+        Assert.True(File.Exists(Path.Combine(draftFolder, "test.txt")));
+    }
+    
+    [Fact]
+    public async Task Failure_DraftFolderAndVersionedFolderExist()
+    {
+        DataSetVersion dataSetVersion = DataFixture
+            .DefaultDataSetVersion()
+            .WithDataSet(DataFixture.DefaultDataSet())
+            .WithStatus(DataSetVersionStatus.Draft)
+            .WithVersionNumber(major: 2, minor: 0);
+        
+        await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
+
+        var pathResolver = TestApp.Services.GetRequiredService<IDataSetVersionPathResolver>();
+
+        var versionedFolder = pathResolver.DirectoryPath(dataSetVersion, dataSetVersion.SemVersion());
+        Directory.CreateDirectory(versionedFolder);
+        File.Create(Path.Combine(versionedFolder, "versioned.txt"));
+        
+        var draftFolder = pathResolver.DirectoryPath(dataSetVersion);
+        Directory.CreateDirectory(draftFolder);
+        File.Create(Path.Combine(draftFolder, "draft.txt"));
+
+        var migration = TestApp.Services.GetRequiredService<EES5660_MigrateDraftDataSetVersionFolderNames>();
+
+        var exception = Assert.Throws<Exception>(migration.Apply);
+        
+        Assert.Equal("The following DataSetVersions have both a versioned " +
+                     "and a draft folder: " + dataSetVersion.Id, exception.Message);
+
+        // Assert that the versioned folder still exists.
+        Assert.True(Directory.Exists(versionedFolder));
+        Assert.True(File.Exists(Path.Combine(versionedFolder, "versioned.txt")));
+        
+        // Assert that the draft folder still exists.
+        Assert.True(Directory.Exists(draftFolder));
+        Assert.True(File.Exists(Path.Combine(draftFolder, "draft.txt")));
+    }
+        
+    [Theory]
+    [MemberData(nameof(PublicDataSetVersionStatusAndTypes))]
+    public async Task Success_PublicVersionsNotMigrated(Tuple<DataSetVersionStatus, DataSetVersionType> statusAndType)
+    {
+        var (status, type) = statusAndType;
+        
+        DataSetVersion dataSetVersion = DataFixture
+            .DefaultDataSetVersion()
+            .WithId(Guid.NewGuid())
+            .WithDataSet(DataFixture
+                .DefaultDataSet()
+                .WithId(Guid.NewGuid()))
+            .WithStatus(status)
+            .WithVersionNumber(
+                major: type == DataSetVersionType.Major ? 2 : 1,
+                minor: type == DataSetVersionType.Major ? 0 : 1);
+        
+        await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSetVersions.Add(dataSetVersion));
+
+        var pathResolver = TestApp.Services.GetRequiredService<IDataSetVersionPathResolver>();
+
+        var versionedFolder = pathResolver.DirectoryPath(dataSetVersion, dataSetVersion.SemVersion());
+        Directory.CreateDirectory(versionedFolder);
+        File.Create(Path.Combine(versionedFolder, "test.txt"));
+        
+        var migration = TestApp.Services.GetRequiredService<EES5660_MigrateDraftDataSetVersionFolderNames>();
+
+        migration.Apply();
+
+        // Assert that the original folder has been left unaffected.
+        Assert.True(Directory.Exists(versionedFolder));
+        Assert.True(File.Exists(Path.Combine(versionedFolder, "test.txt")));
+        
+        // Assert that no draft folder has been created.
+        dataSetVersion.Status = DataSetVersionStatus.Draft;
+        var draftFolder = pathResolver.DirectoryPath(dataSetVersion);
+        Assert.False(Directory.Exists(draftFolder));
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Migrations/EES5660_MigrateDraftDataSetVersionFolderNamesTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Migrations/EES5660_MigrateDraftDataSetVersionFolderNamesTests.cs
@@ -18,19 +18,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Migra
 public class EES5660_MigrateDraftDataSetVersionFolderNamesTests(TestApplicationFactory testApp) 
     : IntegrationTestFixture(testApp)
 {
-    public static readonly TheoryData<Tuple<DataSetVersionStatus, DataSetVersionType>>
+    public static readonly TheoryData<(DataSetVersionStatus, DataSetVersionType)>
         PrivateDataSetVersionStatusAndTypes = new(DataSetVersionAuthExtensions
             .PrivateStatuses
             .Cartesian(EnumUtil.GetEnums<DataSetVersionType>()));
     
-    public static readonly TheoryData<Tuple<DataSetVersionStatus, DataSetVersionType>>
+    public static readonly TheoryData<(DataSetVersionStatus, DataSetVersionType)>
         PublicDataSetVersionStatusAndTypes = new(DataSetVersionAuthExtensions
             .PublicStatuses
             .Cartesian(EnumUtil.GetEnums<DataSetVersionType>()));
     
     [Theory]
     [MemberData(nameof(PrivateDataSetVersionStatusAndTypes))]
-    public async Task Success_NonMigratedDraft(Tuple<DataSetVersionStatus, DataSetVersionType> statusAndType)
+    public async Task Success_NonMigratedDraft((DataSetVersionStatus, DataSetVersionType) statusAndType)
     {
         var (status, type) = statusAndType;
 
@@ -66,7 +66,7 @@ public class EES5660_MigrateDraftDataSetVersionFolderNamesTests(TestApplicationF
 
     [Theory]
     [MemberData(nameof(PrivateDataSetVersionStatusAndTypes))]
-    public async Task Success_AlreadyMigratedDraft(Tuple<DataSetVersionStatus, DataSetVersionType> statusAndType)
+    public async Task Success_AlreadyMigratedDraft((DataSetVersionStatus, DataSetVersionType) statusAndType)
     {
         var (status, type) = statusAndType;
         
@@ -133,7 +133,7 @@ public class EES5660_MigrateDraftDataSetVersionFolderNamesTests(TestApplicationF
         
     [Theory]
     [MemberData(nameof(PublicDataSetVersionStatusAndTypes))]
-    public async Task Success_PublicVersionsNotMigrated(Tuple<DataSetVersionStatus, DataSetVersionType> statusAndType)
+    public async Task Success_PublicVersionsNotMigrated((DataSetVersionStatus, DataSetVersionType) statusAndType)
     {
         var (status, type) = statusAndType;
         

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Migrations/EES5660_MigrateDraftDataSetVersionFolderNames.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Migrations/EES5660_MigrateDraftDataSetVersionFolderNames.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Migrations;
 
+// TODO EES-5660 - remove this migration after it has been run against each Public API-enabled environment.
 public class EES5660_MigrateDraftDataSetVersionFolderNames(
     PublicDataDbContext publicDataDbContext,
     IDataSetVersionPathResolver pathResolver) : ICustomMigration
@@ -18,7 +19,7 @@ public class EES5660_MigrateDraftDataSetVersionFolderNames(
             .WherePrivateStatus()
             .ToList();
 
-        var failureDataSetVersionIds = new List<Guid>();
+        var failedDataSetVersionIds = new List<Guid>();
         
         draftDataSetVersions.ForEach(dataSetVersion =>
         {
@@ -30,7 +31,7 @@ public class EES5660_MigrateDraftDataSetVersionFolderNames(
 
                 if (Directory.Exists(newDraftFolder))
                 {
-                    failureDataSetVersionIds.Add(dataSetVersion.Id);
+                    failedDataSetVersionIds.Add(dataSetVersion.Id);
                 }
                 else
                 {
@@ -39,10 +40,10 @@ public class EES5660_MigrateDraftDataSetVersionFolderNames(
             }
         });
 
-        if (failureDataSetVersionIds.Count > 0)
+        if (failedDataSetVersionIds.Count > 0)
         {
             throw new Exception($"The following DataSetVersions have both a versioned " +
-                                $"and a draft folder: {failureDataSetVersionIds.JoinToString(",")}");
+                                $"and a draft folder: {failedDataSetVersionIds.JoinToString(",")}");
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Migrations/EES5660_MigrateDraftDataSetVersionFolderNames.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Migrations/EES5660_MigrateDraftDataSetVersionFolderNames.cs
@@ -1,0 +1,48 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Migrations;
+
+public class EES5660_MigrateDraftDataSetVersionFolderNames(
+    PublicDataDbContext publicDataDbContext,
+    IDataSetVersionPathResolver pathResolver) : ICustomMigration
+{
+    public void Apply()
+    {
+        var draftDataSetVersions = publicDataDbContext
+            .DataSetVersions
+            .WherePrivateStatus()
+            .ToList();
+
+        var failureDataSetVersionIds = new List<Guid>();
+        
+        draftDataSetVersions.ForEach(dataSetVersion =>
+        {
+            var versionedFolder = pathResolver.DirectoryPath(dataSetVersion, dataSetVersion.SemVersion());
+            
+            if (Directory.Exists(versionedFolder))
+            {
+                var newDraftFolder = pathResolver.DirectoryPath(dataSetVersion);
+
+                if (Directory.Exists(newDraftFolder))
+                {
+                    failureDataSetVersionIds.Add(dataSetVersion.Id);
+                }
+                else
+                {
+                    Directory.Move(versionedFolder, newDraftFolder);
+                }
+            }
+        });
+
+        if (failureDataSetVersionIds.Count > 0)
+        {
+            throw new Exception($"The following DataSetVersions have both a versioned " +
+                                $"and a draft folder: {failureDataSetVersionIds.JoinToString(",")}");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -224,7 +224,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         services.AddScoped<IParquetTimePeriodRepository, ParquetTimePeriodRepository>();
 
         // TODO EES-5660 - remove this migration after it has been run against each Public API-enabled environment.
-        services.AddScoped<EES5660_MigrateDraftDataSetVersionFolderNames>();
+        services.AddScoped<ICustomMigration, EES5660_MigrateDraftDataSetVersionFolderNames>();
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -307,9 +307,6 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
 
         var migrations = serviceScope.ServiceProvider.GetServices<ICustomMigration>();
 
-        foreach (var migration in migrations)
-        {
-            migration.Apply();
-        }
+        migrations.ForEach(migration => migration.Apply());
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -223,6 +223,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         services.AddScoped<IParquetLocationRepository, ParquetLocationRepository>();
         services.AddScoped<IParquetTimePeriodRepository, ParquetTimePeriodRepository>();
 
+        // TODO EES-5660 - remove this migration after it has been run against each Public API-enabled environment.
         services.AddScoped<EES5660_MigrateDraftDataSetVersionFolderNames>();
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -230,7 +230,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
-        UpdateDatabase(app);
+        UpdateDatabase(app, env);
 
         if (_miniProfilerOptions.Enabled)
         {
@@ -285,7 +285,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         app.UseHealthChecks("/health");
     }
 
-    private static void UpdateDatabase(IApplicationBuilder app)
+    private static void UpdateDatabase(IApplicationBuilder app, IHostEnvironment env)
     {
         using var serviceScope = app.ApplicationServices
             .GetRequiredService<IServiceScopeFactory>()
@@ -296,7 +296,10 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         context.Database.SetCommandTimeout(300);
         context.Database.Migrate();
 
-        ApplyCustomMigrations(app);
+        if (!env.IsIntegrationTest())
+        {
+            ApplyCustomMigrations(app);
+        }
     }
 
     private static void ApplyCustomMigrations(IApplicationBuilder app)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetGeneratorExtensions.cs
@@ -13,6 +13,9 @@ public static class DataSetGeneratorExtensions
     public static Generator<DataSet> WithPublicationId(this Generator<DataSet> generator, Guid publicationId)
         => generator.ForInstance(s => s.SetPublicationId(publicationId));
 
+    public static Generator<DataSet> WithId(this Generator<DataSet> generator, Guid id)
+        => generator.ForInstance(s => s.SetId(id));
+
     public static Generator<DataSet> WithTitle(this Generator<DataSet> generator, string title)
         => generator.ForInstance(s => s.SetTitle(title));
 
@@ -39,7 +42,7 @@ public static class DataSetGeneratorExtensions
 
     public static Generator<DataSet> WithSupersedingDataSet(this Generator<DataSet> generator, DataSet? dataSet)
         => generator.ForInstance(s => s.SetSupersedingDataSet(dataSet));
-    
+
     public static Generator<DataSet> WithLatestDraftVersion(
         this Generator<DataSet> generator,
         DataSetVersion? dataSetVersion)
@@ -77,6 +80,11 @@ public static class DataSetGeneratorExtensions
             .SetDefault(ds => ds.Summary)
             .SetDefault(ds => ds.PublicationId)
             .Set(ds => ds.Status, DataSetStatus.Draft);
+
+    public static InstanceSetters<DataSet> SetId(
+        this InstanceSetters<DataSet> instanceSetter,
+        Guid id)
+        => instanceSetter.Set(ds => ds.Id, id);
 
     public static InstanceSetters<DataSet> SetTitle(
         this InstanceSetters<DataSet> instanceSetter,
@@ -162,7 +170,7 @@ public static class DataSetGeneratorExtensions
                     ds.LatestLiveVersionId = dsv?.Id;
                 }
             );
-    
+
     public static InstanceSetters<DataSet> SetLatestDraftVersion(
         this InstanceSetters<DataSet> instanceSetter,
         DataSetVersion? dataSetVersion)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
@@ -32,6 +32,11 @@ public static class DataSetVersionGeneratorExtensions
     public static Generator<DataSetVersion> WithDefaults(this Generator<DataSetVersion> generator)
         => generator.ForInstance(s => s.SetDefaults());
 
+    public static Generator<DataSetVersion> WithId(
+        this Generator<DataSetVersion> generator,
+        Guid id)
+        => generator.ForInstance(s => s.SetId(id));
+
     public static Generator<DataSetVersion> WithDataSet(
         this Generator<DataSetVersion> generator,
         DataSet dataSet)
@@ -211,6 +216,11 @@ public static class DataSetVersionGeneratorExtensions
             .Set(dsv => dsv.VersionPatch, 0)
             .Set(dsv => dsv.TotalResults, f => f.Random.Long(min: 10000, max: 10_000_000))
             .Set(dsv => dsv.Status, DataSetVersionStatus.Draft);
+
+    public static InstanceSetters<DataSetVersion> SetId(
+        this InstanceSetters<DataSetVersion> instanceSetter,
+        Guid id)
+        => instanceSetter.Set(dsv => dsv.Id, id);
 
     public static InstanceSetters<DataSetVersion> SetDataSet(
         this InstanceSetters<DataSetVersion> instanceSetter,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionStatus.cs
@@ -1,5 +1,4 @@
 using System.Text.Json.Serialization;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
@@ -16,20 +15,4 @@ public enum DataSetVersionStatus
     Deprecated,
     Withdrawn,
     Cancelled,
-}
-
-public class DataSetVersionStatusConstants
-{
-    public static readonly IReadOnlyList<DataSetVersionStatus> PublicStatuses = new List<DataSetVersionStatus>(
-        [
-            DataSetVersionStatus.Published,
-            DataSetVersionStatus.Withdrawn,
-            DataSetVersionStatus.Deprecated
-        ]
-    );
-    
-    public static readonly IReadOnlyList<DataSetVersionStatus> PrivateStatuses = EnumUtil
-        .GetEnums<DataSetVersionStatus>()
-        .Except(PublicStatuses)
-        .ToList();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionStatus.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
@@ -15,4 +16,20 @@ public enum DataSetVersionStatus
     Deprecated,
     Withdrawn,
     Cancelled,
+}
+
+public class DataSetVersionStatusConstants
+{
+    public static readonly IReadOnlyList<DataSetVersionStatus> PublicStatuses = new List<DataSetVersionStatus>(
+        [
+            DataSetVersionStatus.Published,
+            DataSetVersionStatus.Withdrawn,
+            DataSetVersionStatus.Deprecated
+        ]
+    );
+    
+    public static readonly IReadOnlyList<DataSetVersionStatus> PrivateStatuses = EnumUtil
+        .GetEnums<DataSetVersionStatus>()
+        .Except(PublicStatuses)
+        .ToList();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionAuthExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionAuthExtensions.cs
@@ -12,4 +12,13 @@ public static class DataSetVersionAuthExtensions
 
     private static Expression<Func<DataSetVersion, bool>> IsPublicStatus()
         => dataSetVersion => DataSetVersionStatusConstants.PublicStatuses.Contains(dataSetVersion.Status);
+
+    public static bool IsPrivateStatus(this DataSetVersion dataSetVersion)
+        => IsPrivateStatus().Compile()(dataSetVersion);
+
+    public static IQueryable<DataSetVersion> WherePrivateStatus(this IQueryable<DataSetVersion> queryable)
+        => queryable.Where(IsPrivateStatus());
+
+    private static Expression<Func<DataSetVersion, bool>> IsPrivateStatus()
+        => dataSetVersion => DataSetVersionStatusConstants.PrivateStatuses.Contains(dataSetVersion.Status);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionAuthExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionAuthExtensions.cs
@@ -4,14 +4,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extension
 
 public static class DataSetVersionAuthExtensions
 {
-    private static readonly IReadOnlyList<DataSetVersionStatus> PublicStatuses = new List<DataSetVersionStatus>(
-        [
-            DataSetVersionStatus.Published,
-            DataSetVersionStatus.Withdrawn,
-            DataSetVersionStatus.Deprecated
-        ]
-    );
-
     public static bool IsPublicStatus(this DataSetVersion dataSetVersion)
         => IsPublicStatus().Compile()(dataSetVersion);
 
@@ -19,5 +11,5 @@ public static class DataSetVersionAuthExtensions
         => queryable.Where(IsPublicStatus());
 
     private static Expression<Func<DataSetVersion, bool>> IsPublicStatus()
-        => dataSetVersion => PublicStatuses.Contains(dataSetVersion.Status);
+        => dataSetVersion => DataSetVersionStatusConstants.PublicStatuses.Contains(dataSetVersion.Status);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionAuthExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionAuthExtensions.cs
@@ -1,9 +1,23 @@
 using System.Linq.Expressions;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extensions;
 
 public static class DataSetVersionAuthExtensions
 {
+    public static readonly IReadOnlyList<DataSetVersionStatus> PublicStatuses = new List<DataSetVersionStatus>(
+        [
+            DataSetVersionStatus.Published,
+            DataSetVersionStatus.Withdrawn,
+            DataSetVersionStatus.Deprecated
+        ]
+    );
+
+    public static readonly IReadOnlyList<DataSetVersionStatus> PrivateStatuses = EnumUtil
+        .GetEnums<DataSetVersionStatus>()
+        .Except(PublicStatuses)
+        .ToList();
+
     public static bool IsPublicStatus(this DataSetVersion dataSetVersion)
         => IsPublicStatus().Compile()(dataSetVersion);
 
@@ -11,7 +25,7 @@ public static class DataSetVersionAuthExtensions
         => queryable.Where(IsPublicStatus());
 
     private static Expression<Func<DataSetVersion, bool>> IsPublicStatus()
-        => dataSetVersion => DataSetVersionStatusConstants.PublicStatuses.Contains(dataSetVersion.Status);
+        => dataSetVersion => PublicStatuses.Contains(dataSetVersion.Status);
 
     public static bool IsPrivateStatus(this DataSetVersion dataSetVersion)
         => IsPrivateStatus().Compile()(dataSetVersion);
@@ -20,5 +34,5 @@ public static class DataSetVersionAuthExtensions
         => queryable.Where(IsPrivateStatus());
 
     private static Expression<Func<DataSetVersion, bool>> IsPrivateStatus()
-        => dataSetVersion => DataSetVersionStatusConstants.PrivateStatuses.Contains(dataSetVersion.Status);
+        => dataSetVersion => PrivateStatuses.Contains(dataSetVersion.Status);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj
@@ -1,40 +1,44 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <RootNamespace>GovUk.Education.ExploreEducationStatistics.Public.Data.Model</RootNamespace>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>GovUk.Education.ExploreEducationStatistics.Public.Data.Model</RootNamespace>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    </PropertyGroup>
 
 
-  <ItemGroup>
-    <CompilerVisibleProperty Include="RootNamespace"/>
-    <CompilerVisibleProperty Include="ProjectDir"/>
-  </ItemGroup>
+    <ItemGroup>
+        <CompilerVisibleProperty Include="RootNamespace" />
+        <CompilerVisibleProperty Include="ProjectDir" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.2"/>
-    <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0"/>
-    <PackageReference Include="linq2db.EntityFrameworkCore" Version="8.1.0"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="MiniProfiler.Shared" Version="4.3.8"/>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4"/>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.2" />
+        <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0" />
+        <PackageReference Include="linq2db.EntityFrameworkCore" Version="8.1.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="MiniProfiler.Shared" Version="4.3.8" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj"/>
-  </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="Migrations\*.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+    <ItemGroup>
+        <Folder Include="Migrations\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Content Include="Migrations\*.sql">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
 
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj
@@ -1,44 +1,40 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <RootNamespace>GovUk.Education.ExploreEducationStatistics.Public.Data.Model</RootNamespace>
-        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>GovUk.Education.ExploreEducationStatistics.Public.Data.Model</RootNamespace>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
 
 
-    <ItemGroup>
-        <CompilerVisibleProperty Include="RootNamespace" />
-        <CompilerVisibleProperty Include="ProjectDir" />
-    </ItemGroup>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="RootNamespace"/>
+    <CompilerVisibleProperty Include="ProjectDir"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.2" />
-        <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0" />
-        <PackageReference Include="linq2db.EntityFrameworkCore" Version="8.1.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="MiniProfiler.Shared" Version="4.3.8" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.2"/>
+    <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0"/>
+    <PackageReference Include="linq2db.EntityFrameworkCore" Version="8.1.0"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="MiniProfiler.Shared" Version="4.3.8"/>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Folder Include="Migrations\" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Content Include="Migrations\*.sql">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
+  <ItemGroup>
+    <Content Include="Migrations\*.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessCompletionOfNextDataSetVersionFunctionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessCompletionOfNextDataSetVersionFunctionsTests.cs
@@ -2990,61 +2990,6 @@ public abstract class ProcessCompletionOfNextDataSetVersionFunctionsTests(
         }
     }
 
-    public class UpdateFileStoragePathTests(
-        ProcessorFunctionsIntegrationTestFixture fixture)
-        : ProcessCompletionOfNextDataSetVersionFunctionsTests(fixture)
-    {
-        private const DataSetVersionImportStage Stage = DataSetVersionImportStage.ManualMapping;
-
-        [Fact]
-        public async Task Success_PathUpdated()
-        {
-            var (_, nextDataSetVersion, instanceId) = await CreateDataSetInitialAndNextVersion(
-                nextVersionStatus: DataSetVersionStatus.Mapping,
-                nextVersionImportStage: Stage);
-
-            var dataSetVersionPathResolver = GetRequiredService<IDataSetVersionPathResolver>();
-            var originalStoragePath = dataSetVersionPathResolver.DirectoryPath(nextDataSetVersion);
-            Directory.CreateDirectory(originalStoragePath);
-
-            await using var publicDataDbContext = GetDbContext<PublicDataDbContext>();
-
-            nextDataSetVersion.VersionMajor++;
-
-            publicDataDbContext.DataSetVersions.Update(nextDataSetVersion);
-            await publicDataDbContext.SaveChangesAsync();
-
-            var newStoragePath = dataSetVersionPathResolver.DirectoryPath(nextDataSetVersion);
-
-            await UpdateFileStoragePath(instanceId);
-
-            Assert.False(Directory.Exists(originalStoragePath));
-            Assert.True(Directory.Exists(newStoragePath));
-        }
-
-        [Fact]
-        public async Task Success_PathNotUpdated()
-        {
-            var (_, nextDataSetVersion, instanceId) = await CreateDataSetInitialAndNextVersion(
-                nextVersionStatus: DataSetVersionStatus.Mapping,
-                nextVersionImportStage: Stage);
-
-            var dataSetVersionPathResolver = GetRequiredService<IDataSetVersionPathResolver>();
-            var originalStoragePath = dataSetVersionPathResolver.DirectoryPath(nextDataSetVersion);
-            Directory.CreateDirectory(originalStoragePath);
-
-            await UpdateFileStoragePath(instanceId);
-
-            Assert.True(Directory.Exists(originalStoragePath));
-        }
-
-        private async Task UpdateFileStoragePath(Guid instanceId)
-        {
-            var function = GetRequiredService<ProcessCompletionOfNextDataSetVersionFunctions>();
-            await function.UpdateFileStoragePath(instanceId, CancellationToken.None);
-        }
-    }
-
     public class CompleteNextDataSetVersionImportProcessingTests(
         ProcessorFunctionsIntegrationTestFixture fixture)
         : ProcessCompletionOfNextDataSetVersionFunctionsTests(fixture)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessCompletionOfNextDataSetVersionOrchestrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessCompletionOfNextDataSetVersionOrchestrationTests.cs
@@ -56,6 +56,11 @@ public abstract class ProcessCompletionOfNextDataSetVersionOrchestrationTests
 
             var activitySequence = new MockSequence();
 
+            var mockEntityFeature = new Mock<TaskOrchestrationEntityFeature>(MockBehavior.Strict);
+            mockEntityFeature.SetupLockForActivity(ActivityNames.ImportMetadata);
+            mockOrchestrationContext.SetupGet(context => context.Entities)
+                .Returns(mockEntityFeature.Object);
+                
             mockOrchestrationContext
                 .InSequence(activitySequence)
                 .Setup(context =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessCompletionOfNextDataSetVersionOrchestrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Functions/ProcessCompletionOfNextDataSetVersionOrchestrationTests.cs
@@ -27,7 +27,6 @@ public abstract class ProcessCompletionOfNextDataSetVersionOrchestrationTests
 
             string[] expectedActivitySequence =
             [
-                ActivityNames.UpdateFileStoragePath,
                 ActivityNames.ImportMetadata,
                 ActivityNames.CreateChanges,
                 ActivityNames.ImportData,
@@ -60,7 +59,7 @@ public abstract class ProcessCompletionOfNextDataSetVersionOrchestrationTests
             mockOrchestrationContext
                 .InSequence(activitySequence)
                 .Setup(context =>
-                    context.CallActivityAsync(ActivityNames.UpdateFileStoragePath,
+                    context.CallActivityAsync(ActivityNames.ImportMetadata,
                         mockOrchestrationContext.Object.InstanceId,
                         null))
                 .Throws<Exception>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ActivityNames.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ActivityNames.cs
@@ -18,8 +18,6 @@ internal static class ActivityNames
 
     public const string CreateChanges =
         nameof(ProcessCompletionOfNextDataSetVersionFunctions.CreateChanges);
-    public const string UpdateFileStoragePath =
-        nameof(ProcessCompletionOfNextDataSetVersionFunctions.UpdateFileStoragePath);
     public const string CompleteNextDataSetVersionImportProcessing =
         nameof(ProcessCompletionOfNextDataSetVersionFunctions.CompleteNextDataSetVersionImportProcessing);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessCompletionOfNextDataSetVersionFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessCompletionOfNextDataSetVersionFunctions.cs
@@ -24,33 +24,6 @@ public class ProcessCompletionOfNextDataSetVersionFunctions(
         await dataSetVersionChangeService.CreateChanges(dataSetVersionImport.DataSetVersionId, cancellationToken);
     }
 
-    [Function(ActivityNames.UpdateFileStoragePath)]
-    public async Task UpdateFileStoragePath(
-        [ActivityTrigger] Guid instanceId,
-        CancellationToken cancellationToken)
-    {
-        var dataSetVersionImport = await GetDataSetVersionImport(instanceId, cancellationToken);
-
-        var dataSetVersion = dataSetVersionImport.DataSetVersion;
-
-        var currentLiveVersion = await publicDataDbContext
-            .DataSets
-            .Where(dataSet => dataSet.Id == dataSetVersion.DataSetId)
-            .Select(dataSet => dataSet.LatestLiveVersion!)
-            .SingleAsync(cancellationToken);
-
-        var originalPath = dataSetVersionPathResolver.DirectoryPath(
-            dataSetVersion: dataSetVersion,
-            versionNumber: currentLiveVersion.DefaultNextVersion());
-
-        var newPath = dataSetVersionPathResolver.DirectoryPath(dataSetVersion);
-
-        if (originalPath != newPath)
-        {
-            Directory.Move(sourceDirName: originalPath, destDirName: newPath);
-        }
-    }
-
     [Function(ActivityNames.CompleteNextDataSetVersionImportProcessing)]
     public async Task CompleteNextDataSetVersionImportProcessing(
         [ActivityTrigger] Guid instanceId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessCompletionOfNextDataSetVersionOrchestration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessCompletionOfNextDataSetVersionOrchestration.cs
@@ -23,7 +23,6 @@ public static class ProcessCompletionOfNextDataSetVersionOrchestration
 
         try
         {
-            await context.CallActivity(ActivityNames.UpdateFileStoragePath, logger, context.InstanceId);
             await context.CallActivityExclusively(ActivityNames.ImportMetadata, logger, context.InstanceId);
             await context.CallActivity(ActivityNames.CreateChanges, logger, context.InstanceId);
             await context.CallActivity(ActivityNames.ImportData, logger, context.InstanceId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/DataSetVersionPathResolverTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/DataSetVersionPathResolverTests.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Parquet.Tables;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
@@ -48,10 +49,10 @@ public abstract class DataSetVersionPathResolverTests
         public static readonly TheoryData<string> GetEnvironmentNames = new(EnvironmentNames);
         
         public static readonly TheoryData<Tuple<string, DataSetVersionStatus>> GetEnvironmentNamesAndPublicStatuses = 
-            new(EnvironmentNames.Cartesian(DataSetVersionStatusConstants.PublicStatuses));
+            new(EnvironmentNames.Cartesian(DataSetVersionAuthExtensions.PublicStatuses));
 
         public static readonly TheoryData<Tuple<string, DataSetVersionStatus>> GetEnvironmentNamesAndPrivateStatuses = 
-            new(EnvironmentNames.Cartesian(DataSetVersionStatusConstants.PrivateStatuses));
+            new(EnvironmentNames.Cartesian(DataSetVersionAuthExtensions.PrivateStatuses));
 
         [Fact]
         public void DevelopmentEnv_ValidBasePath()
@@ -178,6 +179,8 @@ public abstract class DataSetVersionPathResolverTests
                 resolver.DirectoryPath(version));
         }
 
+        // TODO EES-5660 - remove once draft DataSetVersions have had their folders migrated
+        // on each Public API-enabled environment.
         [Theory]
         [MemberData(nameof(GetEnvironmentNames))]
         public void ValidDirectoryPath_VersionArgument(string environmentName)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/DataSetVersionPathResolverTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/DataSetVersionPathResolverTests.cs
@@ -48,10 +48,10 @@ public abstract class DataSetVersionPathResolverTests
         
         public static readonly TheoryData<string> GetEnvironmentNames = new(EnvironmentNames);
         
-        public static readonly TheoryData<Tuple<string, DataSetVersionStatus>> GetEnvironmentNamesAndPublicStatuses = 
+        public static readonly TheoryData<(string, DataSetVersionStatus)> GetEnvironmentNamesAndPublicStatuses = 
             new(EnvironmentNames.Cartesian(DataSetVersionAuthExtensions.PublicStatuses));
 
-        public static readonly TheoryData<Tuple<string, DataSetVersionStatus>> GetEnvironmentNamesAndPrivateStatuses = 
+        public static readonly TheoryData<(string, DataSetVersionStatus)> GetEnvironmentNamesAndPrivateStatuses = 
             new(EnvironmentNames.Cartesian(DataSetVersionAuthExtensions.PrivateStatuses));
 
         [Fact]
@@ -125,7 +125,7 @@ public abstract class DataSetVersionPathResolverTests
 
         [Theory]
         [MemberData(nameof(GetEnvironmentNamesAndPublicStatuses))]
-        public void ValidDirectoryPath_PublicVersion(Tuple<string, DataSetVersionStatus> environmentNameAndStatus)
+        public void ValidDirectoryPath_PublicVersion((string, DataSetVersionStatus) environmentNameAndStatus)
         {
             var (environmentName, status) = environmentNameAndStatus;
             
@@ -153,7 +153,7 @@ public abstract class DataSetVersionPathResolverTests
 
         [Theory]
         [MemberData(nameof(GetEnvironmentNamesAndPrivateStatuses))]
-        public void ValidDirectoryPath_PrivateVersion(Tuple<string, DataSetVersionStatus> environmentNameAndStatus)
+        public void ValidDirectoryPath_PrivateVersion((string, DataSetVersionStatus) environmentNameAndStatus)
         {
             var (environmentName, status) = environmentNameAndStatus;
             

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/TestDataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/TestDataSetVersionPathResolver.cs
@@ -18,7 +18,12 @@ public class TestDataSetVersionPathResolver : IDataSetVersionPathResolver
 
     public string Directory { get; set; } = string.Empty;
 
-    public string DirectoryPath(DataSetVersion dataSetVersion, SemVersion? versionNumber = null)
+    public string DirectoryPath(DataSetVersion dataSetVersion)
+    {
+        return Path.Combine(_basePath, Directory);
+    }
+
+    public string DirectoryPath(DataSetVersion dataSetVersion, SemVersion versionNumber)
     {
         return Path.Combine(_basePath, Directory);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
@@ -1,6 +1,7 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Options;
 using Microsoft.AspNetCore.Hosting;
@@ -12,6 +13,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Services;
 
 public class DataSetVersionPathResolver : IDataSetVersionPathResolver
 {
+    private const string DraftVersionFolderName = "draft";
+    
     private readonly IOptions<DataFilesOptions> _options;
     private readonly IWebHostEnvironment _environment;
     private readonly string _basePath;
@@ -34,12 +37,24 @@ public class DataSetVersionPathResolver : IDataSetVersionPathResolver
 
     public string BasePath() => _basePath;
 
-    public string DirectoryPath(DataSetVersion dataSetVersion, SemVersion? versionNumber = null)
+    public string DirectoryPath(DataSetVersion dataSetVersion)
+    {
+        var folderName = !dataSetVersion.IsPublicStatus() 
+            ? DraftVersionFolderName
+            : $"v{dataSetVersion.SemVersion()}";
+        
+        return Path.Combine(
+            ((IDataSetVersionPathResolver) this).DataSetsPath(),
+            dataSetVersion.DataSetId.ToString(),
+            folderName);
+    }
+    
+    public string DirectoryPath(DataSetVersion dataSetVersion, SemVersion versionNumber)
     {
         return Path.Combine(
             ((IDataSetVersionPathResolver) this).DataSetsPath(),
             dataSetVersion.DataSetId.ToString(),
-            $"v{versionNumber ?? dataSetVersion.SemVersion()}");
+            $"v{versionNumber}");
     }
 
     private string GetBasePath()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/DataSetVersionPathResolver.cs
@@ -39,7 +39,7 @@ public class DataSetVersionPathResolver : IDataSetVersionPathResolver
 
     public string DirectoryPath(DataSetVersion dataSetVersion)
     {
-        var folderName = !dataSetVersion.IsPublicStatus() 
+        var folderName = dataSetVersion.IsPrivateStatus() 
             ? DraftVersionFolderName
             : $"v{dataSetVersion.SemVersion()}";
         

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/Interfaces/IDataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/Interfaces/IDataSetVersionPathResolver.cs
@@ -10,7 +10,9 @@ public interface IDataSetVersionPathResolver
 
     string DataSetsPath() => Path.Combine(BasePath(), DataSetFilenames.DataSetsDirectory);
 
-    string DirectoryPath(DataSetVersion dataSetVersion, SemVersion? versionNumber = null);
+    string DirectoryPath(DataSetVersion dataSetVersion);
+    
+    string DirectoryPath(DataSetVersion dataSetVersion, SemVersion versionNumber);
 
     string CsvDataPath(DataSetVersion dataSetVersion)
         => Path.Combine(DirectoryPath(dataSetVersion), DataSetFilenames.CsvDataFile);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/Interfaces/IDataSetVersionPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services/Interfaces/IDataSetVersionPathResolver.cs
@@ -11,7 +11,9 @@ public interface IDataSetVersionPathResolver
     string DataSetsPath() => Path.Combine(BasePath(), DataSetFilenames.DataSetsDirectory);
 
     string DirectoryPath(DataSetVersion dataSetVersion);
-    
+
+    // TODO EES-5660 - remove after draft DataSetVersion folders are migrated for each
+    // Public API-enabled environment.
     string DirectoryPath(DataSetVersion dataSetVersion, SemVersion versionNumber);
 
     string CsvDataPath(DataSetVersion dataSetVersion)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/appsettings.IntegrationTest.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/appsettings.IntegrationTest.json
@@ -5,5 +5,8 @@
     "NotifierStorageConnectionString": "this-will-be-overridden-at-startup",
     "PublisherStorageConnectionString": "this-will-be-overridden-at-startup"
   },
+  "DataFiles": {
+    "BasePath": "Resources/DataFiles"
+  },
   "PublicDataDbExists": true
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Services\GovUk.Education.ExploreEducationStatistics.Data.Services.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Notifier.Model\GovUk.Education.ExploreEducationStatistics.Notifier.Model.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Public.Data.Model\GovUk.Education.ExploreEducationStatistics.Public.Data.Model.csproj" />
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Public.Data.Services\GovUk.Education.ExploreEducationStatistics.Public.Data.Services.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Publisher.Model\GovUk.Education.ExploreEducationStatistics.Publisher.Model.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
@@ -21,6 +21,9 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Options;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Options;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
@@ -132,6 +135,9 @@ public static class PublisherHostBuilderExtensions
                 // TODO EES-5073 Remove this check when the Public Data db is available in all Azure environments.
                 if (publicDataDbExists)
                 {
+                    services.AddOptions<DataFilesOptions>()
+                        .Bind(configuration.GetRequiredSection(DataFilesOptions.Section));
+                    services.AddScoped<IDataSetVersionPathResolver, DataSetVersionPathResolver>();
                     services.AddScoped<IDataSetPublishingService, DataSetPublishingService>();
                 }
                 else

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/appsettings.json
@@ -12,5 +12,8 @@
     "PublicStorageConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;TableEndpoint=http://data-storage:10002/devstoreaccount1;",
     "PublisherStorageConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;QueueEndpoint=http://data-storage:10001/devstoreaccount1;TableEndpoint=http://data-storage:10002/devstoreaccount1;"
   },
+  "DataFiles": {
+    "BasePath": "data/public-api-data"
+  },
   "PublicDataDbExists": false
 }


### PR DESCRIPTION
# UI test results

![image](https://github.com/user-attachments/assets/f435539e-60f9-4f1b-88d3-a50b1e10e733)

# Overview

This PR:
- fixes a bug around draft DataSetVersions whereby a draft (unpublished) DataSetVersion that was being deleted left its fileshare folder behind if its version changed to a major version, due to the delete code not expecting to look for a folder with a minor version name.

This is the second implementation to fix this issue, the first being an attempt whereby the delete code would attempt to look for both a minor AND major version-named folder and delete either if they exist, which felt untidy.

More importantly, it introduced complexity to an area of the codebase that has already generated 2 bugs, and the crux of the issue seemed to be that it was difficult to rely on a folder name that is version-based during a time where a DataSetVersion's version can fluctuate between minor and major at any time.

# The implementation

## High-level design

To overcome this, the idea here was to move away from a version-based name entirely for a draft DataSetVersion's folder, and instead have a single folder named "draft" which will contain the working files for the current draft version of a DataSet.  This "draft" folder would remain up until the version is finalised and can no longer be changed.  In this case, it is when the DataSetVersion is published.

The lifecycle of a DataSetVersion and its folder would be:

1. A new DataSet is created from Admin.
2. The Data Processor is called to create a brand new DataSet, and its very first `v1.0` DataSetVersion.
3. The `v1.0` draft DataSetVersion is imported in its entirety.  The files go into a `draft` folder within the DataSet's fileshare folder.
4. When the Release that the DataSetVersion's linked Subject belongs to is published, the Publisher renames the `draft` folder to `v1.0.0`.
5. A new Release is created with a new Subject, which is then chosen to be the next version of the DataSet.
6. The Data Processor is called to partially import the next DataSetVersion, prior to carrying out mapping.  The files go into a newly created `draft` folder again.
7. During mapping, the DataSetVersion's version can fluctuate between `v1.1` and `v2.0` depending on the mapping choices, but the fileshare folder will remain the same - `draft`.
8. When the new Release is published, the Publisher renames the `draft` folder to the appropriate value that is based upon the final version of the new DataSetVersion, to either `v1.1.0` or `v2.0.0`.
 
## Implementation details

To facilitate the above flow, the following changes have been put in place:

1. The `DataSetVersionPathResolver` code has been updated to resolve to the `draft` folder path if the DataSetVersion in question is in one of the private statuses (the non-public ones), or the standard version-based folder path if the DataSetVersion is public.
2. For a subsequent DataSetVersion import, the need to update the folder name after completing the DataSetVersion mapping activities is no longer necessary, so that code has been removed. 
3.  In order to allow the Publisher to carry out the folder rename during its publishing of DataSetVersions, the Publisher project now has access to the `Public.Data.Services` project that holds the `DataSetVersionPathResolver`.
4. Additionally, the Publisher is also provided the `PublicData:BasePath` configuration from the ARM template.
5. Additionally, the Public API fileshare is also mounted into the Publisher Function App in the ARM template.  This is conditional on the Public API existing in the target environment during deploy.
6. A migration is supplied that will run on the Public API startup, that finds all draft DataSetVersions and renames their current version-based folder names to the new `draft` folder name.

### Miscellaneous changes

1. `ICustomMigration` has been moved to Common, to allow the `Public.Data.Api` project to leverage it as well as Admin.
2. Custom migration support is now added to the `Public.Data.Api` startup, and both this and the Admin's custom migration code will now look up any ICustomMigration implementations that are registered in DI and run them on startup.
3. A number of areas of the code are now annotated with `// TODO EES-5660` to highlight areas of the code that can be removed once this code has been deployed once to each environment that currently has the Public API enabled.