### PR TITLE
EES 5633 - FE - Redirect the user to the latest version of a page if using an old Release slug in the URL

### DIFF
--- a/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
@@ -299,6 +299,33 @@ describe('redirectPages', () => {
       nonRedirectedCases: findStatisticsReleasePageTestData.nonRedirectedCases,
     };
 
+  const dataTablesPublicationPageTestData: RoutePatternTestCases = {
+    routePattern: `data-tables/${publicationSlugPlaceholder}`,
+    redirectedCases: [
+      {
+        oldSlugNewSlugPairsByPlaceholder: {
+          [publicationSlugPlaceholder]: {
+            oldSlug: 'original-publication-slug-1',
+            newSlug: 'updated-publication-slug-1',
+          },
+        },
+      },
+    ],
+    nonRedirectedCases: [
+      {
+        oldSlugsByPlaceholder: {
+          [publicationSlugPlaceholder]: 'original-publication-slug-2',
+        },
+      },
+      // Matches redirect slugs from another redirect type
+      {
+        oldSlugsByPlaceholder: {
+          [publicationSlugPlaceholder]: 'original-methodology-slug-1',
+        },
+      },
+    ],
+  };
+
   const dataTablesReleasePageTestData: RoutePatternTestCases = {
     routePattern: `data-tables/${publicationSlugPlaceholder}/${releaseSlugPlaceholder}`,
     redirectedCases: mixedPublicationReleasePageRedirectedCases,
@@ -313,6 +340,7 @@ describe('redirectPages', () => {
     findStatisticsReleasePageTestData,
     findStatisticsReleaseDataGuidancePageTestData,
     findStatisticsReleasePrereleaseAccessListPageTestData,
+    dataTablesPublicationPageTestData,
     dataTablesReleasePageTestData,
   ];
 

--- a/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
@@ -326,18 +326,6 @@ describe('redirectPages', () => {
     ],
   };
 
-  const dataTablesPublicationFastTrackPageTestData: RoutePatternTestCases = {
-    routePattern: `data-tables/${publicationSlugPlaceholder}/fast-track/child-route`,
-    redirectedCases: dataTablesPublicationPageTestData.redirectedCases,
-    nonRedirectedCases: dataTablesPublicationPageTestData.nonRedirectedCases,
-  };
-
-  const dataTablesPublicationPermalinkPageTestData: RoutePatternTestCases = {
-    routePattern: `data-tables/${publicationSlugPlaceholder}/permalink/child-route`,
-    redirectedCases: dataTablesPublicationPageTestData.redirectedCases,
-    nonRedirectedCases: dataTablesPublicationPageTestData.nonRedirectedCases,
-  };
-
   const dataTablesReleasePageTestData: RoutePatternTestCases = {
     routePattern: `data-tables/${publicationSlugPlaceholder}/${releaseSlugPlaceholder}`,
     redirectedCases: mixedPublicationReleasePageRedirectedCases,
@@ -353,8 +341,6 @@ describe('redirectPages', () => {
     findStatisticsReleaseDataGuidancePageTestData,
     findStatisticsReleasePrereleaseAccessListPageTestData,
     dataTablesPublicationPageTestData,
-    dataTablesPublicationFastTrackPageTestData,
-    dataTablesPublicationPermalinkPageTestData,
     dataTablesReleasePageTestData,
   ];
 
@@ -418,18 +404,6 @@ describe('redirectPages', () => {
       oldSlugsByPlaceholder: {
         [publicationSlugPlaceholder]: 'original-publication-slug-1',
         [releaseSlugPlaceholder]: 'original-release-slug-1',
-      },
-    },
-    {
-      routePattern: `data-tables/${publicationSlugPlaceholder}/fast-track/child-route/child-route`,
-      oldSlugsByPlaceholder: {
-        [publicationSlugPlaceholder]: 'original-publication-slug-1',
-      },
-    },
-    {
-      routePattern: `data-tables/${publicationSlugPlaceholder}/permalink/child-route/child-route`,
-      oldSlugsByPlaceholder: {
-        [publicationSlugPlaceholder]: 'original-publication-slug-1',
       },
     },
     {

--- a/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
@@ -23,6 +23,10 @@ describe('redirectPages', () => {
       { fromSlug: 'original-slug-3', toSlug: 'updated-slug-3' },
       { fromSlug: 'original-slug-4', toSlug: 'updated-slug-4' },
     ],
+    releases: [
+      { fromSlug: 'original-slug-5', toSlug: 'updated-slug-5' },
+      { fromSlug: 'original-slug-6', toSlug: 'updated-slug-6' },
+    ],
   };
 
   test('does not re-request the list of redirects once it has been fetched', async () => {

--- a/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
@@ -507,15 +507,18 @@ describe('redirectPages', () => {
       async redirectedCase => {
         redirectService.list.mockResolvedValue(testRedirects);
 
-        const route = buildRoute(redirectedCase.routePattern, 'original-slug');
+        const route = buildOldRoute(
+          redirectedCase.routePattern,
+          redirectedCase.oldSlugNewSlugPairsByPlaceholder,
+        );
 
         await runMiddleware(redirectPages, `https://my-env/${route}`);
 
         expect(redirectService.list).toHaveBeenCalledTimes(1);
 
-        const anotherRoute = buildRoute(
+        const anotherRoute = buildOldRoute(
           redirectedCase.routePattern,
-          'another-slug',
+          redirectedCase.oldSlugNewSlugPairsByPlaceholder,
         );
 
         await runMiddleware(redirectPages, `https://my-env/${anotherRoute}`);

--- a/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
@@ -1,4 +1,4 @@
-import redirectPages from '@frontend/middleware/pages/redirectPages';
+import * as redirectPagesModule from '@frontend/middleware/pages/redirectPages';
 import _redirectService, {
   Redirects,
 } from '@frontend/services/redirectService';
@@ -11,40 +11,148 @@ const redirectService = _redirectService as jest.Mocked<
 >;
 
 describe('redirectPages', () => {
-  const redirectSpy = jest.spyOn(NextResponse, 'redirect');
-  const nextSpy = jest.spyOn(NextResponse, 'next');
+  interface TestDataWithoutRedirect {
+    routePattern: string;
+    fromSlug: string;
+  }
+
+  interface TestDataWithRedirect extends TestDataWithoutRedirect {
+    toSlug: string;
+  }
+
+  const slugPlaceholder = '{slug}';
 
   const testRedirects: Redirects = {
-    methodologyRedirects: [
-      { fromSlug: 'original-slug-1', toSlug: 'updated-slug-1' },
-      { fromSlug: 'original-slug-2', toSlug: 'updated-slug-2' },
-    ],
-    publicationRedirects: [
-      { fromSlug: 'original-slug-3', toSlug: 'updated-slug-3' },
-      { fromSlug: 'original-slug-4', toSlug: 'updated-slug-4' },
-    ],
-    releases: [
-      { fromSlug: 'original-slug-5', toSlug: 'updated-slug-5' },
-      { fromSlug: 'original-slug-6', toSlug: 'updated-slug-6' },
-    ],
+    methodologies: [{ fromSlug: 'original-slug-1', toSlug: 'updated-slug-1' }],
+    publications: [{ fromSlug: 'original-slug-2', toSlug: 'updated-slug-2' }],
+    releases: [{ fromSlug: 'original-slug-3', toSlug: 'updated-slug-3' }],
   };
 
-  test('does not re-request the list of redirects once it has been fetched', async () => {
-    redirectService.list.mockResolvedValue(testRedirects);
+  const testRedirectData: TestDataWithRedirect[] = [
+    {
+      routePattern: `methodology/${slugPlaceholder}`,
+      fromSlug: testRedirects.methodologies[0].fromSlug,
+      toSlug: testRedirects.methodologies[0].toSlug,
+    },
+    {
+      routePattern: `find-statistics/${slugPlaceholder}`,
+      fromSlug: testRedirects.publications[0].fromSlug,
+      toSlug: testRedirects.publications[0].toSlug,
+    },
+    {
+      routePattern: `find-statistics/${slugPlaceholder}/data-guidance`,
+      fromSlug: testRedirects.publications[0].fromSlug,
+      toSlug: testRedirects.publications[0].toSlug,
+    },
+    {
+      routePattern: `find-statistics/${slugPlaceholder}/prerelease-access-list`,
+      fromSlug: testRedirects.publications[0].fromSlug,
+      toSlug: testRedirects.publications[0].toSlug,
+    },
+    {
+      routePattern: `find-statistics/publication-slug/${slugPlaceholder}`,
+      fromSlug: testRedirects.releases[0].fromSlug,
+      toSlug: testRedirects.releases[0].toSlug,
+    },
+    {
+      routePattern: `find-statistics/publication-slug/${slugPlaceholder}/data-guidance`,
+      fromSlug: testRedirects.releases[0].fromSlug,
+      toSlug: testRedirects.releases[0].toSlug,
+    },
+    {
+      routePattern: `find-statistics/publication-slug/${slugPlaceholder}/prerelease-access-list`,
+      fromSlug: testRedirects.releases[0].fromSlug,
+      toSlug: testRedirects.releases[0].toSlug,
+    },
+    {
+      routePattern: `data-tables/${slugPlaceholder}`,
+      fromSlug: testRedirects.publications[0].fromSlug,
+      toSlug: testRedirects.publications[0].toSlug,
+    },
+    {
+      routePattern: `data-tables/${slugPlaceholder}/fast-track/child-route`,
+      fromSlug: testRedirects.publications[0].fromSlug,
+      toSlug: testRedirects.publications[0].toSlug,
+    },
+    {
+      routePattern: `data-tables/${slugPlaceholder}/permalink/child-route`,
+      fromSlug: testRedirects.publications[0].fromSlug,
+      toSlug: testRedirects.publications[0].toSlug,
+    },
+    {
+      routePattern: `data-tables/publication-slug/${slugPlaceholder}`,
+      fromSlug: testRedirects.releases[0].fromSlug,
+      toSlug: testRedirects.releases[0].toSlug,
+    },
+  ];
 
-    await runMiddleware(
-      redirectPages,
-      'https://my-env/methodology/original-slug',
-    );
+  const testRedirectDataWithFromSlugMatchingAnotherRedirectType: TestDataWithoutRedirect[] =
+    [
+      {
+        routePattern: `methodology/${slugPlaceholder}`,
+        fromSlug: testRedirects.publications[0].fromSlug,
+      },
+      {
+        routePattern: `find-statistics/${slugPlaceholder}`,
+        fromSlug: testRedirects.methodologies[0].fromSlug,
+      },
+      {
+        routePattern: `find-statistics/${slugPlaceholder}/data-guidance`,
+        fromSlug: testRedirects.methodologies[0].fromSlug,
+      },
+      {
+        routePattern: `find-statistics/${slugPlaceholder}/prerelease-access-list`,
+        fromSlug: testRedirects.methodologies[0].fromSlug,
+      },
+      {
+        routePattern: `find-statistics/publication-slug/${slugPlaceholder}`,
+        fromSlug: testRedirects.publications[0].fromSlug,
+      },
+      {
+        routePattern: `find-statistics/publication-slug/${slugPlaceholder}/data-guidance`,
+        fromSlug: testRedirects.publications[0].fromSlug,
+      },
+      {
+        routePattern: `find-statistics/publication-slug/${slugPlaceholder}/prerelease-access-list`,
+        fromSlug: testRedirects.publications[0].fromSlug,
+      },
+      {
+        routePattern: `data-tables/${slugPlaceholder}`,
+        fromSlug: testRedirects.releases[0].fromSlug,
+      },
+      {
+        routePattern: `data-tables/${slugPlaceholder}/fast-track/child-route`,
+        fromSlug: testRedirects.releases[0].fromSlug,
+      },
+      {
+        routePattern: `data-tables/${slugPlaceholder}/permalink/child-route`,
+        fromSlug: testRedirects.releases[0].fromSlug,
+      },
+      {
+        routePattern: `data-tables/publication-slug/${slugPlaceholder}`,
+        fromSlug: testRedirects.publications[0].fromSlug,
+      },
+    ];
 
-    expect(redirectService.list).toHaveBeenCalledTimes(1);
+  let redirectSpy: jest.SpyInstance;
+  const nextSpy = jest.spyOn(NextResponse, 'next');
 
-    await runMiddleware(
-      redirectPages,
-      'https://my-env/methodology/another-slug',
-    );
+  let redirectPages: typeof redirectPagesModule.default;
 
-    expect(redirectService.list).toHaveBeenCalledTimes(1);
+  function buildRoute(routePattern: string, slug: string): string {
+    return routePattern.replace(slugPlaceholder, slug);
+  }
+
+  beforeEach(async () => {
+    await jest.isolateModulesAsync(async () => {
+      import('@frontend/middleware/pages/redirectPages').then(module => {
+        redirectPages = module.default;
+      });
+
+      import('next/server').then(module => {
+        redirectSpy = jest.spyOn(module.NextResponse, 'redirect');
+      });
+    });
   });
 
   test('does not check for redirects for non release or methodology pages', async () => {
@@ -60,7 +168,7 @@ describe('redirectPages', () => {
     expect(redirectSpy).not.toHaveBeenCalled();
     expect(nextSpy).toHaveBeenCalledTimes(2);
 
-    await runMiddleware(redirectPages, 'https://my-env/data-tables/something');
+    await runMiddleware(redirectPages, 'https://my-env/data-tables');
 
     expect(redirectService.list).not.toHaveBeenCalled();
     expect(redirectSpy).not.toHaveBeenCalled();
@@ -95,237 +203,203 @@ describe('redirectPages', () => {
     expect(nextSpy).not.toHaveBeenCalled();
   });
 
-  describe('redirect methodology pages', () => {
-    test('redirects the request when the slug for the requested page has changed', async () => {
+  it.each(testRedirectData)(
+    'does not re-request the list of redirects once it has been fetched',
+    async redirectData => {
       redirectService.list.mockResolvedValue(testRedirects);
 
-      await runMiddleware(
-        redirectPages,
-        'https://my-env/methodology/original-slug-1',
+      const route = buildRoute(redirectData.routePattern, 'original-slug');
+
+      await runMiddleware(redirectPages, `https://my-env/${route}`);
+
+      expect(redirectService.list).toHaveBeenCalledTimes(1);
+
+      const anotherRoute = buildRoute(
+        redirectData.routePattern,
+        'another-slug',
       );
+
+      await runMiddleware(redirectPages, `https://my-env/${anotherRoute}`);
+
+      expect(redirectService.list).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(testRedirectData)(
+    'redirects the request when the slug for the requested page has changed',
+    async redirectData => {
+      redirectService.list.mockResolvedValue(testRedirects);
+
+      const fromRoute = buildRoute(
+        redirectData.routePattern,
+        redirectData.fromSlug,
+      );
+      const toRoute = buildRoute(
+        redirectData.routePattern,
+        redirectData.toSlug,
+      );
+
+      await runMiddleware(redirectPages, `https://my-env/${fromRoute}`);
 
       expect(redirectSpy).toHaveBeenCalledTimes(1);
       expect(redirectSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          href: 'https://my-env/methodology/updated-slug-1',
+          href: `https://my-env/${toRoute}`,
         }),
         301,
       );
       expect(nextSpy).not.toHaveBeenCalled();
-    });
+    },
+  );
 
-    test('does not redirect when the slug for the requested page has not changed', async () => {
+  it.each(testRedirectData)(
+    'redirects the request when the slug for the requested page has changed, and the url has a trailing slash',
+    async redirectData => {
       redirectService.list.mockResolvedValue(testRedirects);
+
+      const fromRoute = buildRoute(
+        redirectData.routePattern,
+        redirectData.fromSlug,
+      );
+      const toRoute = buildRoute(
+        redirectData.routePattern,
+        redirectData.toSlug,
+      );
+
+      await runMiddleware(redirectPages, `https://my-env/${fromRoute}/`);
+
+      expect(redirectSpy).toHaveBeenCalledTimes(1);
+      expect(redirectSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          href: `https://my-env/${toRoute}/`,
+        }),
+        301,
+      );
+      expect(nextSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(testRedirectData)(
+    'does not redirect when the slug for the requested page has not changed',
+    async redirectData => {
+      redirectService.list.mockResolvedValue(testRedirects);
+
+      const route = buildRoute(
+        redirectData.routePattern,
+        'slug-with-no-redirect',
+      );
+
+      await runMiddleware(redirectPages, `https://my-env/${route}`);
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(testRedirectData)(
+    'does not redirect if the `fromSlug` only partially matches',
+    async redirectData => {
+      redirectService.list.mockResolvedValue(testRedirects);
+
+      const routeWithRedirectSlugSubstring = buildRoute(
+        redirectData.routePattern,
+        redirectData.fromSlug.substring(0, redirectData.fromSlug.length - 1),
+      );
 
       await runMiddleware(
         redirectPages,
-        'https://my-env/methodology/my-methodology',
+        `https://my-env/${routeWithRedirectSlugSubstring}`,
       );
 
       expect(redirectSpy).not.toHaveBeenCalled();
       expect(nextSpy).toHaveBeenCalledTimes(1);
-    });
 
-    test('does not redirect if the `fromSlug` only partially matches', async () => {
-      redirectService.list.mockResolvedValue(testRedirects);
-
-      await runMiddleware(redirectPages, 'https://my-env/methodology/original');
-
-      expect(redirectSpy).not.toHaveBeenCalled();
-      expect(nextSpy).toHaveBeenCalledTimes(1);
+      const routeWithRedirectSlugWithSuffix = buildRoute(
+        redirectData.routePattern,
+        `${redirectData.fromSlug}-extra-suffix`,
+      );
 
       await runMiddleware(
         redirectPages,
-        'https://my-env/methodology/original-slug-and-something',
+        `https://my-env/${routeWithRedirectSlugWithSuffix}`,
       );
 
       expect(redirectSpy).not.toHaveBeenCalled();
       expect(nextSpy).toHaveBeenCalledTimes(2);
-    });
+    },
+  );
 
-    test('redirects child pages', async () => {
+  it.each(testRedirectData)(
+    'redirects with query params',
+    async redirectData => {
       redirectService.list.mockResolvedValue(testRedirects);
+
+      const fromRoute = buildRoute(
+        redirectData.routePattern,
+        redirectData.fromSlug,
+      );
+      const toRoute = buildRoute(
+        redirectData.routePattern,
+        redirectData.toSlug,
+      );
 
       await runMiddleware(
         redirectPages,
-        'https://my-env/methodology/original-slug-1/child-page',
+        `https://my-env/${fromRoute}?search=something`,
       );
 
       expect(redirectSpy).toHaveBeenCalledTimes(1);
       expect(redirectSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          href: 'https://my-env/methodology/updated-slug-1/child-page',
+          href: `https://my-env/${toRoute}?search=something`,
         }),
         301,
       );
       expect(nextSpy).not.toHaveBeenCalled();
-    });
+    },
+  );
 
-    test('redirects with query params', async () => {
+  it.each(testRedirectDataWithFromSlugMatchingAnotherRedirectType)(
+    'does not redirect when the slug matches a `fromSlug` in a different redirect type',
+    async redirectData => {
       redirectService.list.mockResolvedValue(testRedirects);
 
-      await runMiddleware(
-        redirectPages,
-        'https://my-env/methodology/original-slug-1?search=something',
+      const route = buildRoute(
+        redirectData.routePattern,
+        redirectData.fromSlug,
       );
 
-      expect(redirectSpy).toHaveBeenCalledTimes(1);
-      expect(redirectSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: 'https://my-env/methodology/updated-slug-1?search=something',
-        }),
-        301,
-      );
-      expect(nextSpy).not.toHaveBeenCalled();
-    });
-
-    test('does not redirect when the slug matches a `fromSlug` in a different page type', async () => {
-      redirectService.list.mockResolvedValue(testRedirects);
-
-      await runMiddleware(
-        redirectPages,
-        'https://my-env/methodology/original-slug-4',
-      );
+      await runMiddleware(redirectPages, `https://my-env/${route}`);
 
       expect(redirectSpy).not.toHaveBeenCalled();
       expect(nextSpy).toHaveBeenCalledTimes(1);
-    });
+    },
+  );
 
-    test('redirects with uppercase characters', async () => {
+  it.each(testRedirectData)(
+    'redirects with uppercase characters',
+    async redirectData => {
       redirectService.list.mockResolvedValue(testRedirects);
 
-      await runMiddleware(
-        redirectPages,
-        'https://my-env/Methodology/original-SLUG-1',
+      const fromRoute = buildRoute(
+        redirectData.routePattern,
+        redirectData.fromSlug.toUpperCase(),
       );
+      const toRoute = buildRoute(
+        redirectData.routePattern,
+        redirectData.toSlug,
+      );
+
+      await runMiddleware(redirectPages, `https://my-env/${fromRoute}`);
 
       expect(redirectSpy).toHaveBeenCalledTimes(1);
       expect(redirectSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          href: 'https://my-env/methodology/updated-slug-1',
+          href: `https://my-env/${toRoute}`,
         }),
         301,
       );
       expect(nextSpy).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('redirect publication pages', () => {
-    test('redirects the request when the slug for the requested page has changed', async () => {
-      redirectService.list.mockResolvedValue(testRedirects);
-
-      await runMiddleware(
-        redirectPages,
-        'https://my-env/find-statistics/original-slug-3',
-      );
-
-      expect(redirectSpy).toHaveBeenCalledTimes(1);
-      expect(redirectSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: 'https://my-env/find-statistics/updated-slug-3',
-        }),
-        301,
-      );
-      expect(nextSpy).not.toHaveBeenCalled();
-    });
-
-    test('does not redirect when the slug for the requested page has not changed', async () => {
-      redirectService.list.mockResolvedValue(testRedirects);
-
-      await runMiddleware(
-        redirectPages,
-        'https://my-env/find-statistics/my-publication',
-      );
-
-      expect(redirectSpy).not.toHaveBeenCalled();
-      expect(nextSpy).toHaveBeenCalledTimes(1);
-    });
-
-    test('does not redirect if the `fromSlug` only partially matches', async () => {
-      redirectService.list.mockResolvedValue(testRedirects);
-
-      await runMiddleware(
-        redirectPages,
-        'https://my-env/find-statistics/original',
-      );
-
-      expect(redirectSpy).not.toHaveBeenCalled();
-      expect(nextSpy).toHaveBeenCalledTimes(1);
-
-      await runMiddleware(
-        redirectPages,
-        'https://my-env/find-statistics/original-slug-and-something',
-      );
-
-      expect(redirectSpy).not.toHaveBeenCalled();
-      expect(nextSpy).toHaveBeenCalledTimes(2);
-    });
-
-    test('redirects child pages', async () => {
-      redirectService.list.mockResolvedValue(testRedirects);
-
-      await runMiddleware(
-        redirectPages,
-        'https://my-env/find-statistics/original-slug-3/child-page',
-      );
-
-      expect(redirectSpy).toHaveBeenCalledTimes(1);
-      expect(redirectSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: 'https://my-env/find-statistics/updated-slug-3/child-page',
-        }),
-        301,
-      );
-      expect(nextSpy).not.toHaveBeenCalled();
-    });
-
-    test('redirects with query params', async () => {
-      redirectService.list.mockResolvedValue(testRedirects);
-
-      await runMiddleware(
-        redirectPages,
-        'https://my-env/find-statistics/original-slug-3?search=something',
-      );
-
-      expect(redirectSpy).toHaveBeenCalledTimes(1);
-
-      expect(redirectSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: 'https://my-env/find-statistics/updated-slug-3?search=something',
-        }),
-        301,
-      );
-      expect(nextSpy).not.toHaveBeenCalled();
-    });
-
-    test('does not redirect when the slug matches a `fromSlug` in a different page type', async () => {
-      redirectService.list.mockResolvedValue(testRedirects);
-
-      await runMiddleware(
-        redirectPages,
-        'https://my-env/find-statistics/original-slug-1',
-      );
-
-      expect(redirectSpy).not.toHaveBeenCalled();
-      expect(nextSpy).toHaveBeenCalledTimes(1);
-    });
-
-    test('redirects with uppercase characters', async () => {
-      redirectService.list.mockResolvedValue(testRedirects);
-
-      await runMiddleware(
-        redirectPages,
-        'https://my-env/find-Statistics/original-SLUG-3',
-      );
-
-      expect(redirectSpy).toHaveBeenCalledTimes(1);
-      expect(redirectSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: 'https://my-env/find-statistics/updated-slug-3',
-        }),
-        301,
-      );
-      expect(nextSpy).not.toHaveBeenCalled();
-    });
-  });
+    },
+  );
 });

--- a/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
@@ -299,33 +299,6 @@ describe('redirectPages', () => {
       nonRedirectedCases: findStatisticsReleasePageTestData.nonRedirectedCases,
     };
 
-  const dataTablesPublicationPageTestData: RoutePatternTestCases = {
-    routePattern: `data-tables/${publicationSlugPlaceholder}`,
-    redirectedCases: [
-      {
-        oldSlugNewSlugPairsByPlaceholder: {
-          [publicationSlugPlaceholder]: {
-            oldSlug: 'original-publication-slug-1',
-            newSlug: 'updated-publication-slug-1',
-          },
-        },
-      },
-    ],
-    nonRedirectedCases: [
-      {
-        oldSlugsByPlaceholder: {
-          [publicationSlugPlaceholder]: 'original-publication-slug-2',
-        },
-      },
-      // Matches redirect slugs from another redirect type
-      {
-        oldSlugsByPlaceholder: {
-          [publicationSlugPlaceholder]: 'original-methodology-slug-1',
-        },
-      },
-    ],
-  };
-
   const dataTablesReleasePageTestData: RoutePatternTestCases = {
     routePattern: `data-tables/${publicationSlugPlaceholder}/${releaseSlugPlaceholder}`,
     redirectedCases: mixedPublicationReleasePageRedirectedCases,
@@ -340,7 +313,6 @@ describe('redirectPages', () => {
     findStatisticsReleasePageTestData,
     findStatisticsReleaseDataGuidancePageTestData,
     findStatisticsReleasePrereleaseAccessListPageTestData,
-    dataTablesPublicationPageTestData,
     dataTablesReleasePageTestData,
   ];
 

--- a/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
@@ -27,7 +27,7 @@ const redirectPatterns: URLPattern[] = [
     pathname: `/find-statistics/:${publicationSlugKey}/:${releaseSlugKey}/(data-guidance/?|prerelease-access-list/?|.{0})?`,
   }),
   new URLPattern({
-    pathname: `/data-tables/:${publicationSlugKey}/(fast-track/[^/]*/?|permalink/[^/]*/?|.{0})?`,
+    pathname: `/data-tables/:${publicationSlugKey}{/}?`,
   }),
   new URLPattern({
     pathname: `/data-tables/:${publicationSlugKey}/:${releaseSlugKey}{/}?`,

--- a/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
@@ -27,6 +27,9 @@ const redirectPatterns: URLPattern[] = [
     pathname: `/find-statistics/:${publicationSlugKey}/:${releaseSlugKey}/(data-guidance/?|prerelease-access-list/?|.{0})?`,
   }),
   new URLPattern({
+    pathname: `/data-tables/:${publicationSlugKey}{/}?`,
+  }),
+  new URLPattern({
     pathname: `/data-tables/:${publicationSlugKey}/:${releaseSlugKey}{/}?`,
   }),
 ];

--- a/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
@@ -27,9 +27,6 @@ const redirectPatterns: URLPattern[] = [
     pathname: `/find-statistics/:${publicationSlugKey}/:${releaseSlugKey}/(data-guidance/?|prerelease-access-list/?|.{0})?`,
   }),
   new URLPattern({
-    pathname: `/data-tables/:${publicationSlugKey}{/}?`,
-  }),
-  new URLPattern({
     pathname: `/data-tables/:${publicationSlugKey}/:${releaseSlugKey}{/}?`,
   }),
 ];

--- a/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
@@ -42,31 +42,31 @@ const redirectPatterns: RedirectPattern[] = [
   {
     redirectTypes: ['methodologies'],
     urlPattern: new URLPattern({
-      pathname: `/methodology/:${methodologySlugKey}{/*}?`,
+      pathname: `/methodology/:${methodologySlugKey}{/}?`,
     }),
   },
   {
     redirectTypes: ['publications'],
     urlPattern: new URLPattern({
-      pathname: `/find-statistics/:${publicationSlugKey}{/(data-guidance|prerelease-access-list)}?`,
+      pathname: `/find-statistics/:${publicationSlugKey}/(data-guidance/?|prerelease-access-list/?|.{0})?`,
     }),
   },
   {
     redirectTypes: ['publications', 'releases'],
     urlPattern: new URLPattern({
-      pathname: `/find-statistics/:${publicationSlugKey}/:${releaseSlugKey}{/(data-guidance|prerelease-access-list)}?`,
+      pathname: `/find-statistics/:${publicationSlugKey}/:${releaseSlugKey}/(data-guidance/?|prerelease-access-list/?|.{0})?`,
     }),
   },
   {
     redirectTypes: ['publications'],
     urlPattern: new URLPattern({
-      pathname: `/data-tables/:${publicationSlugKey}{/(\\(fast-track|permalink\\)\\(/.*\\))}?`,
+      pathname: `/data-tables/:${publicationSlugKey}/(fast-track/[^/]*/?|permalink/[^/]*/?|.{0})?`,
     }),
   },
   {
     redirectTypes: ['publications', 'releases'],
     urlPattern: new URLPattern({
-      pathname: `/data-tables/:${publicationSlugKey}/:${releaseSlugKey}`,
+      pathname: `/data-tables/:${publicationSlugKey}/:${releaseSlugKey}{/}?`,
     }),
   },
 ];

--- a/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
@@ -157,7 +157,7 @@ function findRedirectIfExists(
         [latestPublicationSlug]: releaseRedirectsForLatestPublication = [],
       } = cachedRedirects?.redirects.releaseRedirectsByPublicationSlug || {};
 
-      return releaseRedirectsForLatestPublication?.find(
+      return releaseRedirectsForLatestPublication.find(
         ({ fromSlug }) => slug === fromSlug,
       );
     }

--- a/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
@@ -27,17 +27,6 @@ const cacheTime = getCacheTime();
 
 let cachedRedirects: CachedRedirects | undefined;
 
-// POSSIBLE REDIRECT ROUTES FOR PUBLICATIONS AND RELEASES:
-// find-statistics/{publication-slug}
-// find-statistics/{publication-slug}/data-guidance
-// find-statistics/{publication-slug}/prerelease-access-list
-// find-statistics/{publication-slug}/{release-slug}
-// find-statistics/{publication-slug}/{release-slug}/data-guidance
-// find-statistics/{publication-slug}/{release-slug}/prerelease-access-list
-// data-tables/{publication-slug}
-// data-tables/{publication-slug}/{release-slug}
-// data-tables/{publication-slug}/fast-track/{data-block-parent-id}
-// data-tables/{publication-slug}/permalink/{permalink}
 const redirectPatterns: RedirectPattern[] = [
   {
     redirectTypes: ['methodologies'],

--- a/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
@@ -1,6 +1,5 @@
 import { Dictionary } from '@common/types';
 import redirectService, { Redirects } from '@frontend/services/redirectService';
-import _ from 'lodash';
 import type { NextFetchEvent, NextMiddleware, NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
@@ -46,7 +45,7 @@ export default async function redirectPages(
   // Check for redirects for publication, release, and methodology pages
   const routeSlugsBySlugKey = findRouteSlugsBySlugKey(lowerCasedPathname);
 
-  if (!_.isEmpty(routeSlugsBySlugKey)) {
+  if (Object.keys(routeSlugsBySlugKey).length > 0) {
     await refreshCache();
 
     const redirectPath = determineRedirectPath(
@@ -154,10 +153,13 @@ function findRedirectIfExists(
         latestPublicationSlug = publicationRedirect.toSlug;
       }
 
-      return _.get(
-        cachedRedirects?.redirects.releaseRedirectsByPublicationSlug,
-        latestPublicationSlug,
-      )?.find(({ fromSlug }) => slug === fromSlug);
+      const {
+        [latestPublicationSlug]: releaseRedirectsForLatestPublication = [],
+      } = cachedRedirects?.redirects.releaseRedirectsByPublicationSlug || {};
+
+      return releaseRedirectsForLatestPublication?.find(
+        ({ fromSlug }) => slug === fromSlug,
+      );
     }
     default:
       throw new Error(`'${slugKey}' is not a valid redirect type.`);

--- a/src/explore-education-statistics-frontend/src/services/redirectService.ts
+++ b/src/explore-education-statistics-frontend/src/services/redirectService.ts
@@ -1,6 +1,7 @@
 export interface Redirects {
-  methodologyRedirects: Redirect[];
-  publicationRedirects: Redirect[];
+  methodologies: Redirect[];
+  publications: Redirect[];
+  releases: Redirect[];
 }
 
 export type RedirectType = keyof Redirects;

--- a/src/explore-education-statistics-frontend/src/services/redirectService.ts
+++ b/src/explore-education-statistics-frontend/src/services/redirectService.ts
@@ -1,7 +1,9 @@
+import { Dictionary } from '@common/types';
+
 export interface Redirects {
-  methodologies: Redirect[];
-  publications: Redirect[];
-  releases: Redirect[];
+  methodologyRedirects: Redirect[];
+  publicationRedirects: Redirect[];
+  releaseRedirectsByPublicationSlug: Dictionary<Redirect[]>;
 }
 
 export type RedirectType = keyof Redirects;


### PR DESCRIPTION
⚠️ This PR depends on some more BE changes we need to make on top of those in https://github.com/dfe-analytical-services/explore-education-statistics/pull/5391. The new changes will be made in another PR under [EES-5632](https://dfedigital.atlassian.net/jira/software/c/projects/EES/boards/105?selectedIssue=EES-5632). Please see https://github.com/dfe-analytical-services/explore-education-statistics/pull/5446 to see those BE changes. [THIS PR IS BLOCKED BY [#5446](https://github.com/dfe-analytical-services/explore-education-statistics/pull/5446) ]⚠️ 

This PR consists of the frontend changes necessary to allow **Release** redirects to work.

Previously, we only had the ability to be able to redirect the user when we detected an old **methodology/publication** slug in the URL. But now, with the introduction of `ReleaseRedirects` in [EES-5631](https://dfedigital.atlassian.net/jira/software/c/projects/EES/boards/105?selectedIssue=EES-5631) & [EES-5632](https://dfedigital.atlassian.net/jira/software/c/projects/EES/boards/105?selectedIssue=EES-5632), we need to be able to handle redirects for **releases** too.


During this work, I had to refactor **how** the redirects worked on the frontend. Previously, we just looked for a prefix of either `/methodology` or `/find-statistics` in the URL and then checked if the next segment of the URL contained an **old** slug for either a methodology or publication, respectively, and then proceeded to redirect **ANY** child route.

However, this no longer works with the introduction of release redirects, because the current pages which contain a release slug in their URL also contain a publication slug. For this reason, if we only checked for the occurrence of a prefix in the URL before redirecting the user on any child route, then the release slug wouldn't be taken into account if we found a redirect for the publication. Equally, if we introduce any further routes in the future which contain multiple possible redirect slugs in their URL, they will be impacted too.

For this reason, I have refactored the redirect logic to only check for very **explicit** patterns in the URL, when trying to determine whether or not the URL looks like one that can be redirected. I've split out the _'URL Patterns'_ into a list, which can be iterated through and easily added to. We use the [URL Pattern Standard](https://urlpattern.spec.whatwg.org/) to implement the matching logic, and use Regex to check for the various valid alternatives for a pattern (including checking for trailing slashes, which should be allowed). I have intentionally only included **existing** routes that need to be checked for redirects, and have not included subsequent child-routes that don't exist yet. Any new routes in the future, that have the potential to be redirected, can easily be added to the list of URL Patterns we check against.

Every (**current**) possible URL Pattern has been tested via Jest unit tests.


# Other Related Changes
---

- Previously, the unit tests were importing and using the same instance of the `redirectPages` module throughout each test. However, due to the `redirectPages` module containing state in the form of the cached redirects (see the `cachedRedirects` property), this was being carried over between tests and potentially interfering. This hasn't been detected until now, because the previous tests, although mocking the response from the `redirectService.list` method, always returned the same mocked data from that method. So, the caching had no consequence to whether the test passed or failed. Now we have multiple test cases for each test, corresponding to each unique URL Pattern, it was necessary to use Jest's [`isolateModulesAsync`](https://jestjs.io/docs/29.4/jest-object#jestisolatemodulesasyncfn) to isolate specific modules for every test so that local module state doesn't conflict between tests (which was being flagged when doing the `expect(redirectService.list).toHaveBeenCalledTimes(1);` checks in the tests)
