### PR TITLE
EES-5912 Prevent NVDA announcing 'unavailable' on button click in admin section

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.tsx
@@ -116,6 +116,7 @@ const EditableAccordion = (props: EditableAccordionProps) => {
             onClick={onAddSection}
             className={styles.addSectionButton}
             disabled={isReordering}
+            preventDoubleClick={false}
           >
             Add new section
           </Button>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -226,7 +226,11 @@ const ReleaseContentAccordionSection = ({
               )}
 
               <ButtonGroup className="govuk-!-margin-bottom-8 dfe-justify-content--center">
-                <Button variant="secondary" onClick={addBlock}>
+                <Button
+                  variant="secondary"
+                  onClick={addBlock}
+                  preventDoubleClick={false}
+                >
                   Add text block
                 </Button>
                 {!showDataBlockForm && (


### PR DESCRIPTION
This PR stops NVDA announcing 'unavailable' immediately after clicking two buttons in the admin section.
It removes 'double click prevention' on the buttons, which stops them from temporarily toggling to 'aria-disabled'.
