### PR TITLE
EES-5959 Create a dedicated DevOps build pipeline for Search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.iws
 
 ## Application
+artifacts
 bin
 obj
 /data/ees-mssql

--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -26,12 +26,20 @@ trigger:
       - test
   paths:
     exclude:
-      - infrastructure/
+      - infrastructure/**
+      - src/GovUk.Education.ExploreEducationStatistics.Content.Search*/**
 
 pr:
-  - master
-  - dev
-  - test
+  branches:
+    include:
+      - master
+      - dev
+      - test
+  drafts: false
+  paths:
+    exclude:
+      - infrastructure/**
+      - src/GovUk.Education.ExploreEducationStatistics.Content.Search*/**
 
 jobs:
   - job: BackendVerify
@@ -250,22 +258,6 @@ jobs:
         inputs:
           artifactName: processor
           targetPath: $(Build.ArtifactStagingDirectory)/processor
-
-      - task: DotNetCoreCLI@2
-        displayName: Package Search Function App
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: '**/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj'
-          arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/search-function-app
-          zipAfterPublish: True
-
-      - task: PublishPipelineArtifact@1
-        displayName: Publish Search Function App artifact
-        condition: and(succeeded(), eq(variables.IsBranchDeployable, true))
-        inputs:
-          artifactName: search-function-app
-          targetPath: $(Build.ArtifactStagingDirectory)/search-function-app
 
   - job: Admin
     pool: ees-ubuntu2204-xlarge

--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -86,7 +86,7 @@ jobs:
           targetType: inline
           script: |
             docker run --rm -t \
-              -v $(System.DefaultWorkingDirectory)/src/$(PublicApiDir)/bin/$(BuildConfiguration)/net8.0:/api \
+              -v $(System.DefaultWorkingDirectory)/src/artifacts/bin/$(PublicApiDir)/${{ lower(variables.BuildConfiguration) }}:/api \
               -v $(System.DefaultWorkingDirectory)/src/$(PublicApiDocsDir):/api-docs \
               -v $(System.DefaultWorkingDirectory)/ci/scripts:/scripts \
               --entrypoint /bin/sh \

--- a/infrastructure/templates/search/ci/azure-pipelines-build.yml
+++ b/infrastructure/templates/search/ci/azure-pipelines-build.yml
@@ -1,0 +1,68 @@
+trigger:
+  branches:
+    include:
+    - master
+    - dev
+    - test
+  paths:
+    include:
+    - src/GovUk.Education.ExploreEducationStatistics.Content.Search*/**
+
+pr:
+  branches:
+    include:
+    - master
+    - dev
+    - test
+  drafts: false
+  paths:
+    include:
+    - src/GovUk.Education.ExploreEducationStatistics.Content.Search*/**
+
+pool:
+  vmImage: 'ubuntu-22.04'
+
+variables:
+  buildConfiguration: 'Release'
+  dotNetVersion: '8.0.x'
+  solution: 'src/GovUk.Education.ExploreEducationStatistics.Search.sln'
+
+jobs:
+- job: BuildAndDeploy
+  displayName: 'Build, test, and publish'
+  steps:
+  - checkout: self
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET SDK'
+    inputs:
+      version: $(dotNetVersion)
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build the solution'
+    inputs:
+      command: 'build'
+      projects: $(solution)
+      arguments: '--configuration $(buildConfiguration)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Test the solution'
+    inputs:
+      command: 'test'
+      projects: $(solution)
+      arguments: '--configuration $(buildConfiguration)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Publish the Search Function App'
+    inputs:
+      command: 'publish'
+      publishWebProjects: false
+      projects: |
+        src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
+      arguments: '--configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)'
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish pipeline artifacts'
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)
+      artifactName: 'drop'

--- a/infrastructure/templates/search/ci/azure-pipelines.yml
+++ b/infrastructure/templates/search/ci/azure-pipelines.yml
@@ -1,4 +1,15 @@
-trigger: none
+trigger:
+  branches:
+    include:
+      - master
+      - dev
+      - test
+  paths:
+    include:
+      - infrastructure/templates/common/**
+      - infrastructure/templates/search/**
+
+pr: none
 
 parameters:
   - name: deployAlerts
@@ -20,9 +31,13 @@ parameters:
 
 resources:
   pipelines:
-    - pipeline: MainBuild
-      source: Explore Education Statistics
-      trigger: none
+    - pipeline: SearchBuild
+      source: EES - Search - Build
+      trigger:
+        branches:
+          - master
+          - dev
+          - test
 
 variables:
   - group: Common

--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -8,7 +8,7 @@ parameters:
 
 jobs:
   - deployment: DeploySearchInfrastructure
-    displayName: Deploy search infrastructure
+    displayName: Deploy Search Infrastructure
     environment: ${{ parameters.environment }}
     variables:
       templateDirectory: $(Build.SourcesDirectory)/infrastructure/templates/search
@@ -20,6 +20,7 @@ jobs:
         deploy:
           steps:
             - checkout: self
+            - download: none
 
             - task: AzureCLI@2
               displayName: Install Bicep

--- a/infrastructure/templates/search/ci/jobs/deploy-search-docs-function-app.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-search-docs-function-app.yml
@@ -19,9 +19,11 @@ jobs:
       runOnce:
         deploy:
           steps:
-            - download: MainBuild
-              displayName: Download Search Docs Function App artifact
-              artifact: search-function-app
+            - download: SearchBuild
+              displayName: Download artifacts
+              artifact: drop
+              patterns: |
+                GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.zip
 
             - template: ../../../public-api/ci/tasks/bicep-output-variables.yml
               parameters:
@@ -40,11 +42,11 @@ jobs:
                   az functionapp deployment source config-zip \
                     --resource-group $(resourceGroupName) \
                     --name $(searchDocsFunctionAppName) \
-                    --src '$(Pipeline.Workspace)/MainBuild/search-function-app/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.zip'
+                    --src '$(Pipeline.Workspace)/SearchBuild/drop/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.zip'
 
             - template: ../../../public-api/ci/tasks/wait-for-endpoint-success.yml
               parameters:
                 serviceConnection: ${{ parameters.serviceConnection }}
-                displayName: Check the Search Docs Function App is healthy after deployment
+                displayName: 'Health check'
                 endpoint: $(searchDocsFunctionAppUrl)/api/HealthCheck
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
+  <PropertyGroup>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+  </PropertyGroup>
+</Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/AssemblyExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/AssemblyExtensionTests.cs
@@ -16,18 +16,18 @@ public static class AssemblyExtensionTests
         {
             var directory = Assembly.GetExecutingAssembly().GetDirectory();
             var expectedPath = Path.Combine(
-                "src", "GovUk.Education.ExploreEducationStatistics.Common.Tests", "bin");
+                "src", "artifacts", "bin", "GovUk.Education.ExploreEducationStatistics.Common.Tests");
 
             Assert.Contains(expectedPath, directory.ToString());
             Assert.True(directory.Exists);
         }
 
         [Fact]
-        public void GetDirectoryName()
+        public void GetDirectoryPath()
         {
             var path = Assembly.GetExecutingAssembly().GetDirectoryPath();
             var expectedPath = Path.Combine(
-                "src", "GovUk.Education.ExploreEducationStatistics.Common.Tests", "bin");
+                "src", "artifacts", "bin", "GovUk.Education.ExploreEducationStatistics.Common.Tests");
 
             Assert.Contains(expectedPath, path);
             Assert.True(Directory.Exists(path));


### PR DESCRIPTION
This PR create a separate pipeline to do the build, test, and publishing steps of the Search solution which currently consists of the  Searchable Documents Azure Function application.

In future any other projects added to the Search solution can be built and published by this pipeline.

It it set up to trigger the existing Search infrastructure and application deployment pipeline created by https://github.com/dfe-analytical-services/explore-education-statistics/pull/5628.

Long build times and build failures in the main service build pipeline are currently delaying PR’s from being merged and delaying deployments of the infrastructure and Searchable Documents Azure Function application.

This new pipeline allows projects in the Search solution to be built, tested and deployed independently of the main service. PR and CI triggered builds of the Search solution will no longer have to wait for the main service build to complete. There will be no checks during the build on projects outside of the Search solution so they won’t fail due to flaky tests in other projects of the main service.

### Other changes

- Exclude changes solely under `/infrastructure` from triggering PR builds of the main EES build pipeline.

- Exclude changes solely under `/src/GovUk.Education.ExploreEducationStatistics.Content.Search*` from triggering PR builds of the main EES build pipeline.

- The main EES build pipeline CI trigger for code changes on the dev, test and master branches now excludes changes under `src/GovUk.Education.ExploreEducationStatistics.Content.Search*`.

- Disable unnecessary download of artifacts in the `DeploySearchInfrastructure` step of the Search infrastructure and application deployment pipeline. 

- Switches all projects to use the simplified _artifacts_ output directory, added by .NET 8. All build outputs from all projects are gathered into a common location, _artifacts_, separated by project. See [Artifacts output layout](https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output).