### PR TITLE
EES-5841 Remove old `/api` prefix from URLs in public API docs

### DIFF
--- a/src/explore-education-statistics-api-docs/source/getting-started/creating-advanced-data-set-queries/index.html.md.erb
+++ b/src/explore-education-statistics-api-docs/source/getting-started/creating-advanced-data-set-queries/index.html.md.erb
@@ -37,7 +37,7 @@ Data set queries can be made using a POST request to the [Query a data set](/ref
 endpoint. At its most basic, such a request would look like the following:
 
 ```
-POST <%= api_url "/api/v1/data-sets/{dataSetId}/query" %>
+POST <%= api_url "/v1/data-sets/{dataSetId}/query" %>
 {
   "criteria": {},
   "indicators": []

--- a/src/explore-education-statistics-api-docs/source/getting-started/debugging-data-set-queries/index.html.md.erb
+++ b/src/explore-education-statistics-api-docs/source/getting-started/debugging-data-set-queries/index.html.md.erb
@@ -366,7 +366,7 @@ endpoint also accepts a `debug` query parameter that enables debug mode. This ca
 request's query string like so:
 
 ```
-<%= api_url %>/api/v1/data-sets/{dataSetId}/query?debug=true
+<%= api_url %>/v1/data-sets/{dataSetId}/query?debug=true
 ```
 
 The response will then be modified to return results that look like the following:

--- a/src/explore-education-statistics-api-docs/source/getting-started/how-to-get-csv-data/index.html.md.erb
+++ b/src/explore-education-statistics-api-docs/source/getting-started/how-to-get-csv-data/index.html.md.erb
@@ -32,7 +32,7 @@ The underlying CSV file can be downloaded via the [Download data set CSV](/refer
 endpoint. To use this endpoint, you need to make a `GET` request:
 
 ```
-GET <%= api_url "/api/v1/data-sets/{dataSetId}/csv" %>
+GET <%= api_url "/v1/data-sets/{dataSetId}/csv" %>
 ```
 
 In the request URL, you'd substitute the `{dataSetId}` parameter with your chosen data set's ID.

--- a/src/explore-education-statistics-api-docs/source/getting-started/quick-start/index.html.md.erb
+++ b/src/explore-education-statistics-api-docs/source/getting-started/quick-start/index.html.md.erb
@@ -53,7 +53,7 @@ To find a publication that you may be interested in, you'll need to make a `GET`
 [List publications](/reference-v1/endpoints/ListPublications/index.html) endpoint:
 
 ```
-GET <%= api_url "/api/v1/publications" %>
+GET <%= api_url "/v1/publications" %>
 ```
 
 This endpoint will respond with something like the following (parts have been omitted for brevity):
@@ -87,10 +87,10 @@ endpoint URL. For example:
 
 ```
 # Fetch page 2
-GET <%= api_url "/api/v1/publications?page=2" %>
+GET <%= api_url "/v1/publications?page=2" %>
 
 # Fetch page 3
-GET <%= api_url "/api/v1/publications?page=3" %>
+GET <%= api_url "/v1/publications?page=3" %>
 ```
 
 The possible values of `page` will be dictated by the total number of results (across all pages)
@@ -98,7 +98,7 @@ and the `pageSize` query parameter. For example, the following request would sho
 page instead of the default:
 
 ```
-GET <%= api_url "/api/v1/publications?page=1&pageSize=30" %>
+GET <%= api_url "/v1/publications?page=1&pageSize=30" %>
 ```
 
 Each page of results contains a `paging` property which describes the current page and the total
@@ -109,14 +109,14 @@ To make it easier to find a specific publication, you can append a `search` quer
 URL as well. The following example would search for publications matching the term 'pupil absence':
 
 ```
-GET <%= api_url "/api/v1/publications?search=pupil+absence" %>
+GET <%= api_url "/v1/publications?search=pupil+absence" %>
 ```
 
 Like a typical URL, you can combine query parameters together with `&`. For example, you'd use
 the following URL to get page 2 of publications matching the term 'pupil absence':
 
 ```
-GET <%= api_url "/api/v1/publications?search=pupil+absence&page=2" %>
+GET <%= api_url "/v1/publications?search=pupil+absence&page=2" %>
 ```
 
 Once you find a publication you are interested in, proceed to the next step.
@@ -129,7 +129,7 @@ the [List a publication's data sets](/reference-v1/endpoints/ListPublicationData
 endpoint:
 
 ```
-GET <%= api_url "/api/v1/publications/{publicationId}/data-sets" %>
+GET <%= api_url "/v1/publications/{publicationId}/data-sets" %>
 ```
 
 For this endpoint URL, you'd substitute the `{publicationId}` parameter with the `id` of the
@@ -150,7 +150,7 @@ For example, given the following publication (parts omitted for brevity):
 You'd make the following `GET` request:
 
 ```
-GET <%= api_url "/api/v1/publications/cbbd299f-8297-44bc-92ac-558bcf51f8ad/data-sets" %>
+GET <%= api_url "/v1/publications/cbbd299f-8297-44bc-92ac-558bcf51f8ad/data-sets" %>
 ```
 
 The endpoint responds with a paginated list of the publication's data sets which will look like the
@@ -232,7 +232,7 @@ Facets and indicators are collectively referenced as a data set's **metadata**. 
 your chosen data set, make the following `GET` request:
 
 ```
-GET <%= api_url "/api/v1/data-sets/{dataSetId}/meta" %>
+GET <%= api_url "/v1/data-sets/{dataSetId}/meta" %>
 ```
 
 To use this URL, substitute in the `{dataSetId}` parameter with the `id` of your chosen data set.
@@ -381,7 +381,7 @@ To use this endpoint, a `POST` request needs to be sent to the endpoint URL with
 request body. The most basic request would look like the following:
 
 ```
-POST <%= api_url "/api/v1/data-sets/{dataSetId}/query" %>
+POST <%= api_url "/v1/data-sets/{dataSetId}/query" %>
 {
   "indicators": []
 }
@@ -398,7 +398,7 @@ To refine your query to a subset of the data, you will also need to provide some
 by adding a `criteria` property to your query request:
 
 ```
-POST <%= api_url "/api/v1/data-sets/{dataSetId}/query" %>
+POST <%= api_url "/v1/data-sets/{dataSetId}/query" %>
 {
   "indicators": [],
   "criteria": {}
@@ -575,7 +575,7 @@ results. For example, the following request would fetch page 5, with each page c
 a maximum of 200 results:
 
 ```
-POST <%= api_url "/api/v1/data-sets/{dataSetId}/query?page=5&pageSize=200" %>
+POST <%= api_url "/v1/data-sets/{dataSetId}/query?page=5&pageSize=200" %>
 ```
 
 ## Conclusions

--- a/src/explore-education-statistics-api-docs/source/overview/versioning/index.html.md.erb
+++ b/src/explore-education-statistics-api-docs/source/overview/versioning/index.html.md.erb
@@ -8,7 +8,7 @@ weight: 4
 # Versioning
 
 The Explore Education Statistics (EES) API uses URL-based versioning. Each endpoint encodes its current
-version within its URL e.g. `/api/v1/the-endpoint`, `/api/v2/the-endpoint`, etc.
+version within its URL e.g. `/v1/the-endpoint`, `/v2/the-endpoint`, etc.
 
 When backwards-incompatible changes to an endpoint are unavoidable, a new version of the endpoint
 will be published. Backwards-incompatible changes may include things like:
@@ -59,9 +59,9 @@ You can find lists of changes via:
 
 ### Requesting data set versions
 
-There are several API endpoints that accept a `dataSetVersion` query parameter e.g. the 
+There are several API endpoints that accept a `dataSetVersion` query parameter e.g. the
 [Get a data set version](/reference-v1/endpoints/GetDataSetVersion/index.html) endpoint.
-The `dataSetVersion` parameter can be supplied with a version number (e.g. 1.0, 1.1, 2.0, 
+The `dataSetVersion` parameter can be supplied with a version number (e.g. 1.0, 1.1, 2.0,
 etc) that controls the data set version that should be used in the request.
 
 For example:
@@ -73,10 +73,10 @@ For example:
 ### Automatically receiving minor version updates
 
 When using the `dataSetVersion` parameter, minor data set version updates can automatically
-be retrieved from the API without having to change the version number explicitly. This can 
+be retrieved from the API without having to change the version number explicitly. This can
 be done by including an asterisk `*` wildcard character in place of a major or minor version.
 
-For example: 
+For example:
 
 - `dataSetVersion=*` uses the latest major and minor version
 - `dataSetVersion=2.*` uses the latest minor version of the v2 series


### PR DESCRIPTION
This PR simply strips the incorrect `/api` prefix from URLs in the public API.