### PR TITLE
EES-5899 Search infrastructure pipeline - Add Prod deploy stage and switch to common variable groups

### DIFF
--- a/infrastructure/templates/search/ci/azure-pipelines.yml
+++ b/infrastructure/templates/search/ci/azure-pipelines.yml
@@ -25,7 +25,7 @@ resources:
       trigger: none
 
 variables:
-  - group: Search Infrastructure - Common
+  - group: Common
   - name: forceDeployToEnvironment
     value: ${{parameters.forceDeployToEnvironment}}
   - name: isDev

--- a/infrastructure/templates/search/ci/azure-pipelines.yml
+++ b/infrastructure/templates/search/ci/azure-pipelines.yml
@@ -68,3 +68,12 @@ stages:
       environment: Pre-Prod
       serviceConnection: $(serviceConnectionPreProd)
       bicepParamFile: preprod
+
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployProd
+      condition:  and(succeeded(), eq(variables.isMaster, true))
+      dependsOn: DeployPreProd
+      environment: Prod
+      serviceConnection: $(serviceConnectionProd)
+      bicepParamFile: prod

--- a/infrastructure/templates/search/ci/stages/deploy.yml
+++ b/infrastructure/templates/search/ci/stages/deploy.yml
@@ -35,7 +35,7 @@ stages:
     lockBehavior: sequential
     condition: ${{ parameters.condition }}
     variables:
-      - group: Search Infrastructure - ${{ parameters.environment }}
+      - group: Common - ${{ parameters.environment }}
       - name: searchDocsFunctionAppName
         value: $(subscription)-ees-fa-searchdocs
       - name: infraDeployName


### PR DESCRIPTION
This PR makes changes to the Search infrastructure and app deploy pipeline:

It adds the Prod deploy stage to the pipeline, dependent on the Pre-Prod stage so that we can deploy to Prod.

It switches from using the variable groups `Search Infrastructure - Common` and `Search Infrastructure - <env>` to use `Common` and `Common - <env>` which are new variable groups we are creating. A few pipelines for different parts of the service are all going to share the same common variables so this avoids having lots of duplicate 'Common' variable groups across all the different areas.