### PR TITLE
EES-5458 fix table headers multi select

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableHeadersReorderableItem.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableHeadersReorderableItem.tsx
@@ -59,7 +59,7 @@ export default function TableHeadersReorderableItem({
         {...draggableProvided.dragHandleProps}
         className={classNames(styles.option, {
           [styles.isDragging]: draggableSnapshot.isDragging,
-          [styles.isSelected]: isSelected && isInActive,
+          [styles.isSelected]: isSelected,
           [styles.isGhosted]: isGhosted || isInActive,
           [styles.isDraggedOutside]:
             draggableSnapshot.isDragging && !draggableSnapshot.draggingOver,

--- a/src/explore-education-statistics-common/src/utils/__tests__/reorderMultiple.test.ts
+++ b/src/explore-education-statistics-common/src/utils/__tests__/reorderMultiple.test.ts
@@ -302,4 +302,34 @@ describe('reorderMultiple', () => {
 
     expect(newList).toEqual(['b', 'd', 'a', 'c', 'e']);
   });
+
+  test('move first two items to the middle', () => {
+    const newList = reorderMultiple({
+      list: [...list, 'e'],
+      destinationIndex: 2,
+      selectedIndices: [0, 1],
+    });
+
+    expect(newList).toEqual(['c', 'a', 'b', 'd', 'e']);
+  });
+
+  test('move first two items to the second to last', () => {
+    const newList = reorderMultiple({
+      list: [...list, 'e'],
+      destinationIndex: 3,
+      selectedIndices: [0, 1],
+    });
+
+    expect(newList).toEqual(['c', 'd', 'a', 'b', 'e']);
+  });
+
+  test('move middle two items to second', () => {
+    const newList = reorderMultiple({
+      list: [...list, 'e'],
+      destinationIndex: 1,
+      selectedIndices: [2, 3],
+    });
+
+    expect(newList).toEqual(['a', 'c', 'd', 'b', 'e']);
+  });
 });

--- a/src/explore-education-statistics-common/src/utils/reorderMultiple.ts
+++ b/src/explore-education-statistics-common/src/utils/reorderMultiple.ts
@@ -35,6 +35,29 @@ export default function reorderMultiple<T>({
     return list;
   }
 
+  // Adapted from https://github.com/atlassian/react-beautiful-dnd/blob/master/stories/src/multi-drag/utils.js
+  const insertAtIndex: number = (() => {
+    const destinationIndexOffset: number = selectedIndices.reduce(
+      (previous: number, current: number): number => {
+        if (current === selectedIndices[0]) {
+          return previous;
+        }
+
+        if (current >= destinationIndex) {
+          return previous;
+        }
+
+        // the selected item is before the destination index
+        // we need to account for this when inserting into the new location
+        return previous + 1;
+      },
+      0,
+    );
+
+    const result: number = destinationIndex - destinationIndexOffset;
+    return result;
+  })();
+
   const [selectedList, newList] = list.reduce<[T[], T[]]>(
     (acc, item, index) => {
       if (selectedIndices.includes(index)) {
@@ -48,17 +71,6 @@ export default function reorderMultiple<T>({
     [[], []],
   );
 
-  const maxIndex = max(selectedIndices) as number;
-
-  let insertIndex = destinationIndex;
-
-  // Last selected item is before the final destination
-  // position, so we need to offset this by 1 for maths reasons
-  if (maxIndex < insertIndex) {
-    insertIndex += 1;
-  }
-
-  newList.splice(insertIndex, 0, ...selectedList);
-
+  newList.splice(insertAtIndex, 0, ...selectedList);
   return newList;
 }


### PR DESCRIPTION
Fixes the styling when reordering table headers to make it obvious which items you've selected when moving multiple items.

Also fixes a bug where moving multiple items was sometimes moving them to the wrong place.

![Screenshot 2025-01-09 125424](https://github.com/user-attachments/assets/2da7e761-4b17-4406-a30b-5f5cd97239ec)
