### PR TITLE
EES-5759 handle empty charts

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/CustomTooltip.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/CustomTooltip.tsx
@@ -51,7 +51,7 @@ const CustomTooltip = ({
         {tooltipLabel}
       </p>
 
-      {!!payload.length && (
+      {payload && !!payload.length && (
         <ul className={styles.itemList} data-testid="chartTooltip-items">
           {getPayloadOrder()?.map((item, index) => {
             const dataKey =

--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -111,6 +111,10 @@ const HorizontalBarBlock = ({
   const chartHasNegativeValues =
     (parseNumber(minorDomainTicks.domain?.[0]) ?? 0) < 0;
 
+  if (!chartData.length) {
+    return <p className="govuk-!-margin-top-5">No data to display.</p>;
+  }
+
   return (
     <ChartContainer
       height={height || 300}

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -105,6 +105,10 @@ const LineChartBlock = ({
   const chartHasNegativeValues =
     (parseNumber(minorDomainTicks.domain?.[0]) ?? 0) < 0;
 
+  if (!chartData.length) {
+    return <p className="govuk-!-margin-top-5">No data to display.</p>;
+  }
+
   return (
     <ChartContainer
       height={height || 300}

--- a/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
@@ -163,6 +163,10 @@ const VerticalBarBlock = ({
     resizeTicks(containerWidth);
   }, 300);
 
+  if (!chartData.length) {
+    return <p className="govuk-!-margin-top-5">No data to display.</p>;
+  }
+
   return (
     <ChartContainer
       height={height || 300}

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/HorizontalBarBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/HorizontalBarBlock.test.tsx
@@ -1,6 +1,8 @@
 import {
   testChartConfiguration,
   testChartTableData,
+  testEmptyChartConfiguration,
+  testEmptyChartTableData,
 } from '@common/modules/charts/components/__tests__/__data__/testChartData';
 import { expectTicks } from '@common/modules/charts/components/__tests__/testUtils';
 import HorizontalBarBlock from '@common/modules/charts/components/HorizontalBarBlock';
@@ -63,6 +65,27 @@ describe('HorizontalBarBlock', () => {
         15,
       );
     });
+  });
+
+  test('does not render the chart if there is no chart data', async () => {
+    const emptyFullTable = mapFullTable(testEmptyChartTableData);
+    const emptyChartProps: VerticalBarProps = {
+      ...testEmptyChartConfiguration,
+      legend: testEmptyChartConfiguration.legend as LegendConfiguration,
+      axes: testEmptyChartConfiguration.axes as VerticalBarProps['axes'],
+      meta: emptyFullTable.subjectMeta,
+      data: emptyFullTable.results,
+      dataLabelPosition: 'inside',
+    };
+    const { container } = render(<HorizontalBarBlock {...emptyChartProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No data to display.')).toBeInTheDocument();
+    });
+
+    expect(
+      container.querySelector('.recharts-wrapper'),
+    ).not.toBeInTheDocument();
   });
 
   test('major axis can be hidden', () => {

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/LineChartBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/LineChartBlock.test.tsx
@@ -1,6 +1,8 @@
 import {
   testChartConfiguration,
   testChartTableData,
+  testEmptyChartConfiguration,
+  testEmptyChartTableData,
 } from '@common/modules/charts/components/__tests__/__data__/testChartData';
 import { expectTicks } from '@common/modules/charts/components/__tests__/testUtils';
 import LineChartBlock, {
@@ -62,6 +64,27 @@ describe('LineChartBlock', () => {
       // expect there to be lines for all 3 data sets
       expect(container.querySelectorAll('.recharts-line')).toHaveLength(3);
     });
+  });
+
+  test('does not render the chart if there is no chart data', async () => {
+    const emptyFullTable = mapFullTable(testEmptyChartTableData);
+    const emptyChartProps: LineChartProps = {
+      ...testEmptyChartConfiguration,
+      legend: testEmptyChartConfiguration.legend as LegendConfiguration,
+      axes: testEmptyChartConfiguration.axes as LineChartProps['axes'],
+      meta: emptyFullTable.subjectMeta,
+      data: emptyFullTable.results,
+      dataLabelPosition: 'above',
+    };
+    const { container } = render(<LineChartBlock {...emptyChartProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No data to display.')).toBeInTheDocument();
+    });
+
+    expect(
+      container.querySelector('.recharts-wrapper'),
+    ).not.toBeInTheDocument();
   });
 
   test('major axis can be hidden', () => {

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/VerticalBarBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/VerticalBarBlock.test.tsx
@@ -1,6 +1,8 @@
 import {
   testChartConfiguration,
   testChartTableData,
+  testEmptyChartConfiguration,
+  testEmptyChartTableData,
 } from '@common/modules/charts/components/__tests__/__data__/testChartData';
 import { expectTicks } from '@common/modules/charts/components/__tests__/testUtils';
 import VerticalBarBlock, {
@@ -64,6 +66,27 @@ describe('VerticalBarBlock', () => {
         15,
       );
     });
+  });
+
+  test('does not render the chart if there is no chart data', async () => {
+    const emptyFullTable = mapFullTable(testEmptyChartTableData);
+    const emptyChartProps: VerticalBarProps = {
+      ...testEmptyChartConfiguration,
+      legend: testEmptyChartConfiguration.legend as LegendConfiguration,
+      axes: testEmptyChartConfiguration.axes as VerticalBarProps['axes'],
+      meta: emptyFullTable.subjectMeta,
+      data: emptyFullTable.results,
+      dataLabelPosition: 'outside',
+    };
+    const { container } = render(<VerticalBarBlock {...emptyChartProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No data to display.')).toBeInTheDocument();
+    });
+
+    expect(
+      container.querySelector('.recharts-wrapper'),
+    ).not.toBeInTheDocument();
   });
 
   test('major axis can be hidden', () => {

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testChartData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testChartData.ts
@@ -238,3 +238,113 @@ export const testChartTableData: TableDataResponse = {
     },
   ],
 };
+
+export const testEmptyChartConfiguration: Chart = {
+  legend: {
+    position: 'top',
+    items: [
+      {
+        dataSet: {
+          indicator: 'indicator-1-id',
+          filters: [],
+        },
+        label: 'Indicator 1',
+        colour: '#4763a5',
+      },
+    ],
+  },
+  axes: {
+    major: {
+      type: 'major',
+      groupBy: 'timePeriod',
+      sortAsc: true,
+      referenceLines: [],
+      dataSets: [
+        {
+          indicator: 'indicator-1-id',
+          filters: [],
+          location: {
+            level: 'localAuthority',
+            value: 'la-1',
+          },
+        },
+      ],
+      visible: true,
+      size: 50,
+      showGrid: true,
+      tickConfig: 'default',
+    },
+    minor: {
+      type: 'major',
+      groupBy: 'timePeriod',
+      referenceLines: [],
+      dataSets: [],
+      sortAsc: true,
+      visible: true,
+      size: 50,
+      showGrid: true,
+      min: 0,
+      tickConfig: 'default',
+    },
+  },
+  type: 'line',
+  title: 'Emptychart',
+  alt: 'Some alt text',
+  height: 300,
+  width: 600,
+};
+
+export const testEmptyChartTableData: TableDataResponse = {
+  subjectMeta: {
+    filters: {},
+    footnotes: [],
+    indicators: [
+      {
+        label: 'Indicator 1',
+        unit: '',
+        value: 'indicator-1-id',
+        name: 'indicator-1',
+      },
+    ],
+    locations: {
+      localAuthority: [
+        { id: 'la-1-id', label: 'LA 1', value: 'la-1' },
+        { id: 'la-2-id', label: 'LA 2', value: 'la-2' },
+      ],
+    },
+    boundaryLevels: [
+      {
+        id: 1,
+        label:
+          'Countries December 2017 Ultra Generalised Clipped Boundaries in UK',
+      },
+    ],
+    publicationName: 'Pupil absence in schools in England',
+    subjectName: 'Absence by characteristic',
+    timePeriodRange: [
+      { code: 'AY', label: '2020/21', year: 2020 },
+      { code: 'AY', label: '2021/22', year: 2021 },
+    ],
+    geoJsonAvailable: true,
+  },
+  results: [
+    {
+      filters: [],
+      geographicLevel: 'localAuthority',
+      locationId: 'la-1-id',
+      measures: {
+        'indicator-1-id': '1',
+      },
+      timePeriod: '2020_AY',
+    },
+    {
+      filters: [],
+      geographicLevel: 'localAuthority',
+      locationId: 'la-2-id',
+      measures: {
+        'indicator-1-id': '2',
+      },
+      timePeriod: '2021_AY',
+    },
+  ],
+};


### PR DESCRIPTION
Previously charts with no data would render as an empty white block, which errored on hover. I've changed it to show n message instead: 
![Screenshot 2025-02-13 134413](https://github.com/user-attachments/assets/ecd9e1e7-65d9-46ad-82fa-9a6114e53c9b)

The change to `CustomTooltip`, which was where the original error was, probably isn't necessary as after I added it I changed it so it doesn't try to render empty charts, but I thought I might as well leave it in just in case there are other circumstances in which `payload` can be undefined.