### PR TITLE
EES-5742 Fix UI tests

### DIFF
--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -63,7 +63,7 @@ user opens ie
 user opens chrome headlessly
     [Arguments]    ${alias}=headless_chrome
     ${c_opts}=    Evaluate    sys.modules['selenium.webdriver'].ChromeOptions()    sys, selenium.webdriver
-    Call Method    ${c_opts}    add_argument    headless\=old
+    Call Method    ${c_opts}    add_argument    headless
     Call Method    ${c_opts}    add_argument    start-maximized
     Call Method    ${c_opts}    add_argument    disable-extensions
     Call Method    ${c_opts}    add_argument    disable-infobars


### PR DESCRIPTION
This PR changes the headless argument we use when opening google-chrome in the UI tests to not use "old".

We did this because we started seeing failures like this:
```
2025-01-28T10:26:13.8418368Z UI Tests.Glossary Page                                                        
2025-01-28T10:26:13.8418684Z ==============================================================================
2025-01-28T10:26:13.8418983Z Navigate to glossary page                                             | FAIL |
2025-01-28T10:26:13.8419220Z Parent suite setup failed:
2025-01-28T10:26:13.8419591Z SessionNotCreatedException: Message: session not created: probably user data directory is already in use, please specify a unique value for --user-data-dir argument, or don't use --user-data-dir
```

It seems like newer version of google-chrome and chromedriver have broken "headless=old".