### PR TITLE
EES-5598 Fix changing geog lvl on mobile

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
@@ -52,10 +52,9 @@ import omit from 'lodash/omit';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
-import locationLevelsMap, {
+import {
   GeographicLevelCode,
   geographicLevelCodesMap,
-  LocationLevelKey,
 } from '@common/utils/locationLevelsMap';
 
 const defaultPageTitle = 'Data catalogue';
@@ -454,6 +453,7 @@ const DataCataloguePage: NextPage<Props> = ({ showTypeFilter }) => {
                   publicationId={publicationId}
                   publications={publications}
                   releaseId={releaseId}
+                  geographicLevel={geographicLevel}
                   releases={releases}
                   showTypeFilter={showTypeFilter}
                   themeId={themeId}


### PR DESCRIPTION
This PR fixes an issue where on the Data Catalogue page, when selecting a geographic level filter in mobile view, the geographic level wouldn't be updated. This was because we're not passing it to the component when using the mobile view.