### PR TITLE
EES-5564 - added error handling when fetching data set details or changelog results

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetChangelogPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetChangelogPage.tsx
@@ -29,14 +29,11 @@ export default function ReleaseApiDataSetChangelogPage() {
     data: dataSet,
     isLoading: isLoadingDataSet,
     refetch: refetchDataSet,
-    isError: errorFetchingDataSet,
   } = useQuery(apiDataSetQueries.get(dataSetId));
 
-  const {
-    data: changes,
-    isLoading: isLoadingChanges,
-    isError: errorFetchingChanges,
-  } = useQuery(apiDataSetVersionQueries.getChanges(dataSetVersionId));
+  const { data: changes, isLoading: isLoadingChanges } = useQuery(
+    apiDataSetVersionQueries.getChanges(dataSetVersionId),
+  );
 
   const isDraft = dataSet?.draftVersion?.id === dataSetVersionId;
 
@@ -80,26 +77,26 @@ export default function ReleaseApiDataSetChangelogPage() {
       </Link>
 
       <LoadingSpinner loading={isLoadingDataSet || isLoadingChanges}>
-        {!errorFetchingDataSet && !errorFetchingChanges ? (
+        {dataSet && dataSetVersion ? (
           <>
             <div className="govuk-grid-row">
               <div className="govuk-grid-column-three-quarters">
                 <span className="govuk-caption-l">API data set changelog</span>
-                <h2>{dataSet?.title}</h2>
+                <h2>{dataSet.title}</h2>
               </div>
             </div>
             <TagGroup className="govuk-!-margin-bottom-7">
               <Tag colour={isDraft ? 'green' : 'blue'}>{`${
                 isDraft ? 'Draft' : 'Published'
-              } v${dataSetVersion?.version}`}</Tag>
+              } v${dataSetVersion.version}`}</Tag>
               <Tag
                 colour={dataSetVersion?.type === 'Major' ? 'blue' : 'grey'}
-              >{`${dataSetVersion?.type} update`}</Tag>
+              >{`${dataSetVersion.type} update`}</Tag>
             </TagGroup>
 
             {isDraft && showForm ? (
               <ApiDataSetGuidanceNotesForm
-                notes={dataSetVersion?.notes}
+                notes={dataSetVersion.notes}
                 onSubmit={handleUpdateNotes}
               />
             ) : (
@@ -117,16 +114,18 @@ export default function ReleaseApiDataSetChangelogPage() {
               </>
             )}
 
-            {changes && dataSetVersion && (
+            {changes ? (
               <ApiDataSetChangelog
                 majorChanges={changes.majorChanges}
                 minorChanges={changes.minorChanges}
-                version={dataSetVersion.version}
+                version={dataSetVersion?.version ?? 'unknown'}
               />
+            ) : (
+              <WarningMessage>Could not load changelog</WarningMessage>
             )}
           </>
         ) : (
-          <WarningMessage>Could not load changelog</WarningMessage>
+          <WarningMessage>Could not load API data set</WarningMessage>
         )}
       </LoadingSpinner>
     </>

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetChangelogPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetChangelogPage.test.tsx
@@ -205,7 +205,7 @@ describe('ReleaseApiDataSetChangelogPage', () => {
     expect(screen.queryByText('Data set title')).not.toBeInTheDocument();
 
     expect(
-      await screen.findByText('Could not load changelog'),
+      await screen.findByText('Could not load API data set'),
     ).toBeInTheDocument();
   });
 
@@ -217,11 +217,9 @@ describe('ReleaseApiDataSetChangelogPage', () => {
 
     renderPage('draft-version-id');
 
-    expect(screen.queryByText('Data set title')).not.toBeInTheDocument();
+    expect(await screen.findByText('Data set title')).toBeInTheDocument();
 
-    expect(
-      await screen.findByText('Could not load changelog'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Could not load changelog')).toBeInTheDocument();
   });
 
   function renderPage(dataSetVersionId: string) {

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetChangelogPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetChangelogPage.test.tsx
@@ -194,6 +194,36 @@ describe('ReleaseApiDataSetChangelogPage', () => {
     });
   });
 
+  test('renders warning if unable to fetch data set', async () => {
+    apiDataSetService.getDataSet.mockRejectedValue(
+      new Error('Unable to fetch changes'),
+    );
+    apiDataSetVersionService.getChanges.mockResolvedValue(testChanges);
+
+    renderPage('draft-version-id');
+
+    expect(screen.queryByText('Data set title')).not.toBeInTheDocument();
+
+    expect(
+      await screen.findByText('Could not load changelog'),
+    ).toBeInTheDocument();
+  });
+
+  test('renders warning if unable to fetch changes', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue(testDataSet);
+    apiDataSetVersionService.getChanges.mockRejectedValue(
+      new Error('Unable to fetch changes'),
+    );
+
+    renderPage('draft-version-id');
+
+    expect(screen.queryByText('Data set title')).not.toBeInTheDocument();
+
+    expect(
+      await screen.findByText('Could not load changelog'),
+    ).toBeInTheDocument();
+  });
+
   function renderPage(dataSetVersionId: string) {
     return render(
       <TestConfigContextProvider>


### PR DESCRIPTION
This PR:
- adds error handling to Admin's data set changelog page.  Rather than failing to fetch the changelog results from the Public API and silently failing without showing any changes, instead we now show an warning message saying "Could not load changelog".  This is in keeping with the wording of other failure messages around the site e.g. `Could not load methodology`.

![image](https://github.com/user-attachments/assets/0eb47d05-604c-46ed-9332-d68009623280)
