### PR TITLE
EES-5469 - Add feedback submission banner and admin view

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/FeedbackControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/FeedbackControllerTests.cs
@@ -1,0 +1,131 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Fixture;
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Bau;
+
+public class FeedbackControllerTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+{
+    private static readonly DateTime Now = DateTime.UtcNow;
+    private const string BaseUrl = "api/feedback";
+    private readonly List<Feedback> Feedback =
+    [
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Created = Now,
+            Response = FeedbackResponse.Useful,
+            Url = "/",
+            UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+            Context = "",
+            Intent = "",
+            Issue = "",
+            Read = false,
+        },
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Created = Now,
+            Response = FeedbackResponse.NotUseful,
+            Url = "/",
+            UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+            Context = "What were you doing?",
+            Intent = "What did you hope to achieve?",
+            Issue = "",
+            Read = true,
+        },
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Created = Now,
+            Response = FeedbackResponse.ProblemEncountered,
+            Url = "/",
+            UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+            Context = "What were you doing?",
+            Intent = "",
+            Issue = "What went wrong?",
+            Read = false,
+        }
+    ];
+
+    [Fact]
+    public async Task ListFeedback_NoQueryParameters_ReturnsOnlyUnreadFeedback()
+    {
+        // Arrange
+        await TestApp.AddTestData<ContentDbContext>(context
+            => context.Feedback.AddRange(Feedback));
+
+        var client = TestApp
+            .SetUser(DataFixture.BauUser())
+            .CreateClient();
+
+        // Act
+        var response = await client.GetAsync(BaseUrl);
+
+        // Assert
+        var result = response.AssertOk<List<FeedbackViewModel>>();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equivalent(Feedback[0], result[0]);
+        Assert.Equivalent(Feedback[2], result[1]);
+    }
+
+    [Fact]
+    public async Task ListFeedback_ShowRead_ReturnsAllFeedback()
+    {
+        // Arrange
+        await TestApp.AddTestData<ContentDbContext>(context
+            => context.Feedback.AddRange(Feedback));
+
+        var client = TestApp
+            .SetUser(DataFixture.BauUser())
+            .CreateClient();
+
+        // Act
+        var response = await client.GetAsync(BaseUrl + "?showRead=true");
+
+        // Assert
+        var result = response.AssertOk<List<FeedbackViewModel>>();
+
+        Assert.Equal(3, result.Count);
+        Assert.Equivalent(Feedback, result);
+    }
+
+    [Fact]
+    public async Task ToggleReadStatus_Success()
+    {
+        // Arrange
+        var feedback = new Feedback
+        {
+            Id = Guid.NewGuid(),
+            Response = FeedbackResponse.Useful,
+            Url = "/",
+            Read = false,
+        };
+
+        await TestApp.AddTestData<ContentDbContext>(context
+            => context.Feedback.Add(feedback));
+
+        await using var context = TestApp.GetDbContext<ContentDbContext>();
+
+        var client = TestApp
+            .SetUser(DataFixture.BauUser())
+            .CreateClient();
+
+        // Act
+        await client.PatchAsync($"{BaseUrl}/{feedback.Id}", content: null);
+
+        // Assert
+        var saved = await context.Feedback.FirstAsync();
+
+        Assert.True(saved.Read);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/FeedbackController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/FeedbackController.cs
@@ -1,0 +1,74 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Models.GlobalRoles;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+
+[Route("api")]
+[ApiController]
+[Authorize(Roles = RoleNames.BauUser)]
+public class FeedbackController(ContentDbContext context) : ControllerBase
+{
+    [HttpGet("feedback")]
+    public async Task<ActionResult> ListFeedback(
+        [FromQuery] bool showRead,
+        CancellationToken cancellationToken)
+    {
+        var query = context.Feedback
+            .OrderByDescending(x => x.Created)
+            .AsQueryable();
+
+        if (!showRead)
+        {
+            query = query.Where(x => !x.Read);
+        }
+
+        var feedback = await query
+            .Select(f => MapToViewModel(f))
+            .ToListAsync(cancellationToken);
+
+        return Ok(feedback);
+    }
+
+    [HttpPatch("feedback/{id:guid}")]
+    public async Task<ActionResult> ToggleReadStatus(Guid id)
+    {
+        var feedback = await context.Feedback.FindAsync(id);
+
+        if (feedback == null)
+        {
+            return NotFound();
+        }
+
+        feedback.Read = !feedback.Read;
+
+        await context.SaveChangesAsync();
+
+        return NoContent();
+    }
+
+    private static FeedbackViewModel MapToViewModel(Feedback entity)
+    {
+        return new FeedbackViewModel
+        {
+            Id = entity.Id,
+            UserAgent = entity.UserAgent,
+            Url = entity.Url,
+            Created = entity.Created,
+            Response = entity.Response.ToString(),
+            Context = entity.Context,
+            Intent = entity.Intent,
+            Issue = entity.Issue,
+            Read = entity.Read,
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250116162758_EES5469_AddFeedbackTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250116162758_EES5469_AddFeedbackTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250116162758_EES5469_AddFeedbackTable")]
+    partial class EES5469_AddFeedbackTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250116162758_EES5469_AddFeedbackTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250116162758_EES5469_AddFeedbackTable.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES5469_AddFeedbackTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Feedback",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Created = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Url = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: false),
+                    UserAgent = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: true),
+                    Response = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Context = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: true),
+                    Issue = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: true),
+                    Intent = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: true),
+                    Read = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Feedback", x => x.Id);
+                });
+
+            migrationBuilder.Sql("GRANT INSERT ON dbo.Feedback TO [content];");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Feedback");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/FeedbackResponse.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/FeedbackResponse.cs
@@ -1,0 +1,15 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Database;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common;
+
+public enum FeedbackResponse
+{
+    [EnumLabelValue("Useful")]
+    Useful,
+
+    [EnumLabelValue("Not useful")]
+    NotUseful,
+
+    [EnumLabelValue("Problem encountered")]
+    ProblemEncountered,
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/FeedbackViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/FeedbackViewModel.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+
+public class FeedbackViewModel
+{
+    public Guid Id { get; set; }
+
+    public DateTime Created { get; set; }
+
+    public required string Url { get; set; }
+
+    public string? UserAgent { get; set; }
+
+    public required string Response { get; set; }
+
+    public string? Context { get; set; }
+
+    public string? Issue { get; set; }
+
+    public string? Intent { get; set; }
+
+    public bool Read { get; set; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/FeedbackControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/FeedbackControllerTests.cs
@@ -1,0 +1,70 @@
+#nullable enable
+using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Content.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers;
+
+public class FeedbackControllerTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+{
+    private const string BaseUrl = "api/feedback";
+
+    [Fact]
+    public async Task CreateFeedback_Success()
+    {
+        // Arrange
+        var client = TestApp.CreateClient();
+
+        var request = new FeedbackCreateRequest
+        {
+            Response = FeedbackResponse.ProblemEncountered,
+            Url = "/",
+            UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+            Context = "What were you doing?",
+            Intent = "What did you hope to achieve?",
+            Issue = "What went wrong?",
+        };
+
+        // Act
+        await client.PostAsync(BaseUrl, JsonContent.Create(request));
+
+        // Assert
+        await using var context = TestApp.GetDbContext<ContentDbContext>();
+        var saved = await context.Feedback.FirstAsync();
+
+        Assert.Equivalent(request, saved);
+    }
+
+    [Fact]
+    public async Task FeedbackCreateRequestValidator_InvalidFields_IncludesRelevantErrors()
+    {
+        // Arrange
+        var validator = new FeedbackCreateRequest.Validator();
+
+        var request = new FeedbackCreateRequest
+        {
+            Response = (FeedbackResponse)5,
+            Context = new string('a', 2001),
+            Intent = new string('b', 2001),
+            Issue = new string('c', 2001),
+        };
+
+        // Act
+        var result = await validator.TestValidateAsync(request);
+
+        // Assert
+        Assert.Equal(5, result.Errors.Count);
+        result.ShouldHaveValidationErrorFor(feedback => feedback.Url);
+        result.ShouldHaveValidationErrorFor(feedback => feedback.Response);
+        result.ShouldHaveValidationErrorFor(feedback => feedback.Context);
+        result.ShouldHaveValidationErrorFor(feedback => feedback.Intent);
+        result.ShouldHaveValidationErrorFor(feedback => feedback.Issue);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/FeedbackController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/FeedbackController.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Content.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class FeedbackController(ContentDbContext context) : ControllerBase
+{
+    [HttpPost]
+    public async Task<ActionResult> CreateFeedback(
+            [FromBody] FeedbackCreateRequest request,
+            CancellationToken cancellationToken)
+    {
+        await context.Feedback.AddAsync(MapToEntity(request), cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+
+        return new CreatedResult();
+    }
+
+    private static Feedback MapToEntity(FeedbackCreateRequest request)
+    {
+        return new Feedback
+        {
+            UserAgent = request.UserAgent,
+            Url = request.Url,
+            Response = request.Response,
+            Context = request.Context,
+            Intent = request.Intent,
+            Issue = request.Issue,
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/FeedbackController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/FeedbackController.cs
@@ -1,7 +1,7 @@
 #nullable enable
-using GovUk.Education.ExploreEducationStatistics.Content.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Requests/FeedbackCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Requests/FeedbackCreateRequest.cs
@@ -1,0 +1,41 @@
+#nullable enable
+using FluentValidation;
+using GovUk.Education.ExploreEducationStatistics.Common;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Requests;
+
+public record FeedbackCreateRequest
+{
+    public string Url { get; set; } = null!;
+
+    public string? UserAgent { get; set; }
+
+    public FeedbackResponse Response { get; set; }
+
+    public string? Context { get; set; }
+
+    public string? Issue { get; set; }
+
+    public string? Intent { get; set; }
+
+    public class Validator : AbstractValidator<FeedbackCreateRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.Url)
+                .NotEmpty();
+
+            RuleFor(request => request.Response)
+                .IsInEnum();
+
+            RuleFor(request => request.Context)
+                .MaximumLength(2000);
+
+            RuleFor(request => request.Issue)
+                .MaximumLength(2000);
+
+            RuleFor(request => request.Intent)
+                .MaximumLength(2000);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
@@ -85,6 +86,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
         public virtual DbSet<Comment> Comment { get; set; }
         public virtual DbSet<UserReleaseInvite> UserReleaseInvites { get; set; }
         public virtual DbSet<UserPublicationInvite> UserPublicationInvites { get; set; }
+        public virtual DbSet<Feedback> Feedback { get; set; }
 
         [DbFunction]
         public virtual IQueryable<FreeTextRank> PublicationsFreeTextTable(string searchTerm) =>
@@ -131,6 +133,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
             ConfigureKeyStatisticsText(modelBuilder);
             ConfigureDataBlockParent(modelBuilder);
             ConfigureDataBlockVersion(modelBuilder);
+            ConfigureFeedback(modelBuilder);
 
             // Apply model configuration for types which implement IEntityTypeConfiguration
             modelBuilder.ApplyConfigurationsFromAssembly(typeof(ContentDbContext).Assembly);
@@ -835,6 +838,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
         {
             modelBuilder.Entity<KeyStatisticText>()
                 .ToTable("KeyStatisticsText");
+        }
+
+        private static void ConfigureFeedback(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Feedback>()
+                .Property(feedback => feedback.Url)
+                .IsRequired()
+                .HasMaxLength(2000);
+
+            modelBuilder.Entity<Feedback>()
+                .Property(feedback => feedback.UserAgent)
+                .HasMaxLength(250);
+
+            modelBuilder.Entity<Feedback>()
+                .Property(feedback => feedback.Context)
+                .HasMaxLength(2000);
+
+            modelBuilder.Entity<Feedback>()
+                .Property(feedback => feedback.Issue)
+                .HasMaxLength(2000);
+
+            modelBuilder.Entity<Feedback>()
+                .Property(feedback => feedback.Intent)
+                .HasMaxLength(2000);
+
+            modelBuilder.Entity<Feedback>()
+                .Property(feedback => feedback.Response)
+                .HasConversion(new EnumToStringConverter<FeedbackResponse>())
+                .IsRequired()
+                .HasMaxLength(50);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Feedback.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Feedback.cs
@@ -1,0 +1,27 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+public record Feedback : ICreatedTimestamp<DateTime>
+{
+    public Guid Id { get; set; }
+
+    public DateTime Created { get; set; }
+
+    public required string Url { get; set; }
+
+    public string? UserAgent { get; set; }
+
+    public FeedbackResponse Response { get; set; }
+
+    public string? Context { get; set; }
+
+    public string? Issue { get; set; }
+
+    public string? Intent { get; set; }
+
+    public bool Read { get; set; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Requests/FeedbackCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Requests/FeedbackCreateRequest.cs
@@ -1,12 +1,11 @@
-#nullable enable
 using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Requests;
+namespace GovUk.Education.ExploreEducationStatistics.Content.Requests;
 
 public record FeedbackCreateRequest
 {
-    public string Url { get; set; } = null!;
+    public string Url { get; set; } = string.Empty;
 
     public string? UserAgent { get; set; }
 
@@ -24,6 +23,9 @@ public record FeedbackCreateRequest
         {
             RuleFor(request => request.Url)
                 .NotEmpty();
+
+            RuleFor(request => request.UserAgent)
+                .MaximumLength(250);
 
             RuleFor(request => request.Response)
                 .IsInEnum();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Requests/PublicationsListGetRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Requests/PublicationsListGetRequest.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
@@ -7,8 +7,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Requests;
 public record PublicationsListGetRequest(
     ReleaseType? ReleaseType,
     Guid? ThemeId,
-    [MinLength(3)] string? Search,
+    string? Search,
     PublicationsSortBy? Sort,
     SortDirection? SortDirection,
-    [Range(1, int.MaxValue)] int Page = 1,
-    [Range(1, int.MaxValue)] int PageSize = 10);
+    int Page = 1,
+    int PageSize = 10)
+{
+    public class Validator : AbstractValidator<PublicationsListGetRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.Search)
+                .MinimumLength(3);
+            RuleFor(request => request.Page)
+                .InclusiveBetween(1, 9999);
+            RuleFor(request => request.PageSize)
+                .InclusiveBetween(1, 40);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Requests/PublicationsListPostRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Requests/PublicationsListPostRequest.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+using FluentValidation;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
@@ -7,9 +7,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Requests;
 public record PublicationsListPostRequest(
     ReleaseType? ReleaseType = null,
     Guid? ThemeId = null,
-    [MinLength(3)] string? Search = null,
+    string? Search = null,
     PublicationsSortBy? Sort = null,
     SortDirection? SortDirection = null,
-    [Range(1, int.MaxValue)] int Page = 1,
-    [Range(1, int.MaxValue)] int PageSize = 10,
-    IEnumerable<Guid>? PublicationIds = null);
+    int Page = 1,
+    int PageSize = 10,
+    IEnumerable<Guid>? PublicationIds = null)
+{
+    public class Validator : AbstractValidator<PublicationsListPostRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.Search)
+                .MinimumLength(3);
+            RuleFor(request => request.Page)
+                .InclusiveBetween(1, 9999);
+            RuleFor(request => request.PageSize)
+                .InclusiveBetween(1, 40);
+        }
+    }
+}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/FeedbackDetailsModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/FeedbackDetailsModal.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import ButtonText from '@common/components/ButtonText';
+import Modal from '@common/components/Modal';
+import { FeedbackViewModel } from '@common/services/types/feedback';
+import FormattedDate from '@common/components/FormattedDate';
+import SummaryList from '@common/components/SummaryList';
+import SummaryListItem from '@common/components/SummaryListItem';
+import { getResponseText } from '@admin/pages/bau/FeedbackPage';
+
+interface Props {
+  feedback: FeedbackViewModel;
+}
+
+export default function FeedbackDetailsModal({ feedback }: Props) {
+  return (
+    <Modal
+      title="Feedback details"
+      showClose
+      triggerButton={
+        <ButtonText className="dfe-white-space--nowrap">
+          View details
+        </ButtonText>
+      }
+    >
+      <SummaryList>
+        <SummaryListItem term="Date">
+          <FormattedDate format="d MMM yyyy, HH:mm">
+            {feedback.created}
+          </FormattedDate>
+        </SummaryListItem>
+        <SummaryListItem term="URL">{feedback.url}</SummaryListItem>
+        <SummaryListItem term="Response">
+          {getResponseText(feedback.response)}
+        </SummaryListItem>
+        {feedback.response !== 'Useful' && (
+          <>
+            <SummaryListItem term="What were you doing?">
+              {feedback.context ?? '-'}
+            </SummaryListItem>
+            <SummaryListItem term="What went wrong?">
+              {feedback.issue ?? '-'}
+            </SummaryListItem>
+            <SummaryListItem term="What did you hope to achieve?">
+              {feedback.intent ?? '-'}
+            </SummaryListItem>
+          </>
+        )}
+        <SummaryListItem term="User agent">
+          {feedback.userAgent}
+        </SummaryListItem>
+      </SummaryList>
+    </Modal>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
@@ -14,7 +14,7 @@ const BauDashboardPage = () => {
     >
       <h2 className="govuk-heading-m govuk-!-margin-top-9">Content and data</h2>
 
-      <div className="govuk-grid-row govuk-!-margin-bottom-9">
+      <div className="govuk-grid-row govuk-!-margin-bottom-6">
         {user?.permissions.canAccessAllImports && (
           <div className="govuk-grid-column-one-third">
             <h3 className="govuk-heading-s govuk-!-margin-bottom-0">
@@ -48,6 +48,19 @@ const BauDashboardPage = () => {
             </h3>
             <p className="govuk-caption-m govuk-!-margin-top-1">
               Clear glossary cache.
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="govuk-grid-row govuk-!-margin-bottom-9">
+        {user?.permissions.isBauUser && (
+          <div className="govuk-grid-column-one-third">
+            <h3 className="govuk-heading-s govuk-!-margin-bottom-0">
+              <Link to="/administration/feedback">View feedback</Link>
+            </h3>
+            <p className="govuk-caption-m govuk-!-margin-top-1">
+              View feedback submitted by consumers of the service.
             </p>
           </div>
         )}

--- a/src/explore-education-statistics-admin/src/pages/bau/FeedbackPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/FeedbackPage.tsx
@@ -1,0 +1,134 @@
+import Page from '@admin/components/Page';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import React from 'react';
+import FormattedDate from '@common/components/FormattedDate';
+import { useQuery } from '@tanstack/react-query';
+import feedbackQueries from '@admin/queries/feedbackQueries';
+import feedbackService from '@admin/services/feedbackService';
+import ButtonText from '@common/components/ButtonText';
+import InsetText from '@common/components/InsetText';
+import ButtonLink from '@admin/components/ButtonLink';
+import useQueryParams from '@admin/hooks/useQueryParams';
+import { FeedbackViewModel } from '@common/services/types/feedback';
+import truncateAround from '@common/utils/string/truncateAround';
+import FeedbackDetailsModal from '../admin-dashboard/components/FeedbackDetailsModal';
+
+type Params = {
+  showRead?: string;
+};
+
+export const getResponseText = (response: FeedbackViewModel['response']) => {
+  switch (response) {
+    case 'Useful':
+      return 'Useful';
+    case 'NotUseful':
+      return 'Not useful';
+    case 'ProblemEncountered':
+      return 'Problem encountered';
+    default:
+      return '';
+  }
+};
+
+const FeedbackPage = () => {
+  const { showRead } = useQueryParams<Params>();
+
+  const {
+    data: feedbackItems = [],
+    isLoading: isLoadingFeedback,
+    refetch: reloadFeedbackItems,
+  } = useQuery(feedbackQueries.getFeedback(showRead ?? ''));
+
+  const toggleReadStatus = async (id: string) => {
+    await feedbackService.toggleReadStatus(id);
+    reloadFeedbackItems();
+  };
+
+  const truncateTextOrBlank = (text: string) => {
+    return text
+      ? truncateAround(text, 0, {
+          startTruncateLength: 200,
+          endTruncateLength: 200,
+        })
+      : '-';
+  };
+
+  return (
+    <Page
+      title="Feedback"
+      caption="View feedback"
+      wide
+      breadcrumbs={[
+        { name: 'Platform administration', link: '/administration' },
+        { name: 'Feedback' },
+      ]}
+    >
+      <LoadingSpinner loading={isLoadingFeedback} text="Loading feedback">
+        <ButtonLink
+          to={{ search: showRead ? '' : 'showRead=true' }}
+          onClick={() => reloadFeedbackItems()}
+        >
+          {showRead ? 'Hide read' : 'Show read'}
+        </ButtonLink>
+
+        {feedbackItems.length === 0 ? (
+          <InsetText>No feedback found</InsetText>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Date</th>
+                <th scope="col">URL</th>
+                <th scope="col">Response</th>
+                <th scope="col">What were you doing?</th>
+                <th scope="col">What went wrong?</th>
+                <th scope="col">What did you hope to achieve?</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="govuk-!-font-size-16">
+              {feedbackItems
+                .filter(feedback => (showRead ? true : !feedback.read))
+                .map(feedback => {
+                  return (
+                    <tr key={feedback.id}>
+                      <td>
+                        <FormattedDate format="d MMM yyyy, HH:mm">
+                          {feedback.created}
+                        </FormattedDate>
+                      </td>
+                      <td>{feedback.url}</td>
+                      <td className="dfe-white-space--nowrap">
+                        {getResponseText(feedback.response)}
+                      </td>
+                      <td className="dfe-white-space--pre-wrap">
+                        {truncateTextOrBlank(feedback.context)}
+                      </td>
+                      <td className="dfe-white-space--pre-wrap">
+                        {truncateTextOrBlank(feedback.issue)}
+                      </td>
+                      <td className="dfe-white-space--pre-wrap">
+                        {truncateTextOrBlank(feedback.intent)}
+                      </td>
+                      <td>
+                        <ButtonText
+                          className="dfe-white-space--nowrap govuk-!-margin-bottom-2"
+                          onClick={() => toggleReadStatus(feedback.id)}
+                        >
+                          Mark as {feedback.read ? 'unread' : 'read'}
+                        </ButtonText>
+                        <br />
+                        <FeedbackDetailsModal feedback={feedback} />
+                      </td>
+                    </tr>
+                  );
+                })}
+            </tbody>
+          </table>
+        )}
+      </LoadingSpinner>
+    </Page>
+  );
+};
+
+export default FeedbackPage;

--- a/src/explore-education-statistics-admin/src/queries/feedbackQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/feedbackQueries.ts
@@ -1,0 +1,13 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+import feedbackService from '@admin/services/feedbackService';
+
+const feedbackQueries = createQueryKeys('release', {
+  getFeedback(showRead: string) {
+    return {
+      queryKey: [showRead],
+      queryFn: () => feedbackService.listFeedback(showRead),
+    };
+  },
+});
+
+export default feedbackQueries;

--- a/src/explore-education-statistics-admin/src/routes/administrationRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/administrationRoutes.ts
@@ -10,6 +10,7 @@ import BoundaryDataPage from '@admin/pages/bau/BoundaryDataPage';
 import BoundaryLevelEditPage from '@admin/pages/bau/BoundaryLevelEditPage';
 import BoundaryDataUploadPage from '@admin/pages/bau/BoundaryDataUploadPage';
 import GlossaryPage from '@admin/pages/bau/GlossaryPage';
+import FeedbackPage from '@admin/pages/bau/FeedbackPage';
 
 export type BoundaryLevelEditPageRouteParams = {
   boundaryLevelId: number;
@@ -57,6 +58,13 @@ export const administrationBoundaryDataUploadRoute: ProtectedRouteProps = {
   exact: true,
 };
 
+export const administrationFeedbackRoute: ProtectedRouteProps = {
+  path: '/administration/feedback',
+  component: FeedbackPage,
+  protectionAction: permissions => permissions.isBauUser,
+  exact: true,
+};
+
 export const administrationUsersRoute: ProtectedRouteProps = {
   path: '/administration/users',
   component: BauUsersPage,
@@ -98,6 +106,7 @@ const administrationRoutes = {
   administrationBoundaryDataEditRoute,
   administrationBoundaryDataUploadRoute,
   administrationGlossaryRoute,
+  administrationFeedbackRoute,
   administrationUsersRoute,
   administrationUserInviteRoute,
   administrationInvitedUsersRoute,

--- a/src/explore-education-statistics-admin/src/services/feedbackService.ts
+++ b/src/explore-education-statistics-admin/src/services/feedbackService.ts
@@ -1,0 +1,15 @@
+import client from '@admin/services/utils/service';
+import { FeedbackViewModel } from '@common/services/types/feedback';
+
+const feedbackService = {
+  listFeedback(showRead: string): Promise<FeedbackViewModel[]> {
+    return showRead
+      ? client.get('/feedback?showRead=true')
+      : client.get('/feedback');
+  },
+  toggleReadStatus(id: string): Promise<void> {
+    return client.patch(`/feedback/${id}`);
+  },
+};
+
+export default feedbackService;

--- a/src/explore-education-statistics-common/src/services/types/feedback.ts
+++ b/src/explore-education-statistics-common/src/services/types/feedback.ts
@@ -1,0 +1,22 @@
+export interface FeedbackRequest {
+  url: string;
+  userAgent: string;
+  response: FeedbackResponse;
+  context?: string;
+  issue?: string;
+  intent?: string;
+}
+
+export interface FeedbackViewModel {
+  id: string;
+  created: Date;
+  url: string;
+  userAgent: string;
+  response: FeedbackResponse;
+  context: string;
+  intent: string;
+  issue: string;
+  read: boolean;
+}
+
+export type FeedbackResponse = 'Useful' | 'NotUseful' | 'ProblemEncountered';

--- a/src/explore-education-statistics-frontend/src/components/Feedback.module.scss
+++ b/src/explore-education-statistics-frontend/src/components/Feedback.module.scss
@@ -1,0 +1,78 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.container {
+  border-top: 1px govuk-colour('mid-grey') solid;
+
+  @include govuk-media-query($until: tablet) {
+    margin: 0;
+  }
+}
+
+.banner {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  background: govuk-colour('light-grey');
+  padding: 0 govuk-spacing(3);
+  gap: govuk-spacing(3);
+
+  @include govuk-media-query($until: tablet) {
+    flex-direction: column;
+    align-items: normal;
+    padding: 0 govuk-spacing(3);
+  }
+}
+
+.heading {
+  margin: 0;
+  @include govuk-font($size: 16, $weight: bold);
+
+  @include govuk-media-query($until: tablet) {
+    @include govuk-font($size: 24, $weight: bold);
+  }
+}
+
+.promptQuestion {
+  display: flex;
+  align-items: center;
+  gap: govuk-spacing(3);
+  padding: govuk-spacing(4) 0;
+}
+
+.reportContainer {
+  composes: promptQuestion;
+
+  @include govuk-media-query($until: tablet) {
+    border-top: 1px govuk-colour('mid-grey') solid;
+  }
+}
+
+.button {
+  border: 1px govuk-colour('black') solid;
+  box-shadow: 0 3px 0 govuk-colour('black');
+  margin: 0;
+  white-space: nowrap;
+
+  @include govuk-font($size: 16);
+
+  @include govuk-media-query($until: tablet) {
+    @include govuk-font($size: 24);
+  }
+}
+
+.buttonYesNo {
+  composes: button;
+  min-width: 100px;
+
+  @include govuk-media-query($until: tablet) {
+    min-width: 80px;
+    max-width: 80px;
+  }
+}
+
+.buttonReport {
+  composes: button;
+  min-width: none;
+  max-width: none;
+}

--- a/src/explore-education-statistics-frontend/src/components/Feedback.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Feedback.tsx
@@ -1,0 +1,188 @@
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import styles from '@frontend/components/Feedback.module.scss';
+import Button from '@common/components/Button';
+import classNames from 'classnames';
+import { useMemo, useState } from 'react';
+import FormProvider from '@common/components/form/FormProvider';
+import { Form, FormFieldTextArea } from '@common/components/form';
+import ButtonGroup from '@common/components/ButtonGroup';
+import feedbackService from '@frontend/services/feedbackService';
+import {
+  FeedbackRequest,
+  FeedbackResponse,
+} from '@common/services/types/feedback';
+import Yup from '@common/validation/yup';
+import { ObjectSchema } from 'yup';
+
+type BannerState = 'initial' | 'notUseful' | 'problemEncountered' | 'thanks';
+
+interface FormValues {
+  context?: string;
+  issue?: string;
+  intent?: string;
+}
+
+const feedbackLimit = 2000;
+
+export default function Feedback() {
+  const [bannerState, setBannerState] = useState<BannerState>('initial');
+  const [response, setResponse] = useState<FeedbackResponse | undefined>();
+
+  const handleUsefulFeedback = async () => {
+    await feedbackService.sendFeedback({
+      url: window.location.pathname,
+      userAgent: navigator.userAgent,
+      response: 'Useful',
+    });
+
+    setBannerState('thanks');
+  };
+
+  const cancel = () => {
+    setResponse(undefined);
+    setBannerState('initial');
+  };
+
+  const handleSubmit = async (values: FeedbackRequest) => {
+    await feedbackService.sendFeedback({
+      url: window.location.pathname,
+      userAgent: navigator.userAgent,
+      response: response as FeedbackResponse,
+      context: values.context,
+      issue: values.issue,
+      intent: values.intent,
+    });
+
+    setBannerState('thanks');
+  };
+
+  const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
+    return Yup.object({
+      context: Yup.string().max(
+        feedbackLimit,
+        `What were you doing must be ${feedbackLimit} characters or less`,
+      ),
+      issue: Yup.string().max(
+        feedbackLimit,
+        `What went wrong must  be ${feedbackLimit} characters or less`,
+      ),
+      intent: Yup.string().max(
+        feedbackLimit,
+        `What were you hoping to achieve must be ${feedbackLimit} characters or less`,
+      ),
+    });
+  }, []);
+
+  return (
+    <div className={classNames('govuk-width-container', styles.container)}>
+      <div className={styles.banner}>
+        {bannerState === 'initial' && (
+          <>
+            <div className={styles.promptQuestion}>
+              <h2 className={styles.heading}>Is this page useful?</h2>
+              <Button
+                className={styles.buttonYesNo}
+                variant="secondary"
+                onClick={handleUsefulFeedback}
+              >
+                Yes<VisuallyHidden> this page is useful</VisuallyHidden>
+              </Button>
+
+              <Button
+                className={styles.buttonYesNo}
+                variant="secondary"
+                ariaControls="feedbackFormContainer"
+                ariaExpanded={response === 'NotUseful'}
+                onClick={() => {
+                  setResponse('NotUseful');
+                  setBannerState('notUseful');
+                }}
+              >
+                No<VisuallyHidden> this page is not useful</VisuallyHidden>
+              </Button>
+            </div>
+
+            <div className={styles.reportContainer}>
+              <Button
+                className={styles.buttonReport}
+                variant="secondary"
+                ariaControls="feedbackFormContainer"
+                ariaExpanded={response === 'ProblemEncountered'}
+                onClick={() => {
+                  setResponse('ProblemEncountered');
+                  setBannerState('problemEncountered');
+                }}
+              >
+                Report a problem with this page
+              </Button>
+            </div>
+          </>
+        )}
+
+        {bannerState === 'thanks' && (
+          <div className={styles.promptQuestion} role="alert">
+            <p className={styles.heading}>Thank you for your feedback</p>
+          </div>
+        )}
+      </div>
+
+      <div
+        id="feedbackFormContainer"
+        className="govuk-!-padding-left-6 govuk-!-padding-right-6"
+        hidden={bannerState === 'initial' || bannerState === 'thanks'}
+      >
+        <h3 className="govuk-!-margin-top-5">
+          Help us improve Explore education statistics
+        </h3>
+        <p>
+          Don't include personal or financial information like your National
+          Insurance number or credit card details.
+        </p>
+
+        <FormProvider validationSchema={validationSchema}>
+          {({ formState }) => {
+            return (
+              <Form id="feedbackForm" onSubmit={handleSubmit}>
+                {response && (
+                  <FormFieldTextArea<FeedbackRequest>
+                    label="What were you doing?"
+                    name="context"
+                    rows={3}
+                    maxLength={2000}
+                  />
+                )}
+
+                {response === 'NotUseful' && (
+                  <FormFieldTextArea<FeedbackRequest>
+                    label="What were you hoping to achieve?"
+                    name="intent"
+                    rows={3}
+                    maxLength={2000}
+                  />
+                )}
+
+                {response === 'ProblemEncountered' && (
+                  <FormFieldTextArea<FeedbackRequest>
+                    label="What went wrong?"
+                    name="issue"
+                    rows={3}
+                    maxLength={2000}
+                  />
+                )}
+
+                <ButtonGroup>
+                  <Button type="submit" disabled={formState.isSubmitting}>
+                    Send
+                  </Button>
+                  <Button variant="secondary" onClick={cancel}>
+                    Cancel
+                  </Button>
+                </ButtonGroup>
+              </Form>
+            );
+          }}
+        </FormProvider>
+      </div>
+    </div>
+  );
+}

--- a/src/explore-education-statistics-frontend/src/components/Feedback.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Feedback.tsx
@@ -31,7 +31,7 @@ export default function Feedback() {
   const handleUsefulFeedback = async () => {
     await feedbackService.sendFeedback({
       url: window.location.pathname,
-      userAgent: navigator.userAgent,
+      userAgent: navigator.userAgent.substring(0, 250),
       response: 'Useful',
     });
 
@@ -44,10 +44,14 @@ export default function Feedback() {
   };
 
   const handleSubmit = async (values: FeedbackRequest) => {
+    if (!response) {
+      throw new Error('Response has not been set');
+    }
+
     await feedbackService.sendFeedback({
       url: window.location.pathname,
-      userAgent: navigator.userAgent,
-      response: response as FeedbackResponse,
+      userAgent: navigator.userAgent.substring(0, 250),
+      response,
       context: values.context,
       issue: values.issue,
       intent: values.intent,
@@ -148,7 +152,7 @@ export default function Feedback() {
                     label="What were you doing?"
                     name="context"
                     rows={3}
-                    maxLength={2000}
+                    maxLength={feedbackLimit}
                   />
                 )}
 
@@ -157,7 +161,7 @@ export default function Feedback() {
                     label="What were you hoping to achieve?"
                     name="intent"
                     rows={3}
-                    maxLength={2000}
+                    maxLength={feedbackLimit}
                   />
                 )}
 
@@ -166,7 +170,7 @@ export default function Feedback() {
                     label="What went wrong?"
                     name="issue"
                     rows={3}
-                    maxLength={2000}
+                    maxLength={feedbackLimit}
                   />
                 )}
 

--- a/src/explore-education-statistics-frontend/src/components/Page.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Page.tsx
@@ -8,6 +8,7 @@ import PageFooter from './PageFooter';
 import PageHeader from './PageHeader';
 import PageMeta, { PageMetaProps } from './PageMeta';
 import PageTitle from './PageTitle';
+import Feedback from './Feedback';
 
 type Props = {
   includeDefaultMetaTitle?: boolean;
@@ -74,6 +75,7 @@ const Page = ({
         </main>
       </div>
 
+      <Feedback />
       <PageFooter wide={wide} />
     </>
   );

--- a/src/explore-education-statistics-frontend/src/components/__tests__/Feedback.test.tsx
+++ b/src/explore-education-statistics-frontend/src/components/__tests__/Feedback.test.tsx
@@ -1,0 +1,158 @@
+import Feedback from '@frontend/components/Feedback';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import _feedbackService from '@frontend/services/feedbackService';
+import { FeedbackRequest } from '@common/services/types/feedback';
+
+jest.mock('@frontend/services/feedbackService');
+
+const feedbackService = jest.mocked(_feedbackService);
+
+describe('Feedback', () => {
+  test('renders initial state correctly', () => {
+    render(<Feedback />);
+
+    expect(screen.getByText('Is this page useful?')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Yes this page is useful' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'No this page is not useful' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Report a problem with this page' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('Help us improve Explore education statistics'),
+    ).not.toBeVisible();
+
+    expect(
+      screen.queryByText('Thank you for your feedback'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correctly and submits when "Yes" is selected', async () => {
+    const user = userEvent.setup();
+
+    render(<Feedback />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Yes this page is useful' }),
+    );
+
+    await waitFor(() => {
+      expect(feedbackService.sendFeedback).toHaveBeenCalledWith(
+        expect.objectContaining<Omit<FeedbackRequest, 'userAgent'>>({
+          url: '/',
+          response: 'Useful',
+        }),
+      );
+    });
+
+    expect(screen.getByText('Thank you for your feedback')).toBeInTheDocument();
+  });
+
+  test('renders correctly when "No" is selected', async () => {
+    const user = userEvent.setup();
+
+    render(<Feedback />);
+
+    expect(
+      screen.queryByLabelText('What were you doing?'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('What were you hoping to achieve?'),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'No this page is not useful' }),
+    );
+
+    expect(screen.getByLabelText('What were you doing?')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('What were you hoping to achieve?'),
+    ).toBeInTheDocument();
+  });
+
+  test('submits correctly when "No" is selected', async () => {
+    const user = userEvent.setup();
+
+    render(<Feedback />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'No this page is not useful' }),
+    );
+
+    const contextTextArea = screen.getByLabelText('What were you doing?');
+    const intentTextArea = screen.getByLabelText(
+      'What were you hoping to achieve?',
+    );
+
+    await user.type(contextTextArea, 'test context');
+    await user.type(intentTextArea, 'test intent');
+    await user.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => {
+      expect(feedbackService.sendFeedback).toHaveBeenCalledWith(
+        expect.objectContaining<Omit<FeedbackRequest, 'userAgent'>>({
+          url: '/',
+          response: 'NotUseful',
+          context: 'test context',
+          intent: 'test intent',
+        }),
+      );
+    });
+
+    expect(screen.getByText('Thank you for your feedback')).toBeInTheDocument();
+  });
+
+  test('renders correctly when "Report a problem with this page" is selected', async () => {
+    const user = userEvent.setup();
+
+    render(<Feedback />);
+
+    expect(
+      screen.queryByLabelText('What were you doing?'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('What went wrong?')).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Report a problem with this page' }),
+    );
+
+    expect(screen.getByLabelText('What were you doing?')).toBeInTheDocument();
+    expect(screen.getByLabelText('What went wrong?')).toBeInTheDocument();
+  });
+
+  test('submits correctly when "Report a problem with this page" is selected', async () => {
+    const user = userEvent.setup();
+
+    render(<Feedback />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Report a problem with this page' }),
+    );
+
+    const contextTextArea = screen.getByLabelText('What were you doing?');
+    const issueTextArea = screen.getByLabelText('What went wrong?');
+
+    await user.type(contextTextArea, 'test context');
+    await user.type(issueTextArea, 'test issue');
+    await user.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => {
+      expect(feedbackService.sendFeedback).toHaveBeenCalledWith(
+        expect.objectContaining<Omit<FeedbackRequest, 'userAgent'>>({
+          url: '/',
+          response: 'ProblemEncountered',
+          context: 'test context',
+          issue: 'test issue',
+        }),
+      );
+    });
+
+    expect(screen.getByText('Thank you for your feedback')).toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-frontend/src/services/feedbackService.ts
+++ b/src/explore-education-statistics-frontend/src/services/feedbackService.ts
@@ -1,0 +1,10 @@
+import { contentApi } from '@common/services/api';
+import { FeedbackRequest } from '@common/services/types/feedback';
+
+const feedbackService = {
+  sendFeedback(feedback: FeedbackRequest): Promise<void> {
+    return contentApi.post('/feedback', feedback);
+  },
+};
+
+export default feedbackService;


### PR DESCRIPTION
This PR includes two pieces of work:
1. a banner above the footer on each page of the public website
2. an administrator page to view received feedback

The first part allows users to quickly and easily share feedback on specific areas of the site, and the second provides a simple UI to view this feedback in the "Platform administration" area. This work is to help ensure the product owner and publishers are better informed of user interactions in order to aid decision making, and consider suggestions which may include changes to the platform or publication content.

NB. The administrator page appearance and functionality was a small piece of additional work added for convenience, so there were no designs or specs - I'm happy to consider any suggestions which may improve the UI or UX of this page. Also I've not included pagination, this can be added at a later date if required.

# Banner
![image](https://github.com/user-attachments/assets/697d4838-1151-41f1-80c3-db0dd6707613)

# Admin area
![image](https://github.com/user-attachments/assets/ffabd366-83c4-41ba-9082-529164b83fd3)