### PR TITLE
EES-5543: Correct BoundaryLevel property in ChartDataSetConfig.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartDataSetConfig.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartDataSetConfig.cs
@@ -1,8 +1,7 @@
-﻿#nullable enable
-using System.Collections.Generic;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+#nullable enable
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using System.Collections.Generic;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
 {
@@ -10,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
     {
         public ChartBaseDataSet DataSet;
         public ChartDataGrouping DataGrouping;
-        public BoundaryLevel BoundaryLevels;
+        public long BoundaryLevel;
     }
 
     [JsonConverter(typeof(StringEnumConverter))]


### PR DESCRIPTION
Boundary level values provided in requests from the client app weren't being persisted following a page refresh. This PR corrects the backend request name and type of the boundary level property to enable this persistence.