### PR TITLE
EES-5864 - reintroduced redirect from non-rooted to rooted Public API URL

### DIFF
--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -118,6 +118,7 @@ param deployRecoveryVault bool = false
 param publicUrls {
   contentApi: string
   publicSite: string
+  publicApi: string
   publicApiAppGateway: string
 }
 
@@ -440,6 +441,17 @@ module appGatewayModule 'application/shared/appGateway.bicep' = if (deployContai
             type: 'backend'
             backendName: resourceNames.publicApi.docsApp
             rewriteSetName: docsRewriteSetName
+          }
+          {
+            // Redirect non-rooted URL (has no trailing slash) to the
+            // rooted URL so that relative links in the docs site
+            // can resolve correctly.
+            name: 'docs-root-redirect'
+            paths: ['/docs']
+            type: 'redirect'
+            redirectUrl: '${publicUrls.publicApi}/docs/'
+            redirectType: 'Permanent'
+            includePath: false
           }
         ]
       }

--- a/infrastructure/templates/public-api/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-dev.bicepparam
@@ -6,6 +6,7 @@ param environmentName = 'Development'
 param publicUrls = {
   contentApi: 'https://content.dev.explore-education-statistics.service.gov.uk'
   publicSite: 'https://dev.explore-education-statistics.service.gov.uk'
+  publicApi: 'https://pp-api.education.gov.uk/statistics-dev'
   publicApiAppGateway: 'https://dev.statistics.api.education.gov.uk'
 }
 

--- a/infrastructure/templates/public-api/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-preprod.bicepparam
@@ -6,6 +6,7 @@ param environmentName = 'Pre-Production'
 param publicUrls = {
   contentApi: 'https://content.pre-production.explore-education-statistics.service.gov.uk'
   publicSite: 'https://pre-production.explore-education-statistics.service.gov.uk'
+  publicApi: 'https://pp-api.education.gov.uk/statistics-preprod'
   publicApiAppGateway: 'https://pre-production.statistics.api.education.gov.uk'
 }
 

--- a/infrastructure/templates/public-api/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-prod.bicepparam
@@ -6,6 +6,7 @@ param environmentName = 'Production'
 param publicUrls = {
   contentApi: 'https://content.explore-education-statistics.service.gov.uk'
   publicSite: 'https://explore-education-statistics.service.gov.uk'
+  publicApi: 'https://api.education.gov.uk/statistics'
   publicApiAppGateway: 'https://statistics.api.education.gov.uk'
 }
 

--- a/infrastructure/templates/public-api/parameters/main-test.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-test.bicepparam
@@ -6,6 +6,7 @@ param environmentName = 'Test'
 param publicUrls = {
   contentApi: 'https://content.test.explore-education-statistics.service.gov.uk'
   publicSite: 'https://test.explore-education-statistics.service.gov.uk'
+  publicApi: 'https://pp-api.education.gov.uk/statistics-test'
   publicApiAppGateway: 'https://test.statistics.api.education.gov.uk'
 }
 


### PR DESCRIPTION
This PR reinstates a redirect from the Public API's `/docs` URL to `/docs/`.  A new `publicUrls.publicApi` variable is introduced to represent FUAPI's public URL for the API.