### PR TITLE
EES-5802 - removed the ability to roll out the Public API direct to the Prod environment from DevOps

### DIFF
--- a/infrastructure/templates/public-api/ci/azure-pipelines.yml
+++ b/infrastructure/templates/public-api/ci/azure-pipelines.yml
@@ -65,7 +65,6 @@ parameters:
       - dev
       - test
       - preprod
-      - prod
     default: none
 
 resources:
@@ -88,8 +87,6 @@ variables:
     value: $[or(eq(variables['forceDeployToEnvironment'], 'test'), eq(variables['Build.SourceBranch'], 'refs/heads/test'))]
   - name: isPreProd
     value: $[or(eq(variables['forceDeployToEnvironment'], 'preprod'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))]
-  - name: isProdDirect
-    value: $[eq(variables['forceDeployToEnvironment'], 'prod')]
   - name: isMaster
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   - name: vmImageName
@@ -144,14 +141,6 @@ stages:
       stageName: DeployProd
       condition:  and(succeeded(), eq(variables.isMaster, true))
       dependsOn: DeployPreProd
-      environment: Prod
-      serviceConnection: $(serviceConnectionProd)
-      bicepParamFile: prod
-
-  - template: stages/deploy.yml
-    parameters:
-      stageName: DeployProdDirect
-      condition:  eq(variables.isProdDirect, true)
       environment: Prod
       serviceConnection: $(serviceConnectionProd)
       bicepParamFile: prod


### PR DESCRIPTION
This PR removes the ability to deploy the Public API directly to the Prod environment.

This was previously used to perform manual rollouts of Public API infrastructure prior to integrating it with the rest of the service.