### PR TITLE
EES-5917 Add extra link for power bi sdk users

### DIFF
--- a/src/explore-education-statistics-api-docs/source/getting-started/building-api-integrations/index.html.md.erb
+++ b/src/explore-education-statistics-api-docs/source/getting-started/building-api-integrations/index.html.md.erb
@@ -17,3 +17,4 @@ develop support for your chosen language or software, [contact us via email](/su
 ## Available SDKs
 
 - for R users - [eesyapi package](https://github.com/dfe-analytical-services/eesyapi)
+- for PowerBi users - [eesyapi.powerbi](https://github.com/dfe-analytical-services/eesyapi.powerbi)


### PR DESCRIPTION
This adds a link in the API docs to PowerBI sdk
![image](https://github.com/user-attachments/assets/fb75cbf0-d4c1-47b3-ac7f-7f6e87560b67)