### PR TITLE
EES-5433 Code clean up after geojson endpoint change

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerIntegrationTests.cs
@@ -72,7 +72,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 .Setup(s => s.Query(
                     ReleaseVersionId,
                     ItIs.DeepEqualTo(FullTableQuery),
-                    It.IsAny<long?>(),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(_tableBuilderResults);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
@@ -99,7 +99,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                             It.Is<FullTableQuery>(
                                 q => q.SubjectId == FullTableQueryRequest.SubjectId
                             ),
-                            It.IsAny<long?>(),
                             cancellationToken
                         )
                 )
@@ -113,7 +112,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var result = await controller.QueryForDataBlock(releaseVersionId: ReleaseVersionId,
                 dataBlockVersion.Id,
-                null,
                 cancellationToken);
             VerifyAllMocks(dataBlockService, tableBuilderService);
 
@@ -133,8 +131,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var result = await controller.QueryForDataBlock(
                 releaseVersionId: ReleaseVersionId,
-                dataBlockParentId: DataBlockId,
-                null);
+                dataBlockParentId: DataBlockId);
             VerifyAllMocks(dataBlockService);
 
             result.AssertNotFoundResult();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/TableBuilderController.cs
@@ -46,7 +46,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
         public async Task<ActionResult> Query(
             Guid releaseVersionId,
             [FromBody] FullTableQueryRequest request,
-            [FromQuery] long? boundaryLevelId, // TODO: Remove in EES-5433
             CancellationToken cancellationToken = default)
         {
             if (Request.AcceptsCsv(exact: true))
@@ -65,7 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
             }
 
             return await _tableBuilderService
-                .Query(releaseVersionId, request.AsFullTableQuery(), boundaryLevelId, cancellationToken)
+                .Query(releaseVersionId, request.AsFullTableQuery(), cancellationToken)
                 .HandleFailuresOr(Ok);
         }
 
@@ -73,12 +72,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
         public async Task<ActionResult<TableBuilderResultViewModel>> QueryForDataBlock(
             Guid releaseVersionId,
             Guid dataBlockParentId,
-            [FromQuery] long? boundaryLevelId, // TODO: Remove in EES-5433
             CancellationToken cancellationToken = default)
         {
             return await _dataBlockService
                 .GetDataBlockVersionForRelease(releaseVersionId: releaseVersionId, dataBlockParentId: dataBlockParentId)
-                .OnSuccess(dataBlockVersion => GetReleaseDataBlockResults(dataBlockVersion, boundaryLevelId, cancellationToken))
+                .OnSuccess(dataBlockVersion => GetReleaseDataBlockResults(dataBlockVersion, cancellationToken))
                 .HandleFailuresOrOk();
         }
 
@@ -98,14 +96,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
         [BlobCache(typeof(DataBlockTableResultCacheKey))]
         private async Task<Either<ActionResult, TableBuilderResultViewModel>> GetReleaseDataBlockResults(
             DataBlockVersion dataBlockVersion,
-            long? boundaryLevelId,
             CancellationToken cancellationToken)
         {
             return await _userService
                 .CheckCanViewReleaseVersion(dataBlockVersion.ReleaseVersion)
                 .OnSuccess(_ => _tableBuilderService.Query(releaseVersionId: dataBlockVersion.ReleaseVersionId,
                     dataBlockVersion.Query,
-                    boundaryLevelId,
                     cancellationToken));
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
@@ -162,7 +162,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                     s => s.Query(
                         releaseVersion.Id,
                         ItIs.DeepEqualTo(FullTableQuery),
-                        It.IsAny<long?>(),
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -265,7 +264,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             var dataBlockService = new Mock<IDataBlockService>();
 
             dataBlockService
-                .Setup(s => s.GetDataBlockTableResult(releaseVersion.Id, dataBlockId, null))
+                .Setup(s => s.GetDataBlockTableResult(releaseVersion.Id, dataBlockId))
                 .ReturnsAsync(_tableBuilderResults);
 
             var client = SetupApp(dataBlockService: dataBlockService.Object)
@@ -393,7 +392,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             var dataBlockService = new Mock<IDataBlockService>(Strict);
 
             dataBlockService
-                .Setup(s => s.GetDataBlockTableResult(releaseVersion.Id, dataBlockId, null))
+                .Setup(s => s.GetDataBlockTableResult(releaseVersion.Id, dataBlockId))
                 .ReturnsAsync(_tableBuilderResults);
 
             var client = SetupApp(dataBlockService: dataBlockService.Object)
@@ -466,7 +465,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             var dataBlockService = new Mock<IDataBlockService>(Strict);
 
             dataBlockService
-                .Setup(s => s.GetDataBlockTableResult(releaseVersion.Id, dataBlockId, null))
+                .Setup(s => s.GetDataBlockTableResult(releaseVersion.Id, dataBlockId))
                 .ReturnsAsync(_tableBuilderResults);
 
             var client = SetupApp(dataBlockService: dataBlockService.Object)
@@ -543,7 +542,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             var dataBlockService = new Mock<IDataBlockService>(Strict);
 
             dataBlockService
-                .Setup(s => s.GetDataBlockTableResult(releaseVersion.Id, dataBlockId, null))
+                .Setup(s => s.GetDataBlockTableResult(releaseVersion.Id, dataBlockId))
                 .ReturnsAsync(_tableBuilderResults);
 
             var client = SetupApp(
@@ -662,7 +661,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             var dataBlockService = new Mock<IDataBlockService>(Strict);
 
             dataBlockService
-                .Setup(s => s.GetDataBlockTableResult(releaseVersion.Id, dataBlockId, null))
+                .Setup(s => s.GetDataBlockTableResult(releaseVersion.Id, dataBlockId))
                 .ReturnsAsync(_tableBuilderResults);
 
             var client = SetupApp(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServicePermissionTests.cs
@@ -38,7 +38,7 @@ public class DataBlockServicePermissionTests
                 {
                     var service = BuildService(
                         userService: userService.Object);
-                    return service.GetDataBlockTableResult(_releaseVersion.Id, _dataBlock.Id, null);
+                    return service.GetDataBlockTableResult(_releaseVersion.Id, _dataBlock.Id);
                 });
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServiceTests.cs
@@ -70,7 +70,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                             s.Query(
                                 dataBlockVersion.ReleaseVersionId,
                                 It.Is<FullTableQuery>(q => q.SubjectId == subjectId),
-                                It.IsAny<long?>(),
                                 default
                             )
                     )
@@ -78,8 +77,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
                 var result = (await service.GetDataBlockTableResult(
                     releaseVersionId: dataBlockVersion.ReleaseVersionId,
-                    dataBlockVersionId: dataBlockVersion.Id,
-                    null)).AssertRight();
+                    dataBlockVersionId: dataBlockVersion.Id)).AssertRight();
 
                 VerifyAllMocks(tableBuilderService);
 
@@ -108,8 +106,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
                 var result = await service.GetDataBlockTableResult(
                     releaseVersionId: htmlBlock.ReleaseVersionId,
-                    dataBlockVersionId: htmlBlock.Id,
-                    null);
+                    dataBlockVersionId: htmlBlock.Id);
 
                 result.AssertNotFound();
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
@@ -360,7 +360,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 .Setup(s => s.Query(releaseVersion.Id,
                     It.Is<FullTableQuery>(ctx =>
                         ctx.Equals(request.Query.AsFullTableQuery())),
-                    null,
                     CancellationToken.None))
                 .ReturnsAsync(tableResult);
 
@@ -670,7 +669,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 .Setup(s => s.Query(releaseVersion.Id,
                     It.Is<FullTableQuery>(ctx =>
                         ctx.Equals(request.Query.AsFullTableQuery())),
-                    It.IsAny<long?>(),
                     CancellationToken.None))
                 .ReturnsAsync(tableResult);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
@@ -81,7 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
             }
 
             return await tableBuilderService
-                .Query(releaseVersionId, request.AsFullTableQuery(), boundaryLevelId: null, cancellationToken)
+                .Query(releaseVersionId, request.AsFullTableQuery(), cancellationToken)
                 .HandleFailuresOr(Ok);
         }
 
@@ -91,13 +91,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
         // DataBlockVersions rather than simply picking the latest published one.
         [HttpGet("tablebuilder/release/{releaseVersionId:guid}/data-block/{dataBlockParentId:guid}")]
         public async Task<ActionResult<TableBuilderResultViewModel>> QueryForTableBuilderResult(
-            Guid dataBlockParentId,
-            [FromQuery] long? boundaryLevelId) // TODO: Remove in EES-5433
+            Guid dataBlockParentId)
         {
             var actionResult = await GetLatestPublishedDataBlockVersion(dataBlockParentId)
                 .OnSuccessDo(dataBlockVersion => this
                     .CacheWithLastModifiedAndETag(lastModified: dataBlockVersion.Published, ApiVersion))
-                .OnSuccess(dataBlockVersion => GetDataBlockTableResult(dataBlockVersion, boundaryLevelId))
+                .OnSuccess(GetDataBlockTableResult)
                 .HandleFailuresOrOk();
 
             if (actionResult.Result is not NotFoundResult)
@@ -147,13 +146,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
 
         [BlobCache(typeof(DataBlockTableResultCacheKey))]
         private Task<Either<ActionResult, TableBuilderResultViewModel>> GetDataBlockTableResult(
-            DataBlockVersion dataBlockVersion,
-            long? boundaryLevelId = null)
+            DataBlockVersion dataBlockVersion)
         {
             return dataBlockService.GetDataBlockTableResult(
                 releaseVersionId: dataBlockVersion.ReleaseVersionId,
-                dataBlockVersionId: dataBlockVersion.Id,
-                boundaryLevelId);
+                dataBlockVersionId: dataBlockVersion.Id);
         }
 
         [BlobCache(typeof(LocationsForDataBlockCacheKey))]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
@@ -39,14 +39,13 @@ public class DataBlockService : IDataBlockService
 
     public async Task<Either<ActionResult, TableBuilderResultViewModel>> GetDataBlockTableResult(
         Guid releaseVersionId,
-        Guid dataBlockVersionId,
-        long? boundaryLevelId)
+        Guid dataBlockVersionId)
     {
         return await _persistenceHelper.CheckEntityExists<ReleaseVersion>(releaseVersionId)
             .OnSuccess(_userService.CheckCanViewReleaseVersion)
             .OnSuccess(() => CheckDataBlockVersionExists(releaseVersionId: releaseVersionId,
                 dataBlockVersionId: dataBlockVersionId))
-            .OnSuccess(dataBlock => _tableBuilderService.Query(releaseVersionId, dataBlock.Query, boundaryLevelId));
+            .OnSuccess(dataBlock => _tableBuilderService.Query(releaseVersionId, dataBlock.Query));
     }
 
     public async Task<Either<ActionResult, Dictionary<string, List<LocationAttributeViewModel>>>> GetLocationsForDataBlock(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/Interfaces/IDataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/Interfaces/IDataBlockService.cs
@@ -13,8 +13,7 @@ public interface IDataBlockService
 {
     Task<Either<ActionResult, TableBuilderResultViewModel>> GetDataBlockTableResult(
         Guid releaseVersionId,
-        Guid dataBlockVersionId,
-        long? boundaryLevelId);
+        Guid dataBlockVersionId);
 
     Task<Either<ActionResult, Dictionary<string, List<LocationAttributeViewModel>>>> GetLocationsForDataBlock(
         Guid releaseVersionId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -88,7 +88,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
                 {
                     return _tableBuilderService.Query(releaseVersionId,
                             request.Query.AsFullTableQuery(),
-                            null,
                             cancellationToken)
                         .OnSuccess<ActionResult, TableBuilderResultViewModel, PermalinkViewModel>(async tableResult =>
                         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/LocationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/LocationServiceTests.cs
@@ -147,7 +147,6 @@ public class LocationServiceTests
         // Act
         var result = await _sut.GetLocationViewModels(
             locations,
-            null,
             hierarchies);
 
         // Assert
@@ -301,8 +300,8 @@ public class LocationServiceTests
         // Act
         var result = await _sut.GetLocationViewModels(
             locations,
-            boundaryLevelId: 123,
-            hierarchies);
+            hierarchies,
+            boundaryLevelId: 123);
 
         // Assert
         VerifyAllMocks(_boundaryDataRepository);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/LocationViewModelBuilderTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/LocationViewModelBuilderTests.cs
@@ -203,14 +203,14 @@ public class LocationViewModelBuilderTests
         var regions = Assert.Contains(GeographicLevel.Region, result);
         var localAuthorities = Assert.Contains(GeographicLevel.LocalAuthority, result);
 
-        // Except no GeoJson at country level 
+        // Except no GeoJson at country level
         var country1 = Assert.Single(countries);
         Assert.Equal(locations[0].Id, country1.Id);
         Assert.Equal(_england.Name, country1.Label);
         Assert.Equal(_england.Code, country1.Value);
         Assert.Null(country1.GeoJson);
 
-        // Except no GeoJson at region level 
+        // Except no GeoJson at region level
         Assert.Equal(3, regions.Count);
 
         var region1 = regions[0];

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectResultMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectResultMetaServiceTests.cs
@@ -67,7 +67,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var result = await service.GetSubjectMeta(
                 releaseVersionId: Guid.NewGuid(),
                 query,
-                boundaryLevelId: null,
                 []);
 
             result.AssertNotFound();
@@ -139,8 +138,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             locationService
                 .Setup(s => s.GetLocationViewModels(
                     It.IsAny<List<Location>>(),
-                    It.IsAny<long?>(),
-                    It.IsAny<Dictionary<GeographicLevel, List<string>>>()))
+                    It.IsAny<Dictionary<GeographicLevel, List<string>>>(),
+                    null))
                 .ReturnsAsync([]);
 
             footnoteRepository.Setup(s => s.GetFilteredFootnotes(
@@ -178,7 +177,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 var result = await service.GetSubjectMeta(
                     releaseVersion.Id,
                     query,
-                    boundaryLevelId: null,
                     observations);
 
                 VerifyAllMocks(
@@ -310,8 +308,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             locationService
                 .Setup(s => s.GetLocationViewModels(
                     It.IsAny<List<Location>>(),
-                    It.IsAny<long?>(),
-                    It.IsAny<Dictionary<GeographicLevel, List<string>>>()))
+                    It.IsAny<Dictionary<GeographicLevel, List<string>>>(),
+                    null))
                 .ReturnsAsync([]);
 
             boundaryLevelRepository.Setup(s => s.FindByGeographicLevels(
@@ -365,7 +363,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 var result = await service.GetSubjectMeta(
                     releaseVersion.Id,
                     query,
-                    boundaryLevelId: null,
                     observations);
 
                 VerifyAllMocks(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServicePermissionTests.cs
@@ -109,8 +109,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                         );
                         return await service.Query(
                             releaseVersionId: releaseVersion.Id,
-                            new FullTableQuery { SubjectId = releaseSubject.SubjectId },
-                            boundaryLevelId: null
+                            new FullTableQuery { SubjectId = releaseSubject.SubjectId }
                         );
                     }
                 );

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
@@ -184,7 +184,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                         s => s.GetSubjectMeta(
                             releaseVersion.Id,
                             query,
-                            It.IsAny<long?>(),
                             It.IsAny<IList<Observation>>()
                         )
                     )
@@ -580,7 +579,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                         s => s.GetSubjectMeta(
                             releaseSubject.ReleaseVersionId,
                             query,
-                            It.IsAny<long?>(),
                             It.IsAny<IList<Observation>>()
                         )
                     )
@@ -592,7 +590,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     subjectResultMetaService: subjectResultMetaService.Object
                 );
 
-                var result = await service.Query(releaseSubject.ReleaseVersionId, query, null);
+                var result = await service.Query(releaseSubject.ReleaseVersionId, query);
 
                 VerifyAllMocks(observationService, subjectResultMetaService);
 
@@ -666,8 +664,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 // Query using a non-existent release version id
                 var result = await service.Query(
                     releaseVersionId: Guid.NewGuid(),
-                    query,
-                    boundaryLevelId: null);
+                    query);
 
                 result.AssertNotFound();
             }
@@ -712,8 +709,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var result = await service.Query(
                     releaseVersionId: releaseVersion.Id,
-                    query,
-                    boundaryLevelId: null);
+                    query);
 
                 result.AssertNotFound();
             }
@@ -793,8 +789,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var result = await service.Query(
                     releaseVersionId: releaseSubject.ReleaseVersionId,
-                    query,
-                    boundaryLevelId: null);
+                    query);
 
                 VerifyAllMocks(filterItemRepository);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ILocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ILocationService.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 public interface ILocationService
 {
     Task<Dictionary<string, List<LocationAttributeViewModel>>> GetLocationViewModels(
-            List<Location> locations,
-            long? boundaryLevelId,
-            Dictionary<GeographicLevel, List<string>>? hierarchies);
+        List<Location> locations,
+        Dictionary<GeographicLevel, List<string>>? hierarchies,
+        long? boundaryLevelId = null);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ISubjectResultMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ISubjectResultMetaService.cs
@@ -15,6 +15,5 @@ public interface ISubjectResultMetaService
     Task<Either<ActionResult, SubjectResultMetaViewModel>> GetSubjectMeta(
         Guid releaseVersionId,
         FullTableQuery query,
-        long? boundaryLevelId,
         IList<Observation> observations);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ITableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ITableBuilderService.cs
@@ -21,7 +21,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
         Task<Either<ActionResult, TableBuilderResultViewModel>> Query(
             Guid releaseVersionId,
             FullTableQuery query,
-            long? boundaryLevelId,
             CancellationToken cancellationToken = default);
 
         Task<Either<ActionResult, Dictionary<string, List<LocationAttributeViewModel>>>> QueryForBoundaryLevel(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationService.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
@@ -8,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interface
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationService.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
@@ -7,18 +8,20 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interface
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Data.ViewModels.Meta;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services;
-public class LocationService(StatisticsDbContext context, IBoundaryDataRepository boundaryDataRepository) : ILocationService
+public class LocationService(
+    StatisticsDbContext context,
+    IBoundaryDataRepository boundaryDataRepository
+    ) : ILocationService
 {
     public async Task<Dictionary<string, List<LocationAttributeViewModel>>> GetLocationViewModels(
             List<Location> locations,
-            long? boundaryLevelId,
-            Dictionary<GeographicLevel, List<string>>? hierarchies)
+            Dictionary<GeographicLevel, List<string>>? hierarchies,
+            long? boundaryLevelId = null)
     {
         var boundaryData = await GetBoundaryData(locations, boundaryLevelId);
 
@@ -29,8 +32,8 @@ public class LocationService(StatisticsDbContext context, IBoundaryDataRepositor
     }
 
     private async Task<Dictionary<GeographicLevel, Dictionary<string, BoundaryData>>> GetBoundaryData(
-            List<Location> locations,
-            long? boundaryLevelId)
+        List<Location> locations,
+        long? boundaryLevelId)
     {
         if (!boundaryLevelId.HasValue)
         {
@@ -38,7 +41,7 @@ public class LocationService(StatisticsDbContext context, IBoundaryDataRepositor
         }
 
         var boundaryLevel = await context.BoundaryLevel.FindAsync(boundaryLevelId)
-            ?? throw new ArgumentOutOfRangeException(nameof(boundaryLevelId));
+                            ?? throw new ArgumentOutOfRangeException(nameof(boundaryLevelId));
 
         var locationsMatchingLevel =
             locations.Where(location => location.GeographicLevel == boundaryLevel.Level);
@@ -50,11 +53,11 @@ public class LocationService(StatisticsDbContext context, IBoundaryDataRepositor
         var boundaryData = boundaryDataRepository.FindByBoundaryLevelAndCodes(boundaryLevelId.Value, codes);
 
         return new Dictionary<GeographicLevel, Dictionary<string, BoundaryData>>
+        {
             {
-                {
-                    boundaryLevel.Level,
-                    boundaryData
-                }
-            };
+                boundaryLevel.Level,
+                boundaryData
+            }
+        };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectResultMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectResultMetaService.cs
@@ -77,7 +77,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         public async Task<Either<ActionResult, SubjectResultMetaViewModel>> GetSubjectMeta(
             Guid releaseVersionId,
             FullTableQuery query,
-            long? boundaryLevelId,
             IList<Observation> observations)
         {
             return await CheckReleaseSubjectExists(releaseVersionId: releaseVersionId,
@@ -128,7 +127,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     var publicationTitle = (await _contentDbContext.Publications.FindAsync(publicationId))!.Title;
 
                     var locationViewModels =
-                        await _locationService.GetLocationViewModels(locations, boundaryLevelId, _locationOptions.Hierarchies);
+                        await _locationService.GetLocationViewModels(locations, _locationOptions.Hierarchies);
                     _logger.LogTrace("Got Location view models in {Time} ms", stopwatch.Elapsed.TotalMilliseconds);
                     stopwatch.Stop();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
@@ -82,13 +82,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             CancellationToken cancellationToken = default)
         {
             return await FindLatestPublishedReleaseVersionId(query.SubjectId)
-                .OnSuccess(releaseVersionId => Query(releaseVersionId, query, boundaryLevelId: null, cancellationToken));
+                .OnSuccess(releaseVersionId => Query(releaseVersionId, query, cancellationToken));
         }
 
         public async Task<Either<ActionResult, TableBuilderResultViewModel>> Query(
             Guid releaseVersionId,
             FullTableQuery query,
-            long? boundaryLevelId,
             CancellationToken cancellationToken = default)
         {
             return await CheckReleaseSubjectExists(subjectId: query.SubjectId,
@@ -104,7 +103,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     }
 
                     return await _subjectResultMetaService
-                        .GetSubjectMeta(releaseVersionId, query, boundaryLevelId, observations)
+                        .GetSubjectMeta(releaseVersionId, query, observations)
                         .OnSuccess(subjectMetaViewModel =>
                         {
                             return new TableBuilderResultViewModel
@@ -140,7 +139,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                         .Distinct()
                         .ToList();
 
-                    return await _locationService.GetLocationViewModels(locations, boundaryLevelId, _locationOptions.Hierarchies);
+                    return await _locationService.GetLocationViewModels(
+                        locations,
+                        _locationOptions.Hierarchies,
+                        boundaryLevelId);
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.ViewModels/LocationViewModelBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.ViewModels/LocationViewModelBuilder.cs
@@ -43,6 +43,7 @@ public static class LocationViewModelBuilder
     {
         var locationAttribute = locationAttributeNode.Attribute;
 
+        // If we are including GeoJson data, it's only included in leaf nodes
         if (!locationAttributeNode.IsLeaf)
         {
             return new LocationAttributeViewModel
@@ -50,7 +51,7 @@ public static class LocationViewModelBuilder
                 Label = locationAttribute.Name ?? string.Empty,
                 Level = locationAttribute.GeographicLevel,
                 Value = locationAttribute.GetCodeOrFallback(),
-                Options = BuildLocationAttributeViewModels(locationAttributeNode.Children, boundaryDataByCode)
+                Options = BuildLocationAttributeViewModels(locationAttributeNode.Children, boundaryDataByCode),
             };
         }
 
@@ -71,7 +72,7 @@ public static class LocationViewModelBuilder
             Id = locationAttributeNode.LocationId,
             GeoJson = feature,
             Label = locationAttribute.Name ?? string.Empty,
-            Value = code
+            Value = code,
         };
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.ViewModels/LocationViewModelBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.ViewModels/LocationViewModelBuilder.cs
@@ -13,12 +13,14 @@ public static class LocationViewModelBuilder
         Dictionary<GeographicLevel, List<string>>? hierarchies,
         Dictionary<GeographicLevel, Dictionary<string, BoundaryData>>? boundaryData = null)
     {
-        var locationAttributes = locations.GetLocationAttributesHierarchical(hierarchies);
+        var locationAttributes =
+            locations.GetLocationAttributesHierarchical(hierarchies);
         return locationAttributes.ToDictionary(
             levelAndLocationAttributes => levelAndLocationAttributes.Key,
             levelAndLocationAttributes =>
             {
-                var boundaryDataByCode = boundaryData?.GetValueOrDefault(levelAndLocationAttributes.Key);
+                var boundaryDataByCode =
+                    boundaryData?.GetValueOrDefault(levelAndLocationAttributes.Key);
                 return BuildLocationAttributeViewModels(levelAndLocationAttributes.Value, boundaryDataByCode);
             });
     }
@@ -40,22 +42,18 @@ public static class LocationViewModelBuilder
         IReadOnlyDictionary<string, BoundaryData>? boundaryDataByCode)
     {
         var locationAttribute = locationAttributeNode.Attribute;
-        return locationAttributeNode.IsLeaf
-            ? BuildLocationAttributeLeafViewModel(locationAttributeNode, boundaryDataByCode)
-            : new LocationAttributeViewModel
+
+        if (!locationAttributeNode.IsLeaf)
+        {
+            return new LocationAttributeViewModel
             {
                 Label = locationAttribute.Name ?? string.Empty,
                 Level = locationAttribute.GeographicLevel,
                 Value = locationAttribute.GetCodeOrFallback(),
                 Options = BuildLocationAttributeViewModels(locationAttributeNode.Children, boundaryDataByCode)
             };
-    }
+        }
 
-    private static LocationAttributeViewModel BuildLocationAttributeLeafViewModel(
-        LocationAttributeNode locationAttributeNode,
-        IReadOnlyDictionary<string, BoundaryData>? boundaryDataByCode)
-    {
-        var locationAttribute = locationAttributeNode.Attribute;
         var code = locationAttribute.GetCodeOrFallback();
 
         var feature = code.IsNullOrEmpty()

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -15,7 +15,6 @@ import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
-import getMapInitialBoundaryLevel from '@common/modules/charts/components/utils/getMapInitialBoundaryLevel';
 import isOrphanedDataSet from '@common/modules/charts/util/isOrphanedDataSet';
 import { InitialTableToolState } from '@common/modules/table-tool/components/TableToolWizard';
 import getInitialStepSubjectMeta from '@common/modules/table-tool/components/utils/getInitialStepSubjectMeta';
@@ -82,9 +81,6 @@ const DataBlockPageTabs = ({
     const tableData = await tableBuilderService.getTableData(
       query,
       releaseVersionId,
-      dataBlock.charts[0]?.type === 'map'
-        ? getMapInitialBoundaryLevel(dataBlock.charts[0])
-        : undefined,
     );
 
     const { initialStep, subjectMeta } = await getInitialStepSubjectMeta(

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
@@ -102,6 +102,7 @@ const filterChartProps = (props: ChartBuilderChartProps): Chart => {
 
 export type TableQueryUpdateHandler = (
   query: Partial<ReleaseTableDataQuery>,
+  boundaryLevel: number | undefined,
 ) => Promise<void>;
 
 interface Props {
@@ -207,7 +208,7 @@ export default function ChartBuilder({
           boundaryLevel: options.boundaryLevel ?? 0,
           type: 'map',
           onBoundaryLevelChange: (boundaryLevel: number) =>
-            onTableQueryUpdate({ boundaryLevel }),
+            onTableQueryUpdate({}, boundaryLevel),
         };
       default:
         return undefined;
@@ -300,9 +301,7 @@ export default function ChartBuilder({
 
       setDataLoading(true);
 
-      await onTableQueryUpdate({
-        boundaryLevel: parseNumber(config.boundaryLevel),
-      });
+      await onTableQueryUpdate({}, parseNumber(config.boundaryLevel));
 
       setDataLoading(false);
     },

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
@@ -90,26 +90,24 @@ const ChartBuilderTabSection = ({
   );
 
   const handleTableQueryUpdate: TableQueryUpdateHandler = useCallback(
-    async updatedQuery => {
+    async (updatedQuery, updatedBoundaryLevel) => {
       const nextQuery: ReleaseTableDataQuery = {
         ...query,
         ...updatedQuery,
       };
 
-      // Don't fetch table data again if queries are the same
-      if (isEqual(query, nextQuery)) {
+      // Don't update if nothing has changed
+      if (isEqual(query, nextQuery) && updatedBoundaryLevel === undefined) {
         return;
       }
 
-      const { boundaryLevel } = nextQuery;
-
       const [tableData, geoJson] = await Promise.all([
         tableBuilderService.getTableData(nextQuery, releaseVersionId),
-        boundaryLevel !== undefined
+        updatedBoundaryLevel
           ? tableBuilderService.getDataBlockGeoJson(
               releaseVersionId,
               dataBlock.dataBlockParentId,
-              boundaryLevel,
+              updatedBoundaryLevel,
             )
           : undefined,
       ]);

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
@@ -104,7 +104,6 @@ const ChartBuilderTabSection = ({
       const tableData = await tableBuilderService.getTableData(
         nextQuery,
         releaseVersionId,
-        nextQuery.boundaryLevel,
       );
 
       onTableUpdate({

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
@@ -111,7 +111,7 @@ const ChartBuilderTabSection = ({
               dataBlock.dataBlockParentId,
               boundaryLevel,
             )
-          : {},
+          : undefined,
       ]);
 
       onTableUpdate({
@@ -119,7 +119,7 @@ const ChartBuilderTabSection = ({
           ...tableData,
           subjectMeta: {
             ...tableData.subjectMeta,
-            locations: geoJson,
+            locations: geoJson ?? tableData.subjectMeta.locations,
           },
         }),
         query: nextQuery,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
@@ -101,17 +101,31 @@ const ChartBuilderTabSection = ({
         return;
       }
 
-      const tableData = await tableBuilderService.getTableData(
-        nextQuery,
-        releaseVersionId,
-      );
+      const { boundaryLevel } = nextQuery;
+
+      const [tableData, geoJson] = await Promise.all([
+        tableBuilderService.getTableData(nextQuery, releaseVersionId),
+        boundaryLevel !== undefined
+          ? tableBuilderService.getDataBlockGeoJson(
+              releaseVersionId,
+              dataBlock.dataBlockParentId,
+              boundaryLevel,
+            )
+          : {},
+      ]);
 
       onTableUpdate({
-        table: mapFullTable(tableData),
+        table: mapFullTable({
+          ...tableData,
+          subjectMeta: {
+            ...tableData.subjectMeta,
+            locations: geoJson,
+          },
+        }),
         query: nextQuery,
       });
     },
-    [onTableUpdate, query, releaseVersionId],
+    [onTableUpdate, query, releaseVersionId, dataBlock],
   );
 
   return (

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilder.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilder.test.tsx
@@ -446,7 +446,7 @@ describe('ChartBuilder', () => {
       '1',
     ]);
 
-    expect(handleUpdate).toHaveBeenCalledWith({ boundaryLevel: 1 });
+    expect(handleUpdate).toHaveBeenCalledWith({}, 1);
   });
 
   describe('data groupings tab', () => {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilderTabSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilderTabSection.test.tsx
@@ -12,8 +12,10 @@ import render from '@common-test/render';
 import { Chart } from '@common/modules/charts/types/chart';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import _tableBuilderService, {
+  LocationGeoJsonOption,
   TableDataQuery,
 } from '@common/services/tableBuilderService';
+import { Dictionary } from '@common/types';
 import { screen } from '@testing-library/react';
 import noop from 'lodash/noop';
 
@@ -162,8 +164,15 @@ describe('ChartBuilderTabSection', () => {
   });
 
   test('calls `getTableData` and `onTableUpdate` when boundary level changed', async () => {
-    // @MarkFix remove this test case?
-    tableBuilderService.getTableData.mockResolvedValue(testTableData);
+    tableBuilderService.getTableData.mockResolvedValue({
+      ...testTableData,
+      subjectMeta: { ...testTableData.subjectMeta, locations: {} },
+    });
+    tableBuilderService.getDataBlockGeoJson.mockResolvedValue(
+      testTableData.subjectMeta.locations as Dictionary<
+        LocationGeoJsonOption[]
+      >,
+    );
 
     const handleUpdate = jest.fn();
 
@@ -193,6 +202,12 @@ describe('ChartBuilderTabSection', () => {
     expect(tableBuilderService.getTableData).toHaveBeenCalledWith(
       { ...testQuery, boundaryLevel: 1 }, // @MarkFix boundaryLevel
       'release-1',
+    );
+
+    expect(tableBuilderService.getDataBlockGeoJson).toHaveBeenCalledWith(
+      'release-1',
+      'data-block-parent-1',
+      1,
     );
 
     expect(handleUpdate).toHaveBeenCalledWith({

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilderTabSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilderTabSection.test.tsx
@@ -200,7 +200,7 @@ describe('ChartBuilderTabSection', () => {
     ]);
 
     expect(tableBuilderService.getTableData).toHaveBeenCalledWith(
-      { ...testQuery, boundaryLevel: 1 }, // @MarkFix boundaryLevel
+      { ...testQuery },
       'release-1',
     );
 
@@ -212,7 +212,7 @@ describe('ChartBuilderTabSection', () => {
 
     expect(handleUpdate).toHaveBeenCalledWith({
       table: testFullTable,
-      query: { ...testQuery, boundaryLevel: 1 },
+      query: { ...testQuery },
     });
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilderTabSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilderTabSection.test.tsx
@@ -162,6 +162,7 @@ describe('ChartBuilderTabSection', () => {
   });
 
   test('calls `getTableData` and `onTableUpdate` when boundary level changed', async () => {
+    // @MarkFix remove this test case?
     tableBuilderService.getTableData.mockResolvedValue(testTableData);
 
     const handleUpdate = jest.fn();
@@ -190,9 +191,8 @@ describe('ChartBuilderTabSection', () => {
     ]);
 
     expect(tableBuilderService.getTableData).toHaveBeenCalledWith(
-      { ...testQuery, boundaryLevel: 1 },
+      { ...testQuery, boundaryLevel: 1 }, // @MarkFix boundaryLevel
       'release-1',
-      1,
     );
 
     expect(handleUpdate).toHaveBeenCalledWith({

--- a/src/explore-education-statistics-admin/src/routes/administrationRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/administrationRoutes.ts
@@ -12,10 +12,6 @@ import BoundaryDataUploadPage from '@admin/pages/bau/BoundaryDataUploadPage';
 import GlossaryPage from '@admin/pages/bau/GlossaryPage';
 import FeedbackPage from '@admin/pages/bau/FeedbackPage';
 
-export type BoundaryLevelEditPageRouteParams = {
-  boundaryLevelId: number;
-};
-
 export const administrationIndexRoute: ProtectedRouteProps = {
   path: '/administration',
   component: BauDashboardPage,

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/DataBlockTabs.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/DataBlockTabs.test.tsx
@@ -199,9 +199,7 @@ describe('DataBlockTabs', () => {
         'block-1-parent',
       );
 
-      expect(
-        screen.queryByText('Could not load content'),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Could not load content')).toBeInTheDocument();
       expect(screen.queryByRole('table')).not.toBeInTheDocument();
     });
   });

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -137,13 +137,12 @@ export interface TimePeriodQuery {
   endCode: string;
 }
 
-export interface TableDataQuery extends FullTableQuery {
-  publicationId?: string;
-  boundaryLevel?: number;
-}
-
 export interface ReleaseTableDataQuery extends TableDataQuery {
   releaseVersionId?: string;
+}
+
+export interface TableDataQuery extends FullTableQuery {
+  publicationId?: string;
 }
 
 export interface FullTableQuery {

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -65,7 +65,6 @@ export interface LocationOption {
   value: string;
   level?: string;
   options?: LocationLeafOption[];
-  geoJson?: GeoJsonFeature;
 }
 
 export interface LocationGeoJsonOption extends LocationOption {
@@ -250,16 +249,8 @@ const tableBuilderService = {
   async getTableData(
     query: FullTableQuery,
     releaseVersionId?: string,
-    boundaryLevelId?: number,
   ): Promise<TableDataResponse> {
-    if (releaseVersionId && boundaryLevelId) {
-      return dataApi.post(
-        `/tablebuilder/release/${releaseVersionId}?boundaryLevelId=${boundaryLevelId}`,
-        query,
-      );
-    }
-
-    return releaseVersionId && !boundaryLevelId
+    return releaseVersionId
       ? dataApi.post(`/tablebuilder/release/${releaseVersionId}`, query)
       : dataApi.post('/tablebuilder', query);
   },

--- a/tests/performance-tests/src/utils/adminService.ts
+++ b/tests/performance-tests/src/utils/adminService.ts
@@ -244,25 +244,25 @@ export class AdminService {
   }
 
   getDataFile({
-    releaseId,
+    releaseVersionId,
     dataFileName,
   }: {
-    releaseId: string;
+    releaseVersionId: string;
     dataFileName: string;
   }) {
     const { json: releaseFiles } = this.client.get<
       { id: string; fileName: string }[]
-    >(`/api/release/${releaseId}/data`, applicationJsonHeaders);
+    >(`/api/release/${releaseVersionId}/data`, applicationJsonHeaders);
     return releaseFiles.find(file => file.fileName === dataFileName);
   }
 
   uploadDataZipFile({
     title,
-    releaseId,
+    releaseVersionId,
     zipFile,
   }: {
     title: string;
-    releaseId: string;
+    releaseVersionId: string;
     zipFile: {
       file: ArrayBuffer;
       filename: string;
@@ -270,19 +270,19 @@ export class AdminService {
   }) {
     return this.uploadDataFile({
       title,
-      releaseId,
+      releaseVersionId,
       dataFile: zipFile,
     });
   }
 
   uploadDataFile({
     title,
-    releaseId,
+    releaseVersionId,
     dataFile,
     metaFile,
   }: {
     title: string;
-    releaseId: string;
+    releaseVersionId: string;
     dataFile: {
       file: ArrayBuffer;
       filename: string;
@@ -312,7 +312,7 @@ export class AdminService {
     };
 
     const { response, json } = this.client.post<{ id: string }>(
-      `/api/release/${releaseId}/${
+      `/api/release/${releaseVersionId}/${
         zipUpload ? 'zip-data' : 'data'
       }?title=${encodeURI(title)}`,
       uploadBody,
@@ -327,7 +327,7 @@ export class AdminService {
   }
 
   waitForDataFileToImport({
-    releaseId,
+    releaseVersionId,
     fileId,
     pollingDelaySeconds = 5,
     onStatusCheckFailed,
@@ -336,7 +336,7 @@ export class AdminService {
     onImportCompleted,
     onImportExceededTimeout,
   }: {
-    releaseId: string;
+    releaseVersionId: string;
     fileId: string;
     pollingDelaySeconds?: number;
     onStatusCheckFailed?: (statusResponse: RefinedResponse<'text'>) => void;
@@ -350,7 +350,7 @@ export class AdminService {
 
     while (Date.now() < importExpireTime) {
       const { importStatus, response } = this.getImportStatus({
-        releaseId,
+        releaseVersionId,
         fileId,
       });
 
@@ -367,7 +367,7 @@ export class AdminService {
             return;
           }
           throw new Error(
-            `Import of file ${fileId} for Release ${releaseId} failed`,
+            `Import of file ${fileId} for Release ${releaseVersionId} failed`,
           );
         }
 
@@ -389,12 +389,12 @@ export class AdminService {
 
   getOrImportDataFile({
     title,
-    releaseId,
+    releaseVersionId,
     dataFile,
     metaFile,
   }: {
     title: string;
-    releaseId: string;
+    releaseVersionId: string;
     dataFile: {
       file: ArrayBuffer;
       filename: string;
@@ -406,18 +406,20 @@ export class AdminService {
   }) {
     return {
       id:
-        this.getDataFile({ releaseId, dataFileName: dataFile.filename })?.id ??
-        this.uploadDataFile({ title, releaseId, dataFile, metaFile })?.id,
+        this.getDataFile({ releaseVersionId, dataFileName: dataFile.filename })
+          ?.id ??
+        this.uploadDataFile({ title, releaseVersionId, dataFile, metaFile })
+          ?.id,
     };
   }
 
   getOrImportDataZipFile({
     title,
-    releaseId,
+    releaseVersionId,
     zipFile,
   }: {
     title: string;
-    releaseId: string;
+    releaseVersionId: string;
     zipFile: {
       file: ArrayBuffer;
       filename: string;
@@ -425,20 +427,21 @@ export class AdminService {
   }) {
     return {
       id:
-        this.getDataFile({ releaseId, dataFileName: zipFile.filename })?.id ??
-        this.uploadDataFile({ title, releaseId, dataFile: zipFile })?.id,
+        this.getDataFile({ releaseVersionId, dataFileName: zipFile.filename })
+          ?.id ??
+        this.uploadDataFile({ title, releaseVersionId, dataFile: zipFile })?.id,
     };
   }
 
   getImportStatus({
-    releaseId,
+    releaseVersionId,
     fileId,
   }: {
-    releaseId: string;
+    releaseVersionId: string;
     fileId: string;
   }) {
     const { response, json } = this.client.get<{ status: string }>(
-      `/api/release/${releaseId}/data/${fileId}/import/status`,
+      `/api/release/${releaseVersionId}/data/${fileId}/import/status`,
     );
     return {
       importStatus: json.status,
@@ -446,9 +449,9 @@ export class AdminService {
     };
   }
 
-  getSubjects({ releaseId }: { releaseId: string }) {
+  getSubjects({ releaseVersionId }: { releaseVersionId: string }) {
     const { response, json } = this.client.get<{ id: string; name: string }[]>(
-      `/api/data/releases/${releaseId}/subjects`,
+      `/api/data/releases/${releaseVersionId}/subjects`,
     );
     return {
       subjects: json.map(subject => ({
@@ -460,14 +463,14 @@ export class AdminService {
   }
 
   getSubjectMeta({
-    releaseId,
+    releaseVersionId,
     subjectId,
   }: {
-    releaseId: string;
+    releaseVersionId: string;
     subjectId: string;
   }) {
     const { response, json } = this.client.get<SubjectMeta>(
-      `/api/data/release/${releaseId}/meta/subject/${subjectId}`,
+      `/api/data/release/${releaseVersionId}/meta/subject/${subjectId}`,
     );
     return {
       subjectMeta: json,
@@ -476,14 +479,14 @@ export class AdminService {
   }
 
   tableQuery({
-    releaseId,
+    releaseVersionId,
     query,
   }: {
-    releaseId: string;
+    releaseVersionId: string;
     query: FullTableQuery;
   }) {
     const { response, json } = this.client.post<{ results: { id: string }[] }>(
-      `/api/data/tablebuilder/release/${releaseId}`,
+      `/api/data/tablebuilder/release/${releaseVersionId}`,
       JSON.stringify(query),
       applicationJsonHeaders,
     );
@@ -494,11 +497,11 @@ export class AdminService {
   }
 
   addDataGuidance({
-    releaseId,
+    releaseVersionId,
     content = '<p>Test Content</p>',
     subjects,
   }: {
-    releaseId: string;
+    releaseVersionId: string;
     content?: string;
     subjects: {
       id: string;
@@ -506,7 +509,7 @@ export class AdminService {
     }[];
   }) {
     const { response } = this.client.patch(
-      `/api/release/${releaseId}/data-guidance`,
+      `/api/release/${releaseVersionId}/data-guidance`,
       JSON.stringify({
         content,
         subjects,
@@ -519,16 +522,16 @@ export class AdminService {
   }
 
   approveRelease({
-    releaseId,
+    releaseVersionId,
     notifySubscribers = false,
     latestInternalReleaseNote = 'Approved',
   }: {
-    releaseId: string;
+    releaseVersionId: string;
     notifySubscribers?: boolean;
     latestInternalReleaseNote?: string;
   }) {
     const { response } = this.client.post(
-      `/api/releases/${releaseId}/status`,
+      `/api/releases/${releaseVersionId}/status`,
       JSON.stringify({
         notifySubscribers,
         latestInternalReleaseNote,
@@ -542,9 +545,9 @@ export class AdminService {
     };
   }
 
-  getReleaseApprovalStatus({ releaseId }: { releaseId: string }) {
+  getReleaseApprovalStatus({ releaseVersionId }: { releaseVersionId: string }) {
     const { response, json } = this.client.get<{ overallStage: OverallStage }>(
-      `/api/releases/${releaseId}/stage-status`,
+      `/api/releases/${releaseVersionId}/stage-status`,
       applicationJsonHeaders,
     );
     return {
@@ -554,7 +557,7 @@ export class AdminService {
   }
 
   waitForReleaseToBePublished({
-    releaseId,
+    releaseVersionId,
     pollingDelaySeconds = 5,
     onStatusCheckFailed,
     onStatusReceived,
@@ -562,7 +565,7 @@ export class AdminService {
     onPublishingCompleted,
     onPublishingExceededTimeout,
   }: {
-    releaseId: string;
+    releaseVersionId: string;
     pollingDelaySeconds?: number;
     onStatusCheckFailed?: (statusResponse: RefinedResponse<'text'>) => void;
     onStatusReceived?: (status: string) => void;
@@ -575,7 +578,9 @@ export class AdminService {
       publishingStartTime + TestData.maxPublishingWaitTimeMillis;
 
     while (Date.now() < publishingExpireTime) {
-      const { status, response } = this.getReleaseApprovalStatus({ releaseId });
+      const { status, response } = this.getReleaseApprovalStatus({
+        releaseVersionId,
+      });
 
       switch (response.status) {
         case 204: {
@@ -594,7 +599,9 @@ export class AdminService {
               onPublishingFailed(status);
               return;
             }
-            throw new Error(`Publishing failed for Release ${releaseId}`);
+            throw new Error(
+              `Publishing failed for Release ${releaseVersionId}`,
+            );
           }
 
           if (status === 'Complete') {
@@ -646,11 +653,11 @@ export function getDataFileUploadStrategy({ filename }: { filename: string }): {
     isZip,
     filename,
     subjectName: filename,
-    getOrImportSubject: (adminService, releaseId) =>
+    getOrImportSubject: (adminService, releaseVersionId) =>
       isZip
         ? adminService.uploadDataZipFile({
             title: subjectName,
-            releaseId,
+            releaseVersionId,
             zipFile: {
               file: zipFile as ArrayBuffer,
               filename: `${subjectName}.zip`,
@@ -658,7 +665,7 @@ export function getDataFileUploadStrategy({ filename }: { filename: string }): {
           })
         : adminService.uploadDataFile({
             title: subjectName,
-            releaseId,
+            releaseVersionId,
             dataFile: {
               file: subjectFile as ArrayBuffer,
               filename: `${subjectName}.csv`,

--- a/tests/performance-tests/src/utils/adminService.ts
+++ b/tests/performance-tests/src/utils/adminService.ts
@@ -243,19 +243,6 @@ export class AdminService {
     };
   }
 
-  getDataFile({
-    releaseVersionId,
-    dataFileName,
-  }: {
-    releaseVersionId: string;
-    dataFileName: string;
-  }) {
-    const { json: releaseFiles } = this.client.get<
-      { id: string; fileName: string }[]
-    >(`/api/release/${releaseVersionId}/data`, applicationJsonHeaders);
-    return releaseFiles.find(file => file.fileName === dataFileName);
-  }
-
   uploadDataZipFile({
     title,
     releaseVersionId,
@@ -386,52 +373,6 @@ export class AdminService {
       onImportExceededTimeout();
     }
   }
-
-  //getOrImportDataFile({ // @MarkFix remove?
-  //  title,
-  //  releaseVersionId,
-  //  dataFile,
-  //  metaFile,
-  //}: {
-  //  title: string;
-  //  releaseVersionId: string;
-  //  dataFile: {
-  //    file: ArrayBuffer;
-  //    filename: string;
-  //  };
-  //  metaFile?: {
-  //    file: ArrayBuffer;
-  //    filename: string;
-  //  };
-  //}) {
-  //  return {
-  //    id:
-  //      this.getDataFile({ releaseVersionId, dataFileName: dataFile.filename })
-  //        ?.id ??
-  //      this.uploadDataFile({ title, releaseVersionId, dataFile, metaFile })
-  //        ?.id,
-  //  };
-  //}
-
-  //getOrImportDataZipFile({ // @MarkFix remove?
-  //  title,
-  //  releaseVersionId,
-  //  zipFile,
-  //}: {
-  //  title: string;
-  //  releaseVersionId: string;
-  //  zipFile: {
-  //    file: ArrayBuffer;
-  //    filename: string;
-  //  };
-  //}) {
-  //  return {
-  //    id:
-  //      this.getDataFile({ releaseVersionId, dataFileName: zipFile.filename })
-  //        ?.id ??
-  //      this.uploadDataFile({ title, releaseVersionId, dataFile: zipFile })?.id,
-  //  };
-  //}
 
   getImportStatus({
     releaseVersionId,

--- a/tests/performance-tests/src/utils/adminService.ts
+++ b/tests/performance-tests/src/utils/adminService.ts
@@ -387,51 +387,51 @@ export class AdminService {
     }
   }
 
-  getOrImportDataFile({
-    title,
-    releaseVersionId,
-    dataFile,
-    metaFile,
-  }: {
-    title: string;
-    releaseVersionId: string;
-    dataFile: {
-      file: ArrayBuffer;
-      filename: string;
-    };
-    metaFile?: {
-      file: ArrayBuffer;
-      filename: string;
-    };
-  }) {
-    return {
-      id:
-        this.getDataFile({ releaseVersionId, dataFileName: dataFile.filename })
-          ?.id ??
-        this.uploadDataFile({ title, releaseVersionId, dataFile, metaFile })
-          ?.id,
-    };
-  }
+  //getOrImportDataFile({ // @MarkFix remove?
+  //  title,
+  //  releaseVersionId,
+  //  dataFile,
+  //  metaFile,
+  //}: {
+  //  title: string;
+  //  releaseVersionId: string;
+  //  dataFile: {
+  //    file: ArrayBuffer;
+  //    filename: string;
+  //  };
+  //  metaFile?: {
+  //    file: ArrayBuffer;
+  //    filename: string;
+  //  };
+  //}) {
+  //  return {
+  //    id:
+  //      this.getDataFile({ releaseVersionId, dataFileName: dataFile.filename })
+  //        ?.id ??
+  //      this.uploadDataFile({ title, releaseVersionId, dataFile, metaFile })
+  //        ?.id,
+  //  };
+  //}
 
-  getOrImportDataZipFile({
-    title,
-    releaseVersionId,
-    zipFile,
-  }: {
-    title: string;
-    releaseVersionId: string;
-    zipFile: {
-      file: ArrayBuffer;
-      filename: string;
-    };
-  }) {
-    return {
-      id:
-        this.getDataFile({ releaseVersionId, dataFileName: zipFile.filename })
-          ?.id ??
-        this.uploadDataFile({ title, releaseVersionId, dataFile: zipFile })?.id,
-    };
-  }
+  //getOrImportDataZipFile({ // @MarkFix remove?
+  //  title,
+  //  releaseVersionId,
+  //  zipFile,
+  //}: {
+  //  title: string;
+  //  releaseVersionId: string;
+  //  zipFile: {
+  //    file: ArrayBuffer;
+  //    filename: string;
+  //  };
+  //}) {
+  //  return {
+  //    id:
+  //      this.getDataFile({ releaseVersionId, dataFileName: zipFile.filename })
+  //        ?.id ??
+  //      this.uploadDataFile({ title, releaseVersionId, dataFile: zipFile })?.id,
+  //  };
+  //}
 
   getImportStatus({
     releaseVersionId,


### PR DESCRIPTION
This PR is to clean up code after switching to have a separate endpoint to fetch geojson data for map charts.

Many PRs ago, we originally returned geojson alongside table data. To help with performance, a new endpoint was created to return geojson data exclusively so it didn't have to be returned with table data. Now with the new endpoint deployed, we can now  update the original table data endpoint to fetch table data only as we no longer use it to fetch geojson.

There was one instance in Admin where the table data endpoint was still being used to fetch geojson. Thanks to Stu for changing this so now the Admin does request the table data and geojson using separate endpoints.

### Other changes

- In `adminService.ts` I've renamed various `releaseId`s to `releaseVersionId`s where appropriate
- Also in `adminService.ts` I found a couple of frontend queries that weren't being used so removed them (getOrImportDataFile and the one for zip files)
- I fixed a unit test in `DataBlockTabs.test.tsx` - totally unrelated to this work, which appears to be failing locally but passing on the pipeline. A ticket has been created to investigate that: EES-5965