### PR TITLE
EES-5755: Add simple BAU glossary management page with button for clearing cache

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
@@ -40,6 +40,17 @@ const BauDashboardPage = () => {
             </p>
           </div>
         )}
+
+        {user?.permissions.isBauUser && (
+          <div className="govuk-grid-column-one-third">
+            <h3 className="govuk-heading-s govuk-!-margin-bottom-0">
+              <Link to="/administration/glossary">Manage glossary</Link>
+            </h3>
+            <p className="govuk-caption-m govuk-!-margin-top-1">
+              Clear glossary cache.
+            </p>
+          </div>
+        )}
       </div>
 
       <hr className="govuk-!-margin-top-9" />

--- a/src/explore-education-statistics-admin/src/pages/bau/GlossaryPage.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/bau/GlossaryPage.module.scss
@@ -1,0 +1,9 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.clearCacheButton {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: $govuk-success-colour;
+  font-weight: bold;
+}

--- a/src/explore-education-statistics-admin/src/pages/bau/GlossaryPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/GlossaryPage.tsx
@@ -1,0 +1,42 @@
+import Page from '@admin/components/Page';
+import React, { useState } from 'react';
+import Button from '@common/components/Button';
+import glossaryService from '@admin/services/glossaryService';
+import styles from './GlossaryPage.module.scss';
+
+const GlossaryPage = () => {
+  const [successMessage, setSuccessMessage] = useState('');
+
+  const clearGlossaryCache = async () => {
+    setSuccessMessage('Clearing cache...');
+    await glossaryService.clearCache();
+    setSuccessMessage('Cache cleared successfully');
+
+    setTimeout(() => {
+      setSuccessMessage('');
+    }, 5000);
+  };
+
+  return (
+    <Page
+      title="Glossary"
+      caption="Manage glossary"
+      wide
+      breadcrumbs={[
+        { name: 'Platform administration', link: '/administration' },
+        { name: 'Glossary' },
+      ]}
+    >
+      <div className={styles.clearCacheButton}>
+        <Button onClick={clearGlossaryCache} className="govuk-!-margin-0">
+          Clear glossary cache
+        </Button>
+        {successMessage && (
+          <span className="govuk-!-margin-0">{successMessage}</span>
+        )}
+      </div>
+    </Page>
+  );
+};
+
+export default GlossaryPage;

--- a/src/explore-education-statistics-admin/src/routes/administrationRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/administrationRoutes.ts
@@ -9,6 +9,7 @@ import UserInvitePage from '@admin/pages/users/UserInvitePage';
 import BoundaryDataPage from '@admin/pages/bau/BoundaryDataPage';
 import BoundaryLevelEditPage from '@admin/pages/bau/BoundaryLevelEditPage';
 import BoundaryDataUploadPage from '@admin/pages/bau/BoundaryDataUploadPage';
+import GlossaryPage from '@admin/pages/bau/GlossaryPage';
 
 export type BoundaryLevelEditPageRouteParams = {
   boundaryLevelId: number;
@@ -38,6 +39,13 @@ export const administrationBoundaryDataRoute: ProtectedRouteProps = {
 export const administrationBoundaryDataEditRoute: ProtectedRouteProps = {
   path: '/administration/boundary-data/boundary-level/:id',
   component: BoundaryLevelEditPage,
+  protectionAction: permissions => permissions.isBauUser,
+  exact: true,
+};
+
+export const administrationGlossaryRoute: ProtectedRouteProps = {
+  path: '/administration/glossary',
+  component: GlossaryPage,
   protectionAction: permissions => permissions.isBauUser,
   exact: true,
 };
@@ -89,6 +97,7 @@ const administrationRoutes = {
   administrationBoundaryDataRoute,
   administrationBoundaryDataEditRoute,
   administrationBoundaryDataUploadRoute,
+  administrationGlossaryRoute,
   administrationUsersRoute,
   administrationUserInviteRoute,
   administrationInvitedUsersRoute,

--- a/src/explore-education-statistics-admin/src/services/glossaryService.ts
+++ b/src/explore-education-statistics-admin/src/services/glossaryService.ts
@@ -11,6 +11,9 @@ const glossaryService = {
   getEntry(slug: string): Promise<GlossaryEntry> {
     return client.get(`/glossary-entries/${slug}`);
   },
+  clearCache(): Promise<Response> {
+    return client.put('bau/public-cache/glossary');
+  },
 };
 
 export default glossaryService;


### PR DESCRIPTION
This PR adds a page to the "Platform administration" section to handle managing the Glossary. The only element available at the moment is a button which calls an existing endpoint to clear the cache, which may seem overkill, however since there are plans to add editing features as part of EES-280 it made sense to create the new page in preparation.

![image](https://github.com/user-attachments/assets/709d4cab-2a6c-4418-99b3-ca3d72bcc1ce)