### PR TITLE
EES-5824 handle alt text length error when saving data blocks

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDetailsForm.tsx
@@ -28,12 +28,14 @@ const featuredTableDescriptionMaxLength = 200;
 const formId = 'dataBlockDetailsForm';
 
 interface Props {
+  hasChart?: boolean;
   initialValues?: DataBlockDetailsFormValues;
   onTitleChange?: (title: string) => void;
   onSubmit: (dataBlock: DataBlockDetailsFormValues) => void;
 }
 
 const DataBlockDetailsForm = ({
+  hasChart = false,
   initialValues = {
     heading: '',
     name: '',
@@ -50,7 +52,7 @@ const DataBlockDetailsForm = ({
     isHighlight,
     ...values
   }: FormValues) => {
-    onSubmit({
+    return onSubmit({
       ...values,
       highlightName: isHighlight ? highlightName : '',
       highlightDescription: isHighlight ? highlightDescription : '',
@@ -93,15 +95,20 @@ const DataBlockDetailsForm = ({
 
   return (
     <FormProvider
+      fallbackServerValidationError={
+        hasChart
+          ? 'The form submission is invalid and could not be processed. Please check the Chart configuration for errors.'
+          : undefined
+      }
       initialValues={{
         ...initialValues,
-        isHighlight: !!initialValues?.highlightName ?? false,
+        isHighlight: !!initialValues?.highlightName,
       }}
       validationSchema={validationSchema}
     >
       {({ formState, getValues }) => {
         return (
-          <Form id={formId} onSubmit={handleSubmit}>
+          <Form id={formId} submitId={formId} onSubmit={handleSubmit}>
             <h2>Data block details</h2>
 
             <FormGroup>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -47,7 +47,7 @@ const DataBlockSourceWizardFinalStep = ({
 
   const handleSubmit = useCallback(
     (details: DataBlockDetailsFormValues) => {
-      onSave({
+      return onSave({
         details,
         table,
         tableHeaders,
@@ -87,6 +87,7 @@ const DataBlockSourceWizardFinalStep = ({
       </div>
 
       <DataBlockDetailsForm
+        hasChart={!!dataBlock?.charts?.length}
         initialValues={{
           heading: dataBlock?.heading ?? generateTableTitle(table.subjectMeta),
           highlightName: dataBlock?.highlightName ?? '',


### PR DESCRIPTION
Currently editing data blocks that were created before the alt text character limit was added (https://github.com/dfe-analytical-services/explore-education-statistics/pull/5497) can result in an unhandled error when the original alt text was longer than the new limit.

I've improved this by showing an error and telling users to check the Chart configuration:
![Screenshot 2025-02-13 173030](https://github.com/user-attachments/assets/5cd9311e-9808-499e-8169-4d2ba526f2fb)

As part of this I've removed the loading spinner that would show for at least 500ms after the form was submitted as I couldn't find a way to remove it when the form errors. This hopefully won't cause any problems as we have double-submit protection on forms now and don't seem to have performance issues creating / updating data blocks. If this is a problem we may need to reconsider how to handle this error.
