### PR TITLE
Fix Unit Tests on Windows

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Migrations/EES5660_MigrateDraftDataSetVersionFolderNamesTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Migrations/EES5660_MigrateDraftDataSetVersionFolderNamesTests.cs
@@ -51,7 +51,7 @@ public class EES5660_MigrateDraftDataSetVersionFolderNamesTests(TestApplicationF
 
         var versionedFolder = pathResolver.DirectoryPath(dataSetVersion, dataSetVersion.SemVersion());
         Directory.CreateDirectory(versionedFolder);
-        File.Create(Path.Combine(versionedFolder, "test.txt"));
+        File.Create(Path.Combine(versionedFolder, "test.txt")).Dispose();
         
         GetMigration().Apply();
 


### PR DESCRIPTION
These unit tests create an empty file and then attempts to move the folder it is in. Windows does not allow this because the file handle is still open. Linux is happy to do it. Fix is to close the file handle.
