### PR TITLE
EES-5720 fix chart decimal places bug

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
@@ -278,7 +278,9 @@ const ChartAxisConfiguration = ({
       min: Yup.number(),
       visible: Yup.boolean(),
       unit: Yup.string(),
-      decimalPlaces: Yup.string(),
+      decimalPlaces: Yup.number().positive(
+        'Displayed decimal places must be positive',
+      ),
       labelText: Yup.string(),
       labelWidth: Yup.number().positive('Label width must be positive'),
     });
@@ -601,12 +603,14 @@ const ChartAxisConfiguration = ({
                             hint="Leave blank to set default from metadata"
                             width={10}
                           />
-                          <FormFieldNumberInput<ChartAxisConfigurationFormValues>
-                            label="Displayed decimal places"
-                            name="decimalPlaces"
-                            hint="Leave blank to set default from metadata"
-                            width={10}
-                          />
+                          {type === 'minor' && (
+                            <FormFieldNumberInput<ChartAxisConfigurationFormValues>
+                              label="Displayed decimal places"
+                              name="decimalPlaces"
+                              hint="Leave blank to set default from metadata"
+                              width={10}
+                            />
+                          )}
                         </>
                       }
                     />

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
@@ -434,6 +434,78 @@ describe('ChartAxisConfiguration', () => {
     });
   });
 
+  describe('displayed decimal places', () => {
+    test('shows the displayed decimal places field for the minor axis', async () => {
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-minor"
+            type="minor"
+            axesConfiguration={testAxesConfiguration}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            onChange={noop}
+            onSubmit={noop}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+      expect(
+        screen.getByLabelText('Displayed decimal places'),
+      ).toBeInTheDocument();
+    });
+
+    test('does not show the displayed decimal places field for the major axis', async () => {
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-major"
+            type="major"
+            axesConfiguration={testAxesConfiguration}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            onChange={noop}
+            onSubmit={noop}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+      expect(
+        screen.queryByLabelText('Displayed decimal places'),
+      ).not.toBeInTheDocument();
+    });
+
+    test('shows validation error if invalid decimal places given', async () => {
+      const { user } = render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-minor"
+            type="minor"
+            axesConfiguration={testAxesConfiguration}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            onChange={noop}
+            onSubmit={noop}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+      await user.clear(screen.getByLabelText('Displayed decimal places'));
+      await user.type(screen.getByLabelText('Displayed decimal places'), '-1');
+      await user.click(
+        screen.getByRole('button', { name: 'Save chart options' }),
+      );
+
+      expect(await screen.findByText('There is a problem')).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('link', {
+          name: 'Displayed decimal places must be positive',
+        }),
+      ).toHaveAttribute('href', '#chartBuilder-minor-decimalPlaces');
+    });
+  });
+
   describe('group data by', () => {
     test('submitting succeeds with the group data by option changed', async () => {
       const handleSubmit = jest.fn();

--- a/src/explore-education-statistics-common/src/utils/number/formatPretty.ts
+++ b/src/explore-education-statistics-common/src/utils/number/formatPretty.ts
@@ -70,7 +70,7 @@ function formatNumber(
 
   let formattedNumber: string;
 
-  if (typeof decimalPlaces === 'undefined') {
+  if (typeof decimalPlaces === 'undefined' || Math.sign(decimalPlaces) === -1) {
     const minDecimalPlaces = clamp(
       countDecimalPlaces(value) ?? 0,
       0,


### PR DESCRIPTION
Fixes a bug where charts errored if you tried to set the displayed decimal places to a negative number. Also, set the decimal places field to only show on the minor axis configuration tab, as it's irrelevant on the major axis.