### PR TITLE
EES-5558 - got "Data and files" link to close modal and navigate to t…

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateModal.tsx
@@ -14,7 +14,7 @@ import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import { useQuery } from '@tanstack/react-query';
 import React, { ReactNode } from 'react';
-import { generatePath, useHistory } from 'react-router-dom';
+import { generatePath } from 'react-router-dom';
 import releaseDataPageTabIds from '@admin/pages/release/data/utils/releaseDataPageTabIds';
 
 interface Props {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateModal.tsx
@@ -14,7 +14,8 @@ import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import { useQuery } from '@tanstack/react-query';
 import React, { ReactNode } from 'react';
-import { generatePath } from 'react-router-dom';
+import { generatePath, useHistory } from 'react-router-dom';
+import releaseDataPageTabIds from '@admin/pages/release/data/utils/releaseDataPageTabIds';
 
 interface Props {
   buttonText?: ReactNode | string;
@@ -65,10 +66,11 @@ export default function ApiDataSetCreateModal({
               No API data sets can be created as there are no candidate data
               files available. New candidate data files can be uploaded in the{' '}
               <Link
-                to={generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
+                to={`${generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
                   publicationId,
                   releaseId,
-                })}
+                })}#${releaseDataPageTabIds.dataUploads}`}
+                onClick={toggleOpen.off}
               >
                 Data and files
               </Link>{' '}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateModal.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateModal.test.tsx
@@ -4,7 +4,7 @@ import _apiDataSetCandidateService, {
 } from '@admin/services/apiDataSetCandidateService';
 import _apiDataSetService from '@admin/services/apiDataSetService';
 import baseRender from '@common-test/render';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import { createMemoryHistory, History } from 'history';
 import noop from 'lodash/noop';
 import { ReactElement } from 'react';
@@ -29,8 +29,6 @@ describe('ApiDataSetCreateModal', () => {
   ];
 
   test('renders warning message in modal when no candidates', async () => {
-    const history = createMemoryHistory();
-
     apiDataSetCandidateService.listCandidates.mockResolvedValue([]);
 
     const { user } = render(
@@ -39,7 +37,6 @@ describe('ApiDataSetCreateModal', () => {
         releaseId="release-id"
         onSubmit={noop}
       />,
-      { history },
     );
 
     expect(await screen.findByText('Create API data set')).toBeInTheDocument();
@@ -50,26 +47,22 @@ describe('ApiDataSetCreateModal', () => {
 
     expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
 
+    const modal = within(screen.getByRole('dialog'));
+
     expect(
-      screen.getByText(
+      modal.getByText(
         /No API data sets can be created as there are no candidate data files available/,
       ),
     ).toBeInTheDocument();
 
-    expect(
-      await screen.findByRole('link', { name: 'Data and files' }),
-    ).toBeInTheDocument();
+    expect(modal.getByRole('link', { name: 'Data and files' })).toHaveAttribute(
+      'href',
+      '/publication/publication-id/release/release-id/data#data-uploads',
+    );
 
     await user.click(screen.getByRole('link', { name: 'Data and files' }));
 
-    expect(
-      screen.queryByRole('link', { name: 'Data and files' }),
-    ).not.toBeInTheDocument();
-
-    expect(history.location.pathname).toEqual(
-      '/publication/publication-id/release/release-id/data',
-    );
-    expect(history.location.hash).toEqual('#data-uploads');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   test('renders form in modal when there are candidates', async () => {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateModal.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateModal.test.tsx
@@ -29,6 +29,8 @@ describe('ApiDataSetCreateModal', () => {
   ];
 
   test('renders warning message in modal when no candidates', async () => {
+    const history = createMemoryHistory();
+
     apiDataSetCandidateService.listCandidates.mockResolvedValue([]);
 
     const { user } = render(
@@ -37,19 +39,37 @@ describe('ApiDataSetCreateModal', () => {
         releaseId="release-id"
         onSubmit={noop}
       />,
+      { history },
     );
+
+    expect(await screen.findByText('Create API data set')).toBeInTheDocument();
 
     await user.click(
       await screen.findByRole('button', { name: 'Create API data set' }),
     );
 
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+
     expect(
-      await screen.findByText(
+      screen.getByText(
         /No API data sets can be created as there are no candidate data files available/,
       ),
     ).toBeInTheDocument();
 
-    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('link', { name: 'Data and files' }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('link', { name: 'Data and files' }));
+
+    expect(
+      screen.queryByRole('link', { name: 'Data and files' }),
+    ).not.toBeInTheDocument();
+
+    expect(history.location.pathname).toEqual(
+      '/publication/publication-id/release/release-id/data',
+    );
+    expect(history.location.hash).toEqual('#data-uploads');
   });
 
   test('renders form in modal when there are candidates', async () => {
@@ -98,7 +118,6 @@ describe('ApiDataSetCreateModal', () => {
       previousReleaseIds: [],
     });
 
-    const history = createMemoryHistory();
     const handleSubmit = jest.fn();
 
     const { user } = render(
@@ -107,7 +126,6 @@ describe('ApiDataSetCreateModal', () => {
         releaseId="release-id"
         onSubmit={handleSubmit}
       />,
-      { history },
     );
 
     expect(await screen.findByText('Create API data set')).toBeInTheDocument();


### PR DESCRIPTION
This PR:
- Corrects the link location for the "Data and files" link in the "Create a data set" modal by adding the "Data uploads" tab hash to the target URL.
- Closes the modal upon click.