### PR TITLE
EES-5691 Create new Files.DataSetFileMeta column

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataSetFileMetaMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataSetFileMetaMigrationController.cs
@@ -1,0 +1,94 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
+
+[Route("api")]
+[ApiController]
+[Authorize(Roles = GlobalRoles.RoleNames.BauUser)]
+public class DataSetFileMetaMigrationController(ContentDbContext contentDbContext) : ControllerBase
+{
+    public class DataSetFileMetaMigrationResult
+    {
+        public bool IsDryRun;
+        public int Processed;
+    }
+
+    [HttpPut("bau/migrate-datasetfilemeta")]
+    public async Task<DataSetFileMetaMigrationResult> MigrationDataSetFileMeta(
+        [FromQuery] bool dryRun = true,
+        [FromQuery] int? num = null,
+        CancellationToken cancellationToken = default)
+    {
+        var queryable = contentDbContext.Files
+            .Where(f => f.DataSetFileMeta == null
+                && f.DataSetFileMetaOld != null);
+
+        if (num != null)
+        {
+            queryable = queryable.Take(num.Value);
+        }
+
+        var files = queryable.ToList();
+
+        var numProcessed = 0;
+
+        foreach (var file in files)
+        {
+            var oldMeta = file.DataSetFileMetaOld;
+            file.DataSetFileMeta = new DataSetFileMeta
+            {
+                GeographicLevels = oldMeta!.GeographicLevels
+                    .Select(gl => new GeographicLevelMeta { Code = gl, })
+                    .ToList(),
+                TimePeriodRange = new TimePeriodRangeMeta
+                {
+                    Start = new TimePeriodRangeBoundMeta
+                    {
+                        Period = oldMeta.TimePeriodRange.Start.Period,
+                        TimeIdentifier = oldMeta.TimePeriodRange.Start.TimeIdentifier,
+                    },
+                    End = new TimePeriodRangeBoundMeta
+                    {
+                        Period = oldMeta.TimePeriodRange.End.Period,
+                        TimeIdentifier = oldMeta.TimePeriodRange.End.TimeIdentifier,
+                    },
+                },
+                Filters = oldMeta.Filters
+                    .Select(filter => new FilterMeta
+                    {
+                        FilterId = filter.Id,
+                        Label = filter.Label,
+                        ColumnName = filter.ColumnName,
+                        Hint = filter.Hint,
+                    }).ToList(),
+                Indicators = oldMeta.Indicators
+                    .Select(i => new IndicatorMeta
+                    {
+                        IndicatorId = i.Id,
+                        Label = i.Label,
+                        ColumnName = i.ColumnName,
+                    }).ToList(),
+            };
+            numProcessed++;
+        }
+
+        if (!dryRun)
+        {
+            await contentDbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return new DataSetFileMetaMigrationResult
+        {
+            IsDryRun = dryRun,
+            Processed = numProcessed,
+        };
+    }
+
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241126104047_EES5666_RenameFilesColumnToDataSetFileMetaOld.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241126104047_EES5666_RenameFilesColumnToDataSetFileMetaOld.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241126104047_EES5666_RenameFilesColumnToDataSetFileMetaOld")]
+    partial class EES5666_RenameFilesColumnToDataSetFileMetaOld
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241126104047_EES5666_RenameFilesColumnToDataSetFileMetaOld.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241126104047_EES5666_RenameFilesColumnToDataSetFileMetaOld.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES5666_RenameFilesColumnToDataSetFileMetaOld : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "DataSetFileMeta",
+                table: "Files",
+                newName: "DataSetFileMetaOld");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "DataSetFileMetaOld",
+                table: "Files",
+                newName: "DataSetFileMeta");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241126112007_EES5666_CreateNewFilesColumnToDataSetFileMeta.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241126112007_EES5666_CreateNewFilesColumnToDataSetFileMeta.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241126112007_EES5666_CreateNewFilesColumnToDataSetFileMeta")]
+    partial class EES5666_CreateNewFilesColumnToDataSetFileMeta
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241126112007_EES5666_CreateNewFilesColumnToDataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241126112007_EES5666_CreateNewFilesColumnToDataSetFileMeta.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES5666_CreateNewFilesColumnToDataSetFileMeta : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DataSetFileMeta",
+                table: "Files",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DataSetFileMeta",
+                table: "Files");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/DbContextService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/DbContextService.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services;
+
+public class DbContextService : IDbContextService
+{
+    public DbContextService()
+    {
+    }
+
+    // Created to be mocked by tests for cases when the in-memory db doesn't emulate the real
+    // db, e.g. with EF8 JSON columns
+    public async Task SaveChangesAsync(DbContext context)
+    {
+        await context.SaveChangesAsync();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -101,7 +101,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         public static string FilesPath(Guid rootPath, FileType type)
         {
-            var typeFolder = (type == Metadata ? Data : type).GetEnumLabel();
+            var typeFolder = (type == Metadata ? FileType.Data : type).GetEnumLabel();
             return $"{rootPath}/{typeFolder}/";
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IDbContextService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IDbContextService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+
+public interface IDbContextService
+{
+    Task SaveChangesAsync(DbContext context);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -1548,14 +1548,14 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                                     .WithEnd("2002", TimeIdentifier.AcademicYear)
                             )
                             .WithFilters([
-                                new FilterMeta { Id = Guid.NewGuid(), Label = "Filter 1", ColumnName = "filter_1", },
-                                new FilterMeta { Id = Guid.NewGuid(), Label = "Filter 2", ColumnName = "filter_2", },
-                                new FilterMeta { Id = Guid.NewGuid(), Label = "Filter 3", ColumnName = "filter_3", },
+                                new FilterMetaOld { Id = Guid.NewGuid(), Label = "Filter 1", ColumnName = "filter_1", },
+                                new FilterMetaOld { Id = Guid.NewGuid(), Label = "Filter 2", ColumnName = "filter_2", },
+                                new FilterMetaOld { Id = Guid.NewGuid(), Label = "Filter 3", ColumnName = "filter_3", },
                             ])
                             .WithIndicators([
-                                new IndicatorMeta { Id = Guid.NewGuid(), Label = "Indicator 1", ColumnName = "indicator_1", },
-                                new IndicatorMeta { Id = Guid.NewGuid(), Label = "Indicator 2", ColumnName = "indicator_2", },
-                                new IndicatorMeta { Id = Guid.NewGuid(), Label = "Indicator 3", ColumnName = "indicator_3", },
+                                new IndicatorMetaOld { Id = Guid.NewGuid(), Label = "Indicator 1", ColumnName = "indicator_1", },
+                                new IndicatorMetaOld { Id = Guid.NewGuid(), Label = "Indicator 2", ColumnName = "indicator_2", },
+                                new IndicatorMetaOld { Id = Guid.NewGuid(), Label = "Indicator 3", ColumnName = "indicator_3", },
                             ])
                         ))
                     .Generate();
@@ -1579,7 +1579,7 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                 var dataSetFileSummaryViewModel = Assert.Single(pagedResult.Results);
                 var dataSetFileMetaViewModel = dataSetFileSummaryViewModel.Meta;
 
-                var originalMeta = releaseFile.File.DataSetFileMeta;
+                var originalMeta = releaseFile.File.DataSetFileMetaOld;
 
                 Assert.Equal(originalMeta!.GeographicLevels
                         .Select(gl => gl.GetEnumLabel())
@@ -2028,7 +2028,7 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                 $"{releaseFile.PublicApiDataSetVersion!.Major}.{releaseFile.PublicApiDataSetVersion.Minor}",
                 viewModel.Api.Version);
 
-            var dataSetFileMeta = file.DataSetFileMeta;
+            var dataSetFileMeta = file.DataSetFileMetaOld;
 
             Assert.Equal(dataSetFileMeta!.GeographicLevels
                     .Select(gl => gl.GetEnumLabel())
@@ -2153,9 +2153,9 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                 .WithFile(_fixture.DefaultFile(FileType.Data)
                     .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
                         .WithFilters([
-                            new FilterMeta { Id = filter3Id, Label = "Filter 3", ColumnName = "filter_3", },
-                            new FilterMeta { Id = filter1Id, Label = "Filter 1", ColumnName = "filter_1", },
-                            new FilterMeta { Id = filter2Id, Label = "Filter 2", ColumnName = "filter_2", },
+                            new FilterMetaOld { Id = filter3Id, Label = "Filter 3", ColumnName = "filter_3", },
+                            new FilterMetaOld { Id = filter1Id, Label = "Filter 1", ColumnName = "filter_1", },
+                            new FilterMetaOld { Id = filter2Id, Label = "Filter 2", ColumnName = "filter_2", },
                         ])));
 
             await TestApp.AddTestData<ContentDbContext>(context =>
@@ -2213,10 +2213,10 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                 .WithFile(_fixture.DefaultFile(FileType.Data)
                     .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
                         .WithIndicators([
-                            new IndicatorMeta { Id = indicator3Id, Label = "Indicator 3", ColumnName = "indicator_3", },
-                            new IndicatorMeta { Id = indicator2Id, Label = "Indicator 2", ColumnName = "indicator_2", },
-                            new IndicatorMeta { Id = indicator1Id, Label = "Indicator 1", ColumnName = "indicator_1", },
-                            new IndicatorMeta { Id = indicator4Id, Label = "Indicator 4", ColumnName = "indicator_4", },
+                            new IndicatorMetaOld { Id = indicator3Id, Label = "Indicator 3", ColumnName = "indicator_3", },
+                            new IndicatorMetaOld { Id = indicator2Id, Label = "Indicator 2", ColumnName = "indicator_2", },
+                            new IndicatorMetaOld { Id = indicator1Id, Label = "Indicator 1", ColumnName = "indicator_1", },
+                            new IndicatorMetaOld { Id = indicator4Id, Label = "Indicator 4", ColumnName = "indicator_4", },
                         ])));
 
             await TestApp.AddTestData<ContentDbContext>(context =>
@@ -2265,15 +2265,15 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                 .WithFile(_fixture.DefaultFile(FileType.Data)
                     .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
                         .WithFilters([
-                            new FilterMeta { Id = Guid.NewGuid(), Label = "Filter 1", ColumnName = "A_filter_1", Hint = "hint", },
-                            new FilterMeta { Id = Guid.NewGuid(), Label = "Filter 2", ColumnName = "G_filter_2", },
-                            new FilterMeta { Id = Guid.NewGuid(), Label = "Filter 3", ColumnName = "C_filter_3", Hint = "Another hint", },
+                            new FilterMetaOld { Id = Guid.NewGuid(), Label = "Filter 1", ColumnName = "A_filter_1", Hint = "hint", },
+                            new FilterMetaOld { Id = Guid.NewGuid(), Label = "Filter 2", ColumnName = "G_filter_2", },
+                            new FilterMetaOld { Id = Guid.NewGuid(), Label = "Filter 3", ColumnName = "C_filter_3", Hint = "Another hint", },
                         ])
                         .WithIndicators([
-                            new IndicatorMeta { Id = Guid.NewGuid(), Label = "Indicator 3", ColumnName = "B_indicator_3", },
-                            new IndicatorMeta { Id = Guid.NewGuid(), Label = "Indicator 2", ColumnName = "E_indicator_2", },
-                            new IndicatorMeta { Id = Guid.NewGuid(), Label = "Indicator 1", ColumnName = "D_indicator_1", },
-                            new IndicatorMeta { Id = Guid.NewGuid(), Label = "Indicator 4", ColumnName = "F_indicator_4", },
+                            new IndicatorMetaOld { Id = Guid.NewGuid(), Label = "Indicator 3", ColumnName = "B_indicator_3", },
+                            new IndicatorMetaOld { Id = Guid.NewGuid(), Label = "Indicator 2", ColumnName = "E_indicator_2", },
+                            new IndicatorMetaOld { Id = Guid.NewGuid(), Label = "Indicator 1", ColumnName = "D_indicator_1", },
+                            new IndicatorMetaOld { Id = Guid.NewGuid(), Label = "Indicator 4", ColumnName = "F_indicator_4", },
                         ])));
 
             await TestApp.AddTestData<ContentDbContext>(context =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/FileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/FileExtensionTests.cs
@@ -33,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
                 Id = Guid.NewGuid(),
                 RootPath = Guid.NewGuid(),
                 Filename = "data.csv",
-                Type = Data
+                Type = FileType.Data
             };
 
             var imageFile = new File
@@ -94,7 +94,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
                 Id = Guid.NewGuid(),
                 RootPath = Guid.NewGuid(),
                 Filename = "data.csv",
-                Type = Data
+                Type = FileType.Data
             };
 
             var imageFile = new File

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
@@ -8,19 +8,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixture
 
 public static class DataSetFileMetaGeneratorExtensions
 {
-    public static Generator<DataSetFileMeta> DefaultDataSetFileMeta(this DataFixture fixture)
-        => fixture.Generator<DataSetFileMeta>().WithDefaults();
+    public static Generator<DataSetFileMetaOld> DefaultDataSetFileMeta(this DataFixture fixture)
+        => fixture.Generator<DataSetFileMetaOld>().WithDefaults();
 
-    public static Generator<DataSetFileMeta> WithDefaults(this Generator<DataSetFileMeta> generator)
+    public static Generator<DataSetFileMetaOld> WithDefaults(this Generator<DataSetFileMetaOld> generator)
         => generator.ForInstance(d => d.SetDefaults());
 
-    public static InstanceSetters<DataSetFileMeta> SetDefaults(this InstanceSetters<DataSetFileMeta> setters)
+    public static InstanceSetters<DataSetFileMetaOld> SetDefaults(this InstanceSetters<DataSetFileMetaOld> setters)
         => setters
             .SetGeographicLevels([GeographicLevel.Country])
-            .SetTimePeriodRange(new TimePeriodRangeMeta
+            .SetTimePeriodRange(new TimePeriodRangeMetaOld
             {
-                Start = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2000", },
-                End = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2001", },
+                Start = new TimePeriodRangeBoundMetaOld { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2000", },
+                End = new TimePeriodRangeBoundMetaOld { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2001", },
             })
             .SetFilters([ new()
                 {
@@ -37,43 +37,43 @@ public static class DataSetFileMetaGeneratorExtensions
                 },
             ]);
 
-    public static Generator<DataSetFileMeta> WithGeographicLevels(
-        this Generator<DataSetFileMeta> generator,
+    public static Generator<DataSetFileMetaOld> WithGeographicLevels(
+        this Generator<DataSetFileMetaOld> generator,
         List<GeographicLevel> geographicLevels)
         => generator.ForInstance(s => s.SetGeographicLevels(geographicLevels));
 
-    public static Generator<DataSetFileMeta> WithTimePeriodRange(
-        this Generator<DataSetFileMeta> generator,
-        TimePeriodRangeMeta timePeriodRange)
+    public static Generator<DataSetFileMetaOld> WithTimePeriodRange(
+        this Generator<DataSetFileMetaOld> generator,
+        TimePeriodRangeMetaOld timePeriodRange)
         => generator.ForInstance(s => s.SetTimePeriodRange(timePeriodRange));
 
-    public static Generator<DataSetFileMeta> WithFilters(
-        this Generator<DataSetFileMeta> generator,
-        List<FilterMeta> filters)
+    public static Generator<DataSetFileMetaOld> WithFilters(
+        this Generator<DataSetFileMetaOld> generator,
+        List<FilterMetaOld> filters)
         => generator.ForInstance(s => s.SetFilters(filters));
 
-    public static Generator<DataSetFileMeta> WithIndicators(
-        this Generator<DataSetFileMeta> generator,
-        List<IndicatorMeta> indicators)
+    public static Generator<DataSetFileMetaOld> WithIndicators(
+        this Generator<DataSetFileMetaOld> generator,
+        List<IndicatorMetaOld> indicators)
         => generator.ForInstance(s => s.SetIndicators(indicators));
 
-    public static InstanceSetters<DataSetFileMeta> SetGeographicLevels(
-        this InstanceSetters<DataSetFileMeta> setters,
+    public static InstanceSetters<DataSetFileMetaOld> SetGeographicLevels(
+        this InstanceSetters<DataSetFileMetaOld> setters,
         List<GeographicLevel> geographicLevels)
         => setters.Set(s => s.GeographicLevels, geographicLevels);
 
-    public static InstanceSetters<DataSetFileMeta> SetTimePeriodRange(
-        this InstanceSetters<DataSetFileMeta> setters,
-        TimePeriodRangeMeta timePeriodRange)
+    public static InstanceSetters<DataSetFileMetaOld> SetTimePeriodRange(
+        this InstanceSetters<DataSetFileMetaOld> setters,
+        TimePeriodRangeMetaOld timePeriodRange)
         => setters.Set(s => s.TimePeriodRange, timePeriodRange);
 
-    public static InstanceSetters<DataSetFileMeta> SetFilters(
-        this InstanceSetters<DataSetFileMeta> setters,
-        List<FilterMeta> filters)
+    public static InstanceSetters<DataSetFileMetaOld> SetFilters(
+        this InstanceSetters<DataSetFileMetaOld> setters,
+        List<FilterMetaOld> filters)
         => setters.Set(s => s.Filters, filters);
 
-    public static InstanceSetters<DataSetFileMeta> SetIndicators(
-        this InstanceSetters<DataSetFileMeta> setters,
-        List<IndicatorMeta> indicators)
+    public static InstanceSetters<DataSetFileMetaOld> SetIndicators(
+        this InstanceSetters<DataSetFileMetaOld> setters,
+        List<IndicatorMetaOld> indicators)
         => setters.Set(s => s.Indicators, indicators);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
@@ -81,7 +81,7 @@ public static class FileGeneratorExtensions
 
     public static Generator<File> WithDataSetFileMeta(
         this Generator<File> generator,
-        DataSetFileMeta? dataSetFileMeta)
+        DataSetFileMetaOld? dataSetFileMeta)
         => generator.ForInstance(s => s.SetDataSetFileMeta(dataSetFileMeta));
 
     public static InstanceSetters<File> SetDefaults(this InstanceSetters<File> setters, FileType? fileType)
@@ -110,7 +110,7 @@ public static class FileGeneratorExtensions
             .SetDefault(f => f.SubjectId)
             .SetContentType("text/csv")
             .SetDefault(f => f.DataSetFileId)
-            .Set(f => f.DataSetFileMeta, (_, _, context) => context.Fixture.DefaultDataSetFileMeta());
+            .Set(f => f.DataSetFileMetaOld, (_, _, context) => context.Fixture.DefaultDataSetFileMeta());
 
     public static InstanceSetters<File> SetMetaFileDefaults(this InstanceSetters<File> setters)
         => setters
@@ -198,6 +198,6 @@ public static class FileGeneratorExtensions
 
     public static InstanceSetters<File> SetDataSetFileMeta(
         this InstanceSetters<File> setters,
-        DataSetFileMeta? dataSetFileMeta)
-        => setters.Set(f => f.DataSetFileMeta, dataSetFileMeta);
+        DataSetFileMetaOld? dataSetFileMeta)
+        => setters.Set(f => f.DataSetFileMetaOld, dataSetFileMeta);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/TimePeriodRangeMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/TimePeriodRangeMetaGeneratorExtensions.cs
@@ -5,44 +5,44 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixture
 
 public static class TimePeriodRangeMetaGeneratorExtensions
 {
-    public static Generator<TimePeriodRangeMeta> DefaultTimePeriodRangeMeta(this DataFixture fixture)
-        => fixture.Generator<TimePeriodRangeMeta>().WithDefaults();
+    public static Generator<TimePeriodRangeMetaOld> DefaultTimePeriodRangeMeta(this DataFixture fixture)
+        => fixture.Generator<TimePeriodRangeMetaOld>().WithDefaults();
 
-    public static Generator<TimePeriodRangeMeta> WithDefaults(this Generator<TimePeriodRangeMeta> generator)
+    public static Generator<TimePeriodRangeMetaOld> WithDefaults(this Generator<TimePeriodRangeMetaOld> generator)
         => generator.ForInstance(d => d.SetDefaults());
 
-    public static Generator<TimePeriodRangeMeta> WithStart(
-        this Generator<TimePeriodRangeMeta> generator,
+    public static Generator<TimePeriodRangeMetaOld> WithStart(
+        this Generator<TimePeriodRangeMetaOld> generator,
         string period,
         TimeIdentifier timeIdentifier)
         => generator.ForInstance(s => s.SetStart(period, timeIdentifier));
 
-    public static Generator<TimePeriodRangeMeta> WithEnd(
-        this Generator<TimePeriodRangeMeta> generator,
+    public static Generator<TimePeriodRangeMetaOld> WithEnd(
+        this Generator<TimePeriodRangeMetaOld> generator,
         string period,
         TimeIdentifier timeIdentifier)
         => generator.ForInstance(s => s.SetEnd(period, timeIdentifier));
 
-    public static InstanceSetters<TimePeriodRangeMeta> SetDefaults(this InstanceSetters<TimePeriodRangeMeta> setters)
+    public static InstanceSetters<TimePeriodRangeMetaOld> SetDefaults(this InstanceSetters<TimePeriodRangeMetaOld> setters)
         => setters
             .SetStart("2000", TimeIdentifier.CalendarYear)
             .SetEnd("2001", TimeIdentifier.CalendarYear);
 
-    public static InstanceSetters<TimePeriodRangeMeta> SetStart(
-        this InstanceSetters<TimePeriodRangeMeta> setters,
+    public static InstanceSetters<TimePeriodRangeMetaOld> SetStart(
+        this InstanceSetters<TimePeriodRangeMetaOld> setters,
         string period,
         TimeIdentifier timeIdentifier)
-        => setters.Set(s => s.Start, new TimePeriodRangeBoundMeta
+        => setters.Set(s => s.Start, new TimePeriodRangeBoundMetaOld
         {
             Period = period,
             TimeIdentifier = timeIdentifier,
         });
 
-    public static InstanceSetters<TimePeriodRangeMeta> SetEnd(
-        this InstanceSetters<TimePeriodRangeMeta> setters,
+    public static InstanceSetters<TimePeriodRangeMetaOld> SetEnd(
+        this InstanceSetters<TimePeriodRangeMetaOld> setters,
         string period,
         TimeIdentifier timeIdentifier)
-        => setters.Set(s => s.End, new TimePeriodRangeBoundMeta
+        => setters.Set(s => s.End, new TimePeriodRangeBoundMetaOld
         {
             Period = period,
             TimeIdentifier = timeIdentifier,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -58,7 +58,7 @@ public class IndicatorMeta
     public required string ColumnName { get; set; }
 }
 
-public class DataSetFileMetaOld
+public class DataSetFileMetaOld // EES-5693 remove
 {
     [JsonConverter(typeof(GeographicLevelsListJsonConverter))]
     public required List<GeographicLevel> GeographicLevels { get; set; }
@@ -70,14 +70,14 @@ public class DataSetFileMetaOld
     public required List<IndicatorMetaOld> Indicators { get; set; }
 }
 
-public class TimePeriodRangeMetaOld
+public class TimePeriodRangeMetaOld // EES-5693 remove
 {
     public required TimePeriodRangeBoundMetaOld Start { get; set; }
 
     public required TimePeriodRangeBoundMetaOld End { get; set; }
 }
 
-public class TimePeriodRangeBoundMetaOld
+public class TimePeriodRangeBoundMetaOld // EES-5693 remove
 {
     [JsonConverter(typeof(TimeIdentifierJsonConverter))]
     public required TimeIdentifier TimeIdentifier { get; set; }
@@ -85,7 +85,7 @@ public class TimePeriodRangeBoundMetaOld
     public required string Period { get; set; }
 }
 
-public class FilterMetaOld
+public class FilterMetaOld // EES-5693 remove
 {
     public required Guid Id { get; set; }
 
@@ -96,7 +96,7 @@ public class FilterMetaOld
     public required string ColumnName { get; set; }
 }
 
-public class IndicatorMetaOld
+public class IndicatorMetaOld // EES-5693 remove
 {
     public required Guid Id { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -8,6 +8,56 @@ using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
+public class DataSetFileMeta
+{
+    public required List<GeographicLevelMeta> GeographicLevels { get; set; }
+
+    public required TimePeriodRangeMeta TimePeriodRange { get; set; }
+
+    public required List<FilterMeta> Filters { get; set; }
+
+    public required List<IndicatorMeta> Indicators { get; set; }
+}
+
+public class GeographicLevelMeta
+{
+    public required GeographicLevel Code { get; set; }
+}
+
+public class TimePeriodRangeMeta
+{
+    public required TimePeriodRangeBoundMeta Start { get; set; }
+
+    public required TimePeriodRangeBoundMeta End { get; set; }
+}
+
+public class TimePeriodRangeBoundMeta
+{
+    public required TimeIdentifier TimeIdentifier { get; set; }
+
+    public required string Period { get; set; }
+}
+
+public class FilterMeta
+{
+    public required Guid FilterId { get; set; }
+
+    public required string Label { get; set; }
+
+    public string? Hint { get; set; }
+
+    public required string ColumnName { get; set; }
+}
+
+public class IndicatorMeta
+{
+    public required Guid IndicatorId { get; set; }
+
+    public required string Label { get; set; }
+
+    public required string ColumnName { get; set; }
+}
+
 public class DataSetFileMetaOld
 {
     [JsonConverter(typeof(GeographicLevelsListJsonConverter))]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -8,26 +8,26 @@ using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
-public class DataSetFileMeta
+public class DataSetFileMetaOld
 {
     [JsonConverter(typeof(GeographicLevelsListJsonConverter))]
     public required List<GeographicLevel> GeographicLevels { get; set; }
 
-    public required TimePeriodRangeMeta TimePeriodRange { get; set; }
+    public required TimePeriodRangeMetaOld TimePeriodRange { get; set; }
 
-    public required List<FilterMeta> Filters { get; set; }
+    public required List<FilterMetaOld> Filters { get; set; }
 
-    public required List<IndicatorMeta> Indicators { get; set; }
+    public required List<IndicatorMetaOld> Indicators { get; set; }
 }
 
-public class TimePeriodRangeMeta
+public class TimePeriodRangeMetaOld
 {
-    public required TimePeriodRangeBoundMeta Start { get; set; }
+    public required TimePeriodRangeBoundMetaOld Start { get; set; }
 
-    public required TimePeriodRangeBoundMeta End { get; set; }
+    public required TimePeriodRangeBoundMetaOld End { get; set; }
 }
 
-public class TimePeriodRangeBoundMeta
+public class TimePeriodRangeBoundMetaOld
 {
     [JsonConverter(typeof(TimeIdentifierJsonConverter))]
     public required TimeIdentifier TimeIdentifier { get; set; }
@@ -35,7 +35,7 @@ public class TimePeriodRangeBoundMeta
     public required string Period { get; set; }
 }
 
-public class FilterMeta
+public class FilterMetaOld
 {
     public required Guid Id { get; set; }
 
@@ -46,7 +46,7 @@ public class FilterMeta
     public required string ColumnName { get; set; }
 }
 
-public class IndicatorMeta
+public class IndicatorMetaOld
 {
     public required Guid Id { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -452,10 +452,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                         v => v.HasValue
                             ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
                             : null);
-                entity.Property(p => p.DataSetFileMeta)
+                entity.Property(p => p.DataSetFileMetaOld)
                     .HasConversion( // You might want to use EF8 JSON support instead of this
                         v => JsonConvert.SerializeObject(v),
-                        v => JsonConvert.DeserializeObject<DataSetFileMeta>(v));
+                        v => JsonConvert.DeserializeObject<DataSetFileMetaOld>(v));
             });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -452,6 +452,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                         v => v.HasValue
                             ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
                             : null);
+                entity.OwnsOne(f => f.DataSetFileMeta, dsfm =>
+                {
+                    dsfm.ToJson();
+
+                    dsfm.OwnsMany(meta => meta.GeographicLevels, gl =>
+                    {
+                        gl.Property(geogLvl => geogLvl.Code)
+                            .HasConversion(new EnumToEnumValueConverter<GeographicLevel>());
+                    });
+                    dsfm.OwnsOne(meta => meta.TimePeriodRange, tpr =>
+                    {
+                        tpr.OwnsOne(range => range.Start, start =>
+                        {
+                            start.Property(s => s.TimeIdentifier)
+                                .HasColumnType("text")
+                                .HasConversion(new EnumToEnumValueConverter<TimeIdentifier>());
+                        });
+                        tpr.OwnsOne(range => range.End, end =>
+                        {
+                            end.Property(s => s.TimeIdentifier)
+                                .HasColumnType("text")
+                                .HasConversion(new EnumToEnumValueConverter<TimeIdentifier>());
+                        });
+                    });
+                    dsfm.OwnsMany(meta => meta.Filters);
+                    dsfm.OwnsMany(meta => meta.Indicators);
+                });
                 entity.Property(p => p.DataSetFileMetaOld)
                     .HasConversion( // You might want to use EF8 JSON support instead of this
                         v => JsonConvert.SerializeObject(v),

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/FileExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/FileExtensions.cs
@@ -14,7 +14,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
         {
             Ancillary,
             Chart,
-            Data,
+            FileType.Data,
             Image,
             DataGuidance
         };
@@ -69,7 +69,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
             return file.Type switch
             {
                 Ancillary => $"supporting-files/{file.Filename}",
-                Data => $"data/{file.Filename}",
+                FileType.Data => $"data/{file.Filename}",
                 _ => throw new ArgumentOutOfRangeException(nameof(file.Type), "Unexpected file type"),
             };
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -22,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public int? DataSetFileVersion { get; set; }
 
-        public DataSetFileMeta? DataSetFileMeta { get; set; }
+        public DataSetFileMetaOld? DataSetFileMetaOld { get; set; }
 
         public Guid? ReplacedById { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -22,6 +22,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public int? DataSetFileVersion { get; set; }
 
+        public DataSetFileMeta? DataSetFileMeta { get; set; }
+
         public DataSetFileMetaOld? DataSetFileMetaOld { get; set; }
 
         public Guid? ReplacedById { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -24,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public DataSetFileMeta? DataSetFileMeta { get; set; }
 
-        public DataSetFileMetaOld? DataSetFileMetaOld { get; set; }
+        public DataSetFileMetaOld? DataSetFileMetaOld { get; set; } // EES-5693 remove
 
         public Guid? ReplacedById { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseDataFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseDataFileRepository.cs
@@ -64,7 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                     DataSetFileVersion = type != Data
                         ? null
                         : replacingDataFile?.DataSetFileVersion + 1 ?? 0,
-                    DataSetFileMeta = null, // If FileType.Data, this is set by Data.Processor when import is complete
+                    DataSetFileMetaOld = null, // If FileType.Data, this is set by Data.Processor when import is complete
                     Filename = filename,
                     ContentLength = contentLength,
                     ContentType = "text/csv",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseDataFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseDataFileRepository.cs
@@ -64,6 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                     DataSetFileVersion = type != Data
                         ? null
                         : replacingDataFile?.DataSetFileVersion + 1 ?? 0,
+                    DataSetFileMeta = null, // If FileType.Data, this is set by Data.Processor when import is complete
                     DataSetFileMetaOld = null, // If FileType.Data, this is set by Data.Processor when import is complete
                     Filename = filename,
                     ContentLength = contentLength,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseDataFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseDataFileRepository.cs
@@ -17,7 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
 
         private static readonly List<FileType> SupportedFileTypes = new()
         {
-            Data,
+            FileType.Data,
             Metadata
         };
 
@@ -58,10 +58,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                     CreatedById = createdById,
                     RootPath = releaseVersionId,
                     SubjectId = subjectId,
-                    DataSetFileId = type != Data
+                    DataSetFileId = type != FileType.Data
                         ? null
                         : replacingDataFile?.DataSetFileId ?? Guid.NewGuid(),
-                    DataSetFileVersion = type != Data
+                    DataSetFileVersion = type != FileType.Data
                         ? null
                         : replacingDataFile?.DataSetFileVersion + 1 ?? 0,
                     DataSetFileMeta = null, // If FileType.Data, this is set by Data.Processor when import is complete
@@ -102,7 +102,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                 .Include(rf => rf.File)
                 .Where(
                     rf => rf.ReleaseVersionId == releaseVersionId
-                          && rf.File.Type == Data
+                          && rf.File.Type == FileType.Data
                           && rf.File.ReplacingId != null
                           && rf.File.SubjectId.HasValue
                 )
@@ -118,7 +118,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                 .SingleAsync(rf =>
                     rf.ReleaseVersionId == releaseVersionId
                     && rf.File.SubjectId == subjectId
-                    && rf.File.Type == Data);
+                    && rf.File.Type == FileType.Data);
         }
 
         private IQueryable<File> ListDataFilesQuery(Guid releaseVersionId)
@@ -128,7 +128,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                 .Include(rf => rf.File)
                 .Where(
                     rf => rf.ReleaseVersionId == releaseVersionId
-                          && rf.File.Type == Data
+                          && rf.File.Type == FileType.Data
                           && rf.File.ReplacingId == null
                 )
                 .OrderBy(rf => rf.Order)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -135,7 +135,7 @@ public class DataSetFileService : IDataSetFileService
                 LastUpdated = result.Value.Published!.Value,
                 Api = BuildDataSetFileApiViewModel(result.Value),
                 Meta = BuildDataSetFileMetaViewModel(
-                    result.Value.File.DataSetFileMeta,
+                    result.Value.File.DataSetFileMetaOld,
                     result.Value.FilterSequence,
                     result.Value.IndicatorSequence),
             };
@@ -196,7 +196,7 @@ public class DataSetFileService : IDataSetFileService
 
         var dataCsvPreview = await GetDataCsvPreview(releaseFile);
 
-        var variables = GetVariables(releaseFile.File.DataSetFileMeta!);
+        var variables = GetVariables(releaseFile.File.DataSetFileMetaOld!);
 
         var footnotes = await _footnoteRepository.GetFootnotes(
             releaseFile.ReleaseVersionId,
@@ -234,7 +234,7 @@ public class DataSetFileService : IDataSetFileService
                 Name = releaseFile.File.Filename,
                 Size = releaseFile.File.DisplaySize(),
                 Meta = BuildDataSetFileMetaViewModel(
-                    releaseFile.File.DataSetFileMeta,
+                    releaseFile.File.DataSetFileMetaOld,
                     releaseFile.FilterSequence,
                     releaseFile.IndicatorSequence),
                 DataCsvPreview = dataCsvPreview,
@@ -276,7 +276,7 @@ public class DataSetFileService : IDataSetFileService
     }
 
     private static DataSetFileMetaViewModel BuildDataSetFileMetaViewModel(
-        DataSetFileMeta? meta,
+        DataSetFileMetaOld? meta,
         List<FilterSequenceEntry>? filterSequence,
         List<IndicatorGroupSequenceEntry>? indicatorGroupSequence)
     {
@@ -343,14 +343,14 @@ public class DataSetFileService : IDataSetFileService
         };
     }
 
-    private List<LabelValue> GetVariables(DataSetFileMeta meta)
+    private List<LabelValue> GetVariables(DataSetFileMetaOld metaOld)
     {
-        var filterVariables = meta.Filters
+        var filterVariables = metaOld.Filters
             .Select(filter => new LabelValue(
                 string.IsNullOrWhiteSpace(filter.Hint) ? filter.Label : $"{filter.Label} - {filter.Hint}",
                 filter.ColumnName))
             .ToList();
-        var indicatorVariables = meta.Indicators
+        var indicatorVariables = metaOld.Indicators
             .Select(indicator => new LabelValue(indicator.Label, indicator.ColumnName));
         return filterVariables.Concat(indicatorVariables)
             .OrderBy(variable => variable.Value)
@@ -358,7 +358,7 @@ public class DataSetFileService : IDataSetFileService
     }
 
     private static List<string> GetOrderedFilters(
-        List<FilterMeta> metaFilters, List<FilterSequenceEntry>? filterSequenceEntries)
+        List<FilterMetaOld> metaFilters, List<FilterSequenceEntry>? filterSequenceEntries)
     {
         var filterSequence = filterSequenceEntries?
             .Select(fs => fs.Id)
@@ -373,7 +373,7 @@ public class DataSetFileService : IDataSetFileService
     }
 
     private static List<string> GetOrderedIndicators(
-        List<IndicatorMeta> metaIndicators, List<IndicatorGroupSequenceEntry>? indicatorGroupSequenceEntries)
+        List<IndicatorMetaOld> metaIndicators, List<IndicatorGroupSequenceEntry>? indicatorGroupSequenceEntries)
     {
         var indicatorSequence = indicatorGroupSequenceEntries?
             .SelectMany(seq => seq.ChildSequence)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -82,6 +82,7 @@ public class DataSetFileService : IDataSetFileService
             .HavingThemeId(themeId)
             .HavingPublicationIdOrNoSupersededPublication(publicationId)
             .HavingReleaseVersionId(releaseVersionId)
+            //.HavingGeographicLevel(GeographicLevel.LocalAuthority) // EES-5598
             .OfDataSetType(dataSetType.Value)
             .HavingLatestPublishedReleaseVersions(latestPublishedReleaseVersions, latestOnly.Value)
             .JoinFreeText(_contentDbContext.ReleaseFilesFreeTextTable, rf => rf.Id, searchTerm);
@@ -490,6 +491,15 @@ internal static class ReleaseFileQueryableExtensions
     {
         return releaseVersionId.HasValue ? query.Where(rf => rf.ReleaseVersionId == releaseVersionId.Value) : query;
     }
+
+    //internal static IQueryable<ReleaseFile> HavingGeographicLevel( // EES-5598
+    //    this IQueryable<ReleaseFile> query,
+    //    GeographicLevel? geographicLevel)
+    //{
+    //    return geographicLevel.HasValue
+    //        ? query.Where(rf => rf.File.DataSetFileMeta!.GeographicLevels.Any(gl => gl.Code == geographicLevel))
+    //        : query;
+    //}
 
     internal static IQueryable<ReleaseFile> OfDataSetType(
         this IQueryable<ReleaseFile> query,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model\GovUk.Education.ExploreEducationStatistics.Content.Model.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage1Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage1Tests.cs
@@ -105,6 +105,7 @@ public class ProcessorStage1Tests
 
         var dataImportService = new DataImportService(
             dbContextSupplier,
+            new DbContextService(),
             Mock.Of<ILogger<DataImportService>>());
 
         var importerLocationCache = new ImporterLocationCache(Mock.Of<ILogger<ImporterLocationCache>>());

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage2Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage2Tests.cs
@@ -222,6 +222,7 @@ public class ProcessorStage2Tests
 
         var dataImportService = new DataImportService(
             dbContextSupplier,
+            new DbContextService(),
             Mock.Of<ILogger<DataImportService>>());
 
         var guidGenerator = new SequentialGuidGenerator();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -289,28 +289,28 @@ public class ProcessorStage3Tests
                 .Single(f => f.Type == FileType.Data
                              && f.SubjectId == import.File.SubjectId);
 
-            Assert.NotNull(file.DataSetFileMeta);
+            Assert.NotNull(file.DataSetFileMetaOld);
 
             // Checking against contents of small-csv.csv in Resources directory / _subject
-            var geographicLevel = Assert.Single(file.DataSetFileMeta.GeographicLevels);
+            var geographicLevel = Assert.Single(file.DataSetFileMetaOld.GeographicLevels);
             Assert.Equal(GeographicLevel.LocalAuthority, geographicLevel);
 
             Assert.Equal(TimeIdentifier.CalendarYear,
-                file.DataSetFileMeta.TimePeriodRange.Start.TimeIdentifier);
+                file.DataSetFileMetaOld.TimePeriodRange.Start.TimeIdentifier);
             Assert.Equal(TimeIdentifier.CalendarYear,
-                file.DataSetFileMeta.TimePeriodRange.End.TimeIdentifier);
-            Assert.Equal("2018", file.DataSetFileMeta.TimePeriodRange.Start.Period);
-            Assert.Equal("2025", file.DataSetFileMeta.TimePeriodRange.End.Period);
+                file.DataSetFileMetaOld.TimePeriodRange.End.TimeIdentifier);
+            Assert.Equal("2018", file.DataSetFileMetaOld.TimePeriodRange.Start.Period);
+            Assert.Equal("2025", file.DataSetFileMetaOld.TimePeriodRange.End.Period);
 
             // Checking against contents of small-csv.meta.csv / _subject
-            file.DataSetFileMeta.Filters
+            file.DataSetFileMetaOld.Filters
                 .Select(f => (f.Label, f.Hint, f.ColumnName)).ToList()
                 .AssertDeepEqualTo([
                     ("Filter one", "Hint 1", "filter_one"),
                     ("Filter two", null, "filter_two")
                 ]);
 
-            file.DataSetFileMeta.Indicators
+            file.DataSetFileMetaOld.Indicators
                 .Select(i => (i.Label, i.ColumnName)).ToList()
                 .AssertDeepEqualTo([
                     ("Indicator one", "indicator_one"),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -25,7 +25,6 @@ using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfa
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
@@ -149,6 +148,7 @@ public class ProcessorStage3Tests
 
         var dataImportService = new DataImportService(
             dbContextSupplier,
+            new DbContextService(),
             Mock.Of<ILogger<DataImportService>>());
 
         var importerLocationCache = new ImporterLocationCache(Mock.Of<ILogger<ImporterLocationCache>>());
@@ -374,6 +374,7 @@ public class ProcessorStage3Tests
 
         var dataImportService = new DataImportService(
             dbContextSupplier,
+            new DbContextService(),
             Mock.Of<ILogger<DataImportService>>());
 
         var importerLocationCache = new ImporterLocationCache(Mock.Of<ILogger<ImporterLocationCache>>());
@@ -506,6 +507,7 @@ public class ProcessorStage3Tests
 
         var dataImportService = new DataImportService(
             dbContextSupplier,
+            new DbContextService(),
             Mock.Of<ILogger<DataImportService>>());
 
         var importerLocationCache = new ImporterLocationCache(Mock.Of<ILogger<ImporterLocationCache>>());
@@ -656,6 +658,7 @@ public class ProcessorStage3Tests
 
         var dataImportService = new DataImportService(
             dbContextSupplier,
+            new DbContextService(),
             Mock.Of<ILogger<DataImportService>>());
 
         var importerLocationCache = new ImporterLocationCache(Mock.Of<ILogger<ImporterLocationCache>>());
@@ -790,8 +793,15 @@ public class ProcessorStage3Tests
 
         var databaseHelper = new InMemoryDatabaseHelper(dbContextSupplier);
 
+        var dbContextService = new Mock<IDbContextService>(Strict);
+
+        dbContextService.Setup(mock =>
+            mock.SaveChangesAsync(It.IsAny<DbContext>()))
+            .Returns(Task.CompletedTask);
+
         var dataImportService = new DataImportService(
             dbContextSupplier,
+            dbContextService.Object,
             Mock.Of<ILogger<DataImportService>>());
 
         var importerLocationCache = new ImporterLocationCache(Mock.Of<ILogger<ImporterLocationCache>>());
@@ -847,6 +857,10 @@ public class ProcessorStage3Tests
         var outputMessages = await function.ProcessUploads(
             new ImportMessage(import.Id),
             new TestFunctionContext());
+
+        dbContextService.Verify(mock =>
+                mock.SaveChangesAsync(It.IsAny<DbContext>()),
+            Times.Once);
 
         VerifyAllMocks(privateBlobStorageService);
 
@@ -954,6 +968,7 @@ public class ProcessorStage3Tests
 
         var dataImportService = new DataImportService(
             dbContextSupplier,
+            new DbContextService(),
             Mock.Of<ILogger<DataImportService>>());
 
         var importerLocationCache = new ImporterLocationCache(Mock.Of<ILogger<ImporterLocationCache>>());
@@ -1096,6 +1111,7 @@ public class ProcessorStage3Tests
 
         var dataImportService = new DataImportService(
             dbContextSupplier,
+            new DbContextService(),
             Mock.Of<ILogger<DataImportService>>());
 
         var importerLocationCache = new ImporterLocationCache(Mock.Of<ILogger<ImporterLocationCache>>());
@@ -1218,6 +1234,7 @@ public class ProcessorStage3Tests
 
         var dataImportService = new DataImportService(
             dbContextSupplier,
+            new DbContextService(),
             Mock.Of<ILogger<DataImportService>>());
 
         var importerLocationCache = new ImporterLocationCache(Mock.Of<ILogger<ImporterLocationCache>>());
@@ -1364,11 +1381,17 @@ public class ProcessorStage3Tests
             contentDbContextId: _contentDbContextId,
             statisticsDbContextId: _statisticsDbContextId);
 
+        var dbContextService = new Mock<IDbContextService>(Strict);
+
+        dbContextService.Setup(mock => mock.SaveChangesAsync(It.IsAny<DbContext>()))
+            .Returns(Task.CompletedTask);
+
         var databaseHelper = new InMemoryDatabaseHelper(dbContextSupplier);
 
         var dataImportService = new DataImportService(
             dbContextSupplier,
-            Mock.Of<ILogger<DataImportService>>());
+            dbContextService.Object,
+        Mock.Of<ILogger<DataImportService>>());
 
         var importerLocationCache = new ImporterLocationCache(Mock.Of<ILogger<ImporterLocationCache>>());
 
@@ -1423,6 +1446,10 @@ public class ProcessorStage3Tests
         var outputMessages = await function.ProcessUploads(
             new ImportMessage(import.Id),
             new TestFunctionContext());
+
+        dbContextService.Verify(mock =>
+                mock.SaveChangesAsync(It.IsAny<DbContext>()),
+            Times.Once);
 
         VerifyAllMocks(privateBlobStorageService);
 
@@ -1536,6 +1563,7 @@ public class ProcessorStage3Tests
 
         var dataImportService = new DataImportService(
             dbContextSupplier,
+            new DbContextService(),
             Mock.Of<ILogger<DataImportService>>());
 
         var importerLocationCache = new ImporterLocationCache(Mock.Of<ILogger<ImporterLocationCache>>());

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
@@ -325,6 +325,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
 
             return new DataImportService(
                 dbContextSupplier,
+                new DbContextService(),
                 Mock.Of<ILogger<DataImportService>>(Strict));
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
@@ -290,9 +290,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             {
                 var updatedFile = contentDbContext.Files.Single(f => f.SubjectId == subject.Id);
 
-                Assert.NotNull(updatedFile.DataSetFileMeta);
+                Assert.NotNull(updatedFile.DataSetFileMetaOld);
 
-                var meta = updatedFile.DataSetFileMeta;
+                var meta = updatedFile.DataSetFileMetaOld;
                 Assert.Equal(3, meta.GeographicLevels.Count);
                 Assert.Contains(GeographicLevel.Country, meta.GeographicLevels);
                 Assert.Contains(GeographicLevel.LocalAuthority, meta.GeographicLevels);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Program.cs
@@ -60,6 +60,7 @@ var host = new HostBuilder()
             .AddSingleton<IDatabaseHelper, DatabaseHelper>()
             .AddSingleton<IImporterLocationCache, ImporterLocationCache>()
             .AddSingleton<IDbContextSupplier, DbContextSupplier>()
+            .AddSingleton<IDbContextService, DbContextService>()
             .Configure<AppOptions>(hostContext.Configuration.GetSection(AppOptions.Section));
     })
     .Build();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -19,13 +19,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
     public class DataImportService : IDataImportService
     {
         private readonly IDbContextSupplier _dbContextSupplier;
+        private readonly IDbContextService _dbContextService;
         private readonly ILogger<DataImportService> _logger;
 
         public DataImportService(
             IDbContextSupplier dbContextSupplier,
+            IDbContextService dbContextService,
             ILogger<DataImportService> logger)
         {
             _dbContextSupplier = dbContextSupplier;
+            _dbContextService = dbContextService;
             _logger = logger;
         }
 
@@ -257,7 +260,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                              && f.SubjectId == subjectId);
             file.DataSetFileMeta = dataSetFileMeta;
             file.DataSetFileMetaOld = dataSetFileMetaOld;
-            await contentDbContext.SaveChangesAsync();
+
+            // The in-memory db we use in tests cannot save to the
+            // DataSetFileMeta JSON column. So to ensure tests succeed
+            // we make the save mockable
+            await _dbContextService.SaveChangesAsync(contentDbContext);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -172,7 +172,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 .OrderBy(o => o.Year)
                 .ThenBy(o => o.TimeIdentifier)
                 .ToList()
-                .Select(tp => new TimePeriodRangeBoundMeta
+                .Select(tp => new TimePeriodRangeBoundMetaOld
                 {
                     Period = tp.Year.ToString(),
                     TimeIdentifier = tp.TimeIdentifier,
@@ -183,7 +183,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 .AsNoTracking()
                 .Where(f => f.SubjectId == subjectId)
                 .OrderBy(f => f.Label)
-                .Select(f => new FilterMeta
+                .Select(f => new FilterMetaOld
                 {
                     Id = f.Id,
                     Label = f.Label,
@@ -195,7 +195,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             var indicators = await statisticsDbContext.Indicator
                 .AsNoTracking()
                 .Where(i => i.IndicatorGroup.SubjectId == subjectId)
-                .Select(i => new IndicatorMeta
+                .Select(i => new IndicatorMetaOld
                 {
                     Id = i.Id,
                     Label = i.Label,
@@ -204,10 +204,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 .OrderBy(i => i.Label)
                 .ToListAsync();
 
-            var dataSetFileMeta = new DataSetFileMeta
+            var dataSetFileMeta = new DataSetFileMetaOld
             {
                 GeographicLevels = geographicLevels,
-                TimePeriodRange = new TimePeriodRangeMeta
+                TimePeriodRange = new TimePeriodRangeMetaOld
                 {
                     Start = timePeriods.First(),
                     End = timePeriods.Last(),
@@ -219,7 +219,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             var file = contentDbContext.Files
                 .Single(f => f.Type == FileType.Data
                              && f.SubjectId == subjectId);
-            file.DataSetFileMeta = dataSetFileMeta;
+            file.DataSetFileMetaOld = dataSetFileMeta;
             await contentDbContext.SaveChangesAsync();
         }
     }


### PR DESCRIPTION
This PR created a new Files.DataSetFileMeta column. The old column is renamed to `DataSetFileMetaOld`

This is being done to allow the JSON in DataSetFileMeta to be queryable, such that we can filter data sets on the Data Catalogue page by geographic level (in EES-5598).

A migration endpoint has been created that will need to be manually hit on each environment after this work has been deployed: see `DataSetFileMetaMigrationController`.

The changes to `ContentDbContext` required lots of finessing to make it work. I mention this because I wouldn't be surprised if Entity Framework break backwards compatibility and this feature fails to work next time we update EF.

As the tests relied on the in-memory DB, and that didn't support EF8 JSON columns, we had a couple of failing tests. To fix them, I made the saving of changes to the database mockable.

The final step of removing `DataSetFileMetaOld` and switching to using DataSetFileMeta everywhere will be done in EES-5693
