### PR TITLE
EES-5635 Change the calculated `Title` property of `Release` to contain `Label`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -34,8 +34,9 @@ public class Release : ICreatedUpdatedTimestamps<DateTime, DateTime?>
 
     public DateTime? Updated { get; set; }
 
-    public string Title =>
-        TimePeriodLabelFormatter.Format(Year, TimePeriodCoverage, TimePeriodLabelFormat.FullLabelBeforeYear);
+    public string TimePeriod => TimePeriodLabelFormatter.Format(Year, TimePeriodCoverage, TimePeriodLabelFormat.FullLabelBeforeYear);
+
+    public string Title => string.IsNullOrEmpty(Label) ? TimePeriod : $"{TimePeriod} {Label}";
 
     public string YearTitle => TimePeriodLabelFormatter.FormatYear(Year, TimePeriodCoverage);
 


### PR DESCRIPTION
This PR changes the calculated `Title` property of `Release` to contain `Label` if it has been set.

Label is now settable but only in the back end create/update requests after https://github.com/dfe-analytical-services/explore-education-statistics/pull/5457.

The front-end work to allow setting a label is being added by EES-5629.

Further work in EES-5635 (to follow) will switch all remaining back-end view models from using `ReleaseVersion.Title` to `Release.Title` as it is currently only used in a limited number of places.