### PR TITLE
Fix corepack integrity key check

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,8 +3,8 @@ engine-strict=true
 # feature parity with npm
 auto-install-peers=true
 
-# create a flat, non-symlinked node_modules structure 
-# (as the project doesn't play nice with symlinks). 
+# create a flat, non-symlinked node_modules structure
+# (as the project doesn't play nice with symlinks).
 # see https://pnpm.io/feature-comparison for more info
 shamefully-hoist=true
 

--- a/README.md
+++ b/README.md
@@ -104,20 +104,13 @@ Corepack is a tool installed as part of your Node.js installation that allows yo
 manage multiple package manager versions in your environment based on per-project configuration 
 (via the `packageManager` field in `package.json`). 
 
-We use corepack to ensure that everyone is using the same version of PNPM to avoid any issues when 
+We use Corepack to ensure that everyone is using the same version of PNPM to avoid any issues when 
 people are using different versions of PNPM. 
 
 In order to install Corepack and the right version of PNPM, run the following command:
 
 ```bash
-corepack enable
-```
-
-If for some reason the above corepack command doesn't work, you can install PNPM manually by running:
-
-```bash
-PNPM_VERSION=$(node -e "console.log(require('./package.json').engines.pnpm)")
-curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=$PNPM_VERSION sh -
+corepack install
 ```
 
 This will install the package manager version specified in the `package.json` file. You can check
@@ -132,6 +125,14 @@ pnpm -v
 Install the project's PNPM dependencies by simply running:
 
 ```sh
+pnpm i
+```
+
+If this fails with an integrity key check, install the latest version of Corepack first:
+
+```bash
+npm i -g corepack@latest
+corepack install
 pnpm i
 ```
 

--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -262,6 +262,13 @@ jobs:
           version: $(NodeVersion)
 
       - task: Bash@3
+        displayName: Install Corepack
+        inputs:
+          workingDir: .
+          targetType: inline
+          script: npm i -g corepack@latest
+
+      - task: Bash@3
         displayName: corepack enable
         inputs:
           workingDir: .
@@ -330,6 +337,13 @@ jobs:
         displayName: Install Node.js $(NodeVersion)
         inputs:
           version: $(NodeVersion)
+
+      - task: Bash@3
+        displayName: Install Corepack
+        inputs:
+          workingDir: .
+          targetType: inline
+          script: npm i -g corepack@latest
 
       - task: Bash@3
         displayName: corepack enable


### PR DESCRIPTION
This PR fixes Corepack failing its integrity key check due to NPM recently rotating its keys. See: https://github.com/nodejs/corepack/issues/612

I believe the general gist is that older versions (bundled with Node) may have hard-coded NPM's public key, which expired last week and was rotated to a new one.

We resolve this by simply using the latest Corepack version which doesn't have this issue.