### PR TITLE
EES-5807 make it clearer new api data set is processing

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateModal.tsx
@@ -13,9 +13,11 @@ import Modal from '@common/components/Modal';
 import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import { useQuery } from '@tanstack/react-query';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { generatePath } from 'react-router-dom';
 import releaseDataPageTabIds from '@admin/pages/release/data/utils/releaseDataPageTabIds';
+import { ApiDataSet } from '@admin/services/apiDataSetService';
+import ApiDataSetCreateProcessing from './ApiDataSetCreateProcessing';
 
 interface Props {
   buttonText?: ReactNode | string;
@@ -23,7 +25,9 @@ interface Props {
   releaseId: string;
   submitText?: string;
   title?: string;
-  onSubmit: (values: ApiDataSetCreateFormValues) => void;
+  onSubmit: (
+    values: ApiDataSetCreateFormValues,
+  ) => Promise<ApiDataSet> | Promise<void>;
 }
 
 export default function ApiDataSetCreateModal({
@@ -35,6 +39,7 @@ export default function ApiDataSetCreateModal({
   onSubmit,
 }: Props) {
   const [isOpen, toggleOpen] = useToggle(false);
+  const [processingDataSetId, setProcessingDataSetId] = useState<string>();
 
   const { data: dataSetCandidates = [], isLoading } = useQuery({
     ...apiDataSetCandidateQueries.list(releaseId),
@@ -44,43 +49,62 @@ export default function ApiDataSetCreateModal({
   return (
     <Modal
       open={isOpen}
-      title={title}
+      title={processingDataSetId ? 'Creating API data set' : title}
       triggerButton={<Button onClick={toggleOpen.on}>{buttonText}</Button>}
+      onExit={() => setProcessingDataSetId(undefined)}
     >
-      <LoadingSpinner loading={isLoading}>
-        <p>
-          Select a data set to become an API data set. This will be made
-          available for third-party applications to consume via the public API.
-        </p>
+      {processingDataSetId ? (
+        <ApiDataSetCreateProcessing
+          dataSetId={processingDataSetId}
+          publicationId={publicationId}
+          releaseId={releaseId}
+          onClose={toggleOpen.off}
+        />
+      ) : (
+        <LoadingSpinner loading={isLoading}>
+          <p>
+            Select a data set to become an API data set. This will be made
+            available for third-party applications to consume via the public
+            API.
+          </p>
 
-        {dataSetCandidates.length > 0 ? (
-          <ApiDataSetCreateForm
-            dataSetCandidates={dataSetCandidates}
-            submitText={submitText}
-            onCancel={toggleOpen.off}
-            onSubmit={onSubmit}
-          />
-        ) : (
-          <>
-            <WarningMessage>
-              No API data sets can be created as there are no candidate data
-              files available. New candidate data files can be uploaded in the{' '}
-              <Link
-                to={`${generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
-                  publicationId,
-                  releaseId,
-                })}#${releaseDataPageTabIds.dataUploads}`}
-                onClick={toggleOpen.off}
-              >
-                Data and files
-              </Link>{' '}
-              section.
-            </WarningMessage>
+          {dataSetCandidates.length > 0 ? (
+            <ApiDataSetCreateForm
+              dataSetCandidates={dataSetCandidates}
+              submitText={submitText}
+              onCancel={toggleOpen.off}
+              onSubmit={async values => {
+                const dataSet = await onSubmit(values);
+                if (dataSet) {
+                  setProcessingDataSetId(dataSet.id);
+                }
+              }}
+            />
+          ) : (
+            <>
+              <WarningMessage>
+                No API data sets can be created as there are no candidate data
+                files available. New candidate data files can be uploaded in the{' '}
+                <Link
+                  to={`${generatePath<ReleaseRouteParams>(
+                    releaseDataRoute.path,
+                    {
+                      publicationId,
+                      releaseId,
+                    },
+                  )}#${releaseDataPageTabIds.dataUploads}`}
+                  onClick={toggleOpen.off}
+                >
+                  Data and files
+                </Link>{' '}
+                section.
+              </WarningMessage>
 
-            <Button onClick={toggleOpen.off}>Close</Button>
-          </>
-        )}
-      </LoadingSpinner>
+              <Button onClick={toggleOpen.off}>Close</Button>
+            </>
+          )}
+        </LoadingSpinner>
+      )}
     </Modal>
   );
 }

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateProcessing.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ApiDataSetCreateProcessing.tsx
@@ -1,0 +1,43 @@
+import ButtonLink from '@admin/components/ButtonLink';
+import {
+  releaseApiDataSetDetailsRoute,
+  ReleaseDataSetRouteParams,
+} from '@admin/routes/releaseRoutes';
+import ButtonGroup from '@common/components/ButtonGroup';
+import ButtonText from '@common/components/ButtonText';
+import React from 'react';
+import { generatePath } from 'react-router-dom';
+
+interface Props {
+  dataSetId: string;
+  publicationId: string;
+  releaseId: string;
+  onClose: () => void;
+}
+export default function ApiDataSetCreateProcessing({
+  dataSetId,
+  publicationId,
+  releaseId,
+  onClose,
+}: Props) {
+  return (
+    <>
+      <p>Your new API data set is being processed.</p>
+      <ButtonGroup>
+        <ButtonLink
+          to={generatePath<ReleaseDataSetRouteParams>(
+            releaseApiDataSetDetailsRoute.path,
+            {
+              publicationId,
+              releaseId,
+              dataSetId,
+            },
+          )}
+        >
+          View API data set details
+        </ButtonLink>
+        <ButtonText onClick={onClose}>Close</ButtonText>
+      </ButtonGroup>
+    </>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseApiDataSetsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseApiDataSetsSection.tsx
@@ -9,23 +9,21 @@ import LiveApiDataSetsTable, {
 } from '@admin/pages/release/data/components/LiveApiDataSetsTable';
 import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
 import apiDataSetService from '@admin/services/apiDataSetService';
-import {
-  releaseApiDataSetDetailsRoute,
-  ReleaseDataSetRouteParams,
-} from '@admin/routes/releaseRoutes';
 import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import { useQuery } from '@tanstack/react-query';
 import React from 'react';
-import { generatePath, useHistory } from 'react-router-dom';
 
 export default function ReleaseApiDataSetsSection() {
-  const history = useHistory();
   const { release } = useReleaseContext();
   const { user } = useAuthContext();
 
-  const { data: dataSets = [], isLoading: hasDataSetsLoading } = useQuery({
+  const {
+    data: dataSets = [],
+    isLoading: hasDataSetsLoading,
+    refetch,
+  } = useQuery({
     ...apiDataSetQueries.list(release.publicationId),
     refetchInterval: 20_000,
   });
@@ -85,16 +83,8 @@ export default function ReleaseApiDataSetsSection() {
                   const dataSet = await apiDataSetService.createDataSet({
                     releaseFileId,
                   });
-                  history.push(
-                    generatePath<ReleaseDataSetRouteParams>(
-                      releaseApiDataSetDetailsRoute.path,
-                      {
-                        publicationId: release.publicationId,
-                        releaseId: release.id,
-                        dataSetId: dataSet.id,
-                      },
-                    ),
-                  );
+                  refetch();
+                  return dataSet;
                 }}
               />
             ) : (

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateModal.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ApiDataSetCreateModal.test.tsx
@@ -35,7 +35,7 @@ describe('ApiDataSetCreateModal', () => {
       <ApiDataSetCreateModal
         publicationId="publication-id"
         releaseId="release-id"
-        onSubmit={noop}
+        onSubmit={Promise.resolve}
       />,
     );
 
@@ -72,7 +72,7 @@ describe('ApiDataSetCreateModal', () => {
       <ApiDataSetCreateModal
         publicationId="publication-id"
         releaseId="release-id"
-        onSubmit={noop}
+        onSubmit={Promise.resolve}
       />,
     );
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseApiDataSetsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseApiDataSetsSection.test.tsx
@@ -245,7 +245,7 @@ describe('ReleaseApiDataSetsSection', () => {
     ).toBeInTheDocument();
   });
 
-  test('submitting the create version form calls the correct service and redirects to next page', async () => {
+  test('submitting the create version form calls the correct service and updates the modal', async () => {
     apiDataSetCandidateService.listCandidates.mockResolvedValue(testCandidates);
     apiDataSetService.listDataSets.mockResolvedValue([]);
     apiDataSetService.createDataSet.mockResolvedValue({
@@ -290,9 +290,9 @@ describe('ReleaseApiDataSetsSection', () => {
       });
     });
 
-    expect(history.location.pathname).toBe(
-      '/publication/publication-1/release/release-1/api-data-sets/data-set-id',
-    );
+    expect(
+      await screen.findByText('Creating API data set'),
+    ).toBeInTheDocument();
   });
 
   function renderPage(options?: {

--- a/tests/robot-tests/tests/public_api/public_api_cancel_and_removal.robot
+++ b/tests/robot-tests/tests/public_api/public_api_cancel_and_removal.robot
@@ -73,6 +73,9 @@ User creates 2nd API data set
     user chooses select option    name:releaseFileId    ${SUBJECT_NAME_2}
     user clicks button    Confirm new API data set
 
+    user waits until page contains    Creating API data set
+    user clicks link    View API data set details
+
     user waits until page finishes loading
     user waits until modal is not visible    Create a new API data set    %{WAIT_LONG}
 
@@ -124,6 +127,9 @@ User creates API data set again
     ${modal}=    user waits until modal is visible    Create a new API data set
     user chooses select option    name:releaseFileId    ${SUBJECT_NAME_1}
     user clicks button    Confirm new API data set
+
+    user waits until page contains    Creating API data set
+    user clicks link    View API data set details
 
     user waits until page finishes loading
     user waits until modal is not visible    Create a new API data set    %{WAIT_LONG}

--- a/tests/robot-tests/tests/public_api/public_api_major_auto_changes.robot
+++ b/tests/robot-tests/tests/public_api/public_api_major_auto_changes.robot
@@ -61,6 +61,9 @@ Create the initial API data set version
     user chooses select option    name:releaseFileId    ${SUBJECT_1_NAME}
     user clicks button    Confirm new API data set
 
+    user waits until page contains    Creating API data set
+    user clicks link    View API data set details
+
     user waits until page finishes loading
     user waits until modal is not visible    Create a new API data set
 

--- a/tests/robot-tests/tests/public_api/public_api_minor_manual_changes.robot
+++ b/tests/robot-tests/tests/public_api/public_api_minor_manual_changes.robot
@@ -61,6 +61,9 @@ Create the initial API data set version
     user chooses select option    name:releaseFileId    ${SUBJECT_1_NAME}
     user clicks button    Confirm new API data set
 
+    user waits until page contains    Creating API data set
+    user clicks link    View API data set details
+
     user waits until page finishes loading
     user waits until modal is not visible    Create a new API data set
 

--- a/tests/robot-tests/tests/public_api/public_api_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_preview_token.robot
@@ -62,6 +62,9 @@ Create API data set
     user chooses select option    name:releaseFileId    ${SUBJECT_NAME_1}
     user clicks button    Confirm new API data set
 
+    user waits until page contains    Creating API data set
+    user clicks link    View API data set details
+
     user waits until page finishes loading
     user waits until modal is not visible    Create a new API data set    %{WAIT_LONG}
 

--- a/tests/robot-tests/tests/public_api/public_api_restricted.robot
+++ b/tests/robot-tests/tests/public_api/public_api_restricted.robot
@@ -67,6 +67,9 @@ Create 1st API data set
     user chooses select option    name:releaseFileId    ${SUBJECT_NAME_1}
     user clicks button    Confirm new API data set
 
+    user waits until page contains    Creating API data set
+    user clicks link    View API data set details
+
     user waits until page finishes loading
     user waits until modal is not visible    Create a new API data set    %{WAIT_LONG}
 
@@ -80,6 +83,9 @@ Create 2nd API data set
     ${modal}=    user waits until modal is visible    Create a new API data set
     user chooses select option    name:releaseFileId    ${SUBJECT_NAME_2}
     user clicks button    Confirm new API data set
+
+    user waits until page contains    Creating API data set
+    user clicks link    View API data set details
 
     user waits until page finishes loading
     user waits until modal is not visible    Create a new API data set    %{WAIT_LONG}
@@ -182,6 +188,9 @@ Create a new API data set version through the first amendment using the invalid 
     ${modal}=    user waits until modal is visible    Create a new API data set
     user chooses select option    name:releaseFileId    ${SUBJECT_NAME_3}
     user clicks button    Confirm new API data set
+
+    user waits until page contains    Creating API data set
+    user clicks link    View API data set details
 
     user waits until page finishes loading
     user waits until modal is not visible    Create a new API data set    %{WAIT_LONG}


### PR DESCRIPTION
When you create a new API data set, instead of being taken automatically to the data set details page, the modal updates to make it clearer that the data set is being processed. The list on the page under the modal is also updated so if you close the modal the new API data set will be visible there.

![Screenshot 2025-01-30 154245](https://github.com/user-attachments/assets/018a62b8-977a-45ca-aff7-b296dc76f014)
