### PR TITLE
EES-5705 correcting failed test count in Slack / EES-5724 failing test suites early on publisher failure / EES-5522 breaking UI pipeline into templates

### DIFF
--- a/azure-pipelines-run-ui-test-suite.yml
+++ b/azure-pipelines-run-ui-test-suite.yml
@@ -1,0 +1,62 @@
+parameters:
+  - name: jobName
+    type: string
+  - name: displayName
+    type: string
+  - name: testFolder
+    type: string
+  - name: artifactName
+    type: string
+
+jobs:
+  - job: ${{ parameters.jobName }}
+    displayName: ${{ parameters.displayName }}
+    timeoutInMinutes: 160
+    cancelTimeoutInMinutes: 10
+    condition: succeededOrFailed()
+    pool: ees-ubuntu2204-large
+    workspace:
+      clean: all
+    steps:
+    - checkout: self
+      clean: true
+      fetchDepth: 5
+      fetchTags: false
+
+    - task: UsePythonVersion@0
+      displayName: Use Python 3.10
+      timeoutInMinutes: 5
+      inputs:
+        versionSpec: 3.10
+
+    - task: AzureKeyVault@2
+      displayName: Azure Key Vault - s101d01-kv-ees-01
+      inputs:
+        azureSubscription: $(SPN_NAME)
+        KeyVaultName: s101d01-kv-ees-01
+        SecretsFilter: ees-test-ADMIN-PASSWORD,ees-test-ANALYST-PASSWORD,ees-test-expiredinvite-password,ees-test-NOINVITE-PASSWORD,ees-test-PENDINGINVITE-PASSWORD,ees-alerts-slackapptoken
+        RunAsPreJob: true
+
+    - task: PythonScript@0
+      displayName: Run tests
+      condition: succeededOrFailed()
+      inputs:
+        scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
+        arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --noinvite-pass '"$(ees-test-NOINVITE-PASSWORD)"' --pendinginvite-pass '"$(ees-test-PENDINGINVITE-PASSWORD)"' --env "dev" --file "${{ parameters.testFolder }}" --processes 4 --rerun-attempts 3
+        # The magic incantation '"$(variable)"'was added by Mark to resolve an issue with Analyst password that contained ampersands.
+        workingDirectory: tests/robot-tests
+      env:
+        SLACK_APP_TOKEN: $(ees-alerts-slackapptoken)
+
+    - task: PublishTestResults@2
+      displayName: Publish test results
+      inputs:
+        testResultsFiles: tests/robot-tests/test-results/xunit.xml
+        failTaskOnFailedTests: true
+
+    - task: PublishPipelineArtifact@1
+      displayName: Publish pipeline artifact
+      condition: succeededOrFailed()
+      inputs:
+        path: tests/robot-tests/test-results/
+        artifactName: ${{ parameters.artifactName }}

--- a/azure-pipelines-ui-tests.yml
+++ b/azure-pipelines-ui-tests.yml
@@ -17,261 +17,41 @@ resources:
     ref: refs/heads/dev
 
 jobs:
-- job: Public
-  displayName: Public suite - Robot UI tests
-  timeoutInMinutes: 160
-  cancelTimeoutInMinutes: 10
-  condition: succeededOrFailed()
-  pool: ees-ubuntu2204-large
-  workspace:
-    clean: all
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
-    fetchTags: false
+- template: azure-pipelines-run-ui-test-suite.yml
+  parameters:
+    jobName: Public
+    displayName: Public suite - Robot UI tests
+    testFolder: tests/general_public
+    artifactName: test-results-public
 
-  - task: UsePythonVersion@0
-    displayName: Use Python 3.10
-    timeoutInMinutes: 5
-    inputs:
-      versionSpec: 3.10
+- template: azure-pipelines-run-ui-test-suite.yml
+  parameters:
+    jobName: PublishAndAmend
+    displayName: Publish release and amend suites - Robot UI tests
+    testFolder: tests/admin_and_public_2
+    artifactName: test-results-admin-and-public-2
 
-  - task: AzureKeyVault@2
-    displayName: Azure Key Vault - s101d01-kv-ees-01
-    inputs:
-      azureSubscription: $(SPN_NAME)
-      KeyVaultName: s101d01-kv-ees-01
-      SecretsFilter: ees-alerts-slackapptoken
-      RunAsPreJob: true
+- template: azure-pipelines-run-ui-test-suite.yml
+  parameters:
+    jobName: Admin
+    displayName: Admin suites - Robot UI tests
+    testFolder: tests/admin
+    artifactName: test-results-admin
 
-  - task: PythonScript@0
-    displayName: Public UI tests
-    inputs:
-      scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass "test" --analyst-pass "test" --expiredinvite-pass "test" --noinvite-pass "test" --pendinginvite-pass "test" --env "dev" --file "tests/general_public" --processes 4 --rerun-attempts 3
-      workingDirectory: tests/robot-tests
-    env:
-      SLACK_APP_TOKEN: $(ees-alerts-slackapptoken)
+- template: azure-pipelines-run-ui-test-suite.yml
+  parameters:
+    jobName: AdminAndPublic
+    displayName: Admin & public suites - Robot UI tests
+    testFolder: tests/admin_and_public
+    artifactName: test-results-admin-public
 
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    condition: succeededOrFailed()
-    inputs:
-      testResultsFiles: tests/robot-tests/test-results/xunit.xml
-      failTaskOnFailedTests: true
+- template: azure-pipelines-run-ui-test-suite.yml
+  parameters:
+    jobName: PublicAPI
+    displayName: Public API suite - Robot UI tests
+    testFolder: tests/public_api
+    artifactName: test-results-admin-public-api
 
-  - task: PublishPipelineArtifact@1
-    displayName: Publish Test Pipeline Artifact
-    condition: succeededOrFailed()
-    inputs:
-      path: tests/robot-tests/test-results/
-      artifactName: test-results-public
-
-- job: PublishAndAmend
-  displayName: Publish release and amend suites - Robot UI tests
-  timeoutInMinutes: 160
-  cancelTimeoutInMinutes: 10
-  condition: succeededOrFailed()
-  pool: ees-ubuntu2204-large
-  workspace:
-    clean: all
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
-    fetchTags: false
-
-  - task: UsePythonVersion@0
-    displayName: Use Python 3.10
-    timeoutInMinutes: 5
-    inputs:
-      versionSpec: 3.10
-
-  - task: AzureKeyVault@2
-    displayName: Azure Key Vault - s101d01-kv-ees-01
-    inputs:
-      azureSubscription: $(SPN_NAME)
-      KeyVaultName: s101d01-kv-ees-01
-      SecretsFilter: ees-test-ADMIN-PASSWORD,ees-test-ANALYST-PASSWORD,ees-test-expiredinvite-password,ees-test-NOINVITE-PASSWORD,ees-test-PENDINGINVITE-PASSWORD,ees-alerts-slackapptoken
-      RunAsPreJob: true
-
-  - task: PythonScript@0
-    displayName: Publish release and amend UI tests
-    condition: succeededOrFailed()
-    inputs:
-      scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --noinvite-pass '"$(ees-test-NOINVITE-PASSWORD)"' --pendinginvite-pass '"$(ees-test-PENDINGINVITE-PASSWORD)"' --env "dev" --file "tests/admin_and_public_2" --processes 4 --rerun-attempts 3
-    #  The magic incantation '"$(variable)"'was added by Mark to resolve an issue with Analyst password that contained ampersands.
-      workingDirectory: tests/robot-tests
-    env:
-      SLACK_APP_TOKEN: $(ees-alerts-slackapptoken)
-
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    inputs:
-      testResultsFiles: tests/robot-tests/test-results/xunit.xml
-      failTaskOnFailedTests: true
-
-  - task: PublishPipelineArtifact@1
-    displayName: Publish Pipeline Artifact
-    condition: succeededOrFailed()
-    inputs:
-      path: tests/robot-tests/test-results/
-      artifactName: test-results-admin-and-public-2
-
-
-- job: Admin
-  displayName: Admin suites - Robot UI tests
-  timeoutInMinutes: 160
-  cancelTimeoutInMinutes: 10
-  condition: succeededOrFailed()
-  pool: ees-ubuntu2204-large
-  workspace:
-    clean: all
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
-    fetchTags: false
-
-  - task: UsePythonVersion@0
-    displayName: Use Python 3.10
-    timeoutInMinutes: 5
-    inputs:
-      versionSpec: 3.10
-
-  - task: AzureKeyVault@2
-    displayName: Azure Key Vault - s101d01-kv-ees-01
-    inputs:
-      azureSubscription: $(SPN_NAME)
-      KeyVaultName: s101d01-kv-ees-01
-      SecretsFilter: ees-test-ADMIN-PASSWORD,ees-test-ANALYST-PASSWORD,ees-test-expiredinvite-password,ees-test-NOINVITE-PASSWORD,ees-test-PENDINGINVITE-PASSWORD,ees-alerts-slackapptoken
-      RunAsPreJob: true
-
-  - task: PythonScript@0
-    displayName: Admin UI tests
-    condition: succeededOrFailed()
-    inputs:
-      scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --noinvite-pass '"$(ees-test-NOINVITE-PASSWORD)"' --pendinginvite-pass '"$(ees-test-PENDINGINVITE-PASSWORD)"' --env "dev" --file "tests/admin" --processes 4 --rerun-attempts 3
-      workingDirectory: tests/robot-tests
-    env:
-      SLACK_APP_TOKEN: $(ees-alerts-slackapptoken)
-
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    condition: succeededOrFailed()
-    inputs:
-      testResultsFiles: tests/robot-tests/test-results/xunit.xml
-      failTaskOnFailedTests: true
-
-  - task: PublishPipelineArtifact@1
-    displayName: Publish Test Pipeline Artifact
-    condition: succeededOrFailed()
-    inputs:
-      path: tests/robot-tests/test-results/
-      artifactName: test-results-admin
-
-- job: AdminAndPublic
-  displayName: Admin & public suites - Robot UI tests
-  timeoutInMinutes: 160
-  cancelTimeoutInMinutes: 10
-  condition: succeededOrFailed()
-  pool: ees-ubuntu2204-large
-  workspace:
-    clean: all
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
-    fetchTags: false
-
-  - task: UsePythonVersion@0
-    displayName: Use Python 3.10
-    timeoutInMinutes: 5
-    inputs:
-      versionSpec: 3.10
-
-  - task: AzureKeyVault@2
-    displayName: Azure Key Vault - s101d01-kv-ees-01
-    inputs:
-      azureSubscription: $(SPN_NAME)
-      KeyVaultName: s101d01-kv-ees-01
-      SecretsFilter: ees-test-ADMIN-PASSWORD,ees-test-ANALYST-PASSWORD,ees-test-expiredinvite-password,ees-test-NOINVITE-PASSWORD,ees-test-PENDINGINVITE-PASSWORD,ees-alerts-slackapptoken
-      RunAsPreJob: true
-
-  - task: PythonScript@0
-    displayName: Admin public UI tests
-    inputs:
-      scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --noinvite-pass '"$(ees-test-NOINVITE-PASSWORD)"' --pendinginvite-pass '"$(ees-test-PENDINGINVITE-PASSWORD)"' --env "dev" --file "tests/admin_and_public" --processes 4 --rerun-attempts 3
-      workingDirectory: tests/robot-tests
-    env:
-      SLACK_APP_TOKEN: $(ees-alerts-slackapptoken)
-
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    inputs:
-      testResultsFiles: tests/robot-tests/test-results/xunit.xml
-      failTaskOnFailedTests: true
-
-  - task: PublishPipelineArtifact@1
-    displayName: Publish Test Pipeline Artifact
-    condition: succeededOrFailed()
-    inputs:
-      path: tests/robot-tests/test-results/
-      artifactName: test-results-admin-public
-
-- job: PublicAPI
-  displayName: Public API suite - Robot UI tests
-  timeoutInMinutes: 160
-  cancelTimeoutInMinutes: 10
-  condition: succeededOrFailed()
-  pool: ees-ubuntu2204-large
-  workspace:
-    clean: all
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 5
-    fetchTags: false
-
-  - task: UsePythonVersion@0
-    displayName: Use Python 3.10
-    timeoutInMinutes: 5
-    inputs:
-      versionSpec: 3.10
-
-  - task: AzureKeyVault@2
-    displayName: Azure Key Vault - s101d01-kv-ees-01
-    inputs:
-      azureSubscription: $(SPN_NAME)
-      KeyVaultName: s101d01-kv-ees-01
-      SecretsFilter: ees-test-ADMIN-PASSWORD,ees-test-ANALYST-PASSWORD,ees-test-expiredinvite-password,ees-test-NOINVITE-PASSWORD,ees-test-PENDINGINVITE-PASSWORD,ees-alerts-slackapptoken
-      RunAsPreJob: true
-
-  - task: PythonScript@0
-    displayName: Public API UI tests
-    inputs:
-      scriptPath: tests/robot-tests/scripts/run_tests_pipeline.py
-      arguments: --admin-pass '"$(ees-test-ADMIN-PASSWORD)"' --analyst-pass '"$(ees-test-ANALYST-PASSWORD)"' --expiredinvite-pass '"$(ees-test-expiredinvite-password)"' --noinvite-pass '"$(ees-test-NOINVITE-PASSWORD)"' --pendinginvite-pass '"$(ees-test-PENDINGINVITE-PASSWORD)"' --env "dev" --file "tests/public_api" --processes 4 --rerun-attempts 3
-      workingDirectory: tests/robot-tests
-    env:
-      SLACK_APP_TOKEN: $(ees-alerts-slackapptoken)
-
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    inputs:
-      testResultsFiles: tests/robot-tests/test-results/xunit.xml
-      failTaskOnFailedTests: true
-
-  - task: PublishPipelineArtifact@1
-    displayName: Publish Test Pipeline Artifact
-    condition: succeededOrFailed()
-    inputs:
-      path: tests/robot-tests/test-results/
-      artifactName: test-results-admin-public-api
 
         #- job: PublicPlaywrightUItest
         #  displayName: Public suite - Playwright UI tests

--- a/tests/robot-tests/report-modifiers/CheckForAtLeastOnePassingRunPrerebotModifier.py
+++ b/tests/robot-tests/report-modifiers/CheckForAtLeastOnePassingRunPrerebotModifier.py
@@ -16,9 +16,3 @@ class CheckForAtLeastOnePassingRunPrerebotModifier(SuiteVisitor):
                 )
                 test.status = "PASS"
                 test.message = f'Marking test "{test}" as PASS because it passed in at least one of the test runs.  Previous message is {test.message}'
-            elif "SKIP" in test.message:
-                self.logger.info(
-                    f'CheckForAtLeastOnePassingRunPrerebotModifier - marking test "{test}" as SKIPPED because it was skipped in the latter run.'
-                )
-                test.status = "SKIP"
-                test.message = f'Marking test "{test}" as SKIP because it was skipped in the latter test run.  Previous message is {test.message}'

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -207,6 +207,9 @@ def run():
             time.sleep(5)
             slack_service.send_test_report(args.env, args.tests, failing_suites, number_of_test_runs)
 
+        if len(failing_suites) > 0:
+            sys.exit(1)
+
     except Exception as ex:
         if args.enable_slack_notifications:
             slack_service = SlackService()

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -127,10 +127,14 @@ def run():
 
     logger.info(f"Running Robot tests with {max_run_attempts} maximum run attempts")
 
+    test_run_results_folder = ""
+
     try:
         # Run tests
         while test_run_index < max_run_attempts:
             try:
+                test_run_results_folder = f"{main_results_folder}{os.sep}run-{test_run_index + 1}"
+
                 # Ensure all SeleniumLibrary elements and keywords are updated to use a brand new
                 # Selenium instance for every test (re)run.
                 if test_run_index > 0:
@@ -142,7 +146,6 @@ def run():
                 _clear_files_before_next_test_run_attempt(rerunning_failed_suites)
 
                 # Create a folder to contain this test run attempt's outputs and reports.
-                test_run_results_folder = f"{main_results_folder}{os.sep}run-{test_run_index + 1}"
                 os.makedirs(test_run_results_folder)
 
                 if not Path(f"{main_results_folder}/downloads").exists():

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -127,8 +127,6 @@ def run():
 
     logger.info(f"Running Robot tests with {max_run_attempts} maximum run attempts")
 
-    test_run_results_folder = ""
-
     try:
         # Run tests
         while test_run_index < max_run_attempts:

--- a/tests/robot-tests/tests/libs/admin-utilities.py
+++ b/tests/robot-tests/tests/libs/admin-utilities.py
@@ -109,12 +109,12 @@ def user_waits_for_release_process_status_to_be(status, timeout):
         try:
             sl().driver.find_element(By.ID, f"release-process-status-Failed")
             raise_assertion_error("Release process status FAILED!")
-        except BaseException:
+        except NoSuchElementException:
             pass
         try:
             sl().driver.find_element(By.ID, f"release-process-status-{status}")
             return
-        except BaseException:
+        except NoSuchElementException:
             sl().reload_page()  # Necessary if release previously scheduled
             time.sleep(3)
     raise_assertion_error(f"Release process status wasn't {status} after {timeout} seconds!")

--- a/tests/robot-tests/tests/libs/slack.py
+++ b/tests/robot-tests/tests/libs/slack.py
@@ -51,8 +51,17 @@ class SlackService:
 
         # Whilst genuine bugs that fail a step every time will always show as FAILED in the merged test report AND
         # the final run report, this is not always true of flaky / intermittent test failures, which can be identified
-        # in part by an unequal number of failures in the merged test report versus that of the final run attempt.
-        flaky_test_failures_likely = failed_tests_in_merged_report != failed_tests_in_final_run
+        # in part by an unequal number of failures in the merged test report versus that of the final run attempt. It can
+        # also be identified by the fact that the tests finally all passed but the number of attempts was greater than 1.
+        flaky_test_failures_likely = (
+            failed_tests_in_merged_report != failed_tests_in_final_run
+            or failed_tests_in_final_run == 0
+            and number_of_test_runs > 1
+        )
+
+        flaky_test_message = (
+            "Yes" if flaky_test_failures_likely else "No" if failed_tests_in_final_run == 0 else "Unknown"
+        )
 
         blocks = [
             {
@@ -74,7 +83,7 @@ class SlackService:
                     {"type": "mrkdwn", "text": f"*Skipped test cases*\n{skipped_tests}"},
                     {
                         "type": "mrkdwn",
-                        "text": f"*Flaky failures likely*\n{'Yes' if flaky_test_failures_likely else 'Unknown'}",
+                        "text": f"*Flaky failures likely*\n{flaky_test_message}",
                     },
                 ],
             },

--- a/tests/robot-tests/tests/libs/slack.py
+++ b/tests/robot-tests/tests/libs/slack.py
@@ -53,14 +53,14 @@ class SlackService:
         # the final run report, this is not always true of flaky / intermittent test failures, which can be identified
         # in part by an unequal number of failures in the merged test report versus that of the final run attempt. It can
         # also be identified by the fact that the tests finally all passed but the number of attempts was greater than 1.
-        flaky_test_failures_likely = (
-            failed_tests_in_merged_report != failed_tests_in_final_run
-            or failed_tests_in_final_run == 0
-            and number_of_test_runs > 1
-        )
-
         flaky_test_message = (
-            "Yes" if flaky_test_failures_likely else "No" if failed_tests_in_final_run == 0 else "Unknown"
+            "Yes"
+            if failed_tests_in_final_run == 0 and number_of_test_runs > 1
+            else "No"
+            if failed_tests_in_final_run == 0 and number_of_test_runs == 1
+            else "Likely"
+            if failed_tests_in_merged_report != failed_tests_in_final_run
+            else "No"
         )
 
         blocks = [
@@ -81,10 +81,7 @@ class SlackService:
                     {"type": "mrkdwn", "text": f"*Passed test cases*\n{passed_tests}"},
                     {"type": "mrkdwn", "text": f"*Failed test cases*\n{failed_tests_in_final_run}"},
                     {"type": "mrkdwn", "text": f"*Skipped test cases*\n{skipped_tests}"},
-                    {
-                        "type": "mrkdwn",
-                        "text": f"*Flaky failures likely*\n{flaky_test_message}",
-                    },
+                    {"type": "mrkdwn", "text": f"*Flaky tests?*\n{flaky_test_message}"},
                 ],
             },
         ]

--- a/tests/robot-tests/tests/libs/slack.py
+++ b/tests/robot-tests/tests/libs/slack.py
@@ -54,13 +54,13 @@ class SlackService:
         # in part by an unequal number of failures in the merged test report versus that of the final run attempt. It can
         # also be identified by the fact that the tests finally all passed but the number of attempts was greater than 1.
         flaky_test_message = (
-            "Yes"
+            "Definitely"
             if failed_tests_in_final_run == 0 and number_of_test_runs > 1
-            else "No"
+            else "Definitely not"
             if failed_tests_in_final_run == 0 and number_of_test_runs == 1
             else "Likely"
             if failed_tests_in_merged_report != failed_tests_in_final_run
-            else "No"
+            else "Unlikely"
         )
 
         blocks = [

--- a/tests/robot-tests/tests/public_api/public_api_cancel_and_removal.robot
+++ b/tests/robot-tests/tests/public_api/public_api_cancel_and_removal.robot
@@ -99,7 +99,7 @@ Click on 'cancel' button while attempting to remove draft API data set
     user clicks button    Cancel    ${modal}
     user waits until h2 is visible    API data sets
 
-Verify the contents inside the 'Draft API data sets' table
+Verify the contents inside the 'Draft API data sets' table again
     user waits until h3 is visible    Draft API data sets
 
     user checks table column heading contains    1    1    Draft version    testid:draft-api-data-sets


### PR DESCRIPTION
This PR:
- changes the reporting of the final failing test count to be derived from the final run attempt's report rather than the merged test report, to more accurately represent the final state of the test runs.
- removes the part of the merge report modifier (`CheckForAtLeastOnePassingRunPrerebotModifier.py`) to not hide failures due to future SKIPs.
- breaks the UI test pipeline yml into a template for easier maintenance and parallelisation, for https://dfedigital.atlassian.net/browse/EES-5522.
- correctly fails a test suite early if a Release publishing status becomes "Failed", for https://dfedigital.atlassian.net/browse/EES-5724.
- exits `run_tests.py` with a failure error code if failed suites exist, allowing the "Run tests" jobs in the pipeline to also fail with a red X.

# Example screenshots of Slack reports

![image](https://github.com/user-attachments/assets/458f1730-9235-4d61-91a8-ba705765f783)

Definitely flaky tests during the run, as all tests eventually passed but it took 4 attempts to do so.

![image](https://github.com/user-attachments/assets/7bb1c6cd-dd76-4cea-b451-cb5970a3fce2)

Definitely no flaky tests, as all tests passed in the first run attempt.

![image](https://github.com/user-attachments/assets/a82f4486-bd78-43e5-8dca-7460b2d05e74)

Unlikely to have flaky tests, as the final run failed with the same number of runs as that reported in the merged report.  In this case, although unlikely, there were actually flaky tests encountered in some runs, so take with a pinch of salt!

# Reporting the correct number of test failures to Slack

We were losing test FAILs in the merged report because they were being masked by SKIPs in later test runs.  The reason this is a problem now is that recently we moved to skipping tests that appear after a failing test rather than marking them as failed. 

Imagine we have a `test.robot` with the following tests:

test.robot
- Test 1
- Test 2
- Test 3
- Test 4

These tests are super-flaky.  On the first run attempt, Test 2 fails, resulting in:

test.robot run attempt 1
- Test 1 - PASS
- Test 2 - FAIL
- Test 3 - SKIP
- Test 4 - SKIP

On the second run attempt, Test 1 fails:

test.robot run attempt 2
- Test 1 - FAIL
- Test 2 - SKIP
- Test 3 - SKIP
- Test 4 - SKIP

If these run attempts are merged together using the existing `CheckForAtLeastOnePassingRunPrerebotModifier.py` behaviour, we get:

test.robot merged report
- Test 1 - PASS (because it succeeded in run 1)
- Test 2 - SKIP (because it was skipped in run 2)
- Test 3 - SKIP (because it was skipped in both runs)
- Test 4 - SKIP (because it was skipped in both runs)

This merged report shows no failures.

## The solution

Removing the behaviour of the SKIP merging in `CheckForAtLeastOnePassingRunPrerebotModifier.py`, the test report will now be merged as:

test.robot merged report
- Test 1 - PASS (because it succeeded in run 1)
- Test 2 - FAIL (because it failed in run 1)
- Test 3 - SKIP (because it was skipped in both runs)
- Test 4 - SKIP (because it was skipped in both runs)

This better represents a merged state.

# Correctly failing a test suite early if a Release publishing status becomes "Failed"

Previously we were throwing a AssertionError if this happened, but this was immediately getting caught by an `except` block.  I've updated the `except` block to only catch `NoSuchElementException` instead, allowing this to properly fail.