### PR TITLE
🐛 EES-5656 Only apply active class for navigation links if the location is matched exactly

### DIFF
--- a/src/explore-education-statistics-admin/src/components/NavLink.tsx
+++ b/src/explore-education-statistics-admin/src/components/NavLink.tsx
@@ -20,6 +20,7 @@ const NavLink = ({ children, className, to, ...props }: Props) => {
         'govuk-link--no-visited-state',
         className,
       )}
+      exact
     >
       {children}
     </RouterNavLink>


### PR DESCRIPTION
This PR fixes a bug on the Release order page after #5442 which renamed the Admin's 'Legacy releases' page to 'Release order'.

The 'Release order' page was updated to use the route `/publication/:publicationId/releases/order` instead of `/publication/:publicationId/legacy` by that change.

However this meant the React router's nav link for the 'Releases' page on route `/publication/:publicationId/releases` also had the active style applied while on the 'Release order' page since it's matching on the first part of the location.

This PR adds `exact` to `RouterNavLinmk` in `NavLink` so that the active class/style is only be applied if the location is matched exactly.

**Before:**

![image](https://github.com/user-attachments/assets/9ecfb9da-486a-46d8-bc38-908a313c9118)

**After:**

![image](https://github.com/user-attachments/assets/4533b1d0-e869-49d4-b1de-d7ec2a43ca1e)

I checked to make sure I couldn't see any problems where `NavLink` is used but if any arise we could consider passing `exact` as a prop to control the value.

Thanks to @amyb-hiveit who pointed me in the direction of the fix. 🙂 