### PR TITLE
EES-5913 - fix issues with using Preview Tokens on draft DataSets

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/PublicationsControllerTests.cs
@@ -520,6 +520,7 @@ public abstract class PublicationsControllerTests(TestApplicationFactory testApp
             Assert.Equal(dataSet.Summary, result.Summary);
             Assert.Equal(dataSet.Status, result.Status);
             Assert.Equal(dataSet.SupersedingDataSetId, result.SupersedingDataSetId);
+            Assert.NotNull(result.LatestVersion);
             Assert.Equal(dataSetVersion.PublicVersion, result.LatestVersion.Version);
             Assert.Equal(
                 dataSetVersion.Published.TruncateNanoseconds(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandlerTests.cs
@@ -22,7 +22,7 @@ public class QueryDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusQueryTheoryData.AvailableStatuses),
         MemberType = typeof(DataSetVersionStatusQueryTheoryData))]
-    public void Success(DataSetVersionStatus status)
+    public async Task Success(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -31,7 +31,7 @@ public class QueryDataSetVersionAuthorizationHandlerTests
         var handler = BuildHandler();
         var context = CreateAnonymousAuthContext<QueryDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.True(context.HasSucceeded);
     }
@@ -39,7 +39,7 @@ public class QueryDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusQueryTheoryData.UnavailableStatuses),
         MemberType = typeof(DataSetVersionStatusQueryTheoryData))]
-    public void Failure(DataSetVersionStatus status)
+    public async Task Failure(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -48,7 +48,7 @@ public class QueryDataSetVersionAuthorizationHandlerTests
         var handler = BuildHandler();
         var context = CreateAnonymousAuthContext<QueryDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }
@@ -56,7 +56,7 @@ public class QueryDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusQueryTheoryData.AvailableStatusesIncludingDraft),
         MemberType = typeof(DataSetVersionStatusQueryTheoryData))]
-    public void Success_PreviewTokenIsActive(DataSetVersionStatus status)
+    public async Task Success_PreviewTokenIsActive(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -79,13 +79,13 @@ public class QueryDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<QueryDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.True(context.HasSucceeded);
     }
 
     [Fact]
-    public void Failure_PreviewTokenIsExpired()
+    public async Task Failure_PreviewTokenIsExpired()
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -108,13 +108,13 @@ public class QueryDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<QueryDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }
 
     [Fact]
-    public void Failure_PreviewTokenIsForWrongDataSetVersion()
+    public async Task Failure_PreviewTokenIsForWrongDataSetVersion()
     {
         var (dataSetVersion1, dataSetVersion2) = _dataFixture
             .DefaultDataSetVersion()
@@ -139,7 +139,7 @@ public class QueryDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<QueryDataSetVersionRequirement, DataSetVersion>(dataSetVersion1);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }
@@ -147,7 +147,7 @@ public class QueryDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusQueryTheoryData.UnavailableStatusesExceptDraft),
         MemberType = typeof(DataSetVersionStatusQueryTheoryData))]
-    public void Failure_PreviewTokenIsForUnavailableDataSetVersion(DataSetVersionStatus status)
+    public async Task Failure_PreviewTokenIsForUnavailableDataSetVersion(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -170,7 +170,7 @@ public class QueryDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<QueryDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandlerTests.cs
@@ -1,8 +1,18 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Constants;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.TheoryData;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Moq.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlerContextFactory;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Security.AuthorizationHandlers;
@@ -14,7 +24,7 @@ public class ViewDataSetAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetStatusTheoryData.AvailableStatuses),
         MemberType = typeof(DataSetStatusTheoryData))]
-    public void Success(DataSetStatus status)
+    public void DataSetHasAvailableStatus_Success(DataSetStatus status)
     {
         DataSet dataSet = _dataFixture
             .DefaultDataSet()
@@ -31,7 +41,7 @@ public class ViewDataSetAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetStatusTheoryData.UnavailableStatuses),
         MemberType = typeof(DataSetStatusTheoryData))]
-    public void Failure(DataSetStatus status)
+    public void DataSetHasUnavailableStatus_Failure(DataSetStatus status)
     {
         DataSet dataSet = _dataFixture
             .DefaultDataSet()
@@ -44,9 +54,215 @@ public class ViewDataSetAuthorizationHandlerTests
 
         Assert.False(context.HasSucceeded);
     }
-
-    private static ViewDataSetAuthorizationHandler BuildHandler()
+    
+    [Theory]
+    [MemberData(nameof(DataSetStatusTheoryData.AllStatuses),
+        MemberType = typeof(DataSetStatusTheoryData))]
+    public void PreviewTokenForDraftDataSetVersionActive_Success(DataSetStatus status)
     {
-        return new ViewDataSetAuthorizationHandler();
+        DataSet dataSet = _dataFixture
+            .DefaultDataSet()
+            .WithStatus(status);
+
+        DataSetVersion dataSetVersion = _dataFixture
+            .DefaultDataSetVersion()
+            .WithStatus(DataSetVersionStatus.Draft)
+            .WithPreviewTokens(() => [_dataFixture.DefaultPreviewToken()])
+            .FinishWith(dsv => dataSet.LatestDraftVersionId = dsv.Id);
+
+        var publicDataDbContext = new Mock<PublicDataDbContext>();
+        publicDataDbContext.SetupGet(dbContext => dbContext.DataSets).ReturnsDbSet([dataSet]);
+        publicDataDbContext.SetupGet(dbContext => dbContext.DataSetVersions).ReturnsDbSet([dataSetVersion]);
+        publicDataDbContext.SetupGet(dbContext => dbContext.PreviewTokens).ReturnsDbSet(dataSetVersion.PreviewTokens);
+
+        var handler = BuildHandler(
+            publicDataDbContext: publicDataDbContext.Object,
+            requestHeaders:
+            [
+                PreviewTokenRequestHeader(dataSetVersion.PreviewTokens[0])
+            ]);
+        var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
+
+        handler.HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+    }
+    
+    /// <summary>
+    /// Despite the Preview Token being used is expired, the DataSet's status itself is
+    /// available to the public, and so the auth succeeds.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DataSetStatusTheoryData.AvailableStatuses),
+        MemberType = typeof(DataSetStatusTheoryData))]
+    public void PreviewTokenForDraftDataSetVersionExpired_DataSetStatusAvailable_Success(DataSetStatus status)
+    {
+        DataSet dataSet = _dataFixture
+            .DefaultDataSet()
+            .WithStatus(status);
+
+        DataSetVersion dataSetVersion = _dataFixture
+            .DefaultDataSetVersion()
+            .WithStatus(DataSetVersionStatus.Draft)
+            .WithPreviewTokens(() => [_dataFixture.DefaultPreviewToken(expired: true)])
+            .FinishWith(dsv => dataSet.LatestDraftVersionId = dsv.Id);
+
+        var publicDataDbContext = new Mock<PublicDataDbContext>();
+        publicDataDbContext.SetupGet(dbContext => dbContext.DataSets).ReturnsDbSet([dataSet]);
+        publicDataDbContext.SetupGet(dbContext => dbContext.DataSetVersions).ReturnsDbSet([dataSetVersion]);
+        publicDataDbContext.SetupGet(dbContext => dbContext.PreviewTokens).ReturnsDbSet(dataSetVersion.PreviewTokens);
+
+        var handler = BuildHandler(
+            publicDataDbContext: publicDataDbContext.Object,
+            requestHeaders:
+            [
+                PreviewTokenRequestHeader(dataSetVersion.PreviewTokens[0])
+            ]);
+        var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
+
+        handler.HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+    }
+    
+    /// <summary>
+    /// The Preview Token being used is expired and the DataSet's status is
+    /// unavailable to the public, and so the auth fails.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DataSetStatusTheoryData.UnavailableStatuses),
+        MemberType = typeof(DataSetStatusTheoryData))]
+    public void PreviewTokenForDraftDataSetVersionExpired_DataSetStatusUnavailable_Failure(DataSetStatus status)
+    {
+        DataSet dataSet = _dataFixture
+            .DefaultDataSet()
+            .WithStatus(status);
+
+        DataSetVersion dataSetVersion = _dataFixture
+            .DefaultDataSetVersion()
+            .WithStatus(DataSetVersionStatus.Draft)
+            .WithPreviewTokens(() => [_dataFixture.DefaultPreviewToken(expired: true)])
+            .FinishWith(dsv => dataSet.LatestDraftVersionId = dsv.Id);
+
+        var publicDataDbContext = new Mock<PublicDataDbContext>();
+        publicDataDbContext.SetupGet(dbContext => dbContext.DataSets).ReturnsDbSet([dataSet]);
+        publicDataDbContext.SetupGet(dbContext => dbContext.DataSetVersions).ReturnsDbSet([dataSetVersion]);
+        publicDataDbContext.SetupGet(dbContext => dbContext.PreviewTokens).ReturnsDbSet(dataSetVersion.PreviewTokens);
+
+        var handler = BuildHandler(
+            publicDataDbContext: publicDataDbContext.Object,
+            requestHeaders:
+            [
+                PreviewTokenRequestHeader(dataSetVersion.PreviewTokens[0])
+            ]);
+        var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
+
+        handler.HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+    
+    /// <summary>
+    /// Despite the Preview Token being used is for a non-draft DataSetVersion, the DataSet's
+    /// status itself is available to the public, and so the auth succeeds.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DataSetStatusTheoryData.AvailableStatuses),
+        MemberType = typeof(DataSetStatusTheoryData))]
+    public void PreviewTokenActiveButForLiveDataSetVersion_DataSetStatusAvailable_Success(DataSetStatus status)
+    {
+        DataSet dataSet = _dataFixture
+            .DefaultDataSet()
+            .WithStatus(status);
+
+        DataSetVersion dataSetVersion = _dataFixture
+            .DefaultDataSetVersion()
+            .WithStatus(DataSetVersionStatus.Published)
+            .WithPreviewTokens(() => [_dataFixture.DefaultPreviewToken()])
+            .FinishWith(dsv => dataSet.LatestLiveVersionId = dsv.Id);
+
+        var publicDataDbContext = new Mock<PublicDataDbContext>();
+        publicDataDbContext.SetupGet(dbContext => dbContext.DataSets).ReturnsDbSet([dataSet]);
+        publicDataDbContext.SetupGet(dbContext => dbContext.DataSetVersions).ReturnsDbSet([dataSetVersion]);
+        publicDataDbContext.SetupGet(dbContext => dbContext.PreviewTokens).ReturnsDbSet(dataSetVersion.PreviewTokens);
+
+        var handler = BuildHandler(
+            publicDataDbContext: publicDataDbContext.Object,
+            requestHeaders:
+            [
+                PreviewTokenRequestHeader(dataSetVersion.PreviewTokens[0])
+            ]);
+        var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
+
+        handler.HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+    }
+    
+    /// <summary>
+    /// The Preview Token being used is for a non-draft DataSetVersion and the DataSet's
+    /// status itself is unavailable to the public, and so the auth false.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DataSetStatusTheoryData.UnavailableStatuses),
+        MemberType = typeof(DataSetStatusTheoryData))]
+    public void PreviewTokenActiveButForLiveDataSetVersion_DataSetStatusUnavailable_Failure(DataSetStatus status)
+    {
+        DataSet dataSet = _dataFixture
+            .DefaultDataSet()
+            .WithStatus(status);
+
+        DataSetVersion dataSetVersion = _dataFixture
+            .DefaultDataSetVersion()
+            .WithStatus(DataSetVersionStatus.Published)
+            .WithPreviewTokens(() => [_dataFixture.DefaultPreviewToken()])
+            .FinishWith(dsv => dataSet.LatestLiveVersionId = dsv.Id);
+
+        var publicDataDbContext = new Mock<PublicDataDbContext>();
+        publicDataDbContext.SetupGet(dbContext => dbContext.DataSets).ReturnsDbSet([dataSet]);
+        publicDataDbContext.SetupGet(dbContext => dbContext.DataSetVersions).ReturnsDbSet([dataSetVersion]);
+        publicDataDbContext.SetupGet(dbContext => dbContext.PreviewTokens).ReturnsDbSet(dataSetVersion.PreviewTokens);
+
+        var handler = BuildHandler(
+            publicDataDbContext: publicDataDbContext.Object,
+            requestHeaders:
+            [
+                PreviewTokenRequestHeader(dataSetVersion.PreviewTokens[0])
+            ]);
+        var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
+
+        handler.HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    private static ViewDataSetAuthorizationHandler BuildHandler(
+        PublicDataDbContext? publicDataDbContext = null,
+        IList<KeyValuePair<string, StringValues>>? requestHeaders = null)
+    {
+        var dbContext = publicDataDbContext ?? Mock.Of<PublicDataDbContext>();
+        
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+        
+        var headers = httpContextAccessor.HttpContext.Request.Headers;
+        requestHeaders?.ForEach(header => 
+            headers.Append(header.Key, header.Value));
+
+        var previewTokenService = new PreviewTokenService(dbContext);
+
+        var authorizationHandlerService = new AuthorizationHandlerService(
+            httpContextAccessor: httpContextAccessor,
+            environment: Mock.Of<IWebHostEnvironment>(),
+            previewTokenService);
+        
+        return new ViewDataSetAuthorizationHandler(authorizationHandlerService);
+    }
+
+    private static KeyValuePair<string, StringValues> PreviewTokenRequestHeader(PreviewToken previewToken)
+    {
+        return new KeyValuePair<string, StringValues>(RequestHeaderNames.PreviewToken, previewToken.Id.ToString());
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandlerTests.cs
@@ -24,7 +24,7 @@ public class ViewDataSetAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetStatusTheoryData.AvailableStatuses),
         MemberType = typeof(DataSetStatusTheoryData))]
-    public void DataSetHasAvailableStatus_Success(DataSetStatus status)
+    public async Task DataSetHasAvailableStatus_Success(DataSetStatus status)
     {
         DataSet dataSet = _dataFixture
             .DefaultDataSet()
@@ -33,7 +33,7 @@ public class ViewDataSetAuthorizationHandlerTests
         var handler = BuildHandler();
         var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.True(context.HasSucceeded);
     }
@@ -41,7 +41,7 @@ public class ViewDataSetAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetStatusTheoryData.UnavailableStatuses),
         MemberType = typeof(DataSetStatusTheoryData))]
-    public void DataSetHasUnavailableStatus_Failure(DataSetStatus status)
+    public async Task DataSetHasUnavailableStatus_Failure(DataSetStatus status)
     {
         DataSet dataSet = _dataFixture
             .DefaultDataSet()
@@ -50,7 +50,7 @@ public class ViewDataSetAuthorizationHandlerTests
         var handler = BuildHandler();
         var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }
@@ -58,7 +58,7 @@ public class ViewDataSetAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetStatusTheoryData.AllStatuses),
         MemberType = typeof(DataSetStatusTheoryData))]
-    public void PreviewTokenForDraftDataSetVersionActive_Success(DataSetStatus status)
+    public async Task PreviewTokenForDraftDataSetVersionActive_Success(DataSetStatus status)
     {
         DataSet dataSet = _dataFixture
             .DefaultDataSet()
@@ -83,7 +83,7 @@ public class ViewDataSetAuthorizationHandlerTests
             ]);
         var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.True(context.HasSucceeded);
     }
@@ -95,7 +95,7 @@ public class ViewDataSetAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetStatusTheoryData.AvailableStatuses),
         MemberType = typeof(DataSetStatusTheoryData))]
-    public void PreviewTokenForDraftDataSetVersionExpired_DataSetStatusAvailable_Success(DataSetStatus status)
+    public async Task PreviewTokenForDraftDataSetVersionExpired_DataSetStatusAvailable_Success(DataSetStatus status)
     {
         DataSet dataSet = _dataFixture
             .DefaultDataSet()
@@ -120,7 +120,7 @@ public class ViewDataSetAuthorizationHandlerTests
             ]);
         var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.True(context.HasSucceeded);
     }
@@ -132,7 +132,7 @@ public class ViewDataSetAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetStatusTheoryData.UnavailableStatuses),
         MemberType = typeof(DataSetStatusTheoryData))]
-    public void PreviewTokenForDraftDataSetVersionExpired_DataSetStatusUnavailable_Failure(DataSetStatus status)
+    public async Task PreviewTokenForDraftDataSetVersionExpired_DataSetStatusUnavailable_Failure(DataSetStatus status)
     {
         DataSet dataSet = _dataFixture
             .DefaultDataSet()
@@ -157,7 +157,7 @@ public class ViewDataSetAuthorizationHandlerTests
             ]);
         var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }
@@ -169,7 +169,7 @@ public class ViewDataSetAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetStatusTheoryData.AvailableStatuses),
         MemberType = typeof(DataSetStatusTheoryData))]
-    public void PreviewTokenActiveButForLiveDataSetVersion_DataSetStatusAvailable_Success(DataSetStatus status)
+    public async Task PreviewTokenActiveButForLiveDataSetVersion_DataSetStatusAvailable_Success(DataSetStatus status)
     {
         DataSet dataSet = _dataFixture
             .DefaultDataSet()
@@ -194,7 +194,7 @@ public class ViewDataSetAuthorizationHandlerTests
             ]);
         var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.True(context.HasSucceeded);
     }
@@ -206,7 +206,7 @@ public class ViewDataSetAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetStatusTheoryData.UnavailableStatuses),
         MemberType = typeof(DataSetStatusTheoryData))]
-    public void PreviewTokenActiveButForLiveDataSetVersion_DataSetStatusUnavailable_Failure(DataSetStatus status)
+    public async Task PreviewTokenActiveButForLiveDataSetVersion_DataSetStatusUnavailable_Failure(DataSetStatus status)
     {
         DataSet dataSet = _dataFixture
             .DefaultDataSet()
@@ -231,7 +231,7 @@ public class ViewDataSetAuthorizationHandlerTests
             ]);
         var context = CreateAnonymousAuthContext<ViewDataSetRequirement, DataSet>(dataSet);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandlerTests.cs
@@ -285,7 +285,6 @@ public class ViewDataSetVersionAuthorizationHandlerTests
         Assert.False(context.HasSucceeded);
     }
 
-
     private static KeyValuePair<string, StringValues> PreviewTokenRequestHeader(PreviewToken previewToken)
     {
         return new KeyValuePair<string, StringValues>(RequestHeaderNames.PreviewToken, previewToken.Id.ToString());
@@ -298,6 +297,8 @@ public class ViewDataSetVersionAuthorizationHandlerTests
         string? userAgentValue = null,
         ClaimsPrincipal? claimsPrincipal = null)
     {
+        var dbContext = publicDataDbContext ?? Mock.Of<PublicDataDbContext>();
+        
         var httpContextAccessor = new HttpContextAccessor
         {
             HttpContext = new DefaultHttpContext
@@ -320,15 +321,13 @@ public class ViewDataSetVersionAuthorizationHandlerTests
             .SetupGet(s => s.EnvironmentName)
             .Returns(environmentName ?? Environments.Production);
 
+        var previewTokenService = new PreviewTokenService(dbContext);
+
         var authorizationHandlerService = new AuthorizationHandlerService(
             httpContextAccessor: httpContextAccessor,
-            environment: environment.Object);
-
-        var previewTokenService = new PreviewTokenService(publicDataDbContext);
-
-        return new ViewDataSetVersionAuthorizationHandler(
-            authorizationHandlerService,
-            httpContextAccessor,
+            environment: environment.Object,
             previewTokenService);
+
+        return new ViewDataSetVersionAuthorizationHandler(authorizationHandlerService);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandlerTests.cs
@@ -28,7 +28,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusViewTheoryData.AvailableStatuses),
         MemberType = typeof(DataSetVersionStatusViewTheoryData))]
-    public void Success(DataSetVersionStatus status)
+    public async Task Success(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -37,7 +37,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
         var handler = BuildHandler();
         var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.True(context.HasSucceeded);
     }
@@ -45,7 +45,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusViewTheoryData.UnavailableStatuses),
         MemberType = typeof(DataSetVersionStatusViewTheoryData))]
-    public void Failure(DataSetVersionStatus status)
+    public async Task Failure(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -54,7 +54,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
         var handler = BuildHandler();
         var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }
@@ -62,7 +62,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusViewTheoryData.AvailableStatusesIncludingDraft),
         MemberType = typeof(DataSetVersionStatusViewTheoryData))]
-    public void Success_PreviewTokenIsActive(DataSetVersionStatus status)
+    public async Task Success_PreviewTokenIsActive(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -85,13 +85,13 @@ public class ViewDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.True(context.HasSucceeded);
     }
 
     [Fact]
-    public void Failure_PreviewTokenIsExpired()
+    public async Task Failure_PreviewTokenIsExpired()
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -114,13 +114,13 @@ public class ViewDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }
 
     [Fact]
-    public void Failure_PreviewTokenIsForWrongDataSetVersion()
+    public async Task Failure_PreviewTokenIsForWrongDataSetVersion()
     {
         var (dataSetVersion1, dataSetVersion2) = _dataFixture
             .DefaultDataSetVersion()
@@ -145,7 +145,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion1);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }
@@ -153,7 +153,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusViewTheoryData.UnavailableStatusesExceptDraft),
         MemberType = typeof(DataSetVersionStatusViewTheoryData))]
-    public void Failure_PreviewTokenIsForUnavailableDataSetVersion(DataSetVersionStatus status)
+    public async Task Failure_PreviewTokenIsForUnavailableDataSetVersion(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -176,7 +176,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }
@@ -184,7 +184,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusViewTheoryData.AllStatuses),
         MemberType = typeof(DataSetVersionStatusViewTheoryData))]
-    public void Success_UserAgentHeaderInDevelopment(DataSetVersionStatus status)
+    public async Task Success_UserAgentHeaderInDevelopment(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -196,7 +196,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.True(context.HasSucceeded);
     }
@@ -204,7 +204,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusViewTheoryData.UnavailableStatuses),
         MemberType = typeof(DataSetVersionStatusViewTheoryData))]
-    public void Failure_UserAgentHeaderInProduction(DataSetVersionStatus status)
+    public async Task Failure_UserAgentHeaderInProduction(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -216,7 +216,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }
@@ -224,7 +224,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusViewTheoryData.UnavailableStatuses),
         MemberType = typeof(DataSetVersionStatusViewTheoryData))]
-    public void Failure_IncorrectUserAgentHeaderInDevelopment(DataSetVersionStatus status)
+    public async Task Failure_IncorrectUserAgentHeaderInDevelopment(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -236,7 +236,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }
@@ -244,7 +244,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusViewTheoryData.AllStatuses),
         MemberType = typeof(DataSetVersionStatusViewTheoryData))]
-    public void Success_ClaimsPrincipalWithRole(DataSetVersionStatus status)
+    public async Task Success_ClaimsPrincipalWithRole(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -258,7 +258,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.True(context.HasSucceeded);
     }
@@ -266,7 +266,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
     [Theory]
     [MemberData(nameof(DataSetVersionStatusViewTheoryData.UnavailableStatuses),
         MemberType = typeof(DataSetVersionStatusViewTheoryData))]
-    public void Failure_ClaimsPrincipalWithIncorrectRole(DataSetVersionStatus status)
+    public async Task Failure_ClaimsPrincipalWithIncorrectRole(DataSetVersionStatus status)
     {
         DataSetVersion dataSetVersion = _dataFixture
             .DefaultDataSetVersion()
@@ -280,7 +280,7 @@ public class ViewDataSetVersionAuthorizationHandlerTests
 
         var context = CreateAnonymousAuthContext<ViewDataSetVersionRequirement, DataSetVersion>(dataSetVersion);
 
-        handler.HandleAsync(context);
+        await handler.HandleAsync(context);
 
         Assert.False(context.HasSucceeded);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/TheoryData/DataSetStatusTheoryData.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/TheoryData/DataSetStatusTheoryData.cs
@@ -9,6 +9,10 @@ public class DataSetStatusTheoryData
         DataSetStatus.Deprecated,
         DataSetStatus.Published,
     ];
+    
+    public static readonly TheoryData<DataSetStatus> AllStatuses = new(
+        EnumUtil.GetEnums<DataSetStatus>()
+    );
 
     public static readonly TheoryData<DataSetStatus> AvailableStatuses = new(AvailableStatusesList);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandler.cs
@@ -35,6 +35,6 @@ public class QueryDataSetVersionAuthorizationHandler(
         return httpContextAccessor.HttpContext.TryGetRequestHeader(
                    RequestHeaderNames.PreviewToken,
                    out var previewToken)
-               && await previewTokenService.ValidatePreviewToken(previewToken.ToString(), dataSetVersion.Id);
+               && await previewTokenService.ValidatePreviewTokenForDataSetVersion(previewToken.ToString(), dataSetVersion.Id);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandler.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using Microsoft.AspNetCore.Authorization;
 
@@ -5,9 +6,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Au
 
 public class ViewDataSetRequirement : IAuthorizationRequirement;
 
-public class ViewDataSetAuthorizationHandler : AuthorizationHandler<ViewDataSetRequirement, DataSet>
+public class ViewDataSetAuthorizationHandler(IAuthorizationHandlerService authorizationHandlerService)
+    : AuthorizationHandler<ViewDataSetRequirement, DataSet>
 {
-    protected override Task HandleRequirementAsync(
+    protected override async Task HandleRequirementAsync(
         AuthorizationHandlerContext context,
         ViewDataSetRequirement requirement,
         DataSet dataSet)
@@ -15,8 +17,12 @@ public class ViewDataSetAuthorizationHandler : AuthorizationHandler<ViewDataSetR
         if (dataSet.Status is DataSetStatus.Published or DataSetStatus.Deprecated)
         {
             context.Succeed(requirement);
+            return;
         }
 
-        return Task.CompletedTask;
+        if (await authorizationHandlerService.RequestHasValidPreviewToken(dataSet))
+        {
+            context.Succeed(requirement);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandler.cs
@@ -10,10 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Au
 
 public class ViewDataSetVersionRequirement : IAuthorizationRequirement;
 
-public class ViewDataSetVersionAuthorizationHandler(
-    IAuthorizationHandlerService authorizationHandlerService,
-    IHttpContextAccessor httpContextAccessor,
-    IPreviewTokenService previewTokenService)
+public class ViewDataSetVersionAuthorizationHandler(IAuthorizationHandlerService authorizationHandlerService)
     : AuthorizationHandler<ViewDataSetVersionRequirement, DataSetVersion>
 {
     protected override async Task HandleRequirementAsync(
@@ -33,17 +30,9 @@ public class ViewDataSetVersionAuthorizationHandler(
             return;
         }
 
-        if (await RequestHasValidPreviewToken(dataSetVersion))
+        if (await authorizationHandlerService.RequestHasValidPreviewToken(dataSetVersion))
         {
             context.Succeed(requirement);
         }
-    }
-
-    private async Task<bool> RequestHasValidPreviewToken(DataSetVersion dataSetVersion)
-    {
-        return httpContextAccessor.HttpContext.TryGetRequestHeader(
-                   RequestHeaderNames.PreviewToken,
-                   out var previewToken)
-               && await previewTokenService.ValidatePreviewToken(previewToken.ToString(), dataSetVersion.Id);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -176,7 +176,7 @@ internal class DataSetService(
             Title = dataSet.Title,
             Summary = dataSet.Summary,
             Status = dataSet.Status,
-            LatestVersion = MapLatestVersion(dataSet.LatestLiveVersion!),
+            LatestVersion = dataSet.LatestLiveVersion != null ? MapLatestVersion(dataSet.LatestLiveVersion) : null,
             SupersedingDataSetId = dataSet.SupersedingDataSetId,
         };
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IPreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IPreviewTokenService.cs
@@ -2,7 +2,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.In
 
 public interface IPreviewTokenService
 {
-    Task<bool> ValidatePreviewToken(
+    Task<bool> ValidatePreviewTokenForDataSet(
+        string previewToken,
+        Guid dataSetId,
+        CancellationToken cancellationToken = default);
+    
+    Task<bool> ValidatePreviewTokenForDataSetVersion(
         string previewToken,
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/Security/IAuthorizationHandlerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/Security/IAuthorizationHandlerService.cs
@@ -1,6 +1,12 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.Security;
 
 public interface IAuthorizationHandlerService
 {
     bool CanAccessUnpublishedData();
+
+    Task<bool> RequestHasValidPreviewToken(DataSet dataSet);
+
+    Task<bool> RequestHasValidPreviewToken(DataSetVersion dataSetVersion);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Security/AuthorizationHandlerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Security/AuthorizationHandlerService.cs
@@ -1,11 +1,17 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Constants;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using Microsoft.Extensions.Primitives;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Security;
 
 public class AuthorizationHandlerService(
     IHttpContextAccessor httpContextAccessor,
-    IWebHostEnvironment environment)
+    IWebHostEnvironment environment,
+    IPreviewTokenService previewTokenService)
     : IAuthorizationHandlerService
 {
     public bool CanAccessUnpublishedData()
@@ -26,5 +32,28 @@ public class AuthorizationHandlerService(
         }
 
         return false;
+    }
+    
+    public async Task<bool> RequestHasValidPreviewToken(DataSet dataSet)
+    {
+        return TryGetPreviewToken(out var previewToken) && 
+               await previewTokenService.ValidatePreviewTokenForDataSet(
+                   previewToken: previewToken.ToString(),
+                   dataSetId: dataSet.Id);
+    }
+
+    public async Task<bool> RequestHasValidPreviewToken(DataSetVersion dataSetVersion)
+    {
+        return TryGetPreviewToken(out var previewToken) && 
+               await previewTokenService.ValidatePreviewTokenForDataSetVersion(
+                   previewToken: previewToken.ToString(),
+                   dataSetVersionId: dataSetVersion.Id);
+    }
+
+    private bool TryGetPreviewToken(out StringValues previewToken)
+    {
+        return httpContextAccessor.HttpContext.TryGetRequestHeader(
+            RequestHeaderNames.PreviewToken,
+            out previewToken);       
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/DataSetViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/ViewModels/DataSetViewModels.cs
@@ -44,7 +44,7 @@ public record DataSetViewModel
     /// <summary>
     /// The latest published data set version.
     /// </summary>
-    public required DataSetLatestVersionViewModel LatestVersion { get; init; }
+    public DataSetLatestVersionViewModel? LatestVersion { get; init; }
 }
 
 /// <summary>

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetPreviewTokenPage.tsx
@@ -2,7 +2,6 @@ import Link from '@admin/components/Link';
 import { useConfig } from '@admin/contexts/ConfigContext';
 import {
   releaseApiDataSetDetailsRoute,
-  releaseApiDataSetPreviewRoute,
   releaseApiDataSetPreviewTokenLogRoute,
   ReleaseDataSetPreviewTokenRouteParams,
   ReleaseDataSetRouteParams,
@@ -64,7 +63,7 @@ export default function ReleaseApiDataSetPreviewTokenPage() {
     history.push(tokenLogPagePath);
   };
 
-  const tokenExampleUrl = `${publicApiUrl}/v1/data-sets/${dataSet?.draftVersion?.id}`;
+  const tokenExampleUrl = `${publicApiUrl}/v1/data-sets/${dataSet?.id}`;
 
   return (
     <>

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetPreviewTokenPage.test.tsx
@@ -85,6 +85,22 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
       screen.getByRole('heading', { name: 'Using the preview token' }),
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByRole('heading', { name: 'Using the preview token' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('tabpanel')).toBeInTheDocument();
+
+    expect(
+      within(screen.getByRole('tabpanel')).getByRole('heading', {
+        name: 'cURL',
+      }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('tabpanel')).toHaveTextContent(
+      /curl -X GET -H "Preview-Token: token-id" \\ http:\/\/public-api\/v1\/data-sets\/data-set-id/,
+    );
+
     expect(screen.getByLabelText('Preview token')).toHaveValue('token-id');
     expect(
       screen.getByRole('button', { name: 'Copy preview token' }),
@@ -109,26 +125,72 @@ describe('ReleaseApiDataSetPreviewTokenPage', () => {
         name: 'API data set details',
       }),
     ).toBeInTheDocument();
+
     expect(
       screen.getByRole('heading', {
-        name: 'Get data set summary',
+        name: 'Download data set as CSV',
       }),
     ).toBeInTheDocument();
+
+    expect(
+      screen.getByTestId('data-set-download-csv-endpoint'),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('data-set-download-csv-endpoint')).toHaveValue(
+      'http://public-api/v1/data-sets/data-set-id/csv?dataSetVersion=2.0',
+    );
+
     expect(
       screen.getByRole('heading', {
         name: 'Data set metadata',
       }),
     ).toBeInTheDocument();
+
+    expect(screen.getByTestId('data-set-meta-endpoint')).toBeInTheDocument();
+
+    expect(screen.getByTestId('data-set-meta-endpoint')).toHaveValue(
+      'http://public-api/v1/data-sets/data-set-id/meta?dataSetVersion=2.0',
+    );
+
     expect(
       screen.getByRole('heading', {
         name: 'Query data set using GET',
       }),
     ).toBeInTheDocument();
+
+    expect(
+      screen.getByTestId('data-set-get-query-endpoint'),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('data-set-get-query-endpoint')).toHaveValue(
+      'http://public-api/v1/data-sets/data-set-id/query?dataSetVersion=2.0',
+    );
+
     expect(
       screen.getByRole('heading', {
         name: 'Query data set using POST',
       }),
     ).toBeInTheDocument();
+
+    expect(
+      screen.getByTestId('data-set-post-query-endpoint'),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('data-set-post-query-endpoint')).toHaveValue(
+      'http://public-api/v1/data-sets/data-set-id/query?dataSetVersion=2.0',
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Get data set summary',
+      }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('data-set-summary-endpoint')).toBeInTheDocument();
+
+    expect(screen.getByTestId('data-set-summary-endpoint')).toHaveValue(
+      'http://public-api/v1/data-sets/data-set-id',
+    );
   });
 
   test('shows a modal and calls the `onRevoke` handler on confirm when the revoke button is clicked', async () => {

--- a/src/explore-education-statistics-api-docs/source/openapi-v1.json
+++ b/src/explore-education-statistics-api-docs/source/openapi-v1.json
@@ -11,7 +11,7 @@
   },
   "servers": [
     {
-      "url": "/",
+      "url": "http://localhost:5050",
       "description": "API server"
     }
   ],
@@ -2883,7 +2883,6 @@
       "DataSetViewModel": {
         "required": [
           "id",
-          "latestVersion",
           "status",
           "summary",
           "title"
@@ -2928,7 +2927,8 @@
                 "$ref": "#/components/schemas/DataSetLatestVersionViewModel"
               }
             ],
-            "description": "The latest published data set version."
+            "description": "The latest published data set version.",
+            "nullable": true
           }
         },
         "additionalProperties": false,


### PR DESCRIPTION
This hotfix PR fixes various issues around the usage of Preview Tokens and the Preview Token page.

Specifically this PR fixes:

## Preview Token page examples

The Preview Tokens page was using the draft DataSetVersion Id in the code example tabs (e.g. the cURL example shown in the screenshot below).

![image](https://github.com/user-attachments/assets/08b6ae43-ef8a-400f-a3a7-a4062b6e687f)

This PR fixes this to use the DataSet Id instead, as per all of the other examples on the page.

This PR also adds Jest tests around the checking of the URLs and code example block on this page.

## Preview Token permissions to query the DataSet summary

Previously we had support for using Preview Tokens to call API endpoints when targeting specific DataSetVersions on the DataSet (by using the dataSetVersion query parameter that is included in all of the example endpoints on this page other than the Data set summary endpoint).

We would also get away with being able to call the Data set summary endpoint of a Data set that's *already published*, as the auth handler responsible for making this decision would see that the DataSet is already public and so allow access, valid Preview Token or no.

What we were failing on was using a Preview Token against a DataSet that's not yet had a published version gone out, and thus is still unavailable to the public.

This PR adds support for the use of Preview Tokens to view a Data set summary of a DataSet that's not yet publicly available.  It does this by checking that the DataSet being called has a *draft* DataSetVersion that has a matching valid token to the one being used.

## Missing test cases

This PR adds lots of additional tests around Preview Tokens for all of the endpoints listed on the Preview Tokens page that didn't yet have Preview Tokens tests.  Specifically, this was for the Data set summary, Download CSV, and Get Metadata endpoints. 