### PR TITLE
EES-5598 Add Geographic lvl filter to Data Catalogue page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/FunctionsIntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/FunctionsIntegrationTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
@@ -13,6 +13,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
 using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using Moq;
 using NCrontab;
 using Newtonsoft.Json;
@@ -31,6 +32,7 @@ public abstract class DataSetFilesControllerCachingTests : CacheServiceTestFixtu
             ThemeId: Guid.NewGuid(),
             PublicationId: Guid.NewGuid(),
             ReleaseId: Guid.NewGuid(),
+            GeographicLevel: GeographicLevel.Country.GetEnumValue(),
             LatestOnly: true,
             DataSetType: DataSetType.Api,
             SearchTerm: "term",
@@ -116,6 +118,7 @@ public abstract class DataSetFilesControllerCachingTests : CacheServiceTestFixtu
                     _query.ThemeId,
                     _query.PublicationId,
                     _query.ReleaseId,
+                    _query.GeographicLevelEnum,
                     _query.LatestOnly,
                     _query.DataSetType,
                     _query.SearchTerm,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
@@ -39,6 +39,7 @@ public class DataSetFilesController : ControllerBase
                 themeId: request.ThemeId,
                 publicationId: request.PublicationId,
                 releaseVersionId: request.ReleaseId,
+                geographicLevel: request.GeographicLevelEnum,
                 latestOnly: request.LatestOnly,
                 dataSetType: request.DataSetType,
                 searchTerm: request.SearchTerm,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
@@ -8,72 +9,73 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixture
 
 public static class DataSetFileMetaGeneratorExtensions
 {
-    public static Generator<DataSetFileMetaOld> DefaultDataSetFileMeta(this DataFixture fixture)
-        => fixture.Generator<DataSetFileMetaOld>().WithDefaults();
+    public static Generator<DataSetFileMeta> DefaultDataSetFileMeta(this DataFixture fixture)
+        => fixture.Generator<DataSetFileMeta>().WithDefaults();
 
-    public static Generator<DataSetFileMetaOld> WithDefaults(this Generator<DataSetFileMetaOld> generator)
+    public static Generator<DataSetFileMeta> WithDefaults(this Generator<DataSetFileMeta> generator)
         => generator.ForInstance(d => d.SetDefaults());
 
-    public static InstanceSetters<DataSetFileMetaOld> SetDefaults(this InstanceSetters<DataSetFileMetaOld> setters)
+    public static InstanceSetters<DataSetFileMeta> SetDefaults(this InstanceSetters<DataSetFileMeta> setters)
         => setters
             .SetGeographicLevels([GeographicLevel.Country])
-            .SetTimePeriodRange(new TimePeriodRangeMetaOld
+            .SetTimePeriodRange(new TimePeriodRangeMeta
             {
-                Start = new TimePeriodRangeBoundMetaOld { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2000", },
-                End = new TimePeriodRangeBoundMetaOld { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2001", },
+                Start = new TimePeriodRangeBoundMeta{ TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2000", },
+                End = new TimePeriodRangeBoundMeta{ TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2001", },
             })
             .SetFilters([ new()
                 {
-                    Id = Guid.NewGuid(),
+                    FilterId = Guid.NewGuid(),
                     Label = "Filter 1",
                     ColumnName = "filter_1",
                 },
             ])
             .SetIndicators([ new()
                 {
-                    Id = Guid.NewGuid(),
+                    IndicatorId = Guid.NewGuid(),
                     Label = "Indicator 1",
                     ColumnName = "indicator_1",
                 },
             ]);
 
-    public static Generator<DataSetFileMetaOld> WithGeographicLevels(
-        this Generator<DataSetFileMetaOld> generator,
+    public static Generator<DataSetFileMeta> WithGeographicLevels(
+        this Generator<DataSetFileMeta> generator,
         List<GeographicLevel> geographicLevels)
         => generator.ForInstance(s => s.SetGeographicLevels(geographicLevels));
 
-    public static Generator<DataSetFileMetaOld> WithTimePeriodRange(
-        this Generator<DataSetFileMetaOld> generator,
-        TimePeriodRangeMetaOld timePeriodRange)
+    public static Generator<DataSetFileMeta> WithTimePeriodRange(
+        this Generator<DataSetFileMeta> generator,
+        TimePeriodRangeMeta timePeriodRange)
         => generator.ForInstance(s => s.SetTimePeriodRange(timePeriodRange));
 
-    public static Generator<DataSetFileMetaOld> WithFilters(
-        this Generator<DataSetFileMetaOld> generator,
-        List<FilterMetaOld> filters)
+    public static Generator<DataSetFileMeta> WithFilters(
+        this Generator<DataSetFileMeta> generator,
+        List<FilterMeta> filters)
         => generator.ForInstance(s => s.SetFilters(filters));
 
-    public static Generator<DataSetFileMetaOld> WithIndicators(
-        this Generator<DataSetFileMetaOld> generator,
-        List<IndicatorMetaOld> indicators)
+    public static Generator<DataSetFileMeta> WithIndicators(
+        this Generator<DataSetFileMeta> generator,
+        List<IndicatorMeta> indicators)
         => generator.ForInstance(s => s.SetIndicators(indicators));
 
-    public static InstanceSetters<DataSetFileMetaOld> SetGeographicLevels(
-        this InstanceSetters<DataSetFileMetaOld> setters,
+    public static InstanceSetters<DataSetFileMeta> SetGeographicLevels(
+        this InstanceSetters<DataSetFileMeta> setters,
         List<GeographicLevel> geographicLevels)
-        => setters.Set(s => s.GeographicLevels, geographicLevels);
+        => setters.Set(s => s.GeographicLevels, geographicLevels
+            .Select(gl => new GeographicLevelMeta { Code = gl }).ToList());
 
-    public static InstanceSetters<DataSetFileMetaOld> SetTimePeriodRange(
-        this InstanceSetters<DataSetFileMetaOld> setters,
-        TimePeriodRangeMetaOld timePeriodRange)
+    public static InstanceSetters<DataSetFileMeta> SetTimePeriodRange(
+        this InstanceSetters<DataSetFileMeta> setters,
+        TimePeriodRangeMeta timePeriodRange)
         => setters.Set(s => s.TimePeriodRange, timePeriodRange);
 
-    public static InstanceSetters<DataSetFileMetaOld> SetFilters(
-        this InstanceSetters<DataSetFileMetaOld> setters,
-        List<FilterMetaOld> filters)
+    public static InstanceSetters<DataSetFileMeta> SetFilters(
+        this InstanceSetters<DataSetFileMeta> setters,
+        List<FilterMeta> filters)
         => setters.Set(s => s.Filters, filters);
 
-    public static InstanceSetters<DataSetFileMetaOld> SetIndicators(
-        this InstanceSetters<DataSetFileMetaOld> setters,
-        List<IndicatorMetaOld> indicators)
+    public static InstanceSetters<DataSetFileMeta> SetIndicators(
+        this InstanceSetters<DataSetFileMeta> setters,
+        List<IndicatorMeta> indicators)
         => setters.Set(s => s.Indicators, indicators);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaOldGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaOldGeneratorExtensions.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+
+public static class DataSetFileMetaOldGeneratorExtensions
+{
+    public static Generator<DataSetFileMetaOld> DefaultDataSetFileMetaOld(this DataFixture fixture)
+        => fixture.Generator<DataSetFileMetaOld>().WithDefaults();
+
+    public static Generator<DataSetFileMetaOld> WithDefaults(this Generator<DataSetFileMetaOld> generator)
+        => generator.ForInstance(d => d.SetDefaults());
+
+    public static InstanceSetters<DataSetFileMetaOld> SetDefaults(this InstanceSetters<DataSetFileMetaOld> setters)
+        => setters
+            .SetGeographicLevels([GeographicLevel.Country])
+            .SetTimePeriodRange(new TimePeriodRangeMetaOld
+            {
+                Start = new TimePeriodRangeBoundMetaOld { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2000", },
+                End = new TimePeriodRangeBoundMetaOld { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2001", },
+            })
+            .SetFilters([ new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Filter 1",
+                    ColumnName = "filter_1",
+                },
+            ])
+            .SetIndicators([ new()
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Indicator 1",
+                    ColumnName = "indicator_1",
+                },
+            ]);
+
+    public static Generator<DataSetFileMetaOld> WithGeographicLevels(
+        this Generator<DataSetFileMetaOld> generator,
+        List<GeographicLevel> geographicLevels)
+        => generator.ForInstance(s => s.SetGeographicLevels(geographicLevels));
+
+    public static Generator<DataSetFileMetaOld> WithTimePeriodRange(
+        this Generator<DataSetFileMetaOld> generator,
+        TimePeriodRangeMetaOld timePeriodRange)
+        => generator.ForInstance(s => s.SetTimePeriodRange(timePeriodRange));
+
+    public static Generator<DataSetFileMetaOld> WithFilters(
+        this Generator<DataSetFileMetaOld> generator,
+        List<FilterMetaOld> filters)
+        => generator.ForInstance(s => s.SetFilters(filters));
+
+    public static Generator<DataSetFileMetaOld> WithIndicators(
+        this Generator<DataSetFileMetaOld> generator,
+        List<IndicatorMetaOld> indicators)
+        => generator.ForInstance(s => s.SetIndicators(indicators));
+
+    public static InstanceSetters<DataSetFileMetaOld> SetGeographicLevels(
+        this InstanceSetters<DataSetFileMetaOld> setters,
+        List<GeographicLevel> geographicLevels)
+        => setters.Set(s => s.GeographicLevels, geographicLevels);
+
+    public static InstanceSetters<DataSetFileMetaOld> SetTimePeriodRange(
+        this InstanceSetters<DataSetFileMetaOld> setters,
+        TimePeriodRangeMetaOld timePeriodRange)
+        => setters.Set(s => s.TimePeriodRange, timePeriodRange);
+
+    public static InstanceSetters<DataSetFileMetaOld> SetFilters(
+        this InstanceSetters<DataSetFileMetaOld> setters,
+        List<FilterMetaOld> filters)
+        => setters.Set(s => s.Filters, filters);
+
+    public static InstanceSetters<DataSetFileMetaOld> SetIndicators(
+        this InstanceSetters<DataSetFileMetaOld> setters,
+        List<IndicatorMetaOld> indicators)
+        => setters.Set(s => s.Indicators, indicators);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
-using Semver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 
@@ -79,9 +77,14 @@ public static class FileGeneratorExtensions
         Guid dataSetFileId)
         => generator.ForInstance(s => s.SetDataSetFileId(dataSetFileId));
 
-    public static Generator<File> WithDataSetFileMeta(
+    public static Generator<File> WithDataSetFileMetaOld(
         this Generator<File> generator,
         DataSetFileMetaOld? dataSetFileMeta)
+        => generator.ForInstance(s => s.SetDataSetFileMetaOld(dataSetFileMeta));
+
+    public static Generator<File> WithDataSetFileMeta(
+        this Generator<File> generator,
+        DataSetFileMeta? dataSetFileMeta)
         => generator.ForInstance(s => s.SetDataSetFileMeta(dataSetFileMeta));
 
     public static InstanceSetters<File> SetDefaults(this InstanceSetters<File> setters, FileType? fileType)
@@ -110,7 +113,8 @@ public static class FileGeneratorExtensions
             .SetDefault(f => f.SubjectId)
             .SetContentType("text/csv")
             .SetDefault(f => f.DataSetFileId)
-            .Set(f => f.DataSetFileMetaOld, (_, _, context) => context.Fixture.DefaultDataSetFileMeta());
+            .Set(f => f.DataSetFileMetaOld, (_, _, context) => context.Fixture.DefaultDataSetFileMetaOld())
+            .Set(f => f.DataSetFileMeta, (_, _, _) => null); // InMemory DB doesn't support JSON Columns, so this avoids issues saving Files
 
     public static InstanceSetters<File> SetMetaFileDefaults(this InstanceSetters<File> setters)
         => setters
@@ -196,8 +200,13 @@ public static class FileGeneratorExtensions
         Guid dataSetFileId)
         => setters.Set(f => f.DataSetFileId, dataSetFileId);
 
-    public static InstanceSetters<File> SetDataSetFileMeta(
+    public static InstanceSetters<File> SetDataSetFileMetaOld(
         this InstanceSetters<File> setters,
         DataSetFileMetaOld? dataSetFileMeta)
         => setters.Set(f => f.DataSetFileMetaOld, dataSetFileMeta);
+    
+    public static InstanceSetters<File> SetDataSetFileMeta(
+        this InstanceSetters<File> setters,
+        DataSetFileMeta? dataSetFileMeta)
+        => setters.Set(f => f.DataSetFileMeta, dataSetFileMeta);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Requests/DataSetFileListRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Requests/DataSetFileListRequest.cs
@@ -1,5 +1,8 @@
 using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Requests;
 
@@ -7,6 +10,7 @@ public record DataSetFileListRequest(
     Guid? ThemeId = null,
     Guid? PublicationId = null,
     Guid? ReleaseId = null,
+    string? GeographicLevel = null,
     bool? LatestOnly = null,
     DataSetType? DataSetType = null,
     string? SearchTerm = null,
@@ -15,6 +19,11 @@ public record DataSetFileListRequest(
     int Page = 1,
     int PageSize = 10)
 {
+    public GeographicLevel? GeographicLevelEnum =>
+        GeographicLevel == null
+            ? null
+            : EnumUtil.GetFromEnumValue<GeographicLevel>(GeographicLevel);
+
     public class Validator : AbstractValidator<DataSetFileListRequest>
     {
         public Validator()
@@ -23,6 +32,9 @@ public record DataSetFileListRequest(
                 .MinimumLength(3);
             RuleFor(request => request.ReleaseId).NotEmpty()
                 .When(request => request.Sort == DataSetsListRequestSortBy.Natural);
+            RuleFor(request => request.GeographicLevel)
+                .AllowedValue(EnumUtil.GetEnumValues<GeographicLevel>())
+                .When(request => request.GeographicLevel != null);
             RuleFor(request => request.SearchTerm).NotEmpty()
                 .When(request => request.Sort == DataSetsListRequestSortBy.Relevance);
             RuleFor(request => request.Page)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.SortDirection;
 using static GovUk.Education.ExploreEducationStatistics.Content.Requests.DataSetsListRequestSortBy;
 using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;
@@ -55,6 +56,7 @@ public class DataSetFileService : IDataSetFileService
         Guid? themeId,
         Guid? publicationId,
         Guid? releaseVersionId,
+        GeographicLevel? geographicLevel,
         bool? latestOnly,
         DataSetType? dataSetType,
         string? searchTerm,
@@ -82,7 +84,7 @@ public class DataSetFileService : IDataSetFileService
             .HavingThemeId(themeId)
             .HavingPublicationIdOrNoSupersededPublication(publicationId)
             .HavingReleaseVersionId(releaseVersionId)
-            //.HavingGeographicLevel(GeographicLevel.LocalAuthority) // EES-5598
+            .HavingGeographicLevel(geographicLevel)
             .OfDataSetType(dataSetType.Value)
             .HavingLatestPublishedReleaseVersions(latestPublishedReleaseVersions, latestOnly.Value)
             .JoinFreeText(_contentDbContext.ReleaseFilesFreeTextTable, rf => rf.Id, searchTerm);
@@ -492,14 +494,14 @@ internal static class ReleaseFileQueryableExtensions
         return releaseVersionId.HasValue ? query.Where(rf => rf.ReleaseVersionId == releaseVersionId.Value) : query;
     }
 
-    //internal static IQueryable<ReleaseFile> HavingGeographicLevel( // EES-5598
-    //    this IQueryable<ReleaseFile> query,
-    //    GeographicLevel? geographicLevel)
-    //{
-    //    return geographicLevel.HasValue
-    //        ? query.Where(rf => rf.File.DataSetFileMeta!.GeographicLevels.Any(gl => gl.Code == geographicLevel))
-    //        : query;
-    //}
+    internal static IQueryable<ReleaseFile> HavingGeographicLevel(
+        this IQueryable<ReleaseFile> query,
+        GeographicLevel? geographicLevel)
+    {
+        return geographicLevel.HasValue
+            ? query.Where(rf => rf.File.DataSetFileMeta!.GeographicLevels.Any(gl => gl.Code == geographicLevel))
+            : query;
+    }
 
     internal static IQueryable<ReleaseFile> OfDataSetType(
         this IQueryable<ReleaseFile> query,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
@@ -17,6 +18,7 @@ public interface IDataSetFileService
         Guid? themeId,
         Guid? publicationId,
         Guid? releaseVersionId,
+        GeographicLevel? geographicLevel,
         bool? latestOnly,
         DataSetType? dataSetType,
         string? searchTerm,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
@@ -219,7 +219,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 .Generate();
 
             var file = _fixture.DefaultFile(FileType.Data)
-                .WithDataSetFileMeta(null)
+                .WithDataSetFileMetaOld(null)
                 .WithSubjectId(subject.Id)
                 .Generate();
 

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
@@ -52,6 +52,7 @@ import omit from 'lodash/omit';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
+import { GeographicLevelCode } from '@common/utils/locationLevelsMap';
 
 const defaultPageTitle = 'Data catalogue';
 
@@ -61,6 +62,7 @@ export interface DataCataloguePageQuery {
   page?: number;
   publicationId?: string;
   releaseId?: string;
+  geographicLevel?: GeographicLevelCode;
   searchTerm?: string;
   sortBy?: DataSetFileSortOption;
   sortDirection?: SortDirection;
@@ -85,6 +87,7 @@ const DataCataloguePage: NextPage<Props> = ({ showTypeFilter }) => {
     sortBy,
     publicationId,
     releaseId,
+    geographicLevel,
     searchTerm,
     themeId,
   } = getParamsFromQuery(router.query);
@@ -131,6 +134,7 @@ const DataCataloguePage: NextPage<Props> = ({ showTypeFilter }) => {
     searchTerm,
     selectedTheme?.title,
     selectedPublication?.title,
+    geographicLevel,
   ]).join(', ');
 
   const updateQueryParams = async (nextQuery: DataCataloguePageQuery) => {

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/Filters.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/Filters.tsx
@@ -13,6 +13,10 @@ import styles from '@frontend/modules/data-catalogue/components/Filters.module.s
 import { DataSetFileFilter } from '@frontend/modules/data-catalogue/utils/dataSetFileFilters';
 import React from 'react';
 import classNames from 'classnames';
+import locationLevelsMap, {
+  GeographicLevelCode,
+} from '@common/utils/locationLevelsMap';
+import typedKeys from '@common/utils/object/typedKeys';
 
 const formId = 'filters-form';
 
@@ -23,6 +27,7 @@ interface Props {
   publications?: PublicationTreeSummary[];
   releaseId?: string;
   releases?: ReleaseSummary[];
+  geographicLevel?: GeographicLevelCode;
   showResetFiltersButton?: boolean;
   showTypeFilter?: boolean;
   themeId?: string;
@@ -44,6 +49,7 @@ export default function Filters({
   publicationId,
   releaseId,
   releases = [],
+  geographicLevel,
   showResetFiltersButton,
   showTypeFilter,
   themeId,
@@ -136,6 +142,36 @@ export default function Filters({
           order={[]}
           onChange={e => {
             onChange({ filterType: 'releaseId', nextValue: e.target.value });
+          }}
+        />
+      </FormGroup>
+
+      <FormGroup>
+        <FormSelect
+          className="govuk-!-width-full"
+          id={`${formId}-geographic-level`}
+          label={
+            <>
+              <VisuallyHidden>Filter by </VisuallyHidden>Geographic level
+            </>
+          }
+          name="geographicLevel"
+          options={[
+            { label: 'All', value: 'all' },
+            ...typedKeys(locationLevelsMap).map(key => {
+              return {
+                label: locationLevelsMap[key].label,
+                value: locationLevelsMap[key].code,
+              };
+            }),
+          ]}
+          value={geographicLevel}
+          order={[]}
+          onChange={e => {
+            onChange({
+              filterType: 'geographicLevel',
+              nextValue: e.target.value,
+            });
           }}
         />
       </FormGroup>

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/createDataSetFileListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/createDataSetFileListRequest.ts
@@ -23,6 +23,7 @@ export default function createDataSetFileListRequest(
     sortBy,
     publicationId,
     releaseId,
+    geographicLevel,
     searchTerm: searchParam,
     themeId,
   } = getParamsFromQuery(query);
@@ -43,6 +44,7 @@ export default function createDataSetFileListRequest(
       page: parseNumber(query.page) ?? 1,
       publicationId,
       releaseId,
+      geographicLevel,
       sort,
       sortDirection,
       searchTerm,
@@ -101,6 +103,7 @@ export function getParamsFromQuery(query: DataCataloguePageQuery) {
         : 'newest',
     publicationId: getFirst(query.publicationId),
     releaseId: getFirst(query.releaseId),
+    geographicLevel: getFirst(query.geographicLevel),
     searchTerm: getFirst(query.searchTerm),
     themeId: getFirst(query.themeId),
   };

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/dataSetFileFilters.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/dataSetFileFilters.ts
@@ -3,6 +3,7 @@ export const dataSetFileFilters = [
   'latest',
   'publicationId',
   'releaseId',
+  'geographicLevel',
   'searchTerm',
   'themeId',
 ] as const;


### PR DESCRIPTION
This PR adds the frontend code to filter by Geographic Level on the Data Catalogue page.

Most of the backend work was completed in EES-5691.

There are a few backend changes made to allow the frontend to provide a geographic level code to the frontend - the backend turns the code into a `GeographicLevel` via `DataSetFileListRequest.GeographicLevelEnum`.

We also add a generator for the new `DataSetFileMeta`, but set it to null. We do this because the InMemory DB does not support EF8 JSON columns, so any test that tries to save a File with DataSetFileMeta set will fail. Our workaround for this issue, if a test needs to set DataSetFileMeta, is to mock it out via a repository - this was done in EES-5691. 

:rotating_light: This PR should be merged into the EES-5691 branch before merging the EES-5691 PR itself :rotating_light: 

