### PR TITLE
EES-5672 5673 fix ui tests

### DIFF
--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -214,6 +214,7 @@ Add content blocks to Test section one
     user adds content to autosaving accordion section text block    Test section one    1    block one test text
     ...    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
 
+    user scrolls up    100
     user adds text block to editable accordion section    Test section one    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
     user adds content to autosaving accordion section text block    Test section one    2    block two test text
     ...    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
@@ -237,6 +238,7 @@ Validate two remaining content blocks
     ...    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
 
 Verify that validation prevents adding an image without alt text
+    user scrolls up    100
     user adds image without alt text to accordion section text block    Test section one    1
     ...    test-infographic.png    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
 

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -467,7 +467,6 @@ user adds image to accordion section text block with retry
     ...    xpath://button[span[.="Upload image from computer"]]/input[@type="file"]
     ...    ${FILES_DIR}${filename}
 
-    user scrolls up    300
     wait until keyword succeeds    ${timeout}    %{WAIT_SMALL} sec    user clicks button
     ...    Change image text alternative
     user enters text into element    label:Text alternative    ${alt_text}


### PR DESCRIPTION
Fixes UI test failures in `release_content.robot` and `create_methodology_amendment.robot` by tweaking the scrolling to make sure the elements are clickable. As noted on https://dfedigital.atlassian.net/browse/EES-5383 we should try to find a more robust solution to the flakiness of tests involving content accordions at some point.