### PR TITLE
EES-5735: Add frontend error mapping for API data set replacement.

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -57,6 +57,7 @@ const fileErrorMappings = {
   FilenameNotUnique: 'FilenameNotUnique',
   FileSizeMustNotBeZero: 'FileSizeMustNotBeZero',
   MustBeCsvFile: 'MustBeCsvFile',
+  CannotReplaceDataSetWithApiDataSet: 'CannotReplaceDataSetWithApiDataSet',
 };
 
 function baseErrorMappings(


### PR DESCRIPTION
Attempting to replace a data set which has been created via the public API returns a 400 error, but currently only shows a generic error message to the user, but there is a more useful error message returned from the backend. This PR adds the missing error mapping to ensure users see the useful server response.