### PR TITLE
EES-5897 Create new parent_filter meta file column for filter hierarc…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -45,7 +45,7 @@ public class FilterMeta
     public required string ColumnName { get; set; }
 
     [JsonIgnore]
-    public string? GroupCsvColumn { get; set; }
+    public string? ParentFilter { get; set; }
 }
 
 public class IndicatorMeta

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Filter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Filter.cs
@@ -11,6 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public string Label { get; set; } = string.Empty;
         public string Name { get; set; } = string.Empty;
         public string? GroupCsvColumn { get; set; }
+        public string? ParentFilter { get; set; }
         public string? AutoSelectFilterItemLabel { get; set; }
         public Guid? AutoSelectFilterItemId { get; set; }
         public FilterItem? AutoSelectFilterItem { get; set; }
@@ -29,6 +30,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             string label,
             string name,
             string? groupCsvColumn,
+            string? parentFilter,
             string? autoSelectFilterItemLabel,
             Guid subjectId)
         {
@@ -37,6 +39,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             Label = label;
             Name = name;
             GroupCsvColumn = groupCsvColumn;
+            ParentFilter = parentFilter;
             AutoSelectFilterItemLabel = autoSelectFilterItemLabel;
             SubjectId = subjectId;
             FilterGroups = new List<FilterGroup>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20250225164205_EES5897_AddParentFilterColumnToFilterTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20250225164205_EES5897_AddParentFilterColumnToFilterTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
-    partial class StatisticsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250225164205_EES5897_AddParentFilterColumnToFilterTable")]
+    partial class EES5897_AddParentFilterColumnToFilterTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20250225164205_EES5897_AddParentFilterColumnToFilterTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20250225164205_EES5897_AddParentFilterColumnToFilterTable.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class EES5897_AddParentFilterColumnToFilterTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ParentFilter",
+                table: "Filter",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ParentFilter",
+                table: "Filter");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
@@ -348,7 +348,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                             ],
                         },
                     ],
-                    GroupCsvColumn = null,
+                    ParentFilter = null,
                 },
                 new()
                 {
@@ -365,7 +365,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                             ],
                         },
                     ],
-                    GroupCsvColumn = "root_filter",
+                    ParentFilter = "root_filter",
                 },
                 new()
                 {
@@ -385,7 +385,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                             ],
                         },
                     ],
-                    GroupCsvColumn = "child_filter1",
+                    ParentFilter = "child_filter1",
                 }
             };
 
@@ -468,7 +468,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                         Label = f.Label,
                         Hint = f.Hint,
                         ColumnName = f.Name,
-                        GroupCsvColumn = f.GroupCsvColumn,
+                        ParentFilter = f.ParentFilter,
                     }).ToList());
 
                 var hierarchy = Assert.Single(results);
@@ -519,7 +519,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                             ],
                         },
                     ],
-                    GroupCsvColumn = null,
+                    ParentFilter = null,
                 },
                 new()
                 {
@@ -534,7 +534,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                             ],
                         },
                     ],
-                    GroupCsvColumn = "root_filter0",
+                    ParentFilter = "root_filter0",
                 },
                 new()
                 {
@@ -549,7 +549,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                             ],
                         },
                     ],
-                    GroupCsvColumn = null,
+                    ParentFilter = null,
                 },
                 new()
                 {
@@ -564,7 +564,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                             ],
                         },
                     ],
-                    GroupCsvColumn = "root_filter1",
+                    ParentFilter = "root_filter1",
                 },
             };
 
@@ -605,7 +605,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                         Label = f.Label,
                         Hint = f.Hint,
                         ColumnName = f.Name,
-                        GroupCsvColumn = f.GroupCsvColumn,
+                        ParentFilter = f.ParentFilter,
                     }).ToList());
 
                 Assert.Equal(2, results.Count);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Models/MetaDataFileReader.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Models/MetaDataFileReader.cs
@@ -43,6 +43,7 @@ public class MetaDataFileReader
             ColumnType = Enum.Parse<ColumnType>(columnType!),
             Label = ReadMetaColumnValue(MetaColumns.label, rowValues),
             FilterGroupingColumn = ReadMetaColumnValue(MetaColumns.filter_grouping_column, rowValues),
+            ParentFilter = ReadMetaColumnValue(MetaColumns.parent_filter, rowValues),
             FilterHint = ReadMetaColumnValue(MetaColumns.filter_hint, rowValues),
             AutoSelectFilterItemLabel = ReadMetaColumnValue(MetaColumns.filter_default, rowValues),
             IndicatorGrouping = ReadMetaColumnValue(MetaColumns.indicator_grouping, rowValues),
@@ -63,6 +64,7 @@ public class MetaDataFileReader
                     label: filterMetaRow.Label,
                     name: filterMetaRow.ColumnName,
                     groupCsvColumn: filterMetaRow.FilterGroupingColumn,
+                    parentFilter: filterMetaRow.ParentFilter,
                     autoSelectFilterItemLabel: filterMetaRow.AutoSelectFilterItemLabel,
                     // NOTE: AutoSelectFilterItemId is set later, after filter items are created
                     subjectId: subject.Id),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Models/MetaRow.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Models/MetaRow.cs
@@ -9,6 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Models
         public ColumnType ColumnType { get; set; }
         public string Label { get; set; } = string.Empty;
         public string? FilterGroupingColumn { get; set; }
+        public string? ParentFilter { get; set; }
         public string? FilterHint { get; set; }
         public string? AutoSelectFilterItemLabel { get; set; }
         public string? IndicatorGrouping { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -189,7 +189,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     Label = f.Label,
                     Hint = f.Hint,
                     ColumnName = f.Name,
-                    GroupCsvColumn = f.GroupCsvColumn,
+                    ParentFilter = f.ParentFilter,
                 })
                 .ToListAsync();
 
@@ -240,9 +240,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             List<FilterMeta> filters)
         {
             var rootFilters = filters
-                .Where(parentFilter => parentFilter.GroupCsvColumn == null
+                .Where(parentFilter => parentFilter.ParentFilter == null
                                        && filters.Any(childFilter =>
-                                           parentFilter.ColumnName == childFilter.GroupCsvColumn));
+                                           parentFilter.ColumnName == childFilter.ParentFilter));
 
             var hierarchies = new List<DataSetFileFilterHierarchy>();
 
@@ -272,7 +272,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             var parentFilter = rootFilter;
             var parentFilterItemIds = rootFilterItemIds;
             var childFilter = filters
-                .Single(f => f.GroupCsvColumn == parentFilter.ColumnName);
+                .Single(f => f.ParentFilter == parentFilter.ColumnName);
 
             // Loop over each parent/child or tier, starting with the root filter, until no child is found
             while (true)
@@ -317,7 +317,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
                 // check whether we're finished
                 var newChildFilter = filters
-                    .SingleOrDefault(newChildFilter => newChildFilter.GroupCsvColumn == childFilter.ColumnName);
+                    .SingleOrDefault(newChildFilter => newChildFilter.ParentFilter == childFilter.ColumnName);
                 if (newChildFilter == null)
                 {
                     break;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterMetaService.cs
@@ -20,6 +20,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         col_type,
         label,
         filter_grouping_column,
+        parent_filter,
         filter_hint,
         filter_default,
         indicator_grouping,
@@ -33,7 +34,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         private readonly IDatabaseHelper _databaseHelper;
 
         public static readonly string[] RequiredMetaColumns = Enum.GetValues<MetaColumns>()
-            .Where(col => col != MetaColumns.filter_default) // if we make other columns optional, screener would also need updating
+            .Where(col =>
+                col != MetaColumns.parent_filter
+                && col != MetaColumns.filter_default) // if we make other columns optional, screener would also need updating
             .Select(col => col.ToString())
             .ToArray();
 

--- a/tests/test-data/files/small-files/filter-hierarchies/filter_hierarchy1.meta.csv
+++ b/tests/test-data/files/small-files/filter-hierarchies/filter_hierarchy1.meta.csv
@@ -1,4 +1,4 @@
-col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
-ind_one,Indicator,Indicator one,,,,,
-filter_one,Filter,Filter one,,,,,
-filter_two,Filter,Filter two,,,,,filter_one
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column,parent_filter
+ind_one,Indicator,Indicator one,,,,,,
+filter_one,Filter,Filter one,,,,,,
+filter_two,Filter,Filter two,,,,,,filter_one

--- a/tests/test-data/files/small-files/filter-hierarchies/filter_hierarchy2.meta.csv
+++ b/tests/test-data/files/small-files/filter-hierarchies/filter_hierarchy2.meta.csv
@@ -1,5 +1,5 @@
-col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
-ind_one,Indicator,Indicator one,,,,,
-filter_one,Filter,Filter one,,,,,
-filter_two,Filter,Filter two,,,,,filter_one
-filter_three,Filter,Filter three,,,,,filter_two
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column,parent_filter
+ind_one,Indicator,Indicator one,,,,,,
+filter_one,Filter,Filter one,,,,,,
+filter_two,Filter,Filter two,,,,,,filter_one
+filter_three,Filter,Filter three,,,,,,filter_two

--- a/tests/test-data/files/small-files/filter-hierarchies/filter_hierarchy3.meta.csv
+++ b/tests/test-data/files/small-files/filter-hierarchies/filter_hierarchy3.meta.csv
@@ -1,7 +1,7 @@
-col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
-ind_one,Indicator,Indicator one,,,,,
-filter_one,Filter,Filter one,,,,,
-filter_two,Filter,Filter two,,,,,filter_one
-filter_three,Filter,Filter three,,,,,filter_two
-other_filter_one,Filter,Other filter one,,,,,
-other_filter_two,Filter,Other filter two,,,,,other_filter_one
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column,parent_filter
+ind_one,Indicator,Indicator one,,,,,,
+filter_one,Filter,Filter one,,,,,,
+filter_two,Filter,Filter two,,,,,,filter_one
+filter_three,Filter,Filter three,,,,,,filter_two
+other_filter_one,Filter,Other filter one,,,,,,
+other_filter_two,Filter,Other filter two,,,,,,other_filter_one


### PR DESCRIPTION
…hies

This PR creates a separate column to meta file CSVs to indicate whether a particular filter has a parent filter for filter hierarchies (to be used in the table tool).

Previously we used the filter_grouping_column for the dual purpose of both creating filter groups for filter items *and* for indicating the parent filter. The problem is that even if you're using filter_grouping_column to indicate a parent filter, it is still used to group the columns as well.

To avoid any confusion over this, I decided it is probably best to separate them into two separate features - it wasn't simple to preventing the grouping behaviour if the filter_grouping_column was indicating a parent filter.

As far as I'm aware, the previous behaviour didn't break anything - this change is just to avoid confusion.