### PR TITLE
EES-XXXX - fixed misplaced variable definitions in "dependsOn" array

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -3297,10 +3297,7 @@
       "location": "[resourceGroup().location]",
       "apiVersion": "2019-08-01",
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', variables('publisherAppName'))]",
-        "[variables('publicDataFileShareMountPath')]",
-        "[variables('publicDataFileShareName')]",
-        "[variables('publicDataStorageAccountName')]"
+        "[resourceId('Microsoft.Web/sites', variables('publisherAppName'))]"
       ],
       "properties": {
         "[variables('publicDataFileShareName')]": {


### PR DESCRIPTION
This PR:
- fixes a problem that was causing Inf Releases to complete.

We had some "[variables]" within a `dependsOn` block, which is only expecting to have resource or module names defined.  These are now removed.