### PR TITLE
Fix start up Public API bug

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
@@ -63,7 +63,7 @@
     <Exec Command="dotnet tool restore"/>
     <Exec
       Command="dotnet tool run swagger tofile --output $(OutputPath)wwwroot/openapi-v%(Version.Identity).json $(OutputPath)$(AssemblyName).dll %(Version.Identity)"
-      EnvironmentVariables="ASPNETCORE_ENVIRONMENT=Development"
+      EnvironmentVariables="DOTNET_ROLL_FORWARD=LatestMajor;ASPNETCORE_ENVIRONMENT=Development"
     />
   </Target>
 


### PR DESCRIPTION
When starting the Public Data API, the following error message can break the application for windows users.
This change prevents this error from breaking the start up process.

Error:  
```
dotnet tool run swagger tofile --output bin\Debug\n…et8.0\wwwroot/openapi-v1.json bin\Debug\net8.0\GovUk.Education.ExploreEducationStatistics.Public.Data.Api.dll exited with code  -532462766.
``` 
(https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2761)