### PR TITLE
EES-5874 Create a searchable version of a release including associated metadata

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/ContentSectionViewModelBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/ContentSectionViewModelBuilder.cs
@@ -1,0 +1,30 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Builders;
+
+public class ContentSectionViewModelBuilder
+{
+    private string _heading = "content section heading";
+    private readonly List<IContentBlockViewModel> _contentBlocks = new();
+    public ContentSectionViewModel Build() => new()
+    {
+        Heading = _heading,
+        Content = _contentBlocks    
+    };
+
+    public ContentSectionViewModelBuilder WithHeading(string heading)
+    {
+        _heading = heading;
+        return this;
+    }
+    
+    public ContentSectionViewModelBuilder AddHtmlContent(string htmlContent)
+    {
+        _contentBlocks.Add(new HtmlBlockViewModel { Body = htmlContent });
+        return this;
+    }
+    
+    public static implicit operator ContentSectionViewModel(ContentSectionViewModelBuilder builder) => builder.Build();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/ThemeViewModelBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/ThemeViewModelBuilder.cs
@@ -1,0 +1,19 @@
+﻿#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Builders;
+
+public class ThemeViewModelBuilder
+{
+    private string? _title;
+    public ThemeViewModel Build() => new(Guid.NewGuid(), "theme slug", _title ?? "theme title", "theme summary");
+
+    public ThemeViewModelBuilder WithTitle(string title)
+    {
+        _title = title;
+        return this;
+    }
+    
+    public static implicit operator ThemeViewModel(ThemeViewModelBuilder builder) => builder.Build();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerTests.cs
@@ -1,16 +1,21 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
+using GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Builders;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.ViewModels.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
@@ -76,6 +81,113 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         }
 
         [Fact]
+        public async Task GetLatestReleaseAsSearchable()
+        {
+            // ARRANGE
+            var publicationId = Guid.NewGuid();
+            var releaseId = Guid.NewGuid();
+            var publishedTimestamp = new DateTime(2025, 02, 19, 11, 41, 00, DateTimeKind.Utc);
+            var releaseType = ReleaseType.OfficialStatistics;
+
+            var publicationCacheViewModel = new PublicationCacheViewModel
+            {
+                Id = publicationId,
+                Title = "Publication Title",
+                Theme = new ThemeViewModelBuilder().WithTitle("the theme"),
+                Slug = "publication-slug",
+                
+            };
+            var releaseCacheViewModel = new ReleaseCacheViewModel(releaseId)
+            {
+                Published = publishedTimestamp,
+                Title = "Release Title",
+                SummarySection = new ContentSectionViewModelBuilder().AddHtmlContent("<p>This is the release summary</p>"),
+                Type = releaseType,
+                Slug = "release-slug",
+                Content = 
+                [
+                    new ContentSectionViewModelBuilder().WithHeading("section one").AddHtmlContent("<p>content section body one</p>"),
+                    new ContentSectionViewModelBuilder().WithHeading("section two").AddHtmlContent("<p>content section body two</p>"),
+                    new ContentSectionViewModelBuilder().WithHeading("section three").AddHtmlContent("<p>content section body three</p>"),
+                ],
+                HeadlinesSection = new ContentSectionViewModelBuilder().AddHtmlContent("<p>here is the headline content</p>")
+            };
+
+            var methodologyCacheService = new Mock<IMethodologyCacheService>(MockBehavior.Strict);
+            var publicationCacheService = new Mock<IPublicationCacheService>(MockBehavior.Strict);
+            var releaseCacheService = new Mock<IReleaseCacheService>(MockBehavior.Strict);
+
+            publicationCacheService.Setup(mock => mock.GetPublication(PublicationSlug))
+                .ReturnsAsync(publicationCacheViewModel);
+
+            releaseCacheService.Setup(mock => mock.GetRelease(PublicationSlug, null))
+                .ReturnsAsync(releaseCacheViewModel);
+
+            var controller = BuildReleaseController(
+                methodologyCacheService: methodologyCacheService.Object,
+                publicationCacheService: publicationCacheService.Object,
+                releaseCacheService: releaseCacheService.Object);
+
+            // ACT
+            var result = await controller.GetLatestReleaseAsSearchableDocument(PublicationSlug);
+
+            // ASSERT
+            MockUtils.VerifyAllMocks(methodologyCacheService,
+                publicationCacheService,
+                releaseCacheService);
+
+            var expectedHtmlContent = """
+                                      <html>
+                                         <head>
+                                             <title>Publication Title</title>
+                                         </head>
+                                          <body>
+                                              <h1>Publication Title</h1>
+                                              <h2>Release Title</h2>
+                                              <h3>Summary</h3>
+                                              <p>This is the release summary</p>
+                                              <h3>Headlines</h3>
+                                              <p>here is the headline content</p>
+                                              <h3>section one</h3>
+                                              <p>content section body one</p>
+                                              <h3>section two</h3>
+                                              <p>content section body two</p>
+                                              <h3>section three</h3>
+                                              <p>content section body three</p>
+                                          </body>
+                                      </html>
+                                      """;
+
+            var actual = result.Value;
+            Assert.NotNull(actual);
+            
+            AssertAll(
+                [
+                    () => Assert.Equal(releaseId, actual.ReleaseId), 
+                    () => Assert.Equal(publishedTimestamp, actual.Published), 
+                    () => Assert.Equal("Publication Title", actual.PublicationTitle), 
+                    () => Assert.Equal("This is the release summary", actual.Summary), 
+                    () => Assert.Equal("the theme", actual.Theme), 
+                    () => Assert.Equal(releaseType.ToDisplayString(), actual.Type), 
+                    () => Assert.Equal(releaseType.ToTypeBoost(), actual.TypeBoost), 
+                    () => Assert.Equal("publication-slug", actual.PublicationSlug), 
+                    () => Assert.Equal("release-slug", actual.ReleaseSlug), 
+                ],
+                GetAssertTrimmedLinesEqual(expectedHtmlContent, actual.HtmlContent));
+        }
+
+        private IEnumerable<Action> GetAssertTrimmedLinesEqual(string expectedLines, string actualLines)
+        {
+            // Trim each line then assert they are the same
+            var expectedList = expectedLines.ToLines().Select(line => line.Trim()).ToList();
+            var actualList = actualLines.ToLines().Select(line => line.Trim()).ToList();
+            Assert.Equal(expectedList.Count, actualList.Count);
+            return expectedList
+                .Zip(actualList, (e, a) => (Expected:e, Actual:a))
+                .Select(x => (Action)(() => Assert.Equal(x.Expected, x.Actual)));
+        }
+
+        [Fact]
         public async Task GetLatestRelease_PublicationNotFound()
         {
             var publicationCacheService = new Mock<IPublicationCacheService>(MockBehavior.Strict);
@@ -86,6 +198,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
             var controller = BuildReleaseController(publicationCacheService: publicationCacheService.Object);
 
             var result = await controller.GetLatestRelease(PublicationSlug);
+
+            MockUtils.VerifyAllMocks(publicationCacheService);
+
+            result.AssertNotFoundResult();
+        }
+        
+        [Fact]
+        public async Task GetLatestReleaseAsSearchable_PublicationNotFound()
+        {
+            var publicationCacheService = new Mock<IPublicationCacheService>(MockBehavior.Strict);
+
+            publicationCacheService.Setup(mock => mock.GetPublication(PublicationSlug))
+                .ReturnsAsync(new NotFoundResult());
+
+            var controller = BuildReleaseController(publicationCacheService: publicationCacheService.Object);
+
+            var result = await controller.GetLatestReleaseAsSearchableDocument(PublicationSlug);
 
             MockUtils.VerifyAllMocks(publicationCacheService);
 
@@ -380,5 +509,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
                 releaseService ?? Mock.Of<IReleaseService>(MockBehavior.Strict)
             );
         }
+        
+        private void AssertAll(params IEnumerable<Action>[] assertions) => Assert.All(assertions.SelectMany(a => a), assertion => assertion());
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/Extensions/ReleaseTypeExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/Extensions/ReleaseTypeExtensions.cs
@@ -1,0 +1,28 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels.Extensions;
+
+public static class ReleaseTypeExtensions
+{
+    public static string ToDisplayString(this ReleaseType releaseType) => releaseType switch
+    {
+        ReleaseType.AdHocStatistics => "Ad Hoc Statistics",
+        ReleaseType.AccreditedOfficialStatistics => "Accredited Official Statistics",
+        ReleaseType.ExperimentalStatistics => "Experimental Statistics",
+        ReleaseType.ManagementInformation => "Management Information",
+        ReleaseType.OfficialStatistics => "Official Statistics",
+        ReleaseType.OfficialStatisticsInDevelopment => "Official Statistics In Development",
+        _ => throw new ArgumentOutOfRangeException(nameof(releaseType), releaseType, null)
+    };
+
+    public static int ToTypeBoost(this ReleaseType releaseType) => releaseType switch
+    {
+        ReleaseType.AccreditedOfficialStatistics => 6,
+        ReleaseType.OfficialStatistics => 5,
+        ReleaseType.OfficialStatisticsInDevelopment => 4,
+        ReleaseType.ExperimentalStatistics => 3,
+        ReleaseType.AdHocStatistics => 2,
+        ReleaseType.ManagementInformation => 1,
+        _ => throw new ArgumentOutOfRangeException()
+    };
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/Extensions/StringExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System.Text.RegularExpressions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels.Extensions;
+
+public static partial class StringExtensions
+{
+    [GeneratedRegex("<.*?>")]
+    private static partial Regex MatchHtmlTags();
+    
+    [GeneratedRegex(@"(\r\n|\r|\n)")]
+    private static partial Regex MatchNewLineRepresentations();
+    
+    /// <summary>
+    /// A very unsophisticated method that removes anything that looks like an html tag from the string  
+    /// </summary>
+    /// <param name="text">html string</param>
+    /// <returns>plain text string</returns>
+    public static string StripHtml(this string text) => MatchHtmlTags().Replace(text, string.Empty);
+    
+    /// <summary>
+    /// Normalise all occurrences of new line to the Unix standard representation
+    /// </summary>
+    public static string UseUnixNewLine(this string value) => value.UseSpecificNewLine("\n");
+    
+    /// <summary>
+    /// Normalise all occurrences of new line to the Windows standard representation
+    /// </summary>
+    public static string UseWindowsNewLine(this string value) => value.UseSpecificNewLine("\r\n");
+
+    /// <summary>
+    /// Normalise all occurrences of new line to the current environment standard representation
+    /// </summary>
+    public static string UseEnvironmentNewLine(this string value) => value.UseSpecificNewLine(Environment.NewLine);
+    
+    /// <summary>
+    /// Normalise all occurrences of new line to the specified format
+    /// </summary>
+    private static string UseSpecificNewLine(this string value, string specificNewline) => MatchNewLineRepresentations().Replace(value, specificNewline);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseSearchViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseSearchViewModel.cs
@@ -1,0 +1,102 @@
+﻿using System.Text;
+using GovUk.Education.ExploreEducationStatistics.Content.ViewModels.Extensions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+
+public record ReleaseSearchViewModel
+{
+    public Guid ReleaseId { get; init; }
+    public DateTimeOffset Published { get; init; }
+    public string PublicationTitle { get; init; }
+    public string Summary { get; init; }
+    public string Theme { get; init; }
+    public string Type { get; init; }
+
+    public int TypeBoost { get; init; }
+
+    public string PublicationSlug { get; init; }
+    public string ReleaseSlug { get; init; }
+
+    public string HtmlContent { get; init; }
+
+    public ReleaseSearchViewModel(
+        ReleaseCacheViewModel release,
+        PublicationCacheViewModel publication)
+    {
+        ReleaseId = release.Id;
+        Published = release.Published ?? throw new ArgumentException("Release must have a published date");
+        PublicationTitle = publication.Title;
+        Summary = ExtractHtmlBlocks(release.SummarySection.Content).StripHtml();
+        Theme = publication.Theme.Title;
+        Type = release.Type.ToDisplayString();
+        TypeBoost = release.Type.ToTypeBoost();
+        PublicationSlug = publication.Slug;
+        ReleaseSlug = release.Slug;
+        HtmlContent = RenderSearchableHtmlContent(publication, release);
+    }
+
+    private string RenderSearchableHtmlContent(
+        PublicationCacheViewModel publication,
+        ReleaseCacheViewModel releaseContent)
+    {
+        var sb = new StringBuilder();
+
+        // HTML Content
+        HtmlHeader(sb, publication.Title);
+        
+        // H1: Publication Title
+        H1(sb, publication.Title);
+        
+        // H2: Release Title
+        H2(sb, releaseContent.Title);
+        
+        // H3: "Summary"
+        AddH3Section(sb, "Summary", releaseContent.SummarySection.Content);
+        
+        // H3: "Headlines"
+        AddH3Section(sb, "Headlines", releaseContent.HeadlinesSection.Content);
+        
+        // Add content blocks
+        foreach (var contentSection in releaseContent.Content)
+        {
+            AddH3Section(sb, contentSection.Heading, contentSection.Content);
+        }
+
+        HtmlFooter(sb);
+        return sb.ToString().UseUnixNewLine(); // Ensure consistency regardless of the runtime platform
+    }
+
+    private void AddH3Section(StringBuilder sb, string sectionTitle, List<IContentBlockViewModel> contentSection)
+    {
+        var htmlBlocks = ExtractHtmlBlocks(contentSection);
+        if (string.IsNullOrEmpty(htmlBlocks)) return;
+            
+        H3(sb, sectionTitle);
+        sb.AppendLine(htmlBlocks);
+    }
+    
+    private void HtmlHeader(StringBuilder sb, string title) => sb.AppendLine(
+        $"""
+         <html>
+             <head>
+                 <title>{title}</title>
+             </head>
+             <body>
+         """);
+    private void H1(StringBuilder sb, string text) => sb.AppendLine($"<h1>{text}</h1>");
+    private void H2(StringBuilder sb, string text) => sb.AppendLine($"<h2>{text}</h2>");
+    private void H3(StringBuilder sb, string text) => sb.AppendLine($"<h3>{text}</h3>");
+    
+    private void HtmlFooter(StringBuilder sb) => sb.AppendLine(  
+        """
+            </body>
+        </html>
+        """);
+    
+    private string ExtractHtmlBlocks(List<IContentBlockViewModel> content) =>
+        string.Join(Environment.NewLine,
+            content
+                .OfType<HtmlBlockViewModel>()
+                .OrderBy(c => c.Order)
+                .Select(c => c.Body));
+}


### PR DESCRIPTION
In order for Azure AI Search to work effectively, we want to have the indexer trawl over a more searchable representation of a release. I have added an end point that provides this representation along with the associated metadata. This will be consumed by an Azure function that will upload the result to Azure storage for the indexer to process.

Note that the html content being created is subject to different new line representations depending on the runtime platform and the compiler. Therefore, I've standardised it to use Unix line endings to ensure a consistent output regardless of where it is being executed.