### PR TITLE
EES-5834 Increase capacity of statistics and statistics replica databases in Prod

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -93,7 +93,7 @@
       "value": 4294967296
     },
     "maxStatsDbSizeBytes": {
-      "value": 1610612736000
+      "value": 2199023255552
     },
     "publicDataDbExists": {
       "value": false


### PR DESCRIPTION
This PR makes an ARM template parameter change to `prod.parameters.json` to increase the capacity of the statistics and statistics replica database in the Prod environment from 1500Gb to 2048Gb.

1536Gb is the max data size limit for a `GP_Gen5_6` scaled database, so when we increase and eventually allocate data above this limit we will not be able to scale back to `GP_Gen5_6`.

`GP_Gen5_8`  and `GP_Gen5_10` have a max data size limit of 2048Gb.

For a while now we’ve had the database scale set at `GP_Gen5_10`. Given that we need to increase the capacity, it seems sensible to set the new limit to match this at 2048Gb.