### PR TITLE
EES-5717 set number of decimal places on chart minor axis

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartAxisConfiguration.cs
@@ -28,6 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
         public bool Visible = true;
         public string Title = null!;
         public string Unit = null!;
+        public int? DecimalPlaces;
         public bool ShowGrid = true;
 
         public AxisLabel Label = null!;

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
@@ -278,6 +278,7 @@ const ChartAxisConfiguration = ({
       min: Yup.number(),
       visible: Yup.boolean(),
       unit: Yup.string(),
+      decimalPlaces: Yup.string(),
       labelText: Yup.string(),
       labelWidth: Yup.number().positive('Label width must be positive'),
     });
@@ -464,6 +465,7 @@ const ChartAxisConfiguration = ({
         labelRotated: values?.label?.rotated ?? false,
         labelText: values?.label?.text ?? '',
         labelWidth: values?.label?.width ?? undefined,
+        decimalPlaces: values?.decimalPlaces ?? undefined,
         referenceLines:
           values?.referenceLines.map(line => {
             return {
@@ -592,12 +594,20 @@ const ChartAxisConfiguration = ({
                       name="visible"
                       label="Show axis"
                       conditional={
-                        <FormFieldTextInput<ChartAxisConfigurationFormValues>
-                          label="Displayed unit"
-                          name="unit"
-                          hint="Leave blank to set default from metadata"
-                          width={10}
-                        />
+                        <>
+                          <FormFieldTextInput<ChartAxisConfigurationFormValues>
+                            label="Displayed unit"
+                            name="unit"
+                            hint="Leave blank to set default from metadata"
+                            width={10}
+                          />
+                          <FormFieldNumberInput<ChartAxisConfigurationFormValues>
+                            label="Displayed decimal places"
+                            name="decimalPlaces"
+                            hint="Leave blank to set default from metadata"
+                            width={10}
+                          />
+                        </>
                       }
                     />
                   )}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
@@ -100,6 +100,7 @@ describe('ChartAxisConfiguration', () => {
     tickSpacing: 1,
     type: 'minor',
     unit: '',
+    decimalPlaces: undefined,
     visible: true,
     label: { text: '', width: 100, rotated: false },
     max: undefined,

--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -103,7 +103,10 @@ const HorizontalBarBlock = ({
     meta,
   });
 
-  const minorAxisDecimals = getMinorAxisDecimalPlaces(dataSetCategoryConfigs);
+  const minorAxisDecimals = getMinorAxisDecimalPlaces(
+    dataSetCategoryConfigs,
+    axes.minor.decimalPlaces,
+  );
   const minorAxisUnit = axes.minor.unit || getUnit(dataSetCategoryConfigs);
   const chartHasNegativeValues =
     (parseNumber(minorDomainTicks.domain?.[0]) ?? 0) < 0;

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -90,7 +90,10 @@ const LineChartBlock = ({
     legendItems: legend.items,
     meta,
   });
-  const minorAxisDecimals = getMinorAxisDecimalPlaces(dataSetCategoryConfigs);
+  const minorAxisDecimals = getMinorAxisDecimalPlaces(
+    dataSetCategoryConfigs,
+    axes.minor.decimalPlaces,
+  );
   const minorAxisUnit = axes.minor.unit || getUnit(dataSetCategoryConfigs);
   const yAxisWidth = getMinorAxisSize({
     dataSetCategories,

--- a/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
@@ -109,7 +109,10 @@ const VerticalBarBlock = ({
     legendItems: legend.items,
     meta,
   });
-  const minorAxisDecimals = getMinorAxisDecimalPlaces(dataSetCategoryConfigs);
+  const minorAxisDecimals = getMinorAxisDecimalPlaces(
+    dataSetCategoryConfigs,
+    axes.minor.decimalPlaces,
+  );
   const minorAxisUnit = axes.minor.unit || getUnit(dataSetCategoryConfigs);
   const yAxisWidth = getMinorAxisSize({
     dataSetCategories,

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -67,6 +67,7 @@ export interface AxisConfiguration {
   referenceLines: ReferenceLine[];
   visible?: boolean;
   unit?: string;
+  decimalPlaces?: number;
   showGrid?: boolean;
   label?: Label;
   size?: number;

--- a/src/explore-education-statistics-common/src/modules/charts/util/getMinorAxisDecimalPlaces.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/getMinorAxisDecimalPlaces.ts
@@ -16,7 +16,11 @@ import { DataSetCategoryConfig } from '@common/modules/charts/util/getDataSetCat
  */
 export default function getMinorAxisDecimalPlaces(
   categoryDataSets: DataSetCategoryConfig[],
+  decimalPlaces?: number,
 ): number | undefined {
+  if (decimalPlaces || decimalPlaces === 0) {
+    return decimalPlaces;
+  }
   return categoryDataSets.reduce<number | undefined>((acc, { dataSet }) => {
     if (typeof dataSet.indicator.decimalPlaces === 'undefined') {
       return acc;


### PR DESCRIPTION
> Retarget of [Amy B's PR](https://github.com/dfe-analytical-services/explore-education-statistics/pull/5431)

Adds a field to the chart minor axis configuration to set the number of decimal places that show on the axis.

I've not been able to run the UI tests because of issues with my local setup, but I don't think it'll cause problem