### PR TITLE
EES-5757 Add ARM template branch variable option "test"

### DIFF
--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -60,7 +60,7 @@
       "value": "G-ZQ5V7CBWMJ"
     },
     "branch": {
-      "value": "dev"
+      "value": "test"
     },
     "enableThemeDeletion": {
       "value": true

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -594,7 +594,8 @@
       "defaultValue": "master",
       "allowedValues": [
         "master",
-        "dev"
+        "dev",
+        "test"
       ]
     },
     "skuContentDb": {


### PR DESCRIPTION
This PR fixes an issue where on the "test" branch, we were still pulling the Data Factory ARM template from "dev".

To fix this, we simply add a new "test" options to the "branch" ARM template variable and use that on the test branch.

On an aside, this is due to the way we pull the Data Factory ARM template - fetching the ARM template from Github was necessary at the time we did it, but it's possible this could be cleaned up now.