### PR TITLE
EES-5756 Set DataSetFileMeta geographic levels to null

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241230161603_EES5756_AddFilesColumnForMigration.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241230161603_EES5756_AddFilesColumnForMigration.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241230161603_EES5756_AddFilesColumnForMigration")]
+    partial class EES5756_AddFilesColumnForMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -454,9 +457,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.Property<string>("Filename")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("FilterHierarchies")
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<Guid?>("ReplacedById")

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241230161603_EES5756_AddFilesColumnForMigration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20241230161603_EES5756_AddFilesColumnForMigration.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES5756_AddFilesColumnForMigration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "DataSetFileMetaGeogLvlMigrated",
+                table: "Files",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.Sql("""
+                                 UPDATE [dbo].Files
+                                 SET DataSetFileMetaGeogLvlMigrated = 1 
+                                 WHERE Type != 'Data'
+                                 """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DataSetFileMetaGeogLvlMigrated",
+                table: "Files");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -1579,8 +1579,8 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                     .WithReleaseVersion(publication.ReleaseVersions[0])
                     .WithFile(_fixture.DefaultFile(FileType.Data)
                         .WithType(FileType.Data)
+                        .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country, GeographicLevel.LocalAuthority])
                         .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
-                            .WithGeographicLevels([GeographicLevel.Country, GeographicLevel.LocalAuthority])
                             .WithTimePeriodRange(
                                 _fixture.DefaultTimePeriodRangeMeta()
                                     .WithStart("2000", TimeIdentifier.AcademicYear)
@@ -1618,12 +1618,15 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                 var dataSetFileSummaryViewModel = Assert.Single(pagedResult.Results);
                 var dataSetFileMetaViewModel = dataSetFileSummaryViewModel.Meta;
 
+                var geographicLevels = releaseFile.File.DataSetFileVersionGeographicLevels
+                    .Select(gl => gl.GeographicLevel)
+                    .ToList();
+                Assert.True(ComparerUtils.SequencesAreEqualIgnoringOrder(
+                    [GeographicLevel.Country, GeographicLevel.LocalAuthority], geographicLevels));
+
                 var originalMeta = releaseFile.File.DataSetFileMeta;
 
-                Assert.Equal(originalMeta!.GeographicLevels
-                        .Select(gl => gl.GetEnumLabel())
-                        .ToList(),
-                    dataSetFileMetaViewModel.GeographicLevels);
+                Assert.Null(originalMeta!.GeographicLevels); // TODO: remove in EES-5750
 
                 Assert.Equal(new DataSetFileTimePeriodRangeViewModel
                 {
@@ -2069,12 +2072,14 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                 $"{releaseFile.PublicApiDataSetVersion!.Major}.{releaseFile.PublicApiDataSetVersion.Minor}",
                 viewModel.Api.Version);
 
-            var dataSetFileMeta = file.DataSetFileMeta;
-
-            Assert.Equal(dataSetFileMeta!.GeographicLevels
-                    .Select(gl => gl.GetEnumLabel())
-                    .ToList(),
+            Assert.Equal([
+                    GeographicLevel.Country.GetEnumLabel(),
+                    GeographicLevel.LocalAuthority.GetEnumLabel(),
+                    GeographicLevel.LocalAuthorityDistrict.GetEnumLabel()
+                ],
                 viewModel.File.Meta.GeographicLevels);
+
+            var dataSetFileMeta = file.DataSetFileMeta;
 
             Assert.Equal(new DataSetFileTimePeriodRangeViewModel
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
@@ -16,7 +16,6 @@ public static class DataSetFileMetaGeneratorExtensions
 
     public static InstanceSetters<DataSetFileMeta> SetDefaults(this InstanceSetters<DataSetFileMeta> setters)
         => setters
-            .SetGeographicLevels([GeographicLevel.Country])
             .SetTimePeriodRange(new TimePeriodRangeMeta
             {
                 Start = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2000", },
@@ -37,11 +36,6 @@ public static class DataSetFileMetaGeneratorExtensions
                 },
             ]);
 
-    public static Generator<DataSetFileMeta> WithGeographicLevels(
-        this Generator<DataSetFileMeta> generator,
-        List<GeographicLevel> geographicLevels)
-        => generator.ForInstance(s => s.SetGeographicLevels(geographicLevels));
-
     public static Generator<DataSetFileMeta> WithTimePeriodRange(
         this Generator<DataSetFileMeta> generator,
         TimePeriodRangeMeta timePeriodRange)
@@ -56,11 +50,6 @@ public static class DataSetFileMetaGeneratorExtensions
         this Generator<DataSetFileMeta> generator,
         List<IndicatorMeta> indicators)
         => generator.ForInstance(s => s.SetIndicators(indicators));
-
-    public static InstanceSetters<DataSetFileMeta> SetGeographicLevels(
-        this InstanceSetters<DataSetFileMeta> setters,
-        List<GeographicLevel> geographicLevels)
-        => setters.Set(s => s.GeographicLevels, geographicLevels);
 
     public static InstanceSetters<DataSetFileMeta> SetTimePeriodRange(
         this InstanceSetters<DataSetFileMeta> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -3,15 +3,16 @@ using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 public class DataSetFileMeta
 {
-    [JsonConverter(typeof(GeographicLevelsListJsonConverter))]
-    public required List<GeographicLevel> GeographicLevels { get; set; }
+    // NOTE: GeographicLevels aren't in DataSetFileMeta JSON because they need to queryable
+    // So that meta data lives in DataSetFileVersionGeographicLevels
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public List<string>? GeographicLevels { get; set; } // TODO: remove in EES-5750
 
     public required TimePeriodRangeMeta TimePeriodRange { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -27,6 +27,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public DataSetFileMeta? DataSetFileMeta { get; set; }
 
+        public bool DataSetFileMetaGeogLvlMigrated { get; set; } = true;
+
         public List<DataSetFileFilterHierarchy>? FilterHierarchies { get; set; }
 
         public Guid? ReplacedById { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -126,6 +126,7 @@ public class DataSetFileService(
                 LastUpdated = result.Value.Published!.Value,
                 Api = BuildDataSetFileApiViewModel(result.Value),
                 Meta = BuildDataSetFileMetaViewModel(
+                    result.Value.File.DataSetFileVersionGeographicLevels,
                     result.Value.File.DataSetFileMeta,
                     result.Value.FilterSequence,
                     result.Value.IndicatorSequence),
@@ -170,7 +171,7 @@ public class DataSetFileService(
         var releaseFile = await contentDbContext.ReleaseFiles
             .Include(rf => rf.ReleaseVersion.Publication.Theme)
             .Include(rf => rf.ReleaseVersion.Publication.SupersededBy)
-            .Include(rf => rf.File)
+            .Include(rf => rf.File.DataSetFileVersionGeographicLevels)
             .Where(rf =>
                 rf.File.DataSetFileId == dataSetFileId
                 && rf.ReleaseVersion.Published.HasValue
@@ -225,6 +226,7 @@ public class DataSetFileService(
                 Name = releaseFile.File.Filename,
                 Size = releaseFile.File.DisplaySize(),
                 Meta = BuildDataSetFileMetaViewModel(
+                    releaseFile.File.DataSetFileVersionGeographicLevels,
                     releaseFile.File.DataSetFileMeta,
                     releaseFile.FilterSequence,
                     releaseFile.IndicatorSequence),
@@ -267,6 +269,7 @@ public class DataSetFileService(
     }
 
     private static DataSetFileMetaViewModel BuildDataSetFileMetaViewModel(
+        List<DataSetFileVersionGeographicLevel> dataSetFileVersionGeographicLevels,
         DataSetFileMeta? meta,
         List<FilterSequenceEntry>? filterSequence,
         List<IndicatorGroupSequenceEntry>? indicatorGroupSequence)
@@ -278,8 +281,8 @@ public class DataSetFileService(
 
         return new DataSetFileMetaViewModel
         {
-            GeographicLevels = meta.GeographicLevels
-                .Select(gl => gl.GetEnumLabel())
+            GeographicLevels = dataSetFileVersionGeographicLevels
+                .Select(gl => gl.GeographicLevel.GetEnumLabel())
                 .ToList(),
             TimePeriodRange = new DataSetFileTimePeriodRangeViewModel
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -287,14 +287,17 @@ public class ProcessorStage3Tests
             Assert.Equal("32", lastObservation.Measures[_subject.IndicatorGroups[0].Indicators[1].Id]);
 
             var file = contentDbContext.Files
+                .Include(f => f.DataSetFileVersionGeographicLevels)
                 .Single(f => f.Type == FileType.Data
                              && f.SubjectId == import.File.SubjectId);
 
-            Assert.NotNull(file.DataSetFileMeta);
-
-            // Checking against contents of small-csv.csv in Resources directory / _subject
-            var geographicLevel = Assert.Single(file.DataSetFileMeta.GeographicLevels);
+            Assert.NotNull(file.DataSetFileVersionGeographicLevels);
+            var geographicLevel = Assert.Single(file.DataSetFileVersionGeographicLevels
+                .Select(gl => gl.GeographicLevel)
+                .ToList());
             Assert.Equal(GeographicLevel.LocalAuthority, geographicLevel);
+
+            Assert.NotNull(file.DataSetFileMeta);
 
             Assert.Equal(TimeIdentifier.CalendarYear,
                 file.DataSetFileMeta.TimePeriodRange.Start.TimeIdentifier);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -207,7 +207,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
             var dataSetFileMeta = new DataSetFileMeta
             {
-                GeographicLevels = geographicLevels,
+                GeographicLevels = null, // TODO: remove in EES-5750
                 TimePeriodRange = new TimePeriodRangeMeta
                 {
                     Start = timePeriods.First(),


### PR DESCRIPTION
This PR sets DataSetFileMeta geographic levels to null. We do this because the same geographic levels are now cached in the new `DataSetFileVersionGeographicLevels` table.

This PR also makes changes to use the new `DataSetFileVersionGeographicLevels` table entries over `DataSetFileMeta.GeographicLevels`.

We set the geog lvls in JSON to null using a migration endpoint. There is no rush on using the endpoint after deploying. 

Unfortunately, we also needed a new temporary column in the Files table to record what entries have been migrated. This will be removed along with `DataSetFileMeta.GeographicLevels` in EES-5750.
