### PR TITLE
EES-5396 Sync public API OpenAPI changes with API docs

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -6,7 +6,15 @@
       "version": "8.0.7",
       "commands": [
         "dotnet-ef"
-      ]
+      ],
+      "rollForward": false
+    },
+    "swashbuckle.aspnetcore.cli": {
+      "version": "7.1.0",
+      "commands": [
+        "swagger"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -15,6 +15,8 @@ variables:
   NodeVersion: '20.16.0'
   RubyVersion: '3.2'
   AcrServiceConnection: s101d-datahub-spn-ees-dfe-gov-uk-docker-managed-service-connection
+  PublicApiDir: GovUk.Education.ExploreEducationStatistics.Public.Data.Api
+  PublicApiDocsDir: explore-education-statistics-api-docs
 
 trigger:
   branches:
@@ -71,6 +73,25 @@ jobs:
           projects: src/GovUk.Education.ExploreEducationStatistics.sln
 
       # TODO: Wrap the above three tasks up into a single `dotnet format` task once all TODOs are done
+
+      - task: DotNetCoreCLI@2
+        displayName: Build Public API
+        inputs:
+          projects: '**/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj'
+          arguments: --configuration $(BuildConfiguration)
+
+      - task: Bash@3
+        displayName: Diff Public API OpenAPI docs
+        inputs:
+          targetType: inline
+          script: |
+            docker run --rm -t \
+              -v $(System.DefaultWorkingDirectory)/src/$(PublicApiDir)/bin/$(BuildConfiguration)/net8.0:/api \
+              -v $(System.DefaultWorkingDirectory)/src/$(PublicApiDocsDir):/api-docs \
+              -v $(System.DefaultWorkingDirectory)/ci/scripts:/scripts \
+              --entrypoint /bin/sh \
+              tufin/oasdiff \
+              /scripts/public-api-openapi-diff.sh
 
   - job: BackendTest
     pool: ees-ubuntu2204-xlarge

--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -163,7 +163,6 @@ jobs:
           projects: '**/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj'
           arguments: -r linux-musl-x64 --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/public-api
           zipAfterPublish: False
-
       - task: Docker@2
         displayName: Build Public API Docker image
         condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
@@ -315,7 +314,7 @@ jobs:
           projects: '**/GovUk.Education.ExploreEducationStatistics.Admin.csproj'
           arguments: --self-contained true -r win-x64 --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)
 
-      - task: PublishPipelineArtifact@0
+      - task: PublishPipelineArtifact@1
         condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
         displayName: Publish Admin artifact
         inputs:
@@ -430,22 +429,44 @@ jobs:
         inputs:
           versionSpec: '>= $(RubyVersion)'
 
+      - task: Cache@2
+        displayName: Cache Gems
+        inputs:
+          key: 'gems | "$(Agent.OS)" | $(WorkingDirectory)/Gemfile.lock'
+          path: $(WorkingDirectory)/vendor
+          restoreKeys: |
+            gems | "$(Agent.OS)"
+            gems
+
       - task: Bash@3
-        displayName: Build
-        env:
-          TECH_DOCS_API_URL: https://dev.statistics.api.education.gov.uk
+        displayName: Set deployment config
         inputs:
           workingDirectory: $(WorkingDirectory)
           targetType: inline
-          script: |
-            bundle install
+          script: bundle config set deployment true
+
+      - task: Bash@3
+        displayName: Install Gems
+        inputs:
+          workingDirectory: $(WorkingDirectory)
+          targetType: inline
+          script: bundle install
+
+      - task: Bash@3
+        displayName: Build
+        inputs:
+          workingDirectory: $(WorkingDirectory)
+          targetType: inline
+          script: | 
             bundle exec middleman build
+            # Remove afterwards as we don't want it in the artifact
+            rm -rf build
 
       - task: PublishPipelineArtifact@1
-        displayName: Publish artifact
+        displayName: Publish Public API docs artifact
         inputs:
           artifactName: public-api-docs
-          targetPath: $(WorkingDirectory)/build
+          targetPath: $(System.DefaultWorkingDirectory)/src/$(PublicApiDocsDir)
 
   - job: MiscellaneousArtifacts
     pool:

--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -11,6 +11,7 @@ variables:
   BuildConfiguration: Release
   IsBranchDeployable: ${{ containsValue(parameters.DeployBranches, variables['Build.SourceBranchName']) }}
   CI: true
+  DotNetVersion: '8.0.x'
   NodeVersion: '20.16.0'
   RubyVersion: '3.2'
   AcrServiceConnection: s101d-datahub-spn-ees-dfe-gov-uk-docker-managed-service-connection
@@ -31,36 +32,28 @@ pr:
   - test
 
 jobs:
-  - job: Backend
-    pool: ees-ubuntu2204-xlarge
+  - job: BackendVerify
+    pool: ees-ubuntu2204-large
     workspace:
       clean: all
     steps:
       - task: UseDotNet@2
-        displayName: Install .NET 8.0 SDK
+        displayName: Install .NET $(DotNetVersion)
         inputs:
-          version: 8.0.x
+          version: $(DotNetVersion)
           performMultiLevelLookup: true
-
-      - task: DotNetCoreCLI@2
-        displayName: Build
-        inputs:
-          projects: |
-            **/GovUk.*/*csproj
-            !**/GovUk.Education.ExploreEducationStatistics.Admin/*csproj
-          arguments: --configuration $(BuildConfiguration)
 
       # TODO: Uncomment this step once formatter has been run globally.
       # This is because whitespace rules cannot be warnings or suggestions; they will always be errors
       # - task: DotNetCoreCLI@2
-      #   displayName:'Verify Formatting and Style
+      #   displayName: Verify formatting
       #   inputs:
       #     command: custom
       #     custom: format whitespace src/GovUk.Education.ExploreEducationStatistics.sln --verify-no-changes --severity error
       #     arguments: --verify-no-changes --verbosity diagnostic
 
       - task: DotNetCoreCLI@2
-        displayName: Verify Formatting and Style
+        displayName: Verify style
         inputs:
           command: custom
           custom: format
@@ -69,7 +62,7 @@ jobs:
           projects: src/GovUk.Education.ExploreEducationStatistics.sln
 
       - task: DotNetCoreCLI@2
-        displayName: Verify Formatting and Style
+        displayName: Verify analyzers
         inputs:
           command: custom
           custom: format
@@ -77,7 +70,18 @@ jobs:
           arguments: analyzers --verify-no-changes --verbosity diagnostic --severity error
           projects: src/GovUk.Education.ExploreEducationStatistics.sln
 
-      # TODO: Wrap these ^ three tasks up into a single `dotnet format` task once all 3 above TODOs are TO-DONE ;)
+      # TODO: Wrap the above three tasks up into a single `dotnet format` task once all TODOs are done
+
+  - job: BackendTest
+    pool: ees-ubuntu2204-xlarge
+    workspace:
+      clean: all
+    steps:
+      - task: UseDotNet@2
+        displayName: Install .NET $(DotNetVersion)
+        inputs:
+          version: $(DotNetVersion)
+          performMultiLevelLookup: true
 
       - task: DotNetCoreCLI@2
         displayName: Test
@@ -88,6 +92,16 @@ jobs:
             !**/GovUk.Education.ExploreEducationStatistics.Admin.Tests/*csproj
           arguments: --configuration $(BuildConfiguration)
 
+  - job: BackendPublish
+    pool:
+      vmImage: ubuntu-22.04
+    steps:
+      - task: UseDotNet@2
+        displayName: Install .NET $(DotNetVersion)
+        inputs:
+          version: $(DotNetVersion)
+          performMultiLevelLookup: true
+
       - task: DotNetCoreCLI@2
         displayName: Package Data API
         inputs:
@@ -97,8 +111,9 @@ jobs:
           arguments: --self-contained true -r win-x64 --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/data-api
           zipAfterPublish: True
 
-      - task: PublishPipelineArtifact@0
+      - task: PublishPipelineArtifact@1
         displayName: Publish Data API artifact
+        condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
         inputs:
           artifactName: data-api
           targetPath: $(Build.ArtifactStagingDirectory)/data-api
@@ -112,8 +127,9 @@ jobs:
           arguments: --self-contained true -r win-x64 --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/content-api
           zipAfterPublish: True
 
-      - task: PublishPipelineArtifact@0
+      - task: PublishPipelineArtifact@1
         displayName: Publish Content API artifact
+        condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
         inputs:
           artifactName: content-api
           targetPath: $(Build.ArtifactStagingDirectory)/content-api
@@ -160,8 +176,9 @@ jobs:
           arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/public-api-data-processor
           zipAfterPublish: True
 
-      - task: PublishPipelineArtifact@0
+      - task: PublishPipelineArtifact@1
         displayName: Publish Public API Data Processor artifact
+        condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
         inputs:
           artifactName: public-api-data-processor
           targetPath: $(Build.ArtifactStagingDirectory)/public-api-data-processor
@@ -175,8 +192,9 @@ jobs:
           arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/notifier
           zipAfterPublish: True
 
-      - task: PublishPipelineArtifact@0
+      - task: PublishPipelineArtifact@1
         displayName: Publish Notifier artifact
+        condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
         inputs:
           artifactName: notifier
           targetPath: $(Build.ArtifactStagingDirectory)/notifier
@@ -190,8 +208,9 @@ jobs:
           arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/publisher
           zipAfterPublish: True
 
-      - task: PublishPipelineArtifact@0
+      - task: PublishPipelineArtifact@1
         displayName: Publish Publisher artifact
+        condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
         inputs:
           artifactName: publisher
           targetPath: $(Build.ArtifactStagingDirectory)/publisher
@@ -205,8 +224,9 @@ jobs:
           arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/processor
           zipAfterPublish: True
 
-      - task: PublishPipelineArtifact@0
+      - task: PublishPipelineArtifact@1
         displayName: Publish Processor artifact
+        condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
         inputs:
           artifactName: processor
           targetPath: $(Build.ArtifactStagingDirectory)/processor
@@ -229,9 +249,9 @@ jobs:
           script: corepack enable
 
       - task: UseDotNet@2
-        displayName: Install .NET 8.0 SDK
+        displayName: Install .NET $(DotNetVersion)
         inputs:
-          version: 8.0.x
+          version: $(DotNetVersion)
           performMultiLevelLookup: true
 
       - task: DotNetCoreCLI@2
@@ -267,6 +287,7 @@ jobs:
 
       - task: DotNetCoreCLI@2
         displayName: Package Admin app
+        condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
         inputs:
           command: publish
           publishWebProjects: false
@@ -274,6 +295,7 @@ jobs:
           arguments: --self-contained true -r win-x64 --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)
 
       - task: PublishPipelineArtifact@0
+        condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
         displayName: Publish Admin artifact
         inputs:
           artifactName: admin

--- a/ci/scripts/public-api-openapi-diff.sh
+++ b/ci/scripts/public-api-openapi-diff.sh
@@ -1,0 +1,60 @@
+#/usr/bin/env sh
+
+set -u
+
+# This script should be run from inside the oasdiff Docker container.
+# It checks for any undocumented changes in the public API.
+
+has_undocumented_changes=false
+
+for file in /api-docs/source/openapi-v*.json; do
+  filename=$(basename $file)
+
+  echo "Checking $filename"
+  oasdiff changelog --flatten-allof -o INFO $file /api/wwwroot/$filename
+
+  if [ $? != 0 ]; then
+    has_undocumented_changes=true
+
+    cat <<- EOF
+ERROR: There were changes that must be documented in the public API docs.
+
+To document these changes, you must update 'src/explore-education-statistics-api-docs/source/$filename'
+by copying the changes from the OpenAPI endpoint when running the public API locally.
+
+The OpenAPI endpoint locally is: http://localhost:5050/$filename
+
+You should ensure that these changes are expected. If there are error level changes reported above, this
+means there are breaking changes that are being introduced. If these changes are intentional, you should:
+
+  1. Create a new major API version in the public API project.
+  2. Create a new 'openapi-v*.json' for the major version in the public API docs.
+  3. Document the major version and its breaking changes in the public API docs (e.g. in a changelog).
+  4. Review any existing API documentation and update accordingly.
+  5. Deprecate the previous API version when appropriate.
+
+Consult the following DevOps wiki page for more information:
+https://dfe-gov-uk.visualstudio.com.mcas.ms/s101-Explore-Education-Statistics/_wiki/wikis/s101-Explore-Education-Statistics.wiki/9070
+EOF
+  fi
+done || true
+
+if $has_undocumented_changes; then
+  exit 1
+fi
+
+has_undocumented_version=false
+
+# Check there isn't an undocumented API version
+for file in /api/wwwroot/openapi-v*.json; do
+  filename=$(basename $file)
+
+  if [ ! -f "/api-docs/source/$filename" ]; then
+    has_undocumented_version=true
+    echo "ERROR: $filename is required in the public API docs"
+  fi
+done
+
+if $has_undocumented_version; then
+  exit 1
+fi

--- a/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
@@ -36,6 +36,9 @@ param resourceAndScalingConfig ContainerAppResourceConfig
 @description('Whether to create or update Azure Monitor alerts during this deploy')
 param deployAlerts bool
 
+@description('Enable the Swagger UI')
+param enableSwagger bool
+
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
@@ -112,6 +115,10 @@ module apiContainerAppModule '../../components/containerApp.bicep' = {
       {
         name: 'App__Url'
         value: publicApiUrl
+      }
+      {
+        name: 'App__EnableSwagger'
+        value: enableSwagger ? 'true' : 'false'
       }
       {
         name: 'AppInsights__ConnectionString'

--- a/infrastructure/templates/public-api/ci/jobs/deploy-api-docs.yml
+++ b/infrastructure/templates/public-api/ci/jobs/deploy-api-docs.yml
@@ -13,20 +13,46 @@ jobs:
     condition: and(succeeded(), eq(variables.deployDocsSite, true))
     dependsOn: ${{ parameters.dependsOn }}
     environment: ${{ parameters.environment }}
+    variables:
+      docsPath: $(Pipeline.Workspace)/MainBuild/public-api-docs
+      nodeVersion: '20.16.0'
+      rubyVersion: '3.2'
     strategy:
       runOnce:
         deploy:
           steps:
-            # Workaround for deprecation warning preventing deployment token for
-            # API docs from being fetched: https://github.com/Azure/azure-cli/issues/30048
-            - task: Bash@3
-              name: InstallAzureCLI
-              displayName: Install Azure CLI 2.64.0 as workaround
+            - download: MainBuild
+              displayName: Download Public API docs artifact
+              artifact: public-api-docs
+
+            - task: UseNode@1
+              displayName: Install Node.js $(nodeVersion)
               inputs:
+                version: $(nodeVersion)
+
+            - task: UseRubyVersion@0
+              displayName: Install Ruby $(rubyVersion)
+              inputs:
+                versionSpec: '>= $(rubyVersion)'
+
+            - task: Bash@3
+              displayName: Create middleman binary
+              inputs:
+                workingDirectory: $(docsPath)
+                targetType: inline
+                script: bundle binstubs middleman-cli
+
+            - task: Bash@3
+              displayName: Build API docs
+              env:
+                TECH_DOCS_API_URL: $(apiAppUrl)
+                TECH_DOCS_ALLOW_INDEXING: $(docsPreventIndexing)
+              inputs:
+                workingDirectory: $(docsPath)
                 targetType: inline
                 script: |
-                  set -e
-                  pip install --force-reinstall azure-cli==2.64.0
+                  chmod -R 755 vendor
+                  ./bin/middleman build
 
             - task: AzureCLI@2
               displayName: Get deployment token
@@ -39,10 +65,6 @@ jobs:
                   deploymentToken=`az staticwebapp secrets list -n $(docsAppName) --query "properties.apiKey" -o tsv`
                   echo "##vso[task.setvariable variable=docsDeploymentToken;]$deploymentToken"
 
-            - download: MainBuild
-              displayName: Download Public API docs artifact
-              artifact: public-api-docs
-
             - task: AzureStaticWebApp@0
               displayName: Deploy API docs
               inputs:
@@ -51,5 +73,5 @@ jobs:
                 skip_app_build: true
                 skip_api_build: true
                 azure_static_web_apps_api_token: $(docsDeploymentToken)
-                cwd: $(Pipeline.Workspace)/MainBuild/public-api-docs
+                cwd: $(docsPath)/build
 

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -103,11 +103,11 @@ param apiAppRegistrationClientId string = ''
 @secure()
 param devopsServicePrincipalId string = ''
 
-// TODO EES-5446 - reinstate pipelineRunnerCidr when the DevOps runners have a static IP range available. 
+// TODO EES-5446 - reinstate pipelineRunnerCidr when the DevOps runners have a static IP range available.
 // @description('Specifies the IP address range of the pipeline runners.')
 // param pipelineRunnerCidr string = ''
 
-@description('Specifies whether or not test Themes can be deleted in the environment.')
+@description('Enable deletion of data relating to a theme that is being deleted.')
 param enableThemeDeletion bool = false
 
 @description('Specifies the workload profiles for this Container App Environment - the default Consumption plan is always included')
@@ -122,6 +122,9 @@ param publicApiContainerAppConfig ContainerAppResourceConfig = {
   scaleAtConcurrentHttpRequests: 10
   workloadProfileName: 'Consumption'
 }
+
+@description('Enable the Swagger UI for public API.')
+param enableSwagger bool = false
 
 var tagValues = union(resourceTags ?? {}, {
   Environment: environmentName
@@ -204,7 +207,7 @@ module coreStorage 'application/shared/coreStorage.bicep' = {
   }
 }
 
-module privateDnsZonesModule 'application/shared/privateDnsZones.bicep' = 
+module privateDnsZonesModule 'application/shared/privateDnsZones.bicep' =
   if (deploySharedPrivateDnsZones) {
   name: 'privateDnsZonesApplicationModuleDeploy'
   params: {
@@ -304,6 +307,7 @@ module apiAppModule 'application/public-api/publicApiApp.bicep' = if (deployCont
     appInsightsConnectionString: appInsightsModule.outputs.appInsightsConnectionString
     deployAlerts: deployAlerts
     resourceAndScalingConfig: publicApiContainerAppConfig
+    enableSwagger: enableSwagger
     tagValues: tagValues
   }
   dependsOn: [
@@ -419,7 +423,7 @@ module dataProcessorModule 'application/public-api/publicApiDataProcessor.bicep'
         tag: 'Default'
         priority: 100
       }
-      // TODO EES-5446 - remove service tag whitelisting when runner scale set IP range reinstated 
+      // TODO EES-5446 - remove service tag whitelisting when runner scale set IP range reinstated
       {
         cidr: 'AzureCloud'
         tag: 'ServiceTag'
@@ -445,7 +449,7 @@ module dataProcessorModule 'application/public-api/publicApiDataProcessor.bicep'
 output dataProcessorContentDbConnectionStringSecretKey string = 'ees-publicapi-data-processor-connectionstring-contentdb'
 output dataProcessorPsqlConnectionStringSecretKey string = 'ees-publicapi-data-processor-connectionstring-publicdatadb'
 
-output dataProcessorFunctionAppManagedIdentityClientId string = deployDataProcessor 
+output dataProcessorFunctionAppManagedIdentityClientId string = deployDataProcessor
   ? dataProcessorModule.outputs.managedIdentityClientId
   : ''
 

--- a/infrastructure/templates/public-api/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-dev.bicepparam
@@ -31,3 +31,4 @@ param publicApiContainerAppWorkloadProfiles = [{
 }]
 
 param enableThemeDeletion = true
+param enableSwagger = true

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Dapper" Version="2.1.35"/>
     <PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.2"/>
     <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0"/>
-    <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.0.0"/>
+    <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="6.1.0"/>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0"/>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7"/>
@@ -40,8 +40,9 @@
     <PackageReference Include="MiniProfiler.EntityFrameworkCore" Version="4.3.8"/>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4"/>
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2"/>
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2"/>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
@@ -53,5 +53,26 @@
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Public.Data.Services\GovUk.Education.ExploreEducationStatistics.Public.Data.Services.csproj"/>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Public.Data.Utils\GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.csproj"/>
   </ItemGroup>
+  
+  <Target Name="BuildOpenApiFiles" AfterTargets="Build">
+    <!-- Add new API versions to this group -->
+    <ItemGroup>
+      <Version Include="1" />
+    </ItemGroup>
+
+    <Exec Command="dotnet tool restore"/>
+    <Exec
+      Command="dotnet tool run swagger tofile --output $(OutputPath)wwwroot/openapi-v%(Version.Identity).json $(OutputPath)$(AssemblyName).dll %(Version.Identity)"
+      EnvironmentVariables="ASPNETCORE_ENVIRONMENT=Development"
+    />
+  </Target>
+
+  <Target Name="CopyOpenApiFilesOnPublish" AfterTargets="Publish">
+    <ItemGroup>
+      <OpenApiFiles Include="$(OutputPath)wwwroot\openapi-*.json" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(OpenApiFiles)" DestinationFolder="$(PublishDir)wwwroot\"/>
+  </Target>
 
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/AppOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Options/AppOptions.cs
@@ -8,4 +8,6 @@ public class AppOptions
     /// The host URL of the public API.
     /// </summary>
     public string Url { get; init; } = string.Empty;
+
+    public bool EnableSwagger { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Program.cs
@@ -2,6 +2,12 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api;
 using Microsoft.Extensions.Logging.ApplicationInsights;
 
+// Update current working directory to ensure we're actually in the location the
+// build is outputted to e.g. `bin/Debug/net8.0`.
+// By default, at least in Rider, this defaults to the project's source directory meaning
+// OpenAPI files copied into the build output's `wwwroot` directory are not detected.
+Directory.SetCurrentDirectory(AppContext.BaseDirectory);
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.WebHost.ConfigureKestrel(options =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Program.cs
@@ -1,9 +1,6 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 using Microsoft.Extensions.Logging.ApplicationInsights;
-using Microsoft.Extensions.Options;
-using Swashbuckle.AspNetCore.SwaggerGen;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -26,9 +23,6 @@ builder.Logging.AddFilter<ApplicationInsightsLoggerProvider>(typeof(Program).Ful
 builder.Logging.AddFilter<ApplicationInsightsLoggerProvider>(typeof(Startup).FullName, LogLevel.Debug);
 builder.Logging.AddAzureWebAppDiagnostics();
 
-builder.Services.AddTransient<IConfigureOptions<SwaggerGenOptions>, SwaggerConfig>();
-builder.Services.AddSwaggerGen();
-
 var startup = new Startup(builder.Configuration, builder.Environment);
 
 startup.ConfigureServices(builder.Services);
@@ -36,22 +30,6 @@ startup.ConfigureServices(builder.Services);
 var app = builder.Build();
 
 startup.Configure(app, app.Environment);
-
-app.UseSwagger(options =>
-{
-    options.RouteTemplate = "/swagger/v{documentName}/openapi.json";
-});
-app.UseSwaggerUI(options =>
-{
-    options.RoutePrefix = "swagger";
-
-    foreach (var description in app.DescribeApiVersions())
-    {
-        options.SwaggerEndpoint(
-            url: $"/swagger/v{description.GroupName}/openapi.json",
-            name: $"v{description.GroupName}");
-    }
-});
 
 await app.StartAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -41,6 +41,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api;
 [ExcludeFromCodeCoverage]
 public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironment)
 {
+    private readonly AppOptions _appOptions = configuration
+        .GetRequiredSection(AppOptions.Section)
+        .Get<AppOptions>()!;
+
     private readonly MiniProfilerOptions _miniProfilerOptions = configuration
         .GetRequiredSection(MiniProfilerOptions.Section)
         .Get<MiniProfilerOptions>()!;
@@ -297,7 +301,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
 
         // Swagger
 
-        if (!hostEnvironment.IsIntegrationTest())
+        if (_appOptions.EnableSwagger)
         {
             app.UseSwagger(options =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -20,6 +20,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Security;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.DuckDb;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services;
@@ -32,6 +33,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using Swashbuckle.AspNetCore.SwaggerGen;
 using RequestTimeoutOptions = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options.RequestTimeoutOptions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api;
@@ -151,6 +153,14 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         services.AddProblemDetails();
         services.AddApiVersioning().AddMvc().AddApiExplorer();
         services.AddEndpointsApiExplorer();
+
+        // Swagger
+
+        if (_appOptions.EnableSwagger)
+        {
+            services.AddSwaggerGen();
+            services.AddTransient<IConfigureOptions<SwaggerGenOptions>, SwaggerConfig>();
+        }
 
         // Databases
 
@@ -283,6 +293,27 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         });
 
         app.UseHealthChecks("/health");
+
+        // Swagger
+
+        if (!hostEnvironment.IsIntegrationTest())
+        {
+            app.UseSwagger(options =>
+            {
+                options.RouteTemplate = "/swagger/v{documentName}/openapi.json";
+            });
+            app.UseSwaggerUI(options =>
+            {
+                options.RoutePrefix = "swagger";
+
+                foreach (var description in (app as WebApplication)!.DescribeApiVersions())
+                {
+                    options.SwaggerEndpoint(
+                        url: $"/swagger/v{description.GroupName}/openapi.json",
+                        name: $"v{description.GroupName}");
+                }
+            });
+        }
     }
 
     private static void UpdateDatabase(IApplicationBuilder app, IHostEnvironment env)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -274,6 +274,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
 
         // Routing / endpoints
 
+        app.UseStaticFiles();
         app.UseRouting();
 
         // Authentication and authorization

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -155,7 +155,16 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
             });
 
         services.AddProblemDetails();
-        services.AddApiVersioning().AddMvc().AddApiExplorer();
+
+        services
+            .AddApiVersioning(options =>
+            {
+                // Supported versions listed in `api-supported-versions` header
+                options.ReportApiVersions = true;
+            })
+            .AddMvc()
+            .AddApiExplorer();
+
         services.AddEndpointsApiExplorer();
 
         // Swagger

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/appsettings.Development.json
@@ -12,7 +12,8 @@
     }
   },
   "App": {
-    "Url": "http://localhost:5050"
+    "Url": "http://localhost:5050",
+    "EnableSwagger": true
   },
   "ContentApi": {
     "Url": "http://localhost:5010"

--- a/src/explore-education-statistics-api-docs/.gitignore
+++ b/src/explore-education-statistics-api-docs/.gitignore
@@ -9,6 +9,7 @@
 # Ignore cache
 /.sass-cache
 /.cache
+/vendor
 
 # Ignore .DS_store file
 .DS_Store

--- a/src/explore-education-statistics-api-docs/config.rb
+++ b/src/explore-education-statistics-api-docs/config.rb
@@ -1,5 +1,6 @@
 require 'dotenv'
 require 'govuk_tech_docs'
+require 'lib/utils/env'
 require 'lib/api_reference_pages_extension'
 require 'lib/helpers'
 require 'lib/api_reference_helpers'
@@ -19,7 +20,7 @@ if ENV.has_key?("TECH_DOCS_HOST")
 end
 
 if ENV.has_key?("TECH_DOCS_PREVENT_INDEXING")
-  config[:tech_docs][:prevent_indexing] = ENV["TECH_DOCS_PREVENT_INDEXING"]
+  config[:tech_docs][:prevent_indexing] = EnvUtils.get_bool("TECH_DOCS_PREVENT_INDEXING")
 end
 
 if ENV.has_key?("TECH_DOCS_API_URL")

--- a/src/explore-education-statistics-api-docs/lib/utils/env.rb
+++ b/src/explore-education-statistics-api-docs/lib/utils/env.rb
@@ -1,0 +1,13 @@
+class EnvUtils
+
+  # @param [String] key
+  # @return [Boolean]
+  def self.get_bool(key)
+    case ENV[key]
+    when "false", "f", "no", "n", "0", ""
+      false
+    else
+      true
+    end
+  end
+end

--- a/src/explore-education-statistics-api-docs/source/openapi-v1.json
+++ b/src/explore-education-statistics-api-docs/source/openapi-v1.json
@@ -16,7 +16,7 @@
     }
   ],
   "paths": {
-    "/api/v1/data-sets/{dataSetId}": {
+    "/v1/data-sets/{dataSetId}": {
       "get": {
         "tags": [
           "DataSets"
@@ -73,7 +73,7 @@
         }
       }
     },
-    "/api/v1/data-sets/{dataSetId}/meta": {
+    "/v1/data-sets/{dataSetId}/meta": {
       "get": {
         "tags": [
           "DataSets"
@@ -165,7 +165,7 @@
         }
       }
     },
-    "/api/v1/data-sets/{dataSetId}/query": {
+    "/v1/data-sets/{dataSetId}/query": {
       "get": {
         "tags": [
           "DataSets"
@@ -673,7 +673,7 @@
         }
       }
     },
-    "/api/v1/data-sets/{dataSetId}/csv": {
+    "/v1/data-sets/{dataSetId}/csv": {
       "get": {
         "tags": [
           "DataSets"
@@ -738,7 +738,7 @@
         }
       }
     },
-    "/api/v1/data-sets/{dataSetId}/versions": {
+    "/v1/data-sets/{dataSetId}/versions": {
       "get": {
         "tags": [
           "DataSetVersions"
@@ -820,7 +820,7 @@
         }
       }
     },
-    "/api/v1/data-sets/{dataSetId}/versions/{dataSetVersion}": {
+    "/v1/data-sets/{dataSetId}/versions/{dataSetVersion}": {
       "get": {
         "tags": [
           "DataSetVersions"
@@ -886,7 +886,7 @@
         }
       }
     },
-    "/api/v1/data-sets/{dataSetId}/versions/{dataSetVersion}/changes": {
+    "/v1/data-sets/{dataSetId}/versions/{dataSetVersion}/changes": {
       "get": {
         "tags": [
           "DataSetVersions"
@@ -952,7 +952,7 @@
         }
       }
     },
-    "/api/v1/publications": {
+    "/v1/publications": {
       "get": {
         "tags": [
           "Publications"
@@ -1027,7 +1027,7 @@
         }
       }
     },
-    "/api/v1/publications/{publicationId}": {
+    "/v1/publications/{publicationId}": {
       "get": {
         "tags": [
           "Publications"
@@ -1074,7 +1074,7 @@
         }
       }
     },
-    "/api/v1/publications/{publicationId}/data-sets": {
+    "/v1/publications/{publicationId}/data-sets": {
       "get": {
         "tags": [
           "Publications"


### PR DESCRIPTION
This PR adds a syncing mechanism to ensure that OpenAPI changes in the public API are documented in the API docs.

To enable this:

1. The public API now generates its OpenAPI documents at build time using the Swashbuckle CLI.
2. We use [oasdiff](https://github.com/Tufin/oasdiff) to diff between the OpenAPI documents used by the API docs and those generated by the public API.
3. If there are any changes in the diff, we fail the build pipeline as this means there are **undocumented** changes.
4. To resolve any undocumented changes, developers need to copy over any changes from the public API to the relevant OpenAPI document in the API docs.

Once this diff has been resolved, the build can pass and deployment can proceed.

The API docs deployment has now been adjusted so that they are built during the build itself. We need to do this as 

## Related changes

- Removed `/api` prefix from `openapi-v1.json` in the API docs.
- Moved Swagger config into public API's `Startup` to enable the Swashbuckle CLI to work.

## Other changes

- Disabled Swagger UI in non-dev environments (i.e. test, pre-prod, prod). This is consistent with our other backend APIs and avoids any problems from hosting the Swagger UI (it's expensive to generate).