### PR TITLE
Ees 5802 add public api support to prod

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -94,9 +94,6 @@
     },
     "maxStatsDbSizeBytes": {
       "value": 2199023255552
-    },
-    "publicDataDbExists": {
-      "value": false
     }
   }
 }

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -94,9 +94,6 @@
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
-    },
-    "publicDataDbExists": {
-      "value": true
     }
   }
 }

--- a/infrastructure/templates/public-api/ci/azure-pipelines.yml
+++ b/infrastructure/templates/public-api/ci/azure-pipelines.yml
@@ -135,12 +135,12 @@ stages:
       environment: Pre-Prod
       serviceConnection: $(serviceConnectionPreProd)
       bicepParamFile: preprod
-#
-#  - template: stages/deploy.yml
-#    parameters:
-#      stageName: DeployProd
-#      condition:  and(succeeded(), eq(variables.isMaster, true))
-#      dependsOn: DeployPreProd
-#      environment: Prod
-#      serviceConnection: $(serviceConnectionProd)
-#      bicepParamFile: prod
+
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployProd
+      condition:  and(succeeded(), eq(variables.isMaster, true))
+      dependsOn: DeployPreProd
+      environment: Prod
+      serviceConnection: $(serviceConnectionProd)
+      bicepParamFile: prod

--- a/infrastructure/templates/public-api/ci/azure-pipelines.yml
+++ b/infrastructure/templates/public-api/ci/azure-pipelines.yml
@@ -65,6 +65,7 @@ parameters:
       - dev
       - test
       - preprod
+      - prod
     default: none
 
 resources:
@@ -87,6 +88,8 @@ variables:
     value: $[or(eq(variables['forceDeployToEnvironment'], 'test'), eq(variables['Build.SourceBranch'], 'refs/heads/test'))]
   - name: isPreProd
     value: $[or(eq(variables['forceDeployToEnvironment'], 'preprod'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))]
+  - name: isProdDirect
+    value: $[eq(variables['forceDeployToEnvironment'], 'prod')]
   - name: isMaster
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   - name: vmImageName
@@ -141,6 +144,14 @@ stages:
       stageName: DeployProd
       condition:  and(succeeded(), eq(variables.isMaster, true))
       dependsOn: DeployPreProd
+      environment: Prod
+      serviceConnection: $(serviceConnectionProd)
+      bicepParamFile: prod
+
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployProdDirect
+      condition:  eq(variables.isProdDirect, true)
       environment: Prod
       serviceConnection: $(serviceConnectionProd)
       bicepParamFile: prod

--- a/infrastructure/templates/public-api/components/postgreSqlFlexibleServer.bicep
+++ b/infrastructure/templates/public-api/components/postgreSqlFlexibleServer.bicep
@@ -110,6 +110,7 @@ resource postgreSQLDatabase 'Microsoft.DBforPostgreSQL/flexibleServers@2023-03-0
   tags: tagValues
 }
 
+@batchSize(1)
 resource settings 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2022-12-01' = [for setting in serverConfig.settings: {
   parent: postgreSQLDatabase
   name: setting.name


### PR DESCRIPTION
This PR:
- enables the Public API in Prod, so that Admin, Publisher and the Public Site become aware of the Public API.
- adds an automated deploy stage to the Public API pipeline to allow an optional deploy stage to Prod following on from a successful deploy to Pre-Prod.  This is protected from automated rollout by manual approvals that have been set up in the Prod DevOps environment.
- adds a manual deploy stage to be able to deploy directly to Prod.  This'll most likely be removed shortly after getting Public API fully deployed and running on Prod.