### PR TITLE
EES-5820 - rewriting "Location" response headers to replace static webapp FQDN with public FQDN

### DIFF
--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -475,6 +475,24 @@ module appGatewayModule 'application/shared/appGateway.bicep' = if (deployContai
               }
             }
           }
+          {
+            name: 'replace-docs-backend-fqdn-with-public-docs-url'
+            conditions: [
+              {
+                variable: 'http_resp_Location'
+                pattern: 'https://${docsModule.outputs.appFqdn}/(.*)'
+                ignoreCase: true
+              }
+            ]
+            actionSet: {
+              responseHeaderConfigurations: [
+                {
+                  headerName: 'Location'
+                  headerValue: '${publicUrls.publicApi}/docs/{http_resp_Location_1}'
+                }
+              ]
+            }
+          }
         ]
       }
     ]

--- a/infrastructure/templates/public-api/types.bicep
+++ b/infrastructure/templates/public-api/types.bicep
@@ -220,7 +220,10 @@ type AppGatewayRewriteCondition = {
 @export()
 type AppGatewayRewriteActionSet = {
   @description('Rewrite config for the URL')
-  urlConfiguration: AppGatewayRewriteUrlConfig
+  urlConfiguration: AppGatewayRewriteUrlConfig?
+
+  @description('Rewrite config for the URL')
+  responseHeaderConfigurations: AppGatewayRewriteHeaderConfig[]?
 }
 
 @export()
@@ -228,11 +231,20 @@ type AppGatewayRewriteUrlConfig = {
   @description('The path after it has been rewritten. Can contain variables from other parts of the request')
   modifiedPath: string?
 
-  @description('The query string after it has been rewritten. Can contain variables from other parts of the request')
+  @description('The query string after it has been rewritten. Can contain variables from other parts of the original request')
   modifiedQueryString: string?
 
   @description('Re-evaluate any associated URL path maps with the rewritten path. Defaults to false')
   reroute: bool?
+}
+
+@export()
+type AppGatewayRewriteHeaderConfig = {
+  @description('The HTTP header to inspect')
+  headerName: string
+
+  @description('The header value after it has been rewritten. Can contain variables from other parts of the original header')
+  headerValue: string
 }
 
 // This is not an exhaustive list. For a list of available operators, see:


### PR DESCRIPTION
This PR:
- fixes issues where the Public API static webapp's trailing slash redirect were including the static webapp's FQDN in the redirect rather than the public FaUAPI FQDN.

Previously if navigating to a docs URL without a trailing slash, the static webapp (being configured with `"trailingSlash": "auto"`) would redirect to a version of the URL with a trailing slash added.  Unfortunately it would implement this as a redirect to an absolute URL with the static webapp's FQDN included.

Thus, navigating to:

https://pp-api.education.gov.uk/statistics-dev/docs/getting-started

would redirect to:

https://witty-bay-020052c03.4.azurestaticapps.net/getting-started/

It doesn't seem like there is any way to override this trailing slash redirect behaviour from the static webapp.

## The solution

Looking into this, it was using the HTTP response's "Location" header to instruct the browser to redirect permanently to the `https://witty-bay-020052c03.4.azurestaticapps.net/getting-started/` URL.

Seeing as we couldn't configure the webapp to change its behaviour, instead we use Application Gateway to rewrite the response's Location header.  We look for Location headers of the form `https://witty-bay-020052c03.4.azurestaticapps.net/*` and rewrite them to be `https://pp-api.education.gov.uk/statistics-dev/docs/*` instead.