### PR TITLE
EES-5763 Fetch geog lvls separately so LINQ can translate query

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -1626,8 +1626,6 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
 
                 var originalMeta = releaseFile.File.DataSetFileMeta;
 
-                Assert.Null(originalMeta!.GeographicLevels); // TODO: remove in EES-5750
-
                 Assert.Equal(new DataSetFileTimePeriodRangeViewModel
                 {
                     From = TimePeriodLabelFormatter.Format(
@@ -1795,6 +1793,8 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
                 .Returns((releaseVersions ?? Array.Empty<ReleaseVersion>()).AsQueryable().BuildMockDbSet().Object);
             contentDbContext.Setup(context => context.ReleaseFiles)
                 .Returns((releaseFiles ?? Array.Empty<ReleaseFile>()).AsQueryable().BuildMockDbSet().Object);
+            contentDbContext.Setup(context => context.Files)
+                .Returns((releaseFiles != null ? releaseFiles.Select(rf => rf.File).ToArray() : []).AsQueryable().BuildMockDbSet().Object);
             contentDbContext.Setup(context => context.ReleaseFilesFreeTextTable(It.IsAny<string>()))
                 .Returns((freeTextRanks ?? Array.Empty<FreeTextRank>()).AsQueryable().BuildMockDbSet().Object);
             return contentDbContext;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetFileMetaGeneratorExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
@@ -35,7 +34,6 @@ public static class DataSetFileMetaGeneratorExtensions
                     ColumnName = "indicator_1",
                 },
             ]);
-
     public static Generator<DataSetFileMeta> WithTimePeriodRange(
         this Generator<DataSetFileMeta> generator,
         TimePeriodRangeMeta timePeriodRange)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -80,8 +80,29 @@ public class DataSetFileService(
         var results = await query
             .OrderBy(sort.Value, sortDirection.Value)
             .Paginate(page: page, pageSize: pageSize)
-            .Select(BuildDataSetFileSummaryViewModel())
+            .Select(BuildDataSetFileSummaryViewModel(includeGeographicLevels: false))
             .ToListAsync(cancellationToken: cancellationToken);
+
+        // We cannot fetch results[x].Meta.GeographicLevels in the previous query, because of the JOIN in
+        // `JoinFreeText`. That JOIN means we cannot fetch any collection, as that means we don't get a one-to-one
+        // matching of search ranks with the results after filtering. So instead we fetch the geographic levels
+        // in a separate query below
+        var geogLvlsDict = contentDbContext.Files
+            .AsNoTracking()
+            .Include(f => f.DataSetFileVersionGeographicLevels)
+            .Where(file => results
+                .Select(r => r.FileId).ToList()
+                .Contains(file.Id))
+            .ToDictionary(
+                file => file.Id,
+                file => file.DataSetFileVersionGeographicLevels
+                    .Select(gl => gl.GeographicLevel.GetEnumLabel())
+                    .Order()
+                    .ToList());
+        foreach (var result in results)
+        {
+            result.Meta.GeographicLevels = geogLvlsDict[result.FileId];
+        }
 
         return new PaginatedListViewModel<DataSetFileSummaryViewModel>(
             // TODO Remove ChangeSummaryHtmlToText once we do further work to remove all HTML at source
@@ -92,7 +113,7 @@ public class DataSetFileService(
     }
 
     private static Expression<Func<FreeTextValueResult<ReleaseFile>, DataSetFileSummaryViewModel>>
-        BuildDataSetFileSummaryViewModel()
+        BuildDataSetFileSummaryViewModel(bool includeGeographicLevels)
     {
         return result =>
             new DataSetFileSummaryViewModel
@@ -126,7 +147,9 @@ public class DataSetFileService(
                 LastUpdated = result.Value.Published!.Value,
                 Api = BuildDataSetFileApiViewModel(result.Value),
                 Meta = BuildDataSetFileMetaViewModel(
-                    result.Value.File.DataSetFileVersionGeographicLevels,
+                    includeGeographicLevels
+                        ? result.Value.File.DataSetFileVersionGeographicLevels
+                        : new List<DataSetFileVersionGeographicLevel>(),
                     result.Value.File.DataSetFileMeta,
                     result.Value.FilterSequence,
                     result.Value.IndicatorSequence),

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -87,18 +87,18 @@ public class DataSetFileService(
         // `JoinFreeText`. That JOIN means we cannot fetch any collection, as that means we don't get a one-to-one
         // matching of search ranks with the results after filtering. So instead we fetch the geographic levels
         // in a separate query below
-        var geogLvlsDict = contentDbContext.Files
+        var geogLvlsDict = await contentDbContext.Files
             .AsNoTracking()
             .Include(f => f.DataSetFileVersionGeographicLevels)
             .Where(file => results
                 .Select(r => r.FileId).ToList()
                 .Contains(file.Id))
-            .ToDictionary(
+            .ToDictionaryAsync(
                 file => file.Id,
                 file => file.DataSetFileVersionGeographicLevels
                     .Select(gl => gl.GeographicLevel.GetEnumLabel())
                     .Order()
-                    .ToList());
+                    .ToList(), cancellationToken: cancellationToken);
         foreach (var result in results)
         {
             result.Meta.GeographicLevels = geogLvlsDict[result.FileId];

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
@@ -2,7 +2,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 
 public record DataSetFileMetaViewModel
 {
-    public required List<string> GeographicLevels { get; init; }
+    public required List<string> GeographicLevels { get; set; }
     public required DataSetFileTimePeriodRangeViewModel TimePeriodRange { get; init; }
     public required List<string> Filters { get; init; }
     public required List<string> Indicators { get; init; }


### PR DESCRIPTION
This PR solves an issue where the updated ListDataSetFiles query wouldn't work when you include a `searchTerm`.

We believe this occurs because fetching DataSetFileGeographicLevels returns multiple results per data set, and so when this is joined with the free text rank table, there are multiple rows for each data set and that leads to issues. This is why HavingGeographicLevel didn't cause an issue, because even though it joins to DataSetFileGeographicLevels, the `Any` means it doesn't return multiple rows.

Credit goes to Ben for the sleuthing.

The solution we've decided on is to fetch the geographic levels in a separate query afterwards. 

We could consider simplifying the ListDataSetFiles in the future by having one query to identify which data sets to return - i.e. could just return ids - and then a separate query to fetch the needed data for those data sets. Although not sure if that's actually worthwhile...