### PR TITLE
EES-5580 validate EditableContentForm on submit after reinitialisation

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentForm.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentForm.tsx
@@ -289,6 +289,7 @@ const EditableContentForm = ({
                   onChange={setElements}
                   onCancelComment={toggleCommentAddForm.off}
                   onClickAddComment={toggleCommentAddForm.on}
+                  onElementsReady={setElements}
                   onImageUpload={onImageUpload}
                   onImageUploadCancel={onImageUploadCancel}
                 />

--- a/src/explore-education-statistics-admin/src/components/form/FormFieldEditor.tsx
+++ b/src/explore-education-statistics-admin/src/components/form/FormFieldEditor.tsx
@@ -42,6 +42,7 @@ export default function FormFieldEditor<TFormValues extends FieldValues>({
   testId,
   onBlur,
   onChange,
+  onElementsReady,
   ...props
 }: Props<TFormValues>) {
   const {
@@ -86,7 +87,10 @@ export default function FormFieldEditor<TFormValues extends FieldValues>({
           }
         }}
         onElementsChange={handleElements}
-        onElementsReady={handleElements}
+        onElementsReady={els => {
+          handleElements(els);
+          onElementsReady?.(els);
+        }}
         onChange={nextValue => {
           setValue(
             name,


### PR DESCRIPTION
Fixes a bug where it was possible to save inaccessible content in release content by switching to the preview view and back.

The custom accessibility validation relies on `elements` from the CKEditor content being available, it's set `onChange` but this isn't triggered when the form is reinitialised after switching back from preview mode. I've updated the form to `setElements` on `onElementsReady` as well which is triggered on reinitialisaiton.