### PR TITLE
Rollback Aspect Injector to 2.8.1 to provide compatibility with M1 Ma…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
+    <PackageReference Include="AspectInjector" Version="2.8.1" PrivateAssets="all" />
     <PackageReference Include="GeoJSON.Net" Version="1.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7" PrivateAssets="all" />
     <PackageReference Include="GovukNotify" Version="7.1.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspectInjector" Version="2.8.2"/>
+    <PackageReference Include="AspectInjector" Version="2.8.1"/>
     <PackageReference Include="Bogus" Version="35.6.0"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" PrivateAssets="all"/>
     <PackageReference Include="CompareNETObjects" Version="4.83.0"/>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -17,7 +17,7 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="AngleSharp" Version="1.1.2" />
-        <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
+        <PackageReference Include="AspectInjector" Version="2.8.1" PrivateAssets="all" />
         <PackageReference Include="Aspects.Universal" Version="1.0.2" />
         <PackageReference Include="AutoMapper" Version="13.0.1" />
         <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspectInjector" Version="2.8.2" />
+        <PackageReference Include="AspectInjector" Version="2.8.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
+        <PackageReference Include="AspectInjector" Version="2.8.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
         <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.2.3" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GovUk.Education.ExploreEducationStatistics.Content.Services.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GovUk.Education.ExploreEducationStatistics.Content.Services.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
+        <PackageReference Include="AspectInjector" Version="2.8.1" PrivateAssets="all" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
         <PackageReference Include="System.Linq.Async.Queryable" Version="6.0.1" />
     </ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspectInjector" Version="2.8.2" PrivateAssets="all" />
+    <PackageReference Include="AspectInjector" Version="2.8.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7" PrivateAssets="all" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.7" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0"/>
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0"/>
-    <PackageReference Include="AspectInjector" Version="2.8.2"/>
+    <PackageReference Include="AspectInjector" Version="2.8.1"/>
     <PackageReference Include="Azure.Identity" Version="1.12.0"/>
     <PackageReference Include="Dapper" Version="2.1.35"/>
     <PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.2"/>


### PR DESCRIPTION
Aspect Injector 2.8.2 broke everything for M1 Macbooks. 2.8.2 is the latest stable release so no fix has been forthcoming since 2023 when this was reported. Rollback to 2.8.1.