### PR TITLE
EES-5874 Further Search Function App tweaks

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Exceptions/UnableToCreateSearchableDocumentException.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Exceptions/UnableToCreateSearchableDocumentException.cs
@@ -6,9 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 /// The creation of a searchable document in Azure Storage failed
 /// </summary>
 public class UnableToCreateSearchableDocumentException(string publicationSlug, string message)
-    : Exception($"Publication: \"{publicationSlug}\" Error: {message}")
-{
-}
+    : Exception($"Publication: \"{publicationSlug}\" Error: {message}");
 
 /// <summary>
 /// The call to the ContentAPI to retrieve the searchable document form of the latest release failed
@@ -21,7 +19,7 @@ public class UnableToGetPublicationLatestReleaseSearchViewModelException : Unabl
         string? errorMessage)
         : base(
             publicationSlug,
-            $"Unable to get latest release search view model for publication \"{publicationSlug}\" with {(statusCode != null ? "status code \"{statusCode}\" and" : string.Empty)} error message: \"{errorMessage}\"")
+            $"Unable to get latest release search view model for publication \"{publicationSlug}\" with {(statusCode != null ? $"status code \"{statusCode}\" and" : string.Empty)} error message: \"{errorMessage}\"")
     {
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ReleaseSearchableDocumentExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ReleaseSearchableDocumentExtensions.cs
@@ -8,15 +8,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 /// </summary>
 public static class SearchableDocumentAzureBlobMetadataKeys
 {
-    public const string ReleaseVersionId = "RELEASE-VERSION-ID";
-    public const string PublicationSlug = "PUBLICATION-SLUG";
-    public const string ReleaseSlug = "RELEASE-SLUG";
-    public const string Published = "PUBLISHED";
-    public const string Summary = "SUMMARY";
-    public const string Title = "TITLE";
-    public const string Theme = "THEME";
-    public const string ReleaseType = "RELEASE-TYPE";
-    public const string TypeBoost = "TYPE-BOOST";
+    public const string ReleaseVersionId = "ReleaseVersionId";
+    public const string PublicationSlug = "PublicationSlug";
+    public const string ReleaseSlug = "ReleaseSlug";
+    public const string Published = "Published";
+    public const string Summary = "Summary";
+    public const string Title = "Title";
+    public const string Theme = "Theme";
+    public const string ReleaseType = "ReleaseType";
+    public const string TypeBoost = "TypeBoost";
 }
 
 public static class ReleaseSearchableDocumentExtensions

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/CreateSearchableReleaseDocumentInAzureStorageFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/CreateSearchableReleaseDocumentInAzureStorageFunction.cs
@@ -19,7 +19,7 @@ public class CreateSearchableReleaseDocumentInAzureStorageFunction(
     {
         logger.LogInformation("{FunctionName} triggered: {Request}", context.FunctionDefinition.Name, message);
 
-        var request = new CreatePublicationLatestReleaseSearchableDocumentRequest{ PublicationSlug = message.ReleaseSlug };
+        var request = new CreatePublicationLatestReleaseSearchableDocumentRequest{ PublicationSlug = message.PublicationSlug };
         var response = await searchableDocumentCreator.CreatePublicationLatestReleaseSearchableDocument(request, cancellationToken);
         var searchDocumentCreatedMessage = new SearchDocumentCreatedMessage
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/ReleasePublishedMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/ReleasePublishedMessage.cs
@@ -1,3 +1,3 @@
 ﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CreateSearchableReleaseDocuments.Dtos;
 
-public record ReleasePublishedMessage(string ReleaseSlug);
+public record ReleasePublishedMessage(string PublicationSlug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/host.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/host.json
@@ -4,7 +4,7 @@
     "applicationInsights": {
       "samplingSettings": {
         "isEnabled": true,
-        "excludedTypes": "Request;Exception"
+        "excludedTypes": "Request;Exception;Trace"
       },
       "enableLiveMetricsFilters": true
     },


### PR DESCRIPTION
This PR makes some further tweaks to the Search Function App.

It renames the metadata keys in SearchableDocumentAzureBlobMetadataKeys  to use underscores instead of hyphens to make them valid C# identifiers. See [metadata-key-and-value-names](https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#metadata-key-and-value-names)

It appears that Azurite will allow metadata keys containing hyphens, but when uploading to Azure these are causing an error:

```
<Error><Code>InvalidMetadata</Code><Message>The metadata specified is invalid. It has characters that are not permitted.
```

If we using the Function App in its current state to upload a blob locally with Azurite and view the properties of that blob in Storage Explorer, a warning can be seen `Metadata keys must be valid C# identifiers` as shown below.

Before this change:

![image (4)](https://github.com/user-attachments/assets/c710d26e-0776-4d4f-a02c-f14016941c13)

After this change:

![image](https://github.com/user-attachments/assets/13b30cce-1b63-4e00-b9a7-af5b1a57d5f2)

Internally metadata is set on blobs using HTTP headers. The [docs on Metadata Header Format](https://learn.microsoft.com/en-us/rest/api/storageservices/setting-and-retrieving-properties-and-metadata-for-blob-resources#Subheading1) say

> Beginning with version 2009-09-19, metadata names must adhere to the naming rules for [C# identifiers](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference).
> 
> Names are case-insensitive. Note that metadata names preserve the case with which they were created, but are case-insensitive when set or read. If two or more metadata headers with the same name are submitted for a resource, the Blob service returns status code 400 (Bad Request).
> 
> The metadata consists of name/value pairs. The total size of all metadata pairs can be up to 8KB in size.
> 
> Metadata name/value pairs are valid HTTP headers, and so they adhere to all restrictions governing HTTP headers.

The docs on [Metadata Key and Value Names](https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#metadata-key-and-value-names) say

> Metadata for a container or blob resource is stored as name-value pairs associated with the resource. Metadata key names must adhere to the following naming rules:
> 
> Must start with a letter or underscore
> 
> Any following characters may be letters, numbers, or underscores
> 
> Metadata key name must be valid ASCII
> 
> Metadata value names must also be valid ASCII. Note that metadata names preserve the case with which they were created, but are case-insensitive when set or read. If two or more metadata headers with the same name are submitted for a resource, the Blob service returns status code 400 (Bad Request).

### Other changes

* Fixes interpolation of 'statusCode' in the message in `UnableToCreateSearchableDocumentException`.
* Renames `ReleaseSlug` to `PublicationSlug` in `ReleasePublishedMessage`.
* Disables sampling of Trace logs in Application Insights.
* Disables an Application Insights logging filter that by default  instructs ILogger to capture only Warning and more severe logs.