### PR TITLE
EES 5629 - Adding a new optional field for the `Label` when creating a new Release (FE)

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -1048,9 +1048,9 @@ public abstract class ReleaseServiceTests
                 Assert.Equal(releaseVersion.Release.Label, viewModel.Label);
                 Assert.Equal(releaseVersion.Version, viewModel.Version);
                 Assert.Equal(releaseVersion.Slug, viewModel.Slug);
-                Assert.Equal(releaseVersion.Publication.Id, viewModel.PublicationId);
-                Assert.Equal(releaseVersion.Publication.Title, viewModel.PublicationTitle);
-                Assert.Equal(releaseVersion.Publication.Slug, viewModel.PublicationSlug);
+                Assert.Equal(releaseVersion.Release.Publication.Id, viewModel.PublicationId);
+                Assert.Equal(releaseVersion.Release.Publication.Title, viewModel.PublicationTitle);
+                Assert.Equal(releaseVersion.Release.Publication.Slug, viewModel.PublicationSlug);
                 Assert.Equal(releaseVersion.LatestInternalReleaseNote, viewModel.LatestInternalReleaseNote);
                 Assert.Equal(releaseVersion.PublishScheduled, viewModel.PublishScheduled);
                 Assert.Equal(releaseVersion.Published, viewModel.Published);
@@ -1131,7 +1131,7 @@ public abstract class ReleaseServiceTests
             Publication publication = _dataFixture.DefaultPublication()
                 .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 2)]);
 
-            var notLatestReleaseVersion = publication.ReleaseVersions[0];
+            var notLatestReleaseVersion = publication.Releases[0].Versions[0];
 
             var contextId = Guid.NewGuid().ToString();
 
@@ -1170,7 +1170,7 @@ public abstract class ReleaseServiceTests
             {
                 var releaseService = BuildReleaseService(context);
 
-                var result = await releaseService.GetRelease(publication.ReleaseVersions[0].Id);
+                var result = await releaseService.GetRelease(publication.Releases[0].Versions[0].Id);
 
                 var releaseViewModel = result.AssertRight();
                 Assert.Null(releaseViewModel.LatestInternalReleaseNote);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -8,6 +8,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -52,11 +53,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                     m => m.MapFrom(rv => rv.Publication.Id))
                 .ForMember(dest => dest.PublicationSlug,
                     m => m.MapFrom(rv => rv.Publication.Slug))
-                .ForMember(model => model.PublishScheduled,
+                .ForMember(dest => dest.PublishScheduled,
                     m => m.MapFrom(rv =>
                         rv.PublishScheduled.HasValue
                             ? rv.PublishScheduled.Value.ConvertUtcToUkTimeZone()
-                            : (DateTime?)null));
+                    : (DateTime?)null))
+                .ForMember(dest => dest.Label,
+                    m => m.MapFrom(rv => rv.Release.Label));
 
             CreateMap<ReleaseVersion, ReleaseSummaryViewModel>()
                 .ForMember(model => model.PublishScheduled,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -126,7 +126,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     return _mapper.Map<ReleaseViewModel>(releaseVersion) with
                     {
-                        PreReleaseUsersOrInvitesAdded = prereleaseRolesOrInvitesAdded
+                        PreReleaseUsersOrInvitesAdded = prereleaseRolesOrInvitesAdded,
+                        Label = releaseVersion.Release.Label
                     };
                 });
         }
@@ -961,6 +962,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             // Require publication / release graph to be able to work out:
             // If the release is the latest
             return values
+                .Include(rv => rv.Release)
                 .Include(rv => rv.Publication)
                 .Include(rv => rv.ReleaseStatuses);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -127,7 +127,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     return _mapper.Map<ReleaseViewModel>(releaseVersion) with
                     {
                         PreReleaseUsersOrInvitesAdded = prereleaseRolesOrInvitesAdded,
-                        Label = releaseVersion.Release.Label
                     };
                 });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -19,6 +19,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public string Slug { get; set; } = string.Empty;
 
+        public string? Label { get; set;}
+
+        public int Version { get; set; }
+
         public Guid PublicationId { get; set; }
 
         public string PublicationTitle { get; set; } = string.Empty;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserReleaseInviteGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserReleaseInviteGeneratorExtensions.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+
+public static class UserReleaseInviteGeneratorExtensions
+{
+    public static Generator<UserReleaseInvite> DefaultUserReleaseInvite(this DataFixture fixture)
+        => fixture.Generator<UserReleaseInvite>().WithDefaults();
+
+    public static Generator<UserReleaseInvite> WithDefaults(this Generator<UserReleaseInvite> generator)
+        => generator.ForInstance(s => s.SetDefaults());
+
+    public static Generator<UserReleaseInvite> WithReleaseVersion(this Generator<UserReleaseInvite> generator,
+        ReleaseVersion releaseVersion)
+        => generator.ForInstance(s => s.SetReleaseVersion(releaseVersion));
+
+    public static Generator<UserReleaseInvite> WithRole(this Generator<UserReleaseInvite> generator, ReleaseRole role)
+        => generator.ForInstance(s => s.SetRole(role));
+
+    public static Generator<UserReleaseInvite> WithRoles(this Generator<UserReleaseInvite> generator,
+        IEnumerable<ReleaseRole> roles)
+    {
+        roles.ForEach((role, index) =>
+            generator.ForIndex(index, s => s.SetRole(role)));
+
+        return generator;
+    }
+
+    public static Generator<UserReleaseInvite> WithEmail(
+        this Generator<UserReleaseInvite> generator, 
+        string email)
+        => generator.ForInstance(s => s.SetEmail(email));
+
+    public static Generator<UserReleaseInvite> WithEmailSent(
+        this Generator<UserReleaseInvite> generator,
+        bool emailSent)
+        => generator.ForInstance(s => s.SetEmailSent(emailSent));
+
+    public static Generator<UserReleaseInvite> WithSoftDeleted(
+        this Generator<UserReleaseInvite> generator,
+        bool softDeleted)
+        => generator.ForInstance(s => s.SetSoftDeleted(softDeleted));
+
+    public static InstanceSetters<UserReleaseInvite> SetDefaults(this InstanceSetters<UserReleaseInvite> setters)
+        => setters
+            .SetDefault(uri => uri.Id)
+            .SetDefault(uri => uri.ReleaseVersionId)
+            .SetDefault(uri => uri.Email)
+            .SetDefault(uri => uri.Role)
+            .SetDefault(uri => uri.Created)
+            .SetDefault(uri => uri.Updated)
+            .SetDefault(uri => uri.CreatedById);
+
+    public static InstanceSetters<UserReleaseInvite> SetReleaseVersion(
+        this InstanceSetters<UserReleaseInvite> setters,
+        ReleaseVersion releaseVersion)
+        => setters
+            .Set(uri => uri.ReleaseVersion, releaseVersion)
+            .Set(uri => uri.ReleaseVersionId, releaseVersion.Id);
+
+    public static InstanceSetters<UserReleaseInvite> SetRole(
+        this InstanceSetters<UserReleaseInvite> setters,
+        ReleaseRole role)
+        => setters.Set(uri => uri.Role, role);
+
+    public static InstanceSetters<UserReleaseInvite> SetEmail(
+        this InstanceSetters<UserReleaseInvite> setters,
+        string email)
+        => setters.Set(uri => uri.Email, email);
+
+    public static InstanceSetters<UserReleaseInvite> SetEmailSent(
+        this InstanceSetters<UserReleaseInvite> setters,
+        bool emailSent)
+        => setters.Set(uri => uri.EmailSent, emailSent);
+
+    public static InstanceSetters<UserReleaseInvite> SetSoftDeleted(
+        this InstanceSetters<UserReleaseInvite> setters,
+        bool softDeleted)
+        => setters.Set(uri => uri.SoftDeleted, softDeleted);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserReleaseRoleGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserReleaseRoleGeneratorExtensions.cs
@@ -10,11 +10,11 @@ public static class UserReleaseRoleGeneratorExtensions
         => fixture.Generator<UserReleaseRole>().WithDefaults();
 
     public static Generator<UserReleaseRole> WithDefaults(this Generator<UserReleaseRole> generator)
-        => generator.ForInstance(d => d.SetDefaults());
+        => generator.ForInstance(s => s.SetDefaults());
 
     public static Generator<UserReleaseRole> WithReleaseVersion(this Generator<UserReleaseRole> generator,
         ReleaseVersion releaseVersion)
-        => generator.ForInstance(d => d.SetReleaseVersion(releaseVersion));
+        => generator.ForInstance(s => s.SetReleaseVersion(releaseVersion));
 
     public static Generator<UserReleaseRole> WithReleaseVersions(this Generator<UserReleaseRole> generator,
         IEnumerable<ReleaseVersion> releaseVersions)
@@ -26,10 +26,10 @@ public static class UserReleaseRoleGeneratorExtensions
     }
 
     public static Generator<UserReleaseRole> WithUser(this Generator<UserReleaseRole> generator, User user)
-        => generator.ForInstance(d => d.SetUser(user));
+        => generator.ForInstance(s => s.SetUser(user));
 
     public static Generator<UserReleaseRole> WithRole(this Generator<UserReleaseRole> generator, ReleaseRole role)
-        => generator.ForInstance(d => d.SetRole(role));
+        => generator.ForInstance(s => s.SetRole(role));
 
     public static Generator<UserReleaseRole> WithRoles(this Generator<UserReleaseRole> generator,
         IEnumerable<ReleaseRole> roles)
@@ -42,22 +42,24 @@ public static class UserReleaseRoleGeneratorExtensions
 
     public static InstanceSetters<UserReleaseRole> SetDefaults(this InstanceSetters<UserReleaseRole> setters)
         => setters
-            .SetDefault(p => p.Id)
-            .SetDefault(p => p.ReleaseVersionId)
-            .SetDefault(p => p.UserId);
+            .SetDefault(urr => urr.Id)
+            .SetDefault(urr => urr.ReleaseVersionId)
+            .SetDefault(urr => urr.UserId);
 
     public static InstanceSetters<UserReleaseRole> SetReleaseVersion(
         this InstanceSetters<UserReleaseRole> setters,
         ReleaseVersion releaseVersion)
-        => setters.Set(d => d.ReleaseVersion, releaseVersion);
+        => setters
+            .Set(urr => urr.ReleaseVersion, releaseVersion)
+            .Set(urr => urr.ReleaseVersionId, releaseVersion.Id);
 
     public static InstanceSetters<UserReleaseRole> SetUser(
         this InstanceSetters<UserReleaseRole> setters,
         User user)
-        => setters.Set(d => d.User, user);
+        => setters.Set(urr => urr.User, user);
 
     public static InstanceSetters<UserReleaseRole> SetRole(
         this InstanceSetters<UserReleaseRole> setters,
         ReleaseRole role)
-        => setters.Set(d => d.Role, role);
+        => setters.Set(urr => urr.Role, role);
 }

--- a/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationManageReleaseContributorsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/__tests__/PublicationManageReleaseContributorsPage.test.tsx
@@ -43,6 +43,8 @@ const testRelease: Release = {
     label: 'Academic year',
   },
   title: 'Release 1',
+  version: 0,
+  label: undefined,
   type: 'AdHocStatistics',
   year: 2000,
   yearTitle: '2000/01',

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseCreatePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseCreatePage.tsx
@@ -63,6 +63,7 @@ const ReleaseCreatePage = ({
       publicationId,
       templateReleaseId:
         values.templateReleaseId !== 'new' ? values.templateReleaseId : '',
+      label: values.releaseLabel,
     });
 
     history.push(
@@ -103,7 +104,9 @@ const ReleaseCreatePage = ({
             timePeriodCoverageStartYear: '',
             templateReleaseId: '',
             releaseType: undefined,
+            releaseLabel: '',
           }}
+          releaseVersion={0}
           templateRelease={model?.templateRelease}
           onSubmit={handleSubmit}
           onCancel={handleCancel}

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
@@ -45,6 +45,7 @@ export default function ReleaseSummaryEditPage({
       },
       type: values.releaseType ?? 'AdHocStatistics',
       preReleaseAccessList: release.preReleaseAccessList,
+      label: values.releaseLabel,
     });
 
     onReleaseChange();
@@ -82,7 +83,9 @@ export default function ReleaseSummaryEditPage({
               timePeriodCoverageCode: release.timePeriodCoverage.value,
               timePeriodCoverageStartYear: release.year.toString(),
               releaseType: release.type,
+              releaseLabel: release.label,
             }}
+            releaseVersion={release.version}
             onSubmit={handleSubmit}
             onCancel={handleCancel}
           />

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
@@ -16,6 +16,8 @@ export const testRelease: Release = {
   publicationSlug: 'publication-1-slug',
   timePeriodCoverage: { value: 'W51', label: 'Week 51' },
   title: 'Release Title',
+  label: undefined,
+  version: 1,
   type: 'OfficialStatistics',
   previousVersionId: '',
   preReleaseAccessList: '',

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
@@ -4,7 +4,7 @@ import metaService, {
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
-import { FormFieldset } from '@common/components/form';
+import { FormFieldset, FormFieldTextInput } from '@common/components/form';
 import FormFieldNumberInput from '@common/components/form/FormFieldNumberInput';
 import { SelectOption } from '@common/components/form/FormSelect';
 import FormProvider from '@common/components/form/FormProvider';
@@ -27,16 +27,17 @@ export interface ReleaseSummaryFormValues {
   templateReleaseId?: string;
   timePeriodCoverageCode: string;
   timePeriodCoverageStartYear: string;
+  releaseLabel?: string;
 }
 
 const formId = 'releaseSummaryForm';
 
 const errorMappings = [
   mapFieldErrors<ReleaseSummaryFormValues>({
-    target: 'timePeriodCoverageStartYear',
+    target: 'releaseLabel',
     messages: {
       SlugNotUnique:
-        'Choose a unique combination of time period and start year',
+        'Choose a unique combination of type, start year and label',
     },
   }),
 ];
@@ -45,12 +46,14 @@ interface Props {
   submitText: string;
   templateRelease?: IdTitlePair;
   initialValues: ReleaseSummaryFormValues;
+  releaseVersion: number;
   onSubmit: (values: ReleaseSummaryFormValues) => Promise<void> | void;
   onCancel: () => void;
 }
 
 export default function ReleaseSummaryForm({
   initialValues,
+  releaseVersion,
   submitText,
   templateRelease,
   onSubmit,
@@ -83,6 +86,11 @@ export default function ReleaseSummaryForm({
         .required('Choose a release type')
         .oneOf(permittedReleaseTypes),
       templateReleaseId: Yup.string(),
+      releaseLabel: Yup.string().max(
+        50,
+        /* eslint-disable no-template-curly-in-string */
+        'Release label must be no longer than ${max} characters',
+      ),
     });
   }, [permittedReleaseTypes]);
 
@@ -116,6 +124,8 @@ export default function ReleaseSummaryForm({
     );
   };
 
+  const disableReleaseSlugChange = releaseVersion > 0;
+
   return (
     <FormProvider
       enableReinitialize
@@ -140,6 +150,7 @@ export default function ReleaseSummaryForm({
                 label="Type"
                 name="timePeriodCoverageCode"
                 optGroups={timePeriodOptions}
+                disabled={disableReleaseSlugChange}
               />
               <FormFieldNumberInput<ReleaseSummaryFormValues>
                 name="timePeriodCoverageStartYear"
@@ -157,8 +168,18 @@ export default function ReleaseSummaryForm({
                       }
                     `}
                 width={4}
+                disabled={disableReleaseSlugChange}
               />
             </FormFieldset>
+            <FormFieldTextInput
+              id="releaseLabel"
+              name="releaseLabel"
+              label="Release label"
+              labelSize="m"
+              hint="Unique label for the release, use if needed to distinguish it from other releases that share the same period."
+              width={20}
+              disabled={disableReleaseSlugChange}
+            />
             <FormFieldRadioGroup<ReleaseSummaryFormValues>
               legend="Release type"
               name="releaseType"

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
@@ -32,6 +32,16 @@ export interface ReleaseSummaryFormValues {
 
 const formId = 'releaseSummaryForm';
 
+const errorMappings = [
+  mapFieldErrors<ReleaseSummaryFormValues>({
+    target: 'releaseLabel',
+    messages: {
+      SlugNotUnique:
+        'Choose a unique combination of type, start year and label',
+    },
+  }),
+];
+
 interface Props {
   submitText: string;
   templateRelease?: IdTitlePair;
@@ -39,7 +49,6 @@ interface Props {
   releaseVersion: number;
   onSubmit: (values: ReleaseSummaryFormValues) => Promise<void> | void;
   onCancel: () => void;
-  hideLabelField?: boolean;
 }
 
 export default function ReleaseSummaryForm({
@@ -49,7 +58,6 @@ export default function ReleaseSummaryForm({
   templateRelease,
   onSubmit,
   onCancel,
-  hideLabelField = true, // This will be removed in EES-5792
 }: Props) {
   const { value: timePeriodCoverageGroups, isLoading } = useAsyncRetry<
     TimePeriodCoverageGroup[]
@@ -118,18 +126,6 @@ export default function ReleaseSummaryForm({
 
   const disableReleaseSlugChange = releaseVersion > 0;
 
-  // This will be moved to be stored outside of this component, and the conditional removed, in EES-5792
-  const errorMappings = [
-    mapFieldErrors<ReleaseSummaryFormValues>({
-      target: 'releaseLabel',
-      messages: {
-        SlugNotUnique: hideLabelField
-          ? 'Choose a unique combination of time period coverage type and start year'
-          : 'Choose a unique combination of time period coverage type, start year and label',
-      },
-    }),
-  ];
-
   return (
     <FormProvider
       enableReinitialize
@@ -175,20 +171,15 @@ export default function ReleaseSummaryForm({
                 disabled={disableReleaseSlugChange}
               />
             </FormFieldset>
-            {
-              // This conditional will be removed in EES-5792
-              !hideLabelField && (
-                <FormFieldTextInput
-                  id="releaseLabel"
-                  name="releaseLabel"
-                  label="Release label"
-                  labelSize="m"
-                  hint="Unique label for the release, use if needed to distinguish it from other releases that share the same period."
-                  width={20}
-                  disabled={disableReleaseSlugChange}
-                />
-              )
-            }
+            <FormFieldTextInput
+              id="releaseLabel"
+              name="releaseLabel"
+              label="Release label"
+              labelSize="m"
+              hint="Unique label for the release, use if needed to distinguish it from other releases that share the same period."
+              width={20}
+              disabled={disableReleaseSlugChange}
+            />
             <FormFieldRadioGroup<ReleaseSummaryFormValues>
               legend="Release type"
               name="releaseType"

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
@@ -32,16 +32,6 @@ export interface ReleaseSummaryFormValues {
 
 const formId = 'releaseSummaryForm';
 
-const errorMappings = [
-  mapFieldErrors<ReleaseSummaryFormValues>({
-    target: 'releaseLabel',
-    messages: {
-      SlugNotUnique:
-        'Choose a unique combination of type, start year and label',
-    },
-  }),
-];
-
 interface Props {
   submitText: string;
   templateRelease?: IdTitlePair;
@@ -49,6 +39,7 @@ interface Props {
   releaseVersion: number;
   onSubmit: (values: ReleaseSummaryFormValues) => Promise<void> | void;
   onCancel: () => void;
+  hideLabelField?: boolean;
 }
 
 export default function ReleaseSummaryForm({
@@ -58,6 +49,7 @@ export default function ReleaseSummaryForm({
   templateRelease,
   onSubmit,
   onCancel,
+  hideLabelField = true, // This will be removed in EES-5792
 }: Props) {
   const { value: timePeriodCoverageGroups, isLoading } = useAsyncRetry<
     TimePeriodCoverageGroup[]
@@ -126,6 +118,18 @@ export default function ReleaseSummaryForm({
 
   const disableReleaseSlugChange = releaseVersion > 0;
 
+  // This will be moved to be stored outside of this component, and the conditional removed, in EES-5792
+  const errorMappings = [
+    mapFieldErrors<ReleaseSummaryFormValues>({
+      target: 'releaseLabel',
+      messages: {
+        SlugNotUnique: hideLabelField
+          ? 'Choose a unique combination of time period coverage type and start year'
+          : 'Choose a unique combination of time period coverage type, start year and label',
+      },
+    }),
+  ];
+
   return (
     <FormProvider
       enableReinitialize
@@ -171,15 +175,20 @@ export default function ReleaseSummaryForm({
                 disabled={disableReleaseSlugChange}
               />
             </FormFieldset>
-            <FormFieldTextInput
-              id="releaseLabel"
-              name="releaseLabel"
-              label="Release label"
-              labelSize="m"
-              hint="Unique label for the release, use if needed to distinguish it from other releases that share the same period."
-              width={20}
-              disabled={disableReleaseSlugChange}
-            />
+            {
+              // This conditional will be removed in EES-5792
+              !hideLabelField && (
+                <FormFieldTextInput
+                  id="releaseLabel"
+                  name="releaseLabel"
+                  label="Release label"
+                  labelSize="m"
+                  hint="Unique label for the release, use if needed to distinguish it from other releases that share the same period."
+                  width={20}
+                  disabled={disableReleaseSlugChange}
+                />
+              )
+            }
             <FormFieldRadioGroup<ReleaseSummaryFormValues>
               legend="Release type"
               name="releaseType"

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
@@ -37,7 +37,9 @@ describe('ReleaseSummaryForm', () => {
           timePeriodCoverageCode: '',
           timePeriodCoverageStartYear: '',
           releaseType: undefined,
+          releaseLabel: '',
         }}
+        releaseVersion={0}
         onSubmit={noop}
         onCancel={noop}
       />,
@@ -103,7 +105,9 @@ describe('ReleaseSummaryForm', () => {
           timePeriodCoverageCode: '',
           timePeriodCoverageStartYear: '',
           releaseType: undefined,
+          releaseLabel: '',
         }}
+        releaseVersion={0}
         templateRelease={{
           id: 'template-id',
           title: 'Template title',
@@ -181,7 +185,9 @@ describe('ReleaseSummaryForm', () => {
           timePeriodCoverageCode: '',
           timePeriodCoverageStartYear: '',
           releaseType: undefined,
+          releaseLabel: '',
         }}
+        releaseVersion={0}
         onSubmit={onSubmit}
         onCancel={noop}
       />,
@@ -224,7 +230,9 @@ describe('ReleaseSummaryForm', () => {
           timePeriodCoverageCode: '',
           timePeriodCoverageStartYear: '',
           releaseType: undefined,
+          releaseLabel: '',
         }}
+        releaseVersion={0}
         onSubmit={onSubmit}
         onCancel={noop}
       />,
@@ -276,7 +284,9 @@ describe('ReleaseSummaryForm', () => {
           timePeriodCoverageCode: '',
           timePeriodCoverageStartYear: '',
           releaseType: undefined,
+          releaseLabel: '',
         }}
+        releaseVersion={0}
         onSubmit={onSubmit}
         onCancel={noop}
       />,
@@ -328,7 +338,9 @@ describe('ReleaseSummaryForm', () => {
           timePeriodCoverageCode: '',
           timePeriodCoverageStartYear: '',
           releaseType: undefined,
+          releaseLabel: '',
         }}
+        releaseVersion={0}
         onSubmit={onSubmit}
         onCancel={noop}
       />,
@@ -377,7 +389,9 @@ describe('ReleaseSummaryForm', () => {
           timePeriodCoverageCode: 'AYQ4',
           timePeriodCoverageStartYear: '1966',
           releaseType: 'AccreditedOfficialStatistics',
+          releaseLabel: 'initial',
         }}
+        releaseVersion={0}
         onSubmit={noop}
         onCancel={noop}
       />,
@@ -396,6 +410,9 @@ describe('ReleaseSummaryForm', () => {
       testTimeIdentifiers[0].category.label,
     );
     expect(inputYear).toHaveValue(1966);
+
+    const inputReleaseLabel = screen.getByLabelText('Release label');
+    expect(inputReleaseLabel).toHaveValue('initial');
 
     const releaseTypeRadios = within(
       screen.getByRole('group', { name: 'Release type' }),
@@ -422,7 +439,9 @@ describe('ReleaseSummaryForm', () => {
           timePeriodCoverageCode: '',
           timePeriodCoverageStartYear: '',
           releaseType: undefined,
+          releaseLabel: '',
         }}
+        releaseVersion={0}
         onSubmit={onSubmit}
         onCancel={noop}
       />,
@@ -438,10 +457,14 @@ describe('ReleaseSummaryForm', () => {
       selector: 'select',
     });
     await userEvent.selectOptions(selectYearType, 'AY');
+
     const inputYear = screen.getByLabelText(
       testTimeIdentifiers[0].category.label,
     );
     await userEvent.type(inputYear, '1966');
+
+    const inputReleaseLabel = screen.getByLabelText('Release label');
+    await userEvent.type(inputReleaseLabel, 'initial');
 
     const radioOptionReleaseTypeNationalStats = screen.getByLabelText(
       releaseTypes.AccreditedOfficialStatistics,
@@ -459,6 +482,67 @@ describe('ReleaseSummaryForm', () => {
     });
   });
 
+  test('validation error when release label over 50 characters', async () => {
+    metaService.getTimePeriodCoverageGroups.mockResolvedValue(
+      testTimeIdentifiers,
+    );
+
+    const onSubmit = jest.fn();
+
+    render(
+      <ReleaseSummaryForm
+        submitText="Create new release"
+        initialValues={{
+          timePeriodCoverageCode: '',
+          timePeriodCoverageStartYear: '',
+          releaseType: undefined,
+          releaseLabel: '',
+        }}
+        releaseVersion={0}
+        onSubmit={onSubmit}
+        onCancel={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Select time period coverage'),
+      ).toBeInTheDocument();
+    });
+
+    const selectYearType = screen.getByLabelText('Type', {
+      selector: 'select',
+    });
+    await userEvent.selectOptions(selectYearType, 'AY');
+
+    const inputYear = screen.getByLabelText(
+      testTimeIdentifiers[0].category.label,
+    );
+    await userEvent.type(inputYear, '2020');
+
+    const inputReleaseLabel = screen.getByLabelText('Release label');
+    await userEvent.type(
+      inputReleaseLabel,
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', // 51 characters
+    );
+
+    await userEvent.click(screen.getByLabelText(releaseTypes.AdHocStatistics));
+
+    const buttonCreate = screen.getByRole('button', {
+      name: 'Create new release',
+    });
+    await userEvent.click(buttonCreate);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Release label must be no longer than 50 characters', {
+          selector: 'a',
+        }),
+      ).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   test('does not show the Experimental statistics release type when empty initial values', async () => {
     metaService.getTimePeriodCoverageGroups.mockResolvedValue(
       testTimeIdentifiers,
@@ -471,7 +555,9 @@ describe('ReleaseSummaryForm', () => {
           timePeriodCoverageCode: '',
           timePeriodCoverageStartYear: '',
           releaseType: undefined,
+          releaseLabel: '',
         }}
+        releaseVersion={0}
         onSubmit={noop}
         onCancel={noop}
       />,
@@ -506,7 +592,9 @@ describe('ReleaseSummaryForm', () => {
           timePeriodCoverageCode: 'AYQ4',
           timePeriodCoverageStartYear: '1966',
           releaseType: 'AccreditedOfficialStatistics',
+          releaseLabel: 'initial',
         }}
+        releaseVersion={0}
         onSubmit={noop}
         onCancel={noop}
       />,
@@ -541,7 +629,9 @@ describe('ReleaseSummaryForm', () => {
           timePeriodCoverageCode: 'AYQ4',
           timePeriodCoverageStartYear: '1966',
           releaseType: 'ExperimentalStatistics',
+          releaseLabel: 'initial',
         }}
+        releaseVersion={0}
         onSubmit={noop}
         onCancel={noop}
       />,
@@ -563,4 +653,45 @@ describe('ReleaseSummaryForm', () => {
       screen.getByLabelText(releaseTypes.ExperimentalStatistics),
     ).toBeInTheDocument();
   });
+
+  test.each([1, 2, 3])(
+    'disables inputs for time period coverage and release label when the release version is > 0',
+    async releaseVersion => {
+      metaService.getTimePeriodCoverageGroups.mockResolvedValue(
+        testTimeIdentifiers,
+      );
+
+      render(
+        <ReleaseSummaryForm
+          submitText="Create new release"
+          initialValues={{
+            timePeriodCoverageCode: 'AYQ4',
+            timePeriodCoverageStartYear: '1966',
+            releaseType: 'AccreditedOfficialStatistics',
+            releaseLabel: 'initial',
+          }}
+          releaseVersion={releaseVersion}
+          onSubmit={noop}
+          onCancel={noop}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Select time period coverage'),
+        ).toBeInTheDocument();
+      });
+
+      const selectYearType = screen.getByLabelText('Type');
+      expect(selectYearType).toBeDisabled();
+
+      const inputYear = screen.getByLabelText(
+        testTimeIdentifiers[0].category.label,
+      );
+      expect(inputYear).toBeDisabled();
+
+      const inputReleaseLabel = screen.getByLabelText('Release label');
+      expect(inputReleaseLabel).toBeDisabled();
+    },
+  );
 });

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
@@ -43,7 +43,6 @@ describe('ReleaseSummaryForm', () => {
         releaseVersion={0}
         onSubmit={noop}
         onCancel={noop}
-        hideLabelField={false} // This will be removed in EES-5792
       />,
     );
 
@@ -60,9 +59,6 @@ describe('ReleaseSummaryForm', () => {
       testTimeIdentifiers[0].category.label,
     );
     expect(inputYear).toBeInTheDocument();
-
-    const inputReleaseLabel = screen.getByLabelText('Release label');
-    expect(inputReleaseLabel).toBeInTheDocument();
 
     const releaseTypeRadios = within(
       screen.getByRole('group', { name: 'Release type' }),
@@ -119,7 +115,6 @@ describe('ReleaseSummaryForm', () => {
         }}
         onSubmit={noop}
         onCancel={noop}
-        hideLabelField={false} // This will be removed in EES-5792
       />,
     );
 
@@ -136,9 +131,6 @@ describe('ReleaseSummaryForm', () => {
       testTimeIdentifiers[0].category.label,
     );
     expect(inputYear).toBeInTheDocument();
-
-    const inputReleaseLabel = screen.getByLabelText('Release label');
-    expect(inputReleaseLabel).toBeInTheDocument();
 
     const releaseTypeRadios = within(
       screen.getByRole('group', { name: 'Release type' }),
@@ -403,7 +395,6 @@ describe('ReleaseSummaryForm', () => {
         releaseVersion={0}
         onSubmit={noop}
         onCancel={noop}
-        hideLabelField={false} // This will be removed in EES-5792
       />,
     );
 
@@ -454,7 +445,6 @@ describe('ReleaseSummaryForm', () => {
         releaseVersion={0}
         onSubmit={onSubmit}
         onCancel={noop}
-        hideLabelField={false} // This will be removed in EES-5792
       />,
     );
 
@@ -512,7 +502,6 @@ describe('ReleaseSummaryForm', () => {
         releaseVersion={0}
         onSubmit={onSubmit}
         onCancel={noop}
-        hideLabelField={false} // This will be removed in EES-5792
       />,
     );
 
@@ -685,7 +674,6 @@ describe('ReleaseSummaryForm', () => {
           releaseVersion={releaseVersion}
           onSubmit={noop}
           onCancel={noop}
-          hideLabelField={false} // This will be removed in EES-5792
         />,
       );
 
@@ -708,64 +696,58 @@ describe('ReleaseSummaryForm', () => {
     },
   );
 
-  test.each([true, false])(
-    'Displays a validation error when the server responds with a slug not unique error',
-    async hideLabelField => {
-      metaService.getTimePeriodCoverageGroups.mockResolvedValue(
-        testTimeIdentifiers,
-      );
+  test('Displays a validation error when the server responds with a slug not unique error', async () => {
+    metaService.getTimePeriodCoverageGroups.mockResolvedValue(
+      testTimeIdentifiers,
+    );
 
-      const onSubmit = jest.fn();
+    const onSubmit = jest.fn();
 
-      const error = createAxiosErrorMock<ValidationProblemDetails>({
-        data: {
-          errors: [{ code: 'SlugNotUnique', message: '' }],
-          title: '',
-          type: '',
-          status: 400,
-        },
-      });
-      onSubmit.mockRejectedValue(error);
+    const error = createAxiosErrorMock<ValidationProblemDetails>({
+      data: {
+        errors: [{ code: 'SlugNotUnique', message: '' }],
+        title: '',
+        type: '',
+        status: 400,
+      },
+    });
+    onSubmit.mockRejectedValue(error);
 
-      render(
-        <ReleaseSummaryForm
-          submitText="Create new release"
-          initialValues={{
-            timePeriodCoverageCode: 'AYQ4',
-            timePeriodCoverageStartYear: '1966',
-            releaseType: 'ExperimentalStatistics',
-            releaseLabel: 'initial',
-          }}
-          releaseVersion={0}
-          onSubmit={onSubmit}
-          onCancel={noop}
-          hideLabelField={hideLabelField} // This will be removed in EES-5792
-        />,
-      );
+    render(
+      <ReleaseSummaryForm
+        submitText="Create new release"
+        initialValues={{
+          timePeriodCoverageCode: 'AYQ4',
+          timePeriodCoverageStartYear: '1966',
+          releaseType: 'ExperimentalStatistics',
+          releaseLabel: 'initial',
+        }}
+        releaseVersion={0}
+        onSubmit={onSubmit}
+        onCancel={noop}
+      />,
+    );
 
-      await waitFor(() => {
-        expect(
-          screen.getByText('Select time period coverage'),
-        ).toBeInTheDocument();
-      });
+    await waitFor(() => {
+      expect(
+        screen.getByText('Select time period coverage'),
+      ).toBeInTheDocument();
+    });
 
-      const buttonCreate = screen.getByRole('button', {
-        name: 'Create new release',
-      });
-      await userEvent.click(buttonCreate);
+    const buttonCreate = screen.getByRole('button', {
+      name: 'Create new release',
+    });
+    await userEvent.click(buttonCreate);
 
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            hideLabelField
-              ? 'Choose a unique combination of time period coverage type and start year'
-              : 'Choose a unique combination of time period coverage type, start year and label',
-            { selector: 'a' },
-          ),
-        ).toBeInTheDocument();
-      });
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Choose a unique combination of type, start year and label',
+          { selector: 'a' },
+        ),
+      ).toBeInTheDocument();
+    });
 
-      expect(onSubmit).toHaveBeenCalledTimes(1);
-    },
-  );
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
@@ -43,6 +43,7 @@ describe('ReleaseSummaryForm', () => {
         releaseVersion={0}
         onSubmit={noop}
         onCancel={noop}
+        hideLabelField={false} // This will be removed in EES-5792
       />,
     );
 
@@ -59,6 +60,9 @@ describe('ReleaseSummaryForm', () => {
       testTimeIdentifiers[0].category.label,
     );
     expect(inputYear).toBeInTheDocument();
+
+    const inputReleaseLabel = screen.getByLabelText('Release label');
+    expect(inputReleaseLabel).toBeInTheDocument();
 
     const releaseTypeRadios = within(
       screen.getByRole('group', { name: 'Release type' }),
@@ -115,6 +119,7 @@ describe('ReleaseSummaryForm', () => {
         }}
         onSubmit={noop}
         onCancel={noop}
+        hideLabelField={false} // This will be removed in EES-5792
       />,
     );
 
@@ -131,6 +136,9 @@ describe('ReleaseSummaryForm', () => {
       testTimeIdentifiers[0].category.label,
     );
     expect(inputYear).toBeInTheDocument();
+
+    const inputReleaseLabel = screen.getByLabelText('Release label');
+    expect(inputReleaseLabel).toBeInTheDocument();
 
     const releaseTypeRadios = within(
       screen.getByRole('group', { name: 'Release type' }),
@@ -395,6 +403,7 @@ describe('ReleaseSummaryForm', () => {
         releaseVersion={0}
         onSubmit={noop}
         onCancel={noop}
+        hideLabelField={false} // This will be removed in EES-5792
       />,
     );
 
@@ -445,6 +454,7 @@ describe('ReleaseSummaryForm', () => {
         releaseVersion={0}
         onSubmit={onSubmit}
         onCancel={noop}
+        hideLabelField={false} // This will be removed in EES-5792
       />,
     );
 
@@ -502,6 +512,7 @@ describe('ReleaseSummaryForm', () => {
         releaseVersion={0}
         onSubmit={onSubmit}
         onCancel={noop}
+        hideLabelField={false} // This will be removed in EES-5792
       />,
     );
 
@@ -674,6 +685,7 @@ describe('ReleaseSummaryForm', () => {
           releaseVersion={releaseVersion}
           onSubmit={noop}
           onCancel={noop}
+          hideLabelField={false} // This will be removed in EES-5792
         />,
       );
 
@@ -696,58 +708,64 @@ describe('ReleaseSummaryForm', () => {
     },
   );
 
-  test('Displays a validation error when the server responds with a slug not unique error', async () => {
-    metaService.getTimePeriodCoverageGroups.mockResolvedValue(
-      testTimeIdentifiers,
-    );
+  test.each([true, false])(
+    'Displays a validation error when the server responds with a slug not unique error',
+    async hideLabelField => {
+      metaService.getTimePeriodCoverageGroups.mockResolvedValue(
+        testTimeIdentifiers,
+      );
 
-    const onSubmit = jest.fn();
+      const onSubmit = jest.fn();
 
-    const error = createAxiosErrorMock<ValidationProblemDetails>({
-      data: {
-        errors: [{ code: 'SlugNotUnique', message: '' }],
-        title: '',
-        type: '',
-        status: 400,
-      },
-    });
-    onSubmit.mockRejectedValue(error);
+      const error = createAxiosErrorMock<ValidationProblemDetails>({
+        data: {
+          errors: [{ code: 'SlugNotUnique', message: '' }],
+          title: '',
+          type: '',
+          status: 400,
+        },
+      });
+      onSubmit.mockRejectedValue(error);
 
-    render(
-      <ReleaseSummaryForm
-        submitText="Create new release"
-        initialValues={{
-          timePeriodCoverageCode: 'AYQ4',
-          timePeriodCoverageStartYear: '1966',
-          releaseType: 'ExperimentalStatistics',
-          releaseLabel: 'initial',
-        }}
-        releaseVersion={0}
-        onSubmit={onSubmit}
-        onCancel={noop}
-      />,
-    );
+      render(
+        <ReleaseSummaryForm
+          submitText="Create new release"
+          initialValues={{
+            timePeriodCoverageCode: 'AYQ4',
+            timePeriodCoverageStartYear: '1966',
+            releaseType: 'ExperimentalStatistics',
+            releaseLabel: 'initial',
+          }}
+          releaseVersion={0}
+          onSubmit={onSubmit}
+          onCancel={noop}
+          hideLabelField={hideLabelField} // This will be removed in EES-5792
+        />,
+      );
 
-    await waitFor(() => {
-      expect(
-        screen.getByText('Select time period coverage'),
-      ).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(
+          screen.getByText('Select time period coverage'),
+        ).toBeInTheDocument();
+      });
 
-    const buttonCreate = screen.getByRole('button', {
-      name: 'Create new release',
-    });
-    await userEvent.click(buttonCreate);
+      const buttonCreate = screen.getByRole('button', {
+        name: 'Create new release',
+      });
+      await userEvent.click(buttonCreate);
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          'Choose a unique combination of type, start year and label',
-          { selector: 'a' },
-        ),
-      ).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            hideLabelField
+              ? 'Choose a unique combination of time period coverage type and start year'
+              : 'Choose a unique combination of time period coverage type, start year and label',
+            { selector: 'a' },
+          ),
+        ).toBeInTheDocument();
+      });
 
-    expect(onSubmit).toHaveBeenCalledTimes(1);
-  });
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    },
+  );
 });

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
@@ -60,6 +60,9 @@ describe('ReleaseSummaryForm', () => {
     );
     expect(inputYear).toBeInTheDocument();
 
+    const inputReleaseLabel = screen.getByLabelText('Release label');
+    expect(inputReleaseLabel).toBeInTheDocument();
+
     const releaseTypeRadios = within(
       screen.getByRole('group', { name: 'Release type' }),
     ).getAllByRole('radio');
@@ -131,6 +134,9 @@ describe('ReleaseSummaryForm', () => {
       testTimeIdentifiers[0].category.label,
     );
     expect(inputYear).toBeInTheDocument();
+
+    const inputReleaseLabel = screen.getByLabelText('Release label');
+    expect(inputReleaseLabel).toBeInTheDocument();
 
     const releaseTypeRadios = within(
       screen.getByRole('group', { name: 'Release type' }),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
@@ -51,6 +51,8 @@ const testRelease: Release = {
     label: 'test',
   },
   title: 'test title',
+  label: undefined,
+  version: 0,
   type: 'AccreditedOfficialStatistics',
   preReleaseAccessList: 'test',
   year: 2023,

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -205,6 +205,8 @@ describe('PreReleaseTableToolPage', () => {
       label: 'test',
     },
     title: 'test title',
+    label: undefined,
+    version: 0,
     type: 'AccreditedOfficialStatistics',
     preReleaseAccessList: 'test',
     year: 2023,

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -23,6 +23,8 @@ export interface Release {
   id: string;
   releaseId: string;
   slug: string;
+  label?: string;
+  version: number;
   approvalStatus: ReleaseApprovalStatus;
   notifySubscribers?: boolean;
   updatePublishedDate: boolean;
@@ -81,6 +83,7 @@ interface BaseReleaseRequest {
     value: string;
   };
   type: ReleaseType;
+  label?: string;
 }
 
 export interface CreateReleaseRequest extends BaseReleaseRequest {


### PR DESCRIPTION
These are the frontend changes associated with the backend changes in https://github.com/dfe-analytical-services/explore-education-statistics/pull/5499.

These changes allow the `Label` to be added to both NEW Releases, and existing Releases which are in DRAFT and only currently have 1 Version, via a new `Label` input field in the Release Summary Page.

For Releases which have **more** than 1 Version, or where the Release **is not** in DRAFT, we disable the time period coverage and label fields in the UI.