### PR TITLE
EES-5403 fix map loading on readonly datablocks

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
@@ -67,6 +67,7 @@ const DataBlockPageReadOnlyTabs = ({ releaseVersionId, dataBlock }: Props) => {
             title="Chart"
             key="chart"
             id="dataBlockTabs-chart"
+            lazy
             testId={`${testId(dataBlock)}-chart-tab`}
           >
             {fullTable && (


### PR DESCRIPTION
Previously when you viewed a map on a read only data block (on a published release) it didn't load properly. Now it works.