### PR TITLE
EES-5719 Fix unique guidance title validation not triggering correctly

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/AddKeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/AddKeyStatistics.tsx
@@ -1,6 +1,7 @@
 import KeyStatDataBlockSelectForm from '@admin/pages/release/content/components/KeyStatDataBlockSelectForm';
 import styles from '@admin/pages/release/content/components/KeyStatistics.module.scss';
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
+import { EditableRelease } from '@admin/services/releaseContentService';
 import Button from '@common/components/Button';
 import WarningMessage from '@common/components/WarningMessage';
 import React, { useCallback, useState } from 'react';
@@ -8,13 +9,12 @@ import { KeyStatisticType } from '@common/services/publicationService';
 import { KeyStatisticTextCreateRequest } from '@admin/services/keyStatisticService';
 import EditableKeyStatTextForm from '@admin/pages/release/content/components/EditableKeyStatTextForm';
 import ButtonGroup from '@common/components/ButtonGroup';
-import { KeyStatisticsProps } from '@admin/pages/release/content/components/KeyStatistics';
 
-interface Props extends KeyStatisticsProps {
-  keyStatisticGuidanceTitles?: (string | undefined)[];
+interface Props {
+  release: EditableRelease;
 }
 
-const AddKeyStatistics = ({ keyStatisticGuidanceTitles, release }: Props) => {
+export default function AddKeyStatistics({ release }: Props) {
   const [formType, setFormType] = useState<KeyStatisticType | undefined>(
     undefined,
   );
@@ -66,7 +66,7 @@ const AddKeyStatistics = ({ keyStatisticGuidanceTitles, release }: Props) => {
       return (
         <div className={styles.textFormContainer}>
           <EditableKeyStatTextForm
-            keyStatisticGuidanceTitles={keyStatisticGuidanceTitles}
+            keyStats={release.keyStatistics}
             testId="keyStatText-createForm"
             onSubmit={values => addKeyStatText(values)}
             onCancel={() => setFormType(undefined)}
@@ -95,6 +95,4 @@ const AddKeyStatistics = ({ keyStatisticGuidanceTitles, release }: Props) => {
         </ButtonGroup>
       );
   }
-};
-
-export default AddKeyStatistics;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStat.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 interface EditableKeyStatProps {
   isEditing?: boolean;
   keyStat: KeyStatistic;
-  keyStatisticGuidanceTitles?: (string | undefined)[];
+  keyStats: KeyStatistic[];
   releaseId: string;
   testId?: string;
 }
@@ -19,7 +19,7 @@ interface EditableKeyStatProps {
 const EditableKeyStat = ({
   isEditing = false,
   keyStat,
-  keyStatisticGuidanceTitles,
+  keyStats,
   releaseId,
   testId = 'keyStat',
 }: EditableKeyStatProps) => {
@@ -35,7 +35,7 @@ const EditableKeyStat = ({
       return (
         <EditableKeyStatDataBlock
           keyStat={keyStat}
-          keyStatisticGuidanceTitles={keyStatisticGuidanceTitles}
+          keyStats={keyStats}
           releaseId={releaseId}
           testId={testId}
           isEditing={isEditing}
@@ -65,7 +65,7 @@ const EditableKeyStat = ({
       return (
         <EditableKeyStatText
           keyStat={keyStat}
-          keyStatisticGuidanceTitles={keyStatisticGuidanceTitles}
+          keyStats={keyStats}
           testId={testId}
           isEditing={isEditing}
           onRemove={async () => {

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlock.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlock.tsx
@@ -8,7 +8,10 @@ import VisuallyHidden from '@common/components/VisuallyHidden';
 import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import tableBuilderQueries from '@common/modules/find-statistics/queries/tableBuilderQueries';
-import { KeyStatisticDataBlock } from '@common/services/publicationService';
+import {
+  KeyStatistic,
+  KeyStatisticDataBlock,
+} from '@common/services/publicationService';
 import { useQuery } from '@tanstack/react-query';
 import React, { useCallback } from 'react';
 
@@ -16,7 +19,7 @@ export interface EditableKeyStatDataBlockProps {
   isEditing?: boolean;
   isReordering?: boolean;
   keyStat: KeyStatisticDataBlock;
-  keyStatisticGuidanceTitles?: (string | undefined)[];
+  keyStats: KeyStatistic[];
   releaseId: string;
   testId?: string;
   onRemove?: () => void;
@@ -27,7 +30,7 @@ export default function EditableKeyStatDataBlock({
   isEditing = false,
   isReordering = false,
   keyStat,
-  keyStatisticGuidanceTitles,
+  keyStats,
   releaseId,
   testId = 'keyStat',
   onRemove,
@@ -76,9 +79,7 @@ export default function EditableKeyStatDataBlock({
     return (
       <EditableKeyStatDataBlockForm
         keyStat={keyStat}
-        keyStatisticGuidanceTitles={keyStatisticGuidanceTitles?.filter(
-          keyStatTitle => keyStatTitle === keyStat.guidanceTitle,
-        )}
+        keyStats={keyStats}
         title={title}
         statistic={statistic}
         testId={testId}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatDataBlockForm.tsx
@@ -6,7 +6,10 @@ import FormProvider from '@common/components/form/FormProvider';
 import Form from '@common/components/form/Form';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
 import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
-import { KeyStatisticDataBlock } from '@common/services/publicationService';
+import {
+  KeyStatistic,
+  KeyStatisticDataBlock,
+} from '@common/services/publicationService';
 import Yup from '@common/validation/yup';
 import React from 'react';
 
@@ -18,7 +21,7 @@ export interface KeyStatDataBlockFormValues {
 
 export interface EditableKeyStatDataBlockFormProps {
   keyStat: KeyStatisticDataBlock;
-  keyStatisticGuidanceTitles?: (string | undefined)[];
+  keyStats: KeyStatistic[];
   statistic: string;
   testId: string;
   title: string;
@@ -28,13 +31,17 @@ export interface EditableKeyStatDataBlockFormProps {
 
 export default function EditableKeyStatDataBlockForm({
   keyStat,
-  keyStatisticGuidanceTitles,
+  keyStats,
   statistic,
   testId,
   title,
   onSubmit,
   onCancel,
 }: EditableKeyStatDataBlockFormProps) {
+  const guidanceTitles = keyStats
+    .filter(stat => stat.id !== keyStat.id && !!stat.guidanceTitle)
+    .map(stat => stat.guidanceTitle) as string[];
+
   const handleSubmit = async (values: KeyStatDataBlockFormValues) => {
     onSubmit({
       ...values,
@@ -59,14 +66,18 @@ export default function EditableKeyStatDataBlockForm({
             then: s => s.required('Enter a guidance title'),
           })
           .test({
-            name: 'duplicateGuidanceTitles',
-            message: 'Guidance titles must be unique',
-            test: (value?: string) =>
-              !(
-                value !== undefined &&
-                value !== '' &&
-                keyStatisticGuidanceTitles?.includes(value?.toLowerCase())
-              ),
+            name: 'duplicateGuidanceTitle',
+            message: 'Guidance title must be unique',
+            test: (value?: string) => {
+              if (!value) {
+                return true;
+              }
+
+              return !guidanceTitles?.some(
+                guidanceTitle =>
+                  guidanceTitle.toLowerCase() === value.toLowerCase(),
+              );
+            },
           }),
         guidanceText: Yup.string(),
       })}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatText.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatText.tsx
@@ -3,13 +3,16 @@ import EditableKeyStatTextForm, {
   KeyStatTextFormValues,
 } from '@admin/pages/release/content/components/EditableKeyStatTextForm';
 import useToggle from '@common/hooks/useToggle';
-import { KeyStatisticText } from '@common/services/publicationService';
+import {
+  KeyStatistic,
+  KeyStatisticText,
+} from '@common/services/publicationService';
 import React, { useCallback } from 'react';
 
 export interface EditableKeyStatTextProps {
   isEditing?: boolean;
   keyStat: KeyStatisticText;
-  keyStatisticGuidanceTitles?: (string | undefined)[];
+  keyStats: KeyStatistic[];
   testId?: string;
   onRemove: () => void;
   onSubmit: (values: KeyStatTextFormValues) => void;
@@ -18,7 +21,7 @@ export interface EditableKeyStatTextProps {
 export default function EditableKeyStatText({
   isEditing = false,
   keyStat,
-  keyStatisticGuidanceTitles,
+  keyStats,
   testId = 'keyStat',
   onRemove,
   onSubmit,
@@ -37,9 +40,7 @@ export default function EditableKeyStatText({
     return (
       <EditableKeyStatTextForm
         keyStat={keyStat}
-        keyStatisticGuidanceTitles={keyStatisticGuidanceTitles?.filter(
-          keyStatTitle => keyStatTitle === keyStat.title,
-        )}
+        keyStats={keyStats}
         testId={testId}
         onSubmit={handleSubmit}
         onCancel={toggleShowForm.off}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatTextForm.tsx
@@ -5,7 +5,10 @@ import Form from '@common/components/form/Form';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
 import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
 import styles from '@common/modules/find-statistics/components/KeyStat.module.scss';
-import { KeyStatisticText } from '@common/services/publicationService';
+import {
+  KeyStatistic,
+  KeyStatisticText,
+} from '@common/services/publicationService';
 import React from 'react';
 import Yup from '@common/validation/yup';
 
@@ -19,7 +22,7 @@ export interface KeyStatTextFormValues {
 
 interface EditableKeyStatTextFormProps {
   keyStat?: KeyStatisticText;
-  keyStatisticGuidanceTitles?: (string | undefined)[];
+  keyStats: KeyStatistic[];
   onSubmit: (values: KeyStatTextFormValues) => void;
   onCancel: () => void;
   testId: string;
@@ -27,11 +30,15 @@ interface EditableKeyStatTextFormProps {
 
 export default function EditableKeyStatTextForm({
   keyStat,
-  keyStatisticGuidanceTitles,
+  keyStats,
   onSubmit,
   onCancel,
   testId,
 }: EditableKeyStatTextFormProps) {
+  const guidanceTitles = keyStats
+    .filter(stat => stat.id !== keyStat?.id && !!stat.guidanceTitle)
+    .map(stat => stat.guidanceTitle) as string[];
+
   const handleSubmit = async (values: KeyStatTextFormValues) => {
     await onSubmit({
       ...values,
@@ -61,14 +68,18 @@ export default function EditableKeyStatTextForm({
               then: s => s.required('Enter a guidance title'),
             })
             .test({
-              name: 'duplicateGuidanceTitles',
-              message: 'Guidance titles must be unique',
-              test: (value?: string) =>
-                !(
-                  value !== undefined &&
-                  value !== '' &&
-                  keyStatisticGuidanceTitles?.includes(value?.toLowerCase())
-                ),
+              name: 'duplicateGuidanceTitle',
+              message: 'Guidance title must be unique',
+              test: (value?: string) => {
+                if (!value) {
+                  return true;
+                }
+
+                return !guidanceTitles?.some(
+                  guidanceTitle =>
+                    guidanceTitle.toLowerCase() === value.toLowerCase(),
+                );
+              },
             }),
           guidanceText: Yup.string(),
         })}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
@@ -16,7 +16,10 @@ export interface KeyStatisticsProps {
   isEditing?: boolean;
 }
 
-const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
+export default function KeyStatistics({
+  release,
+  isEditing,
+}: KeyStatisticsProps) {
   const { reorderKeyStatistics } = useReleaseContentActions();
   const [keyStatistics, setKeyStatistics] = useState(release.keyStatistics);
 
@@ -26,18 +29,11 @@ const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
 
   const [isReordering, toggleIsReordering] = useToggle(false);
 
-  const keyStatisticGuidanceTitles = keyStatistics.map(
-    stat => stat.guidanceTitle?.toLowerCase(),
-  );
-
   return (
     <>
       {isEditing && (
         <>
-          <AddKeyStatistics
-            keyStatisticGuidanceTitles={keyStatisticGuidanceTitles}
-            release={release}
-          />
+          <AddKeyStatistics release={release} />
           <hr />
           {keyStatistics.length > 1 && !isReordering && (
             <Button variant="secondary" onClick={toggleIsReordering.on}>
@@ -62,6 +58,7 @@ const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
                 <EditableKeyStatDataBlock
                   isReordering
                   keyStat={keyStat}
+                  keyStats={[]}
                   releaseId={release.id}
                 />
               ),
@@ -93,7 +90,7 @@ const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
       ) : (
         <div className="govuk-!-margin-bottom-9">
           <KeyStatContainer>
-            {keyStatistics.map(keyStat => (
+            {release.keyStatistics.map(keyStat => (
               <div
                 className={keyStatStyles.wrapper}
                 data-testid="keyStat"
@@ -101,7 +98,7 @@ const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
               >
                 <EditableKeyStat
                   keyStat={keyStat}
-                  keyStatisticGuidanceTitles={keyStatisticGuidanceTitles}
+                  keyStats={release.keyStatistics}
                   releaseId={release.id}
                   isEditing={isEditing}
                 />
@@ -112,6 +109,4 @@ const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
       )}
     </>
   );
-};
-
-export default KeyStatistics;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStat.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStat.test.tsx
@@ -32,7 +32,7 @@ const dataBlockService = _dataBlockService as jest.Mocked<
 
 describe('EditableKeyStat', () => {
   describe('for `KeyStatisticText` type', () => {
-    const keyStatText: KeyStatisticText = {
+    const testKeyStat: KeyStatisticText = {
       type: 'KeyStatisticText',
       id: 'keyStatDataBlock-1',
       title: 'Text title',
@@ -45,7 +45,13 @@ describe('EditableKeyStat', () => {
     };
 
     test('renders correctly', async () => {
-      render(<EditableKeyStat releaseId="release-1" keyStat={keyStatText} />);
+      render(
+        <EditableKeyStat
+          releaseId="release-1"
+          keyStat={testKeyStat}
+          keyStats={[testKeyStat]}
+        />,
+      );
 
       await waitFor(() => {
         expect(
@@ -133,7 +139,7 @@ describe('EditableKeyStat', () => {
       ],
     };
 
-    const keyStatDataBlock: KeyStatisticDataBlock = {
+    const testKeyStat: KeyStatisticDataBlock = {
       type: 'KeyStatisticDataBlock',
       id: 'keyStatDataBlock-1',
       trend: 'Trend',
@@ -150,11 +156,15 @@ describe('EditableKeyStat', () => {
       );
 
       keyStatisticService.updateKeyStatisticDataBlock.mockResolvedValue(
-        keyStatDataBlock,
+        testKeyStat,
       );
 
       render(
-        <EditableKeyStat releaseId="release-1" keyStat={keyStatDataBlock} />,
+        <EditableKeyStat
+          releaseId="release-1"
+          keyStat={testKeyStat}
+          keyStats={[testKeyStat]}
+        />,
       );
 
       await waitFor(() => {
@@ -188,13 +198,14 @@ describe('EditableKeyStat', () => {
       );
 
       keyStatisticService.updateKeyStatisticDataBlock.mockResolvedValue(
-        keyStatDataBlock,
+        testKeyStat,
       );
 
       render(
         <EditableKeyStat
           releaseId="release-1"
-          keyStat={keyStatDataBlock}
+          keyStat={testKeyStat}
+          keyStats={[testKeyStat]}
           isEditing
         />,
       );
@@ -241,13 +252,14 @@ describe('EditableKeyStat', () => {
       );
 
       keyStatisticService.updateKeyStatisticDataBlock.mockResolvedValue(
-        keyStatDataBlock,
+        testKeyStat,
       );
 
       render(
         <EditableKeyStat
           releaseId="release-1"
-          keyStat={keyStatDataBlock}
+          keyStat={testKeyStat}
+          keyStats={[testKeyStat]}
           isEditing
         />,
       );
@@ -288,6 +300,7 @@ describe('EditableKeyStat', () => {
               created: '2023-01-01',
             } as never
           }
+          keyStats={[]}
         />,
       );
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatDataBlock.test.tsx
@@ -63,7 +63,7 @@ describe('EditableKeyStatDataBlock', () => {
     ],
   };
 
-  const keyStatDataBlock: KeyStatisticDataBlock = {
+  const testKeyStat: KeyStatisticDataBlock = {
     type: 'KeyStatisticDataBlock',
     id: 'keyStatDataBlock-1',
     trend: 'DataBlock trend',
@@ -82,7 +82,8 @@ describe('EditableKeyStatDataBlock', () => {
     render(
       <EditableKeyStatDataBlock
         releaseId="release-1"
-        keyStat={keyStatDataBlock}
+        keyStat={testKeyStat}
+        keyStats={[testKeyStat]}
         onRemove={noop}
         onSubmit={noop}
       />,
@@ -123,7 +124,8 @@ describe('EditableKeyStatDataBlock', () => {
       <EditableKeyStatDataBlock
         isEditing
         releaseId="release-1"
-        keyStat={keyStatDataBlock}
+        keyStat={testKeyStat}
+        keyStats={[testKeyStat]}
         onRemove={noop}
         onSubmit={noop}
       />,
@@ -158,7 +160,8 @@ describe('EditableKeyStatDataBlock', () => {
     render(
       <EditableKeyStatDataBlock
         releaseId="release-1"
-        keyStat={{ ...keyStatDataBlock, trend: undefined }}
+        keyStat={{ ...testKeyStat, trend: undefined }}
+        keyStats={[testKeyStat]}
         onRemove={noop}
         onSubmit={noop}
       />,
@@ -177,7 +180,8 @@ describe('EditableKeyStatDataBlock', () => {
     render(
       <EditableKeyStatDataBlock
         releaseId="release-1"
-        keyStat={{ ...keyStatDataBlock, guidanceTitle: undefined }}
+        keyStat={{ ...testKeyStat, guidanceTitle: undefined }}
+        keyStats={[testKeyStat]}
         onRemove={noop}
         onSubmit={noop}
       />,
@@ -203,7 +207,8 @@ describe('EditableKeyStatDataBlock', () => {
     render(
       <EditableKeyStatDataBlock
         releaseId="release-1"
-        keyStat={{ ...keyStatDataBlock, guidanceText: undefined }}
+        keyStat={{ ...testKeyStat, guidanceText: undefined }}
+        keyStats={[testKeyStat]}
         onRemove={noop}
         onSubmit={noop}
       />,
@@ -232,7 +237,8 @@ describe('EditableKeyStatDataBlock', () => {
     render(
       <EditableKeyStatDataBlock
         releaseId="release-1"
-        keyStat={keyStatDataBlock}
+        keyStat={testKeyStat}
+        keyStats={[testKeyStat]}
         isEditing
         onRemove={onRemove}
         onSubmit={noop}
@@ -261,7 +267,8 @@ describe('EditableKeyStatDataBlock', () => {
     render(
       <EditableKeyStatDataBlock
         releaseId="release-1"
-        keyStat={keyStatDataBlock}
+        keyStat={testKeyStat}
+        keyStats={[testKeyStat]}
         isEditing
         onRemove={noop}
         onSubmit={noop}
@@ -287,15 +294,17 @@ describe('EditableKeyStatDataBlock', () => {
   });
 
   test('clicking the cancel button toggles back to preview', async () => {
-    const user = userEvent.setup();
     tableBuilderService.getDataBlockTableData.mockResolvedValue(
       testTableDataResponse,
     );
 
+    const user = userEvent.setup();
+
     render(
       <EditableKeyStatDataBlock
         releaseId="release-1"
-        keyStat={keyStatDataBlock}
+        keyStat={testKeyStat}
+        keyStats={[testKeyStat]}
         isEditing
         onRemove={noop}
         onSubmit={noop}
@@ -326,18 +335,19 @@ describe('EditableKeyStatDataBlock', () => {
   });
 
   test('can click the remove button when data block fails to load', async () => {
-    const user = userEvent.setup();
     tableBuilderService.getDataBlockTableData.mockRejectedValue(
       new Error('Something went wrong'),
     );
 
-    const onRemove = jest.fn();
+    const user = userEvent.setup();
+    const handleRemove = jest.fn();
 
     render(
       <EditableKeyStatDataBlock
         releaseId="release-1"
-        keyStat={keyStatDataBlock}
-        onRemove={onRemove}
+        keyStat={testKeyStat}
+        keyStats={[testKeyStat]}
+        onRemove={handleRemove}
         onSubmit={noop}
       />,
     );
@@ -357,7 +367,7 @@ describe('EditableKeyStatDataBlock', () => {
       screen.queryByRole('button', { name: 'Edit' }),
     ).not.toBeInTheDocument();
 
-    expect(onRemove).not.toHaveBeenCalled();
+    expect(handleRemove).not.toHaveBeenCalled();
 
     await user.click(
       screen.getByRole('button', {
@@ -365,6 +375,6 @@ describe('EditableKeyStatDataBlock', () => {
       }),
     );
 
-    expect(onRemove).toBeCalledTimes(1);
+    expect(handleRemove).toBeCalledTimes(1);
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/EditableKeyStatText.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 
 describe('EditableKeyStatText', () => {
-  const keyStatText: KeyStatisticText = {
+  const testKeyStat: KeyStatisticText = {
     type: 'KeyStatisticText',
     id: 'keyStatDataBlock-1',
     trend: 'Text trend',
@@ -21,7 +21,8 @@ describe('EditableKeyStatText', () => {
   test('renders correctly when `isEditing` is false', async () => {
     render(
       <EditableKeyStatText
-        keyStat={keyStatText}
+        keyStat={testKeyStat}
+        keyStats={[testKeyStat]}
         onRemove={noop}
         onSubmit={noop}
       />,
@@ -57,7 +58,8 @@ describe('EditableKeyStatText', () => {
     render(
       <EditableKeyStatText
         isEditing
-        keyStat={keyStatText}
+        keyStat={testKeyStat}
+        keyStats={[testKeyStat]}
         onRemove={noop}
         onSubmit={noop}
       />,
@@ -88,7 +90,8 @@ describe('EditableKeyStatText', () => {
   test('does not render the trend when `trend` is undefined', async () => {
     render(
       <EditableKeyStatText
-        keyStat={{ ...keyStatText, trend: undefined }}
+        keyStat={{ ...testKeyStat, trend: undefined }}
+        keyStats={[testKeyStat]}
         onRemove={noop}
         onSubmit={noop}
       />,
@@ -100,7 +103,8 @@ describe('EditableKeyStatText', () => {
   test('renders the default guidance title when `guidanceTitle` is undefined', async () => {
     render(
       <EditableKeyStatText
-        keyStat={{ ...keyStatText, guidanceTitle: undefined }}
+        keyStat={{ ...testKeyStat, guidanceTitle: undefined }}
+        keyStats={[testKeyStat]}
         onRemove={noop}
         onSubmit={noop}
       />,
@@ -120,7 +124,8 @@ describe('EditableKeyStatText', () => {
   test('does not render the guidance when `guidanceText` is undefined', async () => {
     render(
       <EditableKeyStatText
-        keyStat={{ ...keyStatText, guidanceText: undefined }}
+        keyStat={{ ...testKeyStat, guidanceText: undefined }}
+        keyStats={[testKeyStat]}
         onRemove={noop}
         onSubmit={noop}
       />,
@@ -139,9 +144,11 @@ describe('EditableKeyStatText', () => {
 
   test('clicking the edit button shows the form', async () => {
     const user = userEvent.setup();
+
     render(
       <EditableKeyStatText
-        keyStat={keyStatText}
+        keyStat={testKeyStat}
+        keyStats={[testKeyStat]}
         isEditing
         onRemove={noop}
         onSubmit={noop}
@@ -182,9 +189,11 @@ describe('EditableKeyStatText', () => {
 
   test('clicking the cancel button toggles back to preview', async () => {
     const user = userEvent.setup();
+
     render(
       <EditableKeyStatText
-        keyStat={keyStatText}
+        keyStat={testKeyStat}
+        keyStats={[testKeyStat]}
         isEditing
         onRemove={noop}
         onSubmit={noop}
@@ -217,18 +226,20 @@ describe('EditableKeyStatText', () => {
   });
 
   test('clicking the remove button calls the onRemove handler', async () => {
-    const handleOnRemove = jest.fn();
+    const handleRemove = jest.fn();
     const user = userEvent.setup();
+
     render(
       <EditableKeyStatText
-        keyStat={keyStatText}
+        keyStat={testKeyStat}
+        keyStats={[testKeyStat]}
         isEditing
-        onRemove={handleOnRemove}
+        onRemove={handleRemove}
         onSubmit={noop}
       />,
     );
 
-    expect(handleOnRemove).not.toHaveBeenCalled();
+    expect(handleRemove).not.toHaveBeenCalled();
 
     await user.click(
       screen.getByRole('button', {
@@ -236,6 +247,6 @@ describe('EditableKeyStatText', () => {
       }),
     );
 
-    expect(handleOnRemove).toHaveBeenCalled();
+    expect(handleRemove).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This PR primarily fixes a bug where the incorrect guidance titles from the other key stats was being passed to the validation in `EditableKeyStatDataBlockForm`. We now calculate the correct set of guidance titles by comparing all key stats with the current form's key stat.
