### PR TITLE
Ees 5399 upgrade function app tls

### DIFF
--- a/infrastructure/templates/public-api/components/functionApp.bicep
+++ b/infrastructure/templates/public-api/components/functionApp.bicep
@@ -280,6 +280,7 @@ var commonSiteProperties = {
     netFrameworkVersion: '8.0'
     linuxFxVersion: operatingSystem == 'Linux' ? 'DOTNET-ISOLATED|8.0' : null
     keyVaultReferenceIdentity: keyVaultReferenceIdentity
+    minTlsVersion: '1.3'
     publicNetworkAccess: publicNetworkAccessEnabled ? 'Enabled' : 'Disabled'
     ipSecurityRestrictions: publicNetworkAccessEnabled && length(firewallRules) > 0 ? firewallRules : null
     ipSecurityRestrictionsDefaultAction: 'Deny'


### PR DESCRIPTION
This PR:
- upgrades the Public API Function App's minimum TLS level to 1.3.

This satisfies the following advisory:

![image](https://github.com/user-attachments/assets/79fa6064-a6be-4925-a0c8-1ce4444a4108)

and results in:

![image](https://github.com/user-attachments/assets/a3fb33c6-d130-41ff-9f75-031af5d0c4bd)
 