### PR TITLE
EES-5662 Fix public API docs URLs on API quick start guide

### DIFF
--- a/infrastructure/templates/public-api/ci/jobs/deploy-api-docs.yml
+++ b/infrastructure/templates/public-api/ci/jobs/deploy-api-docs.yml
@@ -68,10 +68,11 @@ jobs:
             - task: AzureStaticWebApp@0
               displayName: Deploy API docs
               inputs:
-                app_location: /
+                app_location: build
                 output_location: '' # Leave this empty
                 skip_app_build: true
                 skip_api_build: true
                 azure_static_web_apps_api_token: $(docsDeploymentToken)
-                cwd: $(docsPath)/build
+                config_file_location: .
+                cwd: $(docsPath)
 

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -366,17 +366,6 @@ module appGatewayModule 'application/shared/appGateway.bicep' = if (deployContai
             backendName: resourceNames.publicApi.docsApp
             rewriteSetName: docsRewriteSetName
           }
-          {
-            // Redirect non-rooted URL (has no trailing slash) to the
-            // rooted URL so that relative links in the docs site
-            // can resolve correctly.
-            name: 'docs-root-redirect'
-            paths: ['/docs']
-            type: 'redirect'
-            redirectUrl: '${publicUrls.publicApi}/docs/'
-            redirectType: 'Permanent'
-            includePath: false
-          }
         ]
       }
     ]

--- a/src/explore-education-statistics-api-docs/source/404.html.md.erb
+++ b/src/explore-education-statistics-api-docs/source/404.html.md.erb
@@ -1,0 +1,14 @@
+---
+title: Page not found
+hide_in_navigation: true
+prevent_indexing: true
+---
+
+# Page not found
+
+If you typed the web address, check it is correct.
+
+If you pasted the web address, check you copied the entire address.
+
+If the web address is correct or you selected a link or button, [contact our explore education statistics team](/support/index.html)
+if you need any help or support.

--- a/src/explore-education-statistics-api-docs/staticwebapp.config.json
+++ b/src/explore-education-statistics-api-docs/staticwebapp.config.json
@@ -1,0 +1,3 @@
+{
+  "trailingSlash": "auto"
+}

--- a/src/explore-education-statistics-api-docs/staticwebapp.config.json
+++ b/src/explore-education-statistics-api-docs/staticwebapp.config.json
@@ -1,3 +1,8 @@
 {
-  "trailingSlash": "auto"
+  "trailingSlash": "auto",
+  "responseOverrides": {
+    "404": {
+      "rewrite": "/404.html"
+    }
+  }
 }

--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/ApiDataSetQuickStart.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/ApiDataSetQuickStart.tsx
@@ -73,7 +73,7 @@ export default function ApiDataSetQuickStart({
       />
       <p>
         {renderLink({
-          to: `${publicApiDocsUrl}/endpoints/GetDataSet`,
+          to: `${publicApiDocsUrl}/reference-v1/endpoints/GetDataSet/`,
           children: 'Guidance: Get data set summary',
         })}
       </p>
@@ -93,7 +93,7 @@ export default function ApiDataSetQuickStart({
       />
       <p>
         {renderLink({
-          to: `${publicApiDocsUrl}/endpoints/GetDataSetMeta`,
+          to: `${publicApiDocsUrl}/reference-v1/endpoints/GetDataSetMeta/`,
           children: 'Guidance: Get data set metadata',
         })}
       </p>
@@ -113,7 +113,7 @@ export default function ApiDataSetQuickStart({
       />
       <p>
         {renderLink({
-          to: `${publicApiDocsUrl}/endpoints/QueryDataSetGet`,
+          to: `${publicApiDocsUrl}/reference-v1/endpoints/QueryDataSetGet/`,
           children: 'Guidance: Query data set (GET)',
         })}
       </p>
@@ -133,7 +133,7 @@ export default function ApiDataSetQuickStart({
       />
       <p>
         {renderLink({
-          to: `${publicApiDocsUrl}/endpoints/QueryDataSetPost`,
+          to: `${publicApiDocsUrl}/reference-v1/endpoints/QueryDataSetPost/`,
           children: 'Guidance: Query data set (POST)',
         })}
       </p>
@@ -153,7 +153,7 @@ export default function ApiDataSetQuickStart({
       />
       <p>
         {renderLink({
-          to: `${publicApiDocsUrl}/endpoints/DownloadDataSetCsv`,
+          to: `${publicApiDocsUrl}/reference-v1/endpoints/DownloadDataSetCsv/`,
           children: 'Guidance: Download data set as CSV',
         })}
       </p>


### PR DESCRIPTION
:warning: Depends on #5445 :warning: 

---

This PR fixes the links to the public API docs on the API quick start guide of each API data set (in the public frontend).

The previously broken links also helped make it apparent that we:

- Aren't handling 404s and allow the generic Azure 404 page to render
- Dobn't redirect to paths with trailing slashes (which causes broken assets and relative links)

We've now addressed both of these issues by:

- Adding a custom 404 page which we've configured through `staticwebapp.config.json`
- Adding an automatic trailing slash redirection, also through `staticwebapp.config.json`