### PR TITLE
EES-5943 Fix delete ancillary file modal focus restoration

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/AncillaryFileSummaryList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/AncillaryFileSummaryList.tsx
@@ -8,6 +8,7 @@ import releaseAncillaryFileService, {
 } from '@admin/services/releaseAncillaryFileService';
 import ButtonText from '@common/components/ButtonText';
 import FormattedDate from '@common/components/FormattedDate';
+import ModalConfirm from '@common/components/ModalConfirm';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import React from 'react';
@@ -15,17 +16,23 @@ import { generatePath } from 'react-router-dom';
 
 interface Props {
   canUpdateRelease?: boolean;
+  deleteFile?: AncillaryFile;
   file: AncillaryFile;
   publicationId: string;
   releaseVersionId: string;
+  onCancelDelete?: () => void;
+  onConfirmDelete: () => Promise<void>;
   onDelete?: () => void;
 }
 
 export default function AncillaryFileSummaryList({
   canUpdateRelease,
+  deleteFile,
   file,
   publicationId,
   releaseVersionId,
+  onCancelDelete,
+  onConfirmDelete,
   onDelete,
 }: Props) {
   return (
@@ -80,7 +87,21 @@ export default function AncillaryFileSummaryList({
               >
                 Edit file
               </Link>
-              <ButtonText onClick={onDelete}>Delete file</ButtonText>
+              <ModalConfirm
+                open={deleteFile && deleteFile.id === file.id}
+                title="Confirm deletion of file"
+                triggerButton={
+                  <ButtonText onClick={onDelete}>Delete file</ButtonText>
+                }
+                onExit={onCancelDelete}
+                onCancel={onCancelDelete}
+                onConfirm={onConfirmDelete}
+              >
+                <p>
+                  This file will no longer be available for use in this release
+                  ({file.filename})
+                </p>
+              </ModalConfirm>
             </>
           }
         />

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/AncillaryFileSummaryList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/AncillaryFileSummaryList.tsx
@@ -16,7 +16,6 @@ import { generatePath } from 'react-router-dom';
 
 interface Props {
   canUpdateRelease?: boolean;
-  deleteFile?: AncillaryFile;
   file: AncillaryFile;
   publicationId: string;
   releaseVersionId: string;
@@ -27,7 +26,6 @@ interface Props {
 
 export default function AncillaryFileSummaryList({
   canUpdateRelease,
-  deleteFile,
   file,
   publicationId,
   releaseVersionId,
@@ -88,7 +86,6 @@ export default function AncillaryFileSummaryList({
                 Edit file
               </Link>
               <ModalConfirm
-                open={deleteFile && deleteFile.id === file.id}
                 title="Confirm deletion of file"
                 triggerButton={
                   <ButtonText onClick={onDelete}>Delete file</ButtonText>


### PR DESCRIPTION
This PR refactors the "delete supporting file upload" modal to be rendered for each file rather than shared in the top level section. 
This lets us use the `triggerButton` for handling focus, so focus can be restored to the 'Delete file' button when the modal is closed.
