### PR TITLE
EES-5543 bugfix: dataSetConfig BoundaryLevels, no longer defaulted to 0

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartDataSetConfig.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartDataSetConfig.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
     {
         public ChartBaseDataSet DataSet;
         public ChartDataGrouping DataGrouping;
-        public long BoundaryLevel;
+        public long? BoundaryLevel;
     }
 
     [JsonConverter(typeof(StringEnumConverter))]


### PR DESCRIPTION
previous implementation was causing all chart dataset configs without boundaryLevel to be given boundaryLevel of 0 - unset boundaryLevels no remain unset