### PR TITLE
EES-5496 Fix inconsistent anchor IDs causing broken nav links in API data set mapping pages

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetFiltersMappingPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetFiltersMappingPage.tsx
@@ -12,6 +12,7 @@ import getUnmappedFilterErrors from '@admin/pages/release/data/utils/getUnmapped
 import ApiDataSetMappableFilterColumnsTable from '@admin/pages/release/data/components/ApiDataSetMappableFilterColumnsTable';
 import ApiDataSetNewFilterColumnsTable from '@admin/pages/release/data/components/ApiDataSetNewFilterColumnsTable';
 import { PendingMappingUpdate } from '@admin/pages/release/data/types/apiDataSetMappings';
+import { mappableTableId } from '@admin/pages/release/data/utils/mappingTableIds';
 import {
   releaseApiDataSetDetailsRoute,
   ReleaseDataSetRouteParams,
@@ -31,13 +32,25 @@ import PageNav, { NavItem } from '@common/components/PageNav';
 import { Dictionary } from '@common/types';
 import useDebouncedCallback from '@common/hooks/useDebouncedCallback';
 import { useQuery } from '@tanstack/react-query';
+import camelCase from 'lodash/camelCase';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { generatePath, useParams } from 'react-router-dom';
 import omit from 'lodash/omit';
 import { useImmer } from 'use-immer';
 import sumBy from 'lodash/sumBy';
-import kebabCase from 'lodash/kebabCase';
 import compact from 'lodash/compact';
+
+export const sectionIds = {
+  mappableFilterColumns: 'mappable-filter-columns',
+  mappableFilterOptions: 'mappable-filter-options',
+  newFilterColumns: 'new-filter-columns',
+  newFilterOptions: 'new-filter-options',
+  newFilterOptionsGroup: (filterKey: string) =>
+    `new-filter-options-${camelCase(filterKey)}`,
+  autoMappedFilterOptions: 'auto-mapped-filter-options',
+  autoMappedFilterOptionsGroup: (filterKey: string) =>
+    `auto-mapped-filter-options-${camelCase(filterKey)}`,
+} as const;
 
 export default function ReleaseApiDataSetFiltersMappingPage() {
   const [autoMappedFilterOptions, updateAutoMappedFilterOptions] = useImmer<
@@ -111,17 +124,17 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
       ...(Object.keys(mappableFilters).length > 0
         ? [
             {
-              id: 'mappable-filter-columns',
+              id: sectionIds.mappableFilterColumns,
               text: 'Filter columns not found in new data set',
             },
           ]
         : []),
       {
-        id: 'mappable-filter-options',
+        id: sectionIds.mappableFilterOptions,
         text: 'Filter options not found in new data set',
         subNavItems: Object.keys(mappableFilterOptions).map(filterKey => {
           return {
-            id: `mappable-filter-options-${kebabCase(filterKey)}`,
+            id: mappableTableId(filterKey),
             text: filtersMapping?.mappings[filterKey].source.label ?? filterKey,
           };
         }),
@@ -129,27 +142,27 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
       ...(Object.keys(newFilters).length > 0
         ? [
             {
-              id: 'new-filter-columns',
+              id: sectionIds.newFilterColumns,
               text: 'New filter columns',
             },
           ]
         : []),
       {
-        id: 'new-filter-options',
+        id: sectionIds.newFilterOptions,
         text: 'New filter options',
         subNavItems: Object.keys(newFilterOptions).map(filterKey => {
           return {
-            id: `new-filter-options-${kebabCase(filterKey)}`,
+            id: sectionIds.newFilterOptionsGroup(filterKey),
             text: filtersMapping?.candidates[filterKey].label ?? filterKey,
           };
         }),
       },
       {
-        id: 'auto-mapped-filter-options',
+        id: sectionIds.autoMappedFilterOptions,
         text: 'Auto mapped filter options',
         subNavItems: Object.keys(autoMappedFilterOptions).map(filterKey => {
           return {
-            id: `auto-mapped-filter-options-${kebabCase(filterKey)}`,
+            id: sectionIds.autoMappedFilterOptionsGroup(filterKey),
             text: filtersMapping?.mappings[filterKey].source.label ?? filterKey,
           };
         }),
@@ -331,7 +344,7 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
               <>
                 <h3
                   className="govuk-heading-l dfe-flex dfe-align-items--center"
-                  id="mappable-filter-columns"
+                  id={sectionIds.mappableFilterColumns}
                 >
                   Filter columns not found in new data set{' '}
                   <Tag className="govuk-!-margin-left-2" colour="grey">
@@ -345,7 +358,10 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
               </>
             )}
 
-            <h3 className="govuk-heading-l" id="mappable-filter-options">
+            <h3
+              className="govuk-heading-l"
+              id={sectionIds.mappableFilterOptions}
+            >
               Filter options not found in new data set
             </h3>
 
@@ -386,7 +402,7 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
               <>
                 <h3
                   className="govuk-heading-l govuk-!-margin-top-8"
-                  id="new-filter-columns"
+                  id={sectionIds.newFilterColumns}
                 >
                   New filter columns <Tag colour="grey">No action required</Tag>
                 </h3>
@@ -396,7 +412,7 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
 
             <h3
               className="govuk-heading-l govuk-!-margin-top-8"
-              id="new-filter-options"
+              id={sectionIds.newFilterOptions}
             >
               New filter options ({totalNewFilterOptions}){' '}
               <Tag colour="grey">No action required</Tag>
@@ -404,8 +420,8 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
 
             {totalNewFilterOptions > 0 && filtersMapping ? (
               <Accordion
-                id="new-filter-options-accordion"
-                testId="new-filter-options-accordion"
+                id={`${sectionIds.newFilterOptions}-accordion`}
+                testId={`${sectionIds.newFilterOptions}-accordion`}
               >
                 {Object.keys(newFilterOptions).map(filterKey => {
                   if (newFilterOptions[filterKey].length) {
@@ -422,7 +438,7 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
                         goToTop={false}
                         heading={`${filterLabel} (${newFilterOptions[filterKey].length})`}
                         headingTag="h4"
-                        id={`new-filter-options-${kebabCase(filterKey)}`}
+                        id={sectionIds.newFilterOptionsGroup(filterKey)}
                         key={filterKey}
                       >
                         <ApiDataSetNewItemsTable
@@ -444,7 +460,7 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
 
             <h3
               className="govuk-heading-l govuk-!-margin-top-8"
-              id="auto-mapped-filter-options"
+              id={sectionIds.autoMappedFilterOptions}
             >
               Auto mapped filter options ({totalAutoMappedFilterOptions}){' '}
               <Tag colour="grey">No action required</Tag>
@@ -452,9 +468,9 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
 
             {totalAutoMappedFilterOptions > 0 ? (
               <Accordion
-                id="auto-mapped-filter-options-accordion"
+                id={`${sectionIds.autoMappedFilterOptions}-accordion`}
                 showOpenAll={false}
-                testId="auto-mapped-filter-options-accordion"
+                testId={`${sectionIds.autoMappedFilterOptions}-accordion`}
               >
                 {Object.keys(autoMappedFilterOptions).map(filterKey => {
                   if (
@@ -474,9 +490,7 @@ export default function ReleaseApiDataSetFiltersMappingPage() {
                         goToTop={false}
                         heading={`${filterLabel} (${autoMappedFilterOptions[filterKey].length})`}
                         headingTag="h4"
-                        id={`auto-mapped-filter-options-${kebabCase(
-                          filterKey,
-                        )}`}
+                        id={sectionIds.autoMappedFilterOptionsGroup(filterKey)}
                         key={filterKey}
                       >
                         <ApiDataSetAutoMappedTable

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetLocationsMappingPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetLocationsMappingPage.tsx
@@ -13,6 +13,7 @@ import getApiDataSetLocationMappings, {
   MappableLocation,
 } from '@admin/pages/release/data/utils/getApiDataSetLocationMappings';
 import getUnmappedLocationErrors from '@admin/pages/release/data/utils/getUnmappedLocationErrors';
+import { mappableTableId } from '@admin/pages/release/data/utils/mappingTableIds';
 import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
 import apiDataSetVersionQueries from '@admin/queries/apiDataSetVersionQueries';
 import {
@@ -40,6 +41,17 @@ import omit from 'lodash/omit';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { generatePath, useParams } from 'react-router-dom';
 import { useImmer } from 'use-immer';
+
+export const sectionIds = {
+  deletedLocationGroups: 'deleted-location-groups',
+  mappableLocations: 'mappable-locations',
+  newLocationGroups: 'new-location-groups',
+  newLocations: 'new-locations',
+  newLocationsLevel: (level: LocationLevelKey) => `new-locations-${level}`,
+  autoMappedLocations: 'auto-mapped-locations',
+  autoMappedLocationsLevel: (level: LocationLevelKey) =>
+    `auto-mapped-locations-${level}`,
+} as const;
 
 // Fields to omit from mapping diff.
 const omittedDiffingFields: (keyof LocationCandidateWithKey)[] = [
@@ -118,33 +130,36 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
       ...(Object.keys(deletedLocationGroups).length > 0
         ? [
             {
-              id: 'deleted-location-groups',
+              id: sectionIds.deletedLocationGroups,
               text: 'Location groups not found in new data set',
             },
           ]
         : []),
       {
-        id: 'mappable-locations',
+        id: sectionIds.mappableLocations,
         text: 'Locations not found in new data set',
-        subNavItems: getSubNavItems(mappableLocations, 'mappable'),
+        subNavItems: getSubNavItems(mappableLocations, mappableTableId),
       },
       ...(Object.keys(newLocationGroups).length > 0
         ? [
             {
-              id: 'new-location-groups',
+              id: sectionIds.newLocationGroups,
               text: 'New location groups',
             },
           ]
         : []),
       {
-        id: 'new-locations',
+        id: sectionIds.newLocations,
         text: 'New locations',
-        subNavItems: getSubNavItems(newLocations, 'new-locations'),
+        subNavItems: getSubNavItems(newLocations, sectionIds.newLocationsLevel),
       },
       {
-        id: 'auto-mapped-locations',
+        id: sectionIds.autoMappedLocations,
         text: 'Auto mapped locations',
-        subNavItems: getSubNavItems(autoMappedLocations, 'auto-mapped'),
+        subNavItems: getSubNavItems(
+          autoMappedLocations,
+          sectionIds.autoMappedLocationsLevel,
+        ),
       },
     ];
   }, [
@@ -326,7 +341,10 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
 
             {Object.keys(deletedLocationGroups).length > 0 && (
               <>
-                <h3 className="govuk-heading-l" id="deleted-location-groups">
+                <h3
+                  className="govuk-heading-l"
+                  id={sectionIds.deletedLocationGroups}
+                >
                   {`Location groups not found in new data set (${
                     Object.keys(deletedLocationGroups).length
                   }) `}
@@ -339,7 +357,7 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
               </>
             )}
 
-            <h3 className="govuk-heading-l" id="unmapped-locations">
+            <h3 className="govuk-heading-l" id={sectionIds.mappableLocations}>
               Locations not found in new data set
             </h3>
 
@@ -403,7 +421,7 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
               <>
                 <h3
                   className="govuk-heading-l govuk-!-margin-top-8"
-                  id="new-location-groups"
+                  id={sectionIds.newLocationGroups}
                 >
                   {`New location groups (${
                     Object.keys(deletedLocationGroups).length
@@ -419,14 +437,17 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
 
             <h3
               className="govuk-heading-l govuk-!-margin-top-8"
-              id="new-locations"
+              id={sectionIds.newLocations}
             >
               New locations ({totalNewLocations}){' '}
               <Tag colour="grey">No action required</Tag>
             </h3>
 
             {totalNewLocations > 0 ? (
-              <Accordion id="new-locations" testId="new-locations-accordion">
+              <Accordion
+                id={`${sectionIds.newLocations}-accordion`}
+                testId={`${sectionIds.newLocations}-accordion`}
+              >
                 {typedKeys(newLocations).map(level => {
                   const levelNewLocations = newLocations[level];
                   const groupLabel = locationLevelsMap[level].plural;
@@ -437,7 +458,7 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
                         goToTop={false}
                         heading={`${groupLabel} (${levelNewLocations.length})`}
                         headingTag="h4"
-                        id={`new-locations-${level}`}
+                        id={sectionIds.newLocationsLevel(level)}
                         key={level}
                       >
                         <ApiDataSetNewItemsTable
@@ -465,16 +486,16 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
 
             <h3
               className="govuk-heading-l govuk-!-margin-top-8"
-              id="auto-mapped-locations"
+              id={sectionIds.autoMappedLocations}
             >
               Auto mapped locations ({totalAutoMappedLocations}){' '}
               <Tag colour="grey">No action required</Tag>
             </h3>
             {totalAutoMappedLocations > 0 ? (
               <Accordion
-                id="auto-mapped"
+                id={`${sectionIds.autoMappedLocations}-accordion`}
                 showOpenAll={false}
-                testId="auto-mapped-accordion"
+                testId={`${sectionIds.autoMappedLocations}-accordion`}
               >
                 {typedKeys(autoMappedLocations).map(level => {
                   const levelAutoMappedLocations = autoMappedLocations[level];
@@ -486,7 +507,7 @@ export default function ReleaseApiDataSetLocationsMappingPage() {
                         goToTop={false}
                         heading={`${groupLabel} (${levelAutoMappedLocations.length})`}
                         headingTag="h4"
-                        id={`auto-mapped-${level}`}
+                        id={sectionIds.autoMappedLocationsLevel(level)}
                         key={level}
                       >
                         <ApiDataSetAutoMappedTable
@@ -582,12 +603,12 @@ function getSubNavItems(
       (AutoMappedLocation | LocationCandidateWithKey | MappableLocation)[]
     >
   >,
-  key: string,
-) {
+  sectionId: (level: LocationLevelKey) => string,
+): NavItem[] {
   return typedKeys(locations).reduce<NavItem[]>((acc, level) => {
     if (locations[level]?.length) {
       acc.push({
-        id: `${key}-${level}`,
+        id: sectionId(level),
         text: locationLevelsMap[level]?.plural ?? level,
       });
     }

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetFiltersMappingPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetFiltersMappingPage.test.tsx
@@ -95,7 +95,7 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
       name: 'Filter 1 2 unmapped filter options 1 mapped filter option Column: Filter1Key',
     });
     expect(mappableFilter1Table).toBe(
-      screen.getByTestId('mappable-table-Filter1Key'),
+      screen.getByTestId('mappable-table-filter1Key'),
     );
     expect(within(mappableFilter1Table).getAllByRole('row')).toHaveLength(4);
 
@@ -104,7 +104,7 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
       name: 'Filter 2 1 unmapped filter option 2 mapped filter options Column: Filter2Key',
     });
     expect(mappableFilter2Table).toBe(
-      screen.getByTestId('mappable-table-Filter2Key'),
+      screen.getByTestId('mappable-table-filter2Key'),
     );
     expect(within(mappableFilter2Table).getAllByRole('row')).toHaveLength(4);
 
@@ -150,7 +150,7 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
     ).toBeInTheDocument();
     expect(
       within(
-        autoMappedAccordion.getByTestId('auto-mapped-table-Filter1Key'),
+        autoMappedAccordion.getByTestId('auto-mapped-table-filter1Key'),
       ).getAllByRole('row'),
     ).toHaveLength(2);
 
@@ -162,7 +162,7 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
     ).toBeInTheDocument();
     expect(
       within(
-        autoMappedAccordion.getByTestId('auto-mapped-table-Filter3Key'),
+        autoMappedAccordion.getByTestId('auto-mapped-table-filter3Key'),
       ).getAllByRole('row'),
     ).toHaveLength(4);
   });
@@ -196,12 +196,12 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
       within(mappableSubItems[0]).getByRole('link', {
         name: 'Filter 1',
       }),
-    ).toHaveAttribute('href', '#mappable-filter-options-filter-1-key');
+    ).toHaveAttribute('href', '#mappable-table-filter1Key');
     expect(
       within(mappableSubItems[1]).getByRole('link', {
         name: 'Filter 2',
       }),
-    ).toHaveAttribute('href', '#mappable-filter-options-filter-2-key');
+    ).toHaveAttribute('href', '#mappable-table-filter2Key');
 
     expect(
       within(navItems[3]).getByRole('link', {
@@ -214,7 +214,7 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
       within(newSubItems[0]).getByRole('link', {
         name: 'Filter 1',
       }),
-    ).toHaveAttribute('href', '#new-filter-options-filter-1-key');
+    ).toHaveAttribute('href', '#new-filter-options-filter1Key');
 
     expect(
       within(navItems[5]).getByRole('link', {
@@ -227,12 +227,12 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
       within(autoMappedSubItems[0]).getByRole('link', {
         name: 'Filter 1',
       }),
-    ).toHaveAttribute('href', '#auto-mapped-filter-options-filter-1-key');
+    ).toHaveAttribute('href', '#auto-mapped-filter-options-filter1Key');
     expect(
       within(autoMappedSubItems[1]).getByRole('link', {
         name: 'Filter 3',
       }),
-    ).toHaveAttribute('href', '#auto-mapped-filter-options-filter-3-key');
+    ).toHaveAttribute('href', '#auto-mapped-filter-options-filter3Key');
   });
 
   test('renders the notification banner if there are mappable filter options', async () => {
@@ -256,12 +256,12 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
       banner.getByRole('link', {
         name: 'There are 2 unmapped Filter 1 filter options',
       }),
-    ).toHaveAttribute('href', '#mappable-table-filter-1-key');
+    ).toHaveAttribute('href', '#mappable-table-filter1Key');
     expect(
       banner.getByRole('link', {
         name: 'There is 1 unmapped Filter 2 filter option',
       }),
-    ).toHaveAttribute('href', '#mappable-table-filter-2-key');
+    ).toHaveAttribute('href', '#mappable-table-filter2Key');
   });
 
   test('does not render the notification banner if there are no unmapped filter options', async () => {
@@ -486,7 +486,7 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
         screen.getByRole('link', {
           name: 'There are 2 unmapped Filter 1 filter options',
         }),
-      ).toHaveAttribute('href', '#mappable-table-filter-1-key');
+      ).toHaveAttribute('href', '#mappable-table-filter1Key');
 
       // mappable table
       const mappableFilter1Table = screen.getByRole('table', {
@@ -617,7 +617,7 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
         screen.getByRole('link', {
           name: 'There are 2 unmapped Filter 1 filter options',
         }),
-      ).toHaveAttribute('href', '#mappable-table-filter-1-key');
+      ).toHaveAttribute('href', '#mappable-table-filter1Key');
 
       const mappableFilter1Table = screen.getByRole('table', {
         name: 'Filter 1 2 unmapped filter options 1 mapped filter option Column: Filter1Key',
@@ -705,7 +705,7 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
         screen.getByRole('link', {
           name: 'There are 2 unmapped Filter 1 filter options',
         }),
-      ).toHaveAttribute('href', '#mappable-table-filter-1-key');
+      ).toHaveAttribute('href', '#mappable-table-filter1Key');
 
       const mappableFilter1Table = screen.getByRole('table', {
         name: 'Filter 1 2 unmapped filter options 1 mapped filter option Column: Filter1Key',
@@ -785,7 +785,7 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
         }),
       ).toBeInTheDocument();
       const autoMappedTable = screen.getByTestId(
-        'auto-mapped-table-Filter1Key',
+        'auto-mapped-table-filter1Key',
       );
       const autoMappedFilter = within(autoMappedTable).getAllByRole('row')[1];
       const autoMappedFilterCells =
@@ -934,7 +934,7 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
         }),
       ).toBeInTheDocument();
       const autoMappedTable = screen.getByTestId(
-        'auto-mapped-table-Filter1Key',
+        'auto-mapped-table-filter1Key',
       );
       const autoMappedFilter = within(autoMappedTable).getAllByRole('row')[1];
       const autoMappedFilterCells =
@@ -1035,7 +1035,7 @@ describe('ReleaseApiDataSetFiltersMappingPage', () => {
         screen.getByRole('link', {
           name: 'There are 2 unmapped Filter 1 filter options',
         }),
-      ).toHaveAttribute('href', '#mappable-table-filter-1-key');
+      ).toHaveAttribute('href', '#mappable-table-filter1Key');
 
       // mappable table
       const mappableFilter1Table = screen.getByRole('table', {

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetLocationsMappingPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetLocationsMappingPage.test.tsx
@@ -153,7 +153,7 @@ describe('ReleaseApiDataSetLocationsMappingPage', () => {
     ).toBeInTheDocument();
 
     const autoMappedAccordion = within(
-      screen.getByTestId('auto-mapped-accordion'),
+      screen.getByTestId('auto-mapped-locations-accordion'),
     );
 
     // auto mapped LA
@@ -297,10 +297,10 @@ describe('ReleaseApiDataSetLocationsMappingPage', () => {
       within(mappableSubItems[0]).getByRole('link', {
         name: 'Local Authorities',
       }),
-    ).toHaveAttribute('href', '#mappable-localAuthority');
+    ).toHaveAttribute('href', '#mappable-table-localAuthority');
     expect(
       within(mappableSubItems[1]).getByRole('link', { name: 'Regions' }),
-    ).toHaveAttribute('href', '#mappable-region');
+    ).toHaveAttribute('href', '#mappable-table-region');
 
     expect(
       within(navItems[3]).getByRole('link', { name: 'New locations' }),
@@ -328,15 +328,15 @@ describe('ReleaseApiDataSetLocationsMappingPage', () => {
       within(autoMappedSubItems[0]).getByRole('link', {
         name: 'English Devolved Areas',
       }),
-    ).toHaveAttribute('href', '#auto-mapped-englishDevolvedArea');
+    ).toHaveAttribute('href', '#auto-mapped-locations-englishDevolvedArea');
     expect(
       within(autoMappedSubItems[1]).getByRole('link', {
         name: 'Local Authorities',
       }),
-    ).toHaveAttribute('href', '#auto-mapped-localAuthority');
+    ).toHaveAttribute('href', '#auto-mapped-locations-localAuthority');
     expect(
       within(autoMappedSubItems[2]).getByRole('link', { name: 'Regions' }),
-    ).toHaveAttribute('href', '#auto-mapped-region');
+    ).toHaveAttribute('href', '#auto-mapped-locations-region');
   });
 
   test('renders the notification banner if there are mappable locations', async () => {
@@ -450,10 +450,12 @@ describe('ReleaseApiDataSetLocationsMappingPage', () => {
     expect(screen.getByText('No locations.')).toBeInTheDocument();
 
     expect(
-      screen.queryByTestId('mappable-localAuthority'),
+      screen.queryByTestId('mappable-locations-localAuthority'),
     ).not.toBeInTheDocument();
 
-    expect(screen.queryByTestId('mappable-region')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('mappable-locations-region'),
+    ).not.toBeInTheDocument();
   });
 
   test('renders a message if there are no new locations', async () => {
@@ -961,7 +963,7 @@ describe('ReleaseApiDataSetLocationsMappingPage', () => {
         }),
       ).toBeInTheDocument();
       const autoMappedAccordion = within(
-        screen.getByTestId('auto-mapped-accordion'),
+        screen.getByTestId('auto-mapped-locations-accordion'),
       );
       expect(
         autoMappedAccordion.getByRole('heading', {
@@ -1108,7 +1110,7 @@ describe('ReleaseApiDataSetLocationsMappingPage', () => {
         }),
       ).toBeInTheDocument();
       const autoMappedAccordion = within(
-        screen.getByTestId('auto-mapped-accordion'),
+        screen.getByTestId('auto-mapped-locations-accordion'),
       );
       expect(
         autoMappedAccordion.getByRole('heading', {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetAutoMappedTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetAutoMappedTable.tsx
@@ -8,6 +8,7 @@ import {
 } from '@admin/pages/release/data/utils/getApiDataSetFilterMappings';
 import ApiDataSetMappingModal from '@admin/pages/release/data/components/ApiDataSetMappingModal';
 import { PendingMappingUpdate } from '@admin/pages/release/data/types/apiDataSetMappings';
+import { autoMappedTableId } from '@admin/pages/release/data/utils/mappingTableIds';
 import {
   FilterOptionSource,
   LocationCandidate,
@@ -81,6 +82,8 @@ export default function ApiDataSetAutoMappedTable({
   const totalFilteredItems = filteredItems.length;
   const totalPages = filteredItemsChunks.length;
 
+  const tableId = autoMappedTableId(groupKey);
+
   const [handleSearch] = useDebouncedCallback((term: string) => {
     setSearchTerm(term);
     setCurrentPage(1);
@@ -125,8 +128,9 @@ export default function ApiDataSetAutoMappedTable({
       </div>
       {filteredItemsChunks.length > 0 ? (
         <table
-          className="dfe-table--vertical-align-middl"
-          data-testid={`auto-mapped-table-${groupKey}`}
+          className="dfe-table--vertical-align-middle"
+          data-testid={tableId}
+          id={tableId}
         >
           <caption className="govuk-visually-hidden">
             {`Table showing auto mapped options for ${groupLabel}`}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetMappableTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetMappableTable.tsx
@@ -1,3 +1,4 @@
+import { mappableTableId } from '@admin/pages/release/data/utils/mappingTableIds';
 import {
   FilterOptionSource,
   LocationCandidate,
@@ -19,7 +20,6 @@ import ButtonText from '@common/components/ButtonText';
 import TagGroup from '@common/components/TagGroup';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import LoadingSpinner from '@common/components/LoadingSpinner';
-import kebabCase from 'lodash/kebabCase';
 import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 
@@ -70,11 +70,13 @@ export default function ApiDataSetMappableTable({
   ).length;
   const totalManuallyMapped = mappableItems.length - totalUnmapped;
 
+  const tableId = mappableTableId(groupKey);
+
   return (
     <table
       className="dfe-table--vertical-align-middle dfe-table--row-highlights"
-      id={`mappable-table-${kebabCase(groupKey)}`}
-      data-testid={`mappable-table-${groupKey}`}
+      id={tableId}
+      data-testid={tableId}
     >
       <caption className="govuk-!-margin-bottom-3 govuk-!-font-size-24">
         {groupLabel}{' '}

--- a/src/explore-education-statistics-admin/src/pages/release/data/utils/__tests__/getUnmappedFilterErrors.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/data/utils/__tests__/getUnmappedFilterErrors.test.ts
@@ -86,11 +86,11 @@ describe('getUnmappedFilterErrors', () => {
   test('returns the error messages', () => {
     const expected: ErrorSummaryMessage[] = [
       {
-        id: 'mappable-table-filter-1-key',
+        id: 'mappable-table-filter1Key',
         message: 'There are 2 unmapped Filter 1 filter options',
       },
       {
-        id: 'mappable-table-filter-2-key',
+        id: 'mappable-table-filter2Key',
         message: 'There is 1 unmapped Filter 2 filter option',
       },
     ];
@@ -103,11 +103,11 @@ describe('getUnmappedFilterErrors', () => {
   test('does not return error messages for unmapped filter columns', () => {
     const expected: ErrorSummaryMessage[] = [
       {
-        id: 'mappable-table-filter-1-key',
+        id: 'mappable-table-filter1Key',
         message: 'There are 2 unmapped Filter 1 filter options',
       },
       {
-        id: 'mappable-table-filter-2-key',
+        id: 'mappable-table-filter2Key',
         message: 'There is 1 unmapped Filter 2 filter option',
       },
     ];
@@ -221,11 +221,11 @@ describe('getUnmappedFilterErrors', () => {
       getUnmappedFilterErrors(testUnsafeMappableFilters, testUnsafeMappings),
     ).toEqual<ErrorSummaryMessage[]>([
       {
-        id: 'mappable-table-filter-1',
+        id: 'mappable-table-filter1',
         message: 'There is 1 unmapped Filter 1 filter option',
       },
       {
-        id: 'mappable-table-filter-2',
+        id: 'mappable-table-filter2',
         message: 'There is 1 unmapped Filter 2 filter option',
       },
     ]);

--- a/src/explore-education-statistics-admin/src/pages/release/data/utils/getUnmappedFilterErrors.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/data/utils/getUnmappedFilterErrors.ts
@@ -1,8 +1,8 @@
 import { MappableFilterOption } from '@admin/pages/release/data/utils/getApiDataSetFilterMappings';
+import { mappableTableId } from '@admin/pages/release/data/utils/mappingTableIds';
 import { FiltersMapping } from '@admin/services/apiDataSetVersionService';
 import { ErrorSummaryMessage } from '@common/components/ErrorSummary';
 import { Dictionary } from '@common/types';
-import kebabCase from 'lodash/kebabCase';
 import sumBy from 'lodash/sumBy';
 
 export default function getUnmappedFilterErrors(
@@ -25,7 +25,7 @@ export default function getUnmappedFilterErrors(
       const filterLabel = filtersMapping.mappings[filterKey].source.label;
 
       errors.push({
-        id: `mappable-table-${kebabCase(filterKey)}`,
+        id: mappableTableId(filterKey),
         message: `There ${
           total > 1 ? 'are' : 'is'
         } ${total} unmapped ${filterLabel} filter option${

--- a/src/explore-education-statistics-admin/src/pages/release/data/utils/getUnmappedLocationErrors.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/data/utils/getUnmappedLocationErrors.ts
@@ -1,4 +1,5 @@
 import { MappableLocation } from '@admin/pages/release/data/utils/getApiDataSetLocationMappings';
+import { mappableTableId } from '@admin/pages/release/data/utils/mappingTableIds';
 import { ErrorSummaryMessage } from '@common/components/ErrorSummary';
 import locationLevelsMap, {
   LocationLevelKey,
@@ -17,7 +18,7 @@ export default function getUnmappedLocationErrors(
 
     if (total) {
       errors.push({
-        id: `mappable-table-${level}`,
+        id: mappableTableId(level),
         message: `There ${total > 1 ? 'are' : 'is'} ${total} unmapped ${
           total > 1
             ? locationLevelsMap[level]?.plural.toLowerCase() ?? level

--- a/src/explore-education-statistics-admin/src/pages/release/data/utils/mappingTableIds.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/data/utils/mappingTableIds.ts
@@ -1,0 +1,7 @@
+import camelCase from 'lodash/camelCase';
+
+export const mappableTableId = (groupKey: string) =>
+  `mappable-table-${camelCase(groupKey)}`;
+
+export const autoMappedTableId = (groupKey: string) =>
+  `auto-mapped-table-${camelCase(groupKey)}`;

--- a/tests/robot-tests/tests/public_api/public_api_minor_manual_changes.robot
+++ b/tests/robot-tests/tests/public_api/public_api_minor_manual_changes.robot
@@ -163,7 +163,7 @@ Validate the version task statuses inside the 'Draft version task' section
 User clicks on Map locations link
     user clicks link    Map locations
     user waits until h3 is visible    Locations not found in new data set
-    user waits until element contains    xpath://table[@data-testid='mappable-table-region']/caption//strong[1]
+    user waits until element contains    css:[data-testid="mappable-table-region"] caption
     ...    1 unmapped location    %{WAIT_LONG}
 
 Validate the 'unmapped location' notification banner
@@ -190,7 +190,7 @@ User edits location mapping
     user waits until modal is not visible    Map existing location
 
 Verify location mapping changes
-    user waits until element contains    xpath://table[@data-testid='mappable-table-region']/caption//strong[1]
+    user waits until element contains    css:[data-testid="mappable-table-region"] caption
     ...    1 mapped location    %{WAIT_LONG}
 
 Validate the row headings and its contents in the 'Regions' section after mapping
@@ -217,7 +217,7 @@ Validate the version status of location task is now complete
 User clicks on Map filters link
     user clicks link    Map filters
     user waits until h3 is visible    Filter options not found in new data set
-    user waits until element contains    xpath://table[@data-testid='mappable-table-school_type']/caption//strong[1]
+    user waits until element contains    css:[data-testid="mappable-table-schoolType"] caption
     ...    1 unmapped filter option    %{WAIT_LONG}
 
 Validate the 'unmapped filter option' notification banner
@@ -244,7 +244,7 @@ User edits filter mapping
     user waits until modal is not visible    Map existing location
 
 Verify filter mapping changes
-    user waits until element contains    xpath://table[@data-testid='mappable-table-school_type']/caption//strong[1]
+    user waits until element contains    css:[data-testid="mappable-table-schoolType"] caption
     ...    1 mapped filter option    %{WAIT_LONG}
 
 Validate the row headings and its contents in the 'filters options' section after mapping


### PR DESCRIPTION
This PR fixes inconsistent anchor IDs being used across the the public API filters and locations mapping pages. Previously, we were using hard-coded ID strings meaning that it was easy to forget to update them in all places. This would then lead to broken navigation links due to stale IDs being used.

We've not refactored both the filters and locations mappings pages to use common variables and functions to generate the necessary anchor IDs. This should hopefully keep things consistent and less bug-prone moving forward.