### PR TITLE
EES-5878 small FE tweaks to data set page

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -207,7 +207,7 @@ export default function DataSetFilePage({
           </div>
 
           <div className={styles.subscribeContainer}>
-            <ContentHtml html={summary} />
+            <ContentHtml className="dfe-flex-grow--1" html={summary} />
             {apiDataSet && (
               <SubscribeLink
                 url={`/api-subscriptions/new-subscription/${dataSetFile.id}`}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileDetails.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileDetails.tsx
@@ -36,7 +36,7 @@ export default function DataSetFileDetails({
       heading={pageSections.dataSetDetails}
       id="dataSetDetails"
     >
-      <SummaryList noBorder>
+      <SummaryList>
         <SummaryListItem term="Theme">
           {release.publication.themeTitle}
         </SummaryListItem>


### PR DESCRIPTION
- Makes sure the email button doesn't move depending on the length of the description.
- Adds the divider lines back to the data set details.

![Screenshot 2025-03-06 100403](https://github.com/user-attachments/assets/c87f6222-f63c-48b9-82d4-9a0062015a2f)
