### PR TITLE
EES-5656 Remove `IReleaseVersionRepository.ListLatestReleaseVersions`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
@@ -19,12 +19,10 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Utils.AdminM
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
 using static Moq.MockBehavior;
-using IReleaseVersionRepository = GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces.IReleaseVersionRepository;
-using ReleaseVersionRepository = GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.ReleaseVersionRepository;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
-    public class UserManagementServicePermissionTest
+    public class UserManagementServicePermissionTests
     {
         [Fact]
         public async Task ListAllUsers()
@@ -130,7 +128,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             public async Task Success()
             {
                 await using var contentDbContext = DbUtils.InMemoryApplicationDbContext();
-                contentDbContext.Users.Add(new User { Email = "ees-test.user@education.gov.uk"} );
+                contentDbContext.Users.Add(new User { Email = "ees-test.user@education.gov.uk" });
                 await contentDbContext.SaveChangesAsync();
 
                 await PolicyCheckBuilder<SecurityPolicies>()
@@ -154,14 +152,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             UsersAndRolesDbContext? usersAndRolesDbContext = null,
             IPersistenceHelper<UsersAndRolesDbContext>? usersAndRolesPersistenceHelper = null,
             IEmailTemplateService? emailTemplateService = null,
-            IReleaseVersionRepository? releaseVersionRepository = null,
             IUserRoleService? userRoleService = null,
             IUserService? userService = null,
             IUserInviteRepository? userInviteRepository = null,
             IUserReleaseInviteRepository? userReleaseInviteRepository = null,
             IUserPublicationInviteRepository? userPublicationInviteRepository = null,
-            UserManager<ApplicationUser>? userManager = null,
-            bool enableDeletion = false)
+            UserManager<ApplicationUser>? userManager = null)
         {
             contentDbContext ??= InMemoryApplicationDbContext();
             usersAndRolesDbContext ??= InMemoryUserAndRolesDbContext();
@@ -171,7 +167,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 contentDbContext,
                 usersAndRolesPersistenceHelper ?? new PersistenceHelper<UsersAndRolesDbContext>(usersAndRolesDbContext),
                 emailTemplateService ?? Mock.Of<IEmailTemplateService>(Strict),
-                releaseVersionRepository ?? new ReleaseVersionRepository(contentDbContext),
                 userRoleService ?? Mock.Of<IUserRoleService>(Strict),
                 userService ?? AlwaysTrueUserService().Object,
                 userInviteRepository ?? new UserInviteRepository(usersAndRolesDbContext),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserManagementController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/UserManagement/UserManagementController.cs
@@ -68,7 +68,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.UserM
         public async Task<ActionResult<Unit>> AddReleaseRole(Guid userId, UserReleaseRoleCreateRequest request)
         {
             return await _userRoleService
-                .AddReleaseRole(userId, request.ReleaseId, request.ReleaseRole)
+                .AddReleaseRole(userId: userId, releaseId: request.ReleaseId, request.ReleaseRole)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserRoleService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserRoleService.cs
@@ -15,8 +15,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, Unit>> AddPublicationRole(Guid userId, Guid publicationId, PublicationRole role);
 
-        Task<Either<ActionResult, Unit>> AddReleaseRole(Guid userId,
-            Guid releaseVersionId,
+        Task<Either<ActionResult, Unit>> AddReleaseRole(
+            Guid userId,
+            Guid releaseId,
             ReleaseRole role);
 
         Task<Either<ActionResult, Unit>> UpgradeToGlobalRoleIfRequired(string globalRoleNameToSet, Guid userId);
@@ -31,7 +32,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, List<UserPublicationRoleViewModel>>> GetPublicationRolesForUser(Guid userId);
 
-        Task<Either<ActionResult, List<UserPublicationRoleViewModel>>> GetPublicationRolesForPublication(Guid publicationId);
+        Task<Either<ActionResult, List<UserPublicationRoleViewModel>>> GetPublicationRolesForPublication(
+            Guid publicationId);
 
         Task<Either<ActionResult, List<UserReleaseRoleViewModel>>> GetReleaseRoles(Guid userId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/ReleaseVersionRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/ReleaseVersionRepositoryTests.cs
@@ -393,11 +393,12 @@ public class ReleaseVersionRepositoryTests
             var result = await repository.ListLatestPublishedReleaseVersionIds(publications[0].Id);
 
             // Expect the result to contain the highest published version of each release for the specified publication
-            AssertIdsAreEqualIgnoringOrder(new[]
-            {
-                publications[0].ReleaseVersions[2].Id,
-                publications[0].ReleaseVersions[5].Id
-            }, result);
+            AssertIdsAreEqualIgnoringOrder(
+                [
+                    publications[0].ReleaseVersions[2].Id,
+                    publications[0].ReleaseVersions[5].Id
+                ],
+                result);
         }
 
         [Fact]
@@ -479,11 +480,12 @@ public class ReleaseVersionRepositoryTests
             var result = await repository.ListLatestPublishedReleaseVersions(publications[0].Id);
 
             // Expect the result to contain the highest published version of each release for the specified publication
-            AssertIdsAreEqualIgnoringOrder(new[]
-            {
-                publications[0].ReleaseVersions[2].Id,
-                publications[0].ReleaseVersions[5].Id
-            }, result);
+            AssertIdsAreEqualIgnoringOrder(
+                [
+                    publications[0].ReleaseVersions[2].Id,
+                    publications[0].ReleaseVersions[5].Id
+                ],
+                result);
         }
 
         [Fact]
@@ -567,12 +569,13 @@ public class ReleaseVersionRepositoryTests
             var result = await repository.ListLatestReleaseVersionIds(publications[0].Id);
 
             // Expect the result to contain the highest version of each release for the specified publication
-            AssertIdsAreEqualIgnoringOrder(new[]
-            {
-                publications[0].ReleaseVersions[0].Id,
-                publications[0].ReleaseVersions[3].Id,
-                publications[0].ReleaseVersions[5].Id
-            }, result);
+            AssertIdsAreEqualIgnoringOrder(
+                [
+                    publications[0].ReleaseVersions[0].Id,
+                    publications[0].ReleaseVersions[3].Id,
+                    publications[0].ReleaseVersions[5].Id
+                ],
+                result);
         }
 
         [Fact]
@@ -611,136 +614,16 @@ public class ReleaseVersionRepositoryTests
         }
     }
 
-    public class ListLatestReleaseVersionsTests : ReleaseVersionRepositoryTests
-    {
-        [Fact]
-        public async Task AllPublications_Success()
-        {
-            var publications = _dataFixture
-                .DefaultPublication()
-                .WithReleases(_ => ListOf<Release>(
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 0, draftVersion: true),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 2, draftVersion: true),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 2)))
-                .GenerateList(2);
-
-            var contextId = await AddTestData(publications);
-            await using var contentDbContext = InMemoryContentDbContext(contextId);
-            var repository = BuildRepository(contentDbContext);
-
-            var result = await repository.ListLatestReleaseVersions();
-
-            // Expect the result to contain the highest version of each release for each publication
-            AssertIdsAreEqualIgnoringOrder(new[]
-            {
-                publications[0].ReleaseVersions[0].Id,
-                publications[0].ReleaseVersions[3].Id,
-                publications[0].ReleaseVersions[5].Id,
-                publications[1].ReleaseVersions[0].Id,
-                publications[1].ReleaseVersions[3].Id,
-                publications[1].ReleaseVersions[5].Id
-            }, result);
-        }
-
-        [Fact]
-        public async Task AllPublications_PublicationsHaveNoReleaseVersions_ReturnsEmpty()
-        {
-            var publications = _dataFixture
-                .DefaultPublication()
-                .GenerateList(2);
-
-            var contextId = await AddTestData(publications);
-            await using var contentDbContext = InMemoryContentDbContext(contextId);
-            var repository = BuildRepository(contentDbContext);
-
-            Assert.Empty(await repository.ListLatestReleaseVersions());
-        }
-
-        [Fact]
-        public async Task AllPublications_NoPublicationsExist_ReturnsEmpty()
-        {
-            await using var contentDbContext = InMemoryContentDbContext();
-            var repository = BuildRepository(contentDbContext);
-
-            Assert.Empty(await repository.ListLatestReleaseVersions());
-        }
-
-        [Fact]
-        public async Task SpecificPublication_Success()
-        {
-            var publications = _dataFixture
-                .DefaultPublication()
-                .WithReleases(_ => ListOf<Release>(
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 0, draftVersion: true),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 2, draftVersion: true),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 2)))
-                .GenerateList(2);
-
-            var contextId = await AddTestData(publications);
-            await using var contentDbContext = InMemoryContentDbContext(contextId);
-            var repository = BuildRepository(contentDbContext);
-
-            var result = await repository.ListLatestReleaseVersions(publications[0].Id);
-
-            // Expect the result to contain the highest version of each release for the specified publication
-            AssertIdsAreEqualIgnoringOrder(new[]
-            {
-                publications[0].ReleaseVersions[0].Id,
-                publications[0].ReleaseVersions[3].Id,
-                publications[0].ReleaseVersions[5].Id
-            }, result);
-        }
-
-        [Fact]
-        public async Task SpecificPublication_PublicationHasNoReleaseVersions_ReturnsEmpty()
-        {
-            var publications = _dataFixture
-                .DefaultPublication()
-                // Index 0 has no release versions
-                // Index 1 has a published release version
-                .ForIndex(1, p => p.SetReleases(_dataFixture
-                    .DefaultRelease(publishedVersions: 1)
-                    .Generate(1)))
-                .GenerateList(2);
-
-            var contextId = await AddTestData(publications);
-            await using var contentDbContext = InMemoryContentDbContext(contextId);
-            var repository = BuildRepository(contentDbContext);
-
-            Assert.Empty(await repository.ListLatestReleaseVersions(publications[0].Id));
-        }
-
-        [Fact]
-        public async Task SpecificPublication_PublicationDoesNotExist_ReturnsEmpty()
-        {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases(_dataFixture
-                    .DefaultRelease(publishedVersions: 1)
-                    .Generate(1));
-
-            var contextId = await AddTestData(publication);
-            await using var contentDbContext = InMemoryContentDbContext(contextId);
-            var repository = BuildRepository(contentDbContext);
-
-            Assert.Empty(await repository.ListLatestReleaseVersions(Guid.NewGuid()));
-        }
-    }
-
-    private static void AssertIdsAreEqualIgnoringOrder(IReadOnlyCollection<Guid> expectedIds,
+    private static void AssertIdsAreEqualIgnoringOrder(
+        IReadOnlyCollection<Guid> expectedIds,
         IReadOnlyCollection<ReleaseVersion> actualReleaseVersions)
     {
         Assert.Equal(expectedIds.Count, actualReleaseVersions.Count);
         Assert.True(SequencesAreEqualIgnoringOrder(expectedIds, actualReleaseVersions.Select(rv => rv.Id)));
     }
 
-    private static void AssertIdsAreEqualIgnoringOrder(IReadOnlyCollection<Guid> expectedIds,
+    private static void AssertIdsAreEqualIgnoringOrder(
+        IReadOnlyCollection<Guid> expectedIds,
         IReadOnlyCollection<Guid> actualIds)
     {
         Assert.Equal(expectedIds.Count, actualIds.Count);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IReleaseVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IReleaseVersionRepository.cs
@@ -8,7 +8,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 
 public interface IReleaseVersionRepository
 {
-    Task<DateTime> GetPublishedDate(Guid releaseVersionId,
+    Task<DateTime> GetPublishedDate(
+        Guid releaseVersionId,
         DateTime actualPublishedDate);
 
     /// <summary>
@@ -100,13 +101,6 @@ public interface IReleaseVersionRepository
     Task<List<Guid>> ListLatestReleaseVersionIds(
         Guid publicationId,
         CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Retrieves the latest versions of all releases in reverse chronological order.
-    /// </summary>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>A collection of the latest versions of all releases.</returns>
-    Task<List<ReleaseVersion>> ListLatestReleaseVersions(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the latest versions of all releases associated with a given publication in reverse chronological order.

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseVersionRepository.cs
@@ -20,7 +20,8 @@ public class ReleaseVersionRepository : IReleaseVersionRepository
         _contentDbContext = contentDbContext;
     }
 
-    public async Task<DateTime> GetPublishedDate(Guid releaseVersionId,
+    public async Task<DateTime> GetPublishedDate(
+        Guid releaseVersionId,
         DateTime actualPublishedDate)
     {
         var releaseVersion = await _contentDbContext.ReleaseVersions
@@ -136,14 +137,6 @@ public class ReleaseVersionRepository : IReleaseVersionRepository
         return await _contentDbContext.ReleaseVersions.LatestReleaseVersions(publicationId)
             .Select(rv => rv.Id)
             .ToListAsync(cancellationToken: cancellationToken);
-    }
-
-    public async Task<List<ReleaseVersion>> ListLatestReleaseVersions(CancellationToken cancellationToken = default)
-    {
-        return (await _contentDbContext.ReleaseVersions.LatestReleaseVersions()
-                .ToListAsync(cancellationToken: cancellationToken))
-            .OrderByReverseChronologicalOrder()
-            .ToList();
     }
 
     public async Task<List<ReleaseVersion>> ListLatestReleaseVersions(


### PR DESCRIPTION
This PR simplifies two of Admin's BAU User Management screens for inviting users and managing user release access which both use a call to `UserManagementService.ListReleases` to list all releases in a dropdown using labels with the format `<publication title - release title>`.

![image](https://github.com/user-attachments/assets/cbf83974-388b-48f3-9b0b-1b8a8c6b63f7)

![image](https://github.com/user-attachments/assets/284deee0-b782-47a2-825f-193751d97e52)

This has been relying on the table of all release versions to produce a list of all the releases in all publications using the titles of the latest release versions in every release.

Since #5409, this can be simplified to use the table of all releases to do the same thing which means we no longer need to evaluate the latest release version for every release to produce the list.

With this change we can now remove the method `IReleaseVersionRepository.ListLatestReleaseVersions(CancellationToken cancellationToken)`  which returned release versions in reverse chronological order of their release year and time period. This ordering didn't really make sense for this method since the results span across multiple publications, so there can be multiple latest release versions of different releases with identical year and time periods.

In EES-5656 the reverse chronological ordering of returned results in `ReleaseVersionRepository` will be removed in favour of the ordering defined by analysts, added in #4701. The changes in this PR are being raised early to assist with that item of work.

### UI test report

![image](https://github.com/user-attachments/assets/2cbe4e5b-be09-4340-b52a-64dcac2ce763)
