### PR TITLE
Ees 5814 add premium storage accounts

### DIFF
--- a/infrastructure/templates/public-api/abbreviations.bicep
+++ b/infrastructure/templates/public-api/abbreviations.bicep
@@ -5,8 +5,7 @@ var abbreviations = {
   appManagedEnvironments: 'cae'
   // TODO - remove the "-flexibleserver" suffix and change the suffix of our PSQL instance to "-01"
   dBforPostgreSQLServers: 'psql-flexibleserver'
-  // 'fs' is non-standard - it should be 'share'
-  fileShare: 'fs'
+  fileShare: 'share'
   // 'ai' is non-standard - it should be 'appi'
   insightsComponents: 'ai'
   managedIdentityUserAssignedIdentities: 'id'

--- a/infrastructure/templates/public-api/application/public-api/publicApiStorage.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiStorage.bicep
@@ -1,4 +1,4 @@
-import { ResourceNames, IpRange } from '../../types.bicep'
+import { ResourceNames, IpRange, PublicApiStorageAccountConfig } from '../../types.bicep'
 
 @description('Specifies common resource naming variables.')
 param resourceNames ResourceNames
@@ -6,10 +6,10 @@ param resourceNames ResourceNames
 @description('Specifies the location for all resources.')
 param location string
 
-@description('Public API Storage : Size of the file share in GB.')
-param publicApiDataFileShareQuotaGbs int
+@description('Public API storage account and file share configuration.')
+param config PublicApiStorageAccountConfig
 
-@description('Public API Storage : Firewall rules.')
+@description('Firewall rules.')
 param storageFirewallRules IpRange[]
 
 @description('Specifies a set of tags with which to tag the resource in Azure.')
@@ -34,7 +34,8 @@ module publicApiStorageAccountModule '../../components/storageAccount.bicep' = {
     storageAccountName: resourceNames.publicApi.publicApiStorageAccount
     publicNetworkAccessEnabled: false
     firewallRules: storageFirewallRules
-    skuStorageResource: 'Standard_LRS'
+    sku: config.sku
+    kind: config.kind
     keyVaultName: resourceNames.existingResources.keyVault
     alerts: deployAlerts ? {
       availability: true
@@ -52,9 +53,9 @@ module dataFilesFileShareModule '../../components/fileShare.bicep' = {
   name: 'fileShareDeploy'
   params: {
     fileShareName: resourceNames.publicApi.publicApiFileShare
-    fileShareQuotaGbs: publicApiDataFileShareQuotaGbs
+    fileShareQuotaGbs: config.fileShare.quotaGbs
     storageAccountName: publicApiStorageAccountModule.outputs.storageAccountName
-    fileShareAccessTier: 'TransactionOptimized'
+    fileShareAccessTier: config.fileShare.accessTier
     alerts: deployAlerts ? {
       availability: true
       latency: true

--- a/infrastructure/templates/public-api/ci/jobs/deploy-data-processor.yml
+++ b/infrastructure/templates/public-api/ci/jobs/deploy-data-processor.yml
@@ -24,7 +24,7 @@ jobs:
             - template: ../tasks/bicep-output-variables.yml
               parameters:
                 serviceConnection: ${{ parameters.serviceConnection }}
-
+                
             # We do config updates out of Bicep template so we can implement slot swapping.
             # Changes are first deployed to the staging slot and combined with a fresh
             # code deploy prior to being swapped with the production slot.
@@ -73,6 +73,9 @@ jobs:
                 maxAttempts: 20
                 accessTokenScope: $(dataProcessorAppRegistrationClientId)
                 endpoint: $(dataProcessorFunctionAppStagingUrl)/api/HealthCheck
+                # We allow 404s because if this is the first time the Function App is being deployed, there won't be any
+                # deployed code yet in the staging slot.
+                allow404s: true
 
             - task: AzureCLI@2
               displayName: Deploy to staging slot

--- a/infrastructure/templates/public-api/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/public-api/ci/jobs/deploy-infrastructure.yml
@@ -44,21 +44,12 @@ jobs:
                 deployAlerts: false
                 dataProcessorExists: false
 
-            - task: AzureCLI@2
-              displayName: Check if Data Processor Function App exists
-              inputs:
-                azureSubscription: ${{ parameters.serviceConnection }}
-                scriptType: bash
-                scriptLocation: inlineScript
-                inlineScript: |
-                  set -e
-                  dataProcessorExists=`az functionapp list --resource-group $(resourceGroupName) --query "[?name=='$(dataProcessorFunctionAppName)']" | jq '. != []'`
-      
-                  if [[ "$dataProcessorExists" == "true" ]]; then
-                    echo "Data Processor Function App exists"
-                  fi
-      
-                  echo "##vso[task.setvariable variable=dataProcessorExists;]$dataProcessorExists"
+            - template: ../tasks/check-function-app-exists.yml
+              parameters:
+                serviceConnection: ${{ parameters.serviceConnection }}
+                resourceGroupName: $(resourceGroupName)
+                functionAppName: $(dataProcessorFunctionAppName)
+                variableName: dataProcessorExists
 
             - template: ../tasks/deploy-bicep.yml
               parameters:

--- a/infrastructure/templates/public-api/ci/tasks/check-function-app-exists.yml
+++ b/infrastructure/templates/public-api/ci/tasks/check-function-app-exists.yml
@@ -1,0 +1,26 @@
+parameters:
+  - name: serviceConnection
+    type: string
+  - name: resourceGroupName
+    type: string    
+  - name: functionAppName
+    type: string
+  - name: variableName
+    type: string
+
+steps:
+  - task: AzureCLI@2
+    displayName: Check if ${{ parameters.functionAppName }} exists
+    inputs:
+      azureSubscription: ${{ parameters.serviceConnection }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -e
+        functionAppExists=`az functionapp list --resource-group ${{ parameters.resourceGroupName }} --query "[?name=='${{ parameters.functionAppName }}']" | jq '. != []'`
+
+        if [[ "$functionAppExists" == "true" ]]; then
+          echo "${{ parameters.functionAppName }} exists"
+        fi
+
+        echo "##vso[task.setvariable variable=${{ parameters.variableName }};]$functionAppExists"

--- a/infrastructure/templates/public-api/ci/tasks/wait-for-endpoint-success.yml
+++ b/infrastructure/templates/public-api/ci/tasks/wait-for-endpoint-success.yml
@@ -4,6 +4,9 @@ parameters:
   - name: displayName
     type: string
     default: Waiting for a successful response from endpoint
+  - name: condition
+    type: string
+    default: succeeded()
   - name: accessTokenScope
     type: string
     default: null
@@ -15,12 +18,19 @@ parameters:
     default: 50
   - name: endpoint
     type: string
+  - name: endpointStatusCodeVariableName
+    type: string
+    default: endpointStatusCode
+  - name: allow404s
+    type: boolean
+    default: false
 
 steps:
   - task: AzureCLI@2
     displayName: ${{ parameters.displayName }}
     inputs:
       azureSubscription: ${{ parameters.serviceConnection }}
+      condition: ${{ parameters.condition }}
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -32,11 +42,13 @@ steps:
             -o tsv`
         fi
 
+        allow404s=${{ parameters.allow404s }}
+
         for attempt in $(seq 1 ${{ parameters.maxAttempts }});
         do
 
           echo "Attempt number $attempt of ${{ parameters.maxAttempts }} - calling ${{ parameters.endpoint }} to check for successful response."
-          
+
           if [ -n "$accessToken" ]; then
             httpStatusCode=`curl --write-out '%{http_code}' -H "Authorization: Bearer $accessToken" -s --output /dev/null ${{ parameters.endpoint }}`
           else 
@@ -45,6 +57,13 @@ steps:
 
           if (( $httpStatusCode >= 200 && $httpStatusCode <= 204 )); then
             echo "Received successful response with status code $httpStatusCode."
+            echo "##vso[task.setvariable variable=${{ parameters.endpointStatusCodeVariableName }};]$httpStatusCode"
+            exit 0
+          fi
+
+          if [[ "${allow404s,,}" == "true" && "$httpStatusCode" == "404" ]]; then
+            echo "Received allowed 404 status code."
+            echo "##vso[task.setvariable variable=${{ parameters.endpointStatusCodeVariableName }};]$httpStatusCode"
             exit 0
           fi
 
@@ -53,5 +72,6 @@ steps:
         
         done
 
+        echo "##vso[task.setvariable variable=${{ parameters.endpointStatusCodeVariableName }};]$httpStatusCode"
         echo "Timed out waiting for successful response."
         exit 1

--- a/infrastructure/templates/public-api/ci/tasks/wait-for-endpoint-success.yml
+++ b/infrastructure/templates/public-api/ci/tasks/wait-for-endpoint-success.yml
@@ -18,9 +18,6 @@ parameters:
     default: 50
   - name: endpoint
     type: string
-  - name: endpointStatusCodeVariableName
-    type: string
-    default: endpointStatusCode
   - name: allow404s
     type: boolean
     default: false
@@ -57,13 +54,11 @@ steps:
 
           if (( $httpStatusCode >= 200 && $httpStatusCode <= 204 )); then
             echo "Received successful response with status code $httpStatusCode."
-            echo "##vso[task.setvariable variable=${{ parameters.endpointStatusCodeVariableName }};]$httpStatusCode"
             exit 0
           fi
 
           if [[ "${allow404s,,}" == "true" && "$httpStatusCode" == "404" ]]; then
             echo "Received allowed 404 status code."
-            echo "##vso[task.setvariable variable=${{ parameters.endpointStatusCodeVariableName }};]$httpStatusCode"
             exit 0
           fi
 
@@ -72,6 +67,5 @@ steps:
         
         done
 
-        echo "##vso[task.setvariable variable=${{ parameters.endpointStatusCodeVariableName }};]$httpStatusCode"
         echo "Timed out waiting for successful response."
         exit 1

--- a/infrastructure/templates/public-api/components/durableFunctionApp.bicep
+++ b/infrastructure/templates/public-api/components/durableFunctionApp.bicep
@@ -165,7 +165,6 @@ module manamementStorageAccountModule 'storageAccount.bicep' = {
     location: location
     storageAccountName: managementStorageAccountName
     allowedSubnetIds: [subnetId]
-    skuStorageResource: 'Standard_LRS'
     keyVaultName: keyVaultName
     publicNetworkAccessEnabled: false
     privateEndpointSubnetIds: {
@@ -187,7 +186,6 @@ module slot1StorageAccountModule 'storageAccount.bicep' = {
     location: location
     storageAccountName: slot1StorageAccountName
     allowedSubnetIds: [subnetId]
-    skuStorageResource: 'Standard_LRS'
     keyVaultName: keyVaultName
     publicNetworkAccessEnabled: false
     privateEndpointSubnetIds: {
@@ -224,7 +222,6 @@ module slot2StorageAccountModule 'storageAccount.bicep' = {
     location: location
     storageAccountName: slot2StorageAccountName
     allowedSubnetIds: [subnetId]
-    skuStorageResource: 'Standard_LRS'
     keyVaultName: keyVaultName
     publicNetworkAccessEnabled: false
     privateEndpointSubnetIds: {

--- a/infrastructure/templates/public-api/components/fileShare.bicep
+++ b/infrastructure/templates/public-api/components/fileShare.bicep
@@ -45,13 +45,12 @@ resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-0
   }
 }
 
-var alertResourceName = '${storageAccountName}-fs'
 var fileServiceId = resourceId('Microsoft.Storage/storageAccounts/fileServices', storageAccountName, 'default')
 
 module availabilityAlert 'alerts/staticMetricAlert.bicep' = if (alerts != null && alerts!.availability) {
   name: '${storageAccountName}FsAvailabilityAlertModule'
   params: {
-    resourceName: alertResourceName
+    resourceName: storageAccountName
     id: fileServiceId
     resourceMetric: {
       resourceType: 'Microsoft.Storage/storageAccounts/fileServices'
@@ -69,7 +68,7 @@ module availabilityAlert 'alerts/staticMetricAlert.bicep' = if (alerts != null &
 module latencyAlert 'alerts/staticMetricAlert.bicep' = if (alerts != null && alerts!.latency) {
   name: '${storageAccountName}FsLatencyDeploy'
   params: {
-    resourceName: alertResourceName
+    resourceName: storageAccountName
     id: fileServiceId
     resourceMetric: {
       resourceType: 'Microsoft.Storage/storageAccounts/fileServices'
@@ -104,7 +103,7 @@ var capacityAlertThresholds = [{
 module fileCapacityAlerts 'alerts/staticMetricAlert.bicep' = [for capacityThreshold in capacityAlertThresholds: if (alerts != null && alerts!.capacity) {
   name: '${storageAccountName}FsCapacity${capacityThreshold.threshold}Deploy'
   params: {
-    resourceName: alertResourceName
+    resourceName: storageAccountName
     id: fileServiceId
     resourceMetric: {
       resourceType: 'Microsoft.Storage/storageAccounts/fileServices'

--- a/infrastructure/templates/public-api/components/storageAccount.bicep
+++ b/infrastructure/templates/public-api/components/storageAccount.bicep
@@ -15,7 +15,10 @@ param allowedSubnetIds string[] = []
 param firewallRules IpRange[] = []
 
 @description('Storage Account SKU')
-param skuStorageResource 'Standard_LRS' | 'Standard_GRS' | 'Standard_RAGRS' | 'Standard_ZRS' | 'Premium_LRS' | 'Premium_ZRS' | 'Standard_GZRS' | 'Standard_RAGZRS' = 'Standard_LRS'
+param sku 'Standard_LRS' | 'Standard_GRS' | 'Standard_RAGRS' | 'Standard_ZRS' | 'Premium_LRS' | 'Premium_ZRS' | 'Standard_GZRS' | 'Standard_RAGZRS' = 'Standard_LRS'
+
+@description('Storage Account kind')
+param kind 'StorageV2' | 'FileStorage' = 'StorageV2'
 
 @description('Storage Account Name')
 param keyVaultName string
@@ -41,9 +44,9 @@ var endpointSuffix = environment().suffixes.storage
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: storageAccountName
   location: location
-  kind: 'StorageV2'
+  kind: kind
   sku: {
-    name: skuStorageResource
+    name: sku
   }
   properties: {
     supportsHttpsTrafficOnly: true

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -6,6 +6,7 @@ import {
   StaticWebAppSku
   ContainerAppWorkloadProfile
   PostgreSqlFlexibleServerConfig
+  PublicApiStorageAccountConfig
 } from 'types.bicep'
 
 @description('Environment : Subscription name e.g. s101d01. Used as a prefix for created resources.')
@@ -14,8 +15,15 @@ param subscription string = ''
 @description('Environment : Specifies the location in which the Azure resources should be deployed.')
 param location string = resourceGroup().location
 
-@description('Public API Storage : Size of the file share in GB.')
-param publicApiDataFileShareQuotaGbs int = 1
+@description('Public API Storage configuration.')
+param publicApiStorageConfig PublicApiStorageAccountConfig = {
+  kind: 'FileStorage'
+  sku: 'Premium_ZRS'
+  fileShare: {
+    quotaGbs: 100
+    accessTier: 'Premium'
+  }
+}
 
 @description('Provides access to resources for specific IP address ranges used for service maintenance.')
 param maintenanceIpRanges IpRange[] = []
@@ -250,7 +258,7 @@ module publicApiStorageModule 'application/public-api/publicApiStorage.bicep' = 
   params: {
     location: location
     resourceNames: resourceNames
-    publicApiDataFileShareQuotaGbs: publicApiDataFileShareQuotaGbs
+    config: publicApiStorageConfig
     storageFirewallRules: maintenanceIpRanges
     deployAlerts: deployAlerts
     tagValues: tagValues

--- a/infrastructure/templates/public-api/types.bicep
+++ b/infrastructure/templates/public-api/types.bicep
@@ -353,3 +353,13 @@ type PostgreSqlFlexibleServerConfig = {
     autoGrow: bool
   }
 }
+
+@export()
+type PublicApiStorageAccountConfig = {
+  sku: 'Standard_LRS' | 'Premium_LRS' | 'Premium_ZRS'
+  kind: 'StorageV2' | 'FileStorage'
+  fileShare: {
+    quotaGbs: int
+    accessTier: 'Cool' | 'Hot' | 'TransactionOptimized' | 'Premium'
+  }
+}

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1217,7 +1217,7 @@
       "[concat('Microsoft.Web/sites/', variables('dataAppName'))]"
     ],
     "publicDataFileShareMountPathWindows": "\\mounts\\public-api-data",
-    "publicDataFileShareName": "[concat(parameters('subscription'), '-ees-papi-fs-data')]",
+    "publicDataFileShareName": "[concat(parameters('subscription'), '-ees-papi-share-data')]",
     "publicDataStorageAccountName": "[concat(parameters('subscription'), 'eespapisa')]"
   },
   "resources": [


### PR DESCRIPTION
This PR:
- swaps the "Standard" storage account used for the Public API for a "Premium", File share-centric storage account.

## Config changes

Our Public API storage account is now set up as a Premium, `FileStorage` storage account, meaning that it is tailored towards providing file shares with extremely low latency.

Currently all environments are the same, each provisioning a file share of 100GBs (the minimum amount allowed in a Premium storage account.

All other existing storage accounts (e.g. the 3 used by the Data Processor) remain `StandardV2`.

In order to roll out these changes, existing Public API storage accounts firstly needed to be backed up, and then deleted completely, as these settings cannot be applied retrospectively.

## Other changes in this PR

### File share naming convention

As we had to rebuild any existing Public API storage accounts in Resource Groups prior to deploying this, it seemed like a good opportunity to update our file share naming convention, from `fs` to `share` which is the recommended one.

### Data Processor deploy process

I removed the Data Processor from Dev during the roll-out of this PR.  As part of that, I noticed that the deploy of the Data Processor would fail if there wasn't already a deployment in the staging slot (i.e. it would fail the first time you tried to deploy the infrastructure, or after removing the function app for whatever reason).

To fix this, I've now set it to allow 404s from an endpoint check while waiting for the function app to come back to life after appsetting updates, which only occurs the first time the deployment takes place.

### YAML template for checking existence of a function app

I broke this piece of logic out into a template as I though we'd need it multiple times.  Turns out we didn't but it's neater being extracted out so I have left this change in!

 