### PR TITLE
EES-5544 layout polish

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.module.scss
@@ -8,6 +8,7 @@
 
 .title {
   max-width: 500px;
+  overflow-wrap: break-word;
 }
 
 .fileSize {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.module.scss
@@ -11,8 +11,9 @@
 }
 
 .fileSize {
-  width: 5rem;
   text-align: right;
+  white-space: nowrap;
+  width: 5rem;
 }
 
 .fileStatus {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -249,7 +249,7 @@ const ReleaseDataUploadsSection = ({
               releaseId={releaseId}
             />
 
-            {isReordering ? undefined : (
+            {dataFiles.length < 2 || isReordering ? null : (
               <Button onClick={toggleReordering.on} variant="secondary">
                 Reorder data files
               </Button>

--- a/src/explore-education-statistics-common/src/components/ProgressBar.module.scss
+++ b/src/explore-education-statistics-common/src/components/ProgressBar.module.scss
@@ -8,7 +8,7 @@ $bar-height: 10px;
   border-radius: $bar-border-radius;
   display: block;
   height: $bar-height;
-  width: 100%;
+  max-width: 100%;
 }
 
 .bar {


### PR DESCRIPTION
- no wrapping on file upload file-size text
- stop importer status progress bar breaking out of the cell
- hide redundant reorder button when less than 2 files have been uploaded
- title overflow wrapping, stopping huge words breaking out of title cell