### PR TITLE
EES-5299 announce search form errors to screen readers

### DIFF
--- a/src/explore-education-statistics-common/src/components/ErrorMessage.tsx
+++ b/src/explore-education-statistics-common/src/components/ErrorMessage.tsx
@@ -2,13 +2,20 @@ import VisuallyHidden from '@common/components/VisuallyHidden';
 import React, { ReactNode } from 'react';
 
 interface Props {
+  // Announce errors on specific fields only when the form error summary is not used.
+  announceError?: boolean;
   children?: ReactNode;
   id?: string;
 }
 
-const ErrorMessage = ({ children, id }: Props) => {
+const ErrorMessage = ({ announceError = false, children, id }: Props) => {
   return (
-    <span className="govuk-error-message" id={id} data-testid={id}>
+    <span
+      className="govuk-error-message"
+      id={id}
+      data-testid={id}
+      role={announceError ? 'status' : undefined}
+    >
       <VisuallyHidden>Error: </VisuallyHidden>
       {children}
     </span>

--- a/src/explore-education-statistics-common/src/components/form/FormBaseInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormBaseInput.tsx
@@ -17,6 +17,7 @@ export interface FormBaseInputProps
   extends Pick<FormLabelProps, 'hideLabel' | 'label' | 'labelSize'> {
   addOn?: ReactNode;
   addOnContainerClassName?: string;
+  announceError?: boolean;
   className?: string;
   disabled?: boolean;
   error?: ReactNode | string;
@@ -44,6 +45,7 @@ interface HiddenProps {
 function FormBaseInput({
   addOn,
   addOnContainerClassName,
+  announceError,
   className,
   error,
   hint,
@@ -125,8 +127,11 @@ function FormBaseInput({
           {hint}
         </div>
       )}
-
-      {error && <ErrorMessage id={`${id}-error`}>{error}</ErrorMessage>}
+      {(announceError || error) && (
+        <ErrorMessage announceError={announceError} id={`${id}-error`}>
+          {error}
+        </ErrorMessage>
+      )}
       {addOn ? (
         <div className={classNames('dfe-flex', addOnContainerClassName)}>
           {input}

--- a/src/explore-education-statistics-common/src/components/form/FormSearchBar.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormSearchBar.tsx
@@ -65,6 +65,7 @@ const FormSearchBar = ({
             <VisuallyHidden>Search</VisuallyHidden>
           </button>
         }
+        announceError
         className={styles.input}
         error={
           showError ? `Search must be at least ${min} characters` : undefined

--- a/src/explore-education-statistics-frontend/src/components/SearchForm.tsx
+++ b/src/explore-education-statistics-frontend/src/components/SearchForm.tsx
@@ -1,8 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import FormSearchBar from '@common/components/form/FormSearchBar';
+import FormProvider from '@common/components/form/FormProvider';
+import { Form, FormFieldTextInput } from '@common/components/form';
+import SearchIcon from '@common/components/SearchIcon';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import styles from '@common/components/form/FormSearchBar.module.scss';
+import Yup from '@common/validation/yup';
+import React from 'react';
 
 const min = 3;
-const formId = 'searchForm';
 
 interface Props {
   label?: string;
@@ -10,38 +14,41 @@ interface Props {
   onSubmit: (value: string) => void;
 }
 
-const SearchForm = ({
+export default function SearchForm({
   label = 'Search',
   value: initialValue = '',
   onSubmit,
-}: Props) => {
-  const [searchTerm, setSearchTerm] = useState<string>(initialValue);
-
-  useEffect(() => {
-    setSearchTerm(initialValue);
-  }, [initialValue]);
-
+}: Props) {
   return (
-    <form
-      id={formId}
-      className="govuk-!-margin-bottom-2"
-      onSubmit={e => {
-        e.preventDefault();
-        if (searchTerm.length >= min) {
-          onSubmit(searchTerm);
-        }
+    <FormProvider
+      initialValues={{
+        search: initialValue,
       }}
+      validationSchema={Yup.object({
+        search: Yup.string()
+          .min(min, `Search must be at least ${min} characters`)
+          .required('Enter a search term'),
+      })}
     >
-      <FormSearchBar
-        id={`${formId}-search`}
-        label={label}
-        min={min}
-        name="search"
-        value={searchTerm}
-        onChange={setSearchTerm}
-      />
-    </form>
+      <Form
+        id="searchForm"
+        showErrorSummary={false}
+        onSubmit={({ search }) => onSubmit(search)}
+      >
+        <FormFieldTextInput
+          addOn={
+            <button type="submit" className={styles.button}>
+              <SearchIcon className={styles.icon} />
+              <VisuallyHidden>Search</VisuallyHidden>
+            </button>
+          }
+          announceError
+          id="search"
+          label={label}
+          labelSize="m"
+          name="search"
+        />
+      </Form>
+    </FormProvider>
   );
-};
-
-export default SearchForm;
+}


### PR DESCRIPTION
Fixes an accessibility bug where search field errors were not announced to screen readers:

- Find stats and data catalogue search, also updated `SearchForm` to use a standard `Form` 
- Featured table search on step 2 of the table tool (this uses `FormSearchBar` instead of `SearchForm` as it's already inside a form)