### PR TITLE
EES-5689 - added various failure alerts

### DIFF
--- a/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
@@ -166,6 +166,9 @@ module apiContainerAppModule '../../components/containerApp.bicep' = {
       responseTime: true
       cpuPercentage: true
       memoryPercentage: true
+      connectionTimeouts: true
+      requestRetries: true
+      requestTimeouts: true
       alertsGroupName: resourceNames.existingResources.alertsGroup
     } : null
     tagValues: tagValues

--- a/infrastructure/templates/public-api/application/public-api/publicApiAppInsights.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiAppInsights.bicep
@@ -6,11 +6,21 @@ param resourceNames ResourceNames
 @description('Specifies the location for all resources.')
 param location string
 
+@description('Specifies a set of tags with which to tag the resource in Azure.')
+param tagValues object
+
 module applicationInsightsModule '../../components/appInsights.bicep' = {
   name: 'appInsightsDeploy'
   params: {
     location: location
     appInsightsName: resourceNames.publicApi.appInsights
+    alerts: {
+      exceptionCount: true
+      exceptionServerCount: true
+      failedRequests: true
+      alertsGroupName: resourceNames.existingResources.alertsGroup
+    }
+    tagValues: tagValues
   }
 }
 

--- a/infrastructure/templates/public-api/application/public-api/publicApiDataProcessor.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiDataProcessor.bicep
@@ -121,6 +121,7 @@ module dataProcessorFunctionAppModule '../../components/functionApp.bicep' = {
       fileServiceAvailability: true
       fileServiceLatency: false
       fileServiceCapacity: true
+      httpErrors: true
       alertsGroupName: resourceNames.existingResources.alertsGroup
     } : null
     tagValues: tagValues

--- a/infrastructure/templates/public-api/application/shared/appGateway.bicep
+++ b/infrastructure/templates/public-api/application/shared/appGateway.bicep
@@ -54,6 +54,8 @@ module appGatewayModule '../../components/appGateway.bicep' = {
     alerts: deployAlerts ? {
       health: true
       responseTime: true
+      failedRequests: true
+      responseStatuses: true
       alertsGroupName: resourceNames.existingResources.alertsGroup
     } : null
     tagValues: tagValues

--- a/infrastructure/templates/public-api/application/shared/postgreSqlFlexibleServer.bicep
+++ b/infrastructure/templates/public-api/application/shared/postgreSqlFlexibleServer.bicep
@@ -72,6 +72,8 @@ module postgreSqlServerModule '../../components/postgresqlDatabase.bicep' = {
       diskIops: true
       memoryPercentage: true
       capacity: true
+      failedConnections: true
+      deadlocks: true
       alertsGroupName: resourceNames.existingResources.alertsGroup
     } : null
     tagValues: tagValues

--- a/infrastructure/templates/public-api/components/alerts/dynamicAlertConfig.bicep
+++ b/infrastructure/templates/public-api/components/alerts/dynamicAlertConfig.bicep
@@ -76,6 +76,20 @@ var dynamicMaxGreaterThan = {
 }
 
 @export()
+var dynamicTotalGreaterThan = {
+  ...defaultDynamicAlertConfig
+  aggregation: 'Total'
+  operator: 'GreaterThan'
+}
+
+@export()
+var dynamicCountGreaterThan = {
+  ...defaultDynamicAlertConfig
+  aggregation: 'Count'
+  operator: 'GreaterThan'
+}
+
+@export()
 var cpuPercentageConfig = {
   ...dynamicAverageGreaterThan
   nameSuffix: 'cpu-percentage'

--- a/infrastructure/templates/public-api/components/alerts/resourceMetrics.bicep
+++ b/infrastructure/templates/public-api/components/alerts/resourceMetrics.bicep
@@ -4,7 +4,24 @@ type AppGatewayMetric = {
   resourceType: 'Microsoft.Network/applicationGateways'
   metric:
     | 'ApplicationGatewayTotalTime'
+    | 'FailedRequests'
     | 'UnhealthyHostCount'
+    | 'ResponseStatus'
+  dimensions: {
+    name: 
+      | 'BackendSettingsPool'
+      | 'HttpStatusGroup'
+    operator: DimensionOperator?
+    values: string[]
+  }[]?
+}
+
+type AppInsightsMetric = {
+  resourceType: 'Microsoft.Insights/components'
+  metric:
+    | 'exceptions/count'
+    | 'exceptions/server'
+    | 'requests/failed'
 }
 
 type AppServicePlanMetric = {
@@ -19,29 +36,42 @@ type ContainerAppMetric = {
   metric:
     | 'CpuPercentage' 
     | 'MemoryPercentage'
+    | 'ResiliencyConnectTimeouts'
+    | 'ResiliencyRequestRetries'
+    | 'ResiliencyRequestTimeouts'
     | 'ResponseTime'
     | 'RestartCount'
 }
 
 type FileServiceMetric = {
   resourceType: 'Microsoft.Storage/storageAccounts/fileServices'
-  dimensions: {
-    name: 'FileShare' | 'Tier'
-    operator: DimensionOperator?
-    values: string[]
-  }[]?
   metric:
     | 'availability'
     | 'FileCapacity'
     | 'SuccessE2ELatency'
+    dimensions: {
+      name: 
+        | 'FileShare'
+        | 'Tier'
+      operator: DimensionOperator?
+      values: string[]
+    }[]?
 }
 
 type PostgreSqlMetric = {
   resourceType: 'Microsoft.DBforPostgreSQL/flexibleServers'
+  dimensions: {
+    name: 
+      | 'DatabaseName'
+    operator: DimensionOperator?
+    values: string[]
+  }[]?
   metric:
     | 'backup_storage_used'
     | 'client_connections_waiting'
+    | 'connections_failed'
     | 'cpu_percent'
+    | 'deadlocks'
     | 'disk_bandwidth_consumed_percentage'
     | 'disk_iops_consumed_percentage'
     | 'is_db_alive'
@@ -55,6 +85,10 @@ type SiteMetric = {
   resourceType: 'Microsoft.Web/sites'
   metric:
     | 'HealthCheckStatus'
+    | 'Http401'
+    | 'Http403'
+    | 'Http4xx'
+    | 'Http5xx'
 }
 
 type StorageAccountMetric = {
@@ -68,8 +102,9 @@ type StorageAccountMetric = {
 @export()
 @discriminator('resourceType')
 type ResourceMetric = 
-| AppServicePlanMetric
 | AppGatewayMetric
+| AppInsightsMetric
+| AppServicePlanMetric
 | ContainerAppMetric
 | ContainerAppMetric
 | FileServiceMetric

--- a/infrastructure/templates/public-api/components/appInsights.bicep
+++ b/infrastructure/templates/public-api/components/appInsights.bicep
@@ -1,8 +1,21 @@
+import { dynamicCountGreaterThan } from 'alerts/dynamicAlertConfig.bicep'
+
 @description('Specifies the location for all resources.')
 param location string
 
 @description('Specifies the Application Insights name')
 param appInsightsName string
+
+@description('Whether to create or update Azure Monitor alerts during this deploy')
+param alerts {
+  exceptionCount: bool
+  exceptionServerCount: bool
+  failedRequests: bool
+  alertsGroupName: string
+}?
+
+@description('Tags for the resources')
+param tagValues object
 
 var kind = 'web'
 
@@ -14,6 +27,61 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
     Application_Type: kind
     publicNetworkAccessForIngestion: 'Enabled'
     publicNetworkAccessForQuery: 'Enabled'
+  }
+  tags: tagValues
+}
+
+module exceptionCountAlert 'alerts/dynamicMetricAlert.bicep' = if (alerts != null && alerts!.exceptionCount) {
+  name: '${appInsightsName}ExceptionCountDeploy'
+  params: {
+    resourceName: appInsightsName
+    resourceMetric: {
+      resourceType: 'Microsoft.Insights/components'
+      metric: 'exceptions/count'
+    }
+    config: {
+      ...dynamicCountGreaterThan
+      nameSuffix: 'exception-count'
+      windowSize: 'PT30M'
+    }
+    alertsGroupName: alerts!.alertsGroupName
+    tagValues: tagValues
+  }
+}
+
+module exceptionServerCountAlert 'alerts/dynamicMetricAlert.bicep' = if (alerts != null && alerts!.exceptionServerCount) {
+  name: '${appInsightsName}ExceptionServerCountDeploy'
+  params: {
+    resourceName: appInsightsName
+    resourceMetric: {
+      resourceType: 'Microsoft.Insights/components'
+      metric: 'exceptions/server'
+    }
+    config: {
+      ...dynamicCountGreaterThan
+      nameSuffix: 'server-exception-count'
+      windowSize: 'PT30M'
+    }
+    alertsGroupName: alerts!.alertsGroupName
+    tagValues: tagValues
+  }
+}
+
+module failedRequestsAlert 'alerts/dynamicMetricAlert.bicep' = if (alerts != null && alerts!.failedRequests) {
+  name: '${appInsightsName}FailedRequestsDeploy'
+  params: {
+    resourceName: appInsightsName
+    resourceMetric: {
+      resourceType: 'Microsoft.Insights/components'
+      metric: 'requests/failed'
+    }
+    config: {
+      ...dynamicCountGreaterThan
+      nameSuffix: 'failed-requests'
+      windowSize: 'PT30M'
+    }
+    alertsGroupName: alerts!.alertsGroupName
+    tagValues: tagValues
   }
 }
 

--- a/infrastructure/templates/public-api/components/containerApp.bicep
+++ b/infrastructure/templates/public-api/components/containerApp.bicep
@@ -111,6 +111,9 @@ param alerts {
   responseTime: bool
   cpuPercentage: bool
   memoryPercentage: bool
+  connectionTimeouts: bool
+  requestRetries: bool
+  requestTimeouts: bool
   alertsGroupName: string
 }?
 
@@ -270,6 +273,57 @@ module memoryPercentageAlert 'alerts/dynamicMetricAlert.bicep' = if (alerts != n
       metric: 'MemoryPercentage'
     }
     config: memoryPercentageConfig
+    alertsGroupName: alerts!.alertsGroupName
+    tagValues: tagValues
+  }
+}
+
+module connectionTimeoutsAlert 'alerts/staticMetricAlert.bicep' = if (alerts != null && alerts!.connectionTimeouts) {
+  name: '${containerAppName}ConnectionTimeoutsAlertModule'
+  params: {
+    resourceName: containerAppName
+    resourceMetric: {
+      resourceType: 'Microsoft.App/containerApps'
+      metric: 'ResiliencyConnectTimeouts'
+    }
+    config: {
+      ...staticTotalGreaterThanZero
+      nameSuffix: 'connection-timeouts'
+    }
+    alertsGroupName: alerts!.alertsGroupName
+    tagValues: tagValues
+  }
+}
+
+module requestRetriesAlert 'alerts/staticMetricAlert.bicep' = if (alerts != null && alerts!.requestRetries) {
+  name: '${containerAppName}RequestRetriesAlertModule'
+  params: {
+    resourceName: containerAppName
+    resourceMetric: {
+      resourceType: 'Microsoft.App/containerApps'
+      metric: 'ResiliencyRequestRetries'
+    }
+    config: {
+      ...staticTotalGreaterThanZero
+      nameSuffix: 'request-retries'
+    }
+    alertsGroupName: alerts!.alertsGroupName
+    tagValues: tagValues
+  }
+}
+
+module requestTimeoutsAlert 'alerts/staticMetricAlert.bicep' = if (alerts != null && alerts!.requestTimeouts) {
+  name: '${containerAppName}RequestTimeoutsAlertModule'
+  params: {
+    resourceName: containerAppName
+    resourceMetric: {
+      resourceType: 'Microsoft.App/containerApps'
+      metric: 'ResiliencyRequestTimeouts'
+    }
+    config: {
+      ...staticTotalGreaterThanZero
+      nameSuffix: 'request-timeouts'
+    }
     alertsGroupName: alerts!.alertsGroupName
     tagValues: tagValues
   }

--- a/infrastructure/templates/public-api/components/fileShare.bicep
+++ b/infrastructure/templates/public-api/components/fileShare.bicep
@@ -66,7 +66,7 @@ module availabilityAlert 'alerts/staticMetricAlert.bicep' = if (alerts != null &
   }
 }
 
-module latencyAlert 'alerts/dynamicMetricAlert.bicep' = if (alerts != null && alerts!.latency) {
+module latencyAlert 'alerts/staticMetricAlert.bicep' = if (alerts != null && alerts!.latency) {
   name: '${storageAccountName}FsLatencyDeploy'
   params: {
     resourceName: alertResourceName
@@ -75,7 +75,11 @@ module latencyAlert 'alerts/dynamicMetricAlert.bicep' = if (alerts != null && al
       resourceType: 'Microsoft.Storage/storageAccounts/fileServices'
       metric: 'SuccessE2ELatency'
     }
-    config: responseTimeConfig
+    config: {
+      ...staticAverageGreaterThanZero
+      nameSuffix: 'response-time'
+      threshold: '250'
+    }
     alertsGroupName: alerts!.alertsGroupName
     tagValues: tagValues
   }

--- a/infrastructure/templates/public-api/components/functionApp.bicep
+++ b/infrastructure/templates/public-api/components/functionApp.bicep
@@ -505,6 +505,7 @@ module expectedHttpStatusCodeAlerts 'alerts/dynamicMetricAlert.bicep' = [
       config: {
         ...dynamicAverageGreaterThan
         nameSuffix: toLower(httpStatusCode)
+        severity: 'Informational'
       }
       alertsGroupName: alerts!.alertsGroupName
       tagValues: tagValues

--- a/infrastructure/templates/public-api/components/storageAccount.bicep
+++ b/infrastructure/templates/public-api/components/storageAccount.bicep
@@ -1,5 +1,5 @@
 import { responseTimeConfig } from 'alerts/dynamicAlertConfig.bicep'
-import { staticAverageLessThanHundred } from 'alerts/staticAlertConfig.bicep'
+import { staticAverageLessThanHundred, staticAverageGreaterThanZero } from 'alerts/staticAlertConfig.bicep'
 
 import { IpRange } from '../types.bicep'
 
@@ -77,8 +77,7 @@ module availabilityAlert 'alerts/staticMetricAlert.bicep' = if (alerts != null &
   }
 }
 
-
-module latencyAlert 'alerts/dynamicMetricAlert.bicep' = if (alerts != null && alerts!.latency) {
+module latencyAlert 'alerts/staticMetricAlert.bicep' = if (alerts != null && alerts!.latency) {
   name: '${storageAccountName}LatencyDeploy'
   params: {
     resourceName: storageAccountName
@@ -86,7 +85,11 @@ module latencyAlert 'alerts/dynamicMetricAlert.bicep' = if (alerts != null && al
       resourceType: 'Microsoft.Storage/storageAccounts'
       metric: 'SuccessE2ELatency'
     }
-    config: responseTimeConfig
+    config: {
+      ...staticAverageGreaterThanZero
+      nameSuffix: 'response-time'
+      threshold: '250'
+    }
     alertsGroupName: alerts!.alertsGroupName
     tagValues: tagValues
   }

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -243,6 +243,7 @@ module appInsightsModule 'application/public-api/publicApiAppInsights.bicep' = {
   params: {
     location: location
     resourceNames: resourceNames
+    tagValues: tagValues
   }
 }
 


### PR DESCRIPTION
This PR:
- adds alerts for errors and failures to various Azure resources in the Public API.

This PR also makes the assumption that certain "failure" HTTP response codes are expected to happen from our application code and so are treated as a lower priority than unexpected ones.  As an example, 403s are expected for failed authentication responses, whereas 401s aren't expected as our end-user interactions don't generally produce those whereas incorrectly configured infrastructure will. 