### PR TITLE
EES-5849 Hide importer errors from data files table

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.tsx
@@ -72,8 +72,9 @@ export default function DataFilesTable({
             <td data-testid="Status">
               <ImporterStatus
                 className={styles.fileStatus}
-                releaseVersionId={releaseVersionId}
                 dataFile={dataFile}
+                hideErrors
+                releaseVersionId={releaseVersionId}
                 onStatusChange={onStatusChange}
               />
             </td>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
@@ -84,16 +84,18 @@ export type ImporterStatusChangeHandler = (
 ) => void;
 
 interface ImporterStatusProps {
-  releaseVersionId: string;
-  dataFile: DataFile;
-  onStatusChange?: ImporterStatusChangeHandler;
   className?: string;
+  dataFile: DataFile;
+  hideErrors?: boolean;
+  releaseVersionId: string;
+  onStatusChange?: ImporterStatusChangeHandler;
 }
 const ImporterStatus = ({
-  releaseVersionId,
-  dataFile,
-  onStatusChange,
   className,
+  dataFile,
+  hideErrors,
+  releaseVersionId,
+  onStatusChange,
 }: ImporterStatusProps) => {
   const [currentStatus, setCurrentStatus] = useState<StatusState>({
     status: dataFile.status,
@@ -159,7 +161,7 @@ const ImporterStatus = ({
         />
       )}
 
-      {currentStatus.status === 'FAILED' && (
+      {currentStatus.status === 'FAILED' && !hideErrors && (
         <>
           {currentStatus.errors && currentStatus.errors.length > 0 && (
             <Details

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ImporterStatus.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ImporterStatus.test.tsx
@@ -1,5 +1,5 @@
 import flushPromises from '@common-test/flushPromises';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import ImporterStatus from '@admin/pages/release/data/components/ImporterStatus';
 import _releaseDataFileService, {
   DataFile,
@@ -84,12 +84,11 @@ describe('ImporterStatus', () => {
       releaseDataFileService.getDataFileImportStatus,
     ).toHaveBeenCalledTimes(1);
 
-    await waitFor(() => {
-      expect(screen.getByText('Validating')).toBeInTheDocument();
-      expect(
-        releaseDataFileService.getDataFileImportStatus,
-      ).toHaveBeenCalledTimes(1);
-    });
+    expect(await screen.findByText('Validating')).toBeInTheDocument();
+
+    expect(
+      releaseDataFileService.getDataFileImportStatus,
+    ).toHaveBeenCalledTimes(1);
   });
 
   test('renders with updated status from service at regular intervals', async () => {
@@ -116,14 +115,13 @@ describe('ImporterStatus', () => {
       releaseDataFileService.getDataFileImportStatus,
     ).toHaveBeenCalledTimes(1);
 
-    await waitFor(() => {
-      expect(screen.getByText('Validating')).toBeInTheDocument();
-      expect(screen.getByRole('progressbar')).toHaveAttribute(
-        'aria-valuenow',
-        '10',
-      );
-      expect(screen.getByText('10% complete')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Validating')).toBeInTheDocument();
+    expect(await screen.findByText('10% complete')).toBeInTheDocument();
+
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '10',
+    );
 
     releaseDataFileService.getDataFileImportStatus.mockResolvedValue({
       status: 'STAGE_2',
@@ -138,14 +136,13 @@ describe('ImporterStatus', () => {
       releaseDataFileService.getDataFileImportStatus,
     ).toHaveBeenCalledTimes(2);
 
-    await waitFor(() => {
-      expect(screen.getByText('Importing')).toBeInTheDocument();
-      expect(screen.getByRole('progressbar')).toHaveAttribute(
-        'aria-valuenow',
-        '50',
-      );
-      expect(screen.getByText('50% complete')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Importing')).toBeInTheDocument();
+    expect(await screen.findByText('50% complete')).toBeInTheDocument();
+
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '50',
+    );
 
     releaseDataFileService.getDataFileImportStatus.mockResolvedValue({
       status: 'COMPLETE',
@@ -160,12 +157,10 @@ describe('ImporterStatus', () => {
       releaseDataFileService.getDataFileImportStatus,
     ).toHaveBeenCalledTimes(3);
 
-    await waitFor(() => {
-      expect(screen.getByText('Complete')).toBeInTheDocument();
-      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
-      expect(screen.queryByText('100% complete')).not.toBeInTheDocument();
-    });
+    expect(await screen.findByText('Complete')).toBeInTheDocument();
 
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.queryByText('100% complete')).not.toBeInTheDocument();
     expect(screen.queryByRole('group')).not.toBeInTheDocument();
   });
 
@@ -193,21 +188,19 @@ describe('ImporterStatus', () => {
 
     await flushPromises();
 
-    await waitFor(() => {
-      expect(screen.getByText('Failed')).toBeInTheDocument();
+    expect(await screen.findByText('Failed')).toBeInTheDocument();
 
-      const details = within(screen.getByRole('group'));
+    const details = within(screen.getByRole('group'));
 
-      expect(
-        details.getByRole('button', { name: 'See errors' }),
-      ).toBeInTheDocument();
+    expect(
+      details.getByRole('button', { name: 'See errors' }),
+    ).toBeInTheDocument();
 
-      const errors = details.getAllByRole('listitem', { hidden: true });
+    const errors = details.getAllByRole('listitem', { hidden: true });
 
-      expect(errors).toHaveLength(2);
-      expect(errors[0]).toHaveTextContent('Some error 1');
-      expect(errors[1]).toHaveTextContent('Some error 2');
-    });
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toHaveTextContent('Some error 1');
+    expect(errors[1]).toHaveTextContent('Some error 2');
   });
 
   test('does not render error messages from service when `hideErrors` = true', async () => {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ImporterStatus.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ImporterStatus.test.tsx
@@ -209,4 +209,35 @@ describe('ImporterStatus', () => {
       expect(errors[1]).toHaveTextContent('Some error 2');
     });
   });
+
+  test('does not render error messages from service when `hideErrors` = true', async () => {
+    releaseDataFileService.getDataFileImportStatus.mockResolvedValue({
+      status: 'FAILED',
+      percentageComplete: 0,
+      stagePercentageComplete: 100,
+      totalRows: 100,
+      errors: ['Some error 1', 'Some error 2'],
+    });
+
+    render(
+      <ImporterStatus
+        releaseVersionId="release-1"
+        dataFile={{
+          ...testDataFile,
+          status: 'QUEUED',
+        }}
+        hideErrors
+      />,
+    );
+
+    expect(screen.getByText('Queued')).toBeInTheDocument();
+    expect(screen.queryByRole('group')).not.toBeInTheDocument();
+
+    await flushPromises();
+
+    expect(await screen.findByText('Failed')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'See errors' }),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
This PR hides the errors from the data files table to prevent it rendering in a really squashed way.

![image](https://github.com/user-attachments/assets/ced7281e-c957-4607-9cb9-e8ab3950e6ae)

Note the user can still access the importer errors via the 'View details' button that will show the errors as normal.

![image](https://github.com/user-attachments/assets/252e60a9-d63d-4116-9abe-c9ed8fcba6dd)

## Related changes

- Cleaned up `ImporterStatus` tests to remove inefficient `waitFor` blocks