### PR TITLE
EES-5874 Put Publication Summary in the metadata of the search blob instead of Release Version

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerTests.cs
@@ -93,7 +93,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
             {
                 Id = publicationId,
                 Title = "Publication Title",
-                Summary = "<p>This is the publication summary</p>",
+                Summary = "This is the publication summary",
                 Theme = new ThemeViewModelBuilder().WithTitle("the theme"),
                 Slug = "publication-slug",
                 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerTests.cs
@@ -93,6 +93,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
             {
                 Id = publicationId,
                 Title = "Publication Title",
+                Summary = "<p>This is the publication summary</p>",
                 Theme = new ThemeViewModelBuilder().WithTitle("the theme"),
                 Slug = "publication-slug",
                 
@@ -166,7 +167,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
                     () => Assert.Equal(releaseId, actual.ReleaseVersionId), 
                     () => Assert.Equal(publishedTimestamp, actual.Published), 
                     () => Assert.Equal("Publication Title", actual.PublicationTitle), 
-                    () => Assert.Equal("This is the release summary", actual.Summary), 
+                    () => Assert.Equal("This is the publication summary", actual.Summary), 
                     () => Assert.Equal("the theme", actual.Theme), 
                     () => Assert.Equal("OfficialStatistics", actual.Type), 
                     () => Assert.Equal(releaseType.ToSearchDocumentTypeBoost(), actual.TypeBoost), 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -173,6 +173,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
                     Assert.Equal(publication.Id, publicationViewModel.Id);
                     Assert.Equal(publication.Title, publicationViewModel.Title);
+                    Assert.Equal(publication.Summary, publicationViewModel.Summary);
                     Assert.Equal(publication.Slug, publicationViewModel.Slug);
                     Assert.False(publicationViewModel.IsSuperseded);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -204,6 +204,7 @@ public class PublicationService : IPublicationService
         {
             Id = publication.Id,
             Title = publication.Title,
+            Summary = publication.Summary,
             Slug = publication.Slug,
             Theme = new ThemeViewModel(
                 theme.Id,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/PublicationCacheViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/PublicationCacheViewModel.cs
@@ -8,6 +8,8 @@ public record PublicationCacheViewModel
 
     public string Title { get; init; } = string.Empty;
 
+    public string Summary { get; set; } = string.Empty;
+
     public string Slug { get; init; } = string.Empty;
 
     public Guid LatestReleaseId { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseSearchViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseSearchViewModel.cs
@@ -28,7 +28,7 @@ public record ReleaseSearchViewModel
         ReleaseVersionId = releaseVersion.Id;
         Published = releaseVersion.Published ?? throw new ArgumentException("Release must have a published date");
         PublicationTitle = publication.Title;
-        Summary = publication.Summary.StripHtml();
+        Summary = publication.Summary;
         Theme = publication.Theme.Title;
         Type = releaseVersion.Type.ToString();
         TypeBoost = releaseVersion.Type.ToSearchDocumentTypeBoost();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseSearchViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseSearchViewModel.cs
@@ -28,7 +28,7 @@ public record ReleaseSearchViewModel
         ReleaseVersionId = releaseVersion.Id;
         Published = releaseVersion.Published ?? throw new ArgumentException("Release must have a published date");
         PublicationTitle = publication.Title;
-        Summary = ExtractHtmlBlocks(releaseVersion.SummarySection.Content).StripHtml();
+        Summary = publication.Summary.StripHtml();
         Theme = publication.Theme.Title;
         Type = releaseVersion.Type.ToString();
         TypeBoost = releaseVersion.Type.ToSearchDocumentTypeBoost();


### PR DESCRIPTION
Put Publication Summary in the metadata of the search blob instead of Release Version.
This involves bringing the summary into the cache so we'll need a faffy deploy ticket to invalidate the caches.