### PR TITLE
EES-5899 Add HealthCheck function to Search Function App

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthCheckFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthCheckFunction.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions;
+
+public class HealthCheckFunction
+{
+    [Function(nameof(HealthCheck))]
+    [Produces("application/json")]
+    public IActionResult HealthCheck(
+#pragma warning disable IDE0060
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get")]
+        HttpRequest request)
+#pragma warning restore IDE0060
+    {
+        var healthCheckResponse = new HealthCheckResponse();
+
+        if (healthCheckResponse.Healthy)
+        {
+            return new OkObjectResult(healthCheckResponse);
+        }
+
+        return new ObjectResult(healthCheckResponse) { StatusCode = StatusCodes.Status500InternalServerError };
+    }
+}
+
+public record HealthCheckResponse
+{
+    public bool Healthy => true;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Dtos/HealthCheckResponseDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Dtos/HealthCheckResponseDto.cs
@@ -1,0 +1,6 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks.Dtos;
+
+public record HealthCheckResponseDto
+{
+    public bool Healthy => true;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/HealthCheckFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/HealthCheckFunction.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks.Dtos;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions;
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks;
 
 public class HealthCheckFunction
 {
@@ -14,7 +15,7 @@ public class HealthCheckFunction
         HttpRequest request)
 #pragma warning restore IDE0060
     {
-        var healthCheckResponse = new HealthCheckResponse();
+        var healthCheckResponse = new HealthCheckResponseDto();
 
         if (healthCheckResponse.Healthy)
         {
@@ -23,9 +24,4 @@ public class HealthCheckFunction
 
         return new ObjectResult(healthCheckResponse) { StatusCode = StatusCodes.Status500InternalServerError };
     }
-}
-
-public record HealthCheckResponse
-{
-    public bool Healthy => true;
 }


### PR DESCRIPTION
This PR adds a basic `/api/HealthCheck` function to the Search Function App to be used with the Azure Function infrastructure deployment and for checking the resource health in the Azure Portal.

When healthy it returns HTTP response code 200 OK with content:

```json
{"healthy": true}
```

It currently makes no checks but we could improve on this, for example by checking the Azure Storage account blob container for searchable documents exists.