### PR TITLE
EES-5835 fix to latest release link

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -40,7 +40,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
     rsi => rsi.isLegacyLink || rsi.description !== release.title,
   );
 
-  const releaseSeriesNonLegacy = release.publication.releaseSeries.find(
+  const latestReleaseSeriesItem = release.publication.releaseSeries.find(
     rsi => !rsi.isLegacyLink,
   );
 
@@ -130,11 +130,11 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                     <Link
                       className="govuk-!-display-none-print govuk-!-display-block govuk-!-margin-bottom-3"
                       unvisited
-                      to={`/find-statistics/${release.publication.slug}/${releaseSeriesNonLegacy?.releaseSlug}`}
+                      to={`/find-statistics/${release.publication.slug}/${latestReleaseSeriesItem?.releaseSlug}`}
                     >
                       View latest data:{' '}
                       <span className="govuk-!-font-weight-bold">
-                        {releaseSeriesNonLegacy?.description}
+                        {latestReleaseSeriesItem?.description}
                       </span>
                     </Link>
                   )}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -40,6 +40,12 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
     rsi => rsi.isLegacyLink || rsi.description !== release.title,
   );
 
+  const releaseSeriesNonLegacy = release.publication.releaseSeries.find(
+    rsi => !rsi.isLegacyLink,
+  );
+
+  console.log(releaseSeriesNonLegacy);
+
   // Re-order updates in descending order in-case the cached
   // release from the content API has not been updated to
   // have the updates in the correct order.
@@ -126,15 +132,11 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                     <Link
                       className="govuk-!-display-none-print govuk-!-display-block govuk-!-margin-bottom-3"
                       unvisited
-                      to={`/find-statistics/${release.publication.slug}/${release.slug}`}
+                      to={`/find-statistics/${release.publication.slug}/${releaseSeriesNonLegacy?.releaseSlug}`}
                     >
                       View latest data:{' '}
                       <span className="govuk-!-font-weight-bold">
-                        {
-                          release.publication.releaseSeries.find(
-                            rsi => !rsi.isLegacyLink,
-                          )?.description
-                        }
+                        {releaseSeriesNonLegacy?.description}
                       </span>
                     </Link>
                   )}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -44,8 +44,6 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
     rsi => !rsi.isLegacyLink,
   );
 
-  console.log(releaseSeriesNonLegacy);
-
   // Re-order updates in descending order in-case the cached
   // release from the content API has not been updated to
   // have the updates in the correct order.


### PR DESCRIPTION
Fix to latest release link where the user would be redirected to the previously viewed release slug rather than the latest