### PR TITLE
EES-5802 - updated Swagger API server URL to allow API requests through FaUAPI correctly on /statistics-dev/ sub-url.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerConfig.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Swagger/SwaggerConfig.cs
@@ -2,6 +2,7 @@ using Asp.Versioning.ApiExplorer;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -9,7 +10,8 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Swagger;
 
 public class SwaggerConfig(
-    IApiVersionDescriptionProvider provider)
+    IApiVersionDescriptionProvider provider,
+    IOptions<AppOptions> appOptions)
     : IConfigureOptions<SwaggerGenOptions>
 {
     public void Configure(SwaggerGenOptions options)
@@ -74,7 +76,7 @@ public class SwaggerConfig(
         options.AddServer(new OpenApiServer
         {
             Description = "API server",
-            Url = "/"
+            Url = appOptions.Value.Url
         });
     }
 


### PR DESCRIPTION
This PR:
- corrects the API server URL that Swagger uses to send the API requests to take into account the sub-url that we have on FaUAPI.

Before we were missing the `statistics-dev` portion of the Public API URL for requests being sent from FaUAPI's hosted URL:

![image](https://github.com/user-attachments/assets/7a2d2943-0c6f-438d-9e04-89403de04441)

This now updates the API server's base URL to use the correct Public API URL.