### PR TITLE
EES-5866 Fix 'View source' links in public API docs

### DIFF
--- a/src/explore-education-statistics-api-docs/config.rb
+++ b/src/explore-education-statistics-api-docs/config.rb
@@ -4,6 +4,7 @@ require 'lib/utils/env'
 require 'lib/api_reference_pages_extension'
 require 'lib/helpers'
 require 'lib/api_reference_helpers'
+require 'lib/govuk_tech_docs/contribution_banner'
 require 'lib/govuk_tech_docs/path_helpers'
 
 # Check for broken links

--- a/src/explore-education-statistics-api-docs/config/tech-docs.yml
+++ b/src/explore-education-statistics-api-docs/config/tech-docs.yml
@@ -29,6 +29,8 @@ collapsible_nav: true
 # Show links to contribute on GitHub
 show_contribution_banner: true
 github_repo: dfe-analytical-services/explore-education-statistics
+github_branch: master
+github_repo_path: src/explore-education-statistics-api-docs
 
 # Enable search
 enable_search: true

--- a/src/explore-education-statistics-api-docs/lib/govuk_tech_docs/contribution_banner.rb
+++ b/src/explore-education-statistics-api-docs/lib/govuk_tech_docs/contribution_banner.rb
@@ -1,0 +1,19 @@
+module GovukTechDocs
+  class SourceUrls
+    def repo_path
+      path = config[:tech_docs][:github_repo_path] || ""
+
+      if path.empty?
+        return ""
+      end
+
+      path.ends_with?("/") ? path : "#{path}/"
+    end
+
+    # Monkey patch to fix incorrect link to source file
+    # as the API docs don't live in the project root.
+    def source_from_file
+      "#{repo_url}/blob/#{repo_branch}/#{repo_path}source/#{current_page.file_descriptor[:relative_path]}"
+    end
+  end
+end

--- a/src/explore-education-statistics-api-docs/lib/govuk_tech_docs/path_helpers.rb
+++ b/src/explore-education-statistics-api-docs/lib/govuk_tech_docs/path_helpers.rb
@@ -1,18 +1,14 @@
-module PatchedPathHelpers
-  # Monkey patch this function as it doesn't correctly generate
-  # paths when using relative links. This means that the TOC
-  # won't open correctly on the current page as the paths are wrong.
-  def get_path_to_resource(config, resource, current_page)
-    if defined? app
-      Middleman::Util::url_for(app, resource, { current_resource: current_page })
-    else
-      super
-    end
-  end
-end
-
 module GovukTechDocs
   module PathHelpers
-    prepend PatchedPathHelpers
+    # Monkey patch this function as it doesn't correctly generate
+    # paths when using relative links. This means that the TOC
+    # won't open correctly on the current page as the paths are wrong.
+    def get_path_to_resource(config, resource, current_page)
+      if defined? app
+        Middleman::Util::url_for(app, resource, { current_resource: current_page })
+      else
+        super
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the 'View source' links at the bottom of each page. To fix this, we needed to monkey path the existing `GovukTechDocs.SourceUrls` class to provide the correct path. The default implementation expects the docs to live at the project root whilst ours are in `src/explore-education-statistics-api-docs`.

## Other changes

- Tidied up monkey patch for `GovukTechDocs.PathHelpers`.