### PR TITLE
EES-5842-check latest release link

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -550,6 +550,8 @@ Check other release is correct
     user checks page contains    View releases (1)
     user waits until page contains other release    ${RELEASE_2_NAME}
     user checks page does not contain other release    ${RELEASE_1_NAME}
+    user clicks link    View latest data: ${RELEASE_2_NAME}
+    user waits until page contains title caption    ${RELEASE_2_NAME}    %{WAIT_SMALL}
 
 Go to Table Tool page
     user navigates to data tables page on public frontend


### PR DESCRIPTION
This PR adds few keywords in existing tests to check that users can click and visit the 'View latest data' release link on an old release page.