### PR TITLE
EES-5490 respect numStrings in key stats

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.tsx
@@ -24,7 +24,7 @@ const KeyStatTile = ({
       </TitleElement>
 
       <p className="govuk-heading-xl" data-testid={`${testId}-statistic`}>
-        {formatPretty(value)}
+        {value}
       </p>
 
       {children}

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStat.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStat.test.tsx
@@ -7,7 +7,7 @@ describe('KeyStat', () => {
     render(
       <KeyStat
         title="Number of applications received"
-        statistic="608180"
+        statistic="608,180"
         trend="Down from 620,330 in 2017"
         guidanceTitle="What is the number of applications received?"
         guidanceText="Total number of applications received for places at primary and secondary schools."
@@ -43,7 +43,7 @@ describe('KeyStat', () => {
     render(
       <KeyStat
         title="Number of applications received"
-        statistic="608180"
+        statistic="608,180"
         trend="Down from 620,330 in 2017"
         guidanceTitle={undefined}
         guidanceText="Total number of applications received for places at primary and secondary schools."
@@ -79,7 +79,7 @@ describe('KeyStat', () => {
     render(
       <KeyStat
         title="Number of applications received"
-        statistic="608180"
+        statistic="608,180"
         guidanceTitle="This shouldn't appear"
       />,
     );

--- a/src/explore-education-statistics-common/src/queries/tableBuilderQueries.ts
+++ b/src/explore-education-statistics-common/src/queries/tableBuilderQueries.ts
@@ -44,11 +44,14 @@ const tableBuilderQueries = createQueryKeys('tableBuilder', {
 
         return {
           title: indicator.label,
-          value: formatPretty(
-            indicatorValue,
-            indicator.unit,
-            indicator.decimalPlaces,
-          ),
+          value:
+            indicator.unit === 'string'
+              ? indicatorValue
+              : formatPretty(
+                  indicatorValue,
+                  indicator.unit,
+                  indicator.decimalPlaces,
+                ),
         };
       },
     };


### PR DESCRIPTION
When an indicator has `numberString` as the unit they should always be displayed as a string in Key Stats, with no formatting or rounding.