### PR TITLE
Ees 5825 add analytics pipeline and infrastructure

### DIFF
--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -132,6 +132,22 @@ jobs:
           performMultiLevelLookup: true
 
       - task: DotNetCoreCLI@2
+        displayName: Package Analytics Function App
+        inputs:
+          command: publish
+          publishWebProjects: false
+          projects: '**/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.csproj'
+          arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/analytics-function-app
+          zipAfterPublish: True
+
+      - task: PublishPipelineArtifact@1
+        displayName: Publish Analytics Function App artifact
+        condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
+        inputs:
+          artifactName: analytics-function-app
+          targetPath: $(Build.ArtifactStagingDirectory)/analytics-function-app    
+
+      - task: DotNetCoreCLI@2
         displayName: Package Data API
         inputs:
           command: publish

--- a/infrastructure/common/ci/tasks/deploy-function-app.yml
+++ b/infrastructure/common/ci/tasks/deploy-function-app.yml
@@ -3,6 +3,8 @@ parameters:
     type: string
   - name: environment
     type: string
+  - name: displayName
+    type: string
   - name: deploymentName
     type: string
   - name: functionAppName
@@ -19,7 +21,7 @@ parameters:
 
 jobs:
   - deployment: ${{ parameters.deploymentName }}
-    displayName: Deploy ${{ parameters.functionAppName }} Function App
+    displayName: ${{ parameters.displayName }}
     dependsOn: ${{ parameters.dependsOn }}
     environment: ${{ parameters.environment }}
     pool:

--- a/infrastructure/common/ci/tasks/deploy-function-app.yml
+++ b/infrastructure/common/ci/tasks/deploy-function-app.yml
@@ -1,0 +1,59 @@
+parameters:
+  - name: serviceConnection
+    type: string
+  - name: environment
+    type: string
+  - name: deploymentName
+    type: string
+  - name: functionAppName
+    type: string
+  - name: artifactName
+    type: string
+  - name: artifactZipName
+    type: string
+  - name: healthCheckUrl
+    type: string
+  - name: dependsOn
+    type: object
+    default: []
+
+jobs:
+  - deployment: ${{ parameters.deploymentName }}
+    displayName: Deploy ${{ parameters.functionAppName }} Function App
+    dependsOn: ${{ parameters.dependsOn }}
+    environment: ${{ parameters.environment }}
+    pool:
+      vmImage: $(vmImageName)
+
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - download: MainBuild
+              displayName: Download ${{ parameters.functionAppName }} Function App artifact
+              artifact: ${{ parameters.artifactName }}
+
+            - template: ../../../templates/public-api/ci/tasks/bicep-output-variables.yml
+              parameters:
+                serviceConnection: ${{ parameters.serviceConnection }}
+
+            - task: AzureCLI@2
+              displayName: 'Deploy ${{ parameters.functionAppName }} Function App using az cli'
+              retryCountOnTaskFailure: 1
+              inputs:
+                azureSubscription: ${{ parameters.serviceConnection }}
+                scriptType: 'bash'
+                scriptLocation: 'inlineScript'
+                inlineScript: |
+                  set -e
+                  echo "Deploying ${{ parameters.functionAppName }} Function App using zip deploy"
+                  az functionapp deployment source config-zip \
+                    --resource-group $(resourceGroupName) \
+                    --name ${{ parameters.functionAppName }} \
+                    --src '$(Pipeline.Workspace)/MainBuild/${{ parameters.artifactName }}/${{ parameters.artifactZipName }}'
+
+            - template: ../../../templates/public-api/ci/tasks/wait-for-endpoint-success.yml
+              parameters:
+                serviceConnection: ${{ parameters.serviceConnection }}
+                displayName: Check the ${{ parameters.functionAppName }} Function App is healthy after deployment
+                endpoint: ${{ parameters.healthCheckUrl }}

--- a/infrastructure/templates/analytics/application/analyticsApplicationInsights.bicep
+++ b/infrastructure/templates/analytics/application/analyticsApplicationInsights.bicep
@@ -1,0 +1,32 @@
+import { abbreviations } from '../../common/abbreviations.bicep'
+import { ResourceNames } from '../types.bicep'
+
+@description('Resource prefix for all resources.')
+param resourcePrefix string
+
+@description('Specifies common resource naming variables.')
+param resourceNames ResourceNames
+
+@description('Specifies the location for all resources.')
+param location string
+
+@description('Specifies a set of tags with which to tag the resource in Azure.')
+param tagValues object
+
+module applicationInsightsModule '../../public-api/components/appInsights.bicep' = {
+  name: 'applicationInsightsModuleDeploy'
+  params: {
+    location: location
+    appInsightsName: '${resourcePrefix}-${abbreviations.insightsComponents}-search'
+    alerts: {
+      exceptionCount: true
+      exceptionServerCount: true
+      failedRequests: true
+      alertsGroupName: resourceNames.existingResources.alertsGroup
+    }
+    tagValues: tagValues
+  }
+}
+
+output applicationInsightsConnectionString string = applicationInsightsModule.outputs.applicationInsightsConnectionString
+output applicationInsightsName string = applicationInsightsModule.outputs.applicationInsightsName

--- a/infrastructure/templates/analytics/application/analyticsFunctionApp.bicep
+++ b/infrastructure/templates/analytics/application/analyticsFunctionApp.bicep
@@ -88,7 +88,7 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
     functionAppRuntimeVersion: '8.0'
     storageAccountName: '${replace(resourcePrefix, '-', '')}${abbreviations.storageStorageAccounts}anlytfa'
     storageAccountPublicNetworkAccessEnabled: false
-    publicNetworkAccessEnabled: false
+    publicNetworkAccessEnabled: true
     functionAppFirewallRules: functionAppFirewallRules
     storageFirewallRules: storageFirewallRules
     outboundSubnetId: outboundVnetSubnet.id

--- a/infrastructure/templates/analytics/application/analyticsFunctionApp.bicep
+++ b/infrastructure/templates/analytics/application/analyticsFunctionApp.bicep
@@ -26,6 +26,9 @@ param analyticsFileShareName string
 @description('The Application Insights connection string that is associated with this resource.')
 param applicationInsightsConnectionString string = ''
 
+@description('The cron schedule for the Public API queries consumer Function. Defaults to every half hour.')
+param publicApiQueryConsumerCron string
+
 @description('Specifies whether or not the Analytics Function App already exists.')
 param functionAppExists bool
 
@@ -62,6 +65,10 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
       {
         name: 'Analytics__BasePath'
         value: fileShareMountPath
+      }
+      {
+        name: 'App__ConsumePublicApiQueriesCronSchedule'
+        value: publicApiQueryConsumerCron
       }
     ]
     functionAppExists: functionAppExists

--- a/infrastructure/templates/analytics/application/analyticsFunctionApp.bicep
+++ b/infrastructure/templates/analytics/application/analyticsFunctionApp.bicep
@@ -42,6 +42,10 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
 resource vNet 'Microsoft.Network/virtualNetworks@2023-11-01' existing = {
   name: resourceNames.existingResources.vNet
 }
+resource outboundVnetSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
+  name: resourceNames.existingResources.subnets.analyticsFunctionApp
+  parent: vNet
+}
 
 resource analyticsStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
   name: analyticsStorageAccountName
@@ -87,6 +91,7 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
     publicNetworkAccessEnabled: false
     functionAppFirewallRules: functionAppFirewallRules
     storageFirewallRules: storageFirewallRules
+    outboundSubnetId: outboundVnetSubnet.id
     privateEndpoints: {
       storageAccounts: storagePrivateEndpointSubnet.id
     }

--- a/infrastructure/templates/analytics/application/analyticsFunctionApp.bicep
+++ b/infrastructure/templates/analytics/application/analyticsFunctionApp.bicep
@@ -1,0 +1,110 @@
+import { abbreviations } from '../../common/abbreviations.bicep'
+import { IpRange, FirewallRule } from '../../common/types.bicep'
+import { ResourceNames } from '../types.bicep'
+
+@description('The IP address ranges that can access the Analytics Function App endpoints.')
+param functionAppFirewallRules FirewallRule[]
+
+@description('The IP address ranges that can access the Search Docs Function App storage accounts.')
+param storageFirewallRules IpRange[]
+
+@description('Specifies common resource naming variables.')
+param resourceNames ResourceNames
+
+@description('Resource prefix for all resources.')
+param resourcePrefix string
+
+@description('Location for all resources.')
+param location string
+
+@description('Name of the shared analytics storage account.')
+param analyticsStorageAccountName string
+
+@description('Name of the shared analytics file share.')
+param analyticsFileShareName string
+
+@description('The Application Insights connection string that is associated with this resource.')
+param applicationInsightsConnectionString string = ''
+
+@description('Specifies whether or not the Analytics Function App already exists.')
+param functionAppExists bool
+
+@description('Specifies a set of tags with which to tag the resource in Azure.')
+param tagValues object
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: resourceNames.existingResources.keyVault
+}
+
+resource vNet 'Microsoft.Network/virtualNetworks@2023-11-01' existing = {
+  name: resourceNames.existingResources.vNet
+}
+
+resource analyticsStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: analyticsStorageAccountName
+}
+
+resource storagePrivateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
+  name: resourceNames.existingResources.subnets.storagePrivateEndpoints
+  parent: vNet
+}
+
+var fileShareMountPath = '/data/analytics'
+
+module functionAppModule '../../common/components/functionApp.bicep' = {
+  name: 'analyticsFunctionAppModuleDeploy'
+  params: {
+    functionAppName: '${resourcePrefix}-${abbreviations.webSitesFunctions}-analytics'
+    location: location
+    applicationInsightsConnectionString: applicationInsightsConnectionString
+    appServicePlanName: '${resourcePrefix}-${abbreviations.webServerFarms}-analytics'
+    appSettings: [
+      {
+        name: 'Analytics__BasePath'
+        value: fileShareMountPath
+      }
+    ]
+    functionAppExists: functionAppExists
+    keyVaultName: keyVault.name
+    sku: {
+      name: 'EP1'
+      tier: 'ElasticPremium'
+      family: 'EP'
+    }
+    healthCheckPath: '/api/HealthCheck'
+    operatingSystem: 'Linux'
+    functionAppRuntime: 'dotnet-isolated'
+    functionAppRuntimeVersion: '8.0'
+    storageAccountName: '${replace(resourcePrefix, '-', '')}${abbreviations.storageStorageAccounts}anlytfa'
+    storageAccountPublicNetworkAccessEnabled: false
+    publicNetworkAccessEnabled: false
+    functionAppFirewallRules: functionAppFirewallRules
+    storageFirewallRules: storageFirewallRules
+    privateEndpoints: {
+      storageAccounts: storagePrivateEndpointSubnet.id
+    }
+    alerts: {
+      cpuPercentage: true
+      functionAppHealth: true
+      httpErrors: true
+      memoryPercentage: true
+      storageAccountAvailability: false
+      storageLatency: false
+      fileServiceAvailability: false
+      fileServiceLatency: false
+      fileServiceCapacity: false
+      alertsGroupName: resourceNames.existingResources.alertsGroup
+    }
+    azureFileShares: [{
+      storageName: analyticsStorageAccountName
+      storageAccountKey: analyticsStorageAccount.listKeys().keys[0].value
+      storageAccountName: analyticsStorageAccountName
+      fileShareName: analyticsFileShareName
+      mountPath: fileShareMountPath
+    }]
+    tagValues: tagValues
+  }
+}
+
+output functionAppName string = functionAppModule.outputs.name
+output functionAppUrl string = functionAppModule.outputs.url

--- a/infrastructure/templates/analytics/application/analyticsStorage.bicep
+++ b/infrastructure/templates/analytics/application/analyticsStorage.bicep
@@ -47,7 +47,7 @@ module analyticsStorageAccountModule '../../public-api/components/storageAccount
   params: {
     location: location
     storageAccountName: storageAccountName
-    publicNetworkAccessEnabled: false
+    publicNetworkAccessEnabled: true
     firewallRules: storageFirewallRules
     sku: storageAccountConfig.sku
     kind: storageAccountConfig.kind

--- a/infrastructure/templates/analytics/application/analyticsStorage.bicep
+++ b/infrastructure/templates/analytics/application/analyticsStorage.bicep
@@ -1,13 +1,15 @@
-import { ResourceNames, IpRange, StorageAccountConfig } from '../../types.bicep'
+import { abbreviations } from '../../common/abbreviations.bicep'
+import { ResourceNames } from '../types.bicep'
+import { IpRange, StorageAccountConfig } from '../../common/types.bicep'
 
 @description('Specifies common resource naming variables.')
 param resourceNames ResourceNames
 
+@description('Resource prefix for all resources.')
+param resourcePrefix string
+
 @description('Specifies the location for all resources.')
 param location string
-
-@description('Public API storage account and file share configuration.')
-param config StorageAccountConfig
 
 @description('Firewall rules.')
 param storageFirewallRules IpRange[]
@@ -27,15 +29,28 @@ resource storagePrivateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets
   parent: vNet
 }
 
-module analyticsStorageAccountModule '../../components/storageAccount.bicep' = {
+var storageAccountName = '${replace(resourcePrefix, '-', '')}${abbreviations.storageStorageAccounts}anlyt'
+
+var storageAccountConfig = {
+  kind: 'FileStorage'
+  sku: 'Premium_ZRS'
+  fileShare: {
+    quotaGbs: 100
+    accessTier: 'Premium'
+  }
+}
+
+var fileShareName = '${resourcePrefix}-${abbreviations.fileShare}-anlyt'
+
+module analyticsStorageAccountModule '../../public-api/components/storageAccount.bicep' = {
   name: 'analyticsStorageAccountDeploy'
   params: {
     location: location
-    storageAccountName: resourceNames.sharedResources.analyticsStorageAccount
+    storageAccountName: storageAccountName
     publicNetworkAccessEnabled: false
     firewallRules: storageFirewallRules
-    sku: config.sku
-    kind: config.kind
+    sku: storageAccountConfig.sku
+    kind: storageAccountConfig.kind
     keyVaultName: resourceNames.existingResources.keyVault
     alerts: deployAlerts ? {
       availability: true
@@ -49,13 +64,13 @@ module analyticsStorageAccountModule '../../components/storageAccount.bicep' = {
   }
 }
 
-module analyticsFileShareModule '../../components/fileShare.bicep' = {
+module analyticsFileShareModule '../../public-api/components/fileShare.bicep' = {
   name: 'analyticsFileShareDeploy'
   params: {
-    fileShareName: resourceNames.sharedResources.analyticsFileShare
-    fileShareQuotaGbs: config.fileShare.quotaGbs
+    fileShareName: fileShareName
+    fileShareQuotaGbs: storageAccountConfig.fileShare.quotaGbs
     storageAccountName: analyticsStorageAccountModule.outputs.storageAccountName
-    fileShareAccessTier: config.fileShare.accessTier
+    fileShareAccessTier: storageAccountConfig.fileShare.accessTier
     alerts: deployAlerts ? {
       availability: true
       latency: true
@@ -67,5 +82,4 @@ module analyticsFileShareModule '../../components/fileShare.bicep' = {
 }
 
 output storageAccountName string = analyticsStorageAccountModule.outputs.storageAccountName
-output connectionStringSecretName string = analyticsStorageAccountModule.outputs.connectionStringSecretName
-output accessKeySecretName string = analyticsStorageAccountModule.outputs.accessKeySecretName
+output fileShareName string = fileShareName

--- a/infrastructure/templates/analytics/ci/azure-pipelines.yml
+++ b/infrastructure/templates/analytics/ci/azure-pipelines.yml
@@ -22,7 +22,7 @@ resources:
           - master
 
 variables:
-  - group: Analytics - Common
+  - group: Common
   - name: forceDeployToEnvironment
     value: ${{parameters.forceDeployToEnvironment}}
   - name: isDev

--- a/infrastructure/templates/analytics/ci/azure-pipelines.yml
+++ b/infrastructure/templates/analytics/ci/azure-pipelines.yml
@@ -1,0 +1,74 @@
+trigger: none
+
+parameters:
+  - name: forceDeployToEnvironment
+    displayName: Set to either dev or test to force a deploy to that environment from the chosen branch.
+    type: string
+    values:
+      - none
+      - dev
+      - test
+      - preprod
+    default: none
+
+resources:
+  pipelines:
+    - pipeline: MainBuild
+      source: Explore Education Statistics
+      trigger:
+        branches:
+          - dev
+          - test
+          - master
+
+variables:
+  - group: Analytics - Common
+  - name: forceDeployToEnvironment
+    value: ${{parameters.forceDeployToEnvironment}}
+  - name: isDev
+    value: $[or(eq(variables['forceDeployToEnvironment'], 'dev'), eq(variables['Build.SourceBranch'], 'refs/heads/dev'))]
+  - name: isTest
+    value: $[or(eq(variables['forceDeployToEnvironment'], 'test'), eq(variables['Build.SourceBranch'], 'refs/heads/test'))]
+  - name: isPreProd
+    value: $[or(eq(variables['forceDeployToEnvironment'], 'preprod'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))]
+  - name: isMaster
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
+  - name: vmImageName
+    value: ubuntu-latest
+
+pool:
+  vmImage: $(vmImageName)
+
+stages:
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployDev
+      condition: eq(variables.isDev, true)
+      environment: Dev
+      serviceConnection: $(serviceConnectionDev)
+      bicepParamFile: dev
+
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployTest
+      condition: eq(variables.isTest, true)
+      environment: Test
+      serviceConnection: $(serviceConnectionTest)
+      bicepParamFile: test
+
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployPreProd
+      condition: eq(variables.isPreProd, true)
+      environment: Pre-Prod
+      serviceConnection: $(serviceConnectionPreProd)
+      bicepParamFile: preprod
+
+  - template: stages/deploy.yml
+    parameters:
+      stageName: DeployProd
+      condition:  and(succeeded(), eq(variables.isMaster, true))
+      dependsOn: DeployPreProd
+      environment: Prod
+      serviceConnection: $(serviceConnectionProd)
+      bicepParamFile: prod

--- a/infrastructure/templates/analytics/ci/jobs/deploy-analytics-function-app.yml
+++ b/infrastructure/templates/analytics/ci/jobs/deploy-analytics-function-app.yml
@@ -1,0 +1,20 @@
+parameters:
+  - name: serviceConnection
+    type: string
+  - name: environment
+    type: string
+  - name: dependsOn
+    type: object
+    default: []
+
+jobs:
+- template: ../../../../common/ci/tasks/deploy-function-app.yml
+  parameters:
+    serviceConnection: ${{ parameters.serviceConnection }}
+    environment: ${{ parameters.environment }}
+    dependsOn: ${{ parameters.dependsOn }}
+    deploymentName: DeployAnalyticsFunction
+    functionAppName: $(analyticsFunctionAppName)
+    artifactName: analytics-function-app
+    artifactZipName: GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.zip
+    healthCheckUrl: $(analyticsFunctionAppUrl)/api/HealthCheck

--- a/infrastructure/templates/analytics/ci/jobs/deploy-analytics-function-app.yml
+++ b/infrastructure/templates/analytics/ci/jobs/deploy-analytics-function-app.yml
@@ -12,6 +12,7 @@ jobs:
   parameters:
     serviceConnection: ${{ parameters.serviceConnection }}
     environment: ${{ parameters.environment }}
+    displayName: Deploy Analytics Function App
     dependsOn: ${{ parameters.dependsOn }}
     deploymentName: DeployAnalyticsFunction
     functionAppName: $(analyticsFunctionAppName)

--- a/infrastructure/templates/analytics/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/analytics/ci/jobs/deploy-infrastructure.yml
@@ -37,7 +37,7 @@ jobs:
                 parameterFile: $(paramFile)
                 analyticsFunctionAppExists: false
 
-            - template: ../../../public-api/tasks/check-function-app-exists.yml
+            - template: ../../../public-api/ci/tasks/check-function-app-exists.yml
               parameters:
                 serviceConnection: ${{ parameters.serviceConnection }}
                 resourceGroupName: $(resourceGroupName)

--- a/infrastructure/templates/analytics/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/analytics/ci/jobs/deploy-infrastructure.yml
@@ -1,0 +1,53 @@
+parameters:
+  - name: serviceConnection
+    type: string
+  - name: environment
+    type: string
+  - name: bicepParamFile
+    type: string
+
+jobs:
+  - deployment: DeployAnalyticsInfrastructure
+    displayName: Deploy Analytics infrastructure
+    environment: ${{ parameters.environment }}
+    variables:
+      templateDirectory: $(Build.SourcesDirectory)/infrastructure/templates/analytics
+      templateFile: $(templateDirectory)/main.bicep
+      paramDirectory: $(templateDirectory)/parameters
+      paramFile: $(paramDirectory)/main-${{ parameters.bicepParamFile }}.bicepparam
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - checkout: self
+
+            - task: AzureCLI@2
+              displayName: Install Bicep
+              inputs:
+                azureSubscription: ${{ parameters.serviceConnection }}
+                scriptType: bash
+                scriptLocation: inlineScript
+                inlineScript: az bicep install
+
+            - template: ../tasks/deploy-bicep.yml
+              parameters:
+                displayName: Validate Bicep template
+                action: validate
+                serviceConnection: ${{ parameters.serviceConnection }}
+                parameterFile: $(paramFile)
+                analyticsFunctionAppExists: false
+
+            - template: ../../../public-api/tasks/check-function-app-exists.yml
+              parameters:
+                serviceConnection: ${{ parameters.serviceConnection }}
+                resourceGroupName: $(resourceGroupName)
+                functionAppName: $(analyticsFunctionAppName)
+                variableName: analyticsFunctionAppExists
+
+            - template: ../tasks/deploy-bicep.yml
+              parameters:
+                displayName: Deploy Bicep template
+                action: create
+                serviceConnection: ${{ parameters.serviceConnection }}
+                parameterFile: $(paramFile)
+                analyticsFunctionAppExists: $(analyticsFunctionAppExists)

--- a/infrastructure/templates/analytics/ci/stages/deploy.yml
+++ b/infrastructure/templates/analytics/ci/stages/deploy.yml
@@ -34,6 +34,8 @@ stages:
     # be queued and run sequentially in the order that their pipelines were triggered.
     lockBehavior: sequential
     condition: ${{ parameters.condition }}
+    variables:
+      - group: Common - ${{ parameters.environment }}
       - name: analyticsFunctionAppName
         value: $(subscription)-ees-fa-analytics
       - name: infraDeployName

--- a/infrastructure/templates/analytics/ci/stages/deploy.yml
+++ b/infrastructure/templates/analytics/ci/stages/deploy.yml
@@ -1,0 +1,52 @@
+parameters:
+  - name: stageName
+    type: string
+  - name: environment
+    type: string
+  - name: serviceConnection
+    type: string
+  - name: bicepParamFile
+    type: string
+    values:
+      - dev
+      - test
+      - preprod
+      - prod
+  - name: condition
+    type: string
+  - name: dependsOn
+    type: object
+    default: []
+  - name: trigger
+    type: string
+    default: automatic
+    values:
+      - automatic
+      - manual
+
+stages:
+  - stage: ${{ parameters.stageName }}
+    displayName: Deploy ${{ parameters.environment }}
+    dependsOn: ${{ parameters.dependsOn }}
+    trigger: ${{ parameters.trigger }}
+    # Prevent this stage from running in parallel with the same deploy stage in other
+    # ongoing runs of this pipeline. Instead, multiple executions of this stage will
+    # be queued and run sequentially in the order that their pipelines were triggered.
+    lockBehavior: sequential
+    condition: ${{ parameters.condition }}
+      - name: analyticsFunctionAppName
+        value: $(subscription)-ees-fa-analytics
+      - name: infraDeployName
+        value: AnalyticsInfrastructure$(Build.BuildNumber)
+    jobs:
+      - template: ../jobs/deploy-infrastructure.yml
+        parameters:
+          serviceConnection: ${{ parameters.serviceConnection }}
+          environment: ${{ parameters.environment }}
+          bicepParamFile: ${{ parameters.bicepParamFile }}
+
+      - template: ../jobs/deploy-analytics-function-app.yml
+        parameters:
+          serviceConnection: ${{ parameters.serviceConnection }}
+          environment: ${{ parameters.environment }}
+          dependsOn: DeployAnalyticsInfrastructure

--- a/infrastructure/templates/analytics/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/analytics/ci/tasks/deploy-bicep.yml
@@ -1,0 +1,38 @@
+parameters:
+  - name: action
+    type: string
+    default: create
+    values:
+      - create
+      - validate
+  - name: displayName
+    type: string
+  - name: serviceConnection
+    type: string
+  - name: parameterFile
+    type: string
+  - name: analyticsFunctionAppExists
+    type: string
+    default: true
+
+steps:
+  - task: AzureCLI@2
+    displayName: ${{ parameters.displayName }}
+    inputs:
+      azureSubscription: ${{ parameters.serviceConnection }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      addSpnToEnvironment: true
+      inlineScript: |
+        set -e
+
+        az deployment group ${{ parameters.action }} \
+          --name $(infraDeployName) \
+          --resource-group $(resourceGroupName) \
+          --template-file $(templateFile) \
+          --parameters ${{ parameters.parameterFile }} \
+          --parameters \
+              subscription='$(subscription)' \
+              resourceTags='$(resourceTags)' \
+              maintenanceIpRanges='$(maintenanceFirewallRules)' \
+              analyticsFunctionAppExists=${{ parameters.analyticsFunctionAppExists }}

--- a/infrastructure/templates/analytics/main.bicep
+++ b/infrastructure/templates/analytics/main.bicep
@@ -1,0 +1,108 @@
+import { abbreviations } from '../common/abbreviations.bicep'
+import { IpRange } from '../common/types.bicep'
+
+@description('Environment : Subscription name e.g. s101d01. Used as a prefix for created resources.')
+param subscription string = ''
+
+@description('Environment : Specifies the location in which the Azure resources should be deployed.')
+param location string = resourceGroup().location
+
+@description('Tagging : Environment name e.g. Development. Used for tagging resources created by this infrastructure pipeline.')
+param environmentName string
+
+@description('Tagging : Used for tagging resources created by this infrastructure pipeline.')
+param resourceTags {
+  CostCentre: string
+  Department: string
+  Solution: string
+  ServiceOwner: string
+  CreatedBy: string
+  DeploymentRepoUrl: string
+}?
+
+@description('Tagging : Date Provisioned. Used for tagging resources created by this infrastructure pipeline.')
+param dateProvisioned string = utcNow('u')
+
+@description('Specifies whether or not the Analytics Function App already exists.')
+param analyticsFunctionAppExists bool = true
+
+@description('Provides access to resources for specific IP address ranges used for service maintenance.')
+param maintenanceIpRanges IpRange[] = []
+
+var tagValues = union(resourceTags ?? {}, {
+  Environment: environmentName
+  DateProvisioned: dateProvisioned
+})
+
+var maintenanceFirewallRules = [
+  for maintenanceIpRange in maintenanceIpRanges: {
+    name: maintenanceIpRange.name
+    cidr: maintenanceIpRange.cidr
+    tag: 'Default'
+    priority: 100
+  }
+]
+
+var resourcePrefix = '${subscription}-ees'
+
+var resourceNames = {
+  existingResources: {
+    keyVault: '${subscription}-kv-ees-01'
+    vNet: '${subscription}-vnet-ees'
+    alertsGroup: '${subscription}-ag-ees-alertedusers'
+    subnets: {
+      storagePrivateEndpoints: '${resourcePrefix}-snet-${abbreviations.storageStorageAccounts}-anlyt-${abbreviations.privateEndpoints}'
+    }
+  }
+}
+
+// Create an Application Insights resource for Analytics resources to use.
+module applicationInsightsModule 'application/analyticsApplicationInsights.bicep' = {
+  name: 'analyticsApplicationInsightsModule'
+  params: {
+    location: location
+    resourcePrefix: resourcePrefix
+    resourceNames: resourceNames
+    tagValues: tagValues
+  }
+}
+
+module analyticsStorageModule 'application/analyticsStorage.bicep' = {
+  name: 'analyticsStorageAccountApplicationModuleDeploy'
+  params: {
+    resourcePrefix: resourcePrefix
+    location: location
+    resourceNames: resourceNames
+    storageFirewallRules: maintenanceIpRanges
+    deployAlerts: true
+    tagValues: tagValues
+  }
+}
+
+module analyticsFunctionAppModule 'application/analyticsFunctionApp.bicep' = {
+  name: 'analyticsFunctionAppModule'
+  params: {
+    location: location
+    resourceNames: resourceNames
+    resourcePrefix: resourcePrefix
+    functionAppExists: analyticsFunctionAppExists
+    functionAppFirewallRules: union(
+      [
+        {
+          cidr: 'AzureCloud'
+          tag: 'ServiceTag'
+          priority: 101
+          name: 'AzureCloud'
+        }
+      ],
+      maintenanceFirewallRules
+    )
+    storageFirewallRules: maintenanceIpRanges
+    applicationInsightsConnectionString: applicationInsightsModule.outputs.applicationInsightsConnectionString
+    analyticsStorageAccountName: analyticsStorageModule.outputs.storageAccountName
+    analyticsFileShareName: analyticsStorageModule.outputs.fileShareName
+    tagValues: tagValues
+  }
+}
+
+output analyticsFunctionAppUrl string = analyticsFunctionAppModule.outputs.functionAppUrl

--- a/infrastructure/templates/analytics/main.bicep
+++ b/infrastructure/templates/analytics/main.bicep
@@ -29,6 +29,9 @@ param analyticsFunctionAppExists bool = true
 @description('Provides access to resources for specific IP address ranges used for service maintenance.')
 param maintenanceIpRanges IpRange[] = []
 
+@description('The cron schedule for the Public API queries consumer Function. Defaults to every half hour.')
+param publicApiQueryConsumerCron string = '* */30 * * * *'
+
 var tagValues = union(resourceTags ?? {}, {
   Environment: environmentName
   DateProvisioned: dateProvisioned
@@ -101,6 +104,7 @@ module analyticsFunctionAppModule 'application/analyticsFunctionApp.bicep' = {
     applicationInsightsConnectionString: applicationInsightsModule.outputs.applicationInsightsConnectionString
     analyticsStorageAccountName: analyticsStorageModule.outputs.storageAccountName
     analyticsFileShareName: analyticsStorageModule.outputs.fileShareName
+    publicApiQueryConsumerCron: publicApiQueryConsumerCron
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/analytics/main.bicep
+++ b/infrastructure/templates/analytics/main.bicep
@@ -54,6 +54,7 @@ var resourceNames = {
     vNet: '${subscription}-vnet-ees'
     alertsGroup: '${subscription}-ag-ees-alertedusers'
     subnets: {
+      analyticsFunctionApp: '${resourcePrefix}-snet-${abbreviations.webSitesFunctions}-analytics'
       storagePrivateEndpoints: '${resourcePrefix}-snet-${abbreviations.storageStorageAccounts}-anlyt-${abbreviations.privateEndpoints}'
     }
   }

--- a/infrastructure/templates/analytics/main.bicep
+++ b/infrastructure/templates/analytics/main.bicep
@@ -29,8 +29,8 @@ param analyticsFunctionAppExists bool = true
 @description('Provides access to resources for specific IP address ranges used for service maintenance.')
 param maintenanceIpRanges IpRange[] = []
 
-@description('The cron schedule for the Public API queries consumer Function. Defaults to every half hour.')
-param publicApiQueryConsumerCron string = '* */30 * * * *'
+@description('The cron schedule for the Public API queries consumer Function. Defaults to every hour.')
+param publicApiQueryConsumerCron string = '* 0 * * * *'
 
 var tagValues = union(resourceTags ?? {}, {
   Environment: environmentName

--- a/infrastructure/templates/analytics/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/analytics/parameters/main-dev.bicepparam
@@ -1,0 +1,6 @@
+using '../main.bicep'
+
+// Environment Params
+param environmentName = 'Development'
+
+param publicApiQueryConsumerCron = '30 * * * * *'

--- a/infrastructure/templates/analytics/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/analytics/parameters/main-dev.bicepparam
@@ -3,4 +3,4 @@ using '../main.bicep'
 // Environment Params
 param environmentName = 'Development'
 
-param publicApiQueryConsumerCron = '30 * * * * *'
+param publicApiQueryConsumerCron = '* */10 * * * *'

--- a/infrastructure/templates/analytics/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/analytics/parameters/main-preprod.bicepparam
@@ -1,0 +1,4 @@
+using '../main.bicep'
+
+// Environment Params
+param environmentName = 'Pre-Production'

--- a/infrastructure/templates/analytics/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/analytics/parameters/main-prod.bicepparam
@@ -1,0 +1,4 @@
+using '../main.bicep'
+
+// Environment Params
+param environmentName = 'Production'

--- a/infrastructure/templates/analytics/parameters/main-test.bicepparam
+++ b/infrastructure/templates/analytics/parameters/main-test.bicepparam
@@ -1,0 +1,4 @@
+using '../main.bicep'
+
+// Environment Params
+param environmentName = 'Test'

--- a/infrastructure/templates/analytics/types.bicep
+++ b/infrastructure/templates/analytics/types.bicep
@@ -1,0 +1,11 @@
+@export()
+type ResourceNames = {
+  existingResources: {
+    keyVault: string
+    vNet: string
+    alertsGroup: string
+    subnets: {
+      storagePrivateEndpoints: string
+    }
+  }
+}

--- a/infrastructure/templates/analytics/types.bicep
+++ b/infrastructure/templates/analytics/types.bicep
@@ -5,6 +5,7 @@ type ResourceNames = {
     vNet: string
     alertsGroup: string
     subnets: {
+      analyticsFunctionApp: string
       storagePrivateEndpoints: string
     }
   }

--- a/infrastructure/templates/common/abbreviations.bicep
+++ b/infrastructure/templates/common/abbreviations.bicep
@@ -108,6 +108,7 @@ var abbreviations = {
   notificationHubsNamespaces: 'ntfns'
   notificationHubsNamespacesNotificationHubs: 'ntf'
   operationalInsightsWorkspaces: 'log'
+  privateEndpoints: 'pep'
   portalDashboards: 'dash'
   powerBIDedicatedCapacities: 'pbi'
   purviewAccounts: 'pview'

--- a/infrastructure/templates/common/types.bicep
+++ b/infrastructure/templates/common/types.bicep
@@ -1,4 +1,13 @@
 @export()
+type AzureFileShareMount = {
+  storageName: string
+  storageAccountKey: string
+  storageAccountName: string
+  fileShareName: string
+  mountPath: string
+}
+
+@export()
 type IpRange = {
   name: string
   cidr: string
@@ -14,3 +23,13 @@ type FirewallRule = {
 
 @export()
 type StorageAccountRole = 'Storage Blob Data Contributor' | 'Storage Blob Data Owner' | 'Storage Blob Data Reader' | 'Storage Queue Data Contributor'
+
+@export()
+type StorageAccountConfig = {
+  sku: 'Standard_LRS' | 'Premium_LRS' | 'Premium_ZRS'
+  kind: 'StorageV2' | 'FileStorage'
+  fileShare: {
+    quotaGbs: int
+    accessTier: 'Cool' | 'Hot' | 'TransactionOptimized' | 'Premium'
+  }
+}

--- a/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
@@ -101,7 +101,7 @@ module apiContainerAppModule '../../components/containerApp.bicep' = {
       {
         name: 'analytics-file-share-mount'
         storageType: 'AzureFile'
-        storageName: resourceNames.sharedResources.analyticsFileShare
+        storageName: resourceNames.existingResources.analyticsFileShare
       }
       {
         name: 'public-api-file-share-mount'

--- a/infrastructure/templates/public-api/application/public-api/publicApiDataProcessor.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiDataProcessor.bicep
@@ -72,6 +72,7 @@ module dataProcessorFunctionAppModule '../../components/durableFunctionApp.bicep
   name: 'dataProcessorFunctionAppDeploy'
   params: {
     functionAppName: resourceNames.publicApi.dataProcessor
+    // Note that appServicePlan should be resourceNames.publicApi.dataProcessorPlan.
     appServicePlanName: resourceNames.publicApi.dataProcessor
     storageAccountsNamePrefix: resourceNames.publicApi.dataProcessorStorageAccountsPrefix
     location: location

--- a/infrastructure/templates/public-api/application/shared/containerAppEnvironment.bicep
+++ b/infrastructure/templates/public-api/application/shared/containerAppEnvironment.bicep
@@ -16,7 +16,7 @@ param workloadProfiles ContainerAppWorkloadProfile[] = []
 param tagValues object
 
 resource analyticsStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
-  name: resourceNames.sharedResources.analyticsStorageAccount
+  name: resourceNames.existingResources.analyticsStorageAccount
 }
 
 resource publicApiStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
@@ -42,10 +42,10 @@ module containerAppEnvironmentModule '../../components/containerAppEnvironment.b
     applicationInsightsKey: applicationInsightsKey
     azureFileStorages: [
       {
-        storageName: resourceNames.sharedResources.analyticsFileShare
-        storageAccountName: resourceNames.sharedResources.analyticsStorageAccount
+        storageName: resourceNames.existingResources.analyticsFileShare
+        storageAccountName: resourceNames.existingResources.analyticsStorageAccount
         storageAccountKey: analyticsStorageAccount.listKeys().keys[0].value
-        fileShareName: resourceNames.sharedResources.analyticsFileShare
+        fileShareName: resourceNames.existingResources.analyticsFileShare
         accessMode: 'ReadWrite'
       }
       {

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -15,16 +15,6 @@ param subscription string = ''
 @description('Environment : Specifies the location in which the Azure resources should be deployed.')
 param location string = resourceGroup().location
 
-@description('Analytics Storage configuration.')
-param analyticsStorageConfig StorageAccountConfig = {
-  kind: 'FileStorage'
-  sku: 'Premium_ZRS'
-  fileShare: {
-    quotaGbs: 100
-    accessTier: 'Premium'
-  }
-}
-
 @description('Public API Storage configuration.')
 param publicApiStorageConfig StorageAccountConfig = {
   kind: 'FileStorage'
@@ -189,6 +179,8 @@ var legacyResourcePrefix = subscription
 var resourceNames = {
   existingResources: {
     adminApp: '${legacyResourcePrefix}-as-ees-admin'
+    analyticsFileShare: '${commonResourcePrefix}-${abbreviations.fileShare}-anlyt'
+    analyticsStorageAccount: '${replace(commonResourcePrefix, '-', '')}${abbreviations.storageStorageAccounts}anlyt'
     publisherFunction: '${legacyResourcePrefix}-fa-ees-publisher'
     keyVault: '${legacyResourcePrefix}-kv-ees-01'
     vNet: '${legacyResourcePrefix}-vnet-ees'
@@ -211,8 +203,6 @@ var resourceNames = {
     }
   }
   sharedResources: {
-    analyticsFileShare: '${commonResourcePrefix}-${abbreviations.fileShare}-anlyt'
-    analyticsStorageAccount: '${replace(commonResourcePrefix, '-', '')}${abbreviations.storageStorageAccounts}anlyt'
     appGateway: '${commonResourcePrefix}-${abbreviations.networkApplicationGateways}-01'
     appGatewayIdentity: '${commonResourcePrefix}-${abbreviations.managedIdentityUserAssignedIdentities}-${abbreviations.networkApplicationGateways}-01'
     containerAppEnvironment: '${commonResourcePrefix}-${abbreviations.appManagedEnvironments}-01'
@@ -262,18 +252,6 @@ module privateDnsZonesModule 'application/shared/privateDnsZones.bicep' = if (de
   name: 'privateDnsZonesApplicationModuleDeploy'
   params: {
     resourceNames: resourceNames
-    tagValues: tagValues
-  }
-}
-
-module analyticsStorageModule 'application/shared/analyticsStorage.bicep' = {
-  name: 'analyticsStorageAccountApplicationModuleDeploy'
-  params: {
-    location: location
-    resourceNames: resourceNames
-    config: analyticsStorageConfig
-    storageFirewallRules: maintenanceIpRanges
-    deployAlerts: deployAlerts
     tagValues: tagValues
   }
 }
@@ -363,7 +341,6 @@ module containerAppEnvironmentModule 'application/shared/containerAppEnvironment
   }
   dependsOn: [
     publicApiStorageModule
-    analyticsStorageModule
   ]
 }
 

--- a/infrastructure/templates/public-api/types.bicep
+++ b/infrastructure/templates/public-api/types.bicep
@@ -23,6 +23,8 @@ type MonthOfYear =
 type ResourceNames = {
   existingResources: {
     adminApp: string
+    analyticsStorageAccount: string
+    analyticsFileShare: string
     publisherFunction: string
     keyVault: string
     vNet: string
@@ -42,8 +44,6 @@ type ResourceNames = {
     }
   }
   sharedResources: {
-    analyticsStorageAccount: string
-    analyticsFileShare: string
     appGateway: string
     appGatewayIdentity: string
     containerAppEnvironment: string

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -81,7 +81,7 @@ resource searchableDocumentsContainer 'Microsoft.Storage/storageAccounts/blobSer
 }
 
 module functionAppModule '../../common/components/functionApp.bicep' = {
-  name: 'functionAppModuleDeploy'
+  name: 'searchDocsFunctionAppModuleDeploy'
   params: {
     functionAppName: '${resourcePrefix}-${abbreviations.webSitesFunctions}-searchdocs'
     location: location
@@ -130,7 +130,7 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
       functionApp: searchDocsFunctionPrivateEndpointSubnet.id
       storageAccounts: searchDocsFunctionPrivateEndpointSubnet.id
     }
-    subnetId: outboundVnetSubnet.id
+    outboundSubnetId: outboundVnetSubnet.id
     alerts: deployAlerts ? {
       cpuPercentage: true
       functionAppHealth: true

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1094,6 +1094,7 @@
     "vNetRef": "[resourceId('Microsoft.Network/virtualNetworks', variables('vNetName'))]",
     "adminSubnetName": "[concat(parameters('subscription'), '-snet-', parameters('environment'), '-admin')]",
     "adminSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('adminSubnetName'))]",
+    "analyticsStoragePrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-sa-anlyt-pep')]",
     "importerSubnetName": "[concat(parameters('subscription'), '-snet-', parameters('environment'), '-importer')]",
     "importerSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('importerSubnetName'))]",
     "publisherSubnetName": "[concat(parameters('subscription'), '-snet-', parameters('environment'), '-publisher')]",
@@ -3741,6 +3742,12 @@
             "name": "[variables('searchDocsFunctionPrivateEndpointsSubnetName')]",
             "properties": {
               "addressPrefix": "10.0.15.0/24"
+            }
+          },
+          {
+            "name": "[variables('analyticsStoragePrivateEndpointsSubnetName')]",
+            "properties": {
+              "addressPrefix": "10.0.16.0/24"
             }
           }
         ]

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -3755,11 +3755,6 @@
             "name": "[variables('analyticsFunctionAppSubnetName')]",
             "properties": {
               "addressPrefix": "10.0.17.0/24",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.Storage"
-                }
-              ],
               "delegations": [
                 {
                   "name": "webapp",

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1094,6 +1094,7 @@
     "vNetRef": "[resourceId('Microsoft.Network/virtualNetworks', variables('vNetName'))]",
     "adminSubnetName": "[concat(parameters('subscription'), '-snet-', parameters('environment'), '-admin')]",
     "adminSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('adminSubnetName'))]",
+    "analyticsFunctionAppSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-fa-analytics')]",
     "analyticsStoragePrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-sa-anlyt-pep')]",
     "importerSubnetName": "[concat(parameters('subscription'), '-snet-', parameters('environment'), '-importer')]",
     "importerSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('importerSubnetName'))]",
@@ -3748,6 +3749,25 @@
             "name": "[variables('analyticsStoragePrivateEndpointsSubnetName')]",
             "properties": {
               "addressPrefix": "10.0.16.0/24"
+            }
+          },
+          {
+            "name": "[variables('analyticsFunctionAppSubnetName')]",
+            "properties": {
+              "addressPrefix": "10.0.17.0/24",
+              "serviceEndpoints": [
+                {
+                  "service": "Microsoft.Storage"
+                }
+              ],
+              "delegations": [
+                {
+                  "name": "webapp",
+                  "properties": {
+                    "serviceName": "Microsoft.Web/serverFarms"
+                  }
+                }
+              ]
             }
           }
         ]

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
@@ -10,6 +10,11 @@ public class TestAnalyticsPathResolver : IAnalyticsPathResolver
         "Analytics",
         Guid.NewGuid().ToString());
 
+    public string BasePath()
+    {
+        return _basePath;
+    }
+
     public string PublicApiQueriesDirectoryPath()
     {
         return Path.Combine(_basePath, "public-api");

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Functions/HealthCheckFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Functions/HealthCheckFunctions.cs
@@ -1,0 +1,83 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Functions;
+
+// ReSharper disable once ClassNeverInstantiated.Global
+public class HealthCheckFunctions(
+    ILogger<HealthCheckFunctions> logger,
+    IAnalyticsPathResolver pathResolver)
+{
+    [Function(nameof(HealthCheck))]
+    [Produces("application/json")]
+    public Task<IActionResult> HealthCheck(
+#pragma warning disable IDE0060
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequest request)
+#pragma warning restore IDE0060
+    {
+        var fileShareMountHealthCheck = CheckFileShareMountHealth();
+
+        var healthCheckResponse = new HealthCheckResponse(
+            FileShareMount: fileShareMountHealthCheck);
+
+        if (healthCheckResponse.Healthy)
+        {
+            return Task.FromResult<IActionResult>(new OkObjectResult(healthCheckResponse));
+        }
+        
+        return Task.FromResult<IActionResult>(new ObjectResult(healthCheckResponse) {
+            StatusCode = StatusCodes.Status500InternalServerError
+        });
+    }
+    
+    private HealthCheckSummary CheckFileShareMountHealth()
+    {
+        logger.LogInformation("Attempting to read from file share");
+        
+        try
+        {
+            if (Directory.Exists(pathResolver.BasePath()))
+            {
+                return HealthCheckSummary.Healthy();
+            }
+            
+            return HealthCheckSummary.Unhealthy("File Share Mount folder does not exist");
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Error encountered when attempting to find the file share mount");
+            return HealthCheckSummary.Unhealthy(e.Message);
+        }
+    }
+
+    private record HealthCheckResponse(HealthCheckSummary FileShareMount)
+    {
+        public bool Healthy => FileShareMount.IsHealthy;
+    }
+
+    public record HealthCheckSummary
+    {
+        public bool IsHealthy { get; private init; }
+        public string? UnhealthyReason { get; init; }
+
+        public static HealthCheckSummary Healthy()
+        {
+            return new HealthCheckSummary
+            {
+                IsHealthy = true
+            };
+        }
+
+        public static HealthCheckSummary Unhealthy(string reason)
+        {
+            return new HealthCheckSummary
+            {
+                IsHealthy = false,
+                UnhealthyReason = reason
+            };
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="DuckDB.NET.Data.Full" Version="1.2.0"/>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0"/>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1"/>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0"/>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0"/>

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Options/AnalyticsOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Options/AnalyticsOptions.cs
@@ -1,10 +1,8 @@
-namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Options;
 
 public class AnalyticsOptions
 {
     public const string Section = "Analytics";
-
-    public bool Enabled { get; init; }
 
     public string BasePath { get; init; } = string.Empty;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
@@ -1,7 +1,7 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Options;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
@@ -24,6 +24,11 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
         _basePath = GetBasePath(options.Value.BasePath, environment);
     }
 
+    public string BasePath()
+    {
+        return _basePath;
+    }
+
     public string PublicApiQueriesDirectoryPath()
     {
         return Path.Combine(_basePath, "public-api", "queries");

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
@@ -1,7 +1,7 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Options;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
@@ -2,6 +2,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer
 
 public interface IAnalyticsPathResolver
 {
+    string BasePath();
+
     string PublicApiQueriesDirectoryPath();
 
     string PublicApiQueriesProcessingDirectoryPath();


### PR DESCRIPTION
# Overview

This PR:
- adds a new "Analytics Infrastructure and Deploy" pipeline to DevOps.
- adds the build and publish of the Analytics Function App into the main build pipeline (for now).
- adds the infrastructure and deploy into Azure environments via the new pipeline.

The build and deploy process has been tested against the Dev Resource Group and is operating successfully.

## New infrastructure

This PR introduces a new .NET Function App into Azure (the code having previously been reviewed).  The Function App consumes raw data from a file share and generates reports as parquet files which will eventually be pushed to DfE's Delta Lake.

### Moving Analytics Storage Account to new pipeline control

This PR also moves control of the existing `s101<env>eessaanlyt` Analytics Storage Account and file share out from the Public API pipeline and into the new Analytics pipeline.  It was originally added to the Public API pipeline so as to be able to go out at the same time as the Public API on first launch.

The Storage Account has also been switched to visible from select IP ranges / subnets so that we can access the analytics reports more easily until the push to Delta Lake has been done.

Because the existing Storage Account is connected to a Public API-specific subnet for its private endpoint, we have a faffy deploy task https://dfedigital.atlassian.net/browse/EES-5957 to help move it over to a new subnet.

## New pipeline

This PR also introduces a new "Analytics infrastructure and deploy" pipeline.

## Shared Function App deploy task

This PR breaks out a generic Function App deploy YAML template, originally base on Search's deploy process.  It doesn't yet move Search over to using it, but this can be done in a follow-up piece of work.