### PR TITLE
Fix UI test failures in admin and admin_and_public_2 suites

### DIFF
--- a/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
+++ b/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
@@ -179,6 +179,7 @@ Edit release summary
     user clicks button    Update release summary
 
 Verify updated release summary
+    user waits until h2 is visible    Release summary
     user checks page contains element    xpath://li/a[text()="Summary" and contains(@aria-current, 'page')]
     user verifies release summary    Summer term
     ...    2026/27    Official statistics

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -118,8 +118,11 @@ Add three accordion sections to release
     user changes accordion section title    3    Test embedded dashboard section
 
 Add data block to first accordion section
+    user scrolls to accordion section    Dates data block    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
     ${datablock}=    user adds data block to editable accordion section    Dates data block    ${DATABLOCK_NAME}
     ...    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
+    user scrolls to element    ${datablock}
+    user waits until page contains element    ${datablock}    %{WAIT_SMALL}
     user waits until element contains infographic chart    ${datablock}
     user checks chart title contains    ${datablock}    Dates table title
     user checks infographic chart contains alt    ${datablock}    Sample alt text
@@ -201,6 +204,7 @@ Change the Release type
     user checks page contains radio    Official statistics in development
     user clicks radio    Official statistics in development
     user clicks button    Update release summary
+    user waits until h2 is visible    Release summary
     user checks page contains element    xpath://li/a[text()="Summary" and contains(@aria-current, 'page')]
     user verifies release summary    Financial year
     ...    3000-01

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -141,6 +141,7 @@ Add three accordion sections to release
     user changes accordion section title    3    Test embedded dashboard section
 
 Add data block to first accordion section
+    user scrolls to accordion section    Dates data block    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
     user adds data block to editable accordion section    Dates data block    ${DATABLOCK_NAME}
     ...    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
     ${datablock}=    set variable    xpath://*[@data-testid="Data block - ${DATABLOCK_NAME}"]
@@ -482,6 +483,7 @@ Change the Release type
     user checks page contains radio    Official statistics in development
     user clicks radio    Official statistics in development
     user clicks button    Update release summary
+    user waits until h2 is visible    Release summary
     user checks page contains element    xpath://li/a[text()="Summary" and contains(@aria-current, 'page')]
     user verifies release summary    Financial year
     ...    3000-01


### PR DESCRIPTION
This PR fixes the UI test failure on 'Release summary' page in Admin. 
It also fixes a flaky UI test failure at the testcase `Add data block to first accordion section` in 'admin_and_public_2' suite
![image](https://github.com/user-attachments/assets/51505f13-68ea-4400-b8e9-6092449552c8)
