### PR TITLE
EES-5828 - add analytics consumer

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Functions/ConsumePublicApiQueriesFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Functions/ConsumePublicApiQueriesFunctionTests.cs
@@ -1,0 +1,407 @@
+using System.Reflection;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Functions;
+using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using InterpolatedSql.Dapper;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests.Functions;
+
+public abstract class ConsumePublicApiQueriesFunctionTests
+{
+    private readonly string _queryResourcesPath = Path.Combine(
+        Assembly.GetExecutingAssembly().GetDirectoryPath(),
+        "Resources",
+        "PublicApiQueries");
+
+    private readonly TestAnalyticsPathResolver _pathResolver = new();
+    
+    public class FunctionTests : ConsumePublicApiQueriesFunctionTests
+    {
+        [Fact]
+        public async Task NoSourceFolder()
+        {
+            var function = BuildFunction();
+            await function.Run(new TimerInfo());
+            
+            Assert.False(Directory.Exists(_pathResolver.PublicApiQueriesProcessingDirectoryPath()));
+            Assert.False(Directory.Exists(_pathResolver.PublicApiQueriesReportsDirectoryPath()));
+        }
+        
+        [Fact]
+        public async Task NoSourceQueriesToConsume()
+        {
+            Directory.CreateDirectory(_pathResolver.PublicApiQueriesDirectoryPath());
+
+            var function = BuildFunction();
+            await function.Run(new TimerInfo());
+            
+            // Check that as there were no files to process, no working directories were
+            // created as a result.
+            Assert.False(Directory.Exists(_pathResolver.PublicApiQueriesProcessingDirectoryPath()));
+            Assert.False(Directory.Exists(_pathResolver.PublicApiQueriesReportsDirectoryPath()));
+        }
+
+        [Fact]
+        public async Task SingleSourceQuery()
+        {
+            SetupQueryRequest("Query1Request.json");
+
+            var function = BuildFunction();
+            await function.Run(new TimerInfo());
+
+            Assert.False(Directory.Exists(_pathResolver.PublicApiQueriesProcessingDirectoryPath()));
+            Assert.True(Directory.Exists(_pathResolver.PublicApiQueriesReportsDirectoryPath()));
+
+            var reports = Directory.GetFiles(_pathResolver.PublicApiQueriesReportsDirectoryPath());
+
+            Assert.Equal(2, reports.Length);
+            
+            var queryReportFile = reports.Single(file => file.EndsWith("public-api-queries.parquet"));
+            
+            var duckDbConnection = new DuckDbConnection();
+            duckDbConnection.Open();
+
+            var queryReportRows = await ReadQueryReport(duckDbConnection, queryReportFile);
+            
+            // Check that the single recorded query has resulted in a
+            // single line in the query report and the values match the
+            // values from the original JSON file and the calculated fields
+            // match the expected values also.
+            var queryReportRow = Assert.Single(queryReportRows);
+
+            Assert.Equal("502a11b95831e7f57e90cec95a82c1e2", queryReportRow.QueryVersionHash);
+            Assert.Equal("b5e94ee45b26d4f0c16059aee5b09fe8", queryReportRow.QueryHash);
+            Assert.Equal(Guid.Parse("01d29401-7274-a871-a8db-d4bc4e98c324"), queryReportRow.DataSetId);
+            Assert.Equal(Guid.Parse("01d29401-7974-1276-a06b-b28a6a5385c6"), queryReportRow.DataSetVersionId);
+            Assert.Equal("1.2.0", queryReportRow.DataSetVersion);
+            Assert.Equal("Data Set 1", queryReportRow.DataSetTitle);
+            Assert.Equal(44, queryReportRow.ResultsCount);
+            Assert.Equal(800, queryReportRow.TotalRowsCount);
+            Assert.Equal(1, queryReportRow.QueryExecutions);
+            Assert.StartsWith("{\"Criteria\":{\"Filters\":{\"Eq\":\"qOnjG\"}", queryReportRow.Query);
+            
+            var queryAccessReportFile = reports.Single(file => file.EndsWith("public-api-query-access.parquet"));
+
+            // Check that the single recorded query has resulted in a
+            // single line in the query access report and the access times
+            // match the times from the original JSON file, and the calculated
+            // fields match the expected values.
+            var queryAccessReportRows = await duckDbConnection
+                .SqlBuilder($"SELECT * FROM read_parquet('{queryAccessReportFile:raw}')")
+                .QueryAsync<QueryAccessReportLine>();
+            
+            var queryAccessReportRow = Assert.Single(queryAccessReportRows);
+
+            Assert.Equal("502a11b95831e7f57e90cec95a82c1e2", queryAccessReportRow.QueryVersionHash);
+            Assert.Equal(Guid.Parse("01d29401-7974-1276-a06b-b28a6a5385c6"), queryAccessReportRow.DataSetVersionId);
+            Assert.Equal(DateTime.Parse("2025-02-24T03:07:44.710Z"), queryAccessReportRow.StartTime);
+            Assert.Equal(DateTime.Parse("2025-02-24T03:07:44.850Z"), queryAccessReportRow.EndTime);
+            Assert.Equal(140, queryAccessReportRow.DurationMillis);
+        }
+
+        [Fact]
+        public async Task TwoDifferentSourceQueries()
+        {
+            SetupQueryRequest("Query1Request.json");
+            SetupQueryRequest("Query2Request1.json");
+
+            var function = BuildFunction();
+            await function.Run(new TimerInfo());
+
+            var reports = Directory.GetFiles(_pathResolver.PublicApiQueriesReportsDirectoryPath());
+
+            Assert.Equal(2, reports.Length);
+            
+            var queryReportFile = reports.Single(file => file.EndsWith("public-api-queries.parquet"));
+            
+            var duckDbConnection = new DuckDbConnection();
+            duckDbConnection.Open();
+
+            var queryReportRows = await ReadQueryReport(duckDbConnection, queryReportFile);
+            
+            // Check that the 2 different queries have resulted in 2 lines
+            // in the query report and the values match the values from the
+            // original JSON files and the calculated fields match the
+            // expected values also.
+            Assert.Equal(2, queryReportRows.Count);
+                
+            var queryReportRow1 = queryReportRows[0];
+            
+            Assert.Equal("44fdabea15392762ef6e43489ad92e98", queryReportRow1.QueryVersionHash);
+            Assert.Equal("9e261de0f641d55fcca15a8b55c3d089", queryReportRow1.QueryHash);
+            Assert.Equal(Guid.Parse("8b9da0ae-80e4-43e8-9f39-4f670fd1a45a"), queryReportRow1.DataSetId);
+            Assert.Equal(Guid.Parse("5ed5053d-92fc-49a1-b0b1-4c11f3b2c538"), queryReportRow1.DataSetVersionId);
+            Assert.Equal("2.1.0", queryReportRow1.DataSetVersion);
+            Assert.Equal("Data Set 2", queryReportRow1.DataSetTitle);
+            Assert.Equal(20, queryReportRow1.ResultsCount);
+            Assert.Equal(23, queryReportRow1.TotalRowsCount);
+            Assert.Equal(1, queryReportRow1.QueryExecutions);
+            Assert.StartsWith("{\"Criteria\":{\"Filters\":{\"In\":[\"qOnjG\"", queryReportRow1.Query);
+            
+            var queryReportRow2 = queryReportRows[1];
+
+            Assert.Equal("502a11b95831e7f57e90cec95a82c1e2", queryReportRow2.QueryVersionHash);
+            Assert.Equal("b5e94ee45b26d4f0c16059aee5b09fe8", queryReportRow2.QueryHash);
+            Assert.Equal(Guid.Parse("01d29401-7274-a871-a8db-d4bc4e98c324"), queryReportRow2.DataSetId);
+            Assert.Equal(Guid.Parse("01d29401-7974-1276-a06b-b28a6a5385c6"), queryReportRow2.DataSetVersionId);
+            Assert.Equal("1.2.0", queryReportRow2.DataSetVersion);
+            Assert.Equal("Data Set 1", queryReportRow2.DataSetTitle);
+            Assert.Equal(44, queryReportRow2.ResultsCount);
+            Assert.Equal(800, queryReportRow2.TotalRowsCount);
+            Assert.Equal(1, queryReportRow2.QueryExecutions);
+            Assert.StartsWith("{\"Criteria\":{\"Filters\":{\"Eq\":\"qOnjG\"}", queryReportRow2.Query);
+            
+            var queryAccessReportFile = reports.Single(file => file.EndsWith("public-api-query-access.parquet"));
+
+            // Check that the 2 different recorded queries have resulted in
+            // 2 separate lines in the query access report and the access times
+            // match the times from the original JSON file, and the calculated
+            // fields match the expected values.
+            var queryAccessReportRows = (await duckDbConnection
+                .SqlBuilder($"SELECT * FROM read_parquet('{queryAccessReportFile:raw}')")
+                .QueryAsync<QueryAccessReportLine>())
+                .ToList();
+            
+            Assert.Equal(2, queryAccessReportRows.Count);
+            
+            var queryAccessReportRow1 = queryAccessReportRows[0];
+
+            Assert.Equal("44fdabea15392762ef6e43489ad92e98", queryAccessReportRow1.QueryVersionHash);
+            Assert.Equal(Guid.Parse("5ed5053d-92fc-49a1-b0b1-4c11f3b2c538"), queryAccessReportRow1.DataSetVersionId);
+            Assert.Equal(DateTime.Parse("2025-02-23T03:07:44.931Z"), queryAccessReportRow1.StartTime);
+            Assert.Equal(DateTime.Parse("2025-02-23T03:07:44.955Z"), queryAccessReportRow1.EndTime);
+            Assert.Equal(24, queryAccessReportRow1.DurationMillis);
+            
+            var queryAccessReportRow2 = queryAccessReportRows[1];
+
+            Assert.Equal("502a11b95831e7f57e90cec95a82c1e2", queryAccessReportRow2.QueryVersionHash);
+            Assert.Equal(Guid.Parse("01d29401-7974-1276-a06b-b28a6a5385c6"), queryAccessReportRow2.DataSetVersionId);
+            Assert.Equal(DateTime.Parse("2025-02-24T03:07:44.710Z"), queryAccessReportRow2.StartTime);
+            Assert.Equal(DateTime.Parse("2025-02-24T03:07:44.850Z"), queryAccessReportRow2.EndTime);
+            Assert.Equal(140, queryAccessReportRow2.DurationMillis);
+        }
+
+        [Fact] public async Task MultipleSourceFilesForSameQuery()
+        {
+            SetupQueryRequest("Query2Request1.json");
+            SetupQueryRequest("Query2Request2.json");
+            SetupQueryRequest("Query2Request3.json");
+
+            var function = BuildFunction();
+            await function.Run(new TimerInfo());
+
+            var reports = Directory.GetFiles(_pathResolver.PublicApiQueriesReportsDirectoryPath());
+
+            Assert.Equal(2, reports.Length);
+            
+            var queryReportFile = reports.Single(file => file.EndsWith("public-api-queries.parquet"));
+            
+            var duckDbConnection = new DuckDbConnection();
+            duckDbConnection.Open();
+
+            var queryReportRows = (await duckDbConnection
+                .SqlBuilder($"SELECT * FROM read_parquet('{queryReportFile:raw}')")
+                .QueryAsync<QueryReportLine>())
+                    .ToList();
+            
+            // Check that the 3 different source files for the same query
+            // have resulted in a single line in the query report, and the
+            // values match the values from the original JSON files and the
+            // calculated fields match the expected values also.
+            var queryReportRow = Assert.Single(queryReportRows);
+            
+            Assert.Equal("44fdabea15392762ef6e43489ad92e98", queryReportRow.QueryVersionHash);
+            Assert.Equal("9e261de0f641d55fcca15a8b55c3d089", queryReportRow.QueryHash);
+            Assert.Equal(Guid.Parse("8b9da0ae-80e4-43e8-9f39-4f670fd1a45a"), queryReportRow.DataSetId);
+            Assert.Equal(Guid.Parse("5ed5053d-92fc-49a1-b0b1-4c11f3b2c538"), queryReportRow.DataSetVersionId);
+            Assert.Equal("2.1.0", queryReportRow.DataSetVersion);
+            Assert.Equal("Data Set 2", queryReportRow.DataSetTitle);
+            Assert.Equal(20, queryReportRow.ResultsCount);
+            Assert.Equal(23, queryReportRow.TotalRowsCount);
+            
+            // Check that the function successfully spotted that 3 instances of this query
+            // were found in this batch of requests.
+            Assert.Equal(3, queryReportRow.QueryExecutions);
+            Assert.StartsWith("{\"Criteria\":{\"Filters\":{\"In\":[\"qOnjG\"", queryReportRow.Query);
+            
+            var queryAccessReportFile = reports.Single(file => file.EndsWith("public-api-query-access.parquet"));
+
+            var queryAccessReportRows = (await duckDbConnection
+                .SqlBuilder($"SELECT * FROM read_parquet('{queryAccessReportFile:raw}')")
+                .QueryAsync<QueryAccessReportLine>())
+                .ToList();
+            
+            // Check that the 3 different recorded query accesses have resulted in
+            // 3 separate lines in the query access report and the access times
+            // match the times from the original JSON file, and the calculated
+            // fields match the expected values.
+            //
+            // Also check that the accesses were recorded in order of start date.
+            Assert.Equal(3, queryAccessReportRows.Count);
+            
+            var queryAccessReportRow1 = queryAccessReportRows[0];
+
+            // Check that the first query access was recorded.
+            Assert.Equal("44fdabea15392762ef6e43489ad92e98", queryAccessReportRow1.QueryVersionHash);
+            Assert.Equal(Guid.Parse("5ed5053d-92fc-49a1-b0b1-4c11f3b2c538"), queryAccessReportRow1.DataSetVersionId);
+            Assert.Equal(DateTime.Parse("2025-02-22T03:07:44.931Z"), queryAccessReportRow1.StartTime);
+            Assert.Equal(DateTime.Parse("2025-02-22T03:07:44.955Z"), queryAccessReportRow1.EndTime);
+            Assert.Equal(24, queryAccessReportRow1.DurationMillis);
+            
+            var queryAccessReportRow2 = queryAccessReportRows[1];
+            
+            // Check that the second query access was recorded.
+            Assert.Equal("44fdabea15392762ef6e43489ad92e98", queryAccessReportRow2.QueryVersionHash);
+            Assert.Equal(Guid.Parse("5ed5053d-92fc-49a1-b0b1-4c11f3b2c538"), queryAccessReportRow2.DataSetVersionId);
+            Assert.Equal(DateTime.Parse("2025-02-23T03:07:44.931Z"), queryAccessReportRow2.StartTime);
+            Assert.Equal(DateTime.Parse("2025-02-23T03:07:44.955Z"), queryAccessReportRow2.EndTime);
+            Assert.Equal(24, queryAccessReportRow2.DurationMillis);
+            
+            var queryAccessReportRow3 = queryAccessReportRows[2];
+            
+            // Check that the third query access was recorded.
+            Assert.Equal("44fdabea15392762ef6e43489ad92e98", queryAccessReportRow3.QueryVersionHash);
+            Assert.Equal(Guid.Parse("5ed5053d-92fc-49a1-b0b1-4c11f3b2c538"), queryAccessReportRow3.DataSetVersionId);
+            Assert.Equal(DateTime.Parse("2025-02-24T03:07:44.931Z"), queryAccessReportRow3.StartTime);
+            Assert.Equal(DateTime.Parse("2025-02-24T03:07:44.955Z"), queryAccessReportRow3.EndTime);
+            Assert.Equal(24, queryAccessReportRow3.DurationMillis);
+        }
+
+        [Fact]
+        public async Task SameQueryStructureButDifferentDataSetVersion()
+        {
+            SetupQueryRequest("Query1Request.json");
+            SetupQueryRequest("Query1RequestMinorVersionUpdate.json");
+
+            var function = BuildFunction();
+            await function.Run(new TimerInfo());
+
+            var reports = Directory.GetFiles(_pathResolver.PublicApiQueriesReportsDirectoryPath());
+
+            Assert.Equal(2, reports.Length);
+            
+            var queryReportFile = reports.Single(file => file.EndsWith("public-api-queries.parquet"));
+            
+            var duckDbConnection = new DuckDbConnection();
+            duckDbConnection.Open();
+
+            var queryReportRows = await ReadQueryReport(duckDbConnection, queryReportFile);
+            
+            // Check that the 2 different data set versions result in 2 distinct entries in the
+            // report file, despite their queries being structurally the same and for the same
+            // overarching data set.
+            Assert.Equal(2, queryReportRows.Count);
+                
+            var queryReportRow1 = queryReportRows[0];
+            
+            Assert.Equal("502a11b95831e7f57e90cec95a82c1e2", queryReportRow1.QueryVersionHash);
+            Assert.Equal("b5e94ee45b26d4f0c16059aee5b09fe8", queryReportRow1.QueryHash);
+            Assert.Equal(Guid.Parse("01d29401-7274-a871-a8db-d4bc4e98c324"), queryReportRow1.DataSetId);
+            Assert.Equal(Guid.Parse("01d29401-7974-1276-a06b-b28a6a5385c6"), queryReportRow1.DataSetVersionId);
+            Assert.Equal("1.2.0", queryReportRow1.DataSetVersion);
+            Assert.Equal("Data Set 1", queryReportRow1.DataSetTitle);
+            Assert.Equal(44, queryReportRow1.ResultsCount);
+            Assert.Equal(800, queryReportRow1.TotalRowsCount);
+            Assert.Equal(1, queryReportRow1.QueryExecutions);
+            Assert.StartsWith("{\"Criteria\":{\"Filters\":{\"Eq\":\"qOnjG\"}", queryReportRow1.Query);
+            
+            var queryReportRow2 = queryReportRows[1];
+            
+            Assert.Equal("b581a774d622a1f950a20cf6fd178f98", queryReportRow2.QueryVersionHash);
+            Assert.Equal("b5e94ee45b26d4f0c16059aee5b09fe8", queryReportRow2.QueryHash);
+            Assert.Equal(Guid.Parse("01d29401-7274-a871-a8db-d4bc4e98c324"), queryReportRow2.DataSetId);
+            Assert.Equal(Guid.Parse("68c73c8e-808d-47fd-a2d5-268dc6b3a102"), queryReportRow2.DataSetVersionId);
+            Assert.Equal("1.2.1", queryReportRow2.DataSetVersion);
+            Assert.Equal("Data Set 1", queryReportRow2.DataSetTitle);
+            Assert.Equal(52, queryReportRow2.ResultsCount);
+            Assert.Equal(850, queryReportRow2.TotalRowsCount);
+            Assert.Equal(1, queryReportRow2.QueryExecutions);
+            Assert.StartsWith("{\"Criteria\":{\"Filters\":{\"Eq\":\"qOnjG\"}", queryReportRow2.Query);
+            
+            var queryAccessReportFile = reports.Single(file => file.EndsWith("public-api-query-access.parquet"));
+
+            var queryAccessReportRows = (await duckDbConnection
+                .SqlBuilder($"SELECT * FROM read_parquet('{queryAccessReportFile:raw}')")
+                .QueryAsync<QueryAccessReportLine>())
+                .ToList();
+            
+            // Check that the 2 different recorded query accesses have resulted in
+            // 2 separate lines in the query access report.
+            //
+            // Also check that the accesses were recorded in order of start date.
+            Assert.Equal(2, queryAccessReportRows.Count);
+            
+            var queryAccessReportRow1 = queryAccessReportRows[0];
+
+            // Check that the first query access was recorded.
+            Assert.Equal("502a11b95831e7f57e90cec95a82c1e2", queryAccessReportRow1.QueryVersionHash);
+            Assert.Equal(Guid.Parse("01d29401-7974-1276-a06b-b28a6a5385c6"), queryAccessReportRow1.DataSetVersionId);
+            Assert.Equal(DateTime.Parse("2025-02-24T03:07:44.710Z"), queryAccessReportRow1.StartTime);
+            Assert.Equal(DateTime.Parse("2025-02-24T03:07:44.850Z"), queryAccessReportRow1.EndTime);
+            Assert.Equal(140, queryAccessReportRow1.DurationMillis);
+            
+            var queryAccessReportRow2 = queryAccessReportRows[1];
+            
+            // Check that the second query access was recorded.
+            Assert.Equal("b581a774d622a1f950a20cf6fd178f98", queryAccessReportRow2.QueryVersionHash);
+            Assert.Equal(Guid.Parse("68c73c8e-808d-47fd-a2d5-268dc6b3a102"), queryAccessReportRow2.DataSetVersionId);
+            Assert.Equal(DateTime.Parse("2025-02-25T03:07:44.710Z"), queryAccessReportRow2.StartTime);
+            Assert.Equal(DateTime.Parse("2025-02-25T03:07:44.850Z"), queryAccessReportRow2.EndTime);
+            Assert.Equal(140, queryAccessReportRow2.DurationMillis);
+        }
+
+        private static async Task<List<QueryReportLine>> ReadQueryReport(DuckDbConnection duckDbConnection, string queryReportFile)
+        {
+            var queryReportRows = (await duckDbConnection
+                    .SqlBuilder($"SELECT * FROM read_parquet('{queryReportFile:raw}')")
+                    .QueryAsync<QueryReportLine>())
+                .ToList();
+            return queryReportRows;
+        }
+
+        // TODO test for pagination and debug
+
+
+    }
+
+    private ConsumePublicApiQueriesFunction BuildFunction()
+    {
+        return new(
+            duckDbConnection: new DuckDbConnection(),
+            pathResolver: _pathResolver,
+            Mock.Of<ILogger<ConsumePublicApiQueriesFunction>>());
+    }
+    
+    private void SetupQueryRequest(string filename)
+    {
+        Directory.CreateDirectory(_pathResolver.PublicApiQueriesDirectoryPath());
+
+        var sourceFilePath = Path.Combine(_queryResourcesPath, filename);
+        File.Copy(sourceFilePath, Path.Combine(_pathResolver.PublicApiQueriesDirectoryPath(), filename));
+    }
+
+    // ReSharper disable once ClassNeverInstantiated.Local
+    private record QueryReportLine(
+        string QueryVersionHash,
+        string QueryHash,
+        Guid DataSetId,
+        Guid DataSetVersionId,
+        string DataSetVersion,
+        string DataSetTitle,
+        int ResultsCount,
+        int TotalRowsCount,
+        string Query,
+        int QueryExecutions);
+    
+    // ReSharper disable once ClassNeverInstantiated.Local
+    private record QueryAccessReportLine(
+        string QueryVersionHash,
+        Guid DataSetVersionId,
+        DateTime StartTime,
+        DateTime EndTime,
+        int DurationMillis);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Moq" Version="4.20.72"/>
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Resources\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Analytics.Consumer\GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicApiQueries/Query1Request.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicApiQueries/Query1Request.json
@@ -1,0 +1,66 @@
+{
+  "DataSetId": "01d29401-7274-a871-a8db-d4bc4e98c324",
+  "DataSetTitle": "Data Set 1",
+  "DataSetVersion": "1.2.0",
+  "DataSetVersionId": "01d29401-7974-1276-a06b-b28a6a5385c6",
+  "EndTime": "2025-02-24T03:07:44.850Z",
+  "Query": {
+    "Criteria": {
+      "Filters": {
+        "Eq": "qOnjG"
+      },
+      "Locations": {
+        "In": [
+          {
+            "Id": "7zXob",
+            "Level": "LA"
+          },
+          {
+            "Id": "it6Xr",
+            "Level": "LA"
+          },
+          {
+            "Id": "IzBzg",
+            "Level": "LA"
+          },
+          {
+            "Id": "pTSoj",
+            "Level": "LA"
+          },
+          {
+            "Id": "dP0Zw",
+            "Level": "NAT"
+          },
+          {
+            "Id": "6jrfe",
+            "Level": "REG"
+          },
+          {
+            "Id": "LxWjE",
+            "Level": "REG"
+          },
+          {
+            "Id": "0kT5D",
+            "Level": "SCH"
+          }
+        ]
+      },
+      "TimePeriods": {
+        "NotEq": {
+          "Code": "AY",
+          "Period": "2021/2022"
+        }
+      }
+    },
+    "Debug": false,
+    "Indicators": [
+      "7YFXo",
+      "dPe0Z"
+    ],
+    "Page": 1,
+    "PageSize": 1000
+  },
+  "ResultsCount": 44,
+  "StartTime": "2025-02-24T03:07:44.710Z",
+  "TotalRowsCount": 800
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicApiQueries/Query1RequestMinorVersionUpdate.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicApiQueries/Query1RequestMinorVersionUpdate.json
@@ -1,0 +1,66 @@
+{
+  "DataSetId": "01d29401-7274-a871-a8db-d4bc4e98c324",
+  "DataSetTitle": "Data Set 1",
+  "DataSetVersion": "1.2.1",
+  "DataSetVersionId": "68c73c8e-808d-47fd-a2d5-268dc6b3a102",
+  "EndTime": "2025-02-25T03:07:44.850Z",
+  "Query": {
+    "Criteria": {
+      "Filters": {
+        "Eq": "qOnjG"
+      },
+      "Locations": {
+        "In": [
+          {
+            "Id": "7zXob",
+            "Level": "LA"
+          },
+          {
+            "Id": "it6Xr",
+            "Level": "LA"
+          },
+          {
+            "Id": "IzBzg",
+            "Level": "LA"
+          },
+          {
+            "Id": "pTSoj",
+            "Level": "LA"
+          },
+          {
+            "Id": "dP0Zw",
+            "Level": "NAT"
+          },
+          {
+            "Id": "6jrfe",
+            "Level": "REG"
+          },
+          {
+            "Id": "LxWjE",
+            "Level": "REG"
+          },
+          {
+            "Id": "0kT5D",
+            "Level": "SCH"
+          }
+        ]
+      },
+      "TimePeriods": {
+        "NotEq": {
+          "Code": "AY",
+          "Period": "2021/2022"
+        }
+      }
+    },
+    "Debug": false,
+    "Indicators": [
+      "7YFXo",
+      "dPe0Z"
+    ],
+    "Page": 1,
+    "PageSize": 1000
+  },
+  "ResultsCount": 52,
+  "StartTime": "2025-02-25T03:07:44.710Z",
+  "TotalRowsCount": 850
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicApiQueries/Query2Request1.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicApiQueries/Query2Request1.json
@@ -1,0 +1,40 @@
+{
+  "DataSetId": "8b9da0ae-80e4-43e8-9f39-4f670fd1a45a",
+  "DataSetTitle": "Data Set 2",
+  "DataSetVersion": "2.1.0",
+  "DataSetVersionId": "5ed5053d-92fc-49a1-b0b1-4c11f3b2c538",
+  "EndTime": "2025-02-23T03:07:44.955Z",
+  "Query": {
+    "Criteria": {
+      "Filters": {
+        "In": [
+          "qOnjG",
+          "YvoHK"
+        ]
+      },
+      "Locations": {
+        "Eq": {
+          "Id": "6jrfe",
+          "Level": "REG"
+        }
+      },
+      "TimePeriods": {
+        "In": [
+          {
+            "Code": "AY",
+            "Period": "2020/2021"
+          }
+        ]
+      }
+    },
+    "Debug": false,
+    "Indicators": [
+      "7YFXo"
+    ],
+    "Page": 1,
+    "PageSize": 1000
+  },
+  "ResultsCount": 20,
+  "StartTime": "2025-02-23T03:07:44.931Z",
+  "TotalRowsCount": 23
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicApiQueries/Query2Request2.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicApiQueries/Query2Request2.json
@@ -1,0 +1,40 @@
+{
+  "DataSetId": "8b9da0ae-80e4-43e8-9f39-4f670fd1a45a",
+  "DataSetTitle": "Data Set 2",
+  "DataSetVersion": "2.1.0",
+  "DataSetVersionId": "5ed5053d-92fc-49a1-b0b1-4c11f3b2c538",
+  "EndTime": "2025-02-24T03:07:44.955Z",
+  "Query": {
+    "Criteria": {
+      "Filters": {
+        "In": [
+          "qOnjG",
+          "YvoHK"
+        ]
+      },
+      "Locations": {
+        "Eq": {
+          "Id": "6jrfe",
+          "Level": "REG"
+        }
+      },
+      "TimePeriods": {
+        "In": [
+          {
+            "Code": "AY",
+            "Period": "2020/2021"
+          }
+        ]
+      }
+    },
+    "Debug": false,
+    "Indicators": [
+      "7YFXo"
+    ],
+    "Page": 1,
+    "PageSize": 1000
+  },
+  "ResultsCount": 20,
+  "StartTime": "2025-02-24T03:07:44.931Z",
+  "TotalRowsCount": 23
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicApiQueries/Query2Request3.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicApiQueries/Query2Request3.json
@@ -1,0 +1,40 @@
+{
+  "DataSetId": "8b9da0ae-80e4-43e8-9f39-4f670fd1a45a",
+  "DataSetTitle": "Data Set 2",
+  "DataSetVersion": "2.1.0",
+  "DataSetVersionId": "5ed5053d-92fc-49a1-b0b1-4c11f3b2c538",
+  "EndTime": "2025-02-22T03:07:44.955Z",
+  "Query": {
+    "Criteria": {
+      "Filters": {
+        "In": [
+          "qOnjG",
+          "YvoHK"
+        ]
+      },
+      "Locations": {
+        "Eq": {
+          "Id": "6jrfe",
+          "Level": "REG"
+        }
+      },
+      "TimePeriods": {
+        "In": [
+          {
+            "Code": "AY",
+            "Period": "2020/2021"
+          }
+        ]
+      }
+    },
+    "Debug": false,
+    "Indicators": [
+      "7YFXo"
+    ],
+    "Page": 1,
+    "PageSize": 1000
+  },
+  "ResultsCount": 20,
+  "StartTime": "2025-02-22T03:07:44.931Z",
+  "TotalRowsCount": 23
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
@@ -1,0 +1,25 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
+
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests;
+
+public class TestAnalyticsPathResolver : IAnalyticsPathResolver
+{
+    private readonly string _basePath = Path.Combine(
+        Path.GetTempPath(),
+        "ExploreEducationStatistics",
+        "Analytics",
+        Guid.NewGuid().ToString());
+
+    public string PublicApiQueriesDirectoryPath()
+    {
+        return Path.Combine(_basePath, "public-api");
+    }
+
+    public string PublicApiQueriesProcessingDirectoryPath() {
+        return Path.Combine(_basePath, "public-api", "processing");
+    }
+
+    public string PublicApiQueriesReportsDirectoryPath() {
+        return Path.Combine(_basePath, "reports", "public-api", "reports");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Functions/ConsumePublicApiQueriesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Functions/ConsumePublicApiQueriesFunction.cs
@@ -1,0 +1,129 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Functions;
+
+public class ConsumePublicApiQueriesFunction(
+    DuckDbConnection duckDbConnection,
+    IAnalyticsPathResolver pathResolver,
+    ILogger<ConsumePublicApiQueriesFunction> logger)
+{
+    [Function(nameof(ConsumePublicApiQueriesFunction))]
+    public Task Run(
+        [TimerTrigger("%App:ConsumePublicApiQueriesCronSchedule%")]
+        TimerInfo timer)
+    {
+        logger.LogInformation($"{nameof(ConsumePublicApiQueriesFunction)} triggered");
+
+        var sourceDirectory = pathResolver.PublicApiQueriesDirectoryPath();
+
+        if (!Directory.Exists(sourceDirectory))
+        {
+            logger.LogInformation("No data set queries to process");
+            return Task.CompletedTask; 
+        }
+        
+        var filesToProcess = Directory
+            .GetFiles(sourceDirectory)
+            .Select(Path.GetFileName)
+            .Cast<string>()
+            .ToList();
+
+        if (filesToProcess.Count == 0)
+        {
+            logger.LogInformation("No data set queries to process");
+            return Task.CompletedTask;
+        }
+        
+        logger.LogInformation("Found {Count} data set queries to process", filesToProcess.Count);
+
+        var processingDirectory = pathResolver.PublicApiQueriesProcessingDirectoryPath();
+        var reportsDirectory = pathResolver.PublicApiQueriesReportsDirectoryPath();
+        
+        Directory.CreateDirectory(processingDirectory);
+        Directory.CreateDirectory(reportsDirectory);
+
+        Parallel.ForEach(filesToProcess, file =>
+        {
+            var originalPath = Path.Combine(sourceDirectory, file);
+            var newPath = Path.Combine(processingDirectory, file);
+            File.Move(originalPath, newPath);
+        });
+        
+        duckDbConnection.Open();
+        
+        duckDbConnection.ExecuteNonQuery("install json; load json");
+
+        duckDbConnection.ExecuteNonQuery($@"
+            CREATE TABLE Queries AS 
+            SELECT
+                MD5(CONCAT(Query, DataSetVersionId)) AS QueryVersionHash,
+                MD5(Query) AS QueryHash,
+                *
+            FROM read_json('{processingDirectory}/*.json', 
+                format='auto',
+                columns = {{
+                    DataSetId: UUID, 
+                    DataSetVersionId: UUID,
+                    DataSetVersion: VARCHAR,
+                    DataSetTitle: VARCHAR,
+                    ResultsCount: INT,
+                    TotalRowsCount: INT,
+                    StartTime: DATETIME,
+                    EndTime: DATETIME,
+                    Query: JSON
+                }})");
+
+        duckDbConnection.ExecuteNonQuery(@"
+            CREATE TABLE QueryReport AS 
+            SELECT 
+                QueryVersionHash,
+                FIRST(QueryHash) AS QueryHash,
+                FIRST(DataSetId) AS DataSetId,
+                FIRST(DataSetVersionId) AS DataSetVersionId,
+                FIRST(DataSetVersion) AS DataSetVersion,
+                FIRST(DataSetTitle) AS DataSetTitle,
+                FIRST(ResultsCount) AS ResultsCount,
+                FIRST(TotalRowsCount) AS TotalRowsCount,
+                FIRST(Query) AS Query,
+                CAST(COUNT(QueryHash) AS INT) AS QueryExecutions
+            FROM Queries
+            GROUP BY QueryVersionHash
+            ORDER BY QueryVersionHash");
+        
+        duckDbConnection.ExecuteNonQuery(@"
+            CREATE TABLE QueryAccessReport AS 
+            SELECT 
+                QueryVersionHash,
+                DataSetVersionId,
+                StartTime,
+                EndTime,
+                CAST(EXTRACT('milliseconds' FROM EndTime - StartTime) AS INT) AS DurationMillis
+            FROM Queries
+            ORDER BY QueryHash, StartTime");
+
+        var reportFilenamePrefix = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
+        
+        var queryReportFilename = Path.Combine(
+            reportsDirectory, 
+            $"{reportFilenamePrefix}_public-api-queries.parquet");
+        
+        var queryAccessReportFilename = Path.Combine(
+            reportsDirectory, 
+            $"{reportFilenamePrefix}_public-api-query-access.parquet");
+
+        duckDbConnection.ExecuteNonQuery($@"
+            COPY (SELECT * FROM QueryReport)
+            TO '{queryReportFilename}' (FORMAT 'parquet', CODEC 'zstd')");
+        
+        duckDbConnection.ExecuteNonQuery($@"
+            COPY (SELECT * FROM QueryAccessReport)
+            TO '{queryAccessReportFilename}' (FORMAT 'parquet', CODEC 'zstd')");
+        
+        Directory.Delete(processingDirectory, recursive: true);
+        
+        return Task.CompletedTask;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AzureFunctionsVersion>V4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.2.0"/>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0"/>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1"/>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0"/>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0"/>
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0"/>
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.Local.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext"/>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Analytics.Services\GovUk.Education.ExploreEducationStatistics.Analytics.Services.csproj" />
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common.DuckDb\GovUk.Education.ExploreEducationStatistics.Common.DuckDb.csproj" />
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Options/AnalyticsOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Options/AnalyticsOptions.cs
@@ -1,0 +1,10 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
+
+public class AnalyticsOptions
+{
+    public const string Section = "Analytics";
+
+    public bool Enabled { get; init; }
+
+    public string BasePath { get; init; } = string.Empty;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
@@ -1,0 +1,44 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer;
+
+public static class ProcessorHostBuilder
+{
+    public static IHostBuilder ConfigureProcessorHostBuilder(this IHostBuilder hostBuilder)
+    {
+        return hostBuilder
+            .ConfigureAppConfiguration(builder =>
+            {
+                builder
+                    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+                    .AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: false)
+                    .AddEnvironmentVariables();
+            })
+            .ConfigureLogging(logging =>
+            {
+                // TODO EES-5013 Why can't Command logging be suppressed via the logging config in application settings?
+                logging.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Warning);
+            })
+            .ConfigureServices((builder, services) =>
+            {
+                var configuration = builder.Configuration;
+                
+                services.AddOptions<AnalyticsOptions>()
+                    .Bind(configuration.GetRequiredSection(AnalyticsOptions.Section));
+
+                services
+                    .AddApplicationInsightsTelemetryWorkerService()
+                    .ConfigureFunctionsApplicationInsights()
+                    .AddTransient<IAnalyticsPathResolver, AnalyticsPathResolver>()
+                    .AddTransient<DuckDbConnection>(_ => new DuckDbConnection());
+            });
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Program.cs
@@ -1,0 +1,9 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer;
+using Microsoft.Extensions.Hosting;
+
+var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults()
+    .ConfigureProcessorHostBuilder()
+    .Build();
+
+host.Run();

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Properties/launchSettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer": {
+      "commandName": "Project",
+      "commandLineArgs": "host start --pause-on-error --port 7075",
+      "launchBrowser": false
+    }
+  }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
@@ -1,0 +1,56 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services;
+
+public class AnalyticsPathResolver : IAnalyticsPathResolver
+{
+    private readonly string _basePath;
+
+    public AnalyticsPathResolver(IOptions<AnalyticsOptions> options, IHostEnvironment environment)
+    {
+        if (options.Value.BasePath.IsNullOrWhitespace())
+        {
+            throw new ArgumentException(
+                message: $"'{nameof(AnalyticsOptions.BasePath)}' must not be blank",
+                paramName: nameof(options)
+            );
+        }
+        
+        _basePath = GetBasePath(options.Value.BasePath, environment);
+    }
+
+    public string PublicApiQueriesDirectoryPath()
+    {
+        return Path.Combine(_basePath, "public-api", "queries");
+    }
+
+    public string PublicApiQueriesProcessingDirectoryPath()
+    {
+        return Path.Combine(PublicApiQueriesDirectoryPath(), "processing");
+    }
+
+    public string PublicApiQueriesReportsDirectoryPath()
+    {
+        return Path.Combine(ReportsDirectoryPath(), "public-api", "queries");
+    }
+    
+    private string ReportsDirectoryPath()
+    {
+        return Path.Combine(_basePath, "reports");
+    }
+
+    private string GetBasePath(string originalPath, IHostEnvironment environment)
+    {
+        if (!environment.IsDevelopment())
+        {
+            return originalPath;
+        }
+        
+        return Path.Combine(PathUtils.ProjectRootPath, PathUtils.OsPath(originalPath));
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
@@ -1,0 +1,10 @@
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
+
+public interface IAnalyticsPathResolver
+{
+    string PublicApiQueriesDirectoryPath();
+
+    string PublicApiQueriesProcessingDirectoryPath();
+
+    public string PublicApiQueriesReportsDirectoryPath();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "Analytics": {
+    "BasePath": "data/analytics"
+  }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/host.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/host.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingSettings": {
+                "isEnabled": true,
+                "excludedTypes": "Request"
+            },
+            "enableLiveMetricsFilters": true
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/local.settings.json
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://data-storage",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "App:ConsumePublicApiQueriesCronSchedule": "30 * * * * *"
+  }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/DuckDbCommand.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/DuckDbCommand.cs
@@ -1,0 +1,12 @@
+using System.Data.Common;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+
+/// <summary>
+/// Wrapper around underlying DuckDB.NET implementation to patch
+/// functionality that isn't working correctly.
+/// </summary>
+public class DuckDbCommand : DuckDB.NET.Data.DuckDBCommand
+{
+    protected override DbParameter CreateDbParameter() => new DuckDbParameter();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/DuckDbConnection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/DuckDbConnection.cs
@@ -1,0 +1,45 @@
+using DuckDB.NET.Data;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+
+public class DuckDbConnection(string connectionString = DuckDBConnectionStringBuilder.InMemoryConnectionString)
+    : DuckDBConnection(connectionString), IDuckDbConnection
+{
+    public static DuckDbConnection CreateFileConnection(string filename)
+    {
+        return new DuckDbConnection($"DataSource={filename}");
+    }
+
+    public static DuckDbConnection CreateFileConnectionReadOnly(string filename)
+    {
+        return new DuckDbConnection($"DataSource={filename};access_mode=read_only");
+    }
+
+    public override DuckDbCommand CreateCommand()
+    {
+        // Bit rubbish to do this but we don't have access to the
+        // underlying `Transaction` so we need to get a reference
+        // to it through by creating a base command object first.
+        var wrappedCommand = base.CreateCommand();
+
+        return new DuckDbCommand
+        {
+            Connection = this,
+            Transaction = wrappedCommand.Transaction
+        };
+    }
+
+    public DuckDbCommand CreateCommand(string commandText)
+    {
+        var command = CreateCommand();
+        command.CommandText = commandText;
+        return command;
+    }
+    
+    public int ExecuteNonQuery(string commandText)
+    {
+        var command = CreateCommand();
+        command.CommandText = commandText;
+        return command.ExecuteNonQuery();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/DuckDbConnectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/DuckDbConnectionExtensions.cs
@@ -1,0 +1,61 @@
+using InterpolatedSql;
+using InterpolatedSql.SqlBuilders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+
+public static class DuckDbConnectionExtensions
+{
+    public static DuckDbDapperSqlBuilder SqlBuilder(this IDuckDbConnection connection)
+    {
+        return new DuckDbDapperSqlBuilder(connection);
+    }
+
+    public static DuckDbDapperSqlBuilder SqlBuilder(
+        this IDuckDbConnection connection,
+        FormattableString command,
+        InterpolatedSqlBuilderOptions? options = null)
+    {
+        return new DuckDbDapperSqlBuilder(connection, command, options);
+    }
+
+    public static DuckDbDapperSqlBuilder SqlBuilder(
+        this IDuckDbConnection connection,
+        string command,
+        InterpolatedSqlBuilderOptions? options = null)
+    {
+        return new DuckDbDapperSqlBuilder(connection, command, options);
+    }
+
+    public static DuckDbDapperSqlBuilder SqlBuilder(
+        this IDuckDbConnection connection,
+        InterpolatedSqlBuilderOptions options)
+    {
+        return new DuckDbDapperSqlBuilder(connection, options);
+    }
+
+    public static DuckDbDapperSqlBuilder SqlBuilder(
+        this IDuckDbConnection connection,
+        ref InterpolatedSqlHandler command)
+    {
+        if (command.InterpolatedSqlBuilder.Options.AutoAdjustMultilineString)
+        {
+            command.AdjustMultilineString();
+        }
+
+        return new DuckDbDapperSqlBuilder(connection, command.InterpolatedSqlBuilder.AsFormattableString());
+    }
+
+    public static DuckDbDapperSqlBuilder SqlBuilder(
+        this IDuckDbConnection connection,
+        InterpolatedSqlBuilderOptions options,
+        [System.Runtime.CompilerServices.InterpolatedStringHandlerArgument("options")]
+        ref InterpolatedSqlHandler command)
+    {
+        if (command.InterpolatedSqlBuilder.Options.AutoAdjustMultilineString)
+        {
+            command.AdjustMultilineString();
+        }
+
+        return new DuckDbDapperSqlBuilder(connection, command.InterpolatedSqlBuilder.AsFormattableString(), options);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/DuckDbDapperSqlBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/DuckDbDapperSqlBuilder.cs
@@ -1,0 +1,66 @@
+using System.Data;
+using System.Text;
+using InterpolatedSql;
+using InterpolatedSql.Dapper;
+using InterpolatedSql.Dapper.SqlBuilders;
+using InterpolatedSql.SqlBuilders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+
+public class DuckDbDapperSqlBuilder : DuckDbSqlBuilder, IDapperSqlBuilder
+{
+    public DuckDbDapperSqlBuilder(IDbConnection connection, InterpolatedSqlBuilderOptions? options = null)
+        : base(options)
+    {
+        DbConnection = connection;
+    }
+
+    public DuckDbDapperSqlBuilder(IDbConnection connection, FormattableString value)
+        : base(value)
+    {
+        DbConnection = connection;
+    }
+
+    public DuckDbDapperSqlBuilder(
+        IDbConnection connection,
+        FormattableString value,
+        InterpolatedSqlBuilderOptions? options = null)
+        : base(value, options)
+    {
+        DbConnection = connection;
+    }
+
+    public DuckDbDapperSqlBuilder(
+        IDbConnection connection,
+        string value,
+        InterpolatedSqlBuilderOptions? options = null)
+        : base(value, options)
+    {
+        DbConnection = connection;
+    }
+
+    protected internal DuckDbDapperSqlBuilder(
+        IDbConnection connection,
+        InterpolatedSqlBuilderOptions? options,
+        StringBuilder? format,
+        List<InterpolatedSqlParameter>? arguments)
+        : base(options, format, arguments)
+    {
+        DbConnection = connection;
+    }
+
+    public override IDapperSqlCommand Build() => ToDapperSqlCommand();
+
+    public IDapperSqlCommand ToDapperSqlCommand()
+    {
+        var format = _format.ToString();
+
+        return new ImmutableDapperCommand(
+            this.DbConnection!,
+            BuildSql(format, _sqlParameters),
+            format,
+            _sqlParameters,
+            _explicitParameters
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/DuckDbParameter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/DuckDbParameter.cs
@@ -1,0 +1,23 @@
+using DuckDB.NET.Data;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+
+/// <summary>
+/// Wrapper around underlying DuckDB.NET implementation to patch
+/// functionality that isn't working correctly.
+/// </summary>
+public class DuckDbParameter : DuckDBParameter
+{
+    public override string ParameterName
+    {
+        // Hack to prevent `ParameterName` being set. We need to do this as a workaround because
+        // named parameters (e.g. $param) don't seem to work correctly in all environments:
+        // https://github.com/Giorgi/DuckDB.NET/issues/178
+        // Unfortunately, this makes the library pretty incompatible with Dapper which
+        // relies heavily on auto-generated named parameters (e.g. $p0, $p1, $p2).
+        // By not setting `ParameterName`, we go force the usage of auto-incrementing
+        // positional parameters (i.e. ?) which seem to work reliably.
+        get => string.Empty;
+        set => base.ParameterName = string.Empty;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/DuckDbSqlBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/DuckDbSqlBuilder.cs
@@ -1,0 +1,80 @@
+using System.Collections;
+using System.Text;
+using InterpolatedSql;
+using InterpolatedSql.SqlBuilders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+
+public class DuckDbSqlBuilder : InterpolatedSqlBuilderBase<DuckDbSqlBuilder, IInterpolatedSql>
+{
+    private static readonly InterpolatedSqlBuilderOptions DefaultOptions = new()
+    {
+        // Use auto-incrementing positional parameters (i.e. ?), to avoid issues
+        // with named parameters which don't seem to work reliably in all environments.
+        // See: https://github.com/Giorgi/DuckDB.NET/issues/178
+        DatabaseParameterSymbol = "?",
+        CalculateAutoParameterName = (_, _) => string.Empty,
+    };
+
+    public DuckDbSqlBuilder() : this(options: null, format: null, arguments: null)
+    {
+    }
+
+    public DuckDbSqlBuilder(FormattableString value, InterpolatedSqlBuilderOptions? options = null)
+        : this(options: options, format: null, arguments: null)
+    {
+        Options.Parser.ParseAppend(this, value);
+        ResetAutoSpacing();
+    }
+
+    public DuckDbSqlBuilder(IInterpolatedSql value, InterpolatedSqlBuilderOptions? options = null)
+        : this(options: options, format: null, arguments: null)
+    {
+        Append(value);
+        ResetAutoSpacing();
+    }
+
+    public DuckDbSqlBuilder(string value, InterpolatedSqlBuilderOptions? options = null)
+        : this(options: options, format: null, arguments: null)
+    {
+        AppendLiteral(value);
+        ResetAutoSpacing();
+    }
+
+    protected DuckDbSqlBuilder(
+        InterpolatedSqlBuilderOptions? options = null,
+        StringBuilder? format = null,
+        List<InterpolatedSqlParameter>? arguments = null)
+        : base(options: options ?? DefaultOptions, format: format, arguments: arguments)
+    {
+    }
+
+    public override void AppendArgument(object? argument, int alignment = 0, string? format = null)
+    {
+        // Reformat enumerable arguments as a series of parameter
+        // placeholders e.g. three item list becomes ?, ?, ?
+        if (argument is not string and IEnumerable enumerable)
+        {
+            var args = enumerable.Cast<object>().ToArray();
+            var index = 0;
+
+            foreach (var arg in args)
+            {
+                base.AppendArgument(arg, alignment, format);
+
+                if (index < args.Length - 1)
+                {
+                    base.AppendLiteral(", ");
+                }
+
+                index += 1;
+            }
+        }
+        else
+        {
+            base.AppendArgument(argument, alignment, format);
+        }
+    }
+
+    public override IInterpolatedSql Build() => base.AsSql();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/IDuckDbConnection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/IDuckDbConnection.cs
@@ -1,0 +1,9 @@
+using System.Data;
+using DuckDB.NET.Data;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+
+public interface IDuckDbConnection : IDbConnection
+{
+    DuckDBAppender CreateAppender(string table);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/ProfiledDuckDbConnection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/DuckDb/ProfiledDuckDbConnection.cs
@@ -1,0 +1,21 @@
+using DuckDB.NET.Data;
+using StackExchange.Profiling;
+using StackExchange.Profiling.Data;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+
+/// <summary>
+/// DuckDB connection profiled using MiniProfiler.
+/// </summary>
+public class ProfiledDuckDbConnection(
+    string connectionString = DuckDBConnectionStringBuilder.InMemoryConnectionString,
+    IDbProfiler? profiler = null)
+    : ProfiledDbConnection(new DuckDbConnection(connectionString), profiler ?? MiniProfiler.Current), IDuckDbConnection
+{
+    private DuckDbConnection WrappedDuckDbConnection => (DuckDbConnection)WrappedConnection;
+
+    public DuckDBAppender CreateAppender(string table)
+    {
+        return WrappedDuckDbConnection.CreateAppender(table);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/GovUk.Education.ExploreEducationStatistics.Common.DuckDb.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/GovUk.Education.ExploreEducationStatistics.Common.DuckDb.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="DuckDB.NET.Data.Full" Version="1.2.0" />
+      <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0" />
+      <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
+    </ItemGroup>
+
+</Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.sln
+++ b/src/GovUk.Education.ExploreEducationStatistics.sln
@@ -134,6 +134,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Search", "Search", "{316C48
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Function App", "Function App", "{EB58283F-148A-4A51-B023-0757F5D730B1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEducationStatistics.Common.DuckDb", "GovUk.Education.ExploreEducationStatistics.Common.DuckDb\GovUk.Education.ExploreEducationStatistics.Common.DuckDb.csproj", "{4F69E5BF-58DA-4F22-BE24-073627E2F313}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Analytics", "Analytics", "{7C7E2073-76E6-4AEB-9C4E-0FCD904227CF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEducationStatistics.Analytics.Consumer", "GovUk.Education.ExploreEducationStatistics.Analytics.Consumer\GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.csproj", "{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests", "GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests\GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests.csproj", "{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -684,6 +692,42 @@ Global
 		{EA8E2300-3F47-401F-99D1-72DB98B627F2}.Release|x64.Build.0 = Release|Any CPU
 		{EA8E2300-3F47-401F-99D1-72DB98B627F2}.Release|x86.ActiveCfg = Release|Any CPU
 		{EA8E2300-3F47-401F-99D1-72DB98B627F2}.Release|x86.Build.0 = Release|Any CPU
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313}.Debug|x64.Build.0 = Debug|Any CPU
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313}.Debug|x86.Build.0 = Debug|Any CPU
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313}.Release|x64.ActiveCfg = Release|Any CPU
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313}.Release|x64.Build.0 = Release|Any CPU
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313}.Release|x86.ActiveCfg = Release|Any CPU
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313}.Release|x86.Build.0 = Release|Any CPU
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}.Debug|x64.Build.0 = Debug|Any CPU
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}.Debug|x86.Build.0 = Debug|Any CPU
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}.Release|x64.ActiveCfg = Release|Any CPU
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}.Release|x64.Build.0 = Release|Any CPU
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}.Release|x86.ActiveCfg = Release|Any CPU
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB}.Release|x86.Build.0 = Release|Any CPU
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}.Debug|x64.Build.0 = Debug|Any CPU
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}.Debug|x86.Build.0 = Debug|Any CPU
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}.Release|x64.ActiveCfg = Release|Any CPU
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}.Release|x64.Build.0 = Release|Any CPU
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}.Release|x86.ActiveCfg = Release|Any CPU
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -746,5 +790,8 @@ Global
 		{EB58283F-148A-4A51-B023-0757F5D730B1} = {316C48ED-789B-428C-A4D0-FAA5F9856850}
 		{8F5D27F9-339E-440F-8AD6-29189F706FCB} = {EB58283F-148A-4A51-B023-0757F5D730B1}
 		{EA8E2300-3F47-401F-99D1-72DB98B627F2} = {EB58283F-148A-4A51-B023-0757F5D730B1}
+		{4F69E5BF-58DA-4F22-BE24-073627E2F313} = {A58A13A6-EA97-4CE1-A134-83045CC08C85}
+		{06955F3F-DDA0-46CD-B514-DE2F40CD7AEB} = {7C7E2073-76E6-4AEB-9C4E-0FCD904227CF}
+		{BBFFE4D0-CA8E-4A4D-A836-594347DE8F03} = {7C7E2073-76E6-4AEB-9C4E-0FCD904227CF}
 	EndGlobalSection
 EndGlobal

--- a/useful-scripts/start.ts
+++ b/useful-scripts/start.ts
@@ -66,6 +66,7 @@ type ServiceSchemaDockerServices =
 // or we run into various circular reference issues in the types.
 const allowedServiceNames = [
   'admin',
+  'analytics',
   'content',
   'data',
   'frontend',
@@ -79,7 +80,6 @@ const allowedServiceNames = [
   'idp',
   'db',
   'dataStorage',
-  'searchFunctionApp',
 ] as const;
 
 type ServiceName = (typeof allowedServiceNames)[number];
@@ -96,6 +96,13 @@ const serviceSchemas: Record<ServiceName, ServiceSchema> = {
         ? ['db', 'data-storage', 'public-api-db']
         : ['db', 'data-storage', 'public-api-db', 'idp'];
     },
+  },
+  analytics: {
+    root: 'src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer',
+    colour: chalk.rgb(165, 158, 255),
+    port: 7075,
+    type: 'func',
+    dockerServices: ['data-storage'],
   },
   content: {
     root: 'src/GovUk.Education.ExploreEducationStatistics.Content.Api',
@@ -158,13 +165,6 @@ const serviceSchemas: Record<ServiceName, ServiceSchema> = {
     port: 7074,
     type: 'func',
     dockerServices: ['db', 'public-api-db', 'data-storage'],
-  },
-  searchFunctionApp: {
-    root: 'src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp',
-    colour: chalk.rgb(255, 102, 0),
-    port: 7075,
-    type: 'func',
-    dockerServices: ['data-storage'],
   },
   idp: {
     service: 'idp',


### PR DESCRIPTION
This PR introduces the 2nd part of the Analytics work for the Public API (and in future for other, non-Public API-related sources).

In Part 1 (https://github.com/dfe-analytical-services/explore-education-statistics/pull/5655), we added the writing out of Public API queries to an Analytics-specific file share from the Public API Container App.  Successful queries would be written out in a JSON file along with some other information about the query results, the time taken to issue the query etc.

Part 2 (this PR) involves consuming that raw data and converting it into a format that can be used conveniently in DfE's Delta Lake.  In this case, we decided on Parquet files, using the following schema:

Distinct query details (output in a `<timestamp>_public-api-queries.parquet` file):
```
When I talk about "logically distinct queries" or "logical structure" below, I refer to the fact that in Part 1 where we output the Public API queries to the file share, we attempted to "normalise" the queries as much as possible so that the query JSON for 2 different queries that were using the same criteria, filters, indicators, sorts, pagination and debug options (and therefore logically trying to query for the same set of results) would be output in identical format.  

QueryVersionHash - an MD5 hash of the query JSON concatenated with its DataSetVersionId.  This therefore represents a unique logical query along with the exact DataSetVersion that it was issued for.  This makes the distinction between a query that was exactly the same logical structure but was issued against 2 or more distinct DataSetVersions e.g. a query that was issued against a 1.0 version and then a 1.1 version of the same data set.

QueryHash - an MD5 hash of the query JSON.  This represents logically distinct queries but the same hash can apply to the same query but issued against different DataSetVersions.

Query - the query JSON itself.

DataSetId

DataSetVersionId

DataSetVersion - semver string.

DataSetTitle

ResultsCount - number of results returned in this particular query.

TotalRowsCount - the total number of (unpaginated) results available from this query.

QueryExecutions - the number of times this distinct query was executed against this particular DataSetVersion.
```

Distinct query access details (output in a `<timestamp>_public-api-query_access.parquet` file):
```
QueryVersionHash - as above.  This effectively acts as a foreign key to the rows in the file output above.  This lets us identify when each of the distinct queries captured in the first file were accessed.

StartTime - a UTC timestamp of then the start of the query execution occurred.

EndTime - a UTC timestamp of then the start of the query execution occurred.

DurationMillis - the time taken in milliseconds to execute the query.
```
