### PR TITLE
EES-5763 Reinstate DataSetFileMeta.GeographicLevels

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -1581,6 +1581,8 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                         .WithType(FileType.Data)
                         .WithDataSetFileVersionGeographicLevels([GeographicLevel.Country, GeographicLevel.LocalAuthority])
                         .WithDataSetFileMeta(_fixture.DefaultDataSetFileMeta()
+                            .WithGeographicLevels(
+                                [GeographicLevel.Country.GetEnumValue(), GeographicLevel.LocalAuthority.GetEnumValue()]) // TODO: EES-5765
                             .WithTimePeriodRange(
                                 _fixture.DefaultTimePeriodRangeMeta()
                                     .WithStart("2000", TimeIdentifier.AcademicYear)
@@ -1626,7 +1628,9 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
 
                 var originalMeta = releaseFile.File.DataSetFileMeta;
 
-                Assert.Null(originalMeta!.GeographicLevels); // TODO: remove in EES-5750
+                Assert.True(ComparerUtils.SequencesAreEqualIgnoringOrder(
+                    [GeographicLevel.Country.GetEnumLabel(), GeographicLevel.LocalAuthority.GetEnumLabel()], // TODO: EES-5765
+                    dataSetFileMetaViewModel.GeographicLevels));
 
                 Assert.Equal(new DataSetFileTimePeriodRangeViewModel
                 {
@@ -2074,8 +2078,6 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
 
             Assert.Equal([
                     GeographicLevel.Country.GetEnumLabel(),
-                    GeographicLevel.LocalAuthority.GetEnumLabel(),
-                    GeographicLevel.LocalAuthorityDistrict.GetEnumLabel()
                 ],
                 viewModel.File.Meta.GeographicLevels);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
@@ -16,6 +17,7 @@ public static class DataSetFileMetaGeneratorExtensions
 
     public static InstanceSetters<DataSetFileMeta> SetDefaults(this InstanceSetters<DataSetFileMeta> setters)
         => setters
+            .SetGeographicLevels([GeographicLevel.Country.GetEnumValue()]) // TODO: EES-5765
             .SetTimePeriodRange(new TimePeriodRangeMeta
             {
                 Start = new TimePeriodRangeBoundMeta { TimeIdentifier = TimeIdentifier.CalendarYear, Period = "2000", },
@@ -36,6 +38,11 @@ public static class DataSetFileMetaGeneratorExtensions
                 },
             ]);
 
+    public static Generator<DataSetFileMeta> WithGeographicLevels(
+        this Generator<DataSetFileMeta> generator,
+        List<string> geographicLevels) // TODO: EES-5765 type
+        => generator.ForInstance(s => s.SetGeographicLevels(geographicLevels));
+
     public static Generator<DataSetFileMeta> WithTimePeriodRange(
         this Generator<DataSetFileMeta> generator,
         TimePeriodRangeMeta timePeriodRange)
@@ -50,6 +57,11 @@ public static class DataSetFileMetaGeneratorExtensions
         this Generator<DataSetFileMeta> generator,
         List<IndicatorMeta> indicators)
         => generator.ForInstance(s => s.SetIndicators(indicators));
+
+    public static InstanceSetters<DataSetFileMeta> SetGeographicLevels(
+        this InstanceSetters<DataSetFileMeta> setters,
+        List<string> geographicLevels) // TODO: EES-5765 type
+        => setters.Set(s => s.GeographicLevels, geographicLevels);
 
     public static InstanceSetters<DataSetFileMeta> SetTimePeriodRange(
         this InstanceSetters<DataSetFileMeta> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/FileGeneratorExtensions.cs
@@ -117,7 +117,7 @@ public static class FileGeneratorExtensions
             .SetContentType("text/csv")
             .SetDefault(f => f.DataSetFileId)
             .Set(f => f.DataSetFileMeta, (_, _, context) => context.Fixture.DefaultDataSetFileMeta())
-            .SetDataSetFileVersionGeographicLevels([GeographicLevel.Country, GeographicLevel.LocalAuthority, GeographicLevel.LocalAuthorityDistrict]);
+            .SetDataSetFileVersionGeographicLevels([GeographicLevel.Country]);
 
     public static InstanceSetters<File> SetMetaFileDefaults(this InstanceSetters<File> setters)
         => setters

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -9,10 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 public class DataSetFileMeta
 {
-    // NOTE: GeographicLevels aren't in DataSetFileMeta JSON because they need to queryable
-    // So that meta data lives in DataSetFileVersionGeographicLevels
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public List<string>? GeographicLevels { get; set; } // TODO: remove in EES-5750
+    public List<string>? GeographicLevels { get; set; }
+    //[JsonConverter(typeof(GeographicLevelsListJsonConverter))] // TODO: EES-5765
+    //public required List<GeographicLevel> GeographicLevels { get; set; }
 
     public required TimePeriodRangeMeta TimePeriodRange { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public DataSetFileMeta? DataSetFileMeta { get; set; }
 
-        public bool DataSetFileMetaGeogLvlMigrated { get; set; } = true;
+        public bool DataSetFileMetaGeogLvlMigrated { get; set; } = true; // EES-5765
 
         public List<DataSetFileFilterHierarchy>? FilterHierarchies { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -299,6 +299,11 @@ public class ProcessorStage3Tests
 
             Assert.NotNull(file.DataSetFileMeta);
 
+            // Checking against contents of small-csv.csv in Resources directory / _subject
+            Assert.NotNull(file.DataSetFileMeta.GeographicLevels);
+            var metaGeographicLevel = Assert.Single(file.DataSetFileMeta.GeographicLevels);
+            Assert.Equal(GeographicLevel.LocalAuthority.GetEnumValue(), metaGeographicLevel); // TODO: EES-5765
+
             Assert.Equal(TimeIdentifier.CalendarYear,
                 file.DataSetFileMeta.TimePeriodRange.Start.TimeIdentifier);
             Assert.Equal(TimeIdentifier.CalendarYear,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
-using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
@@ -14,7 +13,6 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -306,6 +304,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
 
                 Assert.NotNull(updatedFile.DataSetFileMeta);
                 var meta = updatedFile.DataSetFileMeta;
+
+                Assert.Equal(3, meta.GeographicLevels!.Count);
+                Assert.Contains(GeographicLevel.Country.GetEnumValue(), meta.GeographicLevels); // TODO: EES-5765
+                Assert.Contains(GeographicLevel.LocalAuthority.GetEnumValue(), meta.GeographicLevels);
+                Assert.Contains(GeographicLevel.Region.GetEnumValue(), meta.GeographicLevels);
 
                 Assert.Equal("2000", meta.TimePeriodRange.Start.Period);
                 Assert.Equal(TimeIdentifier.April, meta.TimePeriodRange.Start.TimeIdentifier);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -207,7 +208,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
             var dataSetFileMeta = new DataSetFileMeta
             {
-                GeographicLevels = null, // TODO: remove in EES-5750
+                GeographicLevels = geographicLevels
+                    .Select(gl => gl.GetEnumValue())
+                    .ToList(),
                 TimePeriodRange = new TimePeriodRangeMeta
                 {
                     Start = timePeriods.First(),


### PR DESCRIPTION
This PR creates an endpoint to put geographic levels back in Files.DataSetFilesMeta and uses those geographic levels in `ListDataSetFiles` due to the issues recorded in EES-5750.

The migratoin endpoint only needs to be run against Dev and Test - geographic levels weren't removed from DataSetFileMeta on preprod or prod.

Final cleanup will happen in EES-5765