### PR TITLE
Hotfix: EES-5907 Fix frontend/backend request model mismatch

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
@@ -266,7 +266,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var request = new PermalinkCreateRequest
             {
-                ReleaseId = null,
+                ReleaseVersionId = null,
                 Configuration = new TableBuilderConfiguration
                 {
                     TableHeaders = new TableHeaders()
@@ -582,7 +582,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var request = new PermalinkCreateRequest
             {
-                ReleaseId = releaseVersion.Id,
+                ReleaseVersionId = releaseVersion.Id,
                 Configuration = new TableBuilderConfiguration
                 {
                     TableHeaders = new TableHeaders()

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Requests/PermalinkCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Requests/PermalinkCreateRequest.cs
@@ -8,7 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Requests;
 
 public record PermalinkCreateRequest
 {
-    public Guid? ReleaseId { get; init; }
+    public Guid? ReleaseVersionId { get; init; }
 
     public TableBuilderConfiguration Configuration { get; init; } = new();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -83,7 +83,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
         public async Task<Either<ActionResult, PermalinkViewModel>> CreatePermalink(PermalinkCreateRequest request,
             CancellationToken cancellationToken = default)
         {
-            return await (request.ReleaseId ?? await FindLatestPublishedReleaseVersionId(request.Query.SubjectId))
+            return await (request.ReleaseVersionId ?? await FindLatestPublishedReleaseVersionId(request.Query.SubjectId))
                 .OnSuccess(releaseVersionId =>
                 {
                     return _tableBuilderService.Query(releaseVersionId,


### PR DESCRIPTION
This PR fixes a mismatch in frontend/backend models relating to the `interface CreatePermalink` and `record PermalinkCreateRequest`.

This was preventing uses from creating permalinks in some cases.