### PR TITLE
EES-5799 Add release label to Admin's release summary page

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryPage.tsx
@@ -51,6 +51,9 @@ const ReleaseSummaryPage = () => {
             <SummaryListItem term="Release type">
               {releaseTypes[release.type]}
             </SummaryListItem>
+            <SummaryListItem term="Release label">
+              {release.label ?? ''}
+            </SummaryListItem>
           </SummaryList>
 
           <Gate condition={() => permissionService.canUpdateRelease(releaseId)}>

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
@@ -113,6 +113,7 @@ const ReleasePreReleaseAccessPage = () => {
                     timePeriodCoverage: release.timePeriodCoverage,
                     type: release.type,
                     preReleaseAccessList,
+                    label: release.label,
                   },
                 );
 

--- a/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
+++ b/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
@@ -157,16 +157,17 @@ Verify Release type options
 Create new release
     user chooses select option    name:timePeriodCoverageCode    Spring term
     user enters text into element    name:timePeriodCoverageStartYear    2025
+    user enters text into element    name:releaseLabel    provisional
     user clicks radio    Accredited official statistics
     user clicks button    Create new release
-    user waits until page contains title caption    Edit release for Spring term 2025/26
+    user waits until page contains title caption    Edit release for Spring term 2025/26 provisional
     user waits until h1 is visible    ${PUBLICATION_NAME}
 
 Verify created release summary
     user checks page contains element    xpath://li/a[text()="Summary" and contains(@aria-current, 'page')]
     user waits until h2 is visible    Release summary
     user verifies release summary    Spring term
-    ...    2025/26    Accredited official statistics
+    ...    2025/26    Accredited official statistics    provisional
 
 Edit release summary
     user waits until page contains link    Edit release summary
@@ -175,6 +176,7 @@ Edit release summary
     user waits until page contains element    name:timePeriodCoverageStartYear
     user chooses select option    name:timePeriodCoverageCode    Summer term
     user enters text into element    name:timePeriodCoverageStartYear    2026
+    user enters text into element    name:releaseLabel    final
     user clicks radio    Official statistics
     user clicks button    Update release summary
 
@@ -182,7 +184,7 @@ Verify updated release summary
     user waits until h2 is visible    Release summary
     user checks page contains element    xpath://li/a[text()="Summary" and contains(@aria-current, 'page')]
     user verifies release summary    Summer term
-    ...    2026/27    Official statistics
+    ...    2026/27    Official statistics    final
 
 
 *** Keywords ***

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -14,7 +14,7 @@ Force Tags          Admin    Local    Dev    AltersData
 *** Variables ***
 ${PUBLICATION_NAME}=                    UI tests - publish data %{RUN_IDENTIFIER}
 ${RELEASE_1_NAME}=                      Financial year 3000-01
-${RELEASE_2_NAME}=                      Financial year 3001-02
+${RELEASE_2_NAME}=                      Financial year 3001-02 provisional
 ${SUBJECT_1_NAME}=                      UI test subject 1
 ${SUBJECT_2_NAME}=                      UI test subject 2
 ${FOOTNOTE_ALL}=                        Footnote for all subjects
@@ -62,14 +62,12 @@ Go to "Sign off" page and approve release
 
 Create another release for the same publication
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
-    user creates release from publication page    ${PUBLICATION_NAME}    Financial year    3001
+    user creates release from publication page    ${PUBLICATION_NAME}    Financial year    3001    provisional
 
 Verify new release summary
     user checks page contains element    xpath://li/a[text()="Summary" and contains(@aria-current, 'page')]
-    user waits until h2 is visible    Release summary
-    user checks summary list contains    Time period    Financial year
-    user checks summary list contains    Release period    3001-02
-    user checks summary list contains    Release type    Accredited official statistics
+    user verifies release summary    Financial year
+    ...    3001-02    Accredited official statistics    provisional
 
 Upload subjects to release
     user uploads subject and waits until complete    ${SUBJECT_1_NAME}    tiny-two-filters.csv

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -15,14 +15,15 @@ Force Tags          Admin    Local    Dev    AltersData
 
 *** Variables ***
 ${PUBLICATION_NAME}=    UI tests - publish release and amend %{RUN_IDENTIFIER}
-${RELEASE_NAME}=        Financial year 3000-01
+${RELEASE_LABEL}=       provisional
+${RELEASE_NAME}=        Financial year 3000-01 ${RELEASE_LABEL}
 ${DATABLOCK_NAME}=      Dates data block name
 
 
 *** Test Cases ***
 Create new publication for "UI tests theme" theme
     ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
-    user creates test release via api    ${PUBLICATION_ID}    FY    3000
+    user creates test release via api    ${PUBLICATION_ID}    FY    3000    label=${RELEASE_LABEL}
 
 Go to "Release summary" page
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
@@ -30,7 +31,8 @@ Go to "Release summary" page
 
 Verify release summary
     user checks page contains element    xpath://li/a[text()="Summary" and contains(@aria-current, 'page')]
-    user verifies release summary    Financial year    3000-01    Accredited official statistics
+    user verifies release summary    Financial year
+    ...    3000-01    Accredited official statistics    ${RELEASE_LABEL}
 
 Upload subject
     user uploads subject and waits until complete    Dates test subject    dates.csv    dates.meta.csv

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -168,7 +168,7 @@ user creates publication
     user waits until h1 is visible    Dashboard    %{WAIT_MEDIUM}
 
 user creates release from publication page
-    [Arguments]    ${publication}    ${time_period_coverage}    ${start_year}
+    [Arguments]    ${publication}    ${time_period_coverage}    ${start_year}    ${label}=${EMPTY}
     user waits until page contains title caption    Manage publication    %{WAIT_SMALL}
     user waits until h1 is visible    ${publication}
 
@@ -178,6 +178,7 @@ user creates release from publication page
     user waits until page contains element    id:releaseSummaryForm-timePeriodCoverage    %{WAIT_SMALL}
     user chooses select option    id:releaseSummaryForm-timePeriodCoverageCode    ${time_period_coverage}
     user enters text into element    id:releaseSummaryForm-timePeriodCoverageStartYear    ${start_year}
+    user enters text into element    id:releaseSummaryForm-releaseLabel    ${label}
     user clicks radio    Accredited official statistics
     user clicks radio if exists    Create new template
     user waits until button is enabled    Create new release    %{WAIT_SMALL}
@@ -678,11 +679,12 @@ user waits for scheduled release to be published immediately
     user waits until page contains element    id:release-process-status-Complete    %{WAIT_MEDIUM}
 
 user verifies release summary
-    [Arguments]    ${TIME_PERIOD}    ${RELEASE_PERIOD}    ${RELEASE_TYPE}
+    [Arguments]    ${TIME_PERIOD}    ${RELEASE_PERIOD}    ${RELEASE_TYPE}    ${RELEASE_LABEL}=${EMPTY}
     user waits until h2 is visible    Release summary
     user checks summary list contains    Time period    ${TIME_PERIOD}
     user checks summary list contains    Release period    ${RELEASE_PERIOD}
     user checks summary list contains    Release type    ${RELEASE_TYPE}
+    user checks summary list contains    Release label    ${RELEASE_LABEL}
 
 user changes methodology status to Approved
     [Arguments]

--- a/tests/robot-tests/tests/libs/admin_api.py
+++ b/tests/robot-tests/tests/libs/admin_api.py
@@ -169,7 +169,7 @@ def user_resets_user_roles_via_api_if_required(user_emails: list) -> None:
 
 
 def user_creates_test_release_via_api(
-    publication_id: str, time_period: str, year: str, type: str = "AccreditedOfficialStatistics"
+    publication_id: str, time_period: str, year: str, type: str = "AccreditedOfficialStatistics", label: str = None
 ):
     response = admin_client.post(
         f"/api/publications/{publication_id}/releases",
@@ -180,6 +180,7 @@ def user_creates_test_release_via_api(
             },
             "year": int(year),
             "type": type,
+            "label": label,
             "templateReleaseId": "",
         },
     )


### PR DESCRIPTION
This PR changes the release Summary page in the Admin to include the release label.

It adds in support into the UI test keywords `user creates test release via api` and `user creates release from publication page` for creating a release with a label.

It adds in suppport into the keyword `user verifies release summary` to verify the label.

### Other changes

Fixes a bug where the release label is cleared when a release is updated after saving a public pre-release access list.