### PR TITLE
EES-5819 Can specify chromedriver version in UI tests pipeline run sc…

### DIFF
--- a/tests/robot-tests/scripts/run_tests_pipeline.py
+++ b/tests/robot-tests/scripts/run_tests_pipeline.py
@@ -35,6 +35,9 @@ def run_tests_pipeline():
     if args.rerun_attempts:
         run_tests_command += f" --rerun-attempts {str(args.rerun_attempts)}"
 
+    if args.chromedriver_version:
+        run_tests_command += f" --chromedriver {str(args.chromedriver_version)}"
+
     subprocess.check_call(run_tests_command, shell=True)
 
 
@@ -67,5 +70,13 @@ if __name__ == "__main__":
     parser.add_argument("--processes", dest="processes", help="number of processes to run", required=True)
 
     parser.add_argument("--rerun-attempts", dest="rerun_attempts", type=int, help="Number of rerun attempts")
+
+    parser.add_argument(
+        "--chromedriver",
+        dest="chromedriver_version",
+        metavar="{version}",
+        help="specify which version of chromedriver to use",
+    )
+
     args = parser.parse_args()
     run_tests_pipeline()


### PR DESCRIPTION
…ript

This PR allows us to specify the chromedriver version we want to use when using the UI tests pipeline run script.