### PR TITLE
EES-5911 Move focus to input after clicking 'Edit Section title'

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableAccordionSection.tsx
@@ -60,6 +60,7 @@ const EditableAccordionSection = (props: EditableAccordionSectionProps) => {
           id={`${id}-editHeading`}
           name="heading"
           label="Edit Heading"
+          autoFocus
           value={newHeading}
           onChange={e => {
             setNewHeading(e.target.value);

--- a/src/explore-education-statistics-common/src/components/form/FormBaseInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormBaseInput.tsx
@@ -18,6 +18,7 @@ export interface FormBaseInputProps
   addOn?: ReactNode;
   addOnContainerClassName?: string;
   announceError?: boolean;
+  autoFocus?: boolean;
   className?: string;
   disabled?: boolean;
   error?: ReactNode | string;
@@ -46,6 +47,7 @@ function FormBaseInput({
   addOn,
   addOnContainerClassName,
   announceError,
+  autoFocus = false,
   className,
   error,
   hint,
@@ -110,6 +112,8 @@ function FormBaseInput({
       onBlur={handleBlur}
       onChange={onChange}
       onKeyPress={handleKeyPress}
+      // eslint-disable-next-line jsx-a11y/no-autofocus
+      autoFocus={autoFocus}
     />
   );
 

--- a/src/explore-education-statistics-common/src/components/form/FormBaseInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormBaseInput.tsx
@@ -47,7 +47,6 @@ function FormBaseInput({
   addOn,
   addOnContainerClassName,
   announceError,
-  autoFocus = false,
   className,
   error,
   hint,
@@ -112,8 +111,6 @@ function FormBaseInput({
       onBlur={handleBlur}
       onChange={onChange}
       onKeyPress={handleKeyPress}
-      // eslint-disable-next-line jsx-a11y/no-autofocus
-      autoFocus={autoFocus}
     />
   );
 


### PR DESCRIPTION
Fixes https://dfedigital.atlassian.net/browse/EES-5911

Autofocus attribute ensures that the input is focussed as soon as it is rendered (when the user clicks the 'Edit Section title' button.

n.b I have had to disable the eslint rule for the autofocus attribute as I don't think it is relevant for this - autofocus is expected behaviour and would be implemented by us manually if it wasn't handled by the browser and the `autofocus` attribute.