### PR TITLE
EES-5887 - Fix edit datablock 'duplication'

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -205,7 +205,7 @@ const DataBlockPageTabs = ({
             dataBlockId: dataBlockToSave.id,
           });
 
-          await dataBlocksService.updateDataBlock(
+          return dataBlocksService.updateDataBlock(
             dataBlockToSave.id,
             dataBlockToSave as ReleaseDataBlock,
           );
@@ -226,6 +226,7 @@ const DataBlockPageTabs = ({
 
         return newDataBlock;
       };
+
       const savedDataBlock = await getSavedDataBlock();
 
       if (onDataBlockSave) {


### PR DESCRIPTION
Undo the removal of `return` of the updated datablock, thus preventing a new datablock being created in the same action