### PR TITLE
Ees-5835 release slug hotfix

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PreReleaseAccessListPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PreReleaseAccessListPage.tsx
@@ -22,9 +22,7 @@ const PreReleaseAccessListPage = ({ release }: Props) => {
         { name: 'Find statistics and data', link: '/find-statistics' },
         {
           name: release.publication.title,
-          link: release.latestRelease
-            ? `/find-statistics/${release.publication.slug}`
-            : `/find-statistics/${release.publication.slug}/${release.slug}`,
+          link: `/find-statistics/${release.publication.slug}/${release.slug}`,
         },
       ]}
       breadcrumbLabel="Pre-release access list"

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -126,7 +126,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                     <Link
                       className="govuk-!-display-none-print govuk-!-display-block govuk-!-margin-bottom-3"
                       unvisited
-                      to={`/data-tables/${release.publication.slug}/${release.slug}`}
+                      to={`/find-statistics/${release.publication.slug}/${release.slug}`}
                     >
                       View latest data:{' '}
                       <span className="govuk-!-font-weight-bold">
@@ -295,11 +295,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
             <ul className="govuk-list">
               <li>
                 <Link
-                  to={
-                    release.latestRelease
-                      ? `/find-statistics/${release.publication.slug}/data-guidance`
-                      : `/find-statistics/${release.publication.slug}/${release.slug}/data-guidance`
-                  }
+                  to={`/find-statistics/${release.publication.slug}/${release.slug}/data-guidance`}
                 >
                   Data guidance
                 </Link>
@@ -308,11 +304,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
               {release.hasPreReleaseAccessList && (
                 <li>
                   <Link
-                    to={
-                      release.latestRelease
-                        ? `/find-statistics/${release.publication.slug}/prerelease-access-list`
-                        : `/find-statistics/${release.publication.slug}/${release.slug}/prerelease-access-list`
-                    }
+                    to={`/find-statistics/${release.publication.slug}/${release.slug}/prerelease-access-list`}
                   >
                     Pre-release access list
                   </Link>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/ReleaseDataGuidancePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/ReleaseDataGuidancePage.tsx
@@ -20,9 +20,7 @@ const ReleaseDataGuidancePage = ({ release }: Props) => {
         { name: 'Find statistics and data', link: '/find-statistics' },
         {
           name: release.publication.title,
-          link: release.latestRelease
-            ? `/find-statistics/${release.publication.slug}`
-            : `/find-statistics/${release.publication.slug}/${release.slug}`,
+          link: `/find-statistics/${release.publication.slug}/${release.slug}`,
         },
       ]}
       breadcrumbLabel="Data guidance"


### PR DESCRIPTION
hotfix to:
pre-release access page (breadcrumbing)
data guidance page (breadcrumbing)
Undone accidental change to latest release link on the public release page