### PR TITLE
EES-5942 delete data files modal focus

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.tsx
@@ -15,6 +15,7 @@ import {
 import {
   DataFile,
   DataFileImportStatus,
+  DeleteDataFilePlan,
 } from '@admin/services/releaseDataFileService';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
@@ -22,6 +23,7 @@ import Modal from '@common/components/Modal';
 import React from 'react';
 import { generatePath } from 'react-router';
 import styles from './DataFilesTable.module.scss';
+import DataFilesTableRow from './DataFilesTableRow';
 
 interface Props {
   canUpdateRelease?: boolean;
@@ -30,7 +32,7 @@ interface Props {
   publicationId: string;
   releaseVersionId: string;
   testId?: string;
-  onDeleteFile: (dataFile: DataFile) => Promise<void>;
+  onDeleteFile: (deletedFileId: string) => void;
   onStatusChange: (
     dataFile: DataFile,
     importStatus: DataFileImportStatus,
@@ -62,144 +64,15 @@ export default function DataFilesTable({
 
       <tbody>
         {dataFiles.map(dataFile => (
-          <tr key={dataFile.title}>
-            <td data-testid="Title" className={styles.title}>
-              {dataFile.title}
-            </td>
-            <td data-testid="Size" className={styles.fileSize}>
-              {dataFile.fileSize.size.toLocaleString()} {dataFile.fileSize.unit}
-            </td>
-            <td data-testid="Status">
-              <ImporterStatus
-                className={styles.fileStatus}
-                dataFile={dataFile}
-                hideErrors
-                releaseVersionId={releaseVersionId}
-                onStatusChange={onStatusChange}
-              />
-            </td>
-            <td data-testid="Actions">
-              <ButtonGroup className={styles.actions}>
-                <Modal
-                  showClose
-                  title="Data file details"
-                  triggerButton={<ButtonText>View details</ButtonText>}
-                >
-                  <DataFileSummaryList
-                    dataFile={dataFile}
-                    releaseVersionId={releaseVersionId}
-                    onStatusChange={onStatusChange}
-                  />
-                </Modal>
-                {canUpdateRelease &&
-                  terminalImportStatuses.includes(dataFile.status) && (
-                    <>
-                      {dataFile.status === 'COMPLETE' && (
-                        <>
-                          <Link
-                            to={generatePath<ReleaseDataFileRouteParams>(
-                              releaseDataFileRoute.path,
-                              {
-                                publicationId,
-                                releaseVersionId,
-                                fileId: dataFile.id,
-                              },
-                            )}
-                          >
-                            Edit title
-                          </Link>
-                          {dataFile.publicApiDataSetId ? (
-                            <Modal
-                              showClose
-                              title="Cannot replace data"
-                              triggerButton={
-                                <ButtonText>Replace data</ButtonText>
-                              }
-                            >
-                              <p>
-                                This data file has an API data set linked to it.
-                                Please remove the API data set before replacing
-                                the data.
-                              </p>
-                              <p>
-                                <Link
-                                  to={generatePath<ReleaseDataSetRouteParams>(
-                                    releaseApiDataSetDetailsRoute.path,
-                                    {
-                                      publicationId,
-                                      releaseVersionId,
-                                      dataSetId: dataFile.publicApiDataSetId,
-                                    },
-                                  )}
-                                >
-                                  Go to API data set
-                                </Link>
-                              </p>
-                            </Modal>
-                          ) : (
-                            <Link
-                              to={generatePath<ReleaseDataFileReplaceRouteParams>(
-                                releaseDataFileReplaceRoute.path,
-                                {
-                                  publicationId,
-                                  releaseVersionId,
-                                  fileId: dataFile.id,
-                                },
-                              )}
-                            >
-                              Replace data
-                            </Link>
-                          )}
-                        </>
-                      )}
-                      {dataFile.publicApiDataSetId ? (
-                        <Modal
-                          showClose
-                          title="Cannot delete files"
-                          triggerButton={
-                            <ButtonText variant="warning">
-                              Delete files
-                            </ButtonText>
-                          }
-                        >
-                          <p>
-                            This data file has an API data set linked to it.
-                            Please remove the API data set before deleting.
-                          </p>
-                          <p>
-                            <Link
-                              to={generatePath<ReleaseDataSetRouteParams>(
-                                releaseApiDataSetDetailsRoute.path,
-                                {
-                                  publicationId,
-                                  releaseVersionId,
-                                  dataSetId: dataFile.publicApiDataSetId,
-                                },
-                              )}
-                            >
-                              Go to API data set
-                            </Link>
-                          </p>
-                        </Modal>
-                      ) : (
-                        <ButtonText
-                          onClick={() => onDeleteFile(dataFile)}
-                          variant="warning"
-                        >
-                          Delete files
-                        </ButtonText>
-                      )}
-                    </>
-                  )}
-                {dataFile.permissions.canCancelImport && (
-                  <DataUploadCancelButton
-                    releaseVersionId={releaseVersionId}
-                    fileId={dataFile.id}
-                  />
-                )}
-              </ButtonGroup>
-            </td>
-          </tr>
+          <DataFilesTableRow
+            canUpdateRelease={canUpdateRelease}
+            dataFile={dataFile}
+            key={dataFile.title}
+            publicationId={publicationId}
+            releaseVersionId={releaseVersionId}
+            onConfirmDelete={onDeleteFile}
+            onStatusChange={onStatusChange}
+          />
         ))}
       </tbody>
     </table>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableRow.tsx
@@ -1,0 +1,183 @@
+import Link from '@admin/components/Link';
+import DataFileSummaryList from '@admin/pages/release/data/components/DataFileSummaryList';
+import DataUploadCancelButton from '@admin/pages/release/data/components/DataUploadCancelButton';
+import ImporterStatus, {
+  terminalImportStatuses,
+} from '@admin/pages/release/data/components/ImporterStatus';
+import {
+  releaseApiDataSetDetailsRoute,
+  releaseDataFileReplaceRoute,
+  ReleaseDataFileReplaceRouteParams,
+  releaseDataFileRoute,
+  ReleaseDataFileRouteParams,
+  ReleaseDataSetRouteParams,
+} from '@admin/routes/releaseRoutes';
+import {
+  DataFile,
+  DataFileImportStatus,
+} from '@admin/services/releaseDataFileService';
+import ButtonGroup from '@common/components/ButtonGroup';
+import ButtonText from '@common/components/ButtonText';
+import Modal from '@common/components/Modal';
+import React from 'react';
+import { generatePath } from 'react-router';
+import styles from './DataFilesTable.module.scss';
+import DeleteDataFileModal from './DeleteDataFileModal';
+
+interface Props {
+  canUpdateRelease?: boolean;
+  dataFile: DataFile;
+  publicationId: string;
+  releaseVersionId: string;
+  onConfirmDelete: (deletedFileId: string) => void;
+  onStatusChange: (
+    dataFile: DataFile,
+    importStatus: DataFileImportStatus,
+  ) => Promise<void>;
+}
+
+export default function DataFilesTableRow({
+  canUpdateRelease,
+  dataFile,
+  publicationId,
+  releaseVersionId,
+  onConfirmDelete,
+  onStatusChange,
+}: Props) {
+  return (
+    <tr key={dataFile.title}>
+      <td data-testid="Title" className={styles.title}>
+        {dataFile.title}
+      </td>
+      <td data-testid="Size" className={styles.fileSize}>
+        {dataFile.fileSize.size.toLocaleString()} {dataFile.fileSize.unit}
+      </td>
+      <td data-testid="Status">
+        <ImporterStatus
+          className={styles.fileStatus}
+          dataFile={dataFile}
+          hideErrors
+          releaseVersionId={releaseVersionId}
+          onStatusChange={onStatusChange}
+        />
+      </td>
+      <td data-testid="Actions">
+        <ButtonGroup className={styles.actions}>
+          <Modal
+            showClose
+            title="Data file details"
+            triggerButton={<ButtonText>View details</ButtonText>}
+          >
+            <DataFileSummaryList
+              dataFile={dataFile}
+              releaseVersionId={releaseVersionId}
+              onStatusChange={onStatusChange}
+            />
+          </Modal>
+          {canUpdateRelease &&
+            terminalImportStatuses.includes(dataFile.status) && (
+              <>
+                {dataFile.status === 'COMPLETE' && (
+                  <>
+                    <Link
+                      to={generatePath<ReleaseDataFileRouteParams>(
+                        releaseDataFileRoute.path,
+                        {
+                          publicationId,
+                          releaseVersionId,
+                          fileId: dataFile.id,
+                        },
+                      )}
+                    >
+                      Edit title
+                    </Link>
+                    {dataFile.publicApiDataSetId ? (
+                      <Modal
+                        showClose
+                        title="Cannot replace data"
+                        triggerButton={<ButtonText>Replace data</ButtonText>}
+                      >
+                        <p>
+                          This data file has an API data set linked to it.
+                          Please remove the API data set before replacing the
+                          data.
+                        </p>
+                        <p>
+                          <Link
+                            to={generatePath<ReleaseDataSetRouteParams>(
+                              releaseApiDataSetDetailsRoute.path,
+                              {
+                                publicationId,
+                                releaseVersionId,
+                                dataSetId: dataFile.publicApiDataSetId,
+                              },
+                            )}
+                          >
+                            Go to API data set
+                          </Link>
+                        </p>
+                      </Modal>
+                    ) : (
+                      <Link
+                        to={generatePath<ReleaseDataFileReplaceRouteParams>(
+                          releaseDataFileReplaceRoute.path,
+                          {
+                            publicationId,
+                            releaseVersionId,
+                            fileId: dataFile.id,
+                          },
+                        )}
+                      >
+                        Replace data
+                      </Link>
+                    )}
+                  </>
+                )}
+                {dataFile.publicApiDataSetId ? (
+                  <Modal
+                    showClose
+                    title="Cannot delete files"
+                    triggerButton={
+                      <ButtonText variant="warning">Delete files</ButtonText>
+                    }
+                  >
+                    <p>
+                      This data file has an API data set linked to it. Please
+                      remove the API data set before deleting.
+                    </p>
+                    <p>
+                      <Link
+                        to={generatePath<ReleaseDataSetRouteParams>(
+                          releaseApiDataSetDetailsRoute.path,
+                          {
+                            publicationId,
+                            releaseVersionId,
+                            dataSetId: dataFile.publicApiDataSetId,
+                          },
+                        )}
+                      >
+                        Go to API data set
+                      </Link>
+                    </p>
+                  </Modal>
+                ) : (
+                  // <ButtonText>Delete file</ButtonText>
+                  <DeleteDataFileModal
+                    dataFile={dataFile}
+                    releaseVersionId={releaseVersionId}
+                    onConfirm={() => onConfirmDelete(dataFile.id)}
+                  />
+                )}
+              </>
+            )}
+          {dataFile.permissions.canCancelImport && (
+            <DataUploadCancelButton
+              releaseVersionId={releaseVersionId}
+              fileId={dataFile.id}
+            />
+          )}
+        </ButtonGroup>
+      </td>
+    </tr>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableRow.tsx
@@ -161,7 +161,6 @@ export default function DataFilesTableRow({
                     </p>
                   </Modal>
                 ) : (
-                  // <ButtonText>Delete file</ButtonText>
                   <DeleteDataFileModal
                     dataFile={dataFile}
                     releaseVersionId={releaseVersionId}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DeleteDataFileModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DeleteDataFileModal.tsx
@@ -1,0 +1,129 @@
+import releaseDataFileService, {
+  DataFile,
+  DeleteDataFilePlan,
+} from '@admin/services/releaseDataFileService';
+import ButtonText from '@common/components/ButtonText';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import ModalConfirm from '@common/components/ModalConfirm';
+import useToggle from '@common/hooks/useToggle';
+import logger from '@common/services/logger';
+import React, { useCallback, useEffect, useState } from 'react';
+
+interface Props {
+  dataFile: DataFile;
+  releaseVersionId: string;
+  onConfirm: () => void;
+}
+
+export default function DeleteDataFileModal({
+  dataFile,
+  releaseVersionId,
+  onConfirm,
+}: Props) {
+  const [open, toggleOpen] = useToggle(false);
+  const [plan, setPlan] = useState<DeleteDataFilePlan>();
+
+  // TODO use react-query instead
+  useEffect(() => {
+    async function getPlan() {
+      setPlan(
+        await releaseDataFileService.getDeleteDataFilePlan(
+          releaseVersionId,
+          dataFile,
+        ),
+      );
+    }
+
+    if (open) {
+      getPlan();
+    }
+  }, [dataFile, open, releaseVersionId]);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    try {
+      await releaseDataFileService.deleteDataFiles(
+        releaseVersionId,
+        dataFile.id,
+      );
+
+      onConfirm();
+
+      toggleOpen.off();
+    } catch (err) {
+      logger.error(err);
+      toggleOpen.off();
+    }
+  }, [releaseVersionId, dataFile.id, onConfirm, toggleOpen]);
+
+  // TODO show a loader while it's fetching the plan
+  return (
+    <ModalConfirm
+      open={open}
+      title="Confirm deletion of selected data files"
+      triggerButton={
+        <ButtonText onClick={toggleOpen.on}>Delete files</ButtonText>
+      }
+      onConfirm={handleDeleteConfirm}
+    >
+      <p>
+        Are you sure you want to delete <strong>{dataFile.title}</strong>?
+      </p>
+      <p>This data will no longer be available for use in this release.</p>
+      {plan && (
+        <>
+          {plan.deleteDataBlockPlan.dependentDataBlocks.length > 0 && (
+            <>
+              <p>The following data blocks will also be deleted:</p>
+
+              <ul>
+                {plan.deleteDataBlockPlan.dependentDataBlocks.map(block => (
+                  <li key={block.name}>
+                    <p>{block.name}</p>
+
+                    {block.contentSectionHeading && (
+                      <p>
+                        It will also be removed from the "
+                        {block.contentSectionHeading}" content section.
+                      </p>
+                    )}
+                    {block.infographicFilesInfo.length > 0 && (
+                      <p>
+                        The following infographic files will also be removed:
+                        <ul>
+                          {block.infographicFilesInfo.map(fileInfo => (
+                            <li key={fileInfo.filename}>
+                              <p>{fileInfo.filename}</p>
+                            </li>
+                          ))}
+                        </ul>
+                      </p>
+                    )}
+                    {block.isKeyStatistic && (
+                      <p>
+                        A key statistic associated with this data block will be
+                        removed.
+                      </p>
+                    )}
+                    {block.featuredTable && (
+                      <p>
+                        The featured table "{block.featuredTable.name}" using
+                        this data block will be removed.
+                      </p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+          {plan.footnoteIds.length > 0 && (
+            <p>
+              {`${plan.footnoteIds.length} ${
+                plan.footnoteIds.length > 1 ? 'footnotes' : 'footnote'
+              } will be removed or updated.`}
+            </p>
+          )}
+        </>
+      )}
+    </ModalConfirm>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -29,18 +29,12 @@ interface Props {
   onDataFilesChange?: (dataFiles: DataFile[]) => void;
 }
 
-interface DeleteDataFile {
-  plan: DeleteDataFilePlan;
-  file: DataFile;
-}
-
 export default function ReleaseDataUploadsSection({
   publicationId,
   releaseVersionId,
   canUpdateRelease,
   onDataFilesChange,
 }: Props) {
-  const [deleteDataFile, setDeleteDataFile] = useState<DeleteDataFile>();
   const [allDataFiles, setAllDataFiles] = useState<DataFile[]>([]);
   const [bulkUploadPlan, setBulkUploadPlan] = useState<ArchiveDataSetFile[]>();
   const [isReordering, toggleReordering] = useToggle(false);
@@ -69,19 +63,6 @@ export default function ReleaseDataUploadsSection({
   const dataFiles = useMemo(
     () => allDataFiles.filter(dataFile => !dataFile.replacedBy),
     [allDataFiles],
-  );
-
-  const setFileDeleting = useCallback(
-    (dataFile: DeleteDataFile, deleting: boolean) => {
-      setAllDataFiles(files =>
-        files.map(file =>
-          file.fileName !== dataFile.file.fileName
-            ? file
-            : { ...file, isDeleting: deleting },
-        ),
-      );
-    },
-    [],
   );
 
   const confirmBulkUploadPlan = useCallback(
@@ -128,43 +109,10 @@ export default function ReleaseDataUploadsSection({
     [releaseVersionId],
   );
 
-  const handleDeleteFile = useCallback(
-    async (dataFile: DataFile) => {
-      setDeleteDataFile({
-        plan: await releaseDataFileService.getDeleteDataFilePlan(
-          releaseVersionId,
-          dataFile,
-        ),
-        file: dataFile,
-      });
-    },
-    [releaseVersionId],
-  );
-
-  const handleDeleteConfirm = useCallback(async () => {
-    if (!deleteDataFile) {
-      return;
-    }
-
-    const { file } = deleteDataFile;
-
-    setDeleteDataFile(undefined);
-    setFileDeleting(deleteDataFile, true);
-
-    try {
-      await releaseDataFileService.deleteDataFiles(releaseVersionId, file.id);
-
-      setAllDataFiles(files =>
-        files.filter(dataFile => dataFile.id !== file.id),
-      );
-    } catch (err) {
-      logger.error(err);
-      setFileDeleting(deleteDataFile, false);
-    }
-  }, [deleteDataFile, releaseVersionId, setFileDeleting]);
-
-  const handleDeleteExit = useCallback(() => {
-    setDeleteDataFile(undefined);
+  const handleDeleteConfirm = useCallback(async (deletedFileId: string) => {
+    setAllDataFiles(files =>
+      files.filter(dataFile => dataFile.id !== deletedFileId),
+    );
   }, []);
 
   const handleSubmit = useCallback(
@@ -307,7 +255,7 @@ export default function ReleaseDataUploadsSection({
                     publicationId={publicationId}
                     releaseVersionId={releaseVersionId}
                     testId="Data file replacements table"
-                    onDeleteFile={handleDeleteFile}
+                    onDeleteFile={handleDeleteConfirm}
                     onStatusChange={handleStatusChange}
                   />
                 )}
@@ -320,7 +268,7 @@ export default function ReleaseDataUploadsSection({
                     publicationId={publicationId}
                     releaseVersionId={releaseVersionId}
                     testId="Data files table"
-                    onDeleteFile={handleDeleteFile}
+                    onDeleteFile={handleDeleteConfirm}
                     onStatusChange={handleStatusChange}
                   />
                 )}
@@ -331,95 +279,6 @@ export default function ReleaseDataUploadsSection({
           <InsetText>No data files have been uploaded.</InsetText>
         )}
       </LoadingSpinner>
-
-      {deleteDataFile && (
-        <DeleteDataFileModal
-          file={deleteDataFile.file}
-          plan={deleteDataFile.plan}
-          onConfirm={handleDeleteConfirm}
-          onExit={handleDeleteExit}
-        />
-      )}
     </>
-  );
-}
-
-interface DeleteDataFileModalProps {
-  file: DataFile;
-  plan: DeleteDataFilePlan;
-  onConfirm: () => void;
-  onExit: () => void;
-}
-
-function DeleteDataFileModal({
-  file,
-  plan,
-  onConfirm,
-  onExit,
-}: DeleteDataFileModalProps) {
-  return (
-    <ModalConfirm
-      open
-      title="Confirm deletion of selected data files"
-      onExit={onExit}
-      onConfirm={onConfirm}
-    >
-      <p>
-        Are you sure you want to delete <strong>{file.title}</strong>?
-      </p>
-      <p>This data will no longer be available for use in this release.</p>
-
-      {plan.deleteDataBlockPlan.dependentDataBlocks.length > 0 && (
-        <>
-          <p>The following data blocks will also be deleted:</p>
-
-          <ul>
-            {plan.deleteDataBlockPlan.dependentDataBlocks.map(block => (
-              <li key={block.name}>
-                <p>{block.name}</p>
-
-                {block.contentSectionHeading && (
-                  <p>
-                    It will also be removed from the "
-                    {block.contentSectionHeading}" content section.
-                  </p>
-                )}
-                {block.infographicFilesInfo.length > 0 && (
-                  <p>
-                    The following infographic files will also be removed:
-                    <ul>
-                      {block.infographicFilesInfo.map(fileInfo => (
-                        <li key={fileInfo.filename}>
-                          <p>{fileInfo.filename}</p>
-                        </li>
-                      ))}
-                    </ul>
-                  </p>
-                )}
-                {block.isKeyStatistic && (
-                  <p>
-                    A key statistic associated with this data block will be
-                    removed.
-                  </p>
-                )}
-                {block.featuredTable && (
-                  <p>
-                    The featured table "{block.featuredTable.name}" using this
-                    data block will be removed.
-                  </p>
-                )}
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
-      {plan.footnoteIds.length > 0 && (
-        <p>
-          {`${plan.footnoteIds.length} ${
-            plan.footnoteIds.length > 1 ? 'footnotes' : 'footnote'
-          } will be removed or updated.`}
-        </p>
-      )}
-    </ModalConfirm>
   );
 }

--- a/src/explore-education-statistics-admin/src/queries/releaseDataFileQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/releaseDataFileQueries.ts
@@ -1,11 +1,23 @@
 import { createQueryKeys } from '@lukemorales/query-key-factory';
-import releaseDataFileService from '@admin/services/releaseDataFileService';
+import releaseDataFileService, {
+  DataFile,
+} from '@admin/services/releaseDataFileService';
 
 const releaseDataFileQueries = createQueryKeys('releaseDataFile', {
   list(releaseId: string) {
     return {
       queryKey: [releaseId],
       queryFn: () => releaseDataFileService.getDataFiles(releaseId),
+    };
+  },
+  getDeleteFilePlan(releaseVersionId: string, dataFile: DataFile) {
+    return {
+      queryKey: [releaseVersionId, dataFile],
+      queryFn: () =>
+        releaseDataFileService.getDeleteDataFilePlan(
+          releaseVersionId,
+          dataFile,
+        ),
     };
   },
 });


### PR DESCRIPTION
This PR fixes an issue where focus was not returned to a modal trigger button on the 'delete data files from release' section of the admin site, when the confirmation modal is closed.

It does this by moving the modal to be per file row instead of at the top level component, and using the `triggerButton` prop for the modal.

Mostly done by Amy B and tweaked/finished by me.