### PR TITLE
Cherry-picking various test fixes related to timezone issues

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
@@ -239,7 +239,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
                 Assert.True(contentRelease.LatestRelease);
                 Assert.Equal(releaseVersion.NextReleaseDate, contentRelease.NextReleaseDate);
                 Assert.Equal(releaseVersion.Release.Year.ToString(), contentRelease.ReleaseName);
-                Assert.Equal(releaseVersion.PublishScheduled, contentRelease.PublishScheduled);
+                Assert.Equal(releaseVersion.PublishScheduled?.ConvertUtcToUkTimeZone(),
+                    contentRelease.PublishScheduled);
                 Assert.Equal(releaseVersion.Published, contentRelease.Published);
                 Assert.Equal(publication.Id, contentRelease.PublicationId);
                 Assert.Equal(releaseVersion.Release.Slug, contentRelease.Slug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
@@ -2445,7 +2446,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(releaseVersion.Release.TimePeriodCoverage, summaryViewModel.TimePeriodCoverage);
                 Assert.Equal(releaseVersion.Published, summaryViewModel.Published);
                 Assert.Equal(releaseVersion.Live, summaryViewModel.Live);
-                Assert.Equal(releaseVersion.PublishScheduled, summaryViewModel.PublishScheduled);
+                Assert.Equal(releaseVersion.PublishScheduled?.ConvertUtcToUkTimeZone(), summaryViewModel.PublishScheduled);
                 Assert.Equal(releaseVersion.NextReleaseDate, summaryViewModel.NextReleaseDate);
                 Assert.Equal(releaseVersion.ApprovalStatus, summaryViewModel.ApprovalStatus);
                 Assert.Equal(releaseVersion.Amendment, summaryViewModel.Amendment);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServiceTests.cs
@@ -785,6 +785,7 @@ public abstract class ReleaseVersionServiceTests
                             _dataFixture.DefaultReleaseVersion()
                                 .WithApprovalStatus(ReleaseApprovalStatus.Approved)
                                 .WithPublished(DateTime.UtcNow)
+                                .WithPublishScheduled(DateTime.UtcNow)
                                 .WithReleaseStatuses(_dataFixture.DefaultReleaseStatus()
                                     .Generate(2))
                         ])
@@ -834,7 +835,7 @@ public abstract class ReleaseVersionServiceTests
                 Assert.Equal(releaseVersion.Release.Publication.Slug, viewModel.PublicationSlug);
                 Assert.Equal(releaseVersion.ApprovalStatus, viewModel.ApprovalStatus);
                 Assert.Equal(releaseVersion.LatestInternalReleaseNote, viewModel.LatestInternalReleaseNote);
-                Assert.Equal(releaseVersion.PublishScheduled, viewModel.PublishScheduled);
+                Assert.Equal(releaseVersion.PublishScheduled?.ConvertUtcToUkTimeZone(), viewModel.PublishScheduled);
                 Assert.Equal(releaseVersion.Published, viewModel.Published);
                 Assert.Equal(releaseVersion.PreReleaseAccessList, viewModel.PreReleaseAccessList);
                 Assert.Equal(releaseVersion.NextReleaseDate, viewModel.NextReleaseDate);


### PR DESCRIPTION
test: Fix failing unit tests by converting PublishScheduled in generated data to UK timezone with ConvertUtcToUkTimeZone to match how PublishScheduled is set up in the view model by MappingProfile which uses ConvertUtcToUkTimeZone