### PR TITLE
EES-5802 - allowing base url of Public API to be added to Swagger UI document fetch

### DIFF
--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -362,7 +362,7 @@ module apiAppModule 'application/public-api/publicApiApp.bicep' = if (deployCont
     containerAppEnvironmentId: containerAppEnvironmentModule.outputs.containerAppEnvironmentId
     containerAppEnvironmentIpAddress: containerAppEnvironmentModule.outputs.containerAppEnvironmentIpAddress
     contentApiUrl: publicUrls.contentApi
-    publicApiUrl: publicUrls.publicApiAppGateway
+    publicApiUrl: publicUrls.publicApi
     publicSiteUrl: publicUrls.publicSite
     dockerImagesTag: dockerImagesTag
     appInsightsConnectionString: appInsightsModule.outputs.appInsightsConnectionString

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -323,7 +323,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
                 foreach (var description in (app as WebApplication)!.DescribeApiVersions())
                 {
                     options.SwaggerEndpoint(
-                        url: $"/swagger/v{description.GroupName}/openapi.json",
+                        url: $"{_appOptions.Url}/swagger/v{description.GroupName}/openapi.json",
                         name: $"v{description.GroupName}");
                 }
             });


### PR DESCRIPTION
This PR:
- adds the full base URL of the Public API to the Swagger UI configuration, so that openapi.json docs can be fetched correctly.

Prior to this PR, visiting the Swagger UI through FaUAPI would result in failure.

Visiting `https://pp-api.education.gov.uk/statistics-dev/swagger/index.html` would result in:

![image](https://github.com/user-attachments/assets/a1f6fb69-0737-4611-8db3-2f075d05c182)

Swagger UI was not including the full base URL of the Public API (https://pp-api.education.gov.uk/statistics-dev/swagger) in its request to find `openapi-v1.json`).

This PR adds that full URL onto the file request path.