### PR TITLE
EES-5868 Reducing the Release `Label` character limit to 20

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -220,7 +220,7 @@ public abstract class ReleasesControllerIntegrationTests(TestApplicationFactory 
         }
 
         [Fact]
-        public async Task LabelOver50Characters()
+        public async Task LabelOver20Characters()
         {
             Publication publication = DataFixture.DefaultPublication();
 
@@ -231,13 +231,13 @@ public abstract class ReleasesControllerIntegrationTests(TestApplicationFactory 
                 publicationId: publication.Id,
                 year: 2020,
                 timePeriodCoverage: TimeIdentifier.AcademicYear,
-                label: new string('a', 51));
+                label: new string('a', 21));
 
             var validationProblem = response.AssertValidationProblem();
 
             var error = Assert.Single(validationProblem.Errors);
 
-            Assert.Equal($"The field {nameof(ReleaseCreateRequest.Label)} must be a string or array type with a maximum length of '50'.", error.Message);
+            Assert.Equal($"The field {nameof(ReleaseCreateRequest.Label)} must be a string or array type with a maximum length of '20'.", error.Message);
             Assert.Equal(nameof(ReleaseCreateRequest.Label), error.Path);
         }
 
@@ -953,7 +953,7 @@ public abstract class ReleasesControllerIntegrationTests(TestApplicationFactory 
         }
 
         [Fact]
-        public async Task LabelOver50Characters()
+        public async Task LabelOver20Characters()
         {
             Release release = DataFixture.DefaultRelease(publishedVersions: 1)
                 .WithPublication(DataFixture.DefaultPublication());
@@ -963,13 +963,13 @@ public abstract class ReleasesControllerIntegrationTests(TestApplicationFactory 
 
             var response = await UpdateRelease(
                 releaseId: release.Id,
-                label: new string('a', 51));
+                label: new string('a', 21));
 
             var validationProblem = response.AssertValidationProblem();
 
             var error = Assert.Single(validationProblem.Errors);
 
-            Assert.Equal($"The field {nameof(ReleaseUpdateRequest.Label)} must be a string or array type with a maximum length of '50'.", error.Message);
+            Assert.Equal($"The field {nameof(ReleaseUpdateRequest.Label)} must be a string or array type with a maximum length of '20'.", error.Message);
             Assert.Equal(nameof(ReleaseUpdateRequest.Label), error.Path);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250224184121_EES5868_ReduceReleaseLabelLimitTo20Characters.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250224184121_EES5868_ReduceReleaseLabelLimitTo20Characters.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250224184121_EES5868_ReduceReleaseLabelLimitTo20Characters")]
+    partial class EES5868_ReduceReleaseLabelLimitTo20Characters
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250224184121_EES5868_ReduceReleaseLabelLimitTo20Characters.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250224184121_EES5868_ReduceReleaseLabelLimitTo20Characters.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES5868_ReduceReleaseLabelLimitTo20Characters : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Slug",
+                table: "Releases",
+                type: "nvarchar(51)",
+                maxLength: 51,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(81)",
+                oldMaxLength: 81);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Label",
+                table: "Releases",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Slug",
+                table: "Releases",
+                type: "nvarchar(81)",
+                maxLength: 81,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(51)",
+                oldMaxLength: 51);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Label",
+                table: "Releases",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(20)",
+                oldMaxLength: 20,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseRequests.cs
@@ -25,7 +25,7 @@ public record ReleaseCreateRequest
     [Range(1000, 9999)]
     public int Year { get; init; }
 
-    [MaxLength(50)]
+    [MaxLength(20)]
     public string? Label { get; init; }
 
     public Guid? TemplateReleaseId { get; init; }
@@ -33,6 +33,6 @@ public record ReleaseCreateRequest
 
 public record ReleaseUpdateRequest
 {
-    [MaxLength(50)]
+    [MaxLength(20)]
     public string? Label { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -45,10 +45,10 @@ public class Release : ICreatedUpdatedTimestamps<DateTime, DateTime?>
         public void Configure(EntityTypeBuilder<Release> builder)
         {
             builder.Property(m => m.Slug)
-                .HasMaxLength(81);
+                .HasMaxLength(51);
 
             builder.Property(m => m.Label)
-                .HasMaxLength(50);
+                .HasMaxLength(20);
 
             builder.Property(m => m.TimePeriodCoverage)
                 .HasConversion(new EnumToEnumValueConverter<TimeIdentifier>())

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
@@ -87,7 +87,7 @@ export default function ReleaseSummaryForm({
         .oneOf(permittedReleaseTypes),
       templateReleaseId: Yup.string(),
       releaseLabel: Yup.string().max(
-        50,
+        20,
         /* eslint-disable no-template-curly-in-string */
         'Release label must be no longer than ${max} characters',
       ),

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
@@ -489,7 +489,7 @@ describe('ReleaseSummaryForm', () => {
     });
   });
 
-  test('validation error when release label over 50 characters', async () => {
+  test('validation error when release label over 20 characters', async () => {
     metaService.getTimePeriodCoverageGroups.mockResolvedValue(
       testTimeIdentifiers,
     );
@@ -530,7 +530,7 @@ describe('ReleaseSummaryForm', () => {
     const inputReleaseLabel = screen.getByLabelText('Release label');
     await userEvent.type(
       inputReleaseLabel,
-      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', // 51 characters
+      'aaaaaaaaaaaaaaaaaaaaa', // 21 characters
     );
 
     await userEvent.click(screen.getByLabelText(releaseTypes.AdHocStatistics));
@@ -542,7 +542,7 @@ describe('ReleaseSummaryForm', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('Release label must be no longer than 50 characters', {
+        screen.getByText('Release label must be no longer than 20 characters', {
           selector: 'a',
         }),
       ).toBeInTheDocument();


### PR DESCRIPTION
We currently have a release label limit of 50, we’d like to drop it to 20 before anyone adds anything. We can easily up it back up at a later date if needed but wanting to keep tight control as we start.

⚠️Blocked until https://github.com/dfe-analytical-services/explore-education-statistics/pull/5591 is merged⚠️