### PR TITLE
EES-4359 force text wrapping in map tooltips

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.module.scss
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.module.scss
@@ -15,6 +15,10 @@
     color: govuk-colour('black');
     outline: govuk-colour('black') solid $govuk-focus-width;
   }
+
+  :global(.leaflet-tooltip-pane) {
+    overflow-wrap: break-word;
+  }
 }
 
 .mapSpinner {


### PR DESCRIPTION
Forces long words in map tooltips to break instead of overflowing.