### PR TITLE
EES-5846 Fix incorrect public API URLs on preview token page

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2135,7 +2135,7 @@
         "NEXT_CONFIG_MODE": "server",
         "NODE_ENV": "production",
         "PUBLIC_URL": "[concat(variables('publicAppUrl'), '/')]",
-        "PUBLIC_API_BASE_URL": "[concat('https://', parameters('publicApiUrl'), '/v1')]",
+        "PUBLIC_API_BASE_URL": "[concat('https://', parameters('publicApiUrl'))]",
         "PUBLIC_API_DOCS_URL": "[concat('https://', parameters('publicApiDocsUrl'))]",
         "WEBSITE_NODE_DEFAULT_VERSION": "20.16.0",
         "WEBSITES_PORT": 3000

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
@@ -64,7 +64,7 @@ export default function ReleaseApiDataSetPreviewTokenPage() {
     history.push(tokenLogPagePath);
   };
 
-  const tokenExampleUrl = `${publicApiUrl}/api/v1.0/data-sets/${dataSet?.draftVersion?.id}`;
+  const tokenExampleUrl = `${publicApiUrl}/v1/data-sets/${dataSet?.draftVersion?.id}`;
 
   return (
     <>
@@ -177,7 +177,7 @@ response <- GET(url, add_headers("Preview-Token" = "${previewToken.id}"))
 
                 {dataSet?.draftVersion && (
                   <ApiDataSetQuickStart
-                    publicApiBaseUrl={`${publicApiUrl}/api/v1.0`}
+                    publicApiBaseUrl={publicApiUrl}
                     publicApiDocsUrl={publicApiDocsUrl}
                     dataSetId={dataSet.id}
                     dataSetName={dataSet.title}

--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/ApiDataSetQuickStart.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/ApiDataSetQuickStart.tsx
@@ -12,6 +12,7 @@ interface Props {
   headingsTag?: 'h3' | 'h4';
   publicApiBaseUrl: string;
   publicApiDocsUrl: string;
+  publicApiVersion?: 'v1';
   renderLink: ({
     children,
     toString,
@@ -28,8 +29,12 @@ export default function ApiDataSetQuickStart({
   headingsTag: Heading = 'h3',
   publicApiBaseUrl,
   publicApiDocsUrl,
+  publicApiVersion = 'v1',
   renderLink,
 }: Props) {
+  const publicApiVersionUrl = `${publicApiBaseUrl}/${publicApiVersion}`;
+  const publicApiDocsVersionUrl = `${publicApiDocsUrl}/reference-${publicApiVersion}`;
+
   return (
     <>
       <InsetText>
@@ -69,11 +74,11 @@ export default function ApiDataSetQuickStart({
           </>
         }
         labelHidden={false}
-        url={`${publicApiBaseUrl}/data-sets/${dataSetId}`}
+        url={`${publicApiVersionUrl}/data-sets/${dataSetId}`}
       />
       <p>
         {renderLink({
-          to: `${publicApiDocsUrl}/reference-v1/endpoints/GetDataSet/`,
+          to: `${publicApiDocsVersionUrl}/endpoints/GetDataSet/`,
           children: 'Guidance: Get data set summary',
         })}
       </p>
@@ -89,11 +94,11 @@ export default function ApiDataSetQuickStart({
           </>
         }
         labelHidden={false}
-        url={`${publicApiBaseUrl}/data-sets/${dataSetId}/meta?dataSetVersion=${dataSetVersion}`}
+        url={`${publicApiVersionUrl}/data-sets/${dataSetId}/meta?dataSetVersion=${dataSetVersion}`}
       />
       <p>
         {renderLink({
-          to: `${publicApiDocsUrl}/reference-v1/endpoints/GetDataSetMeta/`,
+          to: `${publicApiDocsVersionUrl}/endpoints/GetDataSetMeta/`,
           children: 'Guidance: Get data set metadata',
         })}
       </p>
@@ -109,11 +114,11 @@ export default function ApiDataSetQuickStart({
           </>
         }
         labelHidden={false}
-        url={`${publicApiBaseUrl}/data-sets/${dataSetId}/query?dataSetVersion=${dataSetVersion}`}
+        url={`${publicApiVersionUrl}/data-sets/${dataSetId}/query?dataSetVersion=${dataSetVersion}`}
       />
       <p>
         {renderLink({
-          to: `${publicApiDocsUrl}/reference-v1/endpoints/QueryDataSetGet/`,
+          to: `${publicApiDocsVersionUrl}/endpoints/QueryDataSetGet/`,
           children: 'Guidance: Query data set (GET)',
         })}
       </p>
@@ -129,11 +134,11 @@ export default function ApiDataSetQuickStart({
           </>
         }
         labelHidden={false}
-        url={`${publicApiBaseUrl}/data-sets/${dataSetId}/query?dataSetVersion=${dataSetVersion}`}
+        url={`${publicApiVersionUrl}/data-sets/${dataSetId}/query?dataSetVersion=${dataSetVersion}`}
       />
       <p>
         {renderLink({
-          to: `${publicApiDocsUrl}/reference-v1/endpoints/QueryDataSetPost/`,
+          to: `${publicApiDocsVersionUrl}/endpoints/QueryDataSetPost/`,
           children: 'Guidance: Query data set (POST)',
         })}
       </p>
@@ -149,11 +154,11 @@ export default function ApiDataSetQuickStart({
           </>
         }
         labelHidden={false}
-        url={`${publicApiBaseUrl}/data-sets/${dataSetId}/csv?dataSetVersion=${dataSetVersion}`}
+        url={`${publicApiVersionUrl}/data-sets/${dataSetId}/csv?dataSetVersion=${dataSetVersion}`}
       />
       <p>
         {renderLink({
-          to: `${publicApiDocsUrl}/reference-v1/endpoints/DownloadDataSetCsv/`,
+          to: `${publicApiDocsVersionUrl}/endpoints/DownloadDataSetCsv/`,
           children: 'Guidance: Download data set as CSV',
         })}
       </p>

--- a/src/explore-education-statistics-common/src/services/api/index.ts
+++ b/src/explore-education-statistics-common/src/services/api/index.ts
@@ -17,7 +17,7 @@ export const dataApi = new Client({
 });
 
 export const publicApi = new Client({
-  baseURL: process.env.PUBLIC_API_BASE_URL,
+  baseURL: `${process.env.PUBLIC_API_BASE_URL}/v1`,
   requestInterceptors: [networkActivityRequestInterceptor],
   responseInterceptors: [networkActivityResponseInterceptor],
 });

--- a/src/explore-education-statistics-frontend/.env
+++ b/src/explore-education-statistics-frontend/.env
@@ -1,6 +1,6 @@
 CONTENT_API_BASE_URL=http://localhost:5010/api
 DATA_API_BASE_URL=http://localhost:5000/api
-PUBLIC_API_BASE_URL=http://localhost:5050/v1
+PUBLIC_API_BASE_URL=http://localhost:5050
 PUBLIC_API_DOCS_URL=https://dev.statistics.api.education.gov.uk/docs
 NOTIFICATION_API_BASE_URL=http://localhost:7073/api
 GA_TRACKING_ID=

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiQuickStart.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiQuickStart.test.tsx
@@ -45,18 +45,52 @@ describe('DataSetFileApiQuickStart', () => {
       screen.getByLabelText('GET data set summary URL'),
     ).toHaveDisplayValue('http://localhost:5050/v1/data-sets/api-data-set-id');
     expect(
+      screen.getByRole('link', { name: 'Guidance: Get data set summary' }),
+    ).toHaveAttribute(
+      'href',
+      'https://dev.statistics.api.education.gov.uk/docs/reference-v1/endpoints/GetDataSet/',
+    );
+
+    expect(
       screen.getByLabelText('GET data set metadata URL'),
     ).toHaveDisplayValue(
       'http://localhost:5050/v1/data-sets/api-data-set-id/meta?dataSetVersion=1.0',
     );
+    expect(
+      screen.getByRole('link', { name: 'Guidance: Get data set metadata' }),
+    ).toHaveAttribute(
+      'href',
+      'https://dev.statistics.api.education.gov.uk/docs/reference-v1/endpoints/GetDataSetMeta/',
+    );
+
     expect(screen.getByLabelText('GET data set query URL')).toHaveDisplayValue(
       'http://localhost:5050/v1/data-sets/api-data-set-id/query?dataSetVersion=1.0',
     );
+    expect(
+      screen.getByRole('link', { name: 'Guidance: Query data set (GET)' }),
+    ).toHaveAttribute(
+      'href',
+      'https://dev.statistics.api.education.gov.uk/docs/reference-v1/endpoints/QueryDataSetGet/',
+    );
+
     expect(screen.getByLabelText('POST data set query URL')).toHaveDisplayValue(
       'http://localhost:5050/v1/data-sets/api-data-set-id/query?dataSetVersion=1.0',
     );
+    expect(
+      screen.getByRole('link', { name: 'Guidance: Query data set (POST)' }),
+    ).toHaveAttribute(
+      'href',
+      'https://dev.statistics.api.education.gov.uk/docs/reference-v1/endpoints/QueryDataSetPost/',
+    );
+
     expect(screen.getByLabelText('GET data set CSV URL')).toHaveDisplayValue(
       'http://localhost:5050/v1/data-sets/api-data-set-id/csv?dataSetVersion=1.0',
+    );
+    expect(
+      screen.getByRole('link', { name: 'Guidance: Download data set as CSV' }),
+    ).toHaveAttribute(
+      'href',
+      'https://dev.statistics.api.education.gov.uk/docs/reference-v1/endpoints/DownloadDataSetCsv/',
     );
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiQuickStart.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetFileApiQuickStart.test.tsx
@@ -43,20 +43,20 @@ describe('DataSetFileApiQuickStart', () => {
 
     expect(
       screen.getByLabelText('GET data set summary URL'),
-    ).toHaveDisplayValue(/data-sets\/api-data-set-id/);
+    ).toHaveDisplayValue('http://localhost:5050/v1/data-sets/api-data-set-id');
     expect(
       screen.getByLabelText('GET data set metadata URL'),
     ).toHaveDisplayValue(
-      /data-sets\/api-data-set-id\/meta\?dataSetVersion=1.0/,
+      'http://localhost:5050/v1/data-sets/api-data-set-id/meta?dataSetVersion=1.0',
     );
     expect(screen.getByLabelText('GET data set query URL')).toHaveDisplayValue(
-      /data-sets\/api-data-set-id\/query\?dataSetVersion=1.0/,
+      'http://localhost:5050/v1/data-sets/api-data-set-id/query?dataSetVersion=1.0',
     );
     expect(screen.getByLabelText('POST data set query URL')).toHaveDisplayValue(
-      /data-sets\/api-data-set-id\/query\?dataSetVersion=1.0/,
+      'http://localhost:5050/v1/data-sets/api-data-set-id/query?dataSetVersion=1.0',
     );
     expect(screen.getByLabelText('GET data set CSV URL')).toHaveDisplayValue(
-      /data-sets\/api-data-set-id\/csv\?dataSetVersion=1.0/,
+      'http://localhost:5050/v1/data-sets/api-data-set-id/csv?dataSetVersion=1.0',
     );
   });
 });


### PR DESCRIPTION
This PR fixes incorrect public API URLs being shown on the preview token page.

We also strip out the API version from `PUBLIC_API_BASE_URL` in favour of controlling the version from the frontend. This creates less opportunity for error if we eventually publish a new API version as we won't need to make updates in multiple places.

We've also added missing test assertions for the public API docs URLs in `DataSetFileApiQuickStart`.