### PR TITLE
EES-5658 Swap usages of `Year`, `TimePeriodCoverage` and `Slug` from `ReleaseVersion` to `Release`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -612,8 +612,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 var releaseVersion = Assert.Single(release.Versions);
                 Assert.Equal(publication.Id, releaseVersion.PublicationId);
                 Assert.Equal(release.Id, releaseVersion.ReleaseId);
+
+                // TODO EES-5659 - Remove the ReleaseVersion assertions on ReleaseName, TimePeriodCoverage, Slug
                 Assert.Equal(year.ToString(), releaseVersion.ReleaseName);
-                Assert.Equal(year, releaseVersion.Year);
                 Assert.Equal(timePeriodCoverage, releaseVersion.TimePeriodCoverage);
                 Assert.Equal(expectedSlug, releaseVersion.Slug);
 
@@ -817,8 +818,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 var releaseVersion = Assert.Single(release.Versions);
                 Assert.Equal(publication.Id, releaseVersion.PublicationId);
                 Assert.Equal(release.Id, releaseVersion.ReleaseId);
+
+                // TODO EES-5659 - Remove the ReleaseVersion assertions on ReleaseName, TimePeriodCoverage, Slug
                 Assert.Equal(newYear.ToString(), releaseVersion.ReleaseName);
-                Assert.Equal(newYear, releaseVersion.Year);
                 Assert.Equal(newTimePeriodCoverage, releaseVersion.TimePeriodCoverage);
                 Assert.Equal(expectedNewSlug, releaseVersion.Slug);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -877,6 +877,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 Assert.Equal(expectedNewLabel, release.Label);
                 Assert.Equal(expectedNewSlug, release.Slug);
 
+                // TODO EES-5659 - Remove the assertion on ReleaseVersion.Slug
                 var releaseVersion = Assert.Single(release.Versions);
                 Assert.Equal(expectedNewSlug, releaseVersion.Slug);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
@@ -55,6 +55,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .DefaultReleaseVersion()
                 .WithRelease(_fixture
                     .DefaultRelease()
+                    .WithYear(2035)
+                    .WithTimePeriodCoverage(TimeIdentifier.March)
                     .WithPublication(_fixture
                         .DefaultPublication()))
                 .WithCreated(
@@ -70,13 +72,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .WithPublished(DateTime.UtcNow.AddDays(-1))
                 .WithApprovalStatus(ReleaseApprovalStatus.Approved)
                 .WithPreviousVersionId(Guid.NewGuid())
-                .WithYear(2035)
                 .WithType(ReleaseType.OfficialStatistics)
                 .WithReleaseStatuses(_fixture
                     .DefaultReleaseStatus()
                     .Generate(1))
                 .WithVersion(2)
-                .WithTimePeriodCoverage(TimeIdentifier.March)
                 .WithNotifiedOn(DateTime.UtcNow.AddDays(-4))
                 .WithNotifySubscribers(true)
                 .WithUpdatePublishedDate(true)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTests.cs
@@ -1787,19 +1787,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             const string dataFileName = "test-data.csv";
             const string metaFileName = "test-data.meta.csv";
 
-            var releaseVersion = new ReleaseVersion
-            {
-                ReleaseName = "2000",
-                Publication = new Publication
-                {
-                    Title = "Test publication",
-                    Theme = new Theme
-                    {
-                        Id = Guid.NewGuid(),
-                        Title = "Test theme"
-                    }
-                }
-            };
+            ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion()
+                .WithRelease(_fixture.DefaultRelease()
+                    .WithPublication(_fixture.DefaultPublication()));
 
             var contentDbContextId = Guid.NewGuid().ToString();
             var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -1927,19 +1917,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             const string dataFileName = "test-data.csv";
             const string metaFileName = "test-data.meta.csv";
 
-            var releaseVersion = new ReleaseVersion
-            {
-                ReleaseName = "2000",
-                Publication = new Publication
-                {
-                    Title = "Test publication",
-                    Theme = new Theme
-                    {
-                        Id = Guid.NewGuid(),
-                        Title = "Test theme"
-                    }
-                }
-            };
+            ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion()
+                .WithRelease(_fixture.DefaultRelease()
+                    .WithPublication(_fixture.DefaultPublication()));
 
             var originalSubject = new Subject
             {
@@ -2143,19 +2123,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             const string dataFileName = "test-data.csv";
             const string metaFileName = "test-data.meta.csv";
 
-            var releaseVersion = new ReleaseVersion
-            {
-                ReleaseName = "2000",
-                Publication = new Publication
-                {
-                    Title = "Test publication",
-                    Theme = new Theme
-                    {
-                        Id = Guid.NewGuid(),
-                        Title = "Test theme"
-                    }
-                },
-            };
+            ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion()
+                .WithRelease(_fixture.DefaultRelease()
+                    .WithPublication(_fixture.DefaultPublication()));
 
             var releaseFiles = new List<ReleaseFile>
             {
@@ -2296,20 +2266,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             const string metaFileName = "test-data.meta.csv";
             const string zipFileName = "test-data-archive.zip";
 
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2000",
-                Publication = new Publication
-                {
-                    Title = "Test publication",
-                    Theme = new Theme
-                    {
-                        Id = Guid.NewGuid(),
-                        Title = "Test theme"
-                    }
-                }
-            };
+            ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion()
+                .WithRelease(_fixture.DefaultRelease()
+                    .WithPublication(_fixture.DefaultPublication()));
 
             var contentDbContextId = Guid.NewGuid().ToString();
             var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -2443,20 +2402,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             const string metaFileName = "test-data.meta.csv";
             const string zipFileName = "test-data-archive.zip";
 
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2000",
-                Publication = new Publication
-                {
-                    Title = "Test publication",
-                    Theme = new Theme
-                    {
-                        Id = Guid.NewGuid(),
-                        Title = "Test theme"
-                    }
-                }
-            };
+            ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion()
+                .WithRelease(_fixture.DefaultRelease()
+                    .WithPublication(_fixture.DefaultPublication()));
 
             var releaseFiles = new List<ReleaseFile>
             {
@@ -2592,19 +2540,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             const string metaFileName = "test-data.meta.csv";
             const string zipFileName = "test-data-archive.zip";
 
-            var releaseVersion = new ReleaseVersion
-            {
-                ReleaseName = "2000",
-                Publication = new Publication
-                {
-                    Title = "Test publication",
-                    Theme = new Theme
-                    {
-                        Id = Guid.NewGuid(),
-                        Title = "Test theme"
-                    }
-                }
-            };
+            ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion()
+                .WithRelease(_fixture.DefaultRelease()
+                    .WithPublication(_fixture.DefaultPublication()));
 
             var originalSubject = new Subject
             {
@@ -2786,20 +2724,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task ValidateAndUploadBulkZip_InvalidZipFile_ReturnsValidationResult()
         {
             // Arrange
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2000",
-                Publication = new Publication
-                {
-                    Title = "Test publication",
-                    Theme = new Theme
-                    {
-                        Id = Guid.NewGuid(),
-                        Title = "Test theme"
-                    }
-                }
-            };
+            ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion()
+                .WithRelease(_fixture.DefaultRelease()
+                    .WithPublication(_fixture.DefaultPublication()));
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
@@ -2839,20 +2766,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task ValidateAndUploadBulkZip()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                ReleaseName = "2000",
-                Publication = new Publication
-                {
-                    Title = "Test publication",
-                    Theme = new Theme
-                    {
-                        Id = Guid.NewGuid(),
-                        Title = "Test theme"
-                    }
-                }
-            };
+            ReleaseVersion releaseVersion = _fixture.DefaultReleaseVersion()
+                .WithRelease(_fixture.DefaultRelease()
+                    .WithPublication(_fixture.DefaultPublication()));
 
             var contentDbContextId = Guid.NewGuid().ToString();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -140,9 +140,11 @@ public abstract class ReleaseServiceTests
                 Assert.Equal(TimeIdentifier.AcademicYear, actualRelease.TimePeriodCoverage);
                 Assert.Equal("2018-19-initial", actualRelease.Slug);
 
-                Assert.Equal(2018, actualReleaseVersion.Year);
+                // TODO EES-5659 - Remove the ReleaseVersion assertions on ReleaseName, TimePeriodCoverage, Slug
+                Assert.Equal("2018", actualReleaseVersion.ReleaseName);
                 Assert.Equal(TimeIdentifier.AcademicYear, actualReleaseVersion.TimePeriodCoverage);
                 Assert.Equal("2018-19-initial", actualReleaseVersion.Slug);
+
                 Assert.Equal(ReleaseType.OfficialStatistics, actualReleaseVersion.Type);
                 Assert.Equal(ReleaseApprovalStatus.Draft, actualReleaseVersion.ApprovalStatus);
                 Assert.Equal(0, actualReleaseVersion.Version);
@@ -938,9 +940,11 @@ public abstract class ReleaseServiceTests
                 Assert.Equal(release.TimePeriodCoverage, actualRelease.TimePeriodCoverage);
                 Assert.Equal(newReleaseSlug, actualRelease.Slug);
 
-                Assert.Equal(release.Year, actualReleaseVersion.Year);
+                // TODO EES-5659 - Remove the ReleaseVersion assertions on Year, TimePeriodCoverage, Slug
+                Assert.Equal(release.Year.ToString(), actualReleaseVersion.ReleaseName);
                 Assert.Equal(release.TimePeriodCoverage, actualReleaseVersion.TimePeriodCoverage);
                 Assert.Equal(newReleaseSlug, actualReleaseVersion.Slug);
+
                 Assert.Equal(releaseVersion.NextReleaseDate, actualReleaseVersion.NextReleaseDate);
                 Assert.Equal(updatedType, actualReleaseVersion.Type);
                 Assert.Equal("New access list", actualReleaseVersion.PreReleaseAccessList);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -2083,24 +2083,19 @@ public abstract class ReleaseServiceTests
     public class UpdateReleasePublishedTests : ReleaseServiceTests
     {
         [Fact]
-        public async Task Success()
+        public async Task Success_NotLatestReleaseInPublication()
         {
-            var releaseVersionId = Guid.NewGuid();
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ => [
+                    _dataFixture.DefaultRelease(publishedVersions: 1, year: 2024),
+                    _dataFixture.DefaultRelease(publishedVersions: 1, year: 2025)
+                ]);
 
-            var publication = new Publication
-            {
-                LatestPublishedReleaseVersionId = Guid.NewGuid(),
-                ReleaseVersions =
-                [
-                    new ReleaseVersion
-                    {
-                        Id = releaseVersionId,
-                        Slug = "release-slug",
-                        Published = DateTime.UtcNow
-                    }
-                ],
-                Slug = "publication-slug"
-            };
+            var release2024 = publication.Releases.Single(r => r.Year == 2024);
+            var release2025 = publication.Releases.Single(r => r.Year == 2025);
+
+            // Check the publication's latest published release version in the generated test data setup
+            Assert.Equal(release2025.Versions[0].Id, publication.LatestPublishedReleaseVersionId);
 
             var request = new ReleasePublishedUpdateRequest { Published = DateTime.UtcNow.AddDays(-1) };
 
@@ -2114,10 +2109,11 @@ public abstract class ReleaseServiceTests
 
             var releaseCacheService = new Mock<IReleaseCacheService>(Strict);
 
-            releaseCacheService.Setup(s => s.UpdateRelease(releaseVersionId,
+            releaseCacheService.Setup(s => s.UpdateRelease(
+                release2024.Versions[0].Id,
                 publication.Slug,
-                publication.ReleaseVersions[0].Slug
-            )).ReturnsAsync(new ReleaseCacheViewModel(releaseVersionId));
+                release2024.Slug
+            )).ReturnsAsync(new ReleaseCacheViewModel(release2024.Versions[0].Id));
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
@@ -2126,7 +2122,7 @@ public abstract class ReleaseServiceTests
 
                 var result = await service
                     .UpdateReleasePublished(
-                        releaseVersionId,
+                        release2024.Versions[0].Id,
                         request
                     );
 
@@ -2138,31 +2134,17 @@ public abstract class ReleaseServiceTests
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var saved = await context.ReleaseVersions
-                    .SingleAsync(rv => rv.Id == releaseVersionId);
+                    .SingleAsync(rv => rv.Id == release2024.Versions[0].Id);
 
                 Assert.Equal(request.Published, saved.Published);
             }
         }
 
         [Fact]
-        public async Task LatestReleaseInPublication()
+        public async Task Success_LatestReleaseInPublication()
         {
-            var releaseVersionId = Guid.NewGuid();
-
-            var publication = new Publication
-            {
-                LatestPublishedReleaseVersionId = releaseVersionId,
-                ReleaseVersions =
-                [
-                    new ReleaseVersion
-                    {
-                        Id = releaseVersionId,
-                        Slug = "release-slug",
-                        Published = DateTime.UtcNow
-                    }
-                ],
-                Slug = "publication-slug"
-            };
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
 
             var request = new ReleasePublishedUpdateRequest { Published = DateTime.UtcNow.AddDays(-1) };
 
@@ -2176,17 +2158,19 @@ public abstract class ReleaseServiceTests
 
             var releaseCacheService = new Mock<IReleaseCacheService>(Strict);
 
-            releaseCacheService.Setup(s => s.UpdateRelease(releaseVersionId,
+            releaseCacheService.Setup(s => s.UpdateRelease(
+                publication.Releases[0].Versions[0].Id,
                 publication.Slug,
-                publication.ReleaseVersions[0].Slug
-            )).ReturnsAsync(new ReleaseCacheViewModel(releaseVersionId));
+                publication.Releases[0].Slug
+            )).ReturnsAsync(new ReleaseCacheViewModel(publication.Releases[0].Versions[0].Id));
 
             // As the release is the latest for the publication the separate cache entry for the publication's latest
             // release should also be updated
-            releaseCacheService.Setup(s => s.UpdateRelease(releaseVersionId,
+            releaseCacheService.Setup(s => s.UpdateRelease(
+                publication.Releases[0].Versions[0].Id,
                 publication.Slug,
                 null
-            )).ReturnsAsync(new ReleaseCacheViewModel(releaseVersionId));
+            )).ReturnsAsync(new ReleaseCacheViewModel(publication.Releases[0].Versions[0].Id));
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
@@ -2195,7 +2179,7 @@ public abstract class ReleaseServiceTests
 
                 var result = await service
                     .UpdateReleasePublished(
-                        releaseVersionId,
+                        publication.Releases[0].Versions[0].Id,
                         request
                     );
 
@@ -2207,7 +2191,7 @@ public abstract class ReleaseServiceTests
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var saved = await context.ReleaseVersions
-                    .SingleAsync(rv => rv.Id == releaseVersionId);
+                    .SingleAsync(rv => rv.Id == publication.Releases[0].Versions[0].Id);
 
                 Assert.Equal(request.Published, saved.Published);
             }
@@ -2216,22 +2200,8 @@ public abstract class ReleaseServiceTests
         [Fact]
         public async Task ReleaseNotPublished()
         {
-            var releaseVersionId = Guid.NewGuid();
-
-            var publication = new Publication
-            {
-                LatestPublishedReleaseVersionId = Guid.NewGuid(),
-                ReleaseVersions =
-                [
-                    new ReleaseVersion
-                    {
-                        Id = releaseVersionId,
-                        Slug = "release-slug",
-                        Published = null
-                    }
-                ],
-                Slug = "publication-slug"
-            };
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 0, draftVersion: true)]);
 
             var request = new ReleasePublishedUpdateRequest { Published = DateTime.UtcNow.AddDays(-1) };
 
@@ -2249,7 +2219,7 @@ public abstract class ReleaseServiceTests
 
                 var result = await service
                     .UpdateReleasePublished(
-                        releaseVersionId,
+                        publication.Releases[0].Versions[0].Id,
                         request
                     );
 
@@ -2260,22 +2230,8 @@ public abstract class ReleaseServiceTests
         [Fact]
         public async Task FutureDate()
         {
-            var releaseVersionId = Guid.NewGuid();
-
-            var publication = new Publication
-            {
-                LatestPublishedReleaseVersionId = Guid.NewGuid(),
-                ReleaseVersions =
-                [
-                    new ReleaseVersion
-                    {
-                        Id = releaseVersionId,
-                        Slug = "release-slug",
-                        Published = DateTime.UtcNow
-                    }
-                ],
-                Slug = "publication-slug"
-            };
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
 
             var request = new ReleasePublishedUpdateRequest { Published = DateTime.UtcNow.AddDays(1) };
 
@@ -2293,7 +2249,7 @@ public abstract class ReleaseServiceTests
 
                 var result = await service
                     .UpdateReleasePublished(
-                        releaseVersionId,
+                        publication.Releases[0].Versions[0].Id,
                         request
                     );
 
@@ -2304,22 +2260,8 @@ public abstract class ReleaseServiceTests
         [Fact]
         public async Task ConvertsPublishedFromLocalToUniversalTimezone()
         {
-            var releaseVersionId = Guid.NewGuid();
-
-            var publication = new Publication
-            {
-                LatestPublishedReleaseVersionId = Guid.NewGuid(),
-                ReleaseVersions =
-                [
-                    new ReleaseVersion
-                    {
-                        Id = releaseVersionId,
-                        Slug = "release-slug",
-                        Published = DateTime.UtcNow
-                    }
-                ],
-                Slug = "publication-slug"
-            };
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
 
             var request = new ReleasePublishedUpdateRequest
             {
@@ -2336,10 +2278,17 @@ public abstract class ReleaseServiceTests
 
             var releaseCacheService = new Mock<IReleaseCacheService>(Strict);
 
-            releaseCacheService.Setup(s => s.UpdateRelease(releaseVersionId,
+            releaseCacheService.Setup(s => s.UpdateRelease(
+                publication.Releases[0].Versions[0].Id,
                 publication.Slug,
-                publication.ReleaseVersions[0].Slug
-            )).ReturnsAsync(new ReleaseCacheViewModel(releaseVersionId));
+                publication.Releases[0].Slug
+            )).ReturnsAsync(new ReleaseCacheViewModel(publication.Releases[0].Versions[0].Id));
+
+            releaseCacheService.Setup(s => s.UpdateRelease(
+                publication.Releases[0].Versions[0].Id,
+                publication.Slug,
+                null
+            )).ReturnsAsync(new ReleaseCacheViewModel(publication.Releases[0].Versions[0].Id));
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
@@ -2348,7 +2297,7 @@ public abstract class ReleaseServiceTests
 
                 var result = await service
                     .UpdateReleasePublished(
-                        releaseVersionId,
+                        publication.Releases[0].Versions[0].Id,
                         request
                     );
 
@@ -2360,7 +2309,7 @@ public abstract class ReleaseServiceTests
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var saved = await context.ReleaseVersions
-                    .SingleAsync(rv => rv.Id == releaseVersionId);
+                    .SingleAsync(rv => rv.Id == publication.Releases[0].Versions[0].Id);
 
                 // The published date retrieved from the database should always be represented in UTC
                 // because of the conversion setup in the database context config.

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseFileController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseFileController.cs
@@ -63,14 +63,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         {
             return await _persistenceHelper.CheckEntityExists<ReleaseVersion>(
                     releaseVersionId,
-                    q => q.Include(rv => rv.Publication)
+                    q => q.Include(rv => rv.Release)
+                        .ThenInclude(r => r.Publication)
                 )
                 .OnSuccess(
                     async releaseVersion =>
                     {
                         Response.ContentDispositionAttachment(
                             contentType: MediaTypeNames.Application.Octet,
-                            filename: $"{releaseVersion.Publication.Slug}_{releaseVersion.Slug}.zip");
+                            filename: $"{releaseVersion.Release.Publication.Slug}_{releaseVersion.Release.Slug}.zip");
 
                         // We start the response immediately, before all of the files have
                         // even downloaded from blob storage. As we download them, they are

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseAmendmentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseAmendmentService.cs
@@ -90,14 +90,16 @@ public class ReleaseAmendmentService : IReleaseAmendmentService
             // Copy various fields directly from the originalRelease.
             Release = originalReleaseVersion.Release,
             Publication = originalReleaseVersion.Publication,
-            Slug = originalReleaseVersion.Slug,
             Type = originalReleaseVersion.Type,
             ApprovalStatus = ReleaseApprovalStatus.Draft,
             DataGuidance = originalReleaseVersion.DataGuidance,
-            ReleaseName = originalReleaseVersion.ReleaseName,
-            TimePeriodCoverage = originalReleaseVersion.TimePeriodCoverage,
             PreReleaseAccessList = originalReleaseVersion.PreReleaseAccessList,
             NextReleaseDate = originalReleaseVersion.NextReleaseDate,
+
+            // TODO EES-5659 Remove setting ReleaseName, TimePeriodCoverage, Slug
+            ReleaseName = originalReleaseVersion.ReleaseName,
+            TimePeriodCoverage = originalReleaseVersion.TimePeriodCoverage,
+            Slug = originalReleaseVersion.Slug,
 
             // Assign new amendment-specific values to various fields.
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleasePermissionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleasePermissionService.cs
@@ -134,9 +134,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return await _persistenceHelper
                 .CheckEntityExists<ReleaseVersion>(releaseVersionId,
                     query =>
-                        query.Include(rv => rv.Publication))
+                        query.Include(rv => rv.Release)
+                            .ThenInclude(r => r.Publication))
                 .OnSuccessDo(releaseVersion => _userService
-                    .CheckCanUpdateReleaseRole(releaseVersion.Publication, Contributor))
+                    .CheckCanUpdateReleaseRole(releaseVersion.Release.Publication, Contributor))
                 .OnSuccess(async releaseVersion =>
                 {
                     var releaseContributorReleaseRoles = await _contentDbContext.UserReleaseRoles

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -109,11 +109,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<Either<ActionResult, ReleaseViewModel>> GetRelease(Guid releaseVersionId)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<ReleaseVersion>(releaseVersionId, q => q
-                    .Include(rv => rv.Release)
-                    .ThenInclude(r => r.Publication)
-                    .Include(rv => rv.ReleaseStatuses))
+            return await _context
+                .ReleaseVersions
+                .Include(rv => rv.Release)
+                .ThenInclude(r => r.Publication)
+                .Include(rv => rv.ReleaseStatuses)
+                .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId)
                 .OnSuccess(_userService.CheckCanViewReleaseVersion)
                 .OnSuccess(releaseVersion =>
                 {
@@ -210,12 +211,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
-        public Task<Either<ActionResult, DeleteReleasePlanViewModel>> GetDeleteReleaseVersionPlan(
+        public async Task<Either<ActionResult, DeleteReleasePlanViewModel>> GetDeleteReleaseVersionPlan(
             Guid releaseVersionId,
             CancellationToken cancellationToken = default)
         {
-            return _persistenceHelper
-                .CheckEntityExists<ReleaseVersion>(releaseVersionId)
+            return await _context
+                .ReleaseVersions
+                .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId, cancellationToken)
                 .OnSuccess(_userService.CheckCanDeleteReleaseVersion)
                 .OnSuccess(_ =>
                 {
@@ -535,13 +537,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             Guid releaseVersionId,
             ReleasePublishedUpdateRequest request)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<ReleaseVersion>(releaseVersionId,
-                    queryable => queryable.Include(rv => rv.Publication))
+            return await _context
+                .ReleaseVersions
+                .Include(rv => rv.Release)
+                .ThenInclude(r => r.Publication)
+                .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId)
                 .OnSuccessDo(_userService.CheckIsBauUser)
-                .OnSuccess<ActionResult, ReleaseVersion, Unit>(async release =>
+                .OnSuccess<ActionResult, ReleaseVersion, Unit>(async releaseVersion =>
                 {
-                    if (release.Published == null)
+                    if (releaseVersion.Published == null)
                     {
                         return ValidationActionResult(ReleaseNotPublished);
                     }
@@ -554,23 +558,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         return ValidationActionResult(ReleasePublishedCannotBeFutureDate);
                     }
 
-                    _context.ReleaseVersions.Update(release);
-                    release.Published = newPublishedDate;
+                    _context.ReleaseVersions.Update(releaseVersion);
+                    releaseVersion.Published = newPublishedDate;
                     await _context.SaveChangesAsync();
 
                     // Update the cached release version
                     await _releaseCacheService.UpdateRelease(
                         releaseVersionId,
-                        publicationSlug: release.Publication.Slug,
-                        releaseSlug: release.Slug);
+                        publicationSlug: releaseVersion.Release.Publication.Slug,
+                        releaseSlug: releaseVersion.Release.Slug);
 
-                    if (release.Publication.LatestPublishedReleaseVersionId == releaseVersionId)
+                    if (releaseVersion.Release.Publication.LatestPublishedReleaseVersionId == releaseVersionId)
                     {
                         // This is the latest published release version so also update the latest cached release version
                         // for the publication which is a separate cache entry
                         await _releaseCacheService.UpdateRelease(
                             releaseVersionId,
-                            publicationSlug: release.Publication.Slug);
+                            publicationSlug: releaseVersion.Release.Publication.Slug);
                     }
 
                     return Unit.Instance;
@@ -730,8 +734,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<Either<ActionResult, Unit>> RemoveDataFiles(Guid releaseVersionId, Guid fileId)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<ReleaseVersion>(releaseVersionId)
+            return await _context.ReleaseVersions
+                .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId)
                 .OnSuccess(_userService.CheckCanUpdateReleaseVersion)
                 .OnSuccess(() => CheckReleaseDataFileExists(releaseVersionId: releaseVersionId, fileId: fileId))
                 .OnSuccessDo(releaseFile => CheckCanDeleteDataFiles(releaseVersionId, releaseFile))

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseFileController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseFileController.cs
@@ -43,7 +43,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
             {
                 return await persistenceHelper.CheckEntityExists<ReleaseVersion>(releaseVersionIdGuid)
                     .OnSuccessDo(rv => this.CacheWithLastModified(rv.Published))
-                    .OnSuccess(rv =>  releaseFileService.StreamFile(releaseVersionId: rv.Id,
+                    .OnSuccess(rv => releaseFileService.StreamFile(releaseVersionId: rv.Id,
                         fileId: fileIdGuid))
                     .OnSuccessDo(result => this.CacheWithETag(result.FileStream.ComputeMd5Hash()))
                     .HandleFailures();
@@ -61,7 +61,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         {
             return await persistenceHelper.CheckEntityExists<ReleaseVersion>(
                     releaseVersionId,
-                    q => q.Include(rv => rv.Publication)
+                    q => q.Include(rv => rv.Release)
+                        .ThenInclude(r => r.Publication)
                 )
                 .OnSuccessDo(releaseVersion => this.CacheWithLastModified(releaseVersion.Published))
                 .OnSuccess(
@@ -69,7 +70,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
                     {
                         Response.ContentDispositionAttachment(
                             contentType: MediaTypeNames.Application.Octet,
-                            filename: $"{releaseVersion.Publication.Slug}_{releaseVersion.Slug}.zip");
+                            filename: $"{releaseVersion.Release.Publication.Slug}_{releaseVersion.Release.Slug}.zip");
 
                         // We start the response immediately, before all of the files have
                         // even downloaded from blob storage. As we download them, they are

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseVersionExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseVersionExtensionTests.cs
@@ -1,28 +1,23 @@
-using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using Xunit;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensions
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensions;
+
+public class ReleaseVersionExtensionTests
 {
-    public class ReleaseVersionExtensionTests
+    private readonly DataFixture _dataFixture = new();
+
+    [Fact]
+    public void AllFilesZipPath()
     {
-        [Fact]
-        public void AllFilesZipPath()
-        {
-            const string releaseSlug = "release-slug";
-            const string publicationSlug = "publication-slug";
+        ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+            .WithRelease(_dataFixture.DefaultRelease()
+                .WithPublication(_dataFixture.DefaultPublication()));
 
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                Slug = releaseSlug,
-                Publication = new Publication
-                {
-                    Slug = publicationSlug
-                }
-            };
-
-            Assert.Equal($"{releaseVersion.Id}/zip/{publicationSlug}_{releaseSlug}.zip", releaseVersion.AllFilesZipPath());
-        }
+        Assert.Equal(
+            $"{releaseVersion.Id}/zip/{releaseVersion.Release.Publication.Slug}_{releaseVersion.Release.Slug}.zip",
+            releaseVersion.AllFilesZipPath());
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationGeneratorExtensions.cs
@@ -85,6 +85,13 @@ public static class PublicationGeneratorExtensions
         string slug)
         => generator.ForInstance(s => s.SetSlug(slug));
 
+    public static Generator<Publication> WithUpdated(
+        this Generator<Publication> generator,
+        DateTime? updated = null)
+    {
+        return generator.ForInstance(s => s.SetUpdated(updated));
+    }
+
     public static InstanceSetters<Publication> SetId(
         this InstanceSetters<Publication> setters,
         Guid id)
@@ -313,4 +320,9 @@ public static class PublicationGeneratorExtensions
 
                 return list;
             });
+
+    private static InstanceSetters<Publication> SetUpdated(
+        this InstanceSetters<Publication> setters,
+        DateTime? updated)
+        => setters.Set(p => p.Updated, updated);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationGeneratorExtensions.cs
@@ -218,26 +218,6 @@ public static class PublicationGeneratorExtensions
             .Set(p => p.LatestPublishedReleaseVersionId,
                 (_, publication, _) => publication.LatestPublishedReleaseVersion?.Id);
 
-    public static InstanceSetters<Publication> SetReleaseVersions(
-        this InstanceSetters<Publication> setters,
-        IEnumerable<ReleaseVersion> releaseVersions)
-        => setters.SetReleaseVersions(_ => releaseVersions);
-
-    private static InstanceSetters<Publication> SetReleaseVersions(
-        this InstanceSetters<Publication> setters,
-        Func<SetterContext, IEnumerable<ReleaseVersion>> releaseVersions)
-        => setters.Set(
-            p => p.ReleaseVersions,
-            (_, publication, context) =>
-            {
-                var list = releaseVersions.Invoke(context).ToList();
-
-                list.ForEach(releaseVersion => releaseVersion.Publication = publication);
-
-                return list;
-            }
-        );
-
     private static InstanceSetters<Publication> SetContact(
         this InstanceSetters<Publication> setters,
         Contact contact)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseGeneratorExtensions.cs
@@ -226,6 +226,8 @@ public static class ReleaseGeneratorExtensions
 
                     releaseVersion.Publication = release.Publication;
                     releaseVersion.PublicationId = release.PublicationId;
+
+                    // TODO EES-5659 Remove setting ReleaseName, TimePeriodCoverage, Slug
                     releaseVersion.ReleaseName = release.Year.ToString();
                     releaseVersion.TimePeriodCoverage = release.TimePeriodCoverage;
                     releaseVersion.Slug = release.Slug;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
@@ -116,11 +116,6 @@ public static class ReleaseVersionGeneratorExtensions
         Guid previousVersionId)
         => generator.ForInstance(releaseVersion => releaseVersion.SetPreviousVersionId(previousVersionId));
 
-    public static Generator<ReleaseVersion> WithYear(
-        this Generator<ReleaseVersion> generator,
-        int year)
-        => generator.ForInstance(releaseVersion => releaseVersion.SetYear(year));
-
     public static Generator<ReleaseVersion> WithSoftDeleted(this Generator<ReleaseVersion> generator)
         => generator.ForInstance(releaseVersion => releaseVersion.SetSoftDeleted());
 
@@ -340,11 +335,6 @@ public static class ReleaseVersionGeneratorExtensions
         this InstanceSetters<ReleaseVersion> setters,
         Guid? previousVersionId)
         => setters.Set(releaseVersion => releaseVersion.PreviousVersionId, previousVersionId);
-
-    public static InstanceSetters<ReleaseVersion> SetYear(
-        this InstanceSetters<ReleaseVersion> setters,
-        int year)
-        => setters.Set(releaseVersion => releaseVersion.ReleaseName, year.ToString());
 
     public static InstanceSetters<ReleaseVersion> SetSoftDeleted(this InstanceSetters<ReleaseVersion> setters)
         => setters.Set(releaseVersion => releaseVersion.SoftDeleted, true);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
@@ -139,11 +139,6 @@ public static class ReleaseVersionGeneratorExtensions
         DateTime notifiedOn)
         => generator.ForInstance(releaseVersion => releaseVersion.SetNotifiedOn(notifiedOn));
 
-    public static Generator<ReleaseVersion> WithTimePeriodCoverage(
-        this Generator<ReleaseVersion> generator,
-        TimeIdentifier timePeriodCoverage)
-        => generator.ForInstance(releaseVersion => releaseVersion.SetTimePeriodCoverage(timePeriodCoverage));
-
     public static Generator<ReleaseVersion> WithNotifySubscribers(
         this Generator<ReleaseVersion> generator,
         bool notifySubscribers)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
@@ -32,7 +32,7 @@ public static class ReleaseVersionGeneratorExtensions
         return generator;
     }
 
-    [Obsolete("Provide relationship with Publication via Release. This will be removed in EES-5658/EES-5659")]
+    [Obsolete("Provide relationship with Publication via Release. This will be removed in EES-5818")]
     public static Generator<ReleaseVersion> WithPublication(
         this Generator<ReleaseVersion> generator,
         Publication publication)
@@ -207,7 +207,7 @@ public static class ReleaseVersionGeneratorExtensions
         Guid id)
         => setters.Set(releaseVersion => releaseVersion.Id, id);
 
-    [Obsolete("Set relationship with Publication via Release. This will be removed in EES-5658/EES-5659")]
+    [Obsolete("Set relationship with Publication via Release. This will be removed in EES-5818")]
     public static InstanceSetters<ReleaseVersion> SetPublication(
         this InstanceSetters<ReleaseVersion> setters,
         Publication publication)
@@ -221,7 +221,7 @@ public static class ReleaseVersionGeneratorExtensions
                 })
             .SetPublicationId(publication.Id);
 
-    [Obsolete("Set relationship with Publication via Release. This will be removed in EES-5658/EES-5659")]
+    [Obsolete("Set relationship with Publication via Release. This will be removed in EES-5818")]
     public static InstanceSetters<ReleaseVersion> SetPublicationId(
         this InstanceSetters<ReleaseVersion> setters,
         Guid publicationId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
@@ -247,6 +247,8 @@ public static class ReleaseVersionGeneratorExtensions
 
                     releaseVersion.Publication = release.Publication;
                     releaseVersion.PublicationId = release.PublicationId;
+
+                    // TODO EES-5659 Remove setting ReleaseName, TimePeriodCoverage, Slug
                     releaseVersion.ReleaseName = release.Year.ToString();
                     releaseVersion.TimePeriodCoverage = release.TimePeriodCoverage;
                     releaseVersion.Slug = release.Slug;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ReleaseVersionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ReleaseVersionTests.cs
@@ -62,36 +62,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 }
             );
         }
-
-        [Fact]
-        public void ReleaseName_Ok()
-        {
-            // None should throw
-            new ReleaseVersion { ReleaseName = "1990" };
-            new ReleaseVersion { ReleaseName = "2011" };
-            new ReleaseVersion { ReleaseName = "3000" };
-            new ReleaseVersion { ReleaseName = "" }; // considered not set
-            new ReleaseVersion { ReleaseName = null }; // considered not set
-        }
-
-        [Fact]
-        public void ReleaseName_InvalidFormats()
-        {
-            Assert.Throws<FormatException>(
-                () => new ReleaseVersion { ReleaseName = "Hello" }
-            );
-
-            Assert.Throws<FormatException>(
-                () => new ReleaseVersion { ReleaseName = "190" }
-            );
-
-            Assert.Throws<FormatException>(
-                () => new ReleaseVersion { ReleaseName = "ABC123" }
-            );
-
-            Assert.Throws<FormatException>(
-                () => new ReleaseVersion { ReleaseName = "20000" }
-            );
-        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -523,6 +523,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .WithMany(p => p.ReleaseVersions)
                 .OnDelete(DeleteBehavior.NoAction);
 
+            // TODO EES-5659 Remove this
             modelBuilder.Entity<ReleaseVersion>()
                 .Property(rv => rv.TimePeriodCoverage)
                 .HasConversion(new EnumToEnumValueConverter<TimeIdentifier>())

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseVersionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseVersionExtensions.cs
@@ -19,13 +19,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
 
         public static string AllFilesZipFileName(this ReleaseVersion releaseVersion)
         {
-            if (releaseVersion.Publication == null)
+            if (releaseVersion.Release?.Publication == null)
             {
                 throw new ArgumentException(
                     "ReleaseVersion must be hydrated with Publication to create All Files zip file name");
             }
 
-            return $"{releaseVersion.Publication.Slug}_{releaseVersion.Slug}.zip";
+            return $"{releaseVersion.Release.Publication.Slug}_{releaseVersion.Release.Slug}.zip";
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Predicates/ReleaseVersionPredicates.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Predicates/ReleaseVersionPredicates.cs
@@ -31,8 +31,8 @@ public static class ReleaseVersionPredicates
         }
 
         var maxVersionsQueryable = releaseVersions
-            .Where(releaseVersion => publicationId == null || releaseVersion.PublicationId == publicationId)
-            .Where(releaseVersion => releaseSlug == null || releaseVersion.Slug == releaseSlug)
+            .Where(releaseVersion => publicationId == null || releaseVersion.Release.PublicationId == publicationId)
+            .Where(releaseVersion => releaseSlug == null || releaseVersion.Release.Slug == releaseSlug)
             .Where(releaseVersion => !publishedOnly || releaseVersion.Published.HasValue)
             .GroupBy(releaseVersion => releaseVersion.ReleaseId)
             .Select(groupedVersions =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -19,6 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<Release> Releases { get; set; } = [];
 
+        [Obsolete("Use indirect relationship via Publication.Releases. This will be removed in EES-5818")] 
         public List<ReleaseVersion> ReleaseVersions { get; set; } = [];
 
         public List<PublicationRedirect> PublicationRedirects { get; set; } = [];

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseVersion.cs
@@ -5,10 +5,8 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Newtonsoft.Json;
 using static System.DateTime;
-using static GovUk.Education.ExploreEducationStatistics.Common.Database.TimePeriodLabelFormat;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.PartialDate;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
@@ -16,10 +14,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
     public class ReleaseVersion : ICreatedTimestamp<DateTime>
     {
         public Guid Id { get; set; }
-
-        public int Year => int.Parse(_releaseName);
-
-        public string YearTitle => TimePeriodLabelFormatter.FormatYear(Year, TimePeriodCoverage);
 
         private string _releaseName;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseVersion.cs
@@ -49,8 +49,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public string Slug { get; set; }
 
+        [Obsolete("Use ReleaseVersion.Release.PublicationId. This will be removed in EES-5818")]
         public Guid PublicationId { get; set; }
 
+        [Obsolete("Use ReleaseVersion.Release.Publication. This will be removed in EES-5818")]
         public Publication Publication { get; set; }
 
         public List<Update> Updates { get; set; } = new();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -1847,70 +1847,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             [Fact]
             public async Task ListSitemapItems()
             {
-                var publicationUpdated = "2018-04-06T13:46:11";
-                var publicationId = Guid.NewGuid();
-
-                var firstReleaseId = Guid.NewGuid();
-                var firstReleaseSlug = "first-release-slug";
-
-                var secondReleaseId = Guid.NewGuid();
-                var secondReleaseSlug = "second-release-slug";
-
-                var firstReleaseVersionPublishedDate = "2019-02-03T07:34:12";
-                var firstReleaseVersionUpdateDate = "2019-02-04T08:29:54";
-
-                var publicationUpdatedDate = DateTime.Parse(publicationUpdated);
-                var firstReleaseVersionPublished = DateTime.Parse(firstReleaseVersionPublishedDate);
-                var firstReleaseVersionUpdated = DateTime.Parse(firstReleaseVersionUpdateDate);
-
-                var releaseOneVersionOne = new ReleaseVersion
-                {
-                    Id = Guid.NewGuid(),
-                    Slug = firstReleaseSlug,
-                    ReleaseId = firstReleaseId,
-                    Published = firstReleaseVersionPublished
-                };
-
-                var releaseOneVersionTwo = new ReleaseVersion
-                {
-                    Id = Guid.NewGuid(),
-                    Slug = firstReleaseSlug,
-                    ReleaseId = firstReleaseId,
-                    Published = firstReleaseVersionUpdated // Two versions with same slug to test de-duping
-                };
-
-                var releaseTwoVersionOne = new ReleaseVersion
-                {
-                    Id = Guid.NewGuid(),
-                    Slug = secondReleaseSlug,
-                    ReleaseId = secondReleaseId,
-                    Published = null // still in draft
-                };
-
-                var publication = new Publication
-                {
-                    Id = publicationId,
-                    Updated = publicationUpdatedDate,
-                    ReleaseSeries =
-                    [
-                        new ReleaseSeriesItem { Id = Guid.NewGuid(), ReleaseId = firstReleaseId },
-                        new ReleaseSeriesItem { Id = Guid.NewGuid(), ReleaseId = secondReleaseId }
-                    ],
-                    ReleaseVersions =
-                    [
-                        releaseOneVersionOne,
-                        releaseOneVersionTwo,
-                        releaseTwoVersionOne
-                    ],
-                    LatestPublishedReleaseVersionId = firstReleaseId
-                };
+                Publication publication = _dataFixture.DefaultPublication()
+                    .WithReleases([
+                        _dataFixture.DefaultRelease(publishedVersions: 2), // Two versions to test de-duping
+                        _dataFixture.DefaultRelease(publishedVersions: 0, draftVersion: true)
+                    ])
+                    .WithUpdated(DateTime.UtcNow.AddDays(-1));
 
                 var contentDbContextId = Guid.NewGuid().ToString();
                 await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
                 {
                     contentDbContext.Publications.Add(publication);
-                    contentDbContext.ReleaseVersions.AddRange(releaseOneVersionOne, releaseOneVersionTwo,
-                        releaseTwoVersionOne);
                     await contentDbContext.SaveChangesAsync();
                 }
 
@@ -1918,17 +1865,95 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 {
                     var service = SetupPublicationService(contentDbContext);
 
-                    var result = (await service.ListSitemapItems()).AssertRight();
+                    var result = await service.ListSitemapItems();
+                    var viewModel = result.AssertRight();
 
-                    var item = Assert.Single(result);
-                    Assert.Equal(publication.Slug, item.Slug);
-                    Assert.Equal(publicationUpdatedDate, item.LastModified);
+                    var publicationItem = Assert.Single(viewModel);
+                    Assert.Equal(publication.Slug, publicationItem.Slug);
+                    Assert.Equal(publication.Updated, publicationItem.LastModified);
 
-                    Assert.NotNull(item.Releases);
-                    var nonDraftReleaseVersion = Assert.Single(item.Releases);
+                    Assert.NotNull(publicationItem.Releases);
+                    var releaseItem = Assert.Single(publicationItem.Releases);
 
-                    Assert.Equal(firstReleaseSlug, nonDraftReleaseVersion.Slug);
-                    Assert.Equal(firstReleaseVersionUpdated, nonDraftReleaseVersion.LastModified);
+                    Assert.Equal(publication.Releases[0].Slug, releaseItem.Slug);
+                    Assert.Equal(publication.Releases[0].Versions[1].Published, releaseItem.LastModified);
+                }
+            }
+
+            [Fact]
+            public async Task ListSitemapItems_ExcludesSupersededPublications()
+            {
+                Publication publication = _dataFixture.DefaultPublication()
+                    .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
+                    .WithSupersededBy(_dataFixture
+                        .DefaultPublication()
+                        .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)]));
+
+                var contentDbContextId = Guid.NewGuid().ToString();
+                await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+                {
+                    contentDbContext.Publications.Add(publication);
+                    await contentDbContext.SaveChangesAsync();
+                }
+
+                await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+                {
+                    var service = SetupPublicationService(contentDbContext);
+
+                    var result = await service.ListSitemapItems();
+                    var viewModel = result.AssertRight();
+
+                    // The sitemap should only include the superseding publication,
+                    // not the superseded publication
+                    var publicationItem = Assert.Single(viewModel);
+                    Assert.Equal(publication.SupersededBy!.Slug, publicationItem.Slug);
+                }
+            }
+
+            [Fact]
+            public async Task ListSitemapItems_ExcludesPublicationsWithNoPublishedReleases()
+            {
+                Publication publication = _dataFixture.DefaultPublication()
+                    .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 0, draftVersion: true)]);
+
+                var contentDbContextId = Guid.NewGuid().ToString();
+                await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+                {
+                    contentDbContext.Publications.Add(publication);
+                    await contentDbContext.SaveChangesAsync();
+                }
+
+                await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+                {
+                    var service = SetupPublicationService(contentDbContext);
+
+                    var result = await service.ListSitemapItems();
+                    var viewModel = result.AssertRight();
+
+                    Assert.Empty(viewModel);
+                }
+            }
+
+            [Fact]
+            public async Task ListSitemapItems_PublicationHasNoReleases()
+            {
+                Publication publication = _dataFixture.DefaultPublication();
+
+                var contentDbContextId = Guid.NewGuid().ToString();
+                await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+                {
+                    contentDbContext.Publications.Add(publication);
+                    await contentDbContext.SaveChangesAsync();
+                }
+
+                await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+                {
+                    var service = SetupPublicationService(contentDbContext);
+
+                    var result = await service.ListSitemapItems();
+                    var viewModel = result.AssertRight();
+
+                    Assert.Empty(viewModel);
                 }
             }
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
@@ -44,18 +44,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task StreamFile()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
-
             var releaseFile = new ReleaseFile
             {
-                ReleaseVersion = releaseVersion,
+                ReleaseVersion = new ReleaseVersion(),
                 File = new Model.File
                 {
                     RootPath = Guid.NewGuid(),
@@ -69,7 +60,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                contentDbContext.ReleaseVersions.Add(releaseVersion);
                 contentDbContext.ReleaseFiles.Add(releaseFile);
                 await contentDbContext.SaveChangesAsync();
             }
@@ -84,7 +74,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 var service = SetupReleaseFileService(contentDbContext: contentDbContext,
                     publicBlobStorageService: publicBlobStorageService.Object);
 
-                var result = await service.StreamFile(releaseVersionId: releaseVersion.Id,
+                var result = await service.StreamFile(releaseVersionId: releaseFile.ReleaseVersionId,
                     fileId: releaseFile.File.Id);
 
                 MockUtils.VerifyAllMocks(publicBlobStorageService);
@@ -156,18 +146,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         [Fact]
         public async Task StreamFile_BlobDoesNotExist()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
-
             var releaseFile = new ReleaseFile
             {
-                ReleaseVersion = releaseVersion,
+                ReleaseVersion = new ReleaseVersion(),
                 File = new Model.File
                 {
                     RootPath = Guid.NewGuid(),
@@ -180,7 +161,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                contentDbContext.ReleaseVersions.Add(releaseVersion);
                 contentDbContext.ReleaseFiles.Add(releaseFile);
                 await contentDbContext.SaveChangesAsync();
             }
@@ -194,7 +174,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 var service = SetupReleaseFileService(contentDbContext: contentDbContext,
                     publicBlobStorageService: publicBlobStorageService.Object);
 
-                var result = await service.StreamFile(releaseVersionId: releaseVersion.Id,
+                var result = await service.StreamFile(releaseVersionId: releaseFile.ReleaseVersionId,
                     fileId: releaseFile.File.Id);
 
                 MockUtils.VerifyAllMocks(publicBlobStorageService);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -330,9 +330,10 @@ public class PublicationService : IPublicationService
         CancellationToken cancellationToken = default) =>
         await
             _contentDbContext.Publications
+                .Include(p => p.Releases)
+                .ThenInclude(r => r.Versions)
                 .Where(p => p.LatestPublishedReleaseVersionId.HasValue &&
                             (p.SupersededById == null || !p.SupersededBy!.LatestPublishedReleaseVersionId.HasValue))
-                .Include(p => p.ReleaseVersions)
                 .Select(p => new PublicationSitemapItemViewModel
                 {
                     Slug = p.Slug,
@@ -342,11 +343,15 @@ public class PublicationService : IPublicationService
                 .ToListAsync(cancellationToken);
 
     private static List<ReleaseSitemapItemViewModel> ListUniqueReleaseVersionSitemapItems(Publication publication) =>
-        publication.ReleaseVersions
-            .Where(r => r.Published != null) // r.Live cannot be translated by LINQ
-            .OrderByDescending(r => r.Published)
-            .GroupBy(r => r.Slug)
-            .Select(slugGroup => slugGroup.First())
-            .Select(r => new ReleaseSitemapItemViewModel { Slug = r.Slug, LastModified = r.Published })
+        publication.Releases
+            .SelectMany(r => r.Versions)
+            .Where(rv => rv.Published != null) // r.Live cannot be translated by LINQ
+            .OrderByDescending(rv => rv.Published)
+            .GroupBy(rv => rv.Release)
+            .Select(grouping => new ReleaseSitemapItemViewModel
+            {
+                Slug = grouping.Key.Slug,
+                LastModified = grouping.First().Published
+            })
             .ToList();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -129,17 +129,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                 .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId, cancellationToken: cancellationToken)
                 .OnSuccess(userService.CheckCanViewReleaseVersion)
                 .OnSuccessVoid(
-                    async release =>
+                    async releaseVersion =>
                     {
                         if (fileIds is null
-                            && await TryStreamCachedAllFilesZip(release, outputStream, cancellationToken))
+                            && await TryStreamCachedAllFilesZip(releaseVersion, outputStream, cancellationToken))
                         {
                             return;
                         }
 
                         if (fileIds is null)
                         {
-                            await ZipAllFilesToStream(release, outputStream, cancellationToken);
+                            await ZipAllFilesToStream(releaseVersion, outputStream, cancellationToken);
                         }
                         else
                         {
@@ -149,7 +149,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                                 .OrderBy(rf => rf.File.ZipFileEntryName())
                                 .ToList();
 
-                            await DoZipFilesToStream(releaseFiles, release, outputStream, cancellationToken);
+                            await DoZipFilesToStream(releaseFiles, releaseVersion, outputStream, cancellationToken);
                         }
                     }
                 );

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderMetaControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderMetaControllerTests.cs
@@ -7,8 +7,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Cache;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
@@ -25,6 +25,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 {
     public class TableBuilderMetaControllerTests : CacheServiceTestFixture
     {
+        private readonly DataFixture _dataFixture = new();
+
         private static readonly Guid ReleaseVersionId = Guid.NewGuid();
         private static readonly Guid SubjectId = Guid.NewGuid();
 
@@ -36,15 +38,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
         [Fact]
         public async Task GetSubjectMeta_LatestRelease()
         {
-            var contentReleaseVersion = new ReleaseVersion
-            {
-                Id = ReleaseVersionId,
-                Slug = "release-slug",
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                }
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseSubject = new ReleaseSubject
             {
@@ -54,11 +50,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 
             var subjectMetaViewModel = new SubjectMetaViewModel();
 
-            var cacheKey = GetCacheKey(contentReleaseVersion, releaseSubject);
+            var cacheKey = GetCacheKey(releaseVersion, releaseSubject);
 
             var (controller, mocks) = BuildControllerAndMocks();
 
-            SetupCall(mocks.contentPersistenceHelper, ReleaseVersionId, contentReleaseVersion);
+            SetupCall(mocks.contentPersistenceHelper, ReleaseVersionId, releaseVersion);
 
             mocks.cacheService
                 .Setup(s => s.GetItemAsync(cacheKey, typeof(SubjectMetaViewModel)))
@@ -85,15 +81,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
         [Fact]
         public async Task GetSubjectMeta_SpecificRelease()
         {
-            var contentReleaseVersion = new ReleaseVersion
-            {
-                Id = ReleaseVersionId,
-                Slug = "release-slug",
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                }
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var releaseSubject = new ReleaseSubject
             {
@@ -103,11 +93,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 
             var subjectMetaViewModel = new SubjectMetaViewModel();
 
-            var cacheKey = GetCacheKey(contentReleaseVersion, releaseSubject);
+            var cacheKey = GetCacheKey(releaseVersion, releaseSubject);
 
             var (controller, mocks) = BuildControllerAndMocks();
 
-            SetupCall(mocks.contentPersistenceHelper, ReleaseVersionId, contentReleaseVersion);
+            SetupCall(mocks.contentPersistenceHelper, ReleaseVersionId, releaseVersion);
 
             mocks.cacheService
                 .Setup(s => s.GetItemAsync(cacheKey, typeof(SubjectMetaViewModel)))
@@ -201,8 +191,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 
         private static SubjectMetaCacheKey GetCacheKey(ReleaseVersion releaseVersion, ReleaseSubject releaseSubject)
         {
-            return new SubjectMetaCacheKey(publicationSlug: releaseVersion.Publication.Slug,
-                releaseSlug: releaseVersion.Slug,
+            return new SubjectMetaCacheKey(publicationSlug: releaseVersion.Release.Publication.Slug,
+                releaseSlug: releaseVersion.Release.Slug,
                 releaseSubject.SubjectId);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/CacheKeyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/CacheKeyServiceTests.cs
@@ -3,8 +3,10 @@ using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Services;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
@@ -13,17 +15,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 {
     public class CacheKeyServiceTests
     {
+        private readonly DataFixture _dataFixture = new();
+
         [Fact]
         public async Task CreateCacheKeyForReleaseSubjects()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Slug = "publication-slug"
-                },
-                Slug = "release-slug"
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()
+                        .WithSlug("publication-slug")));
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
@@ -42,7 +42,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 var cacheKey = result.AssertRight();
                 Assert.Equal(BlobContainers.PublicContent, cacheKey.Container);
                 Assert.Equal(releaseVersion.Id, cacheKey.ReleaseVersionId);
-                Assert.Equal("publications/publication-slug/releases/release-slug/subjects.json", cacheKey.Key);
+                Assert.Equal(
+                    $"publications/{releaseVersion.Release.Publication.Slug}/releases/{releaseVersion.Release.Slug}/subjects.json",
+                    cacheKey.Key);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Cache/CacheableReleaseSubject.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Cache/CacheableReleaseSubject.cs
@@ -17,6 +17,6 @@ public record CacheableReleaseSubject
     }
 
     public Guid SubjectId => ReleaseSubject.SubjectId;
-    public string ReleaseSlug => ContentReleaseVersion.Slug;
-    public string PublicationSlug => ContentReleaseVersion.Publication.Slug;
+    public string ReleaseSlug => ContentReleaseVersion.Release.Slug;
+    public string PublicationSlug => ContentReleaseVersion.Release.Publication.Slug;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Cache/LocationsForDataBlockCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Cache/LocationsForDataBlockCacheKey.cs
@@ -15,8 +15,8 @@ public record LocationsForDataBlockCacheKey : IBlobCacheKey
     private long BoundaryLevelId { get; }
 
     public LocationsForDataBlockCacheKey(DataBlockVersion dataBlockVersion, long boundaryLevelId) : this(
-        publicationSlug: dataBlockVersion.ReleaseVersion.Publication.Slug,
-        releaseSlug: dataBlockVersion.ReleaseVersion.Slug,
+        publicationSlug: dataBlockVersion.ReleaseVersion.Release.Publication.Slug,
+        releaseSlug: dataBlockVersion.ReleaseVersion.Release.Slug,
         dataBlockParentId: dataBlockVersion.DataBlockParentId,
         boundaryLevelId: boundaryLevelId)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderMetaController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderMetaController.cs
@@ -62,7 +62,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
             // In future we should change the storage path for cached items to use Publication and Release id's in the
             // directory structure rather than slugs so that we don't need to lookup the Publication from the Content Release.
             return await _contentPersistenceHelper.CheckEntityExists<ReleaseVersion>(releaseSubject.ReleaseVersionId,
-                    q => q.Include(releaseVersion => releaseVersion.Publication))
+                    q => q.Include(rv => rv.Release)
+                        .ThenInclude(r => r.Publication))
                 .OnSuccess(releaseVersion => new CacheableReleaseSubject(releaseSubject, releaseVersion));
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
@@ -1,14 +1,15 @@
 using System;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
-using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyApprovalStatus;
@@ -18,6 +19,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 {
     public class MethodologyServiceTests
     {
+        private readonly DataFixture _dataFixture = new();
+
         [Fact]
         public async Task GetFiles()
         {
@@ -77,16 +80,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         [Fact]
         public async Task GetLatestVersionByRelease()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Publication = new Publication
-                {
-                    Title = "Publication",
-                    Slug = "publication-slug"
-                },
-                ReleaseName = "2018",
-                TimePeriodCoverage = AcademicYearQ1
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var methodologies = AsList(
                 new MethodologyVersion
@@ -116,7 +112,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var methodologyVersionRepository = new Mock<IMethodologyVersionRepository>(MockBehavior.Strict);
 
-            methodologyVersionRepository.Setup(mock => mock.GetLatestVersionByPublication(releaseVersion.PublicationId))
+            methodologyVersionRepository
+                .Setup(mock => mock.GetLatestVersionByPublication(releaseVersion.Release.PublicationId))
                 .ReturnsAsync(methodologies);
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
@@ -151,21 +148,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         [Fact]
         public async Task IsBeingPublishedAlongsideRelease_Immediately()
         {
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
+
             var methodologyVersion = new MethodologyVersion
             {
                 Status = Approved,
                 PublishingStrategy = Immediately,
             };
 
-            var releaseVersion = new ReleaseVersion
-            {
-                PublicationId = Guid.NewGuid(),
-            };
-
             await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
             var publicationRepository = new Mock<IPublicationRepository>(MockBehavior.Strict);
 
-            publicationRepository.Setup(mock => mock.IsPublished(releaseVersion.PublicationId))
+            publicationRepository.Setup(mock => mock.IsPublished(releaseVersion.Release.PublicationId))
                 .ReturnsAsync(false);
 
             var methodologyService = SetupMethodologyService(contentDbContext,
@@ -179,21 +175,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         [Fact]
         public async Task IsBeingPublishedAlongsideRelease_Immediately_PublicationAlreadyPublished()
         {
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
+
             var methodologyVersion = new MethodologyVersion
             {
                 Status = Approved,
                 PublishingStrategy = Immediately,
             };
 
-            var releaseVersion = new ReleaseVersion
-            {
-                PublicationId = Guid.NewGuid(),
-            };
-
             await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
             var publicationRepository = new Mock<IPublicationRepository>(MockBehavior.Strict);
 
-            publicationRepository.Setup(mock => mock.IsPublished(releaseVersion.PublicationId))
+            publicationRepository.Setup(mock => mock.IsPublished(releaseVersion.Release.PublicationId))
                 .ReturnsAsync(true);
 
             var methodologyService = SetupMethodologyService(contentDbContext,
@@ -207,11 +202,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         [Fact]
         public async Task IsBeingPublishedAlongsideRelease_WithRelease()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                PublicationId = Guid.NewGuid(),
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var methodologyVersion = new MethodologyVersion
             {
@@ -223,7 +216,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
             var publicationRepository = new Mock<IPublicationRepository>(MockBehavior.Strict);
 
-            publicationRepository.Setup(mock => mock.IsPublished(releaseVersion.PublicationId))
+            publicationRepository.Setup(mock => mock.IsPublished(releaseVersion.Release.PublicationId))
                 .ReturnsAsync(false);
 
             var methodologyService = SetupMethodologyService(contentDbContext,
@@ -237,11 +230,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         [Fact]
         public async Task IsBeingPublishedAlongsideRelease_WithRelease_IncorrectRelease()
         {
-            var releaseVersion = new ReleaseVersion
-            {
-                Id = Guid.NewGuid(),
-                PublicationId = Guid.NewGuid(),
-            };
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
+                .WithRelease(_dataFixture.DefaultRelease()
+                    .WithPublication(_dataFixture.DefaultPublication()));
 
             var methodologyVersion = new MethodologyVersion
             {
@@ -253,7 +244,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             await using var contentDbContext = InMemoryContentDbContext(Guid.NewGuid().ToString());
             var publicationRepository = new Mock<IPublicationRepository>(MockBehavior.Strict);
 
-            publicationRepository.Setup(mock => mock.IsPublished(releaseVersion.PublicationId))
+            publicationRepository.Setup(mock => mock.IsPublished(releaseVersion.Release.PublicationId))
                 .ReturnsAsync(false);
 
             var methodologyService = SetupMethodologyService(contentDbContext,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
@@ -1,13 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 
 public interface IContentService
 {
-    Task DeletePreviousVersionsDownloadFiles(params Guid[] releaseVersionIds);
+    Task DeletePreviousVersionsDownloadFiles(IReadOnlyList<Guid> releaseVersionIds);
 
-    Task DeletePreviousVersionsContent(params Guid[] releaseVersionIds);
+    Task DeletePreviousVersionsContent(IReadOnlyList<Guid> releaseVersionIds);
 
     Task UpdateContent(Guid releaseVersionId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseService.cs
@@ -10,8 +10,6 @@ public interface IReleaseService
 {
     Task<ReleaseVersion> Get(Guid releaseVersionId);
 
-    Task<IEnumerable<ReleaseVersion>> List(IEnumerable<Guid> releaseVersionIds);
-
     Task<IEnumerable<ReleaseVersion>> GetAmendedReleases(IEnumerable<Guid> releaseVersionIds);
 
     Task<List<File>> GetFiles(Guid releaseVersionId, params FileType[] types);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
@@ -34,7 +34,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         public async Task<List<MethodologyVersion>> GetLatestVersionByRelease(ReleaseVersion releaseVersion)
         {
-            return await _methodologyVersionRepository.GetLatestVersionByPublication(releaseVersion.PublicationId);
+            return await _methodologyVersionRepository.GetLatestVersionByPublication(
+                releaseVersion.Release.PublicationId);
         }
 
         public async Task<List<File>> GetFiles(Guid methodologyVersionId, params FileType[] types)
@@ -81,7 +82,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 return false;
             }
 
-            var firstRelease = !await _publicationRepository.IsPublished(releaseVersion.PublicationId);
+            var firstRelease = !await _publicationRepository.IsPublished(releaseVersion.Release.PublicationId);
 
             var firstReleaseAndMethodologyScheduledImmediately =
                 firstRelease &&

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleasePublishingStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleasePublishingStatusService.cs
@@ -41,15 +41,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         {
             var releaseVersion = await _context.ReleaseVersions
                 .AsNoTracking()
-                .Include(rv => rv.Publication)
+                .Include(rv => rv.Release)
+                .ThenInclude(r => r.Publication)
                 .FirstAsync(rv => rv.Id == releasePublishingKey.ReleaseVersionId);
 
             var releaseStatus = new ReleasePublishingStatus(
                 releaseVersionId: releaseVersion.Id,
                 releaseStatusId: releasePublishingKey.ReleaseStatusId,
-                publicationSlug: releaseVersion.Publication.Slug,
+                publicationSlug: releaseVersion.Release.Publication.Slug,
                 publish: immediate ? null : releaseVersion.PublishScheduled,
-                releaseSlug: releaseVersion.Slug,
+                releaseSlug: releaseVersion.Release.Slug,
                 state,
                 immediate: immediate,
                 logMessages);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -21,23 +21,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         public async Task<ReleaseVersion> Get(Guid releaseVersionId)
         {
             return await contentDbContext.ReleaseVersions
+                .Include(rv => rv.Release)
                 .SingleAsync(releaseVersion => releaseVersion.Id == releaseVersionId);
-        }
-
-        public async Task<IEnumerable<ReleaseVersion>> List(IEnumerable<Guid> releaseVersionIds)
-        {
-            return await contentDbContext.ReleaseVersions
-                .Where(rv => releaseVersionIds.Contains(rv.Id))
-                .Include(rv => rv.Publication)
-                .Include(rv => rv.PreviousVersion)
-                .ToListAsync();
         }
 
         public async Task<IEnumerable<ReleaseVersion>> GetAmendedReleases(IEnumerable<Guid> releaseVersionIds)
         {
             return await contentDbContext.ReleaseVersions
                 .Include(rv => rv.PreviousVersion)
-                .Include(rv => rv.Publication)
+                .Include(rv => rv.Release)
+                .ThenInclude(r => r.Publication)
                 .Where(rv => releaseVersionIds.Contains(rv.Id) && rv.PreviousVersionId != null)
                 .ToListAsync();
         }


### PR DESCRIPTION
This PR completes swapping out usages of `ReleaseVersion`  properties `ReleaseName`, `TimePeriodCoverage` and `Slug` with their equivalents from `Release`.

`ReleaseVersion.Year` and `ReleaseVersion.YearTitle` are also removed.

A lot of this work was already covered by https://github.com/dfe-analytical-services/explore-education-statistics/pull/5522.

### UI Test report

![image](https://github.com/user-attachments/assets/34b84de1-e5df-4533-81c1-bcbd7a0d08e7)
