### PR TITLE
EES-5848 Remove references to auto-selects and defaults from public API changelog

### DIFF
--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/FilterOptionChangeLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/FilterOptionChangeLabel.tsx
@@ -23,13 +23,6 @@ export default function FilterOptionChangeLabel({
               id changed to: <code>{currentState.id}</code>
             </li>
           )}
-          {previousState.isAutoSelect !== currentState.isAutoSelect && (
-            <li>
-              {currentState.isAutoSelect
-                ? 'changed to be the default option'
-                : 'no longer the default option'}
-            </li>
-          )}
         </ul>
       </>
     );

--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/__tests__/ChangeList.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/__tests__/ChangeList.test.tsx
@@ -89,7 +89,6 @@ describe('ChangeList', () => {
         currentState: {
           id: 'filter-opt-3',
           label: 'Filter option 3 updated',
-          isAutoSelect: true,
         },
       },
     ];
@@ -113,7 +112,6 @@ describe('ChangeList', () => {
     expect(updates[1]).toHaveTextContent('id changed to: filter-opt-2-updated');
 
     expect(updates[2]).toHaveTextContent('Filter option 3 (id: filter-opt-3)');
-    expect(updates[2]).toHaveTextContent('changed to be the default option');
 
     expect(
       screen.queryByRole('heading', { name: 'Deleted filter options' }),

--- a/src/explore-education-statistics-common/src/modules/data-catalogue/components/__tests__/ChangeSection.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/data-catalogue/components/__tests__/ChangeSection.test.tsx
@@ -159,7 +159,6 @@ describe('ChangeSection', () => {
               currentState: {
                 id: 'filter-opt-4',
                 label: 'Filter option 4 updated',
-                isAutoSelect: true,
               },
             },
             { currentState: { id: 'filter-opt-5', label: 'Filter option 5' } },
@@ -180,7 +179,6 @@ describe('ChangeSection', () => {
               currentState: {
                 id: 'filter-opt-8',
                 label: 'Filter option 8',
-                isAutoSelect: false,
               },
             },
             { currentState: { id: 'filter-opt-9', label: 'Filter option 9' } },
@@ -235,12 +233,9 @@ describe('ChangeSection', () => {
       updatedFilter1Options[1],
     ).getAllByRole('listitem');
 
-    expect(updatedFilter1Option2Changes).toHaveLength(2);
+    expect(updatedFilter1Option2Changes).toHaveLength(1);
     expect(updatedFilter1Option2Changes[0]).toHaveTextContent(
       'label changed to: Filter option 4 updated',
-    );
-    expect(updatedFilter1Option2Changes[1]).toHaveTextContent(
-      'changed to be the default option',
     );
 
     const addedFilter1Options = within(
@@ -275,12 +270,9 @@ describe('ChangeSection', () => {
 
     const updatedFilter2Option1Changes = within(
       updatedFilter2Options[0],
-    ).getAllByRole('listitem');
+    ).queryAllByRole('listitem');
 
-    expect(updatedFilter2Option1Changes).toHaveLength(1);
-    expect(updatedFilter2Options[0]).toHaveTextContent(
-      'no longer the default option',
-    );
+    expect(updatedFilter2Option1Changes).toHaveLength(0);
 
     const addedFilter2Options = within(
       screen.getByTestId('added-filterOptions-filter-2'),

--- a/src/explore-education-statistics-common/src/services/types/apiDataSetMeta.ts
+++ b/src/explore-education-statistics-common/src/services/types/apiDataSetMeta.ts
@@ -10,7 +10,6 @@ export interface Filter {
 export interface FilterOption {
   id: string;
   label: string;
-  isAutoSelect?: boolean;
 }
 
 export interface GeographicLevel {

--- a/tests/robot-tests/tests/public_api/public_api_minor_manual_changes.robot
+++ b/tests/robot-tests/tests/public_api/public_api_minor_manual_changes.robot
@@ -85,9 +85,9 @@ Create a second draft release
     user navigates to publication page from dashboard    ${PUBLICATION_NAME}
     user creates release from publication page    ${PUBLICATION_NAME}    Academic year    3010
 
-# In this new subject, the "School type" filter option "Total" is being updated to "State-funded primary and secondary",
-# and is no longer marked as an aggregate option. The location option "Yorkshire and the Humber" is being renamed to
-# "Yorkshire".
+# In this new subject:
+# - the "School type" filter option "Total" is being updated to "State-funded primary and secondary"
+# - the location option "Yorkshire and the Humber" is being renamed to "Yorkshire".
 
 Upload subject to second release
     user uploads subject and waits until complete    ${SUBJECT_2_NAME}    absence_school_minor_manual.csv
@@ -345,7 +345,6 @@ User verifies minor changes in the 'API data set changelog' section
     ${updated_school_types_total}=    user checks changed facet contains option    ${school_types_filter}    Total
     user checks element contains    ${updated_school_types_total}
     ...    label changed to: State-funded primary and secondary
-    user checks element contains    ${updated_school_types_total}    no longer an aggregate
 
     ${updated_regional_options}=    user checks changelog section contains updated location level
     ...    ${minor_changes_section}    Regional


### PR DESCRIPTION
This PR removes any references to auto-selects and defaults from the public API changelog.