### PR TITLE
EES-5838 - replace frontend and backend specific navigation keywords with generic ones

### DIFF
--- a/tests/robot-tests/tests/admin/authentication/expired_invitation.robot
+++ b/tests/robot-tests/tests/admin/authentication/expired_invitation.robot
@@ -17,7 +17,7 @@ Invite user to the service with an unexpired invite via the API
     ...    Analyst
 
 Check that the invite appears on the Invite Users page
-    user navigates to admin frontend    %{ADMIN_URL}/administration/users/invites
+    user navigates to    %{ADMIN_URL}/administration/users/invites
     user waits until page contains    Invited users
     user checks page contains    %{EXPIRED_INVITE_USER_EMAIL}
 
@@ -35,7 +35,7 @@ Check that the invite does not appear on the Invite Users page
 
 Login with an expired invite and assert that the user is redirected to the expired invite page
     user opens the browser    %{ADMIN_URL}
-    user navigates to admin frontend
+    user navigates to admin homepage
     user waits until h1 is visible    Sign in
     user clicks element    id:signin-button
     user logs in via identity provider
@@ -48,5 +48,5 @@ Check that the user is on the Expired Invite page
     user waits until page contains    explore.statistics@education.gov.uk
 
 Check that the expired invite is now removed
-    user navigates to admin frontend
+    user navigates to admin homepage
     user waits until h1 is visible    No invitation    %{WAIT_MEDIUM}

--- a/tests/robot-tests/tests/admin/authentication/login_and_logout.robot
+++ b/tests/robot-tests/tests/admin/authentication/login_and_logout.robot
@@ -11,7 +11,7 @@ Force Tags          Admin    Local    Dev
 
 *** Test Cases ***
 Log in as BAU and check the dashboard is looking OK and the sign out buttons are available
-    user navigates to admin frontend    %{ADMIN_URL}/dashboard
+    user navigates to admin homepage
     user waits until h1 is visible    Sign in
     user clicks element    id:signin-button
     user logs in via identity provider
@@ -26,7 +26,7 @@ Log out using the button in the page header
     user waits until page contains title    Signed out
 
 Check that logging out via the header link has successfully removed the ability to access the dashboard
-    user navigates to admin frontend    %{ADMIN_URL}/dashboard
+    user navigates to admin homepage
     user waits until page contains title    Sign in
 
 Log in again and log out using the button in the dashboard
@@ -41,7 +41,7 @@ Log in again and log out using the button in the dashboard
     user waits until page contains title    Signed out
 
 Check that logging out with the dashboard link has successfully removed the ability to access the dashboard
-    user navigates to admin frontend    %{ADMIN_URL}/dashboard
+    user navigates to admin homepage
     user waits until page contains title    Sign in
 
 Switch users in the same browser

--- a/tests/robot-tests/tests/admin/authentication/no_invitation.robot
+++ b/tests/robot-tests/tests/admin/authentication/no_invitation.robot
@@ -11,7 +11,7 @@ Force Tags          Admin    Local    Dev
 
 *** Test Cases ***
 Login with a user without any invite or user record and assert that the user is redirected to the No Invitation page
-    user navigates to admin frontend
+    user navigates to admin homepage
     user waits until h1 is visible    Sign in
     user clicks element    id:signin-button
     user logs in via identity provider

--- a/tests/robot-tests/tests/admin/authentication/redirect_after_login.robot
+++ b/tests/robot-tests/tests/admin/authentication/redirect_after_login.robot
@@ -11,7 +11,7 @@ Force Tags          Admin    Local    Dev
 
 *** Test Cases ***
 Check that a user is redirected to a protected page after being forced to sign in
-    user navigates to admin frontend    %{ADMIN_URL}/administration
+    user navigates to    %{ADMIN_URL}/administration
     user waits until h1 is visible    Sign in
     user clicks element    id:signin-button
     user logs in via identity provider
@@ -22,7 +22,7 @@ Check that a user is redirected to a protected page after being forced to sign i
 Check that a user is redirected to the dashboard if coming directly from the Sign In page
     user closes the browser
     user opens the browser
-    user navigates to admin frontend    %{ADMIN_URL}/sign-in
+    user navigates to    %{ADMIN_URL}/sign-in
     user waits until h1 is visible    Sign in
     user clicks element    id:signin-button
     user logs in via identity provider
@@ -33,7 +33,7 @@ Check that a user is redirected to the dashboard if coming directly from the Sig
 Check that a user is redirected to the dashboard if coming from the dashboard originally
     user closes the browser
     user opens the browser
-    user navigates to admin frontend    %{ADMIN_URL}/dashboard
+    user navigates to admin homepage
     user waits until h1 is visible    Sign in
     user clicks element    id:signin-button
     user logs in via identity provider
@@ -44,7 +44,7 @@ Check that a user is redirected to the dashboard if coming from the dashboard or
 Check that a user is shown a Forbidden page if redirected to a protected page that they cannot access after login
     user closes the browser
     user opens the browser
-    user navigates to admin frontend    %{ADMIN_URL}/administration
+    user navigates to    %{ADMIN_URL}/administration
     user waits until h1 is visible    Sign in
     user clicks element    id:signin-button
     user logs in via identity provider
@@ -55,7 +55,7 @@ Check that a user is shown a Forbidden page if redirected to a protected page th
 Check that a user is shown a Page Not Found page if redirected to a non-existent page after login
     user closes the browser
     user opens the browser
-    user navigates to admin frontend    %{ADMIN_URL}/sign-in?returnUrl=%2Fnon-existent-page
+    user navigates to    %{ADMIN_URL}/sign-in?returnUrl=%2Fnon-existent-page
     user waits until h1 is visible    Sign in
     user clicks element    id:signin-button
     user logs in via identity provider

--- a/tests/robot-tests/tests/admin/authentication/register.robot
+++ b/tests/robot-tests/tests/admin/authentication/register.robot
@@ -97,7 +97,7 @@ user closes the browser and delete test user
 
 user opens browser and logs in via Identity Provider
     user opens the browser
-    user navigates to admin frontend
+    user navigates to admin homepage
     user waits until h1 is visible    Sign in
     user clicks element    id:signin-button
     user logs in via identity provider

--- a/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
+++ b/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
@@ -127,7 +127,7 @@ Get pre-release url
 
 Validate methodology appears in prerelease for analyst1
     user changes to analyst1
-    user navigates to admin frontend    ${PRERELEASE_URL}
+    user navigates to    ${PRERELEASE_URL}
 
     user clicks link    Methodologies
     user waits until h1 is visible    Methodologies
@@ -151,7 +151,7 @@ Drop adopted Methodology
 
 Validate adopted methodology no longer appears in prerelease
     user changes to analyst1
-    user navigates to admin frontend    ${PRERELEASE_URL}
+    user navigates to    ${PRERELEASE_URL}
 
     user clicks link    Methodologies
     user waits until h1 is visible    Methodologies

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -598,7 +598,7 @@ Validate line chart embeds correctly
     user checks chart tooltip item contains    ${datablock}    1    Admission Numbers (Nailsea Youngwood): 4,198
 
 Configure basic vertical bar chart
-    user navigates to admin frontend    ${DATABLOCK_URL}
+    user navigates to    ${DATABLOCK_URL}
 
     user waits until h2 is visible    ${DATABLOCK_NAME}    %{WAIT_MEDIUM}
     user waits until page finishes loading
@@ -693,7 +693,7 @@ Save and validate vertical bar chart embeds correctly
     user checks chart tooltip item contains    ${datablock}    1    Admissions: 4,198
 
 Configure basic horizontal bar chart
-    user navigates to admin frontend    ${DATABLOCK_URL}
+    user navigates to    ${DATABLOCK_URL}
     user waits until h2 is visible    ${DATABLOCK_NAME}    %{WAIT_SMALL}
     user waits until page finishes loading
 
@@ -775,7 +775,7 @@ Save and validate horizontal bar chart embeds correctly
     user checks chart tooltip item contains    ${datablock}    1    Admissions: 4,198
 
 Configure basic geographic chart
-    user navigates to admin frontend    ${DATABLOCK_URL}
+    user navigates to    ${DATABLOCK_URL}
     user waits until h2 is visible    ${DATABLOCK_NAME}    %{WAIT_SMALL}
     user waits until page finishes loading
 
@@ -932,7 +932,7 @@ Save and validate geographic chart embeds correctly
     user checks map chart indicator tile contains    ${datablock}    Admissions in 2014    9,854
 
 Configure basic infographic chart
-    user navigates to admin frontend    ${DATABLOCK_URL}
+    user navigates to    ${DATABLOCK_URL}
 
     user waits until h2 is visible    ${DATABLOCK_NAME}
     user waits until page finishes loading
@@ -972,7 +972,7 @@ Delete embedded data block
     user clicks button    Confirm
 
 Delete chart from data block
-    user navigates to admin frontend    ${DATABLOCK_URL}
+    user navigates to    ${DATABLOCK_URL}
     user waits until h2 is visible    ${DATABLOCK_NAME}
     user waits until page finishes loading
     user clicks link    Chart

--- a/tests/robot-tests/tests/admin/bau/manage_users_page.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_users_page.robot
@@ -20,7 +20,7 @@ ${RELEASE_2_NAME}=          Academic year 2000/01
 
 *** Test Cases ***
 Navigate to manage users page as bau1
-    user navigates to admin frontend    %{ADMIN_URL}/administration/users
+    user navigates to    %{ADMIN_URL}/administration/users
     user checks table column heading contains    1    1    Name
     user checks table column heading contains    1    2    Email
     user checks table column heading contains    1    3    Role

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -133,7 +133,7 @@ Navigate to prerelease page
     ${current_url}=    get location
     ${RELEASE_URL}=    remove substring from right of string    ${current_url}    /status
     set suite variable    ${RELEASE_URL}
-    user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
+    user navigates to    ${RELEASE_URL}/prerelease/content
 
 Validate prerelease has not started
     user waits until h1 is visible    Pre-release access is not yet available
@@ -148,7 +148,7 @@ Validate prerelease has not started
     ...    Pre-release access will be available from ${start_date} at 00:00 until it is published on ${end_date}.
 
 Go to prerelease access page
-    user navigates to admin frontend    ${RELEASE_URL}/prerelease-access
+    user navigates to    ${RELEASE_URL}/prerelease-access
     user waits until h2 is visible    Manage pre-release user access
 
 Check the invite emails field is required
@@ -240,7 +240,7 @@ Invite a further list of new users but mixed with existing invitees and accepted
 
 Validate prerelease has not started for Analyst user
     user changes to analyst1
-    user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
+    user navigates to    ${RELEASE_URL}/prerelease/content
 
     user waits until h1 is visible    Pre-release access is not yet available
     user checks breadcrumb count should be    2
@@ -259,7 +259,7 @@ Start prerelease
     ${month}=    get london month date    offset_days=1
     ${month_word}=    get london month word    offset_days=1
     ${year}=    get london year    offset_days=1
-    user navigates to admin frontend    ${RELEASE_URL}/status
+    user navigates to    ${RELEASE_URL}/status
     user clicks button    Edit release status
     user enters text into element    id:releaseStatusForm-publishScheduled-day    ${day}
     user enters text into element    id:releaseStatusForm-publishScheduled-month    ${month}
@@ -276,7 +276,7 @@ Validate prerelease has started
     ${current_url}=    get location
     ${RELEASE_URL}=    remove substring from right of string    ${current_url}    /status
     set suite variable    ${RELEASE_URL}
-    user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
+    user navigates to    ${RELEASE_URL}/prerelease/content
 
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
@@ -394,7 +394,7 @@ Create and validate methodology
 
     approve methodology from methodology view
 
-    user navigates to admin frontend    ${RELEASE_URL}/prerelease/methodologies
+    user navigates to    ${RELEASE_URL}/prerelease/methodologies
     user waits until h1 is visible    Methodologies
     user waits until page contains    ${PUBLICATION_NAME} (Owned)
     user clicks link    ${PUBLICATION_NAME} (Owned)
@@ -403,7 +403,7 @@ Create and validate methodology
 
 Validate prerelease has started for Analyst user
     user changes to analyst1
-    user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
+    user navigates to    ${RELEASE_URL}/prerelease/content
 
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
@@ -515,7 +515,7 @@ Unschedule release
     # EES-2826 Cancel scheduled publishing because ReleaseStatus row in table storage isn't removed
     # by test theme teardown. Unscheduling prevents an error when the scheduled publishing begins.
     user changes to bau1
-    user navigates to admin frontend    ${RELEASE_URL}/status
+    user navigates to    ${RELEASE_URL}/status
     user puts release into draft    expected_next_release_date=January 2001
 
 

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -201,7 +201,7 @@ Validate prerelease has not started for Analyst user during amendment as it is s
     ...    /prerelease-access#preReleaseAccess-publicList
     set suite variable    ${RELEASE_URL}
     user changes to analyst1
-    user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
+    user navigates to    ${RELEASE_URL}/prerelease/content
     user waits until h1 is visible    Forbidden
 
 Approve amendment for a scheduled release and check warning text
@@ -210,7 +210,7 @@ Approve amendment for a scheduled release and check warning text
     ${month}=    get london month date    offset_days=2
     ${month_word}=    get london month word    offset_days=2
     ${year}=    get london year    offset_days=2
-    user navigates to admin frontend    ${RELEASE_URL}/status
+    user navigates to    ${RELEASE_URL}/status
     user clicks button    Edit release status
     user clicks radio    Approved for publication
     user enters text into element    id:releaseStatusForm-internalReleaseNote    Approved by prerelease UI tests
@@ -233,7 +233,7 @@ Approve amendment for a scheduled release and check warning text
 
 Validate prerelease window is not yet open for Analyst user
     user changes to analyst1
-    user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
+    user navigates to    ${RELEASE_URL}/prerelease/content
 
     user waits until h1 is visible    Pre-release access is not yet available
     user checks breadcrumb count should be    2
@@ -252,7 +252,7 @@ Start prerelease
     ${month}=    get london month date    offset_days=1
     ${month_word}=    get london month word    offset_days=1
     ${year}=    get london year    offset_days=1
-    user navigates to admin frontend    ${RELEASE_URL}/status
+    user navigates to    ${RELEASE_URL}/status
     user clicks button    Edit release status
     user clicks radio    On a specific date
     user checks page contains    ${SCHEDULED_PRERELEASE_WARNING}
@@ -269,7 +269,7 @@ Start prerelease
 
 Validate prerelease has started for Analyst user after amendment
     user changes to analyst1
-    user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
+    user navigates to    ${RELEASE_URL}/prerelease/content
 
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home

--- a/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
@@ -219,7 +219,7 @@ Check public superseding-publication release page displays correctly
 Check public archive-publication release page displays correctly
     user waits for caches to expire
 
-    user navigates to public frontend    ${PUBLICATION_ARCHIVE_URL}
+    user navigates to    ${PUBLICATION_ARCHIVE_URL}
     user waits until h1 is visible    ${PUBLICATION_NAME_ARCHIVE}    %{WAIT_MEDIUM}
     user checks page does not contain    This is the latest data
 
@@ -295,7 +295,7 @@ Check archive-publication permalink has out-of-date warning
     [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-4269
     [Tags]    Failing
 
-    user navigates to public frontend    ${PERMALINK_URL}
+    user navigates to    ${PERMALINK_URL}
 
     user waits until h1 is visible
     ...    '${SUBJECT_NAME_ARCHIVE}' from '${PUBLICATION_NAME_ARCHIVE}'
@@ -405,7 +405,7 @@ Check archive-publication permalink no longer has out-of-date warning after arch
     [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-4269
     [Tags]    Failing
 
-    user navigates to public frontend    ${PERMALINK_URL}
+    user navigates to    ${PERMALINK_URL}
 
     user waits until h1 is visible
     ...    '${SUBJECT_NAME_ARCHIVE}' from '${PUBLICATION_NAME_ARCHIVE}'

--- a/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
@@ -264,7 +264,7 @@ Removing search
 
 Validate data catalogue page redirect from slug based urls
     environment variable should be set    PUBLIC_URL
-    user navigates to public frontend
+    user navigates to
     ...    %{PUBLIC_URL}/data-catalogue/${PUPIL_ABSENCE_PUBLICATION_SLUG}/2016-17
     user waits until h1 is visible    Data catalogue
 

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -39,7 +39,7 @@ Check release isn't publically visible
     check that variable is not empty    PUBLIC_RELEASE_LINK    ${PUBLIC_RELEASE_LINK}
     Set Suite Variable    ${PUBLIC_RELEASE_LINK}
 
-    user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
+    user navigates to    ${PUBLIC_RELEASE_LINK}
     user waits until page contains    Page not found
     user checks page does not contain    ${RELEASE_NAME}
 
@@ -66,7 +66,7 @@ Check methodology isn't publically visible
     check that variable is not empty    PUBLIC_METHODOLOGY_LINK    ${PUBLIC_METHODOLOGY_LINK}
     Set Suite Variable    ${PUBLIC_METHODOLOGY_LINK}
 
-    user navigates to public frontend    ${PUBLIC_METHODOLOGY_LINK}
+    user navigates to    ${PUBLIC_METHODOLOGY_LINK}
     user waits until page contains    Page not found
 
 Return to admin again
@@ -138,12 +138,12 @@ Check scheduled release isn't visible on public Table Tool
     user checks page does not contain    ${PUBLICATION_NAME}
 
 Go to public release URL and check release isn't visible
-    user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
+    user navigates to    ${PUBLIC_RELEASE_LINK}
     user waits until page contains    Page not found
     user waits until page does not contain    ${PUBLICATION_NAME}
 
 Check methodology isn't accessible via URL
-    user navigates to public frontend    ${PUBLIC_METHODOLOGY_LINK}
+    user navigates to    ${PUBLIC_METHODOLOGY_LINK}
     user waits until page contains    Page not found
 
 Go to admin release summary
@@ -155,7 +155,7 @@ Approve release for immediate publication
     user approves original release for immediate publication
 
 Check release has been published
-    user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
+    user navigates to    ${PUBLIC_RELEASE_LINK}
     user waits until page contains title caption    Calendar year 2000
     user waits until h1 is visible    ${PUBLICATION_NAME}
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -109,7 +109,7 @@ Verify that the publication is not visible on the public methodologies page with
     user checks page does not contain    ${PUBLICATION_NAME}
 
 Verify that the methodology is not publicly accessible by URL without a published release
-    user navigates to public frontend    ${ACCESSIBLE_METHODOLOGY_URL}
+    user navigates to    ${ACCESSIBLE_METHODOLOGY_URL}
     user waits until h1 is visible    Page not found    %{WAIT_MEDIUM}
 
 Alter the approval to publish the methodology with the release
@@ -123,7 +123,7 @@ Verify that the publication is still not visible on the public methodologies pag
     user checks page does not contain    ${PUBLICATION_NAME}
 
 Verify that the methodology is still not publicly accessible by URL without publishing the release
-    user navigates to public frontend    ${ACCESSIBLE_METHODOLOGY_URL}
+    user navigates to    ${ACCESSIBLE_METHODOLOGY_URL}
     user waits until page contains    Page not found
 
 Navigate to release content page and add headline text block
@@ -172,20 +172,20 @@ Verify that the methodology is publicly accessible
 
 Verify that methodology hash links open accordion sections correctly
     [Documentation]    EES-3877
-    user navigates to public frontend    ${METHODOLOGY_URL}#content-section-3-test-title-3
+    user navigates to    ${METHODOLOGY_URL}#content-section-3-test-title-3
     user waits until h1 is visible    ${PUBLICATION_NAME}
     user waits until page contains title caption    Methodology    %{WAIT_SMALL}
     user checks page contains    3.test-title 3
     user checks page contains    Content 3
 
-    user navigates to public frontend    ${METHODOLOGY_URL}#content-section-4-test-title-4
+    user navigates to    ${METHODOLOGY_URL}#content-section-4-test-title-4
     user waits until page finishes loading
 
     user checks page contains    4.-test-.title 4
     user checks page contains    Content 4
 
 Verify that the methodology displays a link to the publication
-    user navigates to public frontend    ${METHODOLOGY_URL}
+    user navigates to    ${METHODOLOGY_URL}
     user waits until h1 is visible    ${PUBLICATION_NAME}
     user waits until page contains title caption    Methodology    %{WAIT_SMALL}
 
@@ -340,7 +340,7 @@ Verify that the user cannot edit the status of the amended methodology
 
 Go to methodology amendment's public page
     ${METHODOLOGY_URL}=    get element attribute    css:#public-methodology-url    value
-    user navigates to public frontend    ${METHODOLOGY_URL}
+    user navigates to    ${METHODOLOGY_URL}
     user waits until page contains title    ${PUBLICATION_NAME} - Amended methodology
     user waits until page contains title caption    Methodology
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
@@ -81,7 +81,7 @@ Check publication is updated on dashboard
     user waits until page contains link    ${PUBLICATION_NAME_UPDATED}
 
 Validate publication redirect works
-    user navigates to public frontend    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}${ACADEMIC_YEAR}
+    user navigates to    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}${ACADEMIC_YEAR}
     user waits until h1 is visible    ${PUBLICATION_NAME_UPDATED}
     user checks url contains    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}-updated${ACADEMIC_YEAR}
 

--- a/tests/robot-tests/tests/admin_and_public/bau/release_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/release_reordering.robot
@@ -135,7 +135,7 @@ Validate first release has latest release status in publication release order
     user checks table cell contains    3    4    Delete
 
 Navigate to first published release on public frontend
-    user navigates to public frontend    ${PUBLIC_RELEASE_1_URL}
+    user navigates to    ${PUBLIC_RELEASE_1_URL}
 
 Validate first published release on public frontend is the latest data
     user checks page contains    This is the latest data
@@ -234,7 +234,7 @@ Validate reordered publication releases
     user checks table cell contains    3    3    Latest release
 
 Navigate to first published release on public frontend after reordering
-    user navigates to public frontend    ${PUBLIC_RELEASE_1_URL}
+    user navigates to    ${PUBLIC_RELEASE_1_URL}
 
 Validate first published release is the latest data after reordering
     user checks page contains    This is the latest data
@@ -326,7 +326,7 @@ Validate second release has latest release status in publication release order
     user checks table cell does not contain    4    3    Latest release
 
 Navigate to second published release on public frontend
-    user navigates to public frontend    ${PUBLIC_RELEASE_2_URL}
+    user navigates to    ${PUBLIC_RELEASE_2_URL}
 
 Validate second published release is the latest data
     user checks page contains    This is the latest data
@@ -406,7 +406,7 @@ Validate first legacy release is deleted from publication release order
     user checks table cell does not contain    3    3    Latest release
 
 Navigate to second published release on public frontend after deleting legacy release
-    user navigates to public frontend    ${PUBLIC_RELEASE_2_URL}
+    user navigates to    ${PUBLIC_RELEASE_2_URL}
 
 Validate other releases section of second published release does not include first legacy release
     user checks number of other releases is correct    2
@@ -454,13 +454,13 @@ Validate first release has latest release status in publication release order af
     user checks table cell contains    3    4    Delete
 
 Navigate to first published release on public frontend after changing the latest release
-    user navigates to public frontend    ${PUBLIC_RELEASE_1_URL}
+    user navigates to    ${PUBLIC_RELEASE_1_URL}
 
 Validate first published release is the latest data after changing the latest release
     user checks page contains    This is the latest data
 
 Navigate to second published release on public frontend after changing the latest release
-    user navigates to public frontend    ${PUBLIC_RELEASE_2_URL}
+    user navigates to    ${PUBLIC_RELEASE_2_URL}
 
 Validate second published release is not the latest data after changing the latest release
     user checks page contains    This is not the latest data

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_methodology_publication_update.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_methodology_publication_update.robot
@@ -102,7 +102,7 @@ Check publication is updated on dashboard
     user waits until page contains link    ${PUBLICATION_NAME_UPDATED}
 
 Validate publication redirect works
-    user navigates to public frontend    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}${ACADEMIC_YEAR}
+    user navigates to    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}${ACADEMIC_YEAR}
     user waits until h1 is visible    ${PUBLICATION_NAME_UPDATED}
     user checks url contains    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}-updated${ACADEMIC_YEAR}
 
@@ -147,7 +147,7 @@ Navigate to sign-off page and approve the methodology immediately
     user waits for caches to expire
 
 Validate methodology re-directs works for the updated publication methodology
-    user navigates to public frontend    %{PUBLIC_URL}${PUBLIC_METHODOLOGY_URL_ENDING}
+    user navigates to    %{PUBLIC_URL}${PUBLIC_METHODOLOGY_URL_ENDING}
     user waits until h1 is visible    ${PUBLICATION_NAME}-methodology update
     user checks url contains    %{PUBLIC_URL}${PUBLIC_METHODOLOGY_URL_ENDING}-methodology-update
 
@@ -178,11 +178,11 @@ Approve second release
     user approves release for immediate publication
 
 Check that first release does not contains the latest data
-    user navigates to public frontend    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}-updated/2050-51-q1
+    user navigates to    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}-updated/2050-51-q1
     user checks page does not contain    This is the latest data
     user checks page contains    This is not the latest data
 
 Check that second release contains the latest data
-    user navigates to public frontend    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}-updated/2051-52-q1
+    user navigates to    %{PUBLIC_URL}${PUBLIC_PUBLICATION_URL_ENDING}-updated/2051-52-q1
     user checks page does not contain    This is not the latest data
     user checks page contains    This is the latest data

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -975,7 +975,7 @@ Verify published date on publication page is overriden with past date
     user checks element contains    ${row}    ${EXPECTED_PUBLISHED_DATE}
 
 Verify public published date is overriden with past date
-    user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
+    user navigates to    ${PUBLIC_RELEASE_LINK}
     user waits until h1 is visible    ${PUBLICATION_NAME}
     user checks summary list contains    Published    ${EXPECTED_PUBLISHED_DATE}
 
@@ -1026,7 +1026,7 @@ Verify published date on publication page has been updated
 
 Navigate to amended public release
     user waits for caches to expire
-    user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
+    user navigates to    ${PUBLIC_RELEASE_LINK}
     user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_MEDIUM}
 
 Verify public published date has been updated

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
@@ -239,7 +239,7 @@ Generate the permalink
     Set Suite Variable    ${PERMA_LOCATION_URL}
 
 Go to permalink
-    user navigates to public frontend    ${PERMA_LOCATION_URL}
+    user navigates to    ${PERMA_LOCATION_URL}
     user waits until h1 is visible    '${SUBJECT_NAME}' from '${PUBLICATION_NAME}'
     user checks page does not contain    WARNING
     user checks page contains    Footnote 1 ${SUBJECT_NAME}
@@ -315,7 +315,7 @@ Check new release status history entry is present
     table cell should contain    testid:release-status-history    2    4    2    # Release version 2
 
 Go to permalink page & check for error element to be present
-    user navigates to public frontend    ${PERMA_LOCATION_URL}
+    user navigates to    ${PERMA_LOCATION_URL}
     user waits until page contains
     ...    WARNING - The data used in this table may be invalid as the subject file has been amended or removed since its creation.
 
@@ -375,7 +375,7 @@ Check the table has the same results as original table
     user checks table cell contains    7    5    1
 
 Check amended release doesn't contain deleted subject
-    user navigates to public frontend    %{PUBLIC_URL}/data-tables
+    user navigates to    %{PUBLIC_URL}/data-tables
     user waits until h1 is visible    Create your own tables
     user clicks radio    %{TEST_THEME_NAME}
     user clicks radio    ${PUBLICATION_NAME}
@@ -431,7 +431,7 @@ Go to "Sign off" to approve amended release for immediate publication
     user approves amended release for immediate publication
 
 Go to public Table Tool page for amendment
-    user navigates to public frontend    %{PUBLIC_URL}/data-tables
+    user navigates to    %{PUBLIC_URL}/data-tables
     user waits until h1 is visible    Create your own tables
 
 Select publication
@@ -502,7 +502,7 @@ Generate the new permalink
     Set Suite Variable    ${PERMA_LOCATION_URL_TWO}
 
 Go to new permalink
-    user navigates to public frontend    ${PERMA_LOCATION_URL_TWO}
+    user navigates to    ${PERMA_LOCATION_URL_TWO}
     user waits until h1 is visible    '${SUBJECT_NAME}' from '${PUBLICATION_NAME}'
     user checks page does not contain    WARNING
     user checks page contains    Updating ${SUBJECT_NAME} footnote

--- a/tests/robot-tests/tests/general_public/fast_track.robot
+++ b/tests/robot-tests/tests/general_public/fast_track.robot
@@ -12,7 +12,7 @@ Test Setup          fail test fast if required
 *** Test Cases ***
 Navigate to publication release page
     environment variable should be set    PUBLIC_URL
-    user navigates to public frontend    %{PUBLIC_URL}${PUPIL_ABSENCE_PUBLICATION_RELATIVE_URL}
+    user navigates to    %{PUBLIC_URL}${PUPIL_ABSENCE_PUBLICATION_RELATIVE_URL}
 
 Click fast track link for 'Pupil absence rates' data block
     user waits until h1 is visible    ${PUPIL_ABSENCE_PUBLICATION_TITLE}

--- a/tests/robot-tests/tests/general_public/glossary_page.robot
+++ b/tests/robot-tests/tests/general_public/glossary_page.robot
@@ -10,7 +10,7 @@ Force Tags          GeneralPublic    Local    Dev    Test    Preprod    Prod
 
 *** Test Cases ***
 Navigate to glossary page
-    user navigates to public frontend
+    user navigates to public site homepage
     user waits until h1 is visible    Explore our statistics and data
 
     user clicks link    Glossary

--- a/tests/robot-tests/tests/general_public/miscellaneous.robot
+++ b/tests/robot-tests/tests/general_public/miscellaneous.robot
@@ -10,7 +10,7 @@ Force Tags          GeneralPublic    Local    Dev    Test    Preprod    Prod
 
 *** Test Cases ***
 Verify public page loads
-    user navigates to public frontend
+    user navigates to public site homepage
     user waits until page contains    Explore education statistics
 
 Verify can accept cookie banner

--- a/tests/robot-tests/tests/general_public/notifications_absence.robot
+++ b/tests/robot-tests/tests/general_public/notifications_absence.robot
@@ -11,7 +11,7 @@ Test Setup          fail test fast if required
 
 *** Test Cases ***
 Navigate to Absence publication
-    user navigates to public frontend    %{PUBLIC_URL}${PUPIL_ABSENCE_PUBLICATION_RELATIVE_URL}
+    user navigates to    %{PUBLIC_URL}${PUPIL_ABSENCE_PUBLICATION_RELATIVE_URL}
     user waits until h1 is visible    ${PUPIL_ABSENCE_PUBLICATION_TITLE}    %{WAIT_MEDIUM}
 
 Go to Notify me page for Absence publication

--- a/tests/robot-tests/tests/general_public/prod_only/notifications_absence.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/notifications_absence.robot
@@ -10,7 +10,7 @@ Test Setup          fail test fast if required
 
 *** Test Cases ***
 Navigate to Absence publication
-    user navigates to public frontend    %{PUBLIC_URL}/find-statistics/pupil-absence-in-schools-in-england
+    user navigates to    %{PUBLIC_URL}/find-statistics/pupil-absence-in-schools-in-england
     user waits until h1 is visible    Pupil absence in schools in England    %{WAIT_MEDIUM}
 
 Go to Notify me page for Absence publication

--- a/tests/robot-tests/tests/general_public/prod_only/permalink_prod_1.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/permalink_prod_1.robot
@@ -13,7 +13,7 @@ Go to Table Tool page
     user navigates to data tables page on public frontend
 
 Go to permalink
-    user navigates to public frontend    %{PUBLIC_URL}/data-tables/permalink/30999037-fcd4-409f-9ff4-d3680da7402d
+    user navigates to    %{PUBLIC_URL}/data-tables/permalink/30999037-fcd4-409f-9ff4-d3680da7402d
     user waits until h1 is visible
     ...    'Total days missed due to fixed period exclusions' from 'Permanent and fixed-period exclusions in England'
 

--- a/tests/robot-tests/tests/general_public/prod_only/permalink_prod_2.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/permalink_prod_2.robot
@@ -13,7 +13,7 @@ Go to Table Tool page
     user navigates to data tables page on public frontend
 
 Go to permalink
-    user navigates to public frontend    %{PUBLIC_URL}/data-tables/permalink/edfe9f83-d1f0-40fc-8dce-9467a250c61b
+    user navigates to    %{PUBLIC_URL}/data-tables/permalink/edfe9f83-d1f0-40fc-8dce-9467a250c61b
     user waits until h1 is visible
     ...    'Exclusions by characteristic' from 'Permanent and fixed-period exclusions in England'
 

--- a/tests/robot-tests/tests/general_public/prod_only/permalink_prod_3.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/permalink_prod_3.robot
@@ -13,7 +13,7 @@ Go to Table Tool page
     user navigates to data tables page on public frontend
 
 Go to permalink
-    user navigates to public frontend    %{PUBLIC_URL}/data-tables/permalink/c5688b39-2630-4de0-a143-725df9e48690
+    user navigates to    %{PUBLIC_URL}/data-tables/permalink/c5688b39-2630-4de0-a143-725df9e48690
     user waits until h1 is visible
     ...    'Exclusions by geographic level' from 'Permanent and fixed-period exclusions in England'
 

--- a/tests/robot-tests/tests/general_public/prod_only/redirects.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/redirects.robot
@@ -10,18 +10,18 @@ Force Tags          GeneralPublic    Prod
 
 *** Test Cases ***
 Verify that absolute paths with trailing slashes are redirected without them
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/
+    user navigates to    %{PUBLIC_URL}/data-catalogue/
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue
 
-    user navigates to public frontend    %{PUBLIC_URL}/glossary/?someRandomUrlParameter=123
+    user navigates to    %{PUBLIC_URL}/glossary/?someRandomUrlParameter=123
     user waits until page contains    Glossary
     user checks url equals    %{PUBLIC_URL}/glossary?someRandomUrlParameter=123
 
 Verify that redirects do not affect browser history
     user navigates to    about:blank
 
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/
+    user navigates to    %{PUBLIC_URL}/data-catalogue/
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue
 
@@ -29,38 +29,38 @@ Verify that redirects do not affect browser history
     user checks url equals    about:blank
 
 Verify that routes without an absolute path still permit trailing slashes
-    user navigates to public frontend    %{PUBLIC_URL}/
+    user navigates to    %{PUBLIC_URL}/
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
 
-    user navigates to public frontend    %{PUBLIC_URL}
+    user navigates to    %{PUBLIC_URL}
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
 
 Verify that routes with www are redirected without them
-    user navigates to public frontend with www    %{PUBLIC_URL}/
+    user navigates to www    %{PUBLIC_URL}/
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
 
-    user navigates to public frontend with www    %{PUBLIC_URL}/data-catalogue/
+    user navigates to www    %{PUBLIC_URL}/data-catalogue/
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue
 
 Verify that routes with /1000 are redirected without them
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/1000
+    user navigates to    %{PUBLIC_URL}/data-catalogue/1000
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue
 
 Verify that routes with search parameters retain them
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue?foo=bar&baz=zod
+    user navigates to    %{PUBLIC_URL}/data-catalogue?foo=bar&baz=zod
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue?foo=bar&baz=zod
 
 Verify that multiple rules work together
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/1000?foo=bar&baz=zod
+    user navigates to    %{PUBLIC_URL}/data-catalogue/1000?foo=bar&baz=zod
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue?foo=bar&baz=zod
 
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/1000/?foo=bar
+    user navigates to    %{PUBLIC_URL}/data-catalogue/1000/?foo=bar
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue?foo=bar

--- a/tests/robot-tests/tests/general_public/redirects.robot
+++ b/tests/robot-tests/tests/general_public/redirects.robot
@@ -12,11 +12,11 @@ Force Tags          GeneralPublic    Local    Dev    Test    Preprod
 
 *** Test Cases ***
 Verify that absolute paths with trailing slashes are redirected without them
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/
+    user navigates to    %{PUBLIC_URL}/data-catalogue/
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue
 
-    user navigates to public frontend    %{PUBLIC_URL}/glossary/?someRandomUrlParameter=123
+    user navigates to    %{PUBLIC_URL}/glossary/?someRandomUrlParameter=123
     user waits until page contains    Glossary
     user checks url equals    %{PUBLIC_URL}/glossary?someRandomUrlParameter=123
 
@@ -25,7 +25,7 @@ Verify that absolute paths with trailing slashes are redirected without them
 Verify that redirects do not affect browser history
     user navigates to    about:blank
 
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/
+    user navigates to    %{PUBLIC_URL}/data-catalogue/
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue
 
@@ -33,29 +33,29 @@ Verify that redirects do not affect browser history
     user checks url equals    about:blank
 
 Verify that routes without an absolute path still permit trailing slashes
-    user navigates to public frontend    %{PUBLIC_URL}/
+    user navigates to    %{PUBLIC_URL}/
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
 
-    user navigates to public frontend    %{PUBLIC_URL}
+    user navigates to    %{PUBLIC_URL}
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
 
 Verify that routes with /1000 are redirected without them
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/1000
+    user navigates to    %{PUBLIC_URL}/data-catalogue/1000
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue
 
 Verify that routes with search parameters retain them
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/?foo=bar&baz=zod
+    user navigates to    %{PUBLIC_URL}/data-catalogue/?foo=bar&baz=zod
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue?foo=bar&baz=zod
 
 Verify that multiple rules work together
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/1000?foo=bar&baz=zod
+    user navigates to    %{PUBLIC_URL}/data-catalogue/1000?foo=bar&baz=zod
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue?foo=bar&baz=zod
 
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue/1000/?foo=bar
+    user navigates to    %{PUBLIC_URL}/data-catalogue/1000/?foo=bar
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue?foo=bar

--- a/tests/robot-tests/tests/general_public/redirects_www.robot
+++ b/tests/robot-tests/tests/general_public/redirects_www.robot
@@ -10,10 +10,10 @@ Force Tags          GeneralPublic    Local
 
 *** Test Cases ***
 Verify that routes with www are redirected without them
-    user navigates to public frontend with www    %{PUBLIC_URL}/
+    user navigates to www    %{PUBLIC_URL}/
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/
 
-    user navigates to public frontend with www    %{PUBLIC_URL}/data-catalogue/
+    user navigates to www    %{PUBLIC_URL}/data-catalogue/
     user waits until page contains    Data catalogue
     user checks url equals    %{PUBLIC_URL}/data-catalogue

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -12,7 +12,7 @@ Force Tags          GeneralPublic    Local    Dev    Preprod
 
 *** Test Cases ***
 Navigate to Absence publication
-    user navigates to public frontend
+    user navigates to public site homepage
     user waits until page contains    Explore our statistics and data
 
     user clicks link    Explore

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -45,7 +45,7 @@ user signs in as bau1
     IF    ${open_browser}
         user opens the browser    ${alias}
     END
-    user navigates to admin frontend
+    user navigates to admin homepage
     user waits until h1 is visible    Sign in    %{WAIT_MEDIUM}
     user signs in as    ADMIN
     user navigates to admin dashboard    Bau1
@@ -58,7 +58,7 @@ user signs in as analyst1
     IF    ${open_browser}
         user opens the browser    ${alias}
     END
-    user navigates to admin frontend
+    user navigates to admin homepage
     user waits until h1 is visible    Sign in
     user signs in as    ANALYST
     user navigates to admin dashboard    Analyst1
@@ -819,7 +819,7 @@ user removes release access from analyst
 
 user goes to manage user
     [Arguments]    ${EMAIL_ADDRESS}
-    user navigates to admin frontend    %{ADMIN_URL}/administration/users
+    user navigates to    %{ADMIN_URL}/administration/users
     user waits until h1 is visible    Users
     user waits until table is visible
     user clicks link    Manage    xpath://td[text()="${EMAIL_ADDRESS}"]/..

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -1011,15 +1011,11 @@ user navigates to admin frontend
     [Arguments]    ${URL}=%{ADMIN_URL}
     go to    ${URL}
 
-# EES-5802 - remove in favour of just using "user navigates to".
-
-user navigates to public frontend
+user navigates to public site homepage
     [Arguments]    ${URL}=%{PUBLIC_URL}
     user navigates to    ${URL}
 
-# EES-5802 - rename to "user navigates to www".
-
-user navigates to public frontend with www
+user navigates to www
     [Arguments]    ${URL}=%{PUBLIC_URL}
     ${www_url}=    get www url    ${URL}
     user navigates to    ${www_url}

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -1005,15 +1005,11 @@ user checks page does not contain other release
     user checks page does not contain element
     ...    xpath://li[@data-testid="other-release-item"]/a[text()="${other_release_title}"]
 
-# EES-5802 - remove in favour of just using "user navigates to".
-
-user navigates to admin frontend
-    [Arguments]    ${URL}=%{ADMIN_URL}
-    go to    ${URL}
+user navigates to admin homepage
+    go to    %{ADMIN_URL}
 
 user navigates to public site homepage
-    [Arguments]    ${URL}=%{PUBLIC_URL}
-    user navigates to    ${URL}
+    user navigates to    %{PUBLIC_URL}
 
 user navigates to www
     [Arguments]    ${URL}=%{PUBLIC_URL}

--- a/tests/robot-tests/tests/libs/public-common.robot
+++ b/tests/robot-tests/tests/libs/public-common.robot
@@ -59,23 +59,23 @@ user goes to release page via breadcrumb
 
 user navigates to public find statistics page
     environment variable should be set    PUBLIC_URL
-    user navigates to public frontend    %{PUBLIC_URL}/find-statistics
+    user navigates to    %{PUBLIC_URL}/find-statistics
     user waits until h1 is visible    Find statistics and data
 
 user navigates to data tables page on public frontend
     environment variable should be set    PUBLIC_URL
-    user navigates to public frontend    %{PUBLIC_URL}/data-tables
+    user navigates to    %{PUBLIC_URL}/data-tables
     user waits until h1 is visible    Create your own tables
 
 user navigates to data catalogue page on public frontend
     environment variable should be set    PUBLIC_URL
-    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue
+    user navigates to    %{PUBLIC_URL}/data-catalogue
     user waits until h1 is visible    Data catalogue
     user waits until page contains    Find and download data sets with associated guidance files.
 
 user navigates to public methodologies page
     environment variable should be set    PUBLIC_URL
-    user navigates to public frontend    %{PUBLIC_URL}/methodology
+    user navigates to    %{PUBLIC_URL}/methodology
     user waits until h1 is visible    Methodologies
     user waits until page contains    Browse to find out about the methodology behind specific
 

--- a/tests/robot-tests/tests/visual_testing/permalinks.robot
+++ b/tests/robot-tests/tests/visual_testing/permalinks.robot
@@ -18,7 +18,7 @@ Check permalink with id
     Log to console    \n\n\t=====================================================================\n
     Log to console    \tProcessing permalink at ${permalink_url}
 
-    user navigates to public frontend    ${permalink_url}
+    user navigates to    ${permalink_url}
 
     Log to console    \n\tCapturing Permalink:
 

--- a/tests/robot-tests/tests/visual_testing/tables_and_charts.robot
+++ b/tests/robot-tests/tests/visual_testing/tables_and_charts.robot
@@ -21,7 +21,7 @@ Check release
     Log to console    \n\n\t=====================================================================\n
     Log to console    \tProcessing release at %{PUBLIC_URL}${release.url}
 
-    user navigates to public frontend    %{PUBLIC_URL}${release.url}
+    user navigates to    %{PUBLIC_URL}${release.url}
 
     IF    ${release.has_key_stat_blocks}
         Log to console    \n\tCapturing Key Stats:
@@ -63,7 +63,7 @@ Check release
 
 Check Fast Track Table
     [Arguments]    ${content_block}
-    user navigates to public frontend    %{PUBLIC_URL}${content_block.content_url}
+    user navigates to    %{PUBLIC_URL}${content_block.content_url}
     user waits until page contains element    id:tableToolWizard
     ${filepath}=    user takes screenshot of element    id:tableToolWizard
     ...    ${SNAPSHOT_FOLDER}/${content_block.release_id}/${FAST_TRACKS_FOLDER}/${content_block.content_block_id}-table.png


### PR DESCRIPTION
This PR removes the now-redundant admin and public frontend-specific navigation keywords, as all browser instances are now capable of using the frontend without specifically needing to request basic auth credentials be present.  This is due to the work done in https://github.com/dfe-analytical-services/explore-education-statistics/pull/5588.

![image](https://github.com/user-attachments/assets/ffc41eb9-fb48-4332-91af-a84a399be0a7)
