### PR TITLE
EES-5899 Add infrastructure and deploy Search Docs Function App

### DIFF
--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -257,15 +257,15 @@ jobs:
           command: publish
           publishWebProjects: false
           projects: '**/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj'
-          arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/searchFunctionApp
+          arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/search-function-app
           zipAfterPublish: True
 
       - task: PublishPipelineArtifact@1
         displayName: Publish Search Function App artifact
         condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
         inputs:
-          artifactName: searchFunctionApp
-          targetPath: $(Build.ArtifactStagingDirectory)/searchFunctionApp
+          artifactName: search-function-app
+          targetPath: $(Build.ArtifactStagingDirectory)/search-function-app
 
   - job: Admin
     pool: ees-ubuntu2204-xlarge

--- a/infrastructure/templates/common/abbreviations.bicep
+++ b/infrastructure/templates/common/abbreviations.bicep
@@ -46,6 +46,7 @@ var abbreviations = {
   eventGridEventSubscriptions: 'evgs'
   eventHubNamespaces: 'evhns'
   eventHubNamespacesEventHubs: 'evh'
+  fileShare: 'share'
   hdInsightClustersHadoop: 'hadoop'
   hdInsightClustersHbase: 'hbase'
   hdInsightClustersKafka: 'kafka'

--- a/infrastructure/templates/common/components/functionApp.bicep
+++ b/infrastructure/templates/common/components/functionApp.bicep
@@ -1,0 +1,328 @@
+import { IpRange, FirewallRule } from '../types.bicep'
+import { staticAverageLessThanHundred, staticMinGreaterThanZero } from '../../public-api/components/alerts/staticAlertConfig.bicep'
+import { dynamicAverageGreaterThan } from '../../public-api/components/alerts/dynamicAlertConfig.bicep'
+
+@description('Specifies the location for all resources.')
+param location string
+
+@description('Specifies the Function App name.')
+param functionAppName string
+
+@description('Specifies the App Service plan name.')
+param appServicePlanName string
+
+@description('Function App Plan : operating system')
+param operatingSystem 'Windows' | 'Linux' = 'Linux'
+
+@description('The language worker runtime to load in the function app.')
+@allowed([
+  'dotnet'
+  'dotnet-isolated'
+  'node'
+  'java'
+  'python'
+])
+param functionAppRuntime string = 'dotnet-isolated'
+
+@description('Function app runtime version.')
+param functionAppRuntimeVersion string = '8.0'
+
+@description('Name of the storage account in use by the Function App.')
+param storageAccountName string
+
+@description('Specifies whether the storage account in use by the Function App is accessible from the public internet.')
+param storageAccountPublicNetworkAccessEnabled bool = false
+
+@description('Specifies firewall rules for the storage account in use by the Function App.')
+param storageFirewallRules IpRange[] = []
+
+@description('Name of the deployment container in the storage account.')
+param storageDeploymentContainerName string = 'app-package'
+
+@description('The Application Insights connection string that is associated with this resource.')
+param applicationInsightsConnectionString string
+
+@description('Specifies whether to grant the Function App role-based access to storage account queue data.')
+param deployQueueRoleAssignment bool = false
+
+@description('Set the amount of memory allocated to each instance of the function app in MB.')
+param instanceMemoryMB int = 2048
+
+@description('The maximum number of instances for the function app.')
+param maximumInstanceCount int = 100
+
+@description('Specifies the subnet id for the function app outbound traffic across the VNet.')
+param subnetId string
+
+@description('Specifies the optional subnet id for function app inbound traffic from the VNet.')
+param privateEndpoints {
+  functionApp: string?
+  storageAccounts: string
+}
+
+@description('Specifies whether this Function App is accessible from the public internet.')
+param publicNetworkAccessEnabled bool = false
+
+@description('IP address ranges that are allowed to access the Function App endpoints. Dependent on "publicNetworkAccessEnabled" being true.')
+param functionAppFirewallRules FirewallRule[] = []
+
+@description('An existing Managed Identity\'s Resource Id with which to associate this Function App.')
+param userAssignedManagedIdentityParams {
+  id: string
+  name: string
+  principalId: string
+}?
+
+@description('Specifies the SKU for the Function App hosting plan.')
+param sku object
+
+@description('Specifies the Key Vault name that this Function App will be permitted to get and list secrets from.')
+param keyVaultName string
+
+@description('Specifies whether or not the Function App will always be on and not idle after periods of no traffic - must be compatible with the chosen hosting plan.')
+param alwaysOn bool = false
+
+@description('Whether to create or update Azure Monitor alerts during this deploy.')
+param alerts {
+  cpuPercentage: bool
+  functionAppHealth: bool
+  httpErrors: bool
+  memoryPercentage: bool
+  storageAccountAvailability: bool
+  storageLatency: bool
+  alertsGroupName: string
+}?
+
+@description('A set of tags with which to tag the resource in Azure.')
+param tagValues object
+
+var firewallRules = [
+  for (firewallRule, index) in functionAppFirewallRules: {
+    name: firewallRule.name
+    ipAddress: firewallRule.cidr
+    action: 'Allow'
+    tag: firewallRule.tag != null ? firewallRule.tag : 'Default'
+    priority: firewallRule.priority != null ? firewallRule.priority : 100 + index
+  }
+]
+
+var identity = userAssignedManagedIdentityParams != null
+  ? {
+      type: 'UserAssigned'
+      userAssignedIdentities: {
+        '${userAssignedManagedIdentityParams!.id}': {}
+      }
+    }
+  : {
+      type: 'SystemAssigned'
+    }
+
+var storageAlerts = alerts != null
+  ? {
+      availability: alerts!.storageAccountAvailability
+      latency: alerts!.storageLatency
+      alertsGroupName: alerts!.alertsGroupName
+    }
+  : null
+
+var functionAppLocation = 'North Europe'
+
+module appServicePlanModule '../../public-api/components/appServicePlan.bicep' = {
+  name: '${appServicePlanName}ModuleDeploy'
+  params: {
+    planName: appServicePlanName
+    location: functionAppLocation
+    kind: 'functionapp'
+    sku: sku
+    operatingSystem: operatingSystem
+    alerts: alerts != null ? {
+      cpuPercentage: alerts!.cpuPercentage
+      memoryPercentage: alerts!.memoryPercentage
+      alertsGroupName: alerts!.alertsGroupName
+    } : null
+    tagValues: tagValues
+  }
+}
+
+module storageAccountModule '../../public-api/components/storageAccount.bicep' = {
+  name: 'storageAccountModuleDeploy'
+  params: {
+    location: location
+    storageAccountName: storageAccountName
+    allowedSubnetIds: [subnetId]
+    firewallRules: storageFirewallRules
+    sku: 'Standard_LRS'
+    kind: 'StorageV2'
+    keyVaultName: keyVaultName
+    privateEndpointSubnetIds: {
+      blob: privateEndpoints.storageAccounts
+      queue: privateEndpoints.storageAccounts
+    }
+    publicNetworkAccessEnabled: storageAccountPublicNetworkAccessEnabled
+    alerts: storageAlerts
+    tagValues: tagValues
+  }
+}
+
+module deploymentBlobServiceModule '../../common/components/blobService.bicep' = {
+  name: '${storageAccountName}BlobServiceModuleDeploy'
+  params: {
+    storageAccountName: storageAccountModule.outputs.storageAccountName
+    containerNames: [storageDeploymentContainerName]
+  }
+}
+
+resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
+  name: functionAppName
+  location: functionAppLocation
+  kind: 'functionapp'
+  identity: identity
+  properties: {
+    serverFarmId: appServicePlanModule.outputs.planId
+    virtualNetworkSubnetId: subnetId
+    siteConfig: {
+      alwaysOn: alwaysOn
+      appSettings: [
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: applicationInsightsConnectionString
+        }
+        // Use managed identity to access the storage account rather than key based access with a connection string
+        {
+          name: 'AzureWebJobsStorage__accountName'
+          value: storageAccountModule.outputs.storageAccountName
+        }
+      ]
+      ftpsState: 'FtpsOnly'
+      minTlsVersion: '1.3'
+      netFrameworkVersion: '8.0'
+      publicNetworkAccess: publicNetworkAccessEnabled ? 'Enabled' : 'Disabled'
+      ipSecurityRestrictions: publicNetworkAccessEnabled && length(firewallRules) > 0 ? firewallRules : null
+      ipSecurityRestrictionsDefaultAction: 'Deny'
+      scmIpSecurityRestrictions: [
+        {
+          ipAddress: 'Any'
+          action: 'Allow'
+          priority: 1
+          name: 'Allow all'
+          description: 'Allow all access'
+        }
+      ]
+      scmIpSecurityRestrictionsUseMain: false
+    }
+    functionAppConfig: {
+      deployment: {
+        storage: {
+          authentication: {
+            type: 'SystemAssignedIdentity'
+          }
+          type: 'blobContainer'
+          value: '${storageAccountModule.outputs.primaryEndpoints.blob}${storageDeploymentContainerName}'
+        }
+      }
+      scaleAndConcurrency: {
+        instanceMemoryMB: instanceMemoryMB
+        maximumInstanceCount: maximumInstanceCount
+      }
+      runtime: { 
+        name: functionAppRuntime
+        version: functionAppRuntimeVersion
+      }
+    }
+    httpsOnly: true
+  }
+  tags: tagValues
+}
+
+module storageAccountBlobRoleAssignmentModule 'storageAccountRoleAssignment.bicep' = {
+  name: '${storageAccountName}BlobRoleAssignmentModuleDeploy'
+  params: {
+    principalIds: [functionApp.identity.principalId]
+    storageAccountName: storageAccountModule.outputs.storageAccountName
+    role: 'Storage Blob Data Owner'
+  }
+}
+
+module storageAccountQueueRoleAssignmentModule 'storageAccountRoleAssignment.bicep' = if (deployQueueRoleAssignment) {
+  name: '${storageAccountName}QueueRoleAssignmentModuleDeploy'
+  params: {
+    principalIds: [functionApp.identity.principalId]
+    storageAccountName: storageAccountModule.outputs.storageAccountName
+    role: 'Storage Queue Data Contributor'
+  }
+}
+
+module privateEndpointModule '../../public-api/components/privateEndpoint.bicep' = if (privateEndpoints.?functionApp != null) {
+  name: '${functionAppName}PrivateEndpointModuleDeploy'
+  params: {
+    serviceId: functionApp.id
+    serviceName: functionApp.name
+    serviceType: 'sites'
+    subnetId: privateEndpoints.?functionApp ?? ''
+    location: location
+    tagValues: tagValues
+  }
+}
+
+module healthAlert '../../public-api/components/alerts/staticMetricAlert.bicep' = if (alerts != null && alerts!.functionAppHealth) {
+  name: '${functionAppName}HealthAlertModule'
+  params: {
+    resourceName: functionApp.name
+    resourceMetric: {
+      resourceType: 'Microsoft.Web/sites'
+      metric: 'HealthCheckStatus'
+    }
+    config: {
+      ...staticAverageLessThanHundred
+      nameSuffix: 'health'
+    }
+    alertsGroupName: alerts!.alertsGroupName
+    tagValues: tagValues
+  }
+}
+
+var unexpectedHttpStatusCodeMetrics = ['Http401', 'Http5xx']
+
+module unexpectedHttpStatusCodeAlerts '../../public-api/components/alerts/staticMetricAlert.bicep' = [
+  for httpStatusCode in unexpectedHttpStatusCodeMetrics: if (alerts != null && alerts!.httpErrors) {
+    name: '${functionAppName}${httpStatusCode}Module'
+    params: {
+      resourceName: functionApp.name
+      resourceMetric: {
+        resourceType: 'Microsoft.Web/sites'
+        metric: httpStatusCode
+      }
+      config: {
+        ...staticMinGreaterThanZero
+        nameSuffix: toLower(httpStatusCode)
+      }
+      alertsGroupName: alerts!.alertsGroupName
+      tagValues: tagValues
+    }
+  }
+]
+
+var expectedHttpStatusCodeMetrics = ['Http403', 'Http4xx']
+
+module expectedHttpStatusCodeAlerts '../../public-api/components/alerts/dynamicMetricAlert.bicep' = [
+  for httpStatusCode in expectedHttpStatusCodeMetrics: if (alerts != null && alerts!.httpErrors) {
+    name: '${functionAppName}${httpStatusCode}Module'
+    params: {
+      resourceName: functionApp.name
+      resourceMetric: {
+        resourceType: 'Microsoft.Web/sites'
+        metric: httpStatusCode
+      }
+      config: {
+        ...dynamicAverageGreaterThan
+        nameSuffix: toLower(httpStatusCode)
+        severity: 'Informational'
+      }
+      alertsGroupName: alerts!.alertsGroupName
+      tagValues: tagValues
+    }
+  }
+]
+
+output name string = functionApp.name
+output url string = 'https://${functionApp.name}.azurewebsites.net'

--- a/infrastructure/templates/common/components/functionApp.bicep
+++ b/infrastructure/templates/common/components/functionApp.bicep
@@ -64,6 +64,9 @@ param publicNetworkAccessEnabled bool = false
 @description('IP address ranges that are allowed to access the Function App endpoints. Dependent on "publicNetworkAccessEnabled" being true.')
 param functionAppFirewallRules FirewallRule[] = []
 
+@description('Specifies the list of origins that should be allowed to make cross-origin calls.')
+param allowedOrigins array = []
+
 @description('Specifies an optional URL for Azure to use to monitor the health of this resource')
 param healthCheckPath string?
 
@@ -245,6 +248,10 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
           value: !functionAppExists ? '1' : null
         }
       ]
+      cors: {
+        allowedOrigins: union(['https://portal.azure.com'], allowedOrigins)
+        supportCredentials: false
+      }
       ftpsState: 'FtpsOnly'
       functionAppScaleLimit: maximumInstanceCount
       healthCheckPath: healthCheckPath

--- a/infrastructure/templates/common/components/functionApp.bicep
+++ b/infrastructure/templates/common/components/functionApp.bicep
@@ -64,6 +64,9 @@ param publicNetworkAccessEnabled bool = false
 @description('IP address ranges that are allowed to access the Function App endpoints. Dependent on "publicNetworkAccessEnabled" being true.')
 param functionAppFirewallRules FirewallRule[] = []
 
+@description('Specifies an optional URL for Azure to use to monitor the health of this resource')
+param healthCheckPath string?
+
 @description('An existing Managed Identity\'s Resource Id with which to associate this Function App.')
 param userAssignedManagedIdentityParams {
   id: string
@@ -244,6 +247,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
       ]
       ftpsState: 'FtpsOnly'
       functionAppScaleLimit: maximumInstanceCount
+      healthCheckPath: healthCheckPath
       minTlsVersion: '1.3'
       netFrameworkVersion: functionAppRuntimeVersion
       linuxFxVersion: operatingSystem == 'Linux' ? 'DOTNET-ISOLATED|8.0' : null

--- a/infrastructure/templates/common/components/storageAccountRoleAssignment.bicep
+++ b/infrastructure/templates/common/components/storageAccountRoleAssignment.bicep
@@ -1,0 +1,38 @@
+import { StorageAccountRole } from '../types.bicep'
+
+@description('Specifies the name of the Storage Account.')
+param storageAccountName string
+
+@description('Specifies the ids of the service principals that are being assigned the role')
+param principalIds string[]
+
+// A subset of allowed roles is supported here in accordance with role assignment conditions.
+// See https://docs.microsoft.com/azure/role-based-access-control/built-in-roles for possible
+// roles to support here, in conjunction with the limited set of roles that the deploying service
+// principal is allowed to assign.
+@description('Specifies the role to assign to the service principals')
+param role StorageAccountRole
+
+var rolesToRoleIds = {
+  'Storage Blob Data Contributor': 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+  'Storage Blob Data Owner': 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'
+  'Storage Blob Data Reader': '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
+  'Storage Queue Data Contributor': '974c5e8b-45b9-4653-ba55-5f855dd0fb88'
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
+  name: storageAccountName
+}
+
+// Create the role assignment. Note that this is dependent on the deploying service principal having
+// "Microsoft.Authorization/roleAssignments/write" permissions on the Storage Account via an appropriate
+// role.
+resource keyVaultRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {
+  scope: storageAccount
+  name: guid(storageAccount.id, principalId, rolesToRoleIds[role])
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', rolesToRoleIds[role])
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}]

--- a/infrastructure/templates/common/types.bicep
+++ b/infrastructure/templates/common/types.bicep
@@ -3,3 +3,14 @@ type IpRange = {
   name: string
   cidr: string
 }
+
+@export()
+type FirewallRule = {
+  name: string
+  cidr: string
+  priority: int
+  tag: string
+}
+
+@export()
+type StorageAccountRole = 'Storage Blob Data Contributor' | 'Storage Blob Data Owner' | 'Storage Blob Data Reader' | 'Storage Queue Data Contributor'

--- a/infrastructure/templates/public-api/ci/tasks/wait-for-endpoint-success.yml
+++ b/infrastructure/templates/public-api/ci/tasks/wait-for-endpoint-success.yml
@@ -15,7 +15,7 @@ parameters:
     default: 5
   - name: maxAttempts
     type: number
-    default: 50
+    default: 20
   - name: endpoint
     type: string
   - name: allow404s

--- a/infrastructure/templates/public-api/components/appInsights.bicep
+++ b/infrastructure/templates/public-api/components/appInsights.bicep
@@ -96,3 +96,4 @@ module failedRequestsAlert 'alerts/dynamicMetricAlert.bicep' = if (alerts != nul
 
 output applicationInsightsKey string = applicationInsights.properties.InstrumentationKey
 output applicationInsightsConnectionString string = applicationInsights.properties.ConnectionString
+output applicationInsightsName string = applicationInsights.name

--- a/infrastructure/templates/public-api/components/storageAccount.bicep
+++ b/infrastructure/templates/public-api/components/storageAccount.bicep
@@ -184,4 +184,3 @@ module storeAccessKeyToKeyVault './keyVaultSecret.bicep' = {
 output storageAccountName string = storageAccount.name
 output connectionStringSecretName string = connectionStringSecretName
 output accessKeySecretName string = accessKeySecretName
-output primaryEndpoints object = storageAccount.properties.primaryEndpoints

--- a/infrastructure/templates/public-api/components/storageAccount.bicep
+++ b/infrastructure/templates/public-api/components/storageAccount.bicep
@@ -184,3 +184,4 @@ module storeAccessKeyToKeyVault './keyVaultSecret.bicep' = {
 output storageAccountName string = storageAccount.name
 output connectionStringSecretName string = connectionStringSecretName
 output accessKeySecretName string = accessKeySecretName
+output primaryEndpoints object = storageAccount.properties.primaryEndpoints

--- a/infrastructure/templates/search/application/searchApplicationInsights.bicep
+++ b/infrastructure/templates/search/application/searchApplicationInsights.bicep
@@ -1,0 +1,32 @@
+import { abbreviations } from '../../common/abbreviations.bicep'
+import { ResourceNames } from '../types.bicep'
+
+@description('Resource prefix for all resources.')
+param resourcePrefix string
+
+@description('Specifies common resource naming variables.')
+param resourceNames ResourceNames
+
+@description('Specifies the location for all resources.')
+param location string
+
+@description('Specifies a set of tags with which to tag the resource in Azure.')
+param tagValues object
+
+module applicationInsightsModule '../../public-api/components/appInsights.bicep' = {
+  name: 'applicationInsightsModuleDeploy'
+  params: {
+    location: location
+    appInsightsName: '${resourcePrefix}-${abbreviations.insightsComponents}-search'
+    alerts: {
+      exceptionCount: true
+      exceptionServerCount: true
+      failedRequests: true
+      alertsGroupName: resourceNames.existingResources.alertsGroup
+    }
+    tagValues: tagValues
+  }
+}
+
+output applicationInsightsConnectionString string = applicationInsightsModule.outputs.applicationInsightsConnectionString
+output applicationInsightsName string = applicationInsightsModule.outputs.applicationInsightsName

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -2,8 +2,21 @@ import { abbreviations } from '../../common/abbreviations.bicep'
 import { IpRange, FirewallRule } from '../../common/types.bicep'
 import { ResourceNames } from '../types.bicep'
 
+@description('The URL of the Content API.')
+param contentApiUrl string
+
 @description('The IP address ranges that can access the Search Docs Function App endpoints.')
 param functionAppFirewallRules FirewallRule[]
+
+@description('Name of the Search storage account.')
+param searchStorageAccountName string
+
+@description('The connection string to the Search storage account.')
+@secure()
+param searchStorageAccountConnectionStringSecretName string
+
+@description('Name of the searchable documents container in the storage account.')
+param searchableDocumentsContainerName string
 
 @description('The IP address ranges that can access the Search Docs Function App storage accounts.')
 param storageFirewallRules IpRange[]
@@ -26,6 +39,12 @@ param applicationInsightsConnectionString string = ''
 @description('Specifies whether or not the Search Docs Function App already exists.')
 param functionAppExists bool
 
+@description('The name of the queue that is used when a release version is published.')
+param releaseVersionPublishedQueueName string = 'release-version-published-queue'
+
+@description('The name of the queue that is used when a searchable document is created.')
+param searchableDocumentCreatedQueueName string = 'search-document-created-queue'
+
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
@@ -47,6 +66,20 @@ resource searchDocsFunctionPrivateEndpointSubnet 'Microsoft.Network/virtualNetwo
   parent: vNet
 }
 
+resource searchStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: searchStorageAccountName
+}
+
+resource searchBlobStorage 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' existing = {
+  name: 'default'
+  parent: searchStorageAccount
+}
+
+resource searchableDocumentsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' existing = {
+  parent: searchBlobStorage
+  name: searchableDocumentsContainerName
+}
+
 module functionAppModule '../../common/components/functionApp.bicep' = {
   name: 'functionAppModuleDeploy'
   params: {
@@ -54,6 +87,28 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
     location: location
     applicationInsightsConnectionString: applicationInsightsConnectionString
     appServicePlanName: '${resourcePrefix}-${abbreviations.webServerFarms}-searchdocs'
+    appSettings: [
+      {
+        name: 'App__SearchStorageConnectionString'
+        value: '@Microsoft.KeyVault(VaultName=${keyVault.name};SecretName=${searchStorageAccountConnectionStringSecretName})'
+      }
+      {
+        name: 'App__SearchableDocumentsContainerName'
+        value: searchableDocumentsContainer.name
+      }
+      {
+        name: 'ContentApi__Url'
+        value: contentApiUrl
+      }
+      {
+        name: 'ReleaseVersionPublishedQueueName'
+        value: releaseVersionPublishedQueueName
+      }
+      {
+        name: 'SearchableDocumentCreatedQueueName'
+        value: searchableDocumentCreatedQueueName
+      }
+    ]
     functionAppExists: functionAppExists
     keyVaultName: keyVault.name
     sku: {

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -23,6 +23,9 @@ param location string
 @description('The Application Insights connection string that is associated with this resource.')
 param applicationInsightsConnectionString string = ''
 
+@description('Specifies whether or not the Search Docs Function App already exists.')
+param functionAppExists bool
+
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
@@ -51,10 +54,12 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
     location: location
     applicationInsightsConnectionString: applicationInsightsConnectionString
     appServicePlanName: '${resourcePrefix}-${abbreviations.webServerFarms}-searchdocs'
+    functionAppExists: functionAppExists
     keyVaultName: keyVault.name
     sku: {
-      name: 'FC1'
-      tier: 'FlexConsumption'
+      name: 'EP1'
+      tier: 'ElasticPremium'
+      family: 'EP'
     }
     operatingSystem: 'Linux'
     functionAppRuntime: 'dotnet-isolated'
@@ -76,7 +81,10 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
       httpErrors: true
       memoryPercentage: true
       storageAccountAvailability: true
-      storageLatency: true
+      storageLatency: false
+      fileServiceAvailability: true
+      fileServiceLatency: false
+      fileServiceCapacity: true
       alertsGroupName: resourceNames.existingResources.alertsGroup
     } : null
     tagValues: tagValues

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -1,0 +1,87 @@
+import { abbreviations } from '../../common/abbreviations.bicep'
+import { IpRange, FirewallRule } from '../../common/types.bicep'
+import { ResourceNames } from '../types.bicep'
+
+@description('The IP address ranges that can access the Search Docs Function App endpoints.')
+param functionAppFirewallRules FirewallRule[]
+
+@description('The IP address ranges that can access the Search Docs Function App storage accounts.')
+param storageFirewallRules IpRange[]
+
+@description('Whether to create or update Azure Monitor alerts during this deploy')
+param deployAlerts bool
+
+@description('Specifies common resource naming variables.')
+param resourceNames ResourceNames
+
+@description('Resource prefix for all resources.')
+param resourcePrefix string
+
+@description('Location for all resources.')
+param location string
+
+@description('The Application Insights connection string that is associated with this resource.')
+param applicationInsightsConnectionString string = ''
+
+@description('Specifies a set of tags with which to tag the resource in Azure.')
+param tagValues object
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: resourceNames.existingResources.keyVault
+}
+
+resource vNet 'Microsoft.Network/virtualNetworks@2023-11-01' existing = {
+  name: resourceNames.existingResources.vNet
+}
+
+resource outboundVnetSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
+  name: resourceNames.existingResources.subnets.searchDocsFunction
+  parent: vNet
+}
+
+resource searchDocsFunctionPrivateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
+  name: resourceNames.existingResources.subnets.searchDocsFunctionPrivateEndpoints
+  parent: vNet
+}
+
+module functionAppModule '../../common/components/functionApp.bicep' = {
+  name: 'functionAppModuleDeploy'
+  params: {
+    functionAppName: '${resourcePrefix}-${abbreviations.webSitesFunctions}-searchdocs'
+    location: location
+    applicationInsightsConnectionString: applicationInsightsConnectionString
+    appServicePlanName: '${resourcePrefix}-${abbreviations.webServerFarms}-searchdocs'
+    keyVaultName: keyVault.name
+    sku: {
+      name: 'FC1'
+      tier: 'FlexConsumption'
+    }
+    operatingSystem: 'Linux'
+    functionAppRuntime: 'dotnet-isolated'
+    functionAppRuntimeVersion: '8.0'
+    deployQueueRoleAssignment: true
+    storageAccountName: '${replace(resourcePrefix, '-', '')}${abbreviations.storageStorageAccounts}searchdocsfn'
+    storageAccountPublicNetworkAccessEnabled: false
+    publicNetworkAccessEnabled: true
+    functionAppFirewallRules: functionAppFirewallRules
+    storageFirewallRules: storageFirewallRules
+    privateEndpoints: {
+      functionApp: searchDocsFunctionPrivateEndpointSubnet.id
+      storageAccounts: searchDocsFunctionPrivateEndpointSubnet.id
+    }
+    subnetId: outboundVnetSubnet.id
+    alerts: deployAlerts ? {
+      cpuPercentage: true
+      functionAppHealth: true
+      httpErrors: true
+      memoryPercentage: true
+      storageAccountAvailability: true
+      storageLatency: true
+      alertsGroupName: resourceNames.existingResources.alertsGroup
+    } : null
+    tagValues: tagValues
+  }
+}
+
+output functionAppName string = functionAppModule.outputs.name
+output functionAppUrl string = functionAppModule.outputs.url

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -61,6 +61,7 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
       tier: 'ElasticPremium'
       family: 'EP'
     }
+    healthCheckPath: '/api/HealthCheck'
     operatingSystem: 'Linux'
     functionAppRuntime: 'dotnet-isolated'
     functionAppRuntimeVersion: '8.0'

--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -23,6 +23,10 @@ param storageFirewallRules IpRange[]
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: resourceNames.existingResources.keyVault
+}
+
 resource vNet 'Microsoft.Network/virtualNetworks@2023-11-01' existing = {
   name: resourceNames.existingResources.vNet
 }
@@ -51,7 +55,7 @@ module searchStorageAccountModule '../../public-api/components/storageAccount.bi
     firewallRules: storageFirewallRules
     sku: 'Standard_LRS'
     kind: 'StorageV2'
-    keyVaultName: resourceNames.existingResources.keyVault
+    keyVaultName: keyVault.name
     alerts: deployAlerts ? {
       availability: true
       latency: true

--- a/infrastructure/templates/search/ci/azure-pipelines.yml
+++ b/infrastructure/templates/search/ci/azure-pipelines.yml
@@ -8,13 +8,6 @@ parameters:
       - Yes
       - No
     default: No
-  - name: deploySearchService
-    displayName: Does the Search Service need creating or updating?
-    type: string
-    values:
-      - Yes
-      - No
-    default: No
   - name: forceDeployToEnvironment
     displayName: Set to either dev, test or preprod to force a deploy to that environment from the chosen branch.
     type: string
@@ -51,8 +44,6 @@ variables:
     value: ubuntu-latest
   - name: deployAlerts
     value: ${{ iif(eq(parameters.deployAlerts, 'Yes'), true, false) }}
-  - name: deploySearchService
-    value: ${{ iif(eq(parameters.deploySearchService, 'Yes'), true, false) }}
 
 pool:
   vmImage: $(vmImageName)

--- a/infrastructure/templates/search/ci/azure-pipelines.yml
+++ b/infrastructure/templates/search/ci/azure-pipelines.yml
@@ -22,11 +22,7 @@ resources:
   pipelines:
     - pipeline: MainBuild
       source: Explore Education Statistics
-      trigger:
-        branches:
-          - dev
-          - test
-          - master
+      trigger: none
 
 variables:
   - group: Search Infrastructure - Common

--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -35,7 +35,6 @@ jobs:
                 action: validate
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
-                deploySearchService: false
 
             - template: ../tasks/deploy-bicep.yml
               parameters:
@@ -43,4 +42,3 @@ jobs:
                 action: create
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
-                deploySearchService: $(deploySearchService)

--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -35,6 +35,14 @@ jobs:
                 action: validate
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
+                searchDocsFunctionAppExists: false
+
+            - template: ../../../public-api/ci/tasks/check-function-app-exists.yml
+              parameters:
+                serviceConnection: ${{ parameters.serviceConnection }}
+                resourceGroupName: $(resourceGroupName)
+                functionAppName: $(searchDocsFunctionAppName)
+                variableName: searchDocsFunctionAppExists
 
             - template: ../tasks/deploy-bicep.yml
               parameters:
@@ -42,3 +50,4 @@ jobs:
                 action: create
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
+                searchDocsFunctionAppExists: $(searchDocsFunctionAppExists)

--- a/infrastructure/templates/search/ci/jobs/deploy-search-docs-function-app.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-search-docs-function-app.yml
@@ -23,6 +23,10 @@ jobs:
               displayName: Download Search Docs Function App artifact
               artifact: search-function-app
 
+            - template: ../../../public-api/ci/tasks/bicep-output-variables.yml
+              parameters:
+                serviceConnection: ${{ parameters.serviceConnection }}
+
             - task: AzureCLI@2
               displayName: 'Deploy Search Docs Function App using az cli'
               retryCountOnTaskFailure: 1
@@ -37,3 +41,10 @@ jobs:
                     --resource-group $(resourceGroupName) \
                     --name $(searchDocsFunctionAppName) \
                     --src '$(Pipeline.Workspace)/MainBuild/search-function-app/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.zip'
+
+            - template: ../../../public-api/ci/tasks/wait-for-endpoint-success.yml
+              parameters:
+                serviceConnection: ${{ parameters.serviceConnection }}
+                displayName: Check the Search Docs Function App is healthy after deployment
+                endpoint: $(searchDocsFunctionAppUrl)/api/HealthCheck
+

--- a/infrastructure/templates/search/ci/jobs/deploy-search-docs-function-app.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-search-docs-function-app.yml
@@ -1,0 +1,39 @@
+parameters:
+  - name: serviceConnection
+    type: string
+  - name: environment
+    type: string
+  - name: dependsOn
+    type: object
+    default: []
+
+jobs:
+  - deployment: DeploySearchDocsFunction
+    displayName: Deploy Search Docs Function
+    dependsOn: ${{ parameters.dependsOn }}
+    environment: ${{ parameters.environment }}
+    pool:
+      vmImage: $(vmImageName)
+
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - download: MainBuild
+              displayName: Download Search Docs Function App artifact
+              artifact: search-function-app
+
+            - task: AzureCLI@2
+              displayName: 'Deploy Search Docs Function App using az cli'
+              retryCountOnTaskFailure: 1
+              inputs:
+                azureSubscription: ${{ parameters.serviceConnection }}
+                scriptType: 'bash'
+                scriptLocation: 'inlineScript'
+                inlineScript: |
+                  set -e
+                  echo "Deploying Search Docs Function App using zip deploy"
+                  az functionapp deployment source config-zip \
+                    --resource-group $(resourceGroupName) \
+                    --name $(searchDocsFunctionAppName) \
+                    --src '$(Pipeline.Workspace)/MainBuild/search-function-app/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.zip'

--- a/infrastructure/templates/search/ci/stages/deploy.yml
+++ b/infrastructure/templates/search/ci/stages/deploy.yml
@@ -36,6 +36,8 @@ stages:
     condition: ${{ parameters.condition }}
     variables:
       - group: Search Infrastructure - ${{ parameters.environment }}
+      - name: searchDocsFunctionAppName
+        value: $(subscription)-ees-fa-searchdocs
       - name: infraDeployName
         value: SearchInfrastructure$(Build.BuildNumber)
     jobs:
@@ -44,3 +46,9 @@ stages:
           serviceConnection: ${{ parameters.serviceConnection }}
           environment: ${{ parameters.environment }}
           bicepParamFile: ${{ parameters.bicepParamFile }}
+
+      - template: ../jobs/deploy-search-docs-function-app.yml
+        parameters:
+          serviceConnection: ${{ parameters.serviceConnection }}
+          environment: ${{ parameters.environment }}
+          dependsOn: DeploySearchInfrastructure

--- a/infrastructure/templates/search/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/search/ci/tasks/deploy-bicep.yml
@@ -11,6 +11,9 @@ parameters:
     type: string
   - name: parameterFile
     type: string
+  - name: searchDocsFunctionAppExists
+    type: string
+    default: true
 
 steps:
   - task: AzureCLI@2
@@ -31,4 +34,5 @@ steps:
           --parameters \
               subscription='$(subscription)' \
               resourceTags='$(resourceTags)' \
-              maintenanceIpRanges='$(maintenanceFirewallRules)'
+              maintenanceIpRanges='$(maintenanceFirewallRules)' \
+              searchDocsFunctionAppExists=${{ parameters.searchDocsFunctionAppExists }}

--- a/infrastructure/templates/search/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/search/ci/tasks/deploy-bicep.yml
@@ -11,8 +11,6 @@ parameters:
     type: string
   - name: parameterFile
     type: string
-  - name: deploySearchService
-    type: string
 
 steps:
   - task: AzureCLI@2
@@ -33,5 +31,4 @@ steps:
           --parameters \
               subscription='$(subscription)' \
               resourceTags='$(resourceTags)' \
-              maintenanceIpRanges='$(maintenanceFirewallRules)' \
-              deploySearchService=${{ parameters.deploySearchService }}
+              maintenanceIpRanges='$(maintenanceFirewallRules)'

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -61,6 +61,17 @@ var resourceNames = {
   }
 }
 
+// Create a shared Application Insights resource for Search resources to use.
+module applicationInsightsModule 'application/searchApplicationInsights.bicep' = {
+  name: 'searchApplicationInsightsModule'
+  params: {
+    location: location
+    resourcePrefix: resourcePrefix
+    resourceNames: resourceNames
+    tagValues: tagValues
+  }
+}
+
 module searchDocsFunctionModule 'application/searchDocsFunction.bicep' = {
   name: 'searchDocsFunctionModule'
   params: {
@@ -80,6 +91,7 @@ module searchDocsFunctionModule 'application/searchDocsFunction.bicep' = {
       maintenanceFirewallRules
     )
     storageFirewallRules: maintenanceIpRanges
+    applicationInsightsConnectionString: applicationInsightsModule.outputs.applicationInsightsConnectionString
     tagValues: tagValues
     deployAlerts: deployAlerts
   }

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -26,6 +26,9 @@ param dateProvisioned string = utcNow('u')
 @description('Do Azure Monitor alerts need creating or updating?')
 param deployAlerts bool = false
 
+@description('Specifies whether or not the Search Docs Function App already exists.')
+param searchDocsFunctionAppExists bool = true
+
 @description('Provides access to resources for specific IP address ranges used for service maintenance.')
 param maintenanceIpRanges IpRange[] = []
 
@@ -64,6 +67,7 @@ module searchDocsFunctionModule 'application/searchDocsFunction.bicep' = {
     location: location
     resourceNames: resourceNames
     resourcePrefix: resourcePrefix
+    functionAppExists: searchDocsFunctionAppExists
     functionAppFirewallRules: union(
       [
         {

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -26,6 +26,9 @@ param dateProvisioned string = utcNow('u')
 @description('Do Azure Monitor alerts need creating or updating?')
 param deployAlerts bool = false
 
+@description('The URL of the Content API.')
+param contentApiUrl string
+
 @description('Specifies whether or not the Search Docs Function App already exists.')
 param searchDocsFunctionAppExists bool = true
 
@@ -78,6 +81,7 @@ module searchDocsFunctionModule 'application/searchDocsFunction.bicep' = {
     location: location
     resourceNames: resourceNames
     resourcePrefix: resourcePrefix
+    contentApiUrl: contentApiUrl
     functionAppExists: searchDocsFunctionAppExists
     functionAppFirewallRules: union(
       [
@@ -90,6 +94,9 @@ module searchDocsFunctionModule 'application/searchDocsFunction.bicep' = {
       ],
       maintenanceFirewallRules
     )
+    searchStorageAccountName: searchServiceModule.outputs.searchStorageAccountName
+    searchStorageAccountConnectionStringSecretName: searchServiceModule.outputs.searchStorageAccountConnectionStringSecretName
+    searchableDocumentsContainerName: searchServiceModule.outputs.searchableDocumentsContainerName
     storageFirewallRules: maintenanceIpRanges
     applicationInsightsConnectionString: applicationInsightsModule.outputs.applicationInsightsConnectionString
     tagValues: tagValues

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -26,9 +26,6 @@ param dateProvisioned string = utcNow('u')
 @description('Do Azure Monitor alerts need creating or updating?')
 param deployAlerts bool = false
 
-@description('Does the Search Service need creating or updating?')
-param deploySearchService bool = false
-
 @description('Provides access to resources for specific IP address ranges used for service maintenance.')
 param maintenanceIpRanges IpRange[] = []
 
@@ -50,7 +47,7 @@ var resourceNames = {
   }
 }
 
-module searchServiceModule 'application/searchService.bicep' = if (deploySearchService) {
+module searchServiceModule 'application/searchService.bicep' = {
   name: 'searchServiceModule'
   params: {
     location: location
@@ -62,4 +59,4 @@ module searchServiceModule 'application/searchService.bicep' = if (deploySearchS
   }
 }
 
-output searchServiceEndpoint string = deploySearchService ? searchServiceModule.outputs.searchServiceEndpoint : ''
+output searchServiceEndpoint string = searchServiceModule.outputs.searchServiceEndpoint

--- a/infrastructure/templates/search/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/search/parameters/main-dev.bicepparam
@@ -2,3 +2,5 @@ using '../main.bicep'
 
 // Environment Params
 param environmentName = 'Development'
+
+param contentApiUrl = 'https://content.dev.explore-education-statistics.service.gov.uk'

--- a/infrastructure/templates/search/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/search/parameters/main-preprod.bicepparam
@@ -2,3 +2,5 @@ using '../main.bicep'
 
 // Environment Params
 param environmentName = 'Pre-Production'
+
+param contentApiUrl = 'https://content.pre-production.explore-education-statistics.service.gov.uk'

--- a/infrastructure/templates/search/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/search/parameters/main-prod.bicepparam
@@ -2,3 +2,5 @@ using '../main.bicep'
 
 // Environment Params
 param environmentName = 'Production'
+
+param contentApiUrl = 'https://content.explore-education-statistics.service.gov.uk'

--- a/infrastructure/templates/search/parameters/main-test.bicepparam
+++ b/infrastructure/templates/search/parameters/main-test.bicepparam
@@ -2,3 +2,5 @@ using '../main.bicep'
 
 // Environment Params
 param environmentName = 'Test'
+
+param contentApiUrl = 'https://content.test.explore-education-statistics.service.gov.uk'

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -5,6 +5,8 @@ type ResourceNames = {
     vNet: string
     alertsGroup: string
     subnets: {
+      searchDocsFunction: string
+      searchDocsFunctionPrivateEndpoints: string
       searchStoragePrivateEndpoints: string
     }
   }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1108,6 +1108,8 @@
     "publicApiDataProcessorSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('publicApiDataProcessorSubnetName'))]",
     "publicApiDataProcessorPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-papi-snet-fa-processor-pep')]",
     "publicApiStoragePrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-papi-snet-sa-pep')]",
+    "searchDocsFunctionSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-fa-searchdocs')]",
+    "searchDocsFunctionPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-fa-searchdocs-pep')]",
     "searchStoragePrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-sa-search-pep')]",
     "containerAppEnvironmentSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-cae-01')]",
     "applicationGatewaySubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-agw-01')]",
@@ -3714,6 +3716,31 @@
             "name": "[variables('searchStoragePrivateEndpointsSubnetName')]",
             "properties": {
               "addressPrefix": "10.0.13.0/24"
+            }
+          },
+          {
+            "name": "[variables('searchDocsFunctionSubnetName')]",
+            "properties": {
+              "addressPrefix": "10.0.14.0/24",
+              "serviceEndpoints": [
+                {
+                  "service": "Microsoft.Storage"
+                }
+              ],
+              "delegations": [
+                {
+                  "name": "environment",
+                  "properties": {
+                    "serviceName": "Microsoft.App/environments"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "[variables('searchDocsFunctionPrivateEndpointsSubnetName')]",
+            "properties": {
+              "addressPrefix": "10.0.15.0/24"
             }
           }
         ]

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -3729,9 +3729,9 @@
               ],
               "delegations": [
                 {
-                  "name": "environment",
+                  "name": "webapp",
                   "properties": {
-                    "serviceName": "Microsoft.App/environments"
+                    "serviceName": "Microsoft.Web/serverFarms"
                   }
                 }
               ]


### PR DESCRIPTION
This PR adds new infrastructure for implementing site-wide search. It contains Bicep defining the infrastructure for the Search Docs Azure Function app added by #5630.

It also changes the DevOps Search pipeline to deploy this infrastructure and publish the built app.

### Minimal refactoring of Public API infrastructure

At the moment we have a requirement to "Keep the Public API stable" so the intention here has been to make the least amount of changes to Public API infrastructure config.

Continuing with the approach taken by #5628, this PR continues to reference some Public API templates rather than refactoring them to make them common. At a later date a larger renaming/refactoring exercise will probably be needed.

### Common functionApp.bicep

This PR adds a new functionApp.bicep template since we don't currently have this in our library of components. This is added to the 'common' folder so it can hopefully be used by other features with a need to deploy Azure functions in future.



