### PR TITLE
EES-5724 - enabling content-over-vnet for Publisher Function App

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -3275,6 +3275,7 @@
         "AzureWebJobsStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher')).secretUriWithVersion, ')')]",
         "AzureWebJobs.StageScheduledReleaseVersionsImmediately.Disabled": "[not(parameters('immediatePublicationOfScheduledReleaseVersionsEnabled'))]",
         "AzureWebJobs.PublishStagedReleaseVersionContentImmediately.Disabled": "[not(parameters('immediatePublicationOfScheduledReleaseVersionsEnabled'))]",
+        "WEBSITE_CONTENTOVERVNET": "1",
         "WEBSITE_TIME_ZONE": "[parameters('timeZone')]",
         "WEBSITE_RUN_FROM_PACKAGE": "1",
         "FUNCTIONS_EXTENSION_VERSION": "~4",


### PR DESCRIPTION
This PR enables `WEBSITE_CONTENTOVERVNET` for the Publisher App, without which it can successfully mount but not see or use the mounted Public API File Share.

Note that although this setting is stated as being a legacy setting that has been replaced by `vnetContentShareEnabled`, this setting doesn't work for the Publisher and the so the legacy setting is being used.