### PR TITLE
Ees 5917 api docs sdk page to add link to powerbi sdk repository

### DIFF
--- a/src/explore-education-statistics-api-docs/source/getting-started/building-api-integrations/index.html.md.erb
+++ b/src/explore-education-statistics-api-docs/source/getting-started/building-api-integrations/index.html.md.erb
@@ -17,4 +17,4 @@ develop support for your chosen language or software, [contact us via email](/su
 ## Available SDKs
 
 - for R users - [eesyapi package](https://github.com/dfe-analytical-services/eesyapi)
-- for PowerBi users - [eesyapi.powerbi](https://github.com/dfe-analytical-services/eesyapi.powerbi)
+- for PowerBI users - [eesyapi.powerbi](https://github.com/dfe-analytical-services/eesyapi.powerbi)


### PR DESCRIPTION
This adds a link in the API docs to PowerBI sdk
![image](https://github.com/user-attachments/assets/960d7cd8-8105-4204-ab3d-35599e6d71f8)
