### PR TITLE
EES-5659 Remove `ReleaseName`, `Slug`, and `TimePeriodCoverage` from `ReleaseVersion`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -613,11 +613,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 Assert.Equal(publication.Id, releaseVersion.PublicationId);
                 Assert.Equal(release.Id, releaseVersion.ReleaseId);
 
-                // TODO EES-5659 - Remove the ReleaseVersion assertions on ReleaseName, TimePeriodCoverage, Slug
-                Assert.Equal(year.ToString(), releaseVersion.ReleaseName);
-                Assert.Equal(timePeriodCoverage, releaseVersion.TimePeriodCoverage);
-                Assert.Equal(expectedSlug, releaseVersion.Slug);
-
                 var releaseSeriesItem = Assert.Single(updatedPublication.ReleaseSeries);
                 Assert.Equal(release.Id, releaseSeriesItem.ReleaseId);
             }
@@ -819,11 +814,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 Assert.Equal(publication.Id, releaseVersion.PublicationId);
                 Assert.Equal(release.Id, releaseVersion.ReleaseId);
 
-                // TODO EES-5659 - Remove the ReleaseVersion assertions on ReleaseName, TimePeriodCoverage, Slug
-                Assert.Equal(newYear.ToString(), releaseVersion.ReleaseName);
-                Assert.Equal(newTimePeriodCoverage, releaseVersion.TimePeriodCoverage);
-                Assert.Equal(expectedNewSlug, releaseVersion.Slug);
-
                 var releaseSeriesItem = Assert.Single(updatedPublication.ReleaseSeries);
                 Assert.Equal(release.Id, releaseSeriesItem.ReleaseId);
             }
@@ -876,10 +866,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 var release = Assert.Single(updatedPublication.Releases);
                 Assert.Equal(expectedNewLabel, release.Label);
                 Assert.Equal(expectedNewSlug, release.Slug);
-
-                // TODO EES-5659 - Remove the assertion on ReleaseVersion.Slug
-                var releaseVersion = Assert.Single(release.Versions);
-                Assert.Equal(expectedNewSlug, releaseVersion.Slug);
             }
 
             [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -140,11 +140,6 @@ public abstract class ReleaseServiceTests
                 Assert.Equal(TimeIdentifier.AcademicYear, actualRelease.TimePeriodCoverage);
                 Assert.Equal("2018-19-initial", actualRelease.Slug);
 
-                // TODO EES-5659 - Remove the ReleaseVersion assertions on ReleaseName, TimePeriodCoverage, Slug
-                Assert.Equal("2018", actualReleaseVersion.ReleaseName);
-                Assert.Equal(TimeIdentifier.AcademicYear, actualReleaseVersion.TimePeriodCoverage);
-                Assert.Equal("2018-19-initial", actualReleaseVersion.Slug);
-
                 Assert.Equal(ReleaseType.OfficialStatistics, actualReleaseVersion.Type);
                 Assert.Equal(ReleaseApprovalStatus.Draft, actualReleaseVersion.ApprovalStatus);
                 Assert.Equal(0, actualReleaseVersion.Version);
@@ -939,11 +934,6 @@ public abstract class ReleaseServiceTests
                 Assert.Equal(release.Year, actualRelease.Year);
                 Assert.Equal(release.TimePeriodCoverage, actualRelease.TimePeriodCoverage);
                 Assert.Equal(newReleaseSlug, actualRelease.Slug);
-
-                // TODO EES-5659 - Remove the ReleaseVersion assertions on Year, TimePeriodCoverage, Slug
-                Assert.Equal(release.Year.ToString(), actualReleaseVersion.ReleaseName);
-                Assert.Equal(release.TimePeriodCoverage, actualReleaseVersion.TimePeriodCoverage);
-                Assert.Equal(newReleaseSlug, actualReleaseVersion.Slug);
 
                 Assert.Equal(releaseVersion.NextReleaseDate, actualReleaseVersion.NextReleaseDate);
                 Assert.Equal(updatedType, actualReleaseVersion.Type);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250123174256_EES5659_RemovePropertiesFromReleaseVersion.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250123174256_EES5659_RemovePropertiesFromReleaseVersion.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250123174256_EES5659_RemovePropertiesFromReleaseVersion")]
+    partial class EES5659_RemovePropertiesFromReleaseVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -488,6 +491,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.Property<string>("DataSetFileMeta")
                         .HasColumnType("nvarchar(max)");
+
+                    b.Property<bool>("DataSetFileMetaGeogLvlMigrated")
+                        .HasColumnType("bit");
 
                     b.Property<int?>("DataSetFileVersion")
                         .HasColumnType("int");

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250123174256_EES5659_RemovePropertiesFromReleaseVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250123174256_EES5659_RemovePropertiesFromReleaseVersion.cs
@@ -1,0 +1,51 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations;
+
+/// <inheritdoc />
+[ExcludeFromCodeCoverage]
+public partial class EES5659_RemovePropertiesFromReleaseVersion : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "ReleaseName",
+            table: "ReleaseVersions");
+
+        migrationBuilder.DropColumn(
+            name: "Slug",
+            table: "ReleaseVersions");
+
+        migrationBuilder.DropColumn(
+            name: "TimePeriodCoverage",
+            table: "ReleaseVersions");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "ReleaseName",
+            table: "ReleaseVersions",
+            type: "nvarchar(max)",
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "Slug",
+            table: "ReleaseVersions",
+            type: "nvarchar(max)",
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "TimePeriodCoverage",
+            table: "ReleaseVersions",
+            type: "nvarchar(6)",
+            maxLength: 6,
+            nullable: false,
+            defaultValue: "");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseAmendmentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseAmendmentService.cs
@@ -96,11 +96,6 @@ public class ReleaseAmendmentService : IReleaseAmendmentService
             PreReleaseAccessList = originalReleaseVersion.PreReleaseAccessList,
             NextReleaseDate = originalReleaseVersion.NextReleaseDate,
 
-            // TODO EES-5659 Remove setting ReleaseName, TimePeriodCoverage, Slug
-            ReleaseName = originalReleaseVersion.ReleaseName,
-            TimePeriodCoverage = originalReleaseVersion.TimePeriodCoverage,
-            Slug = originalReleaseVersion.Slug,
-
             // Assign new amendment-specific values to various fields.
 
             // TODO EES-4637 - we need to decide on how we're being consistent with Created dates in Release Amendments.

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -160,12 +160,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         Release = release,
                         Type = releaseCreate.Type!.Value,
                         ApprovalStatus = ReleaseApprovalStatus.Draft,
-
-                        // TODO Remove the following in EES-5659
                         PublicationId = release.PublicationId,
-                        TimePeriodCoverage = release.TimePeriodCoverage,
-                        ReleaseName = release.Year.ToString(),
-                        Slug = release.Slug
                     };
 
                     if (releaseCreate.TemplateReleaseId.HasValue)
@@ -835,11 +830,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             releaseVersion.Release.TimePeriodCoverage = request.TimePeriodCoverage;
             releaseVersion.Release.Slug = request.Slug;
             releaseVersion.Release.Label = string.IsNullOrWhiteSpace(request.Label) ? null : request.Label.Trim();
-
-            // TODO The following will be removed in EES-5659
-            releaseVersion.ReleaseName = releaseVersion.Release.Year.ToString();
-            releaseVersion.TimePeriodCoverage = releaseVersion.Release.TimePeriodCoverage;
-            releaseVersion.Slug = releaseVersion.Release.Slug;
 
             releaseVersion.Type = request.Type!.Value;
             releaseVersion.PreReleaseAccessList = request.PreReleaseAccessList;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseGeneratorExtensions.cs
@@ -226,11 +226,6 @@ public static class ReleaseGeneratorExtensions
 
                     releaseVersion.Publication = release.Publication;
                     releaseVersion.PublicationId = release.PublicationId;
-
-                    // TODO EES-5659 Remove setting ReleaseName, TimePeriodCoverage, Slug
-                    releaseVersion.ReleaseName = release.Year.ToString();
-                    releaseVersion.TimePeriodCoverage = release.TimePeriodCoverage;
-                    releaseVersion.Slug = release.Slug;
                 });
 
                 return list;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
@@ -187,16 +187,13 @@ public static class ReleaseVersionGeneratorExtensions
     public static InstanceSetters<ReleaseVersion> SetDefaults(this InstanceSetters<ReleaseVersion> setters)
         => setters
             .SetDefault(p => p.Id)
-            .SetDefault(p => p.Slug)
             .SetDefault(p => p.DataGuidance)
             .Set(p => p.Type,
                 f => f.PickRandom(EnumUtil.GetEnums<ReleaseType>().Except([ReleaseType.ExperimentalStatistics])))
             .SetDefault(p => p.PublicationId)
             .SetDefault(p => p.ReleaseId)
             .SetApprovalStatus(ReleaseApprovalStatus.Draft)
-            .SetTimePeriodCoverage(TimeIdentifier.AcademicYear)
             .SetDefault(p => p.PreReleaseAccessList)
-            .Set(p => p.ReleaseName, (_, _, context) => $"{2000 + context.Index}")
             .Set(p => p.NextReleaseDate, (_, _, context) => new PartialDate
             {
                 Day = "1", Month = "1", Year = $"{2000 + context.Index}"
@@ -237,11 +234,6 @@ public static class ReleaseVersionGeneratorExtensions
 
                     releaseVersion.Publication = release.Publication;
                     releaseVersion.PublicationId = release.PublicationId;
-
-                    // TODO EES-5659 Remove setting ReleaseName, TimePeriodCoverage, Slug
-                    releaseVersion.ReleaseName = release.Year.ToString();
-                    releaseVersion.TimePeriodCoverage = release.TimePeriodCoverage;
-                    releaseVersion.Slug = release.Slug;
 
                     return release;
                 })
@@ -348,11 +340,6 @@ public static class ReleaseVersionGeneratorExtensions
         this InstanceSetters<ReleaseVersion> setters,
         int version)
         => setters.Set(releaseVersion => releaseVersion.Version, version);
-
-    public static InstanceSetters<ReleaseVersion> SetTimePeriodCoverage(
-        this InstanceSetters<ReleaseVersion> setters,
-        TimeIdentifier timePeriodCoverage)
-        => setters.Set(releaseVersion => releaseVersion.TimePeriodCoverage, timePeriodCoverage);
 
     public static InstanceSetters<ReleaseVersion> SetNotifySubscribers(
         this InstanceSetters<ReleaseVersion> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -523,12 +523,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .WithMany(p => p.ReleaseVersions)
                 .OnDelete(DeleteBehavior.NoAction);
 
-            // TODO EES-5659 Remove this
-            modelBuilder.Entity<ReleaseVersion>()
-                .Property(rv => rv.TimePeriodCoverage)
-                .HasConversion(new EnumToEnumValueConverter<TimeIdentifier>())
-                .HasMaxLength(6);
-
             modelBuilder.Entity<ReleaseVersion>()
                 .Property<List<Link>>("RelatedInformation")
                 .IsRequired()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseVersion.cs
@@ -3,35 +3,15 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
-using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Newtonsoft.Json;
 using static System.DateTime;
-using static GovUk.Education.ExploreEducationStatistics.Common.Model.PartialDate;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
     public class ReleaseVersion : ICreatedTimestamp<DateTime>
     {
         public Guid Id { get; set; }
-
-        private string _releaseName;
-
-        public string ReleaseName
-        {
-            get => _releaseName;
-            set
-            {
-                if (value == null || YearRegex.Match(value).Success)
-                {
-                    _releaseName = value;
-                }
-                else
-                {
-                    throw new FormatException("The release name is invalid");
-                }
-            }
-        }
 
         /**
          * The last date the release was published - this should be set when the PublishScheduled date is reached and
@@ -46,8 +26,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         [NotMapped] public bool Live => Published.HasValue && UtcNow >= Published.Value;
 
         [NotMapped] public bool Amendment => Version > 0 && !Live;
-
-        public string Slug { get; set; }
 
         [Obsolete("Use ReleaseVersion.Release.PublicationId. This will be removed in EES-5818")]
         public Guid PublicationId { get; set; }
@@ -175,9 +153,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         }
 
         public ReleaseType Type { get; set; }
-
-        [JsonConverter(typeof(TimeIdentifierJsonConverter))]
-        public TimeIdentifier TimePeriodCoverage { get; set; }
 
         public ReleaseApprovalStatus ApprovalStatus { get; set; }
 


### PR DESCRIPTION
⚠️ This PR depends on https://github.com/dfe-analytical-services/explore-education-statistics/pull/5553 and should only be merged once that one has been tested and deployed.⚠️ 

This PR is a tidy-up to remove `ReleaseName`, `Slug`, and `TimePeriodCoverage` from `ReleaseVersion`, including a migration to drop these columns from the database.

[EES-5658](https://github.com/dfe-analytical-services/explore-education-statistics/pull/5553) completed swapping out the usage of these properties in `ReleaseVersion` with their equivalents in `Release`.