### PR TITLE
EES-5639 Fixing the UPDATE `ReleaseVersion` proxy endpoint on the FE

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandler.cs
@@ -16,7 +16,7 @@ public class UpdateSpecificReleaseAuthorizationHandler(
         UpdateSpecificReleaseRequirement requirement,
         Release release)
     {
-        if (SecurityUtils.HasClaim(context.User, SecurityClaimTypes.UpdateAllPublications))
+        if (SecurityUtils.HasClaim(context.User, SecurityClaimTypes.UpdateAllReleases))
         {
             context.Succeed(requirement);
             return;

--- a/src/explore-education-statistics-admin/src/services/releaseVersionService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseVersionService.ts
@@ -214,7 +214,7 @@ const releaseVersionService = {
     id: string,
     updateRequest: UpdateReleaseVersionRequest,
   ): Promise<ReleaseVersion> {
-    return client.put(`/releaseVersions/${id}`, updateRequest);
+    return client.patch(`/releaseVersions/${id}`, updateRequest);
   },
 
   createReleaseVersionStatus(


### PR DESCRIPTION
This PR fixes a bug whereby we were using the wrong HTTP method for the UPDATE `ReleaseVersion` endpoint on the FE.

It subsequently fixes some failing UI tests.