### PR TITLE
EES-5800 Update DataGuidanceFileWriter.DoWrite to use Release title

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
@@ -24,6 +24,8 @@ using System.IO.Compression;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
@@ -38,6 +40,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
     public class ReleaseFileServiceTests : IDisposable
     {
+        private readonly DataFixture _dataFixture = new();
+
         private readonly List<string> _filePaths = new();
 
         public void Dispose()
@@ -1584,14 +1588,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task ZipFilesToStream_ValidFileTypes()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseFile1 = new ReleaseFile
             {
@@ -1690,14 +1689,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task ZipFilesToStream_DataGuidanceForMultipleDataFiles()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseFile1 = new ReleaseFile
             {
@@ -1796,14 +1790,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task ZipFilesToStream_OrderedAlphabetically()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseFile1 = new ReleaseFile
             {
@@ -1900,14 +1889,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task ZipFilesToStream_FiltersInvalidFileTypes()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseFile1 = new ReleaseFile
             {
@@ -1993,14 +1977,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task ZipFilesToStream_FiltersFilesNotInBlobStorage()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseFile1 = new ReleaseFile
             {
@@ -2070,14 +2049,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task ZipFilesToStream_FiltersFilesForOtherReleases()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             // Files are for other releases
             var releaseFile1 = new ReleaseFile
@@ -2144,14 +2118,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task ZipFilesToStream_Empty()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
@@ -2189,14 +2158,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task ZipFilesToStream_Cancelled()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseFile1 = new ReleaseFile
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
@@ -78,6 +78,11 @@ public static class ReleaseVersionGeneratorExtensions
         IEnumerable<DataBlockVersion> dataBlockVersions)
         => generator.ForInstance(releaseVersion => releaseVersion.SetDataBlockVersions(dataBlockVersions));
 
+    public static Generator<ReleaseVersion> WithDataGuidance(
+        this Generator<ReleaseVersion> generator,
+        string dataGuidance)
+        => generator.ForInstance(releaseVersion => releaseVersion.SetDataGuidance(dataGuidance));
+
     public static Generator<ReleaseVersion> WithContent(
         this Generator<ReleaseVersion> generator,
         IEnumerable<ContentSection> content)
@@ -284,6 +289,11 @@ public static class ReleaseVersionGeneratorExtensions
                 });
             });
     }
+
+    public static InstanceSetters<ReleaseVersion> SetDataGuidance(
+        this InstanceSetters<ReleaseVersion> setters,
+        string dataGuidance)
+        => setters.Set(releaseVersion => releaseVersion.DataGuidance, dataGuidance);
 
     public static InstanceSetters<ReleaseVersion> SetContentBlocks(
         this InstanceSetters<ReleaseVersion> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataGuidanceFileWriterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataGuidanceFileWriterTests.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -21,6 +24,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 {
     public class DataGuidanceFileWriterTests : IDisposable
     {
+        private readonly DataFixture _dataFixture = new();
+
         private const string TestDataGuidance = @"
             <h2>Description</h2>
             <p>
@@ -61,17 +66,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_ListDataSetsReturnsNotFound()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestDataGuidance);
 
             var contextId = Guid.NewGuid().ToString();
 
@@ -84,7 +82,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(new NotFoundResult());
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -112,17 +110,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_MultipleDataSets()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestDataGuidance);
 
             var dataSets = new List<DataGuidanceDataSetViewModel>
             {
@@ -197,7 +188,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(dataSets);
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -221,17 +212,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_SingleDataSet()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestDataGuidance);
 
             var dataSets = new List<DataGuidanceDataSetViewModel>
             {
@@ -277,7 +261,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(dataSets);
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -302,16 +286,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         public async Task WriteToStream_NoDataGuidance()
         {
             // Release has no data guidance (aka data guidance)
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(string.Empty);
 
             var dataSets = new List<DataGuidanceDataSetViewModel>
             {
@@ -352,7 +330,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(dataSets);
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -376,17 +354,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_EmptyDataSets()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestDataGuidance);
 
             var contextId = Guid.NewGuid().ToString();
 
@@ -399,7 +370,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(new List<DataGuidanceDataSetViewModel>());
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -423,17 +394,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_FileWithSingleProperties()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestBasicDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestBasicDataGuidance);
 
             var dataSets = new List<DataGuidanceDataSetViewModel>
             {
@@ -469,7 +433,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(dataSets);
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -493,17 +457,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_FileWithEmptyProperties()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestBasicDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestBasicDataGuidance);
 
             var dataSets = new List<DataGuidanceDataSetViewModel>
             {
@@ -525,7 +482,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(dataSets);
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -549,17 +506,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_FileWithEmptyTimePeriodStart()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestBasicDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestBasicDataGuidance);
 
             var dataSets = new List<DataGuidanceDataSetViewModel>
             {
@@ -585,7 +535,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(dataSets);
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -609,17 +559,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_FileWithEmptyTimePeriodEnd()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestBasicDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestBasicDataGuidance);
 
             var dataSets = new List<DataGuidanceDataSetViewModel>
             {
@@ -642,7 +585,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(dataSets);
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -666,17 +609,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_FileWithEmptyVariable()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestBasicDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestBasicDataGuidance);
 
             var dataSets = new List<DataGuidanceDataSetViewModel>
             {
@@ -703,7 +639,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(dataSets);
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -727,17 +663,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_FileWithOverTenFootnotesAndMultiline()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestBasicDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestBasicDataGuidance);
 
             var dataSets = new List<DataGuidanceDataSetViewModel>
             {
@@ -787,7 +716,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(dataSets);
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -811,17 +740,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_FileWithHtmlFootnotes()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestBasicDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestBasicDataGuidance);
 
             var dataSets = new List<DataGuidanceDataSetViewModel>
             {
@@ -857,7 +779,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(dataSets);
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -881,17 +803,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_FileWithEmptyFootnote()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestBasicDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestBasicDataGuidance);
 
             var dataSets = new List<DataGuidanceDataSetViewModel>
             {
@@ -924,7 +839,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(dataSets);
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -948,17 +863,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task WriteToStream_FileStream()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2020",
-                TimePeriodCoverage = TimeIdentifier.ReportingYear,
-                Publication = new Publication
-                {
-                    Title = "Test publication"
-                },
-                DataGuidance = TestBasicDataGuidance
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()))
+                .WithDataGuidance(TestBasicDataGuidance);
 
             var contextId = Guid.NewGuid().ToString();
 
@@ -971,7 +879,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var dataGuidanceDataSetService = new Mock<IDataGuidanceDataSetService>(Strict);
 
             dataGuidanceDataSetService
-                .Setup(s => s.ListDataSets(releaseVersion.Id, null, default))
+                .Setup(s => s.ListDataSets(releaseVersion.Id, null, CancellationToken.None))
                 .ReturnsAsync(new List<DataGuidanceDataSetViewModel>());
 
             await using (var contentDbContext = InMemoryContentDbContext(contextId))
@@ -990,7 +898,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
                 var text = await File.ReadAllTextAsync(path);
 
-                Assert.Contains("Test publication", text);
+                Assert.Contains(releaseVersion.Release.Publication.Title, text);
             }
 
             VerifyAllMocks(dataGuidanceDataSetService);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
@@ -11,11 +11,13 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using Moq;
 using Xunit;
@@ -29,6 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 {
     public class ReleaseFileServiceTests : IDisposable
     {
+        private readonly DataFixture _dataFixture = new();
         private readonly List<string> _filePaths = new();
 
         public void Dispose()
@@ -203,14 +206,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task ZipFilesToStream_ValidFileTypes()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseFile1 = new ReleaseFile
             {
@@ -309,14 +307,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task ZipFilesToStream_DataGuidanceForMultipleDataFiles()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseFile1 = new ReleaseFile
             {
@@ -415,14 +408,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task ZipFilesToStream_OrderedAlphabetically()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseFile1 = new ReleaseFile
             {
@@ -519,14 +507,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task ZipFilesToStream_FiltersInvalidFileTypes()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseFile1 = new ReleaseFile
             {
@@ -612,14 +595,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task ZipFilesToStream_FiltersFilesNotInBlobStorage()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseFile1 = new ReleaseFile
             {
@@ -689,14 +667,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task ZipFilesToStream_FiltersFilesForOtherReleases()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             // Files are for other releases
             var releaseFile1 = new ReleaseFile
@@ -763,14 +736,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task ZipFilesToStream_Empty()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
@@ -808,14 +776,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task ZipFilesToStream_Cancelled()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseFile1 = new ReleaseFile
             {
@@ -900,14 +863,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task ZipFilesToStream_NoFileIds_NoCachedAllFilesZip()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()
+                        .WithSlug("publication-slug")));
 
             var releaseFile1 = new ReleaseFile
             {
@@ -1024,14 +983,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task ZipFilesToStream_NoFileIds_CachedAllFilesZip()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()
+                        .WithSlug("publication-slug")));
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
@@ -1087,14 +1042,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task ZipFilesToStream_NoFileIds_StaleCachedAllFilesZip()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()
+                        .WithSlug("publication-slug")));
 
             var releaseFile1 = new ReleaseFile
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_EmptyDataSets.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_EmptyDataSets.snap
@@ -1,5 +1,5 @@
-﻿Test publication
-2020 Reporting year
+﻿Publication 0 :: Title
+Academic year 2000/01
 
 Description
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithEmptyFootnote.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithEmptyFootnote.snap
@@ -1,5 +1,5 @@
-﻿Test publication
-2020 Reporting year
+﻿Publication 0 :: Title
+Academic year 2000/01
 
 This document describes the data included in the ‘Children looked after in England'
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithEmptyProperties.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithEmptyProperties.snap
@@ -1,5 +1,5 @@
-﻿Test publication
-2020 Reporting year
+﻿Publication 0 :: Title
+Academic year 2000/01
 
 This document describes the data included in the ‘Children looked after in England'
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithEmptyTimePeriodEnd.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithEmptyTimePeriodEnd.snap
@@ -1,5 +1,5 @@
-﻿Test publication
-2020 Reporting year
+﻿Publication 0 :: Title
+Academic year 2000/01
 
 This document describes the data included in the ‘Children looked after in England'
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithEmptyTimePeriodStart.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithEmptyTimePeriodStart.snap
@@ -1,5 +1,5 @@
-﻿Test publication
-2020 Reporting year
+﻿Publication 0 :: Title
+Academic year 2000/01
 
 This document describes the data included in the ‘Children looked after in England'
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithEmptyVariable.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithEmptyVariable.snap
@@ -1,5 +1,5 @@
-﻿Test publication
-2020 Reporting year
+﻿Publication 0 :: Title
+Academic year 2000/01
 
 This document describes the data included in the ‘Children looked after in England'
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithHtmlFootnotes.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithHtmlFootnotes.snap
@@ -1,5 +1,5 @@
-﻿Test publication
-2020 Reporting year
+﻿Publication 0 :: Title
+Academic year 2000/01
 
 This document describes the data included in the ‘Children looked after in England'
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithOverTenFootnotesAndMultiline.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithOverTenFootnotesAndMultiline.snap
@@ -1,5 +1,5 @@
-﻿Test publication
-2020 Reporting year
+﻿Publication 0 :: Title
+Academic year 2000/01
 
 This document describes the data included in the ‘Children looked after in England'
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithSingleProperties.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_FileWithSingleProperties.snap
@@ -1,5 +1,5 @@
-﻿Test publication
-2020 Reporting year
+﻿Publication 0 :: Title
+Academic year 2000/01
 
 This document describes the data included in the ‘Children looked after in England'
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_MultipleDataSets.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_MultipleDataSets.snap
@@ -1,5 +1,5 @@
-﻿Test publication
-2020 Reporting year
+﻿Publication 0 :: Title
+Academic year 2000/01
 
 Description
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_NoDataGuidance.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_NoDataGuidance.snap
@@ -1,5 +1,5 @@
-﻿Test publication
-2020 Reporting year
+﻿Publication 0 :: Title
+Academic year 2000/01
 
 Data files
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_SingleDataSet.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/__snapshots__/DataGuidanceFileWriterTests.WriteToStream_SingleDataSet.snap
@@ -1,5 +1,5 @@
-﻿Test publication
-2020 Reporting year
+﻿Publication 0 :: Title
+Academic year 2000/01
 
 Description
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -75,14 +74,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             IList<DataGuidanceDataSetViewModel> dataSets)
         {
             // Add header information including publication/release title
-            await file.WriteLineAsync(releaseVersion.Publication.Title);
-            await file.WriteLineAsync(
-                TimePeriodLabelFormatter.Format(
-                    releaseVersion.Year,
-                    releaseVersion.TimePeriodCoverage,
-                    TimePeriodLabelFormat.FullLabel
-                )
-            );
+            await file.WriteLineAsync(releaseVersion.Release.Publication.Title);
+            await file.WriteLineAsync(releaseVersion.Release.Title);
 
             if (!releaseVersion.DataGuidance.IsNullOrWhitespace())
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -123,10 +123,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             IEnumerable<Guid>? fileIds = null,
             CancellationToken cancellationToken = default)
         {
-            return await persistenceHelper.CheckEntityExists<ReleaseVersion>(
-                    releaseVersionId,
-                    q => q.Include(rv => rv.Publication)
-                )
+            return await contentDbContext.ReleaseVersions
+                .Include(rv => rv.Release)
+                .ThenInclude(r => r.Publication)
+                .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId, cancellationToken: cancellationToken)
                 .OnSuccess(userService.CheckCanViewReleaseVersion)
                 .OnSuccessVoid(
                     async release =>


### PR DESCRIPTION
This PR updates the `DataGuidanceFileWriter.DoWrite` to write out `Release.Title` in the second line. Previously this consisted of properties of `ReleaseVersion` formatted as `{ReleaseVersion.Year} {ReleaseVersion.TimePeriodCoverage}`.

This fixes a problem where a release label (if set) is not present in the second line of the data guidance. `Release.Title` is a calculated property containing the label.