### PR TITLE
EES-5189 - added option to enable geo-redundant backups to PostgreSQL…

### DIFF
--- a/infrastructure/templates/public-api/application/shared/postgreSqlFlexibleServer.bicep
+++ b/infrastructure/templates/public-api/application/shared/postgreSqlFlexibleServer.bicep
@@ -31,6 +31,9 @@ param privateEndpointSubnetId string
 @description('An array of Entra ID admin principal names for this resource')
 param entraIdAdminPrincipals PrincipalNameAndId[] = []
 
+@description('Whether backups will be geo-redundant rather than zone-redundant')
+param geoRedundantBackupEnabled bool
+
 @description('Whether to create or update Azure Monitor alerts during this deploy')
 param deployAlerts bool
 
@@ -58,6 +61,7 @@ module postgreSqlServerModule '../../components/postgresqlDatabase.bicep' = {
     firewallRules: formattedFirewallRules
     databaseNames: ['public_data']
     privateEndpointSubnetId: privateEndpointSubnetId
+    geoRedundantBackup: geoRedundantBackupEnabled ? 'Enabled' : 'Disabled'
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -39,6 +39,9 @@ param postgreSqlAutoGrowStatus string = 'Disabled'
 @description('Database : Entra ID admin  principal names for this resource')
 param postgreSqlEntraIdAdminPrincipals PrincipalNameAndId[] = []
 
+@description('Database : Is geo-redundant backup enabled?')
+param postgreSqlGeoRedundantBackupEnabled bool
+
 @description('ACR : Specifies the resource group in which the shared Container Registry lives.')
 param acrResourceGroupName string = ''
 
@@ -241,6 +244,7 @@ module postgreSqlServerModule 'application/shared/postgreSqlFlexibleServer.bicep
     sku: postgreSqlSkuName
     storageSizeGB: postgreSqlStorageSizeGB
     deployAlerts: deployAlerts
+    geoRedundantBackupEnabled: postgreSqlGeoRedundantBackupEnabled
     tagValues: tagValues
   }
   dependsOn: [

--- a/infrastructure/templates/public-api/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-dev.bicepparam
@@ -13,5 +13,6 @@ param publicUrls = {
 param postgreSqlSkuName = 'Standard_B1ms'
 param postgreSqlStorageSizeGB = 32
 param postgreSqlAutoGrowStatus = 'Disabled'
+param postgreSqlGeoRedundantBackupEnabled = false
 
 param enableThemeDeletion = true

--- a/infrastructure/templates/public-api/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-preprod.bicepparam
@@ -13,5 +13,6 @@ param publicUrls = {
 param postgreSqlSkuName = 'Standard_B1ms'
 param postgreSqlStorageSizeGB = 32
 param postgreSqlAutoGrowStatus = 'Disabled'
+param postgreSqlGeoRedundantBackupEnabled = true
 
 param enableThemeDeletion = false

--- a/infrastructure/templates/public-api/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-prod.bicepparam
@@ -13,6 +13,7 @@ param publicUrls = {
 param postgreSqlSkuName = 'Standard_B1ms'
 param postgreSqlStorageSizeGB = 32
 param postgreSqlAutoGrowStatus = 'Disabled'
+param postgreSqlGeoRedundantBackupEnabled = true
 
 param docsAppSku = 'Standard'
 

--- a/infrastructure/templates/public-api/parameters/main-test.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-test.bicepparam
@@ -13,5 +13,6 @@ param publicUrls = {
 param postgreSqlSkuName = 'Standard_B1ms'
 param postgreSqlStorageSizeGB = 32
 param postgreSqlAutoGrowStatus = 'Disabled'
+param postgreSqlGeoRedundantBackupEnabled = false
 
 param enableThemeDeletion = false


### PR DESCRIPTION
This PR:
- adds the ability to enable Geo-redundant backup to PSQL Flexible Server per environment.
- enables for Prod and Pre-prod, but disables for Dev and Test as it can only be enabled at creation time of the server.

This brings the PSQL backup policy in line with that of our Azure SQL instances, which have 7-day retention and geo-redundant backups enabled, as shown in the write-up at https://dfedigital.atlassian.net/browse/EES-5189?focusedCommentId=101137. 

Future work will also enable long-term retention backups as well as part of https://dfedigital.atlassian.net/browse/EES-5760.