### PR TITLE
EES-5881: Add templates for containerised Azure Function.

### DIFF
--- a/infrastructure/templates/common/components/containerisedFunctionApp.bicep
+++ b/infrastructure/templates/common/components/containerisedFunctionApp.bicep
@@ -1,0 +1,428 @@
+import {
+  FirewallRule
+  IpRange
+} from '../../common/types.bicep'
+
+import {
+  AzureFileShareMount
+  EntraIdAuthentication
+} from '../../public-api/types.bicep'
+
+import { abbreviations } from '../../common/abbreviations.bicep'
+import { staticAverageLessThanHundred, staticMinGreaterThanZero } from '../../public-api/components/alerts/staticAlertConfig.bicep'
+import { dynamicAverageGreaterThan } from '../../public-api/components/alerts/dynamicAlertConfig.bicep'
+
+@description('An existing Managed Identity\'s Resource Id with which to associate this Function App')
+param userAssignedManagedIdentityParams {
+  id: string
+  name: string
+  principalId: string
+}?
+
+@description('Specifies the Function App name')
+param functionAppName string
+
+@description('Specifies additional Azure Storage Accounts to make available to this Function App')
+param azureFileShares AzureFileShareMount[] = []
+
+@description('Name of the deployment storage account.')
+param deploymentStorageAccountName string
+
+@description('Specifies whether or not the Function App will always be on and not idle after periods of no traffic - must be compatible with the chosen hosting plan')
+param alwaysOn bool?
+
+@description('Specifies whether this Function App is accessible from the public internet')
+param publicNetworkAccessEnabled bool = false
+
+@description('IP address ranges that are allowed to access the Function App endpoints. Dependent on "publicNetworkAccessEnabled" being true.')
+param functionAppFirewallRules FirewallRule[] = []
+
+@description('Specifies the list of origins that should be allowed to make cross-origin calls.')
+param allowedOrigins array = []
+
+@description('Specifies firewall rules for the various storage accounts in use by the Function App')
+param storageFirewallRules IpRange[] = []
+
+@description('Specifies the optional subnet id for function app inbound traffic from the VNet')
+param privateEndpoints {
+  functionApp: string?
+  storageAccounts: string
+}
+
+@description('Specifies the location for all resources.')
+param location string
+
+@description('The Docker image tag. This value should represent a pipeline build number')
+param functionAppDockerImageTag string
+
+@description('Specifies the App Service plan name')
+param appServicePlanName string
+
+@description('The Application Insights connection string that is associated with this resource.')
+param applicationInsightsConnectionString string
+
+@description('Specifies the SKU for the Function App hosting plan')
+param sku object
+
+@description('Function App Plan : operating system')
+param operatingSystem 'Windows' | 'Linux' = 'Linux'
+
+@description('Specifies the login server from the registry.')
+@secure()
+param acrLoginServer string
+
+@description('An existing Service Principal\'s Client Id with which this Function App can pull Docker images (using it as the ACR username)')
+@secure()
+param dockerPullManagedIdentityClientId string
+
+@description('An existing Service Principal\'s Secret value with which this Function App can pull Docker images (using it as the ACR password)')
+@secure()
+param dockerPullManagedIdentitySecretValue string
+
+@description('Specifies the container image to deploy from the registry.')
+param functionAppImageName string
+
+@description('An existing App Registration registered with Entra ID that will be used to control access to this Function App')
+param entraIdAuthentication EntraIdAuthentication?
+
+@description('Enable pulling an image over a Virtual Network')
+param vnetImagePullEnabled bool = false
+
+@description('Specifies the subnet id for the function app outbound traffic across the VNet')
+param subnetId string
+
+@description('The number of preWarmed instances')
+param preWarmedInstanceCount int = 1
+
+@description('Site redundancy mode')
+param redundancyMode string = 'None'
+
+@description('Specifies the Key Vault name that this Function App will be permitted to get and list secrets from')
+param keyVaultName string
+
+@description('Specifies whether or not the Function App already exists.')
+param functionAppExists bool
+
+@description('Specifies an optional URL for Azure to use to monitor the health of this resource')
+param healthCheckPath string?
+
+@description('Whether to create or update Azure Monitor alerts during this deploy')
+param alerts {
+  functionAppHealth: bool
+  httpErrors: bool
+  cpuPercentage: bool
+  memoryPercentage: bool
+  storageAccountAvailability: bool
+  storageLatency: bool
+  alertsGroupName: string
+  fileServiceAvailability: bool
+  fileServiceLatency: bool
+  fileServiceCapacity: bool
+}?
+
+@description('A set of tags with which to tag the resource in Azure')
+param tagValues object
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+var firewallRules = [
+  for (firewallRule, index) in functionAppFirewallRules: {
+    name: firewallRule.name
+    ipAddress: firewallRule.cidr
+    action: 'Allow'
+    tag: firewallRule.tag != null ? firewallRule.tag : 'Default'
+    priority: firewallRule.priority != null ? firewallRule.priority : 100 + index
+  }
+]
+
+var storageAlerts = alerts != null
+  ? {
+      availability: alerts!.storageAccountAvailability
+      latency: alerts!.storageLatency
+      alertsGroupName: alerts!.alertsGroupName
+    }
+  : null
+
+var fileServiceAlerts = alerts != null
+  ? {
+      availability: alerts!.fileServiceAvailability
+      latency: alerts!.fileServiceLatency
+      capacity: alerts!.fileServiceCapacity
+      alertsGroupName: alerts!.alertsGroupName
+    }
+  : null
+
+module appServicePlanModule '../../public-api/components/appServicePlan.bicep' = {
+  name: appServicePlanName
+  params: {
+    planName: appServicePlanName
+    location: location
+    kind: 'functionapp'
+    sku: sku
+    operatingSystem: operatingSystem
+    alerts: alerts != null
+      ? {
+          cpuPercentage: alerts!.cpuPercentage
+          memoryPercentage: alerts!.memoryPercentage
+          alertsGroupName: alerts!.alertsGroupName
+        }
+      : null
+    tagValues: tagValues
+  }
+}
+
+module keyVaultRoleAssignmentModule '../../public-api/components/keyVaultRoleAssignment.bicep' = {
+  name: '${functionAppName}KeyVaultRoleAssignmentModuleDeploy'
+  params: {
+    principalIds: userAssignedManagedIdentityParams != null
+      ? [userAssignedManagedIdentityParams!.principalId]
+      : [functionApp.identity.principalId]
+    keyVaultName: keyVault.name
+    role: 'Secrets User'
+  }
+}
+
+module deploymentStorageAccountModule '../../public-api/components/storageAccount.bicep' = {
+  name: '${functionAppName}DeploymentStorageAccountModuleDeploy'
+  params: {
+    location: location
+    storageAccountName: deploymentStorageAccountName
+    firewallRules: storageFirewallRules
+    sku: 'Standard_LRS'
+    kind: 'StorageV2'
+    keyVaultName: keyVaultName
+    privateEndpointSubnetIds: {
+      blob: privateEndpoints.storageAccounts
+      file: privateEndpoints.storageAccounts
+    }
+    publicNetworkAccessEnabled: false
+    alerts: storageAlerts
+    tagValues: tagValues
+  }
+}
+
+module fileShareModule '../../public-api/components/fileShare.bicep' = {
+  name: '${functionAppName}FileShareDeploy'
+  params: {
+    storageAccountName: deploymentStorageAccountName
+    fileShareName: '${functionAppName}-${abbreviations.fileShare}'
+    alerts: fileServiceAlerts
+    tagValues: tagValues
+  }
+  dependsOn: [
+    deploymentStorageAccountModule
+  ]
+}
+
+module storageAccountBlobRoleAssignmentModule 'storageAccountRoleAssignment.bicep' = {
+  name: '${deploymentStorageAccountName}BlobRoleAssignmentModuleDeploy'
+  params: {
+    principalIds: userAssignedManagedIdentityParams != null
+      ? [userAssignedManagedIdentityParams!.principalId]
+      : [functionApp.identity.principalId]
+    storageAccountName: deploymentStorageAccountModule.outputs.storageAccountName
+    role: 'Storage Blob Data Owner'
+  }
+}
+
+var keyVaultReferenceIdentity = userAssignedManagedIdentityParams != null ? userAssignedManagedIdentityParams!.id : null
+
+var identity = userAssignedManagedIdentityParams != null
+  ? {
+      type: 'UserAssigned'
+      userAssignedIdentities: {
+        '${userAssignedManagedIdentityParams!.id}': {}
+      }
+    }
+  : {
+      type: 'SystemAssigned'
+    }
+
+resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
+  name: functionAppName
+  location: location
+  tags: tagValues
+  kind: 'functionapp,linux,container'
+  identity: identity
+  properties: {
+    enabled: true
+    serverFarmId: appServicePlanModule.outputs.planId
+    reserved: operatingSystem == 'Linux'
+    vnetImagePullEnabled: vnetImagePullEnabled
+    virtualNetworkSubnetId: subnetId
+    siteConfig: {
+      linuxFxVersion: 'DOCKER|${acrLoginServer}/${functionAppImageName}:${functionAppDockerImageTag}'
+      alwaysOn: alwaysOn ?? null
+      keyVaultReferenceIdentity: keyVaultReferenceIdentity
+      scmType: 'None'
+      autoHealEnabled: true
+      healthCheckPath: healthCheckPath
+      vnetRouteAllEnabled: true
+      publicNetworkAccess: publicNetworkAccessEnabled ? 'Enabled' : 'Disabled'
+      ipSecurityRestrictions: publicNetworkAccessEnabled && length(firewallRules) > 0 ? firewallRules : null
+      cors: {
+        allowedOrigins: union(['https://portal.azure.com'], allowedOrigins)
+        supportCredentials: false
+      }
+      http20Enabled: true
+      minTlsVersion: '1.3'
+      preWarmedInstanceCount: preWarmedInstanceCount
+      appSettings: [
+        {
+          name: 'FUNCTIONS_EXTENSION_VERSION'
+          value: '~4'
+        }
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: applicationInsightsConnectionString
+        }
+        // Use managed identity to access the storage account rather than key based access with a connection string
+        {
+          name: 'AzureWebJobsStorage__accountName'
+          value: deploymentStorageAccountModule.outputs.storageAccountName
+        }
+        {
+          name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'
+          value: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=${deploymentStorageAccountModule.outputs.connectionStringSecretName})'
+        }
+        {
+          name: 'WEBSITE_SKIP_CONTENTSHARE_VALIDATION'
+          value: !functionAppExists ? '1' : null
+        }
+        {
+          name: 'WEBSITE_CONTENTSHARE'
+          value: fileShareModule.outputs.fileShareName
+        }
+        {
+          name: 'WEBSITE_CONTENTOVERVNET'
+          value: '1'
+        }
+        {
+          name: 'WEBSITES_ENABLE_APP_SERVICE_STORAGE'
+          value: 'false'
+        }
+        {
+          name: 'DOCKER_REGISTRY_SERVER_URL'
+          value: acrLoginServer
+        }
+        {
+          name: 'DOCKER_REGISTRY_SERVER_USERNAME'
+          value: dockerPullManagedIdentityClientId
+        }
+        {
+          name: 'DOCKER_REGISTRY_SERVER_PASSWORD'
+          value: dockerPullManagedIdentitySecretValue
+        }
+      ]
+    }
+    httpsOnly: true
+    redundancyMode: redundancyMode
+    keyVaultReferenceIdentity: keyVaultReferenceIdentity
+  }
+}
+
+resource azureStorageAccountsConfig 'Microsoft.Web/sites/config@2023-12-01' = {
+  parent: functionApp
+  name: 'azurestorageaccounts'
+  properties: reduce(
+    azureFileShares,
+    {},
+    (cur, next) =>
+      union(cur, {
+        '${next.storageName}': {
+          type: 'AzureFiles'
+          shareName: next.fileShareName
+          mountPath: next.mountPath
+          accountName: next.storageAccountName
+          accessKey: next.storageAccountKey
+        }
+      })
+  )
+}
+
+module privateEndpointModule '../../public-api/components/privateEndpoint.bicep' = if (privateEndpoints.?functionApp != null) {
+  name: '${functionAppName}PrivateEndpointDeploy'
+  params: {
+    serviceId: functionApp.id
+    serviceName: functionApp.name
+    serviceType: 'sites'
+    subnetId: privateEndpoints.?functionApp ?? ''
+    location: location
+    tagValues: tagValues
+  }
+}
+
+module azureAuthentication '../../public-api/components/siteAzureAuthentication.bicep' = if (entraIdAuthentication != null) {
+  name: '${functionAppName}AzureAuthentication'
+  params: {
+    clientId: entraIdAuthentication!.appRegistrationClientId
+    siteName: functionApp.name
+    allowedClientIds: entraIdAuthentication!.allowedClientIds
+    allowedPrincipalIds: entraIdAuthentication!.allowedPrincipalIds
+    requireAuthentication: entraIdAuthentication!.requireAuthentication
+  }
+}
+
+module healthAlert '../../public-api/components/alerts/staticMetricAlert.bicep' = if (alerts != null && alerts!.functionAppHealth) {
+  name: '${functionAppName}HealthAlertModule'
+  params: {
+    resourceName: functionApp.name
+    resourceMetric: {
+      resourceType: 'Microsoft.Web/sites'
+      metric: 'HealthCheckStatus'
+    }
+    config: {
+      ...staticAverageLessThanHundred
+      nameSuffix: 'health'
+    }
+    alertsGroupName: alerts!.alertsGroupName
+    tagValues: tagValues
+  }
+}
+
+var unexpectedHttpStatusCodeMetrics = ['Http401', 'Http5xx']
+
+module unexpectedHttpStatusCodeAlerts '../../public-api/components/alerts/staticMetricAlert.bicep' = [
+  for httpStatusCode in unexpectedHttpStatusCodeMetrics: if (alerts != null && alerts!.httpErrors) {
+    name: '${functionAppName}${httpStatusCode}Module'
+    params: {
+      resourceName: functionApp.name
+      resourceMetric: {
+        resourceType: 'Microsoft.Web/sites'
+        metric: httpStatusCode
+      }
+      config: {
+        ...staticMinGreaterThanZero
+        nameSuffix: toLower(httpStatusCode)
+      }
+      alertsGroupName: alerts!.alertsGroupName
+      tagValues: tagValues
+    }
+  }
+]
+
+var expectedHttpStatusCodeMetrics = ['Http403', 'Http4xx']
+
+module expectedHttpStatusCodeAlerts '../../public-api/components/alerts/dynamicMetricAlert.bicep' = [
+  for httpStatusCode in expectedHttpStatusCodeMetrics: if (alerts != null && alerts!.httpErrors) {
+    name: '${functionAppName}${httpStatusCode}Module'
+    params: {
+      resourceName: functionApp.name
+      resourceMetric: {
+        resourceType: 'Microsoft.Web/sites'
+        metric: httpStatusCode
+      }
+      config: {
+        ...dynamicAverageGreaterThan
+        nameSuffix: toLower(httpStatusCode)
+        severity: 'Informational'
+      }
+      alertsGroupName: alerts!.alertsGroupName
+      tagValues: tagValues
+    }
+  }
+]
+
+output url string = 'https://${functionApp.name}.azurewebsites.net'

--- a/infrastructure/templates/public-api/components/storageAccount.bicep
+++ b/infrastructure/templates/public-api/components/storageAccount.bicep
@@ -20,7 +20,7 @@ param sku 'Standard_LRS' | 'Standard_GRS' | 'Standard_RAGRS' | 'Standard_ZRS' | 
 @description('Storage Account kind')
 param kind 'StorageV2' | 'FileStorage' = 'StorageV2'
 
-@description('Storage Account Name')
+@description('Key Vault Name')
 param keyVaultName string
 
 @description('Whether the storage account is accessible from the public internet')

--- a/infrastructure/templates/screener/application/screenerApplicationInsights.bicep
+++ b/infrastructure/templates/screener/application/screenerApplicationInsights.bicep
@@ -1,0 +1,32 @@
+import { abbreviations } from '../../common/abbreviations.bicep'
+import { ResourceNames } from '../types.bicep'
+
+@description('Resource prefix for all resources.')
+param resourcePrefix string
+
+@description('Specifies common resource naming variables.')
+param resourceNames ResourceNames
+
+@description('Specifies the location for all resources.')
+param location string
+
+@description('Specifies a set of tags with which to tag the resource in Azure.')
+param tagValues object
+
+module applicationInsightsModule '../../public-api/components/appInsights.bicep' = {
+  name: 'applicationInsightsModuleDeploy'
+  params: {
+    location: location
+    appInsightsName: '${resourcePrefix}-${abbreviations.insightsComponents}-screener'
+    alerts: {
+      exceptionCount: true
+      exceptionServerCount: true
+      failedRequests: true
+      alertsGroupName: resourceNames.existingResources.alertsGroup
+    }
+    tagValues: tagValues
+  }
+}
+
+output applicationInsightsConnectionString string = applicationInsightsModule.outputs.applicationInsightsConnectionString
+output applicationInsightsName string = applicationInsightsModule.outputs.applicationInsightsName

--- a/infrastructure/templates/screener/application/screenerContainerisedFunctionApp.bicep
+++ b/infrastructure/templates/screener/application/screenerContainerisedFunctionApp.bicep
@@ -1,0 +1,150 @@
+import {
+  FirewallRule
+  IpRange
+} from '../../common/types.bicep'
+
+import {
+  AzureFileShareMount
+  EntraIdAuthentication
+} from '../../public-api/types.bicep'
+
+import { staticAverageLessThanHundred, staticMinGreaterThanZero } from '../../public-api/components/alerts/staticAlertConfig.bicep'
+import { dynamicAverageGreaterThan } from '../../public-api/components/alerts/dynamicAlertConfig.bicep'
+import { ResourceNames } from '../types.bicep'
+
+@description('Specifies common resource naming variables.')
+param resourceNames ResourceNames
+
+@description('Specifies the location for all resources.')
+param location string
+
+@description('Function App Plan : operating system')
+param operatingSystem 'Windows' | 'Linux' = 'Linux'
+
+@description('The Application Insights connection string that is associated with this resource.')
+param applicationInsightsConnectionString string = ''
+
+@description('Specifies whether or not the Screener Function App already exists.')
+param functionAppExists bool
+
+@description('The IP address ranges that can access the Screener storage accounts.')
+param storageFirewallRules IpRange[]
+
+@description('IP address ranges that are allowed to access the Function App endpoints. Dependent on "publicNetworkAccessEnabled" being true.')
+param functionAppFirewallRules FirewallRule[] = []
+
+@description('Specifies the Application (Client) Id of a pre-existing App Registration used to represent the Screener Function App.')
+param screenerAppRegistrationClientId string
+
+@description('Specifies the principal id of the Azure DevOps SPN.')
+@secure()
+param devopsServicePrincipalId string
+
+@description('Specifies the login server from the registry.')
+@secure()
+param acrLoginServer string
+
+@description('Specifies the container image to deploy from the registry.')
+param functionAppImageName string
+
+@description('The Docker image tag for the data screener. This value should represent a pipeline build number')
+param screenerDockerImageTag string
+
+@description('Whether to create or update Azure Monitor alerts during this deploy')
+param deployAlerts bool
+
+@description('A set of tags with which to tag the resource in Azure')
+param tagValues object
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: resourceNames.existingResources.keyVault
+}
+
+resource vNet 'Microsoft.Network/virtualNetworks@2023-11-01' existing = {
+  name: resourceNames.existingResources.vNet
+}
+
+resource outboundVnetSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
+  name: resourceNames.existingResources.subnets.screenerFunction
+  parent: vNet
+}
+
+resource privateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
+  name: resourceNames.existingResources.subnets.screenerFunctionPrivateEndpoints
+  parent: vNet
+}
+
+resource adminAppService 'Microsoft.Web/sites@2023-12-01' existing = {
+  name: resourceNames.existingResources.adminApp
+}
+
+resource adminAppServiceIdentity 'Microsoft.ManagedIdentity/identities@2023-01-31' existing = {
+  scope: adminAppService
+  name: 'default'
+}
+
+var adminAppClientId = adminAppServiceIdentity.properties.clientId
+
+module containerisedFunctionAppModule '../../common/components/containerisedFunctionApp.bicep' = {
+  name: 'screenerContainerisedFunctionAppModuleDeploy'
+  params: {
+    operatingSystem: operatingSystem
+    sku: {
+      name: 'EP1'
+      tier: 'ElasticPremium'
+      family: 'EP'
+    }
+    functionAppName: resourceNames.screener.screenerFunction
+    acrLoginServer: acrLoginServer
+    functionAppImageName: functionAppImageName
+    functionAppDockerImageTag: screenerDockerImageTag
+    location: location
+    applicationInsightsConnectionString: applicationInsightsConnectionString
+    healthCheckPath: '/api/screen'
+    appServicePlanName: resourceNames.screener.screenerFunction
+    functionAppExists: functionAppExists
+    keyVaultName: keyVault.name
+    // entraIdAuthentication: {
+    //   appRegistrationClientId: screenerAppRegistrationClientId
+    //   allowedClientIds: [
+    //     adminAppClientId
+    //     devopsServicePrincipalId
+    //   ]
+    //   allowedPrincipalIds: []
+    //   requireAuthentication: true
+    // }
+    // userAssignedManagedIdentityParams: {
+    //   id: screenerFunctionAppManagedIdentity.id
+    //   name: screenerFunctionAppManagedIdentity.name
+    //   principalId: screenerFunctionAppManagedIdentity.properties.principalId
+    // }
+    dockerPullManagedIdentityClientId: keyVault.getSecret('DOCKER-REGISTRY-SERVER-USERNAME')
+    dockerPullManagedIdentitySecretValue: keyVault.getSecret('DOCKER-REGISTRY-SERVER-PASSWORD')
+    deploymentStorageAccountName: resourceNames.screener.screenerFunctionStorageAccount
+    functionAppFirewallRules: functionAppFirewallRules
+    storageFirewallRules: storageFirewallRules
+    publicNetworkAccessEnabled: true
+    privateEndpoints: {
+      functionApp: privateEndpointSubnet.id
+      storageAccounts: privateEndpointSubnet.id
+    }
+    subnetId: outboundVnetSubnet.id
+    alerts: deployAlerts
+      ? {
+          cpuPercentage: true
+          memoryPercentage: true
+          storageAccountAvailability: true
+          storageLatency: false
+          alertsGroupName: resourceNames.existingResources.alertsGroup
+          functionAppHealth: true
+          httpErrors: true
+          fileServiceAvailability: true
+          fileServiceCapacity: true
+          fileServiceLatency: true
+        }
+      : null
+    tagValues: tagValues
+  }
+}
+
+output functionAppUrl string = containerisedFunctionAppModule.outputs.url

--- a/infrastructure/templates/screener/bicepconfig.json
+++ b/infrastructure/templates/screener/bicepconfig.json
@@ -1,0 +1,5 @@
+{
+  "experimentalFeaturesEnabled": {
+    "userDefinedTypes": true
+  }
+}

--- a/infrastructure/templates/screener/ci/azure-pipelines.yml
+++ b/infrastructure/templates/screener/ci/azure-pipelines.yml
@@ -1,0 +1,73 @@
+trigger: none
+
+parameters:
+  - name: deployAlerts
+    displayName: Do the Azure Monitor alerts need creating or updating?
+    type: string
+    values:
+      - Yes
+      - No
+    default: No
+  - name: forceDeployToEnvironment
+    displayName: Set to either dev, test or preprod to force a deploy to that environment from the chosen branch.
+    type: string
+    values:
+      - none
+      - dev
+      - test
+      - preprod
+    default: none
+
+variables:
+  - group: Common
+  - name: forceDeployToEnvironment
+    value: ${{parameters.forceDeployToEnvironment}}
+  - name: isDev
+    value: $[or(eq(variables['forceDeployToEnvironment'], 'dev'), eq(variables['Build.SourceBranch'], 'refs/heads/dev'))]
+  - name: isTest
+    value: $[or(eq(variables['forceDeployToEnvironment'], 'test'), eq(variables['Build.SourceBranch'], 'refs/heads/test'))]
+  - name: isPreProd
+    value: $[or(eq(variables['forceDeployToEnvironment'], 'preprod'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))]
+  - name: isMaster
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
+  - name: vmImageName
+    value: ubuntu-latest
+  - name: deployAlerts
+    value: ${{ iif(eq(parameters.deployAlerts, 'Yes'), true, false) }}
+
+pool:
+  vmImage: $(vmImageName)
+
+stages:
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployDev
+      condition: eq(variables.isDev, true)
+      environment: Dev
+      serviceConnection: $(serviceConnectionDev)
+      bicepParamFile: dev
+
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployTest
+      condition: eq(variables.isTest, true)
+      environment: Test
+      serviceConnection: $(serviceConnectionTest)
+      bicepParamFile: test
+
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployPreProd
+      condition: eq(variables.isPreProd, true)
+      environment: Pre-Prod
+      serviceConnection: $(serviceConnectionPreProd)
+      bicepParamFile: preprod
+
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployProd
+      condition:  and(succeeded(), eq(variables.isMaster, true))
+      dependsOn: DeployPreProd
+      environment: Prod
+      serviceConnection: $(serviceConnectionProd)
+      bicepParamFile: prod

--- a/infrastructure/templates/screener/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/screener/ci/jobs/deploy-infrastructure.yml
@@ -1,0 +1,51 @@
+parameters:
+  - name: serviceConnection
+    type: string
+  - name: environment
+    type: string
+  - name: bicepParamFile
+    type: string
+
+jobs:
+  - deployment: DeployScreenerInfrastructure
+    displayName: Deploy screener infrastructure
+    environment: ${{ parameters.environment }}
+    variables:
+      templateDirectory: $(Build.SourcesDirectory)/infrastructure/templates/screener
+      templateFile: $(templateDirectory)/main.bicep
+      paramDirectory: $(templateDirectory)/parameters
+      paramFile: $(paramDirectory)/main-${{ parameters.bicepParamFile }}.bicepparam
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - checkout: self
+
+            - task: AzureCLI@2
+              displayName: Install Bicep
+              inputs:
+                azureSubscription: ${{ parameters.serviceConnection }}
+                scriptType: bash
+                scriptLocation: inlineScript
+                inlineScript: az bicep install
+
+            - template: ../tasks/deploy-bicep.yml
+              parameters:
+                displayName: Validate Bicep template
+                action: validate
+                serviceConnection: ${{ parameters.serviceConnection }}
+                parameterFile: $(paramFile)
+
+            - template: ../../../public-api/ci/tasks/check-function-app-exists.yml
+              parameters:
+                serviceConnection: ${{ parameters.serviceConnection }}
+                resourceGroupName: $(resourceGroupName)
+                functionAppName: $(screenerFunctionAppName)
+                variableName: screenerFunctionAppExists
+
+            - template: ../tasks/deploy-bicep.yml
+              parameters:
+                displayName: Deploy Bicep template
+                action: create
+                serviceConnection: ${{ parameters.serviceConnection }}
+                parameterFile: $(paramFile)

--- a/infrastructure/templates/screener/ci/jobs/deploy-screener-function-app.yml
+++ b/infrastructure/templates/screener/ci/jobs/deploy-screener-function-app.yml
@@ -1,0 +1,31 @@
+parameters:
+  - name: serviceConnection
+    type: string
+  - name: environment
+    type: string
+  - name: dependsOn
+    type: object
+    default: []
+
+jobs:
+  - deployment: DeployScreenerFunction
+    displayName: Deploy Screener Function
+    dependsOn: ${{ parameters.dependsOn }}
+    environment: ${{ parameters.environment }}
+    pool:
+      vmImage: $(vmImageName)
+
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - template: ../../../public-api/ci/tasks/bicep-output-variables.yml
+            parameters:
+              serviceConnection: ${{ parameters.serviceConnection }}
+
+          - template: ../../../public-api/ci/tasks/wait-for-endpoint-success.yml
+            parameters:
+              serviceConnection: ${{ parameters.serviceConnection }}
+              displayName: Check the Screener API Function App is healthy after deployment
+              endpoint: '$(screenerFunctionAppUrl)/api/screen'
+              maxAttempts: 50

--- a/infrastructure/templates/screener/ci/stages/deploy.yml
+++ b/infrastructure/templates/screener/ci/stages/deploy.yml
@@ -1,0 +1,55 @@
+parameters:
+  - name: stageName
+    type: string
+  - name: environment
+    type: string
+  - name: serviceConnection
+    type: string
+  - name: bicepParamFile
+    type: string
+    values:
+      - dev
+      - test
+      - preprod
+      - prod
+  - name: condition
+    type: string
+  - name: dependsOn
+    type: object
+    default: []
+  - name: trigger
+    type: string
+    default: automatic
+    values:
+      - automatic
+      - manual
+
+stages:
+  - stage: ${{ parameters.stageName }}
+    displayName: Deploy ${{ parameters.environment }}
+    dependsOn: ${{ parameters.dependsOn }}
+    trigger: ${{ parameters.trigger }}
+    # Prevent this stage from running in parallel with the same deploy stage in other
+    # ongoing runs of this pipeline. Instead, multiple executions of this stage will
+    # be queued and run sequentially in the order that their pipelines were triggered.
+    lockBehavior: sequential
+    condition: ${{ parameters.condition }}
+    variables:
+      - group: Common - ${{ parameters.environment }}
+      - group: Screener Infrastructure - ${{ parameters.environment }}
+      - name: screenerFunctionAppName
+        value: $(subscription)-ees-sapi-fa-screener
+      - name: infraDeployName
+        value: ScreenerInfrastructure$(Build.BuildNumber)
+    jobs:
+      - template: ../jobs/deploy-infrastructure.yml
+        parameters:
+          serviceConnection: ${{ parameters.serviceConnection }}
+          environment: ${{ parameters.environment }}
+          bicepParamFile: ${{ parameters.bicepParamFile }}
+
+      - template: ../jobs/deploy-screener-function-app.yml
+        parameters:
+          serviceConnection: ${{ parameters.serviceConnection }}
+          environment: ${{ parameters.environment }}
+          dependsOn: DeployScreenerInfrastructure

--- a/infrastructure/templates/screener/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/screener/ci/tasks/deploy-bicep.yml
@@ -1,0 +1,35 @@
+parameters:
+  - name: action
+    type: string
+    default: create
+    values:
+      - create
+      - validate
+  - name: displayName
+    type: string
+  - name: serviceConnection
+    type: string
+  - name: parameterFile
+    type: string
+
+steps:
+  - task: AzureCLI@2
+    displayName: ${{ parameters.displayName }}
+    inputs:
+      azureSubscription: ${{ parameters.serviceConnection }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -e
+
+        az deployment group ${{ parameters.action }} \
+          --name $(infraDeployName) \
+          --resource-group $(resourceGroupName) \
+          --template-file $(templateFile) \
+          --parameters ${{ parameters.parameterFile }} \
+          --parameters \
+              subscription='$(subscription)' \
+              resourceTags='$(resourceTags)' \
+              maintenanceIpRanges='$(maintenanceFirewallRules)' \
+              screenerDockerImageTag='$(screenerDockerImageTag)'

--- a/infrastructure/templates/screener/main.bicep
+++ b/infrastructure/templates/screener/main.bicep
@@ -77,7 +77,17 @@ module screenerFunctionAppModule 'application/screenerContainerisedFunctionApp.b
     screenerDockerImageTag: screenerDockerImageTag
     resourceNames: resourceNames
     functionAppExists: screenerFunctionAppExists
-    functionAppFirewallRules: union([], maintenanceFirewallRules)
+    functionAppFirewallRules: union(
+      [
+        {
+          cidr: 'AzureCloud'
+          tag: 'ServiceTag'
+          priority: 101
+          name: 'AzureCloud'
+        }
+      ],
+      maintenanceFirewallRules
+    )
     storageFirewallRules: maintenanceIpRanges
     applicationInsightsConnectionString: applicationInsightsModule.outputs.applicationInsightsConnectionString
     tagValues: tagValues

--- a/infrastructure/templates/screener/main.bicep
+++ b/infrastructure/templates/screener/main.bicep
@@ -1,0 +1,117 @@
+import { IpRange } from '../common/types.bicep'
+import { abbreviations } from '../common/abbreviations.bicep'
+
+@description('Environment : Subscription name e.g. s101d01. Used as a prefix for created resources.')
+param subscription string = ''
+
+@description('Environment : Specifies the location in which the Azure resources should be deployed.')
+param location string = resourceGroup().location
+
+@description('Tagging : Environment name e.g. Development. Used for tagging resources created by this infrastructure pipeline.')
+param environmentName string
+
+@description('Tagging : Used for tagging resources created by this infrastructure pipeline.')
+param resourceTags {
+  CostCentre: string
+  Department: string
+  Solution: string
+  ServiceOwner: string
+  CreatedBy: string
+  DeploymentRepoUrl: string
+}?
+
+@description('Provides access to resources for specific IP address ranges used for service maintenance.')
+param maintenanceIpRanges IpRange[] = []
+
+@description('Specifies the Application (Client) Id of a pre-existing App Registration used to represent the Screener Function App.')
+param screenerAppRegistrationClientId string = ''
+
+@description('Specifies the principal id of the Azure DevOps SPN.')
+@secure()
+param devopsServicePrincipalId string = ''
+
+@description('Tagging : Date Provisioned. Used for tagging resources created by this infrastructure pipeline.')
+param dateProvisioned string = utcNow('u')
+
+@description('Do Azure Monitor alerts need creating or updating?')
+param deployAlerts bool = false
+
+@description('Specifies whether or not the Screener Function App already exists.')
+param screenerFunctionAppExists bool = true
+
+@description('The Docker image tag for the data screener. This value should represent a pipeline build number')
+param screenerDockerImageTag string = ''
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: resourceNames.existingResources.keyVault
+}
+
+var maintenanceFirewallRules = [
+  for maintenanceIpRange in maintenanceIpRanges: {
+    name: maintenanceIpRange.name
+    cidr: maintenanceIpRange.cidr
+    tag: 'Default'
+    priority: 100
+  }
+]
+
+// Create a shared Application Insights resource for Search resources to use.
+module applicationInsightsModule 'application/screenerApplicationInsights.bicep' = {
+  name: 'screenerApplicationInsightsModule'
+  params: {
+    location: location
+    resourcePrefix: resourcePrefix
+    resourceNames: resourceNames
+    tagValues: tagValues
+  }
+}
+
+module screenerFunctionAppModule 'application/screenerContainerisedFunctionApp.bicep' = {
+  name: 'screenerFunctionApp'
+  params: {
+    location: location
+    functionAppImageName: 'ees-screener-api'
+    acrLoginServer: keyVault.getSecret('DOCKER-REGISTRY-SERVER-DOMAIN')
+    screenerAppRegistrationClientId: screenerAppRegistrationClientId
+    devopsServicePrincipalId: devopsServicePrincipalId
+    screenerDockerImageTag: screenerDockerImageTag
+    resourceNames: resourceNames
+    functionAppExists: screenerFunctionAppExists
+    functionAppFirewallRules: union([], maintenanceFirewallRules)
+    storageFirewallRules: maintenanceIpRanges
+    applicationInsightsConnectionString: applicationInsightsModule.outputs.applicationInsightsConnectionString
+    tagValues: tagValues
+    deployAlerts: deployAlerts
+  }
+}
+
+var tagValues = union(resourceTags ?? {}, {
+  Environment: environmentName
+  DateProvisioned: dateProvisioned
+})
+
+// The resource prefix for resources created in the ARM template.
+var legacyResourcePrefix = subscription
+
+// The resource prefix for anything specific to the Screener API.
+var resourcePrefix = '${subscription}-ees-sapi'
+
+var resourceNames = {
+  existingResources: {
+    adminApp: '${legacyResourcePrefix}-as-ees-admin'
+    keyVault: '${legacyResourcePrefix}-kv-ees-01'
+    vNet: '${legacyResourcePrefix}-vnet-ees'
+    alertsGroup: '${legacyResourcePrefix}-ag-ees-alertedusers'
+    subnets: {
+      adminApp: '${legacyResourcePrefix}-snet-ees-admin'
+      screenerFunction: '${resourcePrefix}-snet-${abbreviations.webSitesFunctions}-screener'
+      screenerFunctionPrivateEndpoints: '${resourcePrefix}-snet-${abbreviations.storageStorageAccounts}-screener-pep'
+    }
+  }
+  screener: {
+    screenerFunction: '${resourcePrefix}-${abbreviations.webSitesFunctions}-screener'
+    screenerFunctionStorageAccount: '${replace(resourcePrefix, '-', '')}${abbreviations.storageStorageAccounts}fn'
+  }
+}
+
+output screenerFunctionAppUrl string = screenerFunctionAppModule.outputs.functionAppUrl

--- a/infrastructure/templates/screener/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/screener/parameters/main-dev.bicepparam
@@ -1,0 +1,4 @@
+using '../main.bicep'
+
+// Environment Params
+param environmentName = 'Development'

--- a/infrastructure/templates/screener/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/screener/parameters/main-preprod.bicepparam
@@ -1,0 +1,4 @@
+using '../main.bicep'
+
+// Environment Params
+param environmentName = 'Pre-Production'

--- a/infrastructure/templates/screener/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/screener/parameters/main-prod.bicepparam
@@ -1,0 +1,4 @@
+using '../main.bicep'
+
+// Environment Params
+param environmentName = 'Production'

--- a/infrastructure/templates/screener/parameters/main-test.bicepparam
+++ b/infrastructure/templates/screener/parameters/main-test.bicepparam
@@ -1,0 +1,4 @@
+using '../main.bicep'
+
+// Environment Params
+param environmentName = 'Test'

--- a/infrastructure/templates/screener/types.bicep
+++ b/infrastructure/templates/screener/types.bicep
@@ -1,0 +1,18 @@
+@export()
+type ResourceNames = {
+  existingResources: {
+    keyVault: string
+    vNet: string
+    adminApp: string
+    alertsGroup: string
+    subnets: {
+      screenerFunction: string
+      screenerFunctionPrivateEndpoints: string
+      adminApp: string
+    }
+  }
+  screener: {
+    screenerFunction: string
+    screenerFunctionStorageAccount: string
+  }
+}

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -732,6 +732,12 @@
         "description": "The Client ID of a manually-created App Registration that represents the Public API Data Processor Function App in Entra ID"
       }
     },
+    // "screenerApiAppRegistrationClientId": {
+    //   "type": "string",
+    //   "metadata": {
+    //     "description": "The Client ID of a manually-created App Registration that represents the Screener API Function App in Entra ID"
+    //   }
+    // },
     "apiAppRegistrationClientId": {
       "type": "string",
       "metadata": {
@@ -778,6 +784,7 @@
     "publisherStorageAccountId": "[concat(resourceGroup().id,'/providers/','Microsoft.Storage/storageAccounts/', variables('publisherStorageAccountName'))]",
     "loggingStorageAccountName": "[concat(parameters('subscription'), 'saeeslogging')]",
     "publicDataProcessorName": "[concat(parameters('subscription'), '-', parameters('environment'), '-papi-fa-processor')]",
+    "screenerApiName": "[concat(parameters('subscription'), '-', parameters('environment'), '-sapi')]",
     "logicAppSlackAlerts": "[concat(parameters('subscription'), '-la-', parameters('environment'), '-slackwebhook')]",
     "actionGroupAlerts": "[concat(parameters('subscription'), '-ag-', parameters('environment'), '-alertedusers')]",
     "metricAlerts": [
@@ -1116,6 +1123,8 @@
     "containerAppEnvironmentSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-cae-01')]",
     "applicationGatewaySubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-agw-01')]",
     "psqlFlexibleServerSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-psql-flexibleserver')]",
+    "screenerFunctionAppSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-sapi-snet-fa-screener')]",
+    "screenerStoragePrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-sapi-snet-sa-screener-pep')]",
     "sqlAllowedSubnets": [
       {
         "name": "admin",
@@ -1828,6 +1837,8 @@
         "PublicDataApi:AppRegistrationClientId": "[parameters('apiAppRegistrationClientId')]",
         "PublicDataProcessor:Url": "[concat('https://', variables('publicDataProcessorName'), '.azurewebsites.net')]",
         "PublicDataProcessor:AppRegistrationClientId": "[parameters('publicDataProcessorAppRegistrationClientId')]"
+        // "ScreenerApi:Url": "[concat('https://', variables('screenerApiName'), '.azurewebsites.net')]",
+        // "ScreenerApi:AppRegistrationClientId": "[parameters('screenerApiAppRegistrationClientId')]"
       }
     },
     {
@@ -3755,6 +3766,31 @@
             "name": "[variables('analyticsFunctionAppSubnetName')]",
             "properties": {
               "addressPrefix": "10.0.17.0/24",
+              "serviceEndpoints": [
+                {
+                  "service": "Microsoft.Storage"
+                }
+              ],
+              "delegations": [
+                {
+                  "name": "webapp",
+                  "properties": {
+                    "serviceName": "Microsoft.Web/serverFarms"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "[variables('screenerStoragePrivateEndpointsSubnetName')]",
+            "properties": {
+              "addressPrefix": "10.0.18.0/24"
+            }
+          },
+          {
+            "name": "[variables('screenerFunctionAppSubnetName')]",
+            "properties": {
+              "addressPrefix": "10.0.19.0/24",
               "serviceEndpoints": [
                 {
                   "service": "Microsoft.Storage"


### PR DESCRIPTION
This PR adds new infrastructure for implementing the data screener API, and contains Bicep templates defining the infrastructure for a containerised Azure Function app.

As per [Ben's recent PR for the site-wide search infrastructure](https://github.com/dfe-analytical-services/explore-education-statistics/pull/5673), this PR contains references to resources defined in the public-api directory - this is to avoid refactoring or changing directory structures during a key point in the Public API's initial release.

### Common containerisedFunctionApp.bicep
This PR adds a new containerisedFunctionApp.bicep template since we don't currently have this in our library of components. This is added to the 'common' folder so it can be used for any future work which may need to deploy function code to Azure as a container - it was required in this case because the screener language runtime (R) isn't supported.