### PR TITLE
EES-5656 Rename Admin 'Legacy releases' to 'Release order'

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationReleaseSeriesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationReleaseSeriesPage.tsx
@@ -32,14 +32,19 @@ export default function PublicationReleaseSeriesPage() {
 
   return (
     <LoadingSpinner loading={isLoading}>
-      <h2>Legacy releases</h2>
+      <h2>Release order</h2>
 
-      <p>Releases will be shown in the order below on the publication.</p>
       <p>
-        Explore education statistics releases from this publication can also be
-        reordered, including those in draft status or with a draft amendment,
-        but cannot be edited or deleted. Only releases with a published version
-        will be shown on the publication.
+        Releases will be shown in the order below on the publication and can be
+        reordered.
+      </p>
+      <p>
+        Legacy releases which link to extenal pages outside the service can be
+        created, edited, deleted, and are included in the release order.
+      </p>
+      <p>
+        Only releases with a published version and legacy releases will appear
+        in the publication.
       </p>
 
       {canManageReleaseSeries && !isReordering && (

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationCreateReleaseSeriesLegacyLinkPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationCreateReleaseSeriesLegacyLinkPage.test.tsx
@@ -30,7 +30,7 @@ describe('PublicationCreateReleaseSeriesLegacyLinkPage', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Cancel' })).toHaveAttribute(
       'href',
-      '/publication/publication-1/legacy',
+      '/publication/publication-1/releases/order',
     );
   });
 

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationEditReleaseSeriesLegacyLinkPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationEditReleaseSeriesLegacyLinkPage.test.tsx
@@ -67,7 +67,7 @@ describe('PublicationEditReleaseSeriesLegacyLinkPage', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Cancel' })).toHaveAttribute(
       'href',
-      '/publication/publication-1/legacy',
+      '/publication/publication-1/releases/order',
     );
   });
 

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationPageContainer.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationPageContainer.test.tsx
@@ -60,7 +60,7 @@ describe('PublicationPageContainer', () => {
     expect(navLinks[3]).not.toHaveAttribute('aria-current');
     expect(navLinks[4]).toHaveTextContent('Team access');
     expect(navLinks[4]).not.toHaveAttribute('aria-current');
-    expect(navLinks[5]).toHaveTextContent('Legacy releases');
+    expect(navLinks[5]).toHaveTextContent('Release order');
     expect(navLinks[5]).not.toHaveAttribute('aria-current');
 
     expect(screen.getByText('Manage releases')).toBeInTheDocument();

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationReleaseSeriesPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationReleaseSeriesPage.test.tsx
@@ -26,7 +26,7 @@ describe('PublicationReleaseSeriesPage', () => {
     publicationService.getReleaseSeries.mockResolvedValue(testReleaseSeries);
 
     renderPage(testPublication);
-    expect(await screen.findByText('Legacy releases')).toBeInTheDocument();
+    expect(await screen.findByText('Release order')).toBeInTheDocument();
 
     const table = screen.getByRole('table');
     expect(within(table).getAllByRole('row')).toHaveLength(5);
@@ -52,7 +52,7 @@ describe('PublicationReleaseSeriesPage', () => {
     publicationService.getReleaseSeries.mockResolvedValue([]);
     renderPage(testPublication);
 
-    expect(await screen.findByText('Legacy releases')).toBeInTheDocument();
+    expect(await screen.findByText('Release order')).toBeInTheDocument();
 
     expect(
       screen.getByText('No releases for this publication.'),
@@ -75,7 +75,7 @@ describe('PublicationReleaseSeriesPage', () => {
       publicationService.getReleaseSeries.mockResolvedValue(testReleaseSeries);
       renderPage(testPublication);
 
-      expect(await screen.findByText('Legacy releases')).toBeInTheDocument();
+      expect(await screen.findByText('Release order')).toBeInTheDocument();
 
       await user.click(
         screen.getByRole('button', { name: 'Reorder releases' }),
@@ -101,7 +101,7 @@ describe('PublicationReleaseSeriesPage', () => {
       publicationService.getReleaseSeries.mockResolvedValue(testReleaseSeries);
       renderPage(testPublication);
 
-      expect(await screen.findByText('Legacy releases')).toBeInTheDocument();
+      expect(await screen.findByText('Release order')).toBeInTheDocument();
 
       await user.click(
         screen.getByRole('button', { name: 'Reorder releases' }),
@@ -130,7 +130,7 @@ describe('PublicationReleaseSeriesPage', () => {
       ).not.toBeInTheDocument();
     });
 
-    test('does not show button to reorder when user does not have permission to manage legacy releases', async () => {
+    test('does not show button to reorder when user does not have permission to manage the release series', async () => {
       publicationService.getReleaseSeries.mockResolvedValue(testReleaseSeries);
       renderPage({
         ...testPublication,
@@ -140,7 +140,7 @@ describe('PublicationReleaseSeriesPage', () => {
         },
       });
 
-      expect(await screen.findByText('Legacy releases')).toBeInTheDocument();
+      expect(await screen.findByText('Release order')).toBeInTheDocument();
 
       expect(
         screen.queryByRole('button', { name: 'Reorder releases' }),
@@ -161,7 +161,7 @@ describe('PublicationReleaseSeriesPage', () => {
       ]);
       renderPage(testPublication);
 
-      expect(await screen.findByText('Legacy releases')).toBeInTheDocument();
+      expect(await screen.findByText('Release order')).toBeInTheDocument();
 
       await user.click(
         screen.getByRole('button', { name: 'Delete Legacy link 1' }),
@@ -207,7 +207,7 @@ describe('PublicationReleaseSeriesPage', () => {
       );
       renderPage(testPublication);
 
-      expect(await screen.findByText('Legacy releases')).toBeInTheDocument();
+      expect(await screen.findByText('Release order')).toBeInTheDocument();
 
       await user.click(
         screen.getByRole('button', { name: 'Create legacy release' }),
@@ -248,7 +248,7 @@ describe('PublicationReleaseSeriesPage', () => {
         </Router>,
       );
 
-      expect(await screen.findByText('Legacy releases')).toBeInTheDocument();
+      expect(await screen.findByText('Release order')).toBeInTheDocument();
 
       await user.click(
         screen.getByRole('button', { name: 'Create legacy release' }),
@@ -261,12 +261,12 @@ describe('PublicationReleaseSeriesPage', () => {
       );
       await waitFor(() => {
         expect(history.location.pathname).toBe(
-          `/publication/${testPublication.id}/legacy/create`,
+          `/publication/${testPublication.id}/releases/legacy/create`,
         );
       });
     });
 
-    test('does not show button to create when user does not have permission to manage legacy releases', async () => {
+    test('does not show button to create when user does not have permission to manage the release series', async () => {
       publicationService.getReleaseSeries.mockResolvedValueOnce(
         testReleaseSeries,
       );
@@ -278,7 +278,7 @@ describe('PublicationReleaseSeriesPage', () => {
         },
       });
 
-      expect(await screen.findByText('Legacy releases')).toBeInTheDocument();
+      expect(await screen.findByText('Release order')).toBeInTheDocument();
 
       expect(
         screen.queryByRole('button', { name: 'Create legacy release' }),

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/ReleaseSeriesTable.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/ReleaseSeriesTable.test.tsx
@@ -161,13 +161,13 @@ describe('ReleaseSeriesTable', () => {
 
       await waitFor(() => {
         expect(history.location.pathname).toBe(
-          `/publication/${testPublicationId}/legacy/${testReleaseSeries[3].id}/edit`,
+          `/publication/${testPublicationId}/releases/legacy/${testReleaseSeries[3].id}/edit`,
         );
       });
     });
   });
 
-  test('does not show edit and delete actions when user does not have permission to manage legacy releases', () => {
+  test('does not show edit and delete actions when user does not have permission to manage the release series', () => {
     render(
       <TestConfigContextProvider>
         <ReleaseSeriesTable

--- a/src/explore-education-statistics-admin/src/routes/publicationRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/publicationRoutes.ts
@@ -92,21 +92,21 @@ export const publicationInviteUsersPageRoute: PublicationRouteProps = {
 };
 
 export const publicationReleaseSeriesRoute: PublicationRouteProps = {
-  path: '/publication/:publicationId/legacy',
-  title: 'Legacy releases',
+  path: '/publication/:publicationId/releases/order',
+  title: 'Release order',
   component: PublicationReleaseSeriesPage,
 };
 
 export const publicationCreateReleaseSeriesLegacyLinkRoute: PublicationRouteProps =
   {
-    path: '/publication/:publicationId/legacy/create',
+    path: '/publication/:publicationId/releases/legacy/create',
     title: 'Create legacy release',
     component: PublicationCreateReleaseSeriesLegacyLinkPage,
   };
 
 export const publicationEditReleaseSeriesLegacyLinkRoute: PublicationRouteProps =
   {
-    path: '/publication/:publicationId/legacy/:releaseSeriesItemId/edit',
+    path: '/publication/:publicationId/releases/legacy/:releaseSeriesItemId/edit',
     title: 'Edit legacy release',
     component: PublicationEditReleaseSeriesLegacyLinkPage,
   };

--- a/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
@@ -36,12 +36,12 @@ Navigate to Seed Data Theme 1 Publication 1 page
     user clicks link    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     user waits until h1 is visible    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
 
-Navigate to legacy releases
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+Navigate to publication release order
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
 
-Validate Analyst1 can see correct legacy releases
-    user checks element count is x    css:tbody tr    7
+Validate Analyst1 can see correct publication release order
+    user checks table body has x rows    7    testid:release-series
 
     user checks table cell contains    1    1    Academic year 2016/17
     user checks table cell contains    1    2
@@ -81,8 +81,8 @@ Validate Analyst1 can see correct legacy releases
 Check Analyst1 cannot create a legacy release
     user checks page does not contain button    Create legacy release
 
-Check Analyst1 cannot reorder legacy releases
-    user checks page does not contain button    Reorder legacy releases
+Check Analyst1 cannot reorder releases
+    user checks page does not contain button    Reorder releases
 
 Check Analyst1 cannot edit a legacy release
     user checks page does not contain button    Edit

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_approver_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_approver_ui_permissions.robot
@@ -23,14 +23,17 @@ Validates publication approver publication page is correct
     user waits until page contains link    Releases
     user waits until page contains link    Methodologies
     user waits until page contains link    Team access
-    user waits until page contains link    Legacy releases    # remove as part of EES-3794
+    user waits until page contains link    Release order
 
     user checks page does not contain link    Details
     user checks page does not contain link    Contact
 
-Check cannot create a legacy release
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+Check cannot reorder releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
+    user checks page does not contain button    Reorder releases
+
+Check cannot create legacy releases
     user checks page does not contain button    Create legacy release
 
 Check cannot create a Methodology for a Publication if they don't have Publication Owner role

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_owner_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_owner_ui_permissions.robot
@@ -25,11 +25,14 @@ Navigate to Publication where analyst has Publication Owner role
     user waits until page contains link    Details
     user waits until page contains link    Contact
     user waits until page contains link    Team access
-    user waits until page contains link    Legacy releases
+    user waits until page contains link    Release order
 
-Check can create a legacy release
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+Check can reorder releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
+    user checks page contains button    Reorder releases
+
+Check can create legacy releases
     user checks page contains button    Create legacy release
 
 Check can create a Methodology for the owned Publication

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_approver_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_approver_ui_permissions.robot
@@ -23,14 +23,17 @@ Validates release approver publication page is correct
     user waits until page contains link    Releases
     user waits until page contains link    Methodologies
     user waits until page contains link    Team access
-    user waits until page contains link    Legacy releases    # remove as part of EES-3794
+    user waits until page contains link    Release order
 
     user checks page does not contain link    Details
     user checks page does not contain link    Contact
 
-Check cannot create a legacy release
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+Check cannot reorder releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
+    user checks page does not contain button    Reorder releases
+
+Check cannot create legacy releases
     user checks page does not contain button    Create legacy release
 
 Check cannot create a Methodology for a Publication if they don't have Publication Owner role

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_contributor_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_contributor_ui_permissions.robot
@@ -24,14 +24,17 @@ Validates release contributor publication page is correct
     user waits until page contains link    Releases
     user waits until page contains link    Methodologies
     user waits until page contains link    Team access
-    user waits until page contains link    Legacy releases    # remove as part of EES-3794
+    user waits until page contains link    Release order
 
     user checks page does not contain link    Details
     user checks page does not contain link    Contact
 
-Check cannot create a legacy release
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+Check cannot reorder releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
+    user checks page does not contain button    Reorder releases
+
+Check cannot create legacy releases
     user checks page does not contain button    Create legacy release
 
 Check cannot create a Methodology for a Publication if they don't have Publication Owner role

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_viewer_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_viewer_ui_permissions.robot
@@ -24,14 +24,17 @@ Validates release viewer publication page is correct
     user waits until page contains link    Releases
     user waits until page contains link    Methodologies
     user waits until page contains link    Team access
-    user waits until page contains link    Legacy releases    # remove as part of EES-3794
+    user waits until page contains link    Release order
 
     user checks page does not contain link    Details
     user checks page does not contain link    Contact
 
-Check cannot create a legacy release
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+Check cannot reorder releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
+    user checks page does not contain button    Reorder releases
+
+Check cannot create legacy releases
     user checks page does not contain button    Create legacy release
 
 Check cannot create a Methodology for a Publication if they don't have Publication Owner role

--- a/tests/robot-tests/tests/admin_and_public/bau/release_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/release_reordering.robot
@@ -31,14 +31,14 @@ Create new publication via api
 
 Validate publication release order table is empty
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
     user checks page contains    No releases for this publication.
 
 Create first legacy release
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
     user creates legacy release    ${LEGACY_RELEASE_1_DESCRIPTION}    ${LEGACY_RELEASE_1_URL}
 
 Validate publication release order table headings
@@ -66,8 +66,8 @@ Create first release via api
 
 Validate first release exists in the publication release order with status unpublished
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
     user checks table body has x rows    2    testid:release-series
 
     user checks table cell contains    1    1    ${RELEASE_1_NAME}
@@ -115,8 +115,8 @@ Approve first release
 
 Validate first release has latest release status in publication release order
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
 
     user checks table body has x rows    3    testid:release-series
 
@@ -156,8 +156,8 @@ Validate other releases section on public frontend
 
 Update first legacy release
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
 
     user clicks element    xpath://tr[2]//*[text()="Edit"]
     ${modal}=    user waits until modal is visible    Edit legacy release
@@ -170,7 +170,7 @@ Update first legacy release
     user clicks button    Save legacy release
 
 Validate the first legacy release is updated
-    user waits until h2 is visible    Legacy releases
+    user waits until h2 is visible    Release order
     user checks table body has x rows    3    testid:release-series
 
     user checks table cell contains    1    1    ${RELEASE_1_NAME}
@@ -255,8 +255,8 @@ Create second release via api
 
 Validate second release exists in the publication release order with status unpublished
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
     user checks table body has x rows    4    testid:release-series
 
     user checks table cell contains    1    1    ${RELEASE_2_NAME}
@@ -292,8 +292,8 @@ Approve second release
 
 Validate second release has latest release status in publication release order
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
 
     user checks table body has x rows    4    testid:release-series
 
@@ -343,8 +343,8 @@ Approve second release amendment
 
 Validate amended second release exists in publication release order
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
 
     user checks table body has x rows    4    testid:release-series
 

--- a/tests/robot-tests/tests/seed_data/generate_seed_data_theme_1.robot
+++ b/tests/robot-tests/tests/seed_data/generate_seed_data_theme_1.robot
@@ -48,8 +48,8 @@ Create ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     ...    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
 
 Add legacy releases to ${PUPIL_ABSENCE_PUBLICATION_TITLE}
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
     user creates legacy release    Academic year 2009/10
     ...    https://www.gov.uk/government/statistics/pupil-absence-in-schools-in-england-including-pupil-characteristics-academic-year-2009-to-2010
     user creates legacy release    Academic year 2010/11
@@ -513,8 +513,8 @@ Create ${EXCLUSIONS_PUBLICATION_TITLE}
     ...    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
 
 Add legacy releases to ${EXCLUSIONS_PUBLICATION_TITLE}
-    user clicks link    Legacy releases
-    user waits until h2 is visible    Legacy releases
+    user clicks link    Release order
+    user waits until h2 is visible    Release order
     user creates legacy release    Academic year 2008/09
     ...    https://www.gov.uk/government/statistics/permanent-and-fixed-period-exclusions-in-england-academic-year-2008-to-2009
     user creates legacy release    Academic year 2009/10


### PR DESCRIPTION
This PR renames the Admin 'Legacy releases' page to 'Release order'.

This is being done to make it more obvious that this page allows reordering releases which will become more commonly required when 'Release labelling' is made available by EES-5626.

When release labelling is introduced, we will allow a publication to contain multiple releases with the same year and time identifier.

Our traditional way of ordering releases within a publication in reverse chronological order by year and then by time period will no longer work after we lose this time period uniqueness. There will be no secondary sorting by label and analysts will decide which release should appear first or last.

The same possibility applies to the 'latest' release for a publication which is currently determined automatically by the first release in the reverse chronological order. In future analysts will be able to decide which release it should be by ordering that release as the top entry on this page.

This change to the title is being made separately ahead of other changes to the page as part of EES-5656.

Before:
![before](https://github.com/user-attachments/assets/26f3d014-5fe8-432c-88b8-fbaddfe5d551)

After:
<img width="841" alt="after" src="https://github.com/user-attachments/assets/0d73e576-f008-49ab-bb8d-f25b4bb6b9a6">

### UI test result

![image](https://github.com/user-attachments/assets/fe81534c-07d8-4610-ab6e-c6fa8314e190)
