### PR TITLE
EES-5656 Release series tidy up

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -591,7 +591,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     var service = BuildPublicationService(
                         context: contentDbContext,
                         userService: userService.Object);
-                    return await service.AddReleaseSeriesLegacyLink(publication.Id, new ReleaseSeriesLegacyLinkAddRequest());
+                    return await service.AddReleaseSeriesLegacyLink(publication.Id,
+                        new ReleaseSeriesLegacyLinkAddRequest
+                        {
+                            Description = "Test description",
+                            Url = "https://test.url"
+                        });
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -1326,7 +1326,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async void UpdatePublication_NoTitleOrSupersededByChange()
+        public async Task UpdatePublication_NoTitleOrSupersededByChange()
         {
             var theme = new Theme
             {
@@ -2648,26 +2648,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task GetReleaseSeries()
         {
-            var legacyLinks = new List<ReleaseSeriesItem>
-            {
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    LegacyLinkDescription = "legacy link 1",
-                    LegacyLinkUrl = "https://test.com/1",
-                },
-            };
+            ReleaseSeriesItem legacyLink = _dataFixture.DefaultLegacyReleaseSeriesItem();
 
             Publication publication = _dataFixture
                 .DefaultPublication()
-                .WithReleases(ListOf<Release>(
+                .WithReleases([
                     _dataFixture
                         .DefaultRelease(publishedVersions: 1, year: 2020),
                     _dataFixture
                         .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
                     _dataFixture
-                        .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)))
-                .WithLegacyLinks(legacyLinks)
+                        .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)
+                ])
+                .WithLegacyLinks([legacyLink])
                 .WithTheme(_dataFixture.DefaultTheme());
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -2686,7 +2679,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(4, viewModels.Count);
 
-                var expectedReleaseVersion1 = publication.ReleaseVersions.Single(rv => rv is { Year: 2022, Version: 1 });
+                var expectedReleaseVersion1 =
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2022, Version: 1 });
                 Assert.Equal(publication.ReleaseSeries[0].Id, viewModels[0].Id);
                 Assert.False(viewModels[0].IsLegacyLink);
                 Assert.Equal(expectedReleaseVersion1.Title, viewModels[0].Description);
@@ -2696,7 +2690,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(viewModels[0].IsPublished);
                 Assert.Null(viewModels[0].LegacyLinkUrl);
 
-                var expectedReleaseVersion2 = publication.ReleaseVersions.Single(rv => rv is { Year: 2021, Version: 0 });
+                var expectedReleaseVersion2 =
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2021, Version: 0 });
                 Assert.Equal(publication.ReleaseSeries[1].Id, viewModels[1].Id);
                 Assert.False(viewModels[1].IsLegacyLink);
                 Assert.Equal(expectedReleaseVersion2.Title, viewModels[1].Description);
@@ -2706,7 +2701,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.False(viewModels[1].IsPublished);
                 Assert.Null(viewModels[1].LegacyLinkUrl);
 
-                var expectedReleaseVersion3 = publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
+                var expectedReleaseVersion3 =
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
                 Assert.Equal(publication.ReleaseSeries[2].Id, viewModels[2].Id);
                 Assert.False(viewModels[2].IsLegacyLink);
                 Assert.Equal(expectedReleaseVersion3.Title, viewModels[2].Description);
@@ -2718,12 +2714,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(publication.ReleaseSeries[3].Id, viewModels[3].Id);
                 Assert.True(viewModels[3].IsLegacyLink);
-                Assert.Equal(legacyLinks[0].LegacyLinkDescription, viewModels[3].Description);
+                Assert.Equal(legacyLink.LegacyLinkDescription, viewModels[3].Description);
                 Assert.Null(viewModels[3].ReleaseId);
                 Assert.Null(viewModels[3].ReleaseSlug);
                 Assert.Null(viewModels[3].IsLatest);
                 Assert.Null(viewModels[3].IsPublished);
-                Assert.Equal(legacyLinks[0].LegacyLinkUrl, viewModels[3].LegacyLinkUrl);
+                Assert.Equal(legacyLink.LegacyLinkUrl, viewModels[3].LegacyLinkUrl);
             }
         }
 
@@ -2732,13 +2728,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             Publication publication = _dataFixture
                 .DefaultPublication()
-                .WithReleases(ListOf<Release>(
+                .WithReleases([
                     _dataFixture
                         .DefaultRelease(publishedVersions: 1, year: 2020),
                     _dataFixture
                         .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
                     _dataFixture
-                        .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)))
+                        .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)
+                ])
                 .WithTheme(_dataFixture.DefaultTheme());
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -2757,7 +2754,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(3, viewModels.Count);
 
-                var expectedReleaseVersion1 = publication.ReleaseVersions.Single(rv => rv is { Year: 2022, Version: 1 });
+                var expectedReleaseVersion1 =
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2022, Version: 1 });
                 Assert.Equal(publication.ReleaseSeries[0].Id, viewModels[0].Id);
                 Assert.False(viewModels[0].IsLegacyLink);
                 Assert.Equal(expectedReleaseVersion1.Title, viewModels[0].Description);
@@ -2767,7 +2765,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(viewModels[0].IsPublished);
                 Assert.Null(viewModels[0].LegacyLinkUrl);
 
-                var expectedReleaseVersion2 = publication.ReleaseVersions.Single(rv => rv is { Year: 2021, Version: 0 });
+                var expectedReleaseVersion2 =
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2021, Version: 0 });
                 Assert.Equal(publication.ReleaseSeries[1].Id, viewModels[1].Id);
                 Assert.False(viewModels[1].IsLegacyLink);
                 Assert.Equal(expectedReleaseVersion2.Title, viewModels[1].Description);
@@ -2777,7 +2776,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.False(viewModels[1].IsPublished);
                 Assert.Null(viewModels[1].LegacyLinkUrl);
 
-                var expectedReleaseVersion3 = publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
+                var expectedReleaseVersion3 =
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
                 Assert.Equal(publication.ReleaseSeries[2].Id, viewModels[2].Id);
                 Assert.False(viewModels[2].IsLegacyLink);
                 Assert.Equal(expectedReleaseVersion3.Title, viewModels[2].Description);
@@ -2792,21 +2792,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task GetReleaseSeries_NoReleases()
         {
-            var legacyLinks = new List<ReleaseSeriesItem>
-            {
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    LegacyLinkDescription = "legacy link 1",
-                    LegacyLinkUrl = "https://test.com/1",
-                },
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    LegacyLinkDescription = "legacy link 2",
-                    LegacyLinkUrl = "https://test.com/2",
-                },
-            };
+            var legacyLinks = _dataFixture.DefaultLegacyReleaseSeriesItem()
+                .GenerateList(2);
 
             Publication publication = _dataFixture
                 .DefaultPublication()
@@ -2877,22 +2864,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task AddReleaseSeriesLegacyLink()
         {
-            var legacyLinks = new List<ReleaseSeriesItem>
-            {
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    LegacyLinkDescription = "legacy link 1",
-                    LegacyLinkUrl = "https://test.com/1",
-                },
-            };
+            ReleaseSeriesItem legacyLink = _dataFixture.DefaultLegacyReleaseSeriesItem();
 
             Publication publication = _dataFixture
                 .DefaultPublication()
-                .WithReleases(ListOf<Release>(
+                .WithReleases([
                     _dataFixture
-                        .DefaultRelease(publishedVersions: 1, year: 2020)))
-                .WithLegacyLinks(legacyLinks)
+                        .DefaultRelease(publishedVersions: 1, year: 2020)
+                ])
+                .WithLegacyLinks([legacyLink])
                 .WithTheme(_dataFixture.DefaultTheme());
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -2920,11 +2900,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Description = "New legacy link",
                         Url = "https://test.com/new"
                     });
+
                 var viewModels = result.AssertRight();
+                VerifyAllMocks(publicationCacheService);
 
                 Assert.Equal(3, viewModels.Count);
 
-                var expectedReleaseVersion1 = publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
+                var expectedReleaseVersion1 =
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
                 Assert.Equal(publication.ReleaseSeries[0].Id, viewModels[0].Id);
                 Assert.False(viewModels[0].IsLegacyLink);
                 Assert.Equal(expectedReleaseVersion1.Title, viewModels[0].Description);
@@ -2936,12 +2919,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(publication.ReleaseSeries[1].Id, viewModels[1].Id);
                 Assert.True(viewModels[1].IsLegacyLink);
-                Assert.Equal(legacyLinks[0].LegacyLinkDescription, viewModels[1].Description);
+                Assert.Equal(legacyLink.LegacyLinkDescription, viewModels[1].Description);
                 Assert.Null(viewModels[1].ReleaseId);
                 Assert.Null(viewModels[1].ReleaseSlug);
                 Assert.Null(viewModels[1].IsLatest);
                 Assert.Null(viewModels[1].IsPublished);
-                Assert.Equal(legacyLinks[0].LegacyLinkUrl, viewModels[1].LegacyLinkUrl);
+                Assert.Equal(legacyLink.LegacyLinkUrl, viewModels[1].LegacyLinkUrl);
 
                 Assert.True(viewModels[2].IsLegacyLink);
                 Assert.Equal("New legacy link", viewModels[2].Description);
@@ -2995,6 +2978,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Description = "New legacy link",
                         Url = "https://test.com/new"
                     });
+                VerifyAllMocks(publicationCacheService);
                 var viewModels = result.AssertRight();
 
                 var newSeriesItem = Assert.Single(viewModels);
@@ -3019,26 +3003,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task UpdateReleaseSeries()
         {
-            var legacyLinks = new List<ReleaseSeriesItem>
-            {
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    LegacyLinkDescription = "legacy link 1",
-                    LegacyLinkUrl = "https://test.com/1",
-                },
-            };
-
             Publication publication = _dataFixture
                 .DefaultPublication()
-                .WithReleases(ListOf<Release>(
+                .WithReleases([
                     _dataFixture
                         .DefaultRelease(publishedVersions: 1, year: 2020),
                     _dataFixture
                         .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
                     _dataFixture
-                        .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)))
-                .WithLegacyLinks(legacyLinks)
+                        .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)
+                ])
+                .WithLegacyLinks([_dataFixture.DefaultLegacyReleaseSeriesItem()])
                 .WithTheme(_dataFixture.DefaultTheme());
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -3059,36 +3034,45 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     contentDbContext,
                     publicationCacheService: publicationCacheService.Object);
 
-                var expectedReleaseVersion2022 = publication.ReleaseVersions.Single(rv => rv is { Year: 2022, Version: 1 });
-                var expectedReleaseVersion2021 = publication.ReleaseVersions.Single(rv => rv is { Year: 2021, Version: 0 });
-                var expectedReleaseVersion2020 = publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
+                var expectedReleaseVersion2022 =
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2022, Version: 1 });
+                var expectedReleaseVersion2021 =
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2021, Version: 0 });
+                var expectedReleaseVersion2020 =
+                    publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
 
                 var result = await publicationService.UpdateReleaseSeries(
                     publication.Id,
-                    new List<ReleaseSeriesItemUpdateRequest>
-                    {
-                        new()
+                    updatedReleaseSeriesItems:
+                    [
+                        new ReleaseSeriesItemUpdateRequest
                         {
                             Id = Guid.NewGuid(),
                             LegacyLinkDescription = "Legacy link new",
                             LegacyLinkUrl = "https://test.com/new",
                         },
-                        new()
+
+                        new ReleaseSeriesItemUpdateRequest
                         {
                             Id = Guid.NewGuid(),
                             ReleaseId = expectedReleaseVersion2021.ReleaseId,
                         },
-                        new()
+
+                        new ReleaseSeriesItemUpdateRequest
                         {
                             Id = Guid.NewGuid(),
                             ReleaseId = expectedReleaseVersion2020.ReleaseId,
                         },
-                        new()
+
+                        new ReleaseSeriesItemUpdateRequest
                         {
                             Id = Guid.NewGuid(),
                             ReleaseId = expectedReleaseVersion2022.ReleaseId,
-                        },
-                    });
+                        }
+                    ]);
+
+                VerifyAllMocks(publicationCacheService);
+
                 var viewModels = result.AssertRight();
 
                 Assert.Equal(4, viewModels.Count);
@@ -3130,19 +3114,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task UpdateReleaseSeries_SetEmpty()
         {
-            var legacyLinks = new List<ReleaseSeriesItem>
-            {
-                new()
-                {
-                    Id = Guid.NewGuid(),
-                    LegacyLinkDescription = "legacy link 1",
-                    LegacyLinkUrl = "https://test.com/1",
-                },
-            };
-
             Publication publication = _dataFixture
                 .DefaultPublication()
-                .WithLegacyLinks(legacyLinks)
+                .WithLegacyLinks([_dataFixture.DefaultLegacyReleaseSeriesItem()])
                 .WithTheme(_dataFixture.DefaultTheme());
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -3165,7 +3139,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await publicationService.UpdateReleaseSeries(
                     publication.Id,
-                    new List<ReleaseSeriesItemUpdateRequest>());
+                    updatedReleaseSeriesItems: []);
+
+                VerifyAllMocks(publicationCacheService);
+
                 var viewModels = result.AssertRight();
 
                 Assert.Empty(viewModels);
@@ -3177,9 +3154,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             Publication publication = _dataFixture
                 .DefaultPublication()
-                .WithReleases(ListOf<Release>(
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, year: 2020)))
+                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1, year: 2020)])
                 .WithTheme(_dataFixture.DefaultTheme());
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -3200,10 +3175,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     contentDbContext,
                     publicationCacheService: publicationCacheService.Object);
 
-                var exception = await Assert.ThrowsAsync<ArgumentException>(() => publicationService.UpdateReleaseSeries(
-                    publication.Id,
-                    new List<ReleaseSeriesItemUpdateRequest>()));
-                Assert.Equal("Missing or duplicate release in new release series. Expected ReleaseIds: " + publication.ReleaseVersions[0].ReleaseId, exception.Message);
+                var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+                    publicationService.UpdateReleaseSeries(
+                        publication.Id,
+                        updatedReleaseSeriesItems: []));
+
+                VerifyAllMocks(publicationCacheService);
+
+                Assert.Equal("Missing or duplicate release in new release series. Expected ReleaseIds: " +
+                             publication.ReleaseVersions[0].ReleaseId,
+                    exception.Message);
             }
         }
 
@@ -3212,9 +3193,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             Publication publication = _dataFixture
                 .DefaultPublication()
-                .WithReleases(ListOf<Release>(
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, year: 2020)))
+                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1, year: 2020)])
                 .WithTheme(_dataFixture.DefaultTheme());
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -3235,22 +3214,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     contentDbContext,
                     publicationCacheService: publicationCacheService.Object);
 
-                var exception = await Assert.ThrowsAsync<ArgumentException>(() => publicationService.UpdateReleaseSeries(
-                    publication.Id,
-                    new List<ReleaseSeriesItemUpdateRequest>
-                    {
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            ReleaseId = publication.ReleaseVersions[0].ReleaseId,
-                        },
-                        new()
-                        {
-                            Id = Guid.NewGuid(),
-                            ReleaseId = publication.ReleaseVersions[0].ReleaseId,
-                        },
-                    }));
-                Assert.Equal("Missing or duplicate release in new release series. Expected ReleaseIds: " + publication.ReleaseVersions[0].ReleaseId, exception.Message);
+                var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+                    publicationService.UpdateReleaseSeries(
+                        publication.Id,
+                        updatedReleaseSeriesItems:
+                        [
+                            new ReleaseSeriesItemUpdateRequest
+                            {
+                                Id = Guid.NewGuid(),
+                                ReleaseId = publication.ReleaseVersions[0].ReleaseId,
+                            },
+
+                            new ReleaseSeriesItemUpdateRequest
+                            {
+                                Id = Guid.NewGuid(),
+                                ReleaseId = publication.ReleaseVersions[0].ReleaseId,
+                            }
+                        ]));
+
+                VerifyAllMocks(publicationCacheService);
+
+                Assert.Equal("Missing or duplicate release in new release series. Expected ReleaseIds: " +
+                             publication.ReleaseVersions[0].ReleaseId,
+                    exception.Message);
             }
         }
 
@@ -3259,9 +3245,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             Publication publication = _dataFixture
                 .DefaultPublication()
-                .WithReleases(ListOf<Release>(
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, year: 2020)))
+                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1, year: 2020)])
                 .WithTheme(_dataFixture.DefaultTheme());
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -3282,20 +3266,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     contentDbContext,
                     publicationCacheService: publicationCacheService.Object);
 
-                var seriesItemId = Guid.NewGuid();
-                var exception = await Assert.ThrowsAsync<ArgumentException>(() => publicationService.UpdateReleaseSeries(
-                    publication.Id,
-                    new List<ReleaseSeriesItemUpdateRequest>
-                    {
-                        new()
-                        {
-                            Id = seriesItemId,
-                            ReleaseId = publication.ReleaseVersions[0].ReleaseId,
-                            LegacyLinkDescription = "this should be null",
-                            LegacyLinkUrl = "https://should.be/null",
-                        },
-                    }));
-                Assert.Equal($"LegacyLink details shouldn't be set if ReleaseId is set. ReleaseSeriesItem: {seriesItemId}", exception.Message);
+                var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+                    publicationService.UpdateReleaseSeries(
+                        publication.Id,
+                        [
+                            new ReleaseSeriesItemUpdateRequest
+                            {
+                                Id = Guid.NewGuid(),
+                                ReleaseId = publication.ReleaseVersions[0].ReleaseId,
+                                LegacyLinkDescription = "this should be null",
+                                LegacyLinkUrl = "https://should.be/null",
+                            }
+                        ]));
+
+                VerifyAllMocks(publicationCacheService);
+
+                Assert.Equal(
+                    $"LegacyLink details shouldn't be set if ReleaseId is set. ReleaseSeriesItem: {Guid.NewGuid()}",
+                    exception.Message);
             }
         }
 
@@ -3324,20 +3312,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     contentDbContext,
                     publicationCacheService: publicationCacheService.Object);
 
-                var seriesItemId = Guid.NewGuid();
-                var exception = await Assert.ThrowsAsync<ArgumentException>(() => publicationService.UpdateReleaseSeries(
-                    publication.Id,
-                    new List<ReleaseSeriesItemUpdateRequest>
-                    {
-                        new()
-                        {
-                            Id = seriesItemId,
-                            ReleaseId = null,
-                            LegacyLinkDescription = null,
-                            LegacyLinkUrl = null,
-                        },
-                    }));
-                Assert.Equal($"LegacyLink details should be set if ReleaseId is null. ReleaseSeriesItem: {seriesItemId}", exception.Message);
+                var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+                    publicationService.UpdateReleaseSeries(
+                        publication.Id,
+                        [
+                            new ReleaseSeriesItemUpdateRequest
+                            {
+                                Id = Guid.NewGuid(),
+                                ReleaseId = null,
+                                LegacyLinkDescription = null,
+                                LegacyLinkUrl = null,
+                            }
+                        ]));
+
+                VerifyAllMocks(publicationCacheService);
+
+                Assert.Equal(
+                    $"LegacyLink details should be set if ReleaseId is null. ReleaseSeriesItem: {Guid.NewGuid()}",
+                    exception.Message);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -2663,6 +2663,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .WithLegacyLinks([legacyLink])
                 .WithTheme(_dataFixture.DefaultTheme());
 
+            var release2020 = publication.Releases.Single(r => r.Year == 2020);
+            var release2021 = publication.Releases.Single(r => r.Year == 2021);
+            var release2022 = publication.Releases.Single(r => r.Year == 2022);
+
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -2679,40 +2683,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(4, viewModels.Count);
 
-                var expectedReleaseVersion1 =
-                    publication.ReleaseVersions.Single(rv => rv is { Year: 2022, Version: 1 });
-                Assert.Equal(publication.ReleaseSeries[0].Id, viewModels[0].Id);
                 Assert.False(viewModels[0].IsLegacyLink);
-                Assert.Equal(expectedReleaseVersion1.Title, viewModels[0].Description);
-                Assert.Equal(expectedReleaseVersion1.ReleaseId, viewModels[0].ReleaseId);
-                Assert.Equal(expectedReleaseVersion1.Slug, viewModels[0].ReleaseSlug);
+                Assert.Equal(release2022.Title, viewModels[0].Description);
+                Assert.Equal(release2022.Id, viewModels[0].ReleaseId);
+                Assert.Equal(release2022.Slug, viewModels[0].ReleaseSlug);
                 Assert.True(viewModels[0].IsLatest);
                 Assert.True(viewModels[0].IsPublished);
                 Assert.Null(viewModels[0].LegacyLinkUrl);
 
-                var expectedReleaseVersion2 =
-                    publication.ReleaseVersions.Single(rv => rv is { Year: 2021, Version: 0 });
-                Assert.Equal(publication.ReleaseSeries[1].Id, viewModels[1].Id);
                 Assert.False(viewModels[1].IsLegacyLink);
-                Assert.Equal(expectedReleaseVersion2.Title, viewModels[1].Description);
-                Assert.Equal(expectedReleaseVersion2.ReleaseId, viewModels[1].ReleaseId);
-                Assert.Equal(expectedReleaseVersion2.Slug, viewModels[1].ReleaseSlug);
+                Assert.Equal(release2021.Title, viewModels[1].Description);
+                Assert.Equal(release2021.Id, viewModels[1].ReleaseId);
+                Assert.Equal(release2021.Slug, viewModels[1].ReleaseSlug);
                 Assert.False(viewModels[1].IsLatest);
                 Assert.False(viewModels[1].IsPublished);
                 Assert.Null(viewModels[1].LegacyLinkUrl);
 
-                var expectedReleaseVersion3 =
-                    publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
-                Assert.Equal(publication.ReleaseSeries[2].Id, viewModels[2].Id);
                 Assert.False(viewModels[2].IsLegacyLink);
-                Assert.Equal(expectedReleaseVersion3.Title, viewModels[2].Description);
-                Assert.Equal(expectedReleaseVersion3.ReleaseId, viewModels[2].ReleaseId);
-                Assert.Equal(expectedReleaseVersion3.Slug, viewModels[2].ReleaseSlug);
+                Assert.Equal(release2020.Title, viewModels[2].Description);
+                Assert.Equal(release2020.Id, viewModels[2].ReleaseId);
+                Assert.Equal(release2020.Slug, viewModels[2].ReleaseSlug);
                 Assert.False(viewModels[2].IsLatest);
                 Assert.True(viewModels[2].IsPublished);
                 Assert.Null(viewModels[2].LegacyLinkUrl);
 
-                Assert.Equal(publication.ReleaseSeries[3].Id, viewModels[3].Id);
                 Assert.True(viewModels[3].IsLegacyLink);
                 Assert.Equal(legacyLink.LegacyLinkDescription, viewModels[3].Description);
                 Assert.Null(viewModels[3].ReleaseId);
@@ -2720,72 +2714,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Null(viewModels[3].IsLatest);
                 Assert.Null(viewModels[3].IsPublished);
                 Assert.Equal(legacyLink.LegacyLinkUrl, viewModels[3].LegacyLinkUrl);
-            }
-        }
-
-        [Fact]
-        public async Task GetReleaseSeries_NoLegacyLinks()
-        {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases([
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, year: 2020),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)
-                ])
-                .WithTheme(_dataFixture.DefaultTheme());
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(contentDbContext);
-
-                var result = await publicationService.GetReleaseSeries(publication.Id);
-                var viewModels = result.AssertRight();
-
-                Assert.Equal(3, viewModels.Count);
-
-                var expectedReleaseVersion1 =
-                    publication.ReleaseVersions.Single(rv => rv is { Year: 2022, Version: 1 });
-                Assert.Equal(publication.ReleaseSeries[0].Id, viewModels[0].Id);
-                Assert.False(viewModels[0].IsLegacyLink);
-                Assert.Equal(expectedReleaseVersion1.Title, viewModels[0].Description);
-                Assert.Equal(expectedReleaseVersion1.ReleaseId, viewModels[0].ReleaseId);
-                Assert.Equal(expectedReleaseVersion1.Slug, viewModels[0].ReleaseSlug);
-                Assert.True(viewModels[0].IsLatest);
-                Assert.True(viewModels[0].IsPublished);
-                Assert.Null(viewModels[0].LegacyLinkUrl);
-
-                var expectedReleaseVersion2 =
-                    publication.ReleaseVersions.Single(rv => rv is { Year: 2021, Version: 0 });
-                Assert.Equal(publication.ReleaseSeries[1].Id, viewModels[1].Id);
-                Assert.False(viewModels[1].IsLegacyLink);
-                Assert.Equal(expectedReleaseVersion2.Title, viewModels[1].Description);
-                Assert.Equal(expectedReleaseVersion2.ReleaseId, viewModels[1].ReleaseId);
-                Assert.Equal(expectedReleaseVersion2.Slug, viewModels[1].ReleaseSlug);
-                Assert.False(viewModels[1].IsLatest);
-                Assert.False(viewModels[1].IsPublished);
-                Assert.Null(viewModels[1].LegacyLinkUrl);
-
-                var expectedReleaseVersion3 =
-                    publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
-                Assert.Equal(publication.ReleaseSeries[2].Id, viewModels[2].Id);
-                Assert.False(viewModels[2].IsLegacyLink);
-                Assert.Equal(expectedReleaseVersion3.Title, viewModels[2].Description);
-                Assert.Equal(expectedReleaseVersion3.ReleaseId, viewModels[2].ReleaseId);
-                Assert.Equal(expectedReleaseVersion3.Slug, viewModels[2].ReleaseSlug);
-                Assert.False(viewModels[2].IsLatest);
-                Assert.True(viewModels[2].IsPublished);
-                Assert.Null(viewModels[2].LegacyLinkUrl);
             }
         }
 
@@ -2816,7 +2744,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(2, viewModels.Count);
 
-                Assert.Equal(publication.ReleaseSeries[0].Id, viewModels[0].Id);
                 Assert.True(viewModels[0].IsLegacyLink);
                 Assert.Equal(legacyLinks[0].LegacyLinkDescription, viewModels[0].Description);
                 Assert.Null(viewModels[0].ReleaseId);
@@ -2825,7 +2752,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Null(viewModels[0].IsPublished);
                 Assert.Equal(legacyLinks[0].LegacyLinkUrl, viewModels[0].LegacyLinkUrl);
 
-                Assert.Equal(publication.ReleaseSeries[1].Id, viewModels[1].Id);
                 Assert.True(viewModels[1].IsLegacyLink);
                 Assert.Equal(legacyLinks[1].LegacyLinkDescription, viewModels[1].Description);
                 Assert.Null(viewModels[1].ReleaseId);
@@ -2868,12 +2794,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             Publication publication = _dataFixture
                 .DefaultPublication()
-                .WithReleases([
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, year: 2020)
-                ])
+                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
                 .WithLegacyLinks([legacyLink])
                 .WithTheme(_dataFixture.DefaultTheme());
+
+            var release = publication.Releases.Single();
 
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -2906,18 +2831,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(3, viewModels.Count);
 
-                var expectedReleaseVersion1 =
-                    publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
-                Assert.Equal(publication.ReleaseSeries[0].Id, viewModels[0].Id);
                 Assert.False(viewModels[0].IsLegacyLink);
-                Assert.Equal(expectedReleaseVersion1.Title, viewModels[0].Description);
-                Assert.Equal(expectedReleaseVersion1.ReleaseId, viewModels[0].ReleaseId);
-                Assert.Equal(expectedReleaseVersion1.Slug, viewModels[0].ReleaseSlug);
+                Assert.Equal(release.Title, viewModels[0].Description);
+                Assert.Equal(release.Id, viewModels[0].ReleaseId);
+                Assert.Equal(release.Slug, viewModels[0].ReleaseSlug);
                 Assert.True(viewModels[0].IsLatest);
                 Assert.True(viewModels[0].IsPublished);
                 Assert.Null(viewModels[0].LegacyLinkUrl);
 
-                Assert.Equal(publication.ReleaseSeries[1].Id, viewModels[1].Id);
                 Assert.True(viewModels[1].IsLegacyLink);
                 Assert.Equal(legacyLink.LegacyLinkDescription, viewModels[1].Description);
                 Assert.Null(viewModels[1].ReleaseId);
@@ -2933,16 +2854,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Null(viewModels[2].IsLatest);
                 Assert.Null(viewModels[2].IsPublished);
                 Assert.Equal("https://test.com/new", viewModels[2].LegacyLinkUrl);
+            }
 
-                var dbReleaseSeries = contentDbContext.Publications
-                    .Where(p => p.Id == publication.Id)
-                    .Select(p => p.ReleaseSeries)
-                    .Single();
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var actualPublication = await contentDbContext.Publications
+                    .SingleAsync(p => p.Id == publication.Id);
 
-                Assert.Equal(3, dbReleaseSeries.Count);
-                Assert.Equal(viewModels[0].Id, dbReleaseSeries[0].Id);
-                Assert.Equal(viewModels[1].Id, dbReleaseSeries[1].Id);
-                Assert.Equal(viewModels[2].Id, dbReleaseSeries[2].Id);
+                var actualReleaseSeries = actualPublication.ReleaseSeries;
+                Assert.Equal(3, actualReleaseSeries.Count);
+
+                Assert.Equal(release.Id, actualReleaseSeries[0].ReleaseId);
+
+                Assert.Equal(legacyLink.LegacyLinkDescription, actualReleaseSeries[1].LegacyLinkDescription);
+                Assert.Equal(legacyLink.LegacyLinkUrl, actualReleaseSeries[1].LegacyLinkUrl);
+
+                Assert.Equal("New legacy link", actualReleaseSeries[2].LegacyLinkDescription);
+                Assert.Equal("https://test.com/new", actualReleaseSeries[2].LegacyLinkUrl);
             }
         }
 
@@ -2978,7 +2906,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Description = "New legacy link",
                         Url = "https://test.com/new"
                     });
+
                 VerifyAllMocks(publicationCacheService);
+
                 var viewModels = result.AssertRight();
 
                 var newSeriesItem = Assert.Single(viewModels);
@@ -2989,14 +2919,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Null(newSeriesItem.IsLatest);
                 Assert.Null(newSeriesItem.IsPublished);
                 Assert.Equal("https://test.com/new", newSeriesItem.LegacyLinkUrl);
+            }
 
-                var dbReleaseSeries = contentDbContext.Publications
-                    .Where(p => p.Id == publication.Id)
-                    .Select(p => p.ReleaseSeries)
-                    .Single();
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var actualPublication = await contentDbContext.Publications
+                    .SingleAsync(p => p.Id == publication.Id);
 
-                var dbSeriesItem = Assert.Single(dbReleaseSeries);
-                Assert.Equal(viewModels[0].Id, dbSeriesItem.Id);
+                var actualReleaseSeriesItem = Assert.Single(actualPublication.ReleaseSeries);
+
+                Assert.Equal("New legacy link", actualReleaseSeriesItem.LegacyLinkDescription);
+                Assert.Equal("https://test.com/new", actualReleaseSeriesItem.LegacyLinkUrl);
             }
         }
 
@@ -3016,6 +2949,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .WithLegacyLinks([_dataFixture.DefaultLegacyReleaseSeriesItem()])
                 .WithTheme(_dataFixture.DefaultTheme());
 
+            var release2020 = publication.Releases.Single(r => r.Year == 2020);
+            var release2021 = publication.Releases.Single(r => r.Year == 2021);
+            var release2022 = publication.Releases.Single(r => r.Year == 2022);
+
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -3034,40 +2971,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     contentDbContext,
                     publicationCacheService: publicationCacheService.Object);
 
-                var expectedReleaseVersion2022 =
-                    publication.ReleaseVersions.Single(rv => rv is { Year: 2022, Version: 1 });
-                var expectedReleaseVersion2021 =
-                    publication.ReleaseVersions.Single(rv => rv is { Year: 2021, Version: 0 });
-                var expectedReleaseVersion2020 =
-                    publication.ReleaseVersions.Single(rv => rv is { Year: 2020, Version: 0 });
-
                 var result = await publicationService.UpdateReleaseSeries(
                     publication.Id,
                     updatedReleaseSeriesItems:
                     [
                         new ReleaseSeriesItemUpdateRequest
                         {
-                            Id = Guid.NewGuid(),
                             LegacyLinkDescription = "Legacy link new",
                             LegacyLinkUrl = "https://test.com/new",
                         },
-
                         new ReleaseSeriesItemUpdateRequest
                         {
-                            Id = Guid.NewGuid(),
-                            ReleaseId = expectedReleaseVersion2021.ReleaseId,
+                            ReleaseId = release2021.Id
                         },
-
                         new ReleaseSeriesItemUpdateRequest
                         {
-                            Id = Guid.NewGuid(),
-                            ReleaseId = expectedReleaseVersion2020.ReleaseId,
+                            ReleaseId = release2020.Id
                         },
-
                         new ReleaseSeriesItemUpdateRequest
                         {
-                            Id = Guid.NewGuid(),
-                            ReleaseId = expectedReleaseVersion2022.ReleaseId,
+                            ReleaseId = release2022.Id
                         }
                     ]);
 
@@ -3086,28 +3009,44 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("https://test.com/new", viewModels[0].LegacyLinkUrl);
 
                 Assert.False(viewModels[1].IsLegacyLink);
-                Assert.Equal(expectedReleaseVersion2021.Title, viewModels[1].Description);
-                Assert.Equal(expectedReleaseVersion2021.ReleaseId, viewModels[1].ReleaseId);
-                Assert.Equal(expectedReleaseVersion2021.Slug, viewModels[1].ReleaseSlug);
+                Assert.Equal(release2021.Title, viewModels[1].Description);
+                Assert.Equal(release2021.Id, viewModels[1].ReleaseId);
+                Assert.Equal(release2021.Slug, viewModels[1].ReleaseSlug);
                 Assert.False(viewModels[1].IsLatest);
                 Assert.False(viewModels[1].IsPublished);
                 Assert.Null(viewModels[1].LegacyLinkUrl);
 
                 Assert.False(viewModels[2].IsLegacyLink);
-                Assert.Equal(expectedReleaseVersion2020.Title, viewModels[2].Description);
-                Assert.Equal(expectedReleaseVersion2020.ReleaseId, viewModels[2].ReleaseId);
-                Assert.Equal(expectedReleaseVersion2020.Slug, viewModels[2].ReleaseSlug);
+                Assert.Equal(release2020.Title, viewModels[2].Description);
+                Assert.Equal(release2020.Id, viewModels[2].ReleaseId);
+                Assert.Equal(release2020.Slug, viewModels[2].ReleaseSlug);
                 Assert.False(viewModels[2].IsLatest);
                 Assert.True(viewModels[2].IsPublished);
                 Assert.Null(viewModels[2].LegacyLinkUrl);
 
                 Assert.False(viewModels[3].IsLegacyLink);
-                Assert.Equal(expectedReleaseVersion2022.Title, viewModels[3].Description);
-                Assert.Equal(expectedReleaseVersion2022.ReleaseId, viewModels[3].ReleaseId);
-                Assert.Equal(expectedReleaseVersion2022.Slug, viewModels[3].ReleaseSlug);
+                Assert.Equal(release2022.Title, viewModels[3].Description);
+                Assert.Equal(release2022.Id, viewModels[3].ReleaseId);
+                Assert.Equal(release2022.Slug, viewModels[3].ReleaseSlug);
                 Assert.True(viewModels[3].IsLatest);
                 Assert.True(viewModels[3].IsPublished);
                 Assert.Null(viewModels[3].LegacyLinkUrl);
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var actualPublication = await contentDbContext.Publications
+                    .SingleAsync(p => p.Id == publication.Id);
+
+                var actualReleaseSeries = actualPublication.ReleaseSeries;
+                Assert.Equal(4, actualReleaseSeries.Count);
+
+                Assert.Equal("Legacy link new", actualReleaseSeries[0].LegacyLinkDescription);
+                Assert.Equal("https://test.com/new", actualReleaseSeries[0].LegacyLinkUrl);
+
+                Assert.Equal(release2021.Id, actualReleaseSeries[1].ReleaseId);
+                Assert.Equal(release2020.Id, actualReleaseSeries[2].ReleaseId);
+                Assert.Equal(release2022.Id, actualReleaseSeries[3].ReleaseId);
             }
         }
 
@@ -3147,6 +3086,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Empty(viewModels);
             }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var actualPublication = await contentDbContext.Publications
+                    .SingleAsync(p => p.Id == publication.Id);
+
+                Assert.Empty(actualPublication.ReleaseSeries);
+            }
         }
 
         [Fact]
@@ -3154,8 +3101,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             Publication publication = _dataFixture
                 .DefaultPublication()
-                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1, year: 2020)])
+                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
                 .WithTheme(_dataFixture.DefaultTheme());
+
+            var release = publication.Releases.Single();
 
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -3166,24 +3115,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var publicationService = BuildPublicationService(
-                    contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
+                var publicationService = BuildPublicationService(contentDbContext);
 
                 var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
                     publicationService.UpdateReleaseSeries(
                         publication.Id,
                         updatedReleaseSeriesItems: []));
 
-                VerifyAllMocks(publicationCacheService);
-
-                Assert.Equal("Missing or duplicate release in new release series. Expected ReleaseIds: " +
-                             publication.ReleaseVersions[0].ReleaseId,
+                Assert.Equal($"Missing or duplicate release in new release series. Expected ReleaseIds: {release.Id}",
                     exception.Message);
             }
         }
@@ -3193,8 +3132,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             Publication publication = _dataFixture
                 .DefaultPublication()
-                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1, year: 2020)])
+                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
                 .WithTheme(_dataFixture.DefaultTheme());
+
+            var release = publication.Releases.Single();
 
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -3205,14 +3146,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var publicationService = BuildPublicationService(
-                    contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
+                var publicationService = BuildPublicationService(contentDbContext);
 
                 var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
                     publicationService.UpdateReleaseSeries(
@@ -3221,21 +3155,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         [
                             new ReleaseSeriesItemUpdateRequest
                             {
-                                Id = Guid.NewGuid(),
-                                ReleaseId = publication.ReleaseVersions[0].ReleaseId,
+                                ReleaseId = release.Id
                             },
-
                             new ReleaseSeriesItemUpdateRequest
                             {
-                                Id = Guid.NewGuid(),
-                                ReleaseId = publication.ReleaseVersions[0].ReleaseId,
+                                ReleaseId = release.Id
                             }
                         ]));
 
-                VerifyAllMocks(publicationCacheService);
-
-                Assert.Equal("Missing or duplicate release in new release series. Expected ReleaseIds: " +
-                             publication.ReleaseVersions[0].ReleaseId,
+                Assert.Equal($"Missing or duplicate release in new release series. Expected ReleaseIds: {release.Id}",
                     exception.Message);
             }
         }
@@ -3245,8 +3173,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             Publication publication = _dataFixture
                 .DefaultPublication()
-                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1, year: 2020)])
+                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
                 .WithTheme(_dataFixture.DefaultTheme());
+
+            var release = publication.Releases.Single();
 
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -3257,14 +3187,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var publicationService = BuildPublicationService(
-                    contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
+                var publicationService = BuildPublicationService(contentDbContext);
 
                 var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
                     publicationService.UpdateReleaseSeries(
@@ -3272,18 +3195,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         [
                             new ReleaseSeriesItemUpdateRequest
                             {
-                                Id = Guid.NewGuid(),
-                                ReleaseId = publication.ReleaseVersions[0].ReleaseId,
+                                ReleaseId = release.Id,
                                 LegacyLinkDescription = "this should be null",
                                 LegacyLinkUrl = "https://should.be/null",
                             }
                         ]));
 
-                VerifyAllMocks(publicationCacheService);
-
-                Assert.Equal(
-                    $"LegacyLink details shouldn't be set if ReleaseId is set. ReleaseSeriesItem: {Guid.NewGuid()}",
-                    exception.Message);
+                Assert.Equal("LegacyLink details shouldn't be set if ReleaseId is set.", exception.Message);
             }
         }
 
@@ -3303,14 +3221,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var publicationService = BuildPublicationService(
-                    contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
+                var publicationService = BuildPublicationService(contentDbContext);
 
                 var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
                     publicationService.UpdateReleaseSeries(
@@ -3318,18 +3229,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         [
                             new ReleaseSeriesItemUpdateRequest
                             {
-                                Id = Guid.NewGuid(),
                                 ReleaseId = null,
                                 LegacyLinkDescription = null,
                                 LegacyLinkUrl = null,
                             }
                         ]));
 
-                VerifyAllMocks(publicationCacheService);
-
-                Assert.Equal(
-                    $"LegacyLink details should be set if ReleaseId is null. ReleaseSeriesItem: {Guid.NewGuid()}",
-                    exception.Message);
+                Assert.Equal("LegacyLink details should be set if ReleaseId is null.", exception.Message);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseSeriesItemRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseSeriesItemRequests.cs
@@ -1,21 +1,22 @@
 #nullable enable
-
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
-public class ReleaseSeriesLegacyLinkAddRequest
+public record ReleaseSeriesLegacyLinkAddRequest
 {
-    public string Description { get; set; } = string.Empty;
-    public string Url { get; set; } = string.Empty;
+    [Required]
+    public required string Description { get; init; }
+
+    [Required]
+    public required string Url { get; init; }
 }
 
-public class ReleaseSeriesItemUpdateRequest
+public record ReleaseSeriesItemUpdateRequest
 {
-    public Guid Id { get; set; }
-    public Guid? ReleaseId { get; set; }
+    public Guid? ReleaseId { get; init; }
 
-    public string? LegacyLinkDescription { get; set; }
-    public string? LegacyLinkUrl { get; set; }
+    public string? LegacyLinkDescription { get; init; }
+    public string? LegacyLinkUrl { get; init; }
 }
-

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseSeriesItemRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseSeriesItemRequests.cs
@@ -1,15 +1,12 @@
 #nullable enable
 using System;
-using System.ComponentModel.DataAnnotations;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
 public record ReleaseSeriesLegacyLinkAddRequest
 {
-    [Required]
     public required string Description { get; init; }
 
-    [Required]
     public required string Url { get; init; }
 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
@@ -118,8 +118,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                             {
                                 return new ReleaseSeriesItemViewModel
                                 {
-                                    Id = rsi.Id,
-                                    IsLegacyLink = rsi.IsLegacyLink,
                                     Description = rsi.LegacyLinkDescription!,
                                     LegacyLinkUrl = rsi.LegacyLinkUrl,
                                 };
@@ -130,10 +128,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
 
                             return new ReleaseSeriesItemViewModel
                             {
-                                Id = rsi.Id,
-                                IsLegacyLink = rsi.IsLegacyLink,
                                 Description = latestReleaseVersion.Title,
-
                                 ReleaseId = latestReleaseVersion.ReleaseId,
                                 ReleaseSlug = latestReleaseVersion.Slug,
                             };

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -197,7 +197,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     publication.ReleaseSeries.Insert(0, new ReleaseSeriesItem
                     {
                         Id = Guid.NewGuid(),
-                        ReleaseId = newReleaseVersion.ReleaseId,
+                        ReleaseId = release.Id
                     });
                     _context.Publications.Update(publication);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseSeriesTableEntryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseSeriesTableEntryViewModel.cs
@@ -5,17 +5,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
 public record ReleaseSeriesTableEntryViewModel
 {
-    public Guid Id { get; set; }
-    public bool IsLegacyLink { get; set; }
-    public string Description { get; set; } = string.Empty;
+    public required Guid Id { get; init; }
+    public required string Description { get; init; }
 
     // used by EES release series item
-    public Guid? ReleaseId { get; set; }
-    public string? ReleaseSlug { get; set; }
-    public bool? IsLatest { get; set; }
-    public bool? IsPublished { get; set; }
+    public Guid? ReleaseId { get; init; }
+    public string? ReleaseSlug { get; init; }
+    public bool? IsLatest { get; init; }
+    public bool? IsPublished { get; init; }
 
     // used by legacy link series item
-    public string? LegacyLinkUrl { get; set; }
-}
+    public string? LegacyLinkUrl { get; init; }
 
+    public bool IsLegacyLink => ReleaseId == null;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/ReleaseSeriesItemViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/ReleaseSeriesItemViewModel.cs
@@ -5,14 +5,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 
 public record ReleaseSeriesItemViewModel
 {
-    public Guid Id { get; set; }
-    public bool IsLegacyLink { get; set; }
-    public string Description { get; set; } = string.Empty;
+    public required string Description { get; init; }
 
     // used by EES release series item
-    public Guid? ReleaseId { get; set; }
-    public string? ReleaseSlug { get; set; }
+    public Guid? ReleaseId { get; init; }
+    public string? ReleaseSlug { get; init; }
 
     // used by legacy link series item
-    public string? LegacyLinkUrl { get; set; }
+    public string? LegacyLinkUrl { get; init; }
+
+    public bool IsLegacyLink => ReleaseId == null;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseSeriesItem.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseSeriesItem.cs
@@ -6,6 +6,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 public record ReleaseSeriesItem
 {
+    /// <summary>
+    /// Unique identifier for the ReleaseSeriesItem which exists to allow safely managing legacy links in the UI.
+    /// </summary>
     public Guid Id { get; set; }
 
     public Guid? ReleaseId { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/PublicationCacheServiceTests.cs
@@ -52,16 +52,14 @@ public class PublicationCacheServiceTests : CacheServiceTestFixture
                 Title = ""
             }
         },
-        ReleaseSeries = new()
-        {
-            new()
+        ReleaseSeries =
+        [
+            new ReleaseSeriesItemViewModel
             {
-                Id = Guid.NewGuid(),
-                IsLegacyLink = true,
                 Description = "legacy link description",
                 LegacyLinkUrl = "http://test.com/",
             }
-        },
+        ],
         Theme = new ThemeViewModel(
             Guid.NewGuid(),
             Slug: "",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -205,7 +205,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     Assert.Null(releaseSeriesItem2.LegacyLinkUrl);
 
                     var releaseSeriesItem3 = publicationViewModel.ReleaseSeries[2];
-                    Assert.Equal(_legacyLinks[0].Id, releaseSeriesItem3.Id);
                     Assert.True(releaseSeriesItem3.IsLegacyLink);
                     Assert.Null(releaseSeriesItem3.ReleaseId);
                     Assert.Equal(_legacyLinks[0].LegacyLinkDescription, releaseSeriesItem3.Description);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -100,8 +100,6 @@ public class PublicationService : IPublicationService
                         {
                             return new ReleaseSeriesItemViewModel
                             {
-                                Id = rsi.Id,
-                                IsLegacyLink = rsi.IsLegacyLink,
                                 Description = rsi.LegacyLinkDescription!,
                                 LegacyLinkUrl = rsi.LegacyLinkUrl,
                             };
@@ -112,10 +110,7 @@ public class PublicationService : IPublicationService
 
                         return new ReleaseSeriesItemViewModel
                         {
-                            Id = rsi.Id,
-                            IsLegacyLink = rsi.IsLegacyLink,
                             Description = latestReleaseVersion.Title,
-
                             ReleaseId = latestReleaseVersion.ReleaseId,
                             ReleaseSlug = latestReleaseVersion.Slug,
                         };

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationEditReleaseSeriesLegacyLinkPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationEditReleaseSeriesLegacyLinkPage.tsx
@@ -19,7 +19,6 @@ export const mapToReleaseSeriesItemUpdateRequest = (
   releaseSeries: ReleaseSeriesTableEntry[],
 ): ReleaseSeriesItemUpdateRequest[] => {
   return releaseSeries.map(seriesItem => ({
-    id: seriesItem.id,
     releaseId: seriesItem.releaseId,
     legacyLinkDescription: seriesItem.isLegacyLink
       ? seriesItem.description

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationEditReleaseSeriesLegacyLinkPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationEditReleaseSeriesLegacyLinkPage.test.tsx
@@ -25,24 +25,24 @@ const publicationService = _publicationService as jest.Mocked<
 describe('PublicationEditReleaseSeriesLegacyLinkPage', () => {
   const releaseSeries: ReleaseSeriesTableEntry[] = [
     {
-      id: 'legacy-release-1',
+      id: 'release-series-item-1',
       isLegacyLink: true,
       description: 'Legacy link 1',
 
       legacyLinkUrl: 'https://gov.uk/1',
     },
     {
-      id: 'release-1',
+      id: 'release-series-item-2',
       isLegacyLink: false,
       description: 'Academic Year 2000/01',
 
-      releaseId: 'release-parent-1',
+      releaseId: 'release-1',
       releaseSlug: 'release-slug',
       isLatest: true,
       isPublished: true,
     },
     {
-      id: 'legacy-release-2',
+      id: 'release-series-item-3',
       isLegacyLink: true,
       description: 'Legacy link 2',
 
@@ -55,7 +55,7 @@ describe('PublicationEditReleaseSeriesLegacyLinkPage', () => {
   });
 
   test('renders the edit legacy release page', async () => {
-    renderPage(testPublication, 'legacy-release-1');
+    renderPage(testPublication, 'release-series-item-1');
 
     await waitFor(() => {
       expect(screen.getByText('Edit legacy release')).toBeInTheDocument();
@@ -72,7 +72,7 @@ describe('PublicationEditReleaseSeriesLegacyLinkPage', () => {
   });
 
   test('handles successfully submitting the form', async () => {
-    renderPage(testPublication, 'legacy-release-1');
+    renderPage(testPublication, 'release-series-item-1');
     await waitFor(() => {
       expect(screen.getByText('Edit legacy release')).toBeInTheDocument();
     });
@@ -90,19 +90,13 @@ describe('PublicationEditReleaseSeriesLegacyLinkPage', () => {
         'publication-1',
         [
           {
-            id: 'legacy-release-1',
-
             legacyLinkDescription: 'Legacy link 1 edited',
             legacyLinkUrl: 'https://gov.uk/1/edit',
           },
           {
-            id: 'release-1',
-
-            releaseId: 'release-parent-1',
+            releaseId: 'release-1',
           },
           {
-            id: 'legacy-release-2',
-
             legacyLinkDescription: 'Legacy link 2',
             legacyLinkUrl: 'https://gov.uk/2',
           },

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -346,14 +346,19 @@ const ReleaseContent = ({
                     <ul className="govuk-list">
                       {[
                         ...releaseSeries.map(
-                          ({
-                            id,
-                            isLegacyLink,
-                            description,
-                            legacyLinkUrl,
-                            releaseSlug,
-                          }) => (
-                            <li key={id} data-testid="other-release-item">
+                          (
+                            {
+                              isLegacyLink,
+                              description,
+                              legacyLinkUrl,
+                              releaseSlug,
+                            },
+                            index,
+                          ) => (
+                            <li
+                              key={`release-${index.toString()}`}
+                              data-testid="other-release-item"
+                            >
                               {isLegacyLink ? (
                                 <a href={legacyLinkUrl}>{description}</a>
                               ) : (

--- a/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/page-view/PrototypeReleaseContent.tsx
@@ -308,14 +308,19 @@ const PrototypeReleaseContent = ({
                     <ul className="govuk-list">
                       {[
                         ...releaseSeries.map(
-                          ({
-                            id,
-                            isLegacyLink,
-                            description,
-                            legacyLinkUrl,
-                            releaseSlug,
-                          }) => (
-                            <li key={id} data-testid="other-release-item">
+                          (
+                            {
+                              isLegacyLink,
+                              description,
+                              legacyLinkUrl,
+                              releaseSlug,
+                            },
+                            index,
+                          ) => (
+                            <li
+                              key={`release-${index.toString()}`}
+                              data-testid="other-release-item"
+                            >
                               {isLegacyLink ? (
                                 <a href={legacyLinkUrl}>{description}</a>
                               ) : (

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -83,7 +83,6 @@ export interface ReleaseSeriesLegacyLinkAddRequest {
 }
 
 export interface ReleaseSeriesItemUpdateRequest {
-  id: string;
   releaseId?: string;
   legacyLinkDescription?: string;
   legacyLinkUrl?: string;
@@ -97,6 +96,7 @@ export interface ListReleasesParams {
 }
 
 export interface ReleaseSeriesTableEntry extends ReleaseSeriesItem {
+  id: string;
   isLatest?: boolean;
   isPublished?: boolean;
 }

--- a/src/explore-education-statistics-admin/test/generators/releaseContentGenerators.ts
+++ b/src/explore-education-statistics-admin/test/generators/releaseContentGenerators.ts
@@ -95,7 +95,6 @@ const defaultPublication: Publication = {
   releases: [],
   releaseSeries: [
     {
-      id: 'legacylink-id',
       isLegacyLink: true,
       description: 'legacy link 1',
       legacyLinkUrl: 'https://test.com/1',

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -39,7 +39,6 @@ export interface Publication {
 }
 
 export interface ReleaseSeriesItem {
-  id: string;
   isLegacyLink: boolean;
   description: string;
   releaseId?: string;

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -341,14 +341,19 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                     <ul className="govuk-list">
                       {[
                         ...releaseSeries.map(
-                          ({
-                            id,
-                            isLegacyLink,
-                            description,
-                            legacyLinkUrl,
-                            releaseSlug,
-                          }) => (
-                            <li key={id} data-testid="other-release-item">
+                          (
+                            {
+                              isLegacyLink,
+                              description,
+                              legacyLinkUrl,
+                              releaseSlug,
+                            },
+                            index,
+                          ) => (
+                            <li
+                              key={`release-${index.toString()}`}
+                              data-testid="other-release-item"
+                            >
                               {isLegacyLink ? (
                                 <a href={legacyLinkUrl}>{description}</a>
                               ) : (

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testReleaseData.ts
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testReleaseData.ts
@@ -18,33 +18,28 @@ export const testPublication: Publication = {
   ],
   releaseSeries: [
     {
-      id: 'release-2',
       isLegacyLink: false,
       description: 'Academic year 2018/19',
       releaseSlug: '2018-19',
     },
     {
-      id: 'legacy-release-3',
       isLegacyLink: true,
       description: 'Academic year 2014/15',
       legacyLinkUrl:
         'https://www.gov.uk/government/statistics/pupil-absence-in-schools-in-england-2014-to-2015',
     },
     {
-      id: 'release-1',
       isLegacyLink: false,
       description: 'Academic year 2017/18',
       releaseSlug: '2017-18',
     },
     {
-      id: 'legacy-release-2',
       isLegacyLink: true,
       description: 'Academic year 2013/14',
       legacyLinkUrl:
         'https://www.gov.uk/government/statistics/pupil-absence-in-schools-in-england-2013-to-2014',
     },
     {
-      id: 'legacy-release-1',
       isLegacyLink: true,
       description: 'Academic year 2012/13',
       legacyLinkUrl:


### PR DESCRIPTION
This PR contains mainly backend changes, separating out a few bits of tidy up ahead of the main changes in EES-5656.

There are two main changes amongst some other smaller improvements.

1. I attempted to remove `Id` from `ReleaseSeriesItem`, thinking that in cases where a publication has no legacy releases it would be nice if the `ReleaseSeries` field only contained an array of release id's. I backtracked on removing it entirely when I realised it's needed to be able to safely select the chosen legacy release from the release series array in the Admin UI when choosing to 'Edit' a legacy link. I've left in a lot of the changes where it doesn't need to be present though. For example, it's removed from `ReleaseSeriesItemViewModel` so it's no longer exposed to the public frontend. It's also removed from `ReleaseSeriesItemUpdateRequest` where supplying with each entry in the update made no difference, since we replace all the entries in the old value of `ReleaseSeries` with an entirely new set of entries.

2. I changed the building of the view model in `PublicationService.GetReleaseSeries` to be built from a `Release` rather than `ReleaseVersion` which is possible now the fields `Title` and `Slug` have moved to `Release`. This also makes things a bit clearer in test code where we can compare fields in the view model with expected releases, rather than release versions.