### PR TITLE
EES-5902 Update migration endpoint to set auto select for group Total…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/AutoSelectFilterItemMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/AutoSelectFilterItemMigrationController.cs
@@ -16,7 +16,6 @@ public class AutoSelectFilterItemMigrationController(StatisticsDbContext statist
 {
     public class MigrationResult
     {
-        public bool IsDryRun;
         public int Processed;
     }
 
@@ -28,11 +27,11 @@ public class AutoSelectFilterItemMigrationController(StatisticsDbContext statist
         var queryable = statisticsDbContext.Filter
             .Where(f =>
                 f.AutoSelectFilterItemId == null
-                && f.FilterGroups.Count(
-                    group => group.FilterItems.Count(
-                        item => item.Label == "Total" // this will be case agnostic (i.e. also find "total")
-                    ) == 1
-                ) == 1) // only one Total filter item across all filter items
+                // one group with label "Total" that contains one item with label "Total"
+                && f.FilterGroups.Count(group => group.Label == "Total"
+                                               && group.FilterItems.Count(item => item.Label == "Total")
+                                               == 1)
+                == 1)
             .Select(f => f.Id);
 
         if (num != null)
@@ -48,7 +47,8 @@ public class AutoSelectFilterItemMigrationController(StatisticsDbContext statist
         {
             var autoSelectFilterItemId = statisticsDbContext.FilterItem
                 .Where(fi => fi.FilterGroup.FilterId == filterId
-                             && fi.Label == "Total")
+                             && fi.Label == "Total"
+                             && fi.FilterGroup.Label == "Total")
                 .Select(fi => fi.Id)
                 .SingleOrDefault();
 


### PR DESCRIPTION
… item Total filters

When the auto select work was initially deployed, we only set an auto select item for a filter if it only had one item labelled "Total". But this was incorrect - we also want to set the auto select item for filters where there are multiple totals, providing one of them belongs to the group "Total".

This change to the migration endpoint allows us to set these filter `AutoSelectFilterItemId`s to restore the previous behaviour from before the new auto select work was deployed.