### PR TITLE
EES-5285 5294 focus styles for tables and table header groups

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.module.scss
@@ -28,6 +28,8 @@
   width: 100%;
 
   &:focus {
-    outline: none;
+    box-shadow: 0 0 0 4px;
+    outline: $govuk-focus-colour solid $govuk-focus-width;
+    outline-offset: 4px;
   }
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableHeadersGroup.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableHeadersGroup.module.scss
@@ -28,7 +28,9 @@
 
   &.focused {
     border-color: transparent;
+    box-shadow: inset 0 0 0 4px;
     outline: $govuk-focus-colour solid $govuk-focus-width;
+    outline-offset: -2px;
   }
 
   &.dragEnabled:hover {


### PR DESCRIPTION
Fixes two issues raised by DAC related to focus styles, for both I've made the focus style the same as when text inputs are focused.

EES-5285: table header groups when reordering
![Screenshot 2025-01-09 164559](https://github.com/user-attachments/assets/c472f899-2f1e-4c43-af1f-b98e2571b106)

EES-5294: data block tables in releases
![Screenshot 2025-01-09 164623](https://github.com/user-attachments/assets/2caef521-8b5b-430a-b257-982d1484b7b6)


