### PR TITLE
EES-5628 - Adding the ability to add an optional `Label` when creating a new Release (BE part)

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -36,7 +36,7 @@ using ValidationUtils = GovUk.Education.ExploreEducationStatistics.Common.Valida
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 {
-    public abstract class ReleasesControllerUnitTests
+    public class ReleasesControllerUnitTests
     {
         private readonly Guid _releaseVersionId = Guid.NewGuid();
         private readonly Guid _publicationId = Guid.NewGuid();
@@ -882,7 +882,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
                 var validationProblem = response.AssertValidationProblem();
 
-                var error = Assert.Single(validationProblem.Errors); // Need to change the code to stop throwing an error and return a Validation Result instead
+                var error = Assert.Single(validationProblem.Errors);
+
+                Assert.Equal(UpdateRequestForPublishedReleaseInvalid.ToString(), error.Code);
             }
 
             [Fact]
@@ -908,7 +910,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
                 var validationProblem = response.AssertValidationProblem();
 
-                var error = Assert.Single(validationProblem.Errors); // Need to change the code to stop throwing an error and return a Validation Result instead
+                var error = Assert.Single(validationProblem.Errors);
+
+                Assert.Equal(UpdateRequestForPublishedReleaseInvalid.ToString(), error.Code);
             }
 
             [Fact]
@@ -934,7 +938,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
                 var validationProblem = response.AssertValidationProblem();
 
-                var error = Assert.Single(validationProblem.Errors); // Need to change the code to stop throwing an error and return a Validation Result instead
+                var error = Assert.Single(validationProblem.Errors);
+
+                Assert.Equal(UpdateRequestForPublishedReleaseInvalid.ToString(), error.Code);
             }
 
             [Fact]
@@ -1036,11 +1042,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 string existingReleaseSlug)
             {
                 Publication publication = DataFixture.DefaultPublication()
-                    .WithReleases([
+                    .WithReleases(
                         DataFixture
                             .DefaultRelease(publishedVersions: 0, draftVersion: true)
                             .WithSlug(existingReleaseSlug)
-                        ]);
+                            .GenerateList(2)
+                        );
 
                 await TestApp.AddTestData<ContentDbContext>(
                     context => context.Publications.Add(publication));

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -713,7 +713,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 Assert.Equal(SlugNotUnique.ToString(), error.Code);
             }
 
-            // Add test for character limit on Label of 50
+            [Fact]
+            public async Task LabelOver50Characters()
+            {
+                Publication publication = DataFixture.DefaultPublication();
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var response = await CreateRelease(
+                    publicationId: publication.Id,
+                    year: 2020,
+                    timePeriodCoverage: TimeIdentifier.AcademicYear,
+                    label: new string('a', 51));
+
+                var validationProblem = response.AssertValidationProblem();
+
+                var error = Assert.Single(validationProblem.Errors);
+
+                Assert.Equal($"The field {nameof(ReleaseCreateRequest.Label)} must be a string or array type with a maximum length of '50'.", error.Message);
+                Assert.Equal(nameof(ReleaseCreateRequest.Label), error.Path);
+            }
 
             private WebApplicationFactory<TestStartup> BuildApp(
                 ClaimsPrincipal? user = null)
@@ -1065,7 +1085,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 Assert.Equal(SlugNotUnique.ToString(), error.Code);
             }
 
-            // Add test for character limit on Label of 50
+            [Fact]
+            public async Task LabelOver50Characters()
+            {
+                Publication publication = DataFixture.DefaultPublication()
+                    .WithReleases([
+                            DataFixture
+                                .DefaultRelease(publishedVersions: 0, draftVersion: true)
+                        ]);
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var response = await UpdateRelease(
+                    releaseVersionId: publication.Releases[0].Versions[0].Id,
+                    year: 2020,
+                    timePeriodCoverage: TimeIdentifier.AcademicYear,
+                    label: new string('a', 51));
+
+                var validationProblem = response.AssertValidationProblem();
+
+                var error = Assert.Single(validationProblem.Errors);
+
+                Assert.Equal($"The field {nameof(ReleaseCreateRequest.Label)} must be a string or array type with a maximum length of '50'.", error.Message);
+                Assert.Equal(nameof(ReleaseCreateRequest.Label), error.Path);
+            }
 
             private WebApplicationFactory<TestStartup> BuildApp(
                 ClaimsPrincipal? user = null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -3,17 +3,27 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Fixture;
+using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
@@ -22,10 +32,11 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Services.Collecti
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
 using ErrorViewModel = GovUk.Education.ExploreEducationStatistics.Common.ViewModels.ErrorViewModel;
+using ValidationUtils = GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 {
-    public class ReleasesControllerTests
+    public abstract class ReleasesControllerUnitTests
     {
         private readonly Guid _releaseVersionId = Guid.NewGuid();
         private readonly Guid _publicationId = Guid.NewGuid();
@@ -541,6 +552,542 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 releaseStatusService ?? Mock.Of<IReleasePublishingStatusService>(Strict),
                 releaseChecklistService ?? Mock.Of<IReleaseChecklistService>(Strict),
                 importService ?? Mock.Of<IDataImportService>(Strict));
+        }
+    }
+
+    public abstract class ReleasesControllerIntegrationTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+    {
+        public class CreateReleaseTests(TestApplicationFactory testApp) : ReleasesControllerIntegrationTests(testApp)
+        {
+            [Theory]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "initial", "initial", "2020-21-initial")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "Initial", "Initial", "2020-21-initial")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, " initial", "initial", "2020-21-initial")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "initial ", "initial", "2020-21-initial")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "initial 2", "initial 2", "2020-21-initial-2")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "initial  2", "initial  2", "2020-21-initial-2")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "", null, "2020-21")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, " ", null, "2020-21")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "  ", null, "2020-21")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, null, null, "2020-21")]
+            public async Task Success(
+                int year,
+                TimeIdentifier timePeriodCoverage,
+                string? label,
+                string? expectedLabel,
+                string expectedSlug)
+            {
+                Publication publication = DataFixture.DefaultPublication();
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var response = await CreateRelease(
+                    publicationId: publication.Id,
+                    year: year,
+                    timePeriodCoverage: timePeriodCoverage,
+                    label: label);
+
+                var viewModel = response.AssertOk<ReleaseViewModel>();
+
+                var contentDbContext = TestApp.GetDbContext<ContentDbContext>();
+
+                var updatedPublication = contentDbContext.Publications
+                    .Include(p => p.Releases)
+                    .ThenInclude(r => r.Versions)
+                    .Single(p => p.Id == publication.Id);
+
+                Assert.Equal(publication.Id, viewModel.PublicationId);
+                Assert.Equal(year, viewModel.Year);
+                Assert.Equal(timePeriodCoverage, viewModel.TimePeriodCoverage);
+                Assert.Equal(expectedSlug, viewModel.Slug);
+
+                var release = Assert.Single(updatedPublication.Releases);
+                Assert.Equal(publication.Id, release.PublicationId);
+                Assert.Equal(year, release.Year);
+                Assert.Equal(timePeriodCoverage, release.TimePeriodCoverage);
+                Assert.Equal(expectedLabel, release.Label);
+                Assert.Equal(expectedSlug, release.Slug);
+
+                var releaseVersion = Assert.Single(release.Versions);
+                Assert.Equal(publication.Id, releaseVersion.PublicationId);
+                Assert.Equal(release.Id, releaseVersion.ReleaseId);
+                Assert.Equal(year.ToString(), releaseVersion.ReleaseName);
+                Assert.Equal(year, releaseVersion.Year);
+                Assert.Equal(timePeriodCoverage, releaseVersion.TimePeriodCoverage);
+                Assert.Equal(expectedSlug, releaseVersion.Slug);
+
+                var releaseSeriesItem = Assert.Single(updatedPublication.ReleaseSeries);
+                Assert.Equal(release.Id, releaseSeriesItem.ReleaseId);
+            }
+
+            [Fact]
+            public async Task PublicationNotFound()
+            {
+                var response = await CreateRelease(
+                    publicationId: Guid.NewGuid(),
+                    year: 2020,
+                    timePeriodCoverage: TimeIdentifier.AcademicYear,
+                    label: null);
+
+                response.AssertNotFound();
+            }
+
+            [Fact]
+            public async Task UserDoesNotHavePermission()
+            {
+                Publication publication = DataFixture.DefaultPublication();
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var client = BuildApp(DataFixture.AuthenticatedUser()).CreateClient();
+
+                var response = await CreateRelease(
+                    publicationId: publication.Id,
+                    year: 2020,
+                    timePeriodCoverage: TimeIdentifier.AcademicYear,
+                    label: null,
+                    client: client);
+
+                response.AssertForbidden();
+            }
+
+            [Fact]
+            public async Task ReleaseTypeInvalid()
+            {
+                Publication publication = DataFixture.DefaultPublication();
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var response = await CreateRelease(
+                    publicationId: publication.Id,
+                    year: 2020,
+                    timePeriodCoverage: TimeIdentifier.AcademicYear,
+                    label: null,
+                    type: ReleaseType.ExperimentalStatistics);
+
+                var validationProblem = response.AssertValidationProblem();
+
+                var error = Assert.Single(validationProblem.Errors);
+
+                Assert.Equal(ValidationErrorMessages.ReleaseTypeInvalid.ToString(), error.Code);
+            }
+
+            [Theory]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "initial", "2020-21-initial")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "Initial", "2020-21-initial")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, " initial ", "2020-21-initial")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, null, "2020-21")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "", "2020-21")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, " ", "2020-21")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "  ", "2020-21")]
+            [InlineData(2020, TimeIdentifier.AcademicYearQ1, "initial", "2020-21-q1-initial")]
+            public async Task SlugNotUniqueToPublication(
+                int year,
+                TimeIdentifier timePeriodCoverage,
+                string? label,
+                string existingReleaseSlug)
+            {
+                Publication publication = DataFixture.DefaultPublication()
+                    .WithReleases([
+                        DataFixture
+                            .DefaultRelease(publishedVersions: 1)
+                            .WithSlug(existingReleaseSlug)
+                        ]);
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var response = await CreateRelease(
+                    publicationId: publication.Id,
+                    year: year,
+                    timePeriodCoverage: timePeriodCoverage,
+                    label: label);
+
+                var validationProblem = response.AssertValidationProblem();
+
+                var error = Assert.Single(validationProblem.Errors);
+
+                Assert.Equal(SlugNotUnique.ToString(), error.Code);
+            }
+
+            // Add test for character limit on Label of 50
+
+            private WebApplicationFactory<TestStartup> BuildApp(
+                ClaimsPrincipal? user = null)
+            {
+                return TestApp.SetUser(user ?? DataFixture.BauUser());
+            }
+
+            private async Task<HttpResponseMessage> CreateRelease(
+                Guid publicationId,
+                int year,
+                TimeIdentifier timePeriodCoverage,
+                string? label = null,
+                ReleaseType? type = ReleaseType.OfficialStatistics,
+                HttpClient? client = null)
+            {
+                client ??= BuildApp().CreateClient();
+
+                var request = new
+                {
+                    Type = type,
+                    Year = year,
+                    TimePeriodCoverage = new { Value = timePeriodCoverage.GetEnumValue() },
+                    Label = label,
+                };
+
+                return await client.PostAsJsonAsync($"api/publications/{publicationId}/releases", request);
+            }
+        }
+
+        public class UpdateReleaseTests(TestApplicationFactory testApp) : ReleasesControllerIntegrationTests(testApp)
+        {
+            [Fact]
+            public async Task Success()
+            {
+                Publication publication = DataFixture.DefaultPublication()
+                    .WithReleases(
+                        [
+                            DataFixture
+                                .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2020)
+                                .WithTimePeriodCoverage(TimeIdentifier.AcademicYear)
+                                .WithLabel(null)
+                        ]);
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var newYear = 2021;
+                var newTimePeriodCoverage = TimeIdentifier.AcademicYearQ1;
+                var newLabel = "initial";
+                var newPreReleaseAccessList = "new-list";
+                var expectedNewSlug = "2021-22-q1-initial";
+
+                var response = await UpdateRelease(
+                    releaseVersionId: publication.Releases[0].Versions[0].Id,
+                    year: newYear,
+                    timePeriodCoverage: newTimePeriodCoverage,
+                    label: newLabel,
+                    preReleaseAccessList: newPreReleaseAccessList);
+
+                var viewModel = response.AssertOk<ReleaseViewModel>();
+
+                var contentDbContext = TestApp.GetDbContext<ContentDbContext>();
+
+                var updatedPublication = contentDbContext.Publications
+                    .Include(p => p.Releases)
+                    .ThenInclude(r => r.Versions)
+                    .Single(p => p.Id == publication.Id);
+
+                Assert.Equal(publication.Id, viewModel.PublicationId);
+                Assert.Equal(newYear, viewModel.Year);
+                Assert.Equal(newTimePeriodCoverage, viewModel.TimePeriodCoverage);
+                Assert.Equal(expectedNewSlug, viewModel.Slug);
+
+                var release = Assert.Single(updatedPublication.Releases);
+                Assert.Equal(publication.Id, release.PublicationId);
+                Assert.Equal(newYear, release.Year);
+                Assert.Equal(newTimePeriodCoverage, release.TimePeriodCoverage);
+                Assert.Equal(newLabel, release.Label);
+                Assert.Equal(expectedNewSlug, release.Slug);
+
+                var releaseVersion = Assert.Single(release.Versions);
+                Assert.Equal(publication.Id, releaseVersion.PublicationId);
+                Assert.Equal(release.Id, releaseVersion.ReleaseId);
+                Assert.Equal(newYear.ToString(), releaseVersion.ReleaseName);
+                Assert.Equal(newYear, releaseVersion.Year);
+                Assert.Equal(newTimePeriodCoverage, releaseVersion.TimePeriodCoverage);
+                Assert.Equal(expectedNewSlug, releaseVersion.Slug);
+
+                var releaseSeriesItem = Assert.Single(updatedPublication.ReleaseSeries);
+                Assert.Equal(release.Id, releaseSeriesItem.ReleaseId);
+            }
+
+            [Theory]
+            [InlineData("initial", "initial", "2020-21-initial")]
+            [InlineData("Initial", "Initial", "2020-21-initial")]
+            [InlineData(" initial", "initial", "2020-21-initial")]
+            [InlineData("initial ", "initial", "2020-21-initial")]
+            [InlineData("initial 2", "initial 2", "2020-21-initial-2")]
+            [InlineData("initial  2", "initial  2", "2020-21-initial-2")]
+            [InlineData("", null, "2020-21")]
+            [InlineData(" ", null, "2020-21")]
+            [InlineData("  ", null, "2020-21")]
+            [InlineData(null, null, "2020-21")]
+            public async Task LabelAndSlugChanged(
+                string? newLabel,
+                string? expectedNewLabel,
+                string expectedNewSlug)
+            {
+                Publication publication = DataFixture.DefaultPublication()
+                    .WithReleases(
+                        [
+                            DataFixture
+                                .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2020)
+                                .WithTimePeriodCoverage(TimeIdentifier.AcademicYear)
+                                .WithLabel(null)
+                        ]);
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var response = await UpdateRelease(
+                    releaseVersionId: publication.Releases[0].Versions[0].Id,
+                    year: 2020,
+                    timePeriodCoverage: TimeIdentifier.AcademicYear,
+                    label: newLabel);
+
+                var viewModel = response.AssertOk<ReleaseViewModel>();
+
+                var contentDbContext = TestApp.GetDbContext<ContentDbContext>();
+
+                var updatedPublication = contentDbContext.Publications
+                    .Include(p => p.Releases)
+                    .ThenInclude(r => r.Versions)
+                    .Single(p => p.Id == publication.Id);
+
+                Assert.Equal(expectedNewSlug, viewModel.Slug);
+
+                var release = Assert.Single(updatedPublication.Releases);
+                Assert.Equal(expectedNewLabel, release.Label);
+                Assert.Equal(expectedNewSlug, release.Slug);
+
+                var releaseVersion = Assert.Single(release.Versions);
+                Assert.Equal(expectedNewSlug, releaseVersion.Slug);
+            }
+
+            [Fact]
+            public async Task ReleaseVersionNotFirstVersion_YearChanged()
+            {
+                Publication publication = DataFixture.DefaultPublication()
+                    .WithReleases(
+                        DataFixture
+                            .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2020)
+                            .WithTimePeriodCoverage(TimeIdentifier.AcademicYear)
+                            .WithLabel(null)
+                            .GenerateList(2)
+                        );
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var response = await UpdateRelease(
+                    releaseVersionId: publication.Releases[0].Versions[1].Id,
+                    year: 2021,
+                    timePeriodCoverage: TimeIdentifier.AcademicYear,
+                    label: null);
+
+                var validationProblem = response.AssertValidationProblem();
+
+                var error = Assert.Single(validationProblem.Errors); // Need to change the code to stop throwing an error and return a Validation Result instead
+            }
+
+            [Fact]
+            public async Task ReleaseVersionNotFirstVersion_TimePeriodCoverageChanged()
+            {
+                Publication publication = DataFixture.DefaultPublication()
+                    .WithReleases(
+                        DataFixture
+                            .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2020)
+                            .WithTimePeriodCoverage(TimeIdentifier.AcademicYear)
+                            .WithLabel(null)
+                            .GenerateList(2)
+                        );
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var response = await UpdateRelease(
+                    releaseVersionId: publication.Releases[0].Versions[1].Id,
+                    year: 2020,
+                    timePeriodCoverage: TimeIdentifier.AcademicYearQ1,
+                    label: null);
+
+                var validationProblem = response.AssertValidationProblem();
+
+                var error = Assert.Single(validationProblem.Errors); // Need to change the code to stop throwing an error and return a Validation Result instead
+            }
+
+            [Fact]
+            public async Task ReleaseVersionNotFirstVersion_LabelChanged()
+            {
+                Publication publication = DataFixture.DefaultPublication()
+                    .WithReleases(
+                        DataFixture
+                            .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2020)
+                            .WithTimePeriodCoverage(TimeIdentifier.AcademicYear)
+                            .WithLabel(null)
+                            .GenerateList(2)
+                        );
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var response = await UpdateRelease(
+                    releaseVersionId: publication.Releases[0].Versions[1].Id,
+                    year: 2020,
+                    timePeriodCoverage: TimeIdentifier.AcademicYear,
+                    label: "initial");
+
+                var validationProblem = response.AssertValidationProblem();
+
+                var error = Assert.Single(validationProblem.Errors); // Need to change the code to stop throwing an error and return a Validation Result instead
+            }
+
+            [Fact]
+            public async Task ReleaseVersionIsPublished()
+            {
+                Publication publication = DataFixture.DefaultPublication()
+                    .WithReleases([
+                        DataFixture
+                            .DefaultRelease(publishedVersions: 1)
+                        ]);
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var response = await UpdateRelease(
+                    releaseVersionId: publication.Releases[0].Versions[0].Id,
+                    year: 2020,
+                    timePeriodCoverage: TimeIdentifier.AcademicYear,
+                    label: null);
+
+                response.AssertForbidden();
+            }
+
+            [Fact]
+            public async Task ReleaseVersionNotFound()
+            {
+                var response = await UpdateRelease(
+                    releaseVersionId: Guid.NewGuid(),
+                    year: 2020,
+                    timePeriodCoverage: TimeIdentifier.AcademicYear,
+                    label: null);
+
+                response.AssertNotFound();
+            }
+
+            [Fact]
+            public async Task UserDoesNotHavePermission()
+            {
+                Publication publication = DataFixture.DefaultPublication()
+                    .WithReleases([
+                        DataFixture
+                            .DefaultRelease(publishedVersions: 0, draftVersion: true)
+                        ]);
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var client = BuildApp(DataFixture.AuthenticatedUser()).CreateClient();
+
+                var response = await UpdateRelease(
+                    releaseVersionId: publication.Releases[0].Versions[0].Id,
+                    year: 2020,
+                    timePeriodCoverage: TimeIdentifier.AcademicYear,
+                    label: null,
+                    client: client);
+
+                response.AssertForbidden();
+            }
+
+            [Fact]
+            public async Task ReleaseTypeInvalid()
+            {
+                Publication publication = DataFixture.DefaultPublication()
+                    .WithReleases([
+                        DataFixture
+                            .DefaultRelease(publishedVersions: 0, draftVersion: true)
+                        ]);
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var response = await UpdateRelease(
+                    releaseVersionId: publication.Releases[0].Versions[0].Id,
+                    year: 2020,
+                    timePeriodCoverage: TimeIdentifier.AcademicYear,
+                    label: null,
+                    type: ReleaseType.ExperimentalStatistics);
+
+                var validationProblem = response.AssertValidationProblem();
+
+                var error = Assert.Single(validationProblem.Errors);
+
+                Assert.Equal(ValidationErrorMessages.ReleaseTypeInvalid.ToString(), error.Code);
+            }
+
+            [Theory]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "initial", "2020-21-initial")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "Initial", "2020-21-initial")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, " initial ", "2020-21-initial")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, null, "2020-21")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "", "2020-21")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, " ", "2020-21")]
+            [InlineData(2020, TimeIdentifier.AcademicYear, "  ", "2020-21")]
+            [InlineData(2020, TimeIdentifier.AcademicYearQ1, "initial", "2020-21-q1-initial")]
+            public async Task SlugNotUniqueToPublication(
+                int year,
+                TimeIdentifier timePeriodCoverage,
+                string? label,
+                string existingReleaseSlug)
+            {
+                Publication publication = DataFixture.DefaultPublication()
+                    .WithReleases([
+                        DataFixture
+                            .DefaultRelease(publishedVersions: 0, draftVersion: true)
+                            .WithSlug(existingReleaseSlug)
+                        ]);
+
+                await TestApp.AddTestData<ContentDbContext>(
+                    context => context.Publications.Add(publication));
+
+                var response = await UpdateRelease(
+                    releaseVersionId: publication.Releases[0].Versions[0].Id,
+                    year: year,
+                    timePeriodCoverage: timePeriodCoverage,
+                    label: label);
+
+                var validationProblem = response.AssertValidationProblem();
+
+                var error = Assert.Single(validationProblem.Errors);
+
+                Assert.Equal(SlugNotUnique.ToString(), error.Code);
+            }
+
+            // Add test for character limit on Label of 50
+
+            private WebApplicationFactory<TestStartup> BuildApp(
+                ClaimsPrincipal? user = null)
+            {
+                return TestApp.SetUser(user ?? DataFixture.BauUser());
+            }
+
+            private async Task<HttpResponseMessage> UpdateRelease(
+                Guid releaseVersionId,
+                int year,
+                TimeIdentifier timePeriodCoverage,
+                string? label = null,
+                ReleaseType? type = ReleaseType.OfficialStatistics,
+                string? preReleaseAccessList = "",
+                HttpClient? client = null)
+            {
+                client ??= BuildApp().CreateClient();
+
+                var request = new
+                {
+                    Type = type,
+                    Year = year,
+                    TimePeriodCoverage = new { Value = timePeriodCoverage.GetEnumValue() },
+                    Label = label,
+                    PreReleaseAccessList = preReleaseAccessList
+                };
+
+                return await client.PutAsJsonAsync($"api/releases/{releaseVersionId}", request);
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Fixture/TestApplicationFactory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Fixture/TestApplicationFactory.cs
@@ -47,8 +47,7 @@ public class TestApplicationFactory : TestApplicationFactory<TestStartup>
                         options =>
                         {
                             options.UseNpgsql(
-                                _postgreSqlContainer.GetConnectionString(),
-                                psqlOptions => psqlOptions.EnableRetryOnFailure());
+                                _postgreSqlContainer.GetConnectionString());
                         });
 
                 using var serviceScope = services.BuildServiceProvider()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Fixture/TestApplicationFactory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Fixture/TestApplicationFactory.cs
@@ -2,6 +2,8 @@
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -38,13 +40,16 @@ public class TestApplicationFactory : TestApplicationFactory<TestStartup>
             .CreateHostBuilder()
             .ConfigureServices(services =>
             {
-                services.AddDbContext<PublicDataDbContext>(
-                    options =>
-                    {
-                        options.UseNpgsql(
-                            _postgreSqlContainer.GetConnectionString(),
-                            psqlOptions => psqlOptions.EnableRetryOnFailure());
-                    });
+                services
+                    .UseInMemoryDbContext<ContentDbContext>()
+                    .UseInMemoryDbContext<StatisticsDbContext>()
+                    .AddDbContext<PublicDataDbContext>(
+                        options =>
+                        {
+                            options.UseNpgsql(
+                                _postgreSqlContainer.GetConnectionString(),
+                                psqlOptions => psqlOptions.EnableRetryOnFailure());
+                        });
 
                 using var serviceScope = services.BuildServiceProvider()
                     .GetRequiredService<IServiceScopeFactory>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -69,7 +69,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .AssertForbidden(
                     userService =>
                     {
-                        var service = BuildReleaseService(userService.Object);
+                        using var contextDbContext = InMemoryApplicationDbContext();
+                        contextDbContext.Publications.Add(Publication);
+                        contextDbContext.SaveChangesAsync();
+
+                        var service = BuildReleaseService(
+                            context: contextDbContext,
+                            userService: userService.Object);
+
                         return service.CreateRelease(
                             new ReleaseCreateRequest
                             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseRequests.cs
@@ -20,7 +20,7 @@ public record ReleaseCreateRequest
     [JsonConverter(typeof(TimeIdentifierJsonConverter))]
     public TimeIdentifier TimePeriodCoverage { get; init; }
 
-    public string Slug => CreateSlug(year: Year, timePeriodCoverage: TimePeriodCoverage, label: Label);
+    public string Slug => CreateReleaseSlug(year: Year, timePeriodCoverage: TimePeriodCoverage, label: Label);
 
     [Range(1000, 9999)]
     public int Year { get; init; }
@@ -42,7 +42,7 @@ public record ReleaseUpdateRequest
 
     public string PreReleaseAccessList { get; init; } = string.Empty;
 
-    public string Slug => CreateSlug(year: Year, timePeriodCoverage: TimePeriodCoverage, label: Label);
+    public string Slug => CreateReleaseSlug(year: Year, timePeriodCoverage: TimePeriodCoverage, label: Label);
 
     [Range(1000, 9999)]
     public int Year { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseRequests.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.ComponentModel.DataAnnotations;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
@@ -6,7 +6,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.NamingUtils;
-using static GovUk.Education.ExploreEducationStatistics.Common.Utils.TimePeriodLabelFormatter;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
@@ -21,12 +20,13 @@ public record ReleaseCreateRequest
     [JsonConverter(typeof(TimeIdentifierJsonConverter))]
     public TimeIdentifier TimePeriodCoverage { get; init; }
 
-    public string Slug => SlugFromTitle(Title);
-
-    private string Title => Format(Year, TimePeriodCoverage);
+    public string Slug => CreateSlug(year: Year, timePeriodCoverage: TimePeriodCoverage, label: Label);
 
     [Range(1000, 9999)]
     public int Year { get; init; }
+
+    [MaxLength(50)]
+    public string? Label { get; init; }
 
     public Guid? TemplateReleaseId { get; init; }
 }
@@ -42,10 +42,11 @@ public record ReleaseUpdateRequest
 
     public string PreReleaseAccessList { get; init; } = string.Empty;
 
-    public string Slug => SlugFromTitle(Title);
-
-    private string Title => Format(Year, TimePeriodCoverage);
+    public string Slug => CreateSlug(year: Year, timePeriodCoverage: TimePeriodCoverage, label: Label);
 
     [Range(1000, 9999)]
     public int Year { get; init; }
+
+    [MaxLength(50)]
+    public string? Label { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -831,11 +831,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             var labelChanged = releaseVersion.Release.Label != request.Label;
 
             return yearChanged || timePeriodCoverageChanged || labelChanged
-                ? throw new ArgumentException(
-                    $"Cannot update '{nameof(request.Year)}', '{nameof(request.TimePeriodCoverage)}' or '{nameof(request.Label)}' for a release that has already been published",
-                    nameof(request))
+                ? ValidationActionResult(UpdateRequestForPublishedReleaseInvalid)
                 : Unit.Instance;
-            // Wondering if we should convert this into a Validation Result
         }
 
         private async Task<Either<ActionResult, Unit>> UpdateReleaseAndVersion(ReleaseUpdateRequest request, ReleaseVersion releaseVersion)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -80,6 +80,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         // Release update
         ReleasePublishedCannotBeFutureDate,
         ReleaseNotPublished,
+        UpdateRequestForPublishedReleaseInvalid,
 
         // Release checklist errors
         DataFileImportsMustBeCompleted,

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/TestApplicationFactory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/TestApplicationFactory.cs
@@ -29,8 +29,6 @@ public class TestApplicationFactory<TStartup> : WebApplicationFactory<TStartup> 
 
         supplier.Invoke(context);
         await context.SaveChangesAsync();
-
-        var x = 2;
     }
 
     public async Task EnsureDatabaseDeleted<TDbContext>() where TDbContext : DbContext

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/TestApplicationFactory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/TestApplicationFactory.cs
@@ -29,6 +29,8 @@ public class TestApplicationFactory<TStartup> : WebApplicationFactory<TStartup> 
 
         supplier.Invoke(context);
         await context.SaveChangesAsync();
+
+        var x = 2;
     }
 
     public async Task EnsureDatabaseDeleted<TDbContext>() where TDbContext : DbContext

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/NamingUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/NamingUtils.cs
@@ -1,28 +1,40 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using static System.Char;
+using static GovUk.Education.ExploreEducationStatistics.Common.Utils.TimePeriodLabelFormatter;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Model
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+public static class NamingUtils
 {
-    public static class NamingUtils
+    public static string CreateSlug(
+        int year,
+        TimeIdentifier timePeriodCoverage,
+        string? label = null)
     {
-        public static string SlugFromTitle(string title)
-        {
-            // NOTE: If you change anything here, you should also update `slugFromTitle.ts` in the frontend
-            var replaceNonAlphaNumericWithSpace = ReplaceNonAlphaNumericWithSpaceAndTrim(title);
-            var toLower = new string(replaceNonAlphaNumericWithSpace.Select(ToLower).ToArray());
-            var removeMultipleSpaces = Regex.Replace(toLower, @"\s+", " ");
-            var replaceSpaces = new string(removeMultipleSpaces.Select(c => IsWhiteSpace(c) ? '-' : c).ToArray());
-            return replaceSpaces;
-        }
+        var trimmedLowercaseLabel = label?.Trim().ToLower();
 
-        private static string ReplaceNonAlphaNumericWithSpaceAndTrim(string s)
-        {
-            return new string(s.Select(ReplaceNonAlphaNumericWithSpace).ToArray()).Trim();
-        }
-
-        private static Func<char, char> ReplaceNonAlphaNumericWithSpace =>
-            c => IsLetter(c) || IsWhiteSpace(c) || IsDigit(c) ? c : ' ';
+        return SlugFromTitle($"{Format(year, timePeriodCoverage)}{(string.IsNullOrWhiteSpace(trimmedLowercaseLabel) ? "" : $"-{trimmedLowercaseLabel}")}");
     }
+
+    public static string SlugFromTitle(string title)
+    {
+        // NOTE: If you change anything here, you should also update `slugFromTitle.ts` in the frontend
+        var replaceNonAlphaNumericWithSpace = ReplaceNonAlphaNumericWithSpaceAndTrim(title);
+        var toLower = new string(replaceNonAlphaNumericWithSpace.Select(ToLower).ToArray());
+        var removeMultipleSpaces = Regex.Replace(toLower, @"\s+", " ");
+        var replaceSpaces = new string(removeMultipleSpaces.Select(c => IsWhiteSpace(c) ? '-' : c).ToArray());
+        return replaceSpaces;
+    }
+
+    private static string ReplaceNonAlphaNumericWithSpaceAndTrim(string s)
+    {
+        return new string(s.Select(ReplaceNonAlphaNumericWithSpace).ToArray()).Trim();
+    }
+
+    private static Func<char, char> ReplaceNonAlphaNumericWithSpace =>
+        c => IsLetter(c) || IsWhiteSpace(c) || IsDigit(c) ? c : ' ';
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/NamingUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/NamingUtils.cs
@@ -10,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 public static class NamingUtils
 {
-    public static string CreateSlug(
+    public static string CreateReleaseSlug(
         int year,
         TimeIdentifier timePeriodCoverage,
         string? label = null)


### PR DESCRIPTION
As part of [EES-5351 - Release Labelling](https://dfedigital.atlassian.net/jira/software/c/projects/EES/boards/105?selectedIssue=EES-5351), we want to give the user the ability to give any Release a `Label`. This `Label` will be used to distinguish the Release from another Release with the same year and time period.

This PR is the back-end work for the associated [EES-5626](https://dfedigital.atlassian.net/jira/software/c/projects/EES/boards/105?selectedIssue=EES-5626) ticket, whereby we are adding the functionality to add and edit this `Label` for any **NEW** Release. Adding the ability to add/edit this `Label` for existing Releases will come later in another ticket; namely, [EES-5637](https://dfedigital.atlassian.net/jira/software/c/projects/EES/boards/105?selectedIssue=EES-5637).

## Other Changes
- When writing the integration tests for these changes, I realised that we had an issue running the tests due to the operations wrapped in a **transaction** [here](https://github.com/dfe-analytical-services/explore-education-statistics/pull/5499/files#diff-eacc06f6f6c99307be5d72ea5e42f2b6a9273f63a2db6115fd069825b821f015:~:text=await%20_context.RequireTransaction,releaseVersion). I reverted my changes and wrote an integration test against the old code, and still had the same issue. So it wasn't a newly introduced issue from my changes. I span up the admin app and tested the endpoint manually using Postman, and had no issues. So it was purely a test environment specific issue. 
The issue boiled down to using the `ContentDbContext` [here](https://github.com/dfe-analytical-services/explore-education-statistics/pull/5499/files#diff-eacc06f6f6c99307be5d72ea5e42f2b6a9273f63a2db6115fd069825b821f015:~:text=await%20_context.RequireTransaction,releaseVersion) to open up a new transaction scope, but only having set up the `PublicDataDbContext` with a retry policy [here](https://github.com/dfe-analytical-services/explore-education-statistics/pull/5499/files#diff-b4b68e42d1455ecfb4629bcc07844bc6f339ec54682720940171f1981cdf29d2:~:text=psqlOptions%20%3D%3E%20psqlOptions.EnableRetryOnFailure()), and not setting up a retry policy for the `ContentDbContext`. The error was due to opening up the transaction scope with a different context to the one which had a retry policy set up. We couldn't, however, set up a retry policy for the `ContentDbContext` (which it **does** have in the production environment) due to it being an in-memory database. So, in order to fix the issue, I removed the retry policy for the `PublicDataDbContext` in the test environment. This didn't look to break any existing tests, and I don't see the need for it unless we decide to write tests for the retry policy.