### PR TITLE
EES-5554 Fix accessibility issues in public API docs

### DIFF
--- a/src/explore-education-statistics-api-docs/source/partials/_parameter_table.html.erb
+++ b/src/explore-education-statistics-api-docs/source/partials/_parameter_table.html.erb
@@ -3,7 +3,7 @@
   role="region"
   tabindex="0"
 >
-  <table>
+  <table class="app-parameter-table">
     <thead>
     <tr>
       <th scope="col">Parameter</th>
@@ -18,7 +18,7 @@
         <td><code class="app-word-break--normal"><%= parameter.name %></code></td>
         <td><%= render_schema_type(parameter.schema) %></td>
         <td><%= parameter.required? %></td>
-        <td>
+        <td class="app-parameter-table__description">
           <%= partial("partials/schema_description", :locals => {
             description: parameter.description,
             schema: parameter.schema

--- a/src/explore-education-statistics-api-docs/source/partials/_parameter_table.html.erb
+++ b/src/explore-education-statistics-api-docs/source/partials/_parameter_table.html.erb
@@ -1,4 +1,8 @@
-<div aria-label="Parameters" class="app-table-container" role="region" tabindex="0">
+<div <% if defined? labelled_by %>aria-labelledby="<%= labelled_by %>"<% end %>
+  class="app-table-container"
+  role="region"
+  tabindex="0"
+>
   <table>
     <thead>
     <tr>

--- a/src/explore-education-statistics-api-docs/source/stylesheets/app.scss
+++ b/src/explore-education-statistics-api-docs/source/stylesheets/app.scss
@@ -1,5 +1,7 @@
 .technical-documentation {
+  hyphens: auto;
   max-width: 50em;
+  word-break: break-word;
 }
 
 .toc__list li {

--- a/src/explore-education-statistics-api-docs/source/stylesheets/app.scss
+++ b/src/explore-education-statistics-api-docs/source/stylesheets/app.scss
@@ -4,17 +4,6 @@
   word-break: break-word;
 }
 
-.toc__list li {
-  a:link,
-  a:visited {
-    padding: 8px 10px;
-  }
-}
-
-.collapsible {
-  word-break: break-word;
-}
-
 .highlight {
   position: relative;
 }

--- a/src/explore-education-statistics-api-docs/source/stylesheets/components/_header.scss
+++ b/src/explore-education-statistics-api-docs/source/stylesheets/components/_header.scss
@@ -1,0 +1,34 @@
+.app-header {
+  @include govuk-media-query($until: tablet) {
+    .govuk-header__container {
+      align-items: center;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      padding: govuk-spacing(2) !important;
+    }
+
+    .govuk-header__logo {
+      padding-right: 0;
+      margin-bottom: govuk-spacing(1);
+    }
+
+    .govuk-header__content {
+      flex-grow: 1;
+    }
+
+    .govuk-header__navigation--end {
+      text-align: right;
+    }
+
+    .govuk-header__menu-button {
+      display: inline-block;
+      position: unset;
+    }
+
+    .govuk-header__navigation-list {
+      text-align: left;
+      width: 100%;
+    }
+  }
+}

--- a/src/explore-education-statistics-api-docs/source/stylesheets/components/_table.scss
+++ b/src/explore-education-statistics-api-docs/source/stylesheets/components/_table.scss
@@ -1,4 +1,6 @@
 .app-table-container {
+  margin-bottom: govuk-spacing(4);
+
   &:focus {
     box-shadow: 0 0 0 2px;
     outline: $govuk-focus-width solid $govuk-focus-colour;
@@ -8,5 +10,18 @@
   @include govuk-media-query($until: desktop) {
     display: block;
     overflow-x: auto;
+  }
+
+  table {
+    margin-bottom: 0;
+  }
+}
+
+.app-parameter-table {
+  hyphens: none;
+  word-break: normal;
+
+  &__description {
+    min-width: 200px;
   }
 }

--- a/src/explore-education-statistics-api-docs/source/stylesheets/components/_toc.scss
+++ b/src/explore-education-statistics-api-docs/source/stylesheets/components/_toc.scss
@@ -9,10 +9,20 @@
   word-break: break-word;
 }
 
-@include govuk-media-query($until: desktop) {
+@include govuk-media-query($until: tablet) {
   .js .toc__list {
     margin-right: 0;
   }
+
+  /* stylelint-disable selector-max-compound-selectors */
+  .js .toc li li li {
+    display: initial;
+
+    a {
+      padding-left: govuk-spacing(3);
+    }
+  }
+  /* stylelint-enable selector-max-compound-selectors */
 
   .collapsible {
     align-items: center;
@@ -42,6 +52,7 @@
   }
 
   .collapsible__body {
+    word-break: break-all;
     width: 100%;
 
     a {

--- a/src/explore-education-statistics-api-docs/source/stylesheets/components/_toc.scss
+++ b/src/explore-education-statistics-api-docs/source/stylesheets/components/_toc.scss
@@ -1,0 +1,51 @@
+.toc__list li {
+  a:link,
+  a:visited {
+    padding: 8px 10px;
+  }
+}
+
+.collapsible {
+  word-break: break-word;
+}
+
+@include govuk-media-query($until: desktop) {
+  .js .toc__list {
+    margin-right: 0;
+  }
+
+  .collapsible {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .collapsible__toggle {
+    align-items: center;
+    display: flex;
+    height: 30px;
+    justify-content: center;
+    right: 0;
+    top: 5px;
+    width: 20px;
+  }
+
+  .collapsible__toggle-icon {
+    position: relative;
+    top: -5px;
+    right: unset;
+  }
+
+  .collapsible__toggle-label {
+    position: absolute;
+  }
+
+  .collapsible__body {
+    width: 100%;
+
+    a {
+      width: fit-content;
+    }
+  }
+}

--- a/src/explore-education-statistics-api-docs/source/stylesheets/screen.css.scss
+++ b/src/explore-education-statistics-api-docs/source/stylesheets/screen.css.scss
@@ -8,3 +8,4 @@
 @import './components/copy';
 @import './components/header';
 @import './components/table';
+@import './components/toc';

--- a/src/explore-education-statistics-api-docs/source/stylesheets/screen.css.scss
+++ b/src/explore-education-statistics-api-docs/source/stylesheets/screen.css.scss
@@ -6,4 +6,5 @@
 @import './utils';
 
 @import './components/copy';
+@import './components/header';
 @import './components/table';

--- a/src/explore-education-statistics-api-docs/source/templates/reference/endpoint.html.md.erb
+++ b/src/explore-education-statistics-api-docs/source/templates/reference/endpoint.html.md.erb
@@ -63,31 +63,33 @@ body_schema = schema.type.nil? && schema.all_of&.count == 1 ? schema.all_of[0] :
 body_parameters = get_schema_properties(schema)
 %>
 
-<table>
-  <thead>
-  <tr>
-    <th scope="col">Name</th>
-    <th scope="col">Type</th>
-    <th scope="col">Required</th>
-    <th scope="col">Description</th>
-  </tr>
-  </thead>
-  <tbody>
-  <% body_parameters.each do |name, parameter| %>
+<div aria-label="Request body properties" class="app-table-container" role="region" tabindex="0">
+  <table class="app-parameter-table">
+    <thead>
     <tr>
-      <td><code class="app-word-break--normal"><%= name %></code></td>
-      <td><%= render_schema_type(parameter) %></td>
-      <td><%= body_schema.requires?(parameter) %></td>
-      <td>
-        <%= partial("partials/schema_description", :locals => {
-          description: parameter.description,
-          schema: parameter
-        }) %>
-      </td>
+      <th scope="col">Name</th>
+      <th scope="col">Type</th>
+      <th scope="col">Required</th>
+      <th scope="col">Description</th>
     </tr>
-  <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+    <% body_parameters.each do |name, parameter| %>
+      <tr>
+        <td><code class="app-word-break--normal"><%= name %></code></td>
+        <td><%= render_schema_type(parameter) %></td>
+        <td><%= body_schema.requires?(parameter) %></td>
+        <td>
+          <%= partial("partials/schema_description", :locals => {
+            description: parameter.description,
+            schema: parameter
+          }) %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>
 
 ### Example request body
 
@@ -150,32 +152,34 @@ languages.
 <% if responses.any? %>
 ## Responses
 
-<table>
-  <thead>
-  <tr>
-    <th scope="col">Status</th>
-    <th scope="col">Description</th>
-    <th scope="col">Media Type</th>
-    <th scope="col">Schema</th>
-  </tr>
-  </thead>
-  <tbody>
-<% responses.each do |status, response| %>
-<% response.content.each do |media_type, content| %>
+<div aria-labelledby="responses" class="app-table-container" role="region" tabindex="0">
+  <table class="app-parameter-table">
+    <thead>
     <tr>
-      <td><%= status %></td>
-      <td><%= render_markdown(response.description) %></td>
-      <td>
-        <%= media_type %>
-      </td>
-      <td>
-        <%= render_schema_type(content.schema) %>
-      </td>
+      <th scope="col">Status</th>
+      <th scope="col">Description</th>
+      <th scope="col">Media Type</th>
+      <th scope="col">Schema</th>
     </tr>
-<% end %>
-<% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+  <% responses.each do |status, response| %>
+  <% response.content.each do |media_type, content| %>
+      <tr>
+        <td><%= status %></td>
+        <td><%= render_markdown(response.description) %></td>
+        <td>
+          <%= media_type %>
+        </td>
+        <td>
+          <%= render_schema_type(content.schema) %>
+        </td>
+      </tr>
+  <% end %>
+  <% end %>
+    </tbody>
+  </table>
+</div>
 
 <% if responses[200] %>
 ### Example successful response

--- a/src/explore-education-statistics-api-docs/source/templates/reference/endpoint.html.md.erb
+++ b/src/explore-education-statistics-api-docs/source/templates/reference/endpoint.html.md.erb
@@ -23,7 +23,10 @@ The URL for this endpoint is:
 
 The following parameters will need to be substituted into the URL path.
 
-<%= partial("partials/parameter_table", :locals => { parameters: path_parameters }) %>
+<%= partial("partials/parameter_table", :locals => {
+  labelled_by: "path-parameters",
+  parameters: path_parameters })
+%>
 <% end %>
 
 <% query_parameters = parameters.select { |parameter| parameter.in == "query" } %>
@@ -31,14 +34,20 @@ The following parameters will need to be substituted into the URL path.
 <% if query_parameters.any? %>
 ### Query parameters
 
-<%= partial("partials/parameter_table", :locals => { parameters: query_parameters }) %>
+<%= partial("partials/parameter_table", :locals => {
+  labelled_by: "query-parameters",
+  parameters: query_parameters }) %>
 <% end %>
 
 <% headers = parameters.select { |parameter| parameter.in == "header" } %>
 
 <% if headers.any? %>
 ### Headers
-<%= partial("partials/parameter_table", :locals => { parameters: headers }) %>
+
+<%= partial("partials/parameter_table", :locals => {
+  labelled_by: "headers",
+  parameters: headers
+}) %>
 <% end %>
 <% end %>
 

--- a/src/explore-education-statistics-api-docs/source/templates/reference/schema.html.md.erb
+++ b/src/explore-education-statistics-api-docs/source/templates/reference/schema.html.md.erb
@@ -22,8 +22,8 @@ Allowed options:
 <% if properties.any? %>
 ## Properties
 
-<div aria-label="Properties" class="app-table-container" role="region" tabindex="0">
-  <table>
+<div aria-labelledby="properties" class="app-table-container" role="region" tabindex="0">
+  <table class="app-parameter-table">
     <thead>
     <tr>
       <th scope="col">Property</th>


### PR DESCRIPTION
This PR fixes various accessibility issues that have been highlighted by @N-moh

- Added unique `aria-label` / `aria-labelledby` attributes for parameter tables
- Fixed header appearing really broken at 200%+ zoom
- Fixed overflowing text from large word breaking the entire layout at 200%+ zoom (using `word-break`)
- Fixed mobile TOC styling being mostly broken when 200%+ zoom

Additionally, I've made some more tweaks whilst in the area:

- Fixed 'Endpoints' and 'Schemas' child items not being displayed in the mobile TOC
- Fixed parameter table styling being mostly broken at 200%+ zoom

## Screenshots

New header:

![image](https://github.com/user-attachments/assets/b752e0e3-68cc-4749-9b2b-4474cd56a461)

New TOC:

![image](https://github.com/user-attachments/assets/35e40ae8-5027-4918-9ed1-d184ba00a4d8)

New parameter tables:

![image](https://github.com/user-attachments/assets/85ecadc4-5c8e-4b2a-9d83-7096839db6bb)