### PR TITLE
EES-5778 Enable Azure Hybrid Benefit in Azure SQL statistics databases

### DIFF
--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -71,6 +71,9 @@
     "capacityContentDb": {
       "value": 50
     },
+    "licenseTypeStatisticsDb": {
+      "value": "BasePrice"
+    },
     "skuStatisticsDb": {
       "value": "GP_Gen5"
     },

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -74,6 +74,9 @@
     "minCapacityContentDb": {
       "value": "0.5"
     },
+    "licenseTypeStatisticsDb": {
+      "value": "BasePrice"
+    },
     "skuStatisticsDb": {
       "value": "GP_Gen5"
     },

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -598,6 +598,22 @@
         "test"
       ]
     },
+    "licenseTypeContentDb": {
+      "type": "string",
+      "defaultValue": "LicenseIncluded",
+      "allowedValues": [
+        "BasePrice",
+        "LicenseIncluded"
+      ]
+    },
+    "licenseTypeStatisticsDb": {
+      "type": "string",
+      "defaultValue": "LicenseIncluded",
+      "allowedValues": [
+        "BasePrice",
+        "LicenseIncluded"
+      ]
+    },
     "skuContentDb": {
       "type": "string",
       "allowedValues": [
@@ -2291,6 +2307,7 @@
           },
           "properties": {
             "collation": "SQL_Latin1_General_CP1_CI_AS",
+            "licenseType": "[parameters('licenseTypeStatisticsDb')]",
             "maxSizeBytes": "[parameters('maxStatsDbSizeBytes')]",
             "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
             "zoneRedundant": false,
@@ -2328,6 +2345,7 @@
           },
           "properties": {
             "collation": "SQL_Latin1_General_CP1_CI_AS",
+            "licenseType": "[parameters('licenseTypeContentDb')]",
             "maxSizeBytes": "[parameters('maxContentDbSizeBytes')]",
             "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
             "zoneRedundant": false,
@@ -2535,6 +2553,7 @@
           },
           "properties": {
             "collation": "SQL_Latin1_General_CP1_CI_AS",
+            "licenseType": "[parameters('licenseTypeStatisticsDb')]",
             "maxSizeBytes": "[parameters('maxStatsDbSizeBytes')]",
             "catalogCollation": "SQL_Latin1_General_CP1_CI_AS",
             "zoneRedundant": false,


### PR DESCRIPTION
This PR is an infrastructure change to enable Azure Hybrid Benefit in the Pre-prod and Prod Azure SQL statistics databases including the geo replicas.

This is done by setting the value of the `licenseType` property from `LicenseIncluded` (default) to `BasePrice`.

![image (1)](https://github.com/user-attachments/assets/47479916-675a-4054-844a-466c59d3f8a2)
