### PR TITLE
EES-5768: Remove "National tutoring programme" from time period categories

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifierCategory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifierCategory.cs
@@ -30,10 +30,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 
         [EnumLabelValue("Financial year part")]
         FinancialYearPart,
-
-        // EES-3959 Temporary category for the National tutoring programme publication
-        // TODO remove this once we've got a solution for ordering releases which mix categories of time periods
-        [EnumLabelValue("National tutoring programme")]
-        NationalTutoringProgramme,
     }
 }


### PR DESCRIPTION
Although the time period itself has been removed, the category shown in the dropdown list remained. This PR removes the empty category.

![image](https://github.com/user-attachments/assets/6150b1b5-00d6-4d70-af03-fe6eaa593fda)