### PR TITLE
EES-5867 Fix UI test failure in release_status.robot

### DIFF
--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -341,9 +341,9 @@ Validate checklist errors
 
 Navigate to data upload and confirm data replacement
     user clicks link    Data and files
-    user waits until page contains data uploads table
-
+    user waits until page contains element    testid:Data file replacements table
     user clicks link    Replace data
+    user waits until h2 is visible    Data file details
     user waits until page contains    Footnotes: OK
     user waits until page contains    Data blocks: OK
     user waits until button is enabled    Confirm data replacement


### PR DESCRIPTION
This PR fixes a robot test that was failing because it was looking for 'Data uploads table' instead of 'Data file replacements table' 

![image](https://github.com/user-attachments/assets/4de6fb64-bc76-4aad-9cc3-6cc0ef20f839)

