### PR TITLE
EES-5838 - temporarily adding trailing slash to Public API docs URLs

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1818,7 +1818,7 @@
         "PublicDataDbExists": "[parameters('publicDataDbExists')]",
         "PublicDataApi:PublicUrl": "[concat('https://', parameters('publicApiUrl'))]",
         "PublicDataApi:PrivateUrl": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-publicapi-public-api-containerapp-private-url'), '2018-02-14').secretUriWithVersion, ')')]",
-        "PublicDataApi:DocsUrl": "[concat('https://', parameters('publicApiDocsUrl'))]",
+        "PublicDataApi:DocsUrl": "[concat('https://', parameters('publicApiDocsUrl'), '/')]",
         "PublicDataApi:AppRegistrationClientId": "[parameters('apiAppRegistrationClientId')]",
         "PublicDataProcessor:Url": "[concat('https://', variables('publicDataProcessorName'), '.azurewebsites.net')]",
         "PublicDataProcessor:AppRegistrationClientId": "[parameters('publicDataProcessorAppRegistrationClientId')]"
@@ -2138,7 +2138,7 @@
         "NODE_ENV": "production",
         "PUBLIC_URL": "[concat(variables('publicAppUrl'), '/')]",
         "PUBLIC_API_BASE_URL": "[concat('https://', parameters('publicApiUrl'))]",
-        "PUBLIC_API_DOCS_URL": "[concat('https://', parameters('publicApiDocsUrl'))]",
+        "PUBLIC_API_DOCS_URL": "[concat('https://', parameters('publicApiDocsUrl'), '/')]",
         "WEBSITE_NODE_DEFAULT_VERSION": "20.16.0",
         "WEBSITES_PORT": 3000
       }


### PR DESCRIPTION
…prior to supporting url without the trailing slash.

At the moment, the Public API docs site is only accessible with a trailing slash on the end of `docs/`.

This is a temporary measure to ensure that the trailing slash is added to our various web pages until the non-trailing slash version can be supported.