### PR TITLE
🐛 EES-5625 Exclude soft deleted release versions in releases migration query

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241122105739_EES5625_CopyReleaseVersionFieldsToRelease.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241122105739_EES5625_CopyReleaseVersionFieldsToRelease.sql
@@ -11,7 +11,8 @@ FROM Releases
          INNER JOIN
      (SELECT RV2.ReleaseId, MAX(RV2.Version) AS Version
       FROM ReleaseVersions RV2
-      WHERE RV2.Published IS NOT NULL
-         OR (RV2.Published IS NULL AND RV2.Version = 0)
+      WHERE RV2.SoftDeleted = 0
+         AND (RV2.Published IS NOT NULL OR (RV2.Published IS NULL AND RV2.Version = 0))
       GROUP BY ReleaseId) LatestVersion
      ON ReleaseVersions.ReleaseId = LatestVersion.ReleaseId AND ReleaseVersions.Version = LatestVersion.Version
+WHERE ReleaseVersions.SoftDeleted = 0


### PR DESCRIPTION
This PR fixes a bug in the releases migration query added as part of #5409. It excludes soft deleted release versions from being evaluated.

Prior to this change, there can be duplicate releases in the query due to each release potentially being matched on a soft deleted release version and a non-soft deleted release version, both with the same version number.