### PR TITLE
EES-5298 improve download file legend text

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadTable.tsx
@@ -91,7 +91,7 @@ const DownloadTable = ({
                 'Download Table',
               )}
               <FormFieldRadioGroup<FormValues>
-                legend="Select file format:"
+                legend="Select a file format to download:"
                 legendSize="s"
                 legendWeight="regular"
                 name="fileFormat"


### PR DESCRIPTION
Updates the legend on the table download form to make it more descriptive, as per the DAC recommendation.