### PR TITLE
Fix corepack integrity key check for public frontend Dockerfile

### DIFF
--- a/docker/public-frontend/Dockerfile
+++ b/docker/public-frontend/Dockerfile
@@ -3,6 +3,7 @@ FROM node:20.16.0-alpine AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
+RUN npm i -g corepack@latest
 RUN corepack enable
 
 WORKDIR /app


### PR DESCRIPTION
Adds similar fix from #5580 to public frontend's Dockerfile.

Relates to: https://github.com/nodejs/corepack/issues/612