### PR TITLE
EES-5808 go to preview log after api token revoked

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
@@ -41,15 +41,6 @@ export default function ReleaseApiDataSetPreviewTokenPage() {
     ...previewTokenQueries.get(previewTokenId),
   });
 
-  const previewPagePath = generatePath<ReleaseDataSetRouteParams>(
-    releaseApiDataSetPreviewRoute.path,
-    {
-      publicationId,
-      releaseId,
-      dataSetId,
-    },
-  );
-
   const detailsPagePath = generatePath<ReleaseDataSetRouteParams>(
     releaseApiDataSetDetailsRoute.path,
     {
@@ -70,12 +61,7 @@ export default function ReleaseApiDataSetPreviewTokenPage() {
 
   const handleRevoke = async (id: string) => {
     await previewTokenService.revokePreviewToken(id);
-
-    history.push(
-      lastLocation?.pathname === tokenLogPagePath
-        ? tokenLogPagePath
-        : previewPagePath,
-    );
+    history.push(tokenLogPagePath);
   };
 
   const tokenExampleUrl = `${publicApiUrl}/api/v1.0/data-sets/${dataSet?.draftVersion?.id}`;

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenPage.test.tsx
@@ -171,7 +171,7 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
 
     await waitFor(() => {
       expect(history.location.pathname).toBe(
-        '/publication/publication-1/release/release-1/api-data-sets/data-set-id/preview',
+        '/publication/publication-1/release/release-1/api-data-sets/data-set-id/preview-tokens',
       );
     });
   });

--- a/tests/robot-tests/tests/public_api/public_api_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_preview_token.robot
@@ -150,9 +150,10 @@ User revokes preview token
     user clicks button    Confirm
     user waits until page finishes loading
     user waits until modal is not visible    Revoke preview token    %{WAIT_LONG}
-    user waits until page contains    Generate API data set preview token
+    user waits until page contains    API data set preview token log
 
 User again clicks on 'Generate preview token'
+    user clicks link    Generate preview token
     user clicks button    Generate preview token
 
 User creates another preview token through 'Generate preview token' modal window


### PR DESCRIPTION
After revoking an API preview token redirect to the preview token log page instead of the generate token page as users found this confusing.