### PR TITLE
EES-5732 prevent ui test failures after data replacement

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -111,6 +111,14 @@ const ReleaseDataUploadsSection = ({
     dataFile: DataFile,
     { totalRows, status }: DataFileImportStatus,
   ) => {
+    // EES-5732 UI tests related to data replacement sometimes fail
+    // because of a permission call for the replaced file being called,
+    // probably caused by the speed of the tests.
+    // This prevents this happening.
+    if (status === 'NOT_FOUND') {
+      return;
+    }
+
     const permissions = await permissionService.getDataFilePermissions(
       releaseId,
       dataFile.id,


### PR DESCRIPTION
`data_reordering.robot` is currently failing when it tries to go back to the 'Data and Files' tab after replacing the data files.

It errors because a request to the data file permissions endpoint fails because it uses the previous file id (from before the data was replaced). I can't replicate this manually at all so my guess is it's related to the speed of the UI tests.

This adds a check to `handleStatusChange` to check that the file still exists before calling the permissions service.

There might well be a better way to fix this. I initially tried adding a short `sleep` before clicking the 'Data and Files' tab but it didn't help. 