### PR TITLE
EES-5787 Allow request Chart.Title to be null

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/DataBlockRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/DataBlockRequests.cs
@@ -70,8 +70,7 @@ public record DataBlockUpdateRequest
             {
                 chart
                     .RuleFor(request => request.Title)
-                    .NotEmpty()
-                    .MaximumLength(220);
+                    .Length(1, 220);
 
                 chart.RuleFor(request => request.Alt)
                     .NotEmpty()


### PR DESCRIPTION
This fixes a bug introduced in EES-5731. A chart couldn't be created because the backend validation didn't allow a null chart title.

When creating a chart, the chart title is only provided in the request if the user is providing an alternative chart title. Otherwise, the chart title is generated by the backend (I believe).