### PR TITLE
EES-5308 improve small radio hover style

### DIFF
--- a/src/explore-education-statistics-common/src/styles/_form.scss
+++ b/src/explore-education-statistics-common/src/styles/_form.scss
@@ -12,3 +12,16 @@
 [type='search']::-webkit-search-cancel-button {
   appearance: none;
 }
+
+// EES-5308 - increase the radio border width on hover to make
+// the hover style more noticeable.
+// This has been suggested as a change to the design system,
+// if it's adopted we can remove this override.
+// https://github.com/alphagov/govuk-design-system-backlog/issues/59#issuecomment-2610085003
+// stylelint-disable-next-line selector-max-compound-selectors
+.govuk-radios--small
+  .govuk-radios__item:hover
+  .govuk-radios__input:not(:disabled)
+  + .govuk-radios__label::before {
+  border-width: 4px;
+}


### PR DESCRIPTION
Updates the hover style for small radio buttons to make it clearer for low vision users.

I've [suggested this as a change to the design system team](https://github.com/alphagov/govuk-design-system-backlog/issues/59#issuecomment-2610085003), if they agree I'll raise a PR for it in the design system repo and we can remove this override later on.

Current:
![radio-current](https://github.com/user-attachments/assets/0f9fd47f-dbfd-4654-9b5f-9a4d7a6601b2)
New:
![border](https://github.com/user-attachments/assets/9ee24891-1f7f-4257-89d0-cd1973802117)
