### PR TITLE
EES-5709 Delete core storage 'releases-temp' blobs after a day

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2250,6 +2250,38 @@
           "dependsOn": [
             "[variables('coreStorageAccountName')]"
           ]
+        },
+        {
+          "name": "default",
+          "type": "managementPolicies",
+          "apiVersion": "2019-04-01",
+          "properties": {
+            "policy": {
+              "rules": [
+                {
+                  "enabled": true,
+                  "type": "Lifecycle",
+                  "name": "Delete temp data/meta files after a day",
+                  "definition": {
+                    "actions": {
+                      "baseBlob": {
+                        "delete": {
+                          "daysAfterModificationGreaterThan": 1
+                        }
+                      }
+                    },
+                    "filters": {
+                      "blobTypes": ["blockBlob"],
+                      "prefixMatch": ["releases-temp"]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "dependsOn": [
+            "[variables('coreStorageAccountName')]"
+          ]
         }
       ],
       "tags": {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/BlobContainers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/BlobContainers.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common
     public static class BlobContainers
     {
         public static readonly IBlobContainer PrivateReleaseFiles = new BlobContainer("releases");
-        public static readonly IBlobContainer PrivateReleaseTempFiles = new BlobContainer("releases-temp");
+        public static readonly IBlobContainer PrivateReleaseTempFiles = new BlobContainer("releases-temp"); // if you change this, also update it in the ARM template!
         public static readonly IBlobContainer PublicReleaseFiles = new BlobContainer("downloads");
         public static readonly IBlobContainer PrivateContent = new PrivateBlobContainer("cache");
         public static readonly IBlobContainer PublicContent = new PublicBlobContainer("cache");


### PR DESCRIPTION
This PR changes management policies associated with the core Azure Storage instance so that any blob file in the `releases-temp` container is removed if it is not modified for a day.

This ensures that this does slowly fill up with blob files, which can happen if a user starting importing several data sets via a bulk import but then doesn't complete the process and/or if there is an error (maybe).