### PR TITLE
EES-5896 Azure DevOps pipeline for Search infrastructure deployment

### DIFF
--- a/infrastructure/infrastructure-pipeline.yml
+++ b/infrastructure/infrastructure-pipeline.yml
@@ -11,6 +11,7 @@ trigger:
     exclude:
     - README.md
     - infrastructure/templates/public-api/*
+    - infrastructure/templates/search/*
 pr: none
 
 pool:

--- a/infrastructure/templates/search/abbreviations.bicep
+++ b/infrastructure/templates/search/abbreviations.bicep
@@ -1,0 +1,4 @@
+// Originally sourced from https://github.com/Azure-Samples/todo-csharp-sql/blob/main/infra/abbreviations.json.
+@export()
+var abbreviations = {
+}

--- a/infrastructure/templates/search/bicepconfig.json
+++ b/infrastructure/templates/search/bicepconfig.json
@@ -1,0 +1,5 @@
+{
+  "experimentalFeaturesEnabled": {
+    "userDefinedTypes": true
+  }
+}

--- a/infrastructure/templates/search/ci/azure-pipelines.yml
+++ b/infrastructure/templates/search/ci/azure-pipelines.yml
@@ -1,0 +1,83 @@
+trigger: none
+
+parameters:
+  - name: deployAlerts
+    displayName: Do the Azure Monitor alerts need creating or updating?
+    type: string
+    values:
+      - Yes
+      - No
+    default: No
+  - name: deploySearchService
+    displayName: Does the Search Service need creating or updating?
+    type: string
+    values:
+      - Yes
+      - No
+    default: No
+  - name: forceDeployToEnvironment
+    displayName: Set to either dev, test or preprod to force a deploy to that environment from the chosen branch.
+    type: string
+    values:
+      - none
+      - dev
+      - test
+      - preprod
+    default: none
+
+resources:
+  pipelines:
+    - pipeline: MainBuild
+      source: Explore Education Statistics
+      trigger:
+        branches:
+          - dev
+          - test
+          - master
+
+variables:
+  - group: Search Infrastructure - Common
+  - name: forceDeployToEnvironment
+    value: ${{parameters.forceDeployToEnvironment}}
+  - name: isDev
+    value: $[or(eq(variables['forceDeployToEnvironment'], 'dev'), eq(variables['Build.SourceBranch'], 'refs/heads/dev'))]
+  - name: isTest
+    value: $[or(eq(variables['forceDeployToEnvironment'], 'test'), eq(variables['Build.SourceBranch'], 'refs/heads/test'))]
+  - name: isPreProd
+    value: $[or(eq(variables['forceDeployToEnvironment'], 'preprod'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))]
+  - name: isMaster
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
+  - name: vmImageName
+    value: ubuntu-latest
+  - name: deployAlerts
+    value: ${{ iif(eq(parameters.deployAlerts, 'Yes'), true, false) }}
+  - name: deploySearchService
+    value: ${{ iif(eq(parameters.deploySearchService, 'Yes'), true, false) }}
+
+pool:
+  vmImage: $(vmImageName)
+
+stages:
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployDev
+      condition: eq(variables.isDev, true)
+      environment: Dev
+      serviceConnection: $(serviceConnectionDev)
+      bicepParamFile: dev
+
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployTest
+      condition: eq(variables.isTest, true)
+      environment: Test
+      serviceConnection: $(serviceConnectionTest)
+      bicepParamFile: test
+
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployPreProd
+      condition: eq(variables.isPreProd, true)
+      environment: Pre-Prod
+      serviceConnection: $(serviceConnectionPreProd)
+      bicepParamFile: preprod

--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -1,0 +1,46 @@
+parameters:
+  - name: serviceConnection
+    type: string
+  - name: environment
+    type: string
+  - name: bicepParamFile
+    type: string
+
+jobs:
+  - deployment: DeploySearchInfrastructure
+    displayName: Deploy search infrastructure
+    environment: ${{ parameters.environment }}
+    variables:
+      templateDirectory: $(Build.SourcesDirectory)/infrastructure/templates/search
+      templateFile: $(templateDirectory)/main.bicep
+      paramDirectory: $(templateDirectory)/parameters
+      paramFile: $(paramDirectory)/main-${{ parameters.bicepParamFile }}.bicepparam
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - checkout: self
+
+            - task: AzureCLI@2
+              displayName: Install Bicep
+              inputs:
+                azureSubscription: ${{ parameters.serviceConnection }}
+                scriptType: bash
+                scriptLocation: inlineScript
+                inlineScript: az bicep install
+
+            - template: ../tasks/deploy-bicep.yml
+              parameters:
+                displayName: Validate Bicep template
+                action: validate
+                serviceConnection: ${{ parameters.serviceConnection }}
+                parameterFile: $(paramFile)
+                deploySearchService: false
+
+            - template: ../tasks/deploy-bicep.yml
+              parameters:
+                displayName: Deploy Bicep template
+                action: create
+                serviceConnection: ${{ parameters.serviceConnection }}
+                parameterFile: $(paramFile)
+                deploySearchService: $(deploySearchService)

--- a/infrastructure/templates/search/ci/stages/deploy.yml
+++ b/infrastructure/templates/search/ci/stages/deploy.yml
@@ -1,0 +1,46 @@
+parameters:
+  - name: stageName
+    type: string
+  - name: environment
+    type: string
+  - name: serviceConnection
+    type: string
+  - name: bicepParamFile
+    type: string
+    values:
+      - dev
+      - test
+      - preprod
+      - prod
+  - name: condition
+    type: string
+  - name: dependsOn
+    type: object
+    default: []
+  - name: trigger
+    type: string
+    default: automatic
+    values:
+      - automatic
+      - manual
+
+stages:
+  - stage: ${{ parameters.stageName }}
+    displayName: Deploy ${{ parameters.environment }}
+    dependsOn: ${{ parameters.dependsOn }}
+    trigger: ${{ parameters.trigger }}
+    # Prevent this stage from running in parallel with the same deploy stage in other
+    # ongoing runs of this pipeline. Instead, multiple executions of this stage will
+    # be queued and run sequentially in the order that their pipelines were triggered.
+    lockBehavior: sequential
+    condition: ${{ parameters.condition }}
+    variables:
+      - group: Search Infrastructure - ${{ parameters.environment }}
+      - name: infraDeployName
+        value: SearchInfrastructure$(Build.BuildNumber)
+    jobs:
+      - template: ../jobs/deploy-infrastructure.yml
+        parameters:
+          serviceConnection: ${{ parameters.serviceConnection }}
+          environment: ${{ parameters.environment }}
+          bicepParamFile: ${{ parameters.bicepParamFile }}

--- a/infrastructure/templates/search/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/search/ci/tasks/deploy-bicep.yml
@@ -1,0 +1,36 @@
+parameters:
+  - name: action
+    type: string
+    default: create
+    values:
+      - create
+      - validate
+  - name: displayName
+    type: string
+  - name: serviceConnection
+    type: string
+  - name: parameterFile
+    type: string
+  - name: deploySearchService
+    type: string
+
+steps:
+  - task: AzureCLI@2
+    displayName: ${{ parameters.displayName }}
+    inputs:
+      azureSubscription: ${{ parameters.serviceConnection }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -e
+
+        az deployment group ${{ parameters.action }} \
+          --name $(infraDeployName) \
+          --resource-group $(resourceGroupName) \
+          --template-file $(templateFile) \
+          --parameters ${{ parameters.parameterFile }} \
+          --parameters \
+              subscription='$(subscription)' \
+              resourceTags='$(resourceTags)' \
+              deploySearchService=${{ parameters.deploySearchService }}

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -1,0 +1,34 @@
+import { abbreviations } from 'abbreviations.bicep'
+
+@description('Environment : Subscription name e.g. s101d01. Used as a prefix for created resources.')
+param subscription string = ''
+
+@description('Environment : Specifies the location in which the Azure resources should be deployed.')
+param location string = resourceGroup().location
+
+@description('Tagging : Environment name e.g. Development. Used for tagging resources created by this infrastructure pipeline.')
+param environmentName string
+
+@description('Tagging : Used for tagging resources created by this infrastructure pipeline.')
+param resourceTags {
+  CostCentre: string
+  Department: string
+  Solution: string
+  ServiceOwner: string
+  CreatedBy: string
+  DeploymentRepoUrl: string
+}?
+
+@description('Tagging : Date Provisioned. Used for tagging resources created by this infrastructure pipeline.')
+param dateProvisioned string = utcNow('u')
+
+@description('Do Azure Monitor alerts need creating or updating?')
+param deployAlerts bool = false
+
+@description('Does the Search Service need creating or updating?')
+param deploySearchService bool = false
+
+var tagValues = union(resourceTags ?? {}, {
+  Environment: environmentName
+  DateProvisioned: dateProvisioned
+})

--- a/infrastructure/templates/search/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/search/parameters/main-dev.bicepparam
@@ -1,0 +1,4 @@
+using '../main.bicep'
+
+// Environment Params
+param environmentName = 'Development'

--- a/infrastructure/templates/search/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/search/parameters/main-preprod.bicepparam
@@ -1,0 +1,4 @@
+using '../main.bicep'
+
+// Environment Params
+param environmentName = 'Pre-Production'

--- a/infrastructure/templates/search/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/search/parameters/main-prod.bicepparam
@@ -1,0 +1,4 @@
+using '../main.bicep'
+
+// Environment Params
+param environmentName = 'Production'

--- a/infrastructure/templates/search/parameters/main-test.bicepparam
+++ b/infrastructure/templates/search/parameters/main-test.bicepparam
@@ -1,0 +1,4 @@
+using '../main.bicep'
+
+// Environment Params
+param environmentName = 'Test'

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -1,0 +1,7 @@
+@export()
+type ResourceNames = {
+  existingResources: {
+  }
+  search: {
+  }
+}


### PR DESCRIPTION
This PR adds an Azure DevOps pipeline to create and update Azure components defined as Bicep related to implementing site-wide search.

We would like to define the infrastructure for implementing site-wide search as Bicep, but up until now the Public API infrastructure pipeline is the only other pipeline setup to deploy configuration defined as Bicep.

At the moment we have a requirement to "Keep the Public API stable" so the intention here has been to make the least amount of changes to Public API infrastructure config in order to create a pipeline for deploying search components independently of the Public API. 

At a later date a larger renaming/refactoring exercise will probably be needed to organise common resources and variables.