### PR TITLE
EES-3088 / EES-5747 fix error links for nested form fields

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataGuidanceSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataGuidanceSection.test.tsx
@@ -480,7 +480,7 @@ describe('ReleaseDataGuidanceSection', () => {
           screen.getByRole('link', {
             name: 'Enter file guidance content for Data set 1',
           }),
-        ).toHaveAttribute('href', '#dataGuidanceForm-dataSets0Content');
+        ).toHaveAttribute('href', '#dataGuidanceForm-dataSets-0-content');
 
         expect(fileGuidanceContent).toHaveAttribute(
           'id',
@@ -555,7 +555,7 @@ describe('ReleaseDataGuidanceSection', () => {
           screen.getByRole('link', {
             name: 'Enter file guidance content for Data set 1',
           }),
-        ).toHaveAttribute('href', '#dataGuidanceForm-dataSets0Content');
+        ).toHaveAttribute('href', '#dataGuidanceForm-dataSets-0-content');
 
         expect(
           releaseDataGuidanceService.updateDataGuidance,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartLegendConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartLegendConfiguration.test.tsx
@@ -724,7 +724,7 @@ describe('ChartLegendConfiguration', () => {
       ).toHaveAttribute(
         'href',
         // Item ids are zero indexed
-        '#chartLegendConfigurationForm-items1Label',
+        '#chartLegendConfigurationForm-items-1-label',
       );
     });
   });

--- a/src/explore-education-statistics-common/src/components/form/Form.tsx
+++ b/src/explore-education-statistics-common/src/components/form/Form.tsx
@@ -93,7 +93,10 @@ export default function Form<TFormValues extends FieldValues>({
       return {
         id:
           field !== 'root' && !field.startsWith('root.')
-            ? `${id}-${camelCase(field)}`
+            ? `${id}-${field
+                .split('.') // nested fields in react hook form use the format `field.NestedField`
+                .map(fieldPart => camelCase(fieldPart))
+                .join('-')}`
             : submitId,
         message: typeof message === 'string' ? message : '',
       };

--- a/src/explore-education-statistics-common/src/components/form/__tests__/Form.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/Form.test.tsx
@@ -102,7 +102,7 @@ describe('Form', () => {
     await waitFor(() => {
       expect(screen.getByText('Line 1 of address is required')).toHaveAttribute(
         'href',
-        '#test-form-addressLine1',
+        '#test-form-address-line1',
       );
     });
   });


### PR DESCRIPTION
Fixes an issue where the links in the error summary didn't work for nested form fields as the ids were incorrect, they were using the format `formId-fieldIdNestedFieldId` instead of the expected `formId-fieldId-nestedFieldId` because it didn't handle React Hook Form's naming of nested fields correctly.

This affected:

- table tool filters form (EES-3088)
- data guidance form (EES-5747)
- anywhere else with validation on nested fields