### PR TITLE
EES-5901 - added temporary support for both "releaseId" AND "releaseV…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/HtmlImageUtilTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/HtmlImageUtilTests.cs
@@ -165,8 +165,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void GetReleaseImages_ContentWithMalformedImage()
         {
             var result = HtmlImageUtil.GetReleaseImages(@"
-    <img src=""/api/releases/{releaseId}/images/not-a-valid-uuid""/>
-    <img src=""/api/releases/{releaseId}/images/8205b65b-9fd4-40b9-9d77-08d8e53df837""/>"
+    <img src=""/api/releases/{releaseVersionId}/images/not-a-valid-uuid""/>
+    <img src=""/api/releases/{releaseVersionId}/images/8205b65b-9fd4-40b9-9d77-08d8e53df837""/>"
             );
 
             Assert.Single(result);
@@ -175,6 +175,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
         [Fact]
         public void GetReleaseImages_ContentWithOtherImages()
+        {
+            var result = HtmlImageUtil.GetReleaseImages(@"
+    <img src=""some-other-image.png""/>
+    <img src=""/images/some-other-image.png""/>
+    <img src=""/images/03c51f5d-f2ef-4ed6-9fa2-0842b94bcebb""/>
+    <img src=""/api/releases/{releaseVersionId}/images/8205b65b-9fd4-40b9-9d77-08d8e53df837""/>"
+            );
+
+            Assert.Single(result);
+            Assert.Equal(Guid.Parse("8205b65b-9fd4-40b9-9d77-08d8e53df837"), result[0]);
+        }
+        
+        // TODO EES-5901 - migrate all content placeholders to be "releaseVersionId" and then remove the legacy
+        // "releaseId" test below.
+        [Fact]
+        public void GetReleaseImages_ContentWithMalformedImage_LegacyPlaceholder()
+        {
+            var result = HtmlImageUtil.GetReleaseImages(@"
+    <img src=""/api/releases/{releaseId}/images/not-a-valid-uuid""/>
+    <img src=""/api/releases/{releaseId}/images/8205b65b-9fd4-40b9-9d77-08d8e53df837""/>"
+            );
+
+            Assert.Single(result);
+            Assert.Equal(Guid.Parse("8205b65b-9fd4-40b9-9d77-08d8e53df837"), result[0]);
+        }
+
+        // TODO EES-5901 - migrate all content placeholders to be "releaseVersionId" and then remove the legacy
+        // "releaseId" test below.
+        [Fact]
+        public void GetReleaseImages_ContentWithOtherImages_LegacyPlaceholder()
         {
             var result = HtmlImageUtil.GetReleaseImages(@"
     <img src=""some-other-image.png""/>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/HtmlImageUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/HtmlImageUtil.cs
@@ -15,9 +15,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return GetImages(htmlContent, idCapturingRegex);
         }
 
+        // TODO EES-5901 - migrate all content placeholders to be "releaseVersionId" and then remove the legacy
+        // "releaseId" checks below.
         public static List<Guid> GetReleaseImages(string htmlContent)
         {
-            var idCapturingRegex = new Regex(@"^/api/releases/{releaseId}/images/(.+)$");
+            var idCapturingRegex = new Regex(@"^/api/releases/{(releaseId|releaseVersionId)}/images/(.+)$");
             return GetImages(htmlContent, idCapturingRegex);
         }
 
@@ -33,7 +35,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .Select(node => node.Attributes["src"].Value)
                 .Select(srcVal => idCapturingRegex.Match(srcVal))
                 .Where(match => match.Success)
-                .Select(match => match.Groups[1].Value)
+                .Select(match => match.Groups[^1].Value)
                 .ToList();
 
             // Convert to Guids, removing any that are malformed

--- a/src/explore-education-statistics-common/src/modules/release/utils/__tests__/releaseImageUrls.test.ts
+++ b/src/explore-education-statistics-common/src/modules/release/utils/__tests__/releaseImageUrls.test.ts
@@ -52,6 +52,57 @@ describe('replaceReleaseIdPlaceholders', () => {
   });
 });
 
+// TODO EES-5901 - migrate all content placeholders to be "releaseVersionId"
+//  and then remove the legacy "releaseId" checks below.
+describe('replaceReleaseIdPlaceholders - legacy "releaseId" placeholder', () => {
+  test('adds release id to single uri', () => {
+    expect(
+      replaceReleaseIdPlaceholders(
+        '/api/releases/{releaseId}/images/some-image-id',
+        'some-release-id',
+      ),
+    ).toBe('/api/releases/some-release-id/images/some-image-id');
+  });
+
+  test('adds release id for multiple uris', () => {
+    expect(
+      replaceReleaseIdPlaceholders(
+        '/api/releases/{releaseId}/images/some-image-id-100 100w, ' +
+          '/api/releases/{releaseId}/images/some-image-id-200 200w, ' +
+          '/api/releases/{releaseId}/images/some-image-id-300 300w',
+        'some-release-id',
+      ),
+    ).toBe(
+      '/api/releases/some-release-id/images/some-image-id-100 100w, ' +
+        '/api/releases/some-release-id/images/some-image-id-200 200w, ' +
+        '/api/releases/some-release-id/images/some-image-id-300 300w',
+    );
+  });
+
+  test('does not add release id when no matching placeholder', () => {
+    expect(
+      replaceReleaseIdPlaceholders(
+        '/api/releases/[releaseId]/images/some-image-id',
+        'some-release-id',
+      ),
+    ).toBe('/api/releases/[releaseId]/images/some-image-id');
+
+    expect(
+      replaceReleaseIdPlaceholders(
+        '/api/releases/not-a-placeholder/images/some-image-id',
+        'some-release-id',
+      ),
+    ).toBe('/api/releases/not-a-placeholder/images/some-image-id');
+
+    expect(
+      replaceReleaseIdPlaceholders(
+        '/api/releases/images/some-image-id',
+        'some-release-id',
+      ),
+    ).toBe('/api/releases/images/some-image-id');
+  });
+});
+
 describe('insertReleaseIdPlaceholders', () => {
   test('adds release id placeholder to single uri', () => {
     expect(

--- a/src/explore-education-statistics-common/src/modules/release/utils/__tests__/releaseImageUrls.test.ts
+++ b/src/explore-education-statistics-common/src/modules/release/utils/__tests__/releaseImageUrls.test.ts
@@ -109,7 +109,7 @@ describe('insertReleaseIdPlaceholders', () => {
       insertReleaseIdPlaceholders(
         '/api/releases/some-release-id/images/some-image-id',
       ),
-    ).toBe('/api/releases/{releaseVersionId}/images/some-image-id');
+    ).toBe('/api/releases/{releaseId}/images/some-image-id');
   });
 
   test('adds release id placeholder for multiple uris', () => {
@@ -120,9 +120,9 @@ describe('insertReleaseIdPlaceholders', () => {
           '/api/releases/some-release-id-3/images/some-image-id-300 300w',
       ),
     ).toBe(
-      '/api/releases/{releaseVersionId}/images/some-image-id-100 100w, ' +
-        '/api/releases/{releaseVersionId}/images/some-image-id-200 200w, ' +
-        '/api/releases/{releaseVersionId}/images/some-image-id-300 300w',
+      '/api/releases/{releaseId}/images/some-image-id-100 100w, ' +
+        '/api/releases/{releaseId}/images/some-image-id-200 200w, ' +
+        '/api/releases/{releaseId}/images/some-image-id-300 300w',
     );
   });
 

--- a/src/explore-education-statistics-common/src/modules/release/utils/releaseImageUrls.ts
+++ b/src/explore-education-statistics-common/src/modules/release/utils/releaseImageUrls.ts
@@ -20,12 +20,15 @@ export const insertReleaseIdPlaceholders = (str: string) =>
  *
  * This allows us to create amendments without having
  * to replace all of the release ids in the content.
+ *
+ * TODO EES-5901 - migrate all content placeholders to be "releaseVersionId"
+ * and then remove the legacy "releaseId" checks below.
  */
 export const replaceReleaseIdPlaceholders = (
   str: string,
   releaseVersionId: string,
 ) =>
   str.replaceAll(
-    '/api/releases/{releaseVersionId}/images',
+    /\/api\/releases\/\{(releaseId|releaseVersionId)}\/images/g,
     `/api/releases/${releaseVersionId}/images`,
   );

--- a/src/explore-education-statistics-common/src/modules/release/utils/releaseImageUrls.ts
+++ b/src/explore-education-statistics-common/src/modules/release/utils/releaseImageUrls.ts
@@ -7,12 +7,14 @@ const releaseImageApiRegex = /\/api\/releases\/[A-Za-z0-9-]+\/images/g;
  * when we render the content. This is important for
  * amendments, as we want to avoid having to replace all
  * of the content's release ids when it's created.
+ *
+ * TODO EES-5901 - migrate all content placeholders to be "releaseVersionId"
+ * and then remove the legacy "releaseId" value below. In the meantime, we
+ * will continue to use the old "{releaseId}" placeholder to minimise the
+ * mixture of placeholders being created.
  */
 export const insertReleaseIdPlaceholders = (str: string) =>
-  str.replaceAll(
-    releaseImageApiRegex,
-    `/api/releases/{releaseVersionId}/images`,
-  );
+  str.replaceAll(releaseImageApiRegex, `/api/releases/{releaseId}/images`);
 
 /**
  * Replace release id placeholders in a {@param str}


### PR DESCRIPTION
This PR:
- hotfixes broken links on Prod, where the code is mismatched between using `{releaseId}` and `{releaseVersionId}` placeholders in image URLs.

For now because we potentially have a mismatch of placeholder values in HTML content on Prod, we're supporting both placeholders until a migration can be carried out.

I have reverted the code to use the old `{releaseId}` placeholder for now to minimise the mixing of the 2 placeholder types.