### PR TITLE
EES-5934 Fixing Admin Public API Data Set Changelog page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
@@ -76,23 +76,15 @@ public class DataSetVersionsController(IDataSetVersionService dataSetVersionServ
 
     [HttpGet("{dataSetVersionId:guid}/changes")]
     [Produces("application/json")]
-    public async Task<ActionResult> GetVersionChanges(
+    public async Task<ActionResult<DataSetVersionChangesViewModel>> GetVersionChanges(
         Guid dataSetVersionId,
         CancellationToken cancellationToken)
     {
-        // We use a streaming approach as we don't have to share the public API view models
-        // with the admin. This means we can avoid inefficiently re-serializing a second JSON
-        // response and don't need to load the original response into memory.
         return await dataSetVersionService
             .GetVersionChanges(
                 dataSetVersionId: dataSetVersionId,
                 cancellationToken: cancellationToken)
-            .OnSuccessVoid(async response =>
-            {
-                Response.ContentType = response.Content.Headers.ContentType?.ToString();
-                await response.Content.CopyToAsync(Response.BodyWriter.AsStream(), cancellationToken);
-            })
-            .HandleFailuresOrNoOp();
+            .HandleFailuresOrOk();
     }
 
     [HttpPatch("{dataSetVersionId:guid}")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -214,7 +214,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
 
             CreateMap<ReleaseVersion, ReleasePublicationStatusViewModel>();
 
-            CreateMap<DataSetVersionChangesViewModelDto, DataSetVersionChangesViewModel2>();
+            CreateDataSetVersionChangesMap();
         }
 
         private void CreateContentBlockMap()
@@ -244,6 +244,57 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
             CreateMap<HtmlBlock, HtmlBlockViewModel>();
 
             CreateMap<MarkDownBlock, MarkDownBlockViewModel>();
+        }
+
+        private void CreateDataSetVersionChangesMap()
+        {
+            CreateMap<DataSetVersionChangesViewModelDto, DataSetVersionChangesViewModel2>();
+
+            CreateMap<ChangeSetViewModelDto, ChangeSetViewModel>()
+                .ForMember(dest => dest.Filters,
+                    m => m.AllowNull())
+                .ForMember(dest => dest.FilterOptions,
+                    m => m.AllowNull())
+                .ForMember(dest => dest.GeographicLevels,
+                    m => m.AllowNull())
+                .ForMember(dest => dest.Indicators,
+                    m => m.AllowNull())
+                .ForMember(dest => dest.LocationGroups,
+                    m => m.AllowNull())
+                .ForMember(dest => dest.LocationOptions,
+                    m => m.AllowNull())
+                .ForMember(dest => dest.TimePeriods,
+                    m => m.AllowNull());
+
+            CreateMap<FilterChangeViewModelDto, FilterChangeViewModel>();
+            CreateMap<FilterViewModelDto, FilterViewModel>();
+
+            CreateMap<FilterOptionChangeViewModelDto, FilterOptionChangeViewModel>();
+            CreateMap<FilterOptionChangesViewModelDto, FilterOptionChangesViewModel>()
+                .ForMember(dest => dest.Options,
+                    m => m.MapFrom(filterOptionChanges =>
+                        filterOptionChanges.Options));
+            CreateMap<FilterOptionViewModelDto, FilterOptionViewModel>();
+
+            CreateMap<GeographicLevelChangeViewModelDto, GeographicLevelChangeViewModel>();
+            CreateMap<GeographicLevelViewModelDto, GeographicLevelViewModel>();
+
+            CreateMap<IndicatorChangeViewModelDto, IndicatorChangeViewModel>();
+            CreateMap<IndicatorViewModelDto, IndicatorViewModel>();
+
+            CreateMap<LocationGroupChangeViewModelDto, LocationGroupChangeViewModel>();
+            CreateMap<LocationGroupViewModelDto, LocationGroupViewModel>();
+
+            CreateMap<LocationOptionChangeViewModelDto, LocationOptionChangeViewModel>();
+            CreateMap<LocationOptionChangesViewModelDto, LocationOptionChangesViewModel>()
+                .ForMember(dest => dest.Options,
+                    m => m.MapFrom(locationOptionChanges =>
+                        locationOptionChanges.Options));
+            CreateMap<LocationOptionViewModelDto, LocationOptionViewModel>();
+
+            CreateMap<TimePeriodOptionChangeViewModelDto, TimePeriodOptionChangeViewModel>();
+            CreateMap<TimePeriodOptionViewModelDto, TimePeriodOptionViewModel>();
+            CreateMap<TimePeriodViewModelDto, TimePeriodViewModel>();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -1,7 +1,9 @@
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data.PublicDataApiClient;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Mappings;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
@@ -211,6 +213,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                         methodologyVersion.Notes.OrderByDescending(note => note.DisplayDate)));
 
             CreateMap<ReleaseVersion, ReleasePublicationStatusViewModel>();
+
+            CreateMap<DataSetVersionChangesViewModelDto, DataSetVersionChangesViewModel2>();
         }
 
         private void CreateContentBlockMap()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
@@ -45,7 +45,7 @@ public interface IDataSetVersionService
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default);
 
-    Task<Either<ActionResult, HttpResponseMessage>> GetVersionChanges(
+    Task<Either<ActionResult, DataSetVersionChangesViewModel>> GetVersionChanges(
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPublicDataApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPublicDataApiClient.cs
@@ -1,8 +1,8 @@
 #nullable enable
 using System;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data.PublicDataApiClient;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.P
 
 public interface IPublicDataApiClient
 {
-    Task<Either<ActionResult, HttpResponseMessage>> GetDataSetVersionChanges(
+    Task<Either<ActionResult, DataSetVersionChangesViewModelDto>> GetDataSetVersionChanges(
         Guid dataSetId,
         string dataSetVersion,
         CancellationToken cancellationToken = default);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPublicDataApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IPublicDataApiClient.cs
@@ -10,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.P
 
 public interface IPublicDataApiClient
 {
-    Task<Either<ActionResult, DataSetVersionChangesViewModelDto>> GetDataSetVersionChanges(
+    Task<Either<ActionResult, DataSetVersionChangesViewModelDto?>> GetDataSetVersionChanges(
         Guid dataSetId,
         string dataSetVersion,
         CancellationToken cancellationToken = default);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionService.cs
@@ -389,13 +389,15 @@ public class DataSetVersionService(
         };
     }
 
-    private DataSetVersionChangesViewModel MapVersionChanges(DataSetVersion dataSetVersion, DataSetVersionChangesViewModelDto dataSetVersionChanges)
+    private DataSetVersionChangesViewModel MapVersionChanges(DataSetVersion dataSetVersion, DataSetVersionChangesViewModelDto? dataSetVersionChanges)
     {
         return new DataSetVersionChangesViewModel
         {
             DataSet = new IdTitleViewModel(dataSetVersion.DataSetId, dataSetVersion.DataSet.Title),
             DataSetVersion = MapDataSetVersion(dataSetVersion),
-            Changes = mapper.Map<DataSetVersionChangesViewModel2>(dataSetVersionChanges),
+            Changes = dataSetVersionChanges == null 
+                ? null 
+                : mapper.Map<DataSetVersionChangesViewModel2>(dataSetVersionChanges),
         };
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient/DataSetVersionChangesViewModelDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient/DataSetVersionChangesViewModelDto.cs
@@ -1,0 +1,142 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Converters.SystemJson;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data.PublicDataApiClient;
+
+public record DataSetVersionChangesViewModelDto
+{
+    public required ChangeSetViewModelDto MajorChanges { get; init; }
+
+    public required ChangeSetViewModelDto MinorChanges { get; init; }
+}
+
+public record ChangeSetViewModelDto
+{
+    public IReadOnlyList<FilterChangeViewModelDto>? Filters { get; init; }
+
+    public IReadOnlyList<FilterOptionChangesViewModelDto>? FilterOptions { get; init; }
+
+    public IReadOnlyList<GeographicLevelChangeViewModelDto>? GeographicLevels { get; init; }
+
+    public IReadOnlyList<IndicatorChangeViewModelDto>? Indicators { get; init; }
+
+    public IReadOnlyList<LocationGroupChangeViewModelDto>? LocationGroups { get; init; }
+    
+    public IReadOnlyList<LocationOptionChangesViewModelDto>? LocationOptions { get; init; }
+
+    public IReadOnlyList<TimePeriodOptionChangeViewModelDto>? TimePeriods { get; init; }
+}
+
+public record FilterOptionChangesViewModelDto
+{
+    public required FilterViewModelDto Filter { get; init; }
+
+    public required IReadOnlyList<FilterOptionChangeViewModelDto> Options { get; init; }
+}
+
+public record LocationOptionChangesViewModelDto
+{
+    public required GeographicLevelViewModelDto Level { get; init; }
+
+    public required IReadOnlyList<LocationOptionChangeViewModelDto> Options { get; init; }
+}
+
+public abstract record ChangeViewModelDto<TChange>
+{
+    public TChange? CurrentState { get; init; }
+
+    public TChange? PreviousState { get; init; }
+}
+
+public record FilterChangeViewModelDto : ChangeViewModelDto<FilterViewModelDto>;
+
+public record FilterOptionChangeViewModelDto : ChangeViewModelDto<FilterOptionViewModelDto>;
+
+public record GeographicLevelChangeViewModelDto : ChangeViewModelDto<GeographicLevelViewModelDto>;
+
+public record IndicatorChangeViewModelDto : ChangeViewModelDto<IndicatorViewModelDto>;
+
+public record LocationGroupChangeViewModelDto : ChangeViewModelDto<LocationGroupViewModelDto>;
+
+public record LocationOptionChangeViewModelDto : ChangeViewModelDto<LocationOptionViewModelDto>;
+
+public record TimePeriodOptionChangeViewModelDto : ChangeViewModelDto<TimePeriodOptionViewModelDto>;
+
+public record FilterViewModelDto
+{
+    public required string Id { get; init; }
+
+    public required string Column { get; init; }
+
+    public required string Label { get; init; }
+
+    public string Hint { get; init; } = string.Empty;
+}
+
+public record FilterOptionViewModelDto
+{
+    public required string Id { get; init; }
+
+    public required string Label { get; init; }
+}
+
+public record GeographicLevelViewModelDto
+{
+    [JsonConverter(typeof(EnumToEnumValueJsonConverter<GeographicLevel>))]
+    public required GeographicLevel Code { get; init; }
+
+    public required string Label { get; init; }
+}
+
+public record IndicatorViewModelDto
+{
+    public required string Id { get; init; }
+
+    public required string Column { get; init; }
+
+    public required string Label { get; init; }
+
+    [JsonConverter(typeof(EnumToEnumLabelJsonConverter<IndicatorUnit>))]
+    public required IndicatorUnit? Unit { get; init; }
+
+    public int? DecimalPlaces { get; init; }
+}
+
+public record LocationGroupViewModelDto
+{
+    public required GeographicLevelViewModelDto Level { get; init; }
+}
+
+public abstract record LocationOptionViewModelDto
+{
+    public required string Id { get; init; }
+
+    public required string Label { get; init; }
+
+    public string? Code { get; init; }
+
+    public string? OldCode { get; init; }
+
+    public string? Ukprn { get; init; }
+
+    public string? Urn { get; init; }
+
+    public string? LaEstab { get; init; }
+}
+
+public record TimePeriodOptionViewModelDto : TimePeriodViewModelDto
+{
+    public required string Label { get; init; }
+}
+
+public record TimePeriodViewModelDto
+{
+    [JsonConverter(typeof(EnumToEnumValueJsonConverter<TimeIdentifier>))]
+    public required TimeIdentifier Code { get; init; }
+
+    public required string Period { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient/DataSetVersionChangesViewModelDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient/DataSetVersionChangesViewModelDto.cs
@@ -101,7 +101,7 @@ public record IndicatorViewModelDto
     public required string Label { get; init; }
 
     [JsonConverter(typeof(EnumToEnumLabelJsonConverter<IndicatorUnit>))]
-    public required IndicatorUnit? Unit { get; init; }
+    public IndicatorUnit? Unit { get; init; }
 
     public int? DecimalPlaces { get; init; }
 }
@@ -111,7 +111,7 @@ public record LocationGroupViewModelDto
     public required GeographicLevelViewModelDto Level { get; init; }
 }
 
-public abstract record LocationOptionViewModelDto
+public record LocationOptionViewModelDto
 {
     public required string Id { get; init; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient/PublicDataApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient/PublicDataApiClient.cs
@@ -38,7 +38,7 @@ public class PublicDataApiClient(
                 cancellationToken
             ),
             cancellationToken
-        ).OnSuccess(async response => (await response.Content.ReadFromJsonAsync<DataSetVersionChangesViewModelDto>()));
+        ).OnSuccess(async response => await response.Content.ReadFromJsonAsync<DataSetVersionChangesViewModelDto>());
     }
 
     private async Task<Either<ActionResult, HttpResponseMessage>> SendRequest(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient/PublicDataApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient/PublicDataApiClient.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
-using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Options;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -28,7 +27,7 @@ public class PublicDataApiClient(
     IWebHostEnvironment environment)
     : IPublicDataApiClient
 {
-    public async Task<Either<ActionResult, HttpResponseMessage>> GetDataSetVersionChanges(
+    public async Task<Either<ActionResult, DataSetVersionChangesViewModelDto>> GetDataSetVersionChanges(
         Guid dataSetId,
         string dataSetVersion,
         CancellationToken cancellationToken = default)
@@ -39,7 +38,7 @@ public class PublicDataApiClient(
                 cancellationToken
             ),
             cancellationToken
-        );
+        ).OnSuccess(async response => (await response.Content.ReadFromJsonAsync<DataSetVersionChangesViewModelDto>())!);
     }
 
     private async Task<Either<ActionResult, HttpResponseMessage>> SendRequest(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient/PublicDataApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient/PublicDataApiClient.cs
@@ -18,7 +18,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data.PublicDataApiClient;
 
 public class PublicDataApiClient(
     ILogger<PublicDataApiClient> logger,
@@ -27,7 +27,7 @@ public class PublicDataApiClient(
     IWebHostEnvironment environment)
     : IPublicDataApiClient
 {
-    public async Task<Either<ActionResult, DataSetVersionChangesViewModelDto>> GetDataSetVersionChanges(
+    public async Task<Either<ActionResult, DataSetVersionChangesViewModelDto?>> GetDataSetVersionChanges(
         Guid dataSetId,
         string dataSetVersion,
         CancellationToken cancellationToken = default)
@@ -38,7 +38,7 @@ public class PublicDataApiClient(
                 cancellationToken
             ),
             cancellationToken
-        ).OnSuccess(async response => (await response.Content.ReadFromJsonAsync<DataSetVersionChangesViewModelDto>())!);
+        ).OnSuccess(async response => (await response.Content.ReadFromJsonAsync<DataSetVersionChangesViewModelDto>()));
     }
 
     private async Task<Either<ActionResult, HttpResponseMessage>> SendRequest(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -80,7 +80,6 @@ using Notify.Interfaces;
 using Semver;
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Thinktecture;
@@ -127,6 +126,7 @@ using SameSiteMode = Microsoft.AspNetCore.Http.SameSiteMode;
 using ThemeService = GovUk.Education.ExploreEducationStatistics.Admin.Services.ThemeService;
 using IReleaseService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseService;
 using ReleaseService = GovUk.Education.ExploreEducationStatistics.Admin.Services.ReleaseService;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data.PublicDataApiClient;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin
 {
@@ -903,7 +903,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             return Task.FromResult(new Either<ActionResult, Unit>(Unit.Instance));
         }
 
-        public Task<Either<ActionResult, HttpResponseMessage>> GetVersionChanges(
+        public Task<Either<ActionResult, DataSetVersionChangesViewModel>> GetVersionChanges(
             Guid dataSetVersionId,
             CancellationToken cancellationToken = default)
             => throw new NotImplementedException();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
@@ -1,10 +1,13 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 
@@ -84,4 +87,162 @@ public record MappingStatusViewModel
     public required bool LocationsComplete { get; init; }
     
     public required bool FiltersComplete { get; init; }
+}
+
+public record DataSetVersionChangesViewModel
+{
+    public required IdTitleViewModel DataSet { get; init; }
+
+    public required DataSetVersionViewModel2 DataSetVersion { get; init; }
+
+    public required DataSetVersionChangesViewModel2 Changes { get; init; }
+}
+
+public record DataSetVersionViewModel2
+{
+    public required Guid Id { get; init; }
+
+    public required string Version { get; init; }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public required DataSetVersionStatus Status { get; init; }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public required DataSetVersionType Type { get; init; }
+
+    public required string Notes { get; init; }
+}
+
+public record DataSetVersionChangesViewModel2
+{
+    public required ChangeSetViewModel MajorChanges { get; init; }
+
+    public required ChangeSetViewModel MinorChanges { get; init; }
+}
+
+public record ChangeSetViewModel
+{
+    public IReadOnlyList<FilterChangeViewModel>? Filters { get; init; }
+
+    public IReadOnlyList<FilterOptionChangesViewModel>? FilterOptions { get; init; }
+
+    public IReadOnlyList<GeographicLevelChangeViewModel>? GeographicLevels { get; init; }
+
+    public IReadOnlyList<IndicatorChangeViewModel>? Indicators { get; init; }
+
+    public IReadOnlyList<LocationGroupChangeViewModel>? LocationGroups { get; init; }
+
+    public IReadOnlyList<LocationOptionChangesViewModel>? LocationOptions { get; init; }
+
+    public IReadOnlyList<TimePeriodOptionChangeViewModel>? TimePeriods { get; init; }
+}
+
+public record FilterOptionChangesViewModel
+{
+    public required FilterViewModel Filter { get; init; }
+
+    public required IReadOnlyList<FilterOptionChangeViewModel> Options { get; init; }
+}
+
+public record LocationOptionChangesViewModel
+{
+    public required GeographicLevelViewModel Level { get; init; }
+
+    public required IReadOnlyList<LocationOptionChangeViewModel> Options { get; init; }
+}
+
+public abstract record ChangeViewModel<TChange>
+{
+    public TChange? CurrentState { get; init; }
+
+    public TChange? PreviousState { get; init; }
+}
+
+public record FilterChangeViewModel : ChangeViewModel<FilterViewModel>;
+
+public record FilterOptionChangeViewModel : ChangeViewModel<FilterOptionViewModel>;
+
+public record GeographicLevelChangeViewModel : ChangeViewModel<GeographicLevelViewModel>;
+
+public record IndicatorChangeViewModel : ChangeViewModel<IndicatorViewModel>;
+
+public record LocationGroupChangeViewModel : ChangeViewModel<LocationGroupViewModel>;
+
+public record LocationOptionChangeViewModel : ChangeViewModel<LocationOptionViewModel>;
+
+public record TimePeriodOptionChangeViewModel : ChangeViewModel<TimePeriodOptionViewModel>;
+
+public record FilterViewModel
+{
+    public required string Id { get; init; }
+
+    public required string Column { get; init; }
+
+    public required string Label { get; init; }
+
+    public string Hint { get; init; } = string.Empty;
+}
+
+public record FilterOptionViewModel
+{
+    public required string Id { get; init; }
+
+    public required string Label { get; init; }
+}
+
+public record GeographicLevelViewModel
+{
+    [JsonConverter(typeof(EnumToEnumValueJsonConverter<GeographicLevel>))]
+    public required GeographicLevel Code { get; init; }
+
+    public required string Label { get; init; }
+}
+
+public record IndicatorViewModel
+{
+    public required string Id { get; init; }
+
+    public required string Column { get; init; }
+
+    public required string Label { get; init; }
+
+    [JsonConverter(typeof(EnumToEnumLabelJsonConverter<IndicatorUnit>))]
+    public required IndicatorUnit? Unit { get; init; }
+
+    public int? DecimalPlaces { get; init; }
+}
+
+public record LocationGroupViewModel
+{
+    public required GeographicLevelViewModel Level { get; init; }
+}
+
+public abstract record LocationOptionViewModel
+{
+    public required string Id { get; init; }
+
+    public required string Label { get; init; }
+
+    public string? Code { get; init; }
+
+    public string? OldCode { get; init; }
+
+    public string? Ukprn { get; init; }
+
+    public string? Urn { get; init; }
+
+    public string? LaEstab { get; init; }
+}
+
+public record TimePeriodOptionViewModel : TimePeriodViewModel
+{
+    public required string Label { get; init; }
+}
+
+public record TimePeriodViewModel
+{
+    [JsonConverter(typeof(EnumToEnumValueJsonConverter<TimeIdentifier>))]
+    public required TimeIdentifier Code { get; init; }
+
+    public required string Period { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
@@ -95,7 +95,7 @@ public record DataSetVersionChangesViewModel
 
     public required DataSetVersionViewModel2 DataSetVersion { get; init; }
 
-    public required DataSetVersionChangesViewModel2 Changes { get; init; }
+    public DataSetVersionChangesViewModel2? Changes { get; init; }
 }
 
 public record DataSetVersionViewModel2
@@ -207,7 +207,7 @@ public record IndicatorViewModel
     public required string Label { get; init; }
 
     [JsonConverter(typeof(EnumToEnumLabelJsonConverter<IndicatorUnit>))]
-    public required IndicatorUnit? Unit { get; init; }
+    public IndicatorUnit? Unit { get; init; }
 
     public int? DecimalPlaces { get; init; }
 }
@@ -217,7 +217,7 @@ public record LocationGroupViewModel
     public required GeographicLevelViewModel Level { get; init; }
 }
 
-public abstract record LocationOptionViewModel
+public record LocationOptionViewModel
 {
     public required string Id { get; init; }
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetChangelogPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetChangelogPage.tsx
@@ -7,7 +7,6 @@ import {
   ReleaseDataSetChangelogRouteParams,
   ReleaseDataSetRouteParams,
 } from '@admin/routes/releaseRoutes';
-import apiDataSetQueries from '@admin/queries/apiDataSetQueries';
 import apiDataSetVersionQueries from '@admin/queries/apiDataSetVersionQueries';
 import apiDataSetVersionService from '@admin/services/apiDataSetVersionService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -20,34 +19,40 @@ import { useQuery } from '@tanstack/react-query';
 import { generatePath, useParams } from 'react-router-dom';
 import React, { useEffect } from 'react';
 import WarningMessage from '@common/components/WarningMessage';
+import {
+  DataSetDraftVersionStatus,
+  DataSetDraftVersionStatuses,
+  DataSetVersionStatus,
+} from '@admin/services/apiDataSetService';
+
+const dataSetVersionIsDraft = (
+  dataSetVersionStatus: DataSetVersionStatus,
+): dataSetVersionStatus is DataSetDraftVersionStatus =>
+  DataSetDraftVersionStatuses.includes(
+    dataSetVersionStatus as DataSetDraftVersionStatus,
+  );
 
 export default function ReleaseApiDataSetChangelogPage() {
   const { dataSetId, dataSetVersionId, releaseVersionId, publicationId } =
     useParams<ReleaseDataSetChangelogRouteParams>();
 
   const {
-    data: dataSet,
-    isLoading: isLoadingDataSet,
-    refetch: refetchDataSet,
-  } = useQuery(apiDataSetQueries.get(dataSetId));
+    data: dataSetVersionChanges,
+    isLoading: isLoadingChanges,
+    refetch: refetchChanges,
+  } = useQuery(apiDataSetVersionQueries.getChanges(dataSetVersionId));
 
-  const { data: changes, isLoading: isLoadingChanges } = useQuery(
-    apiDataSetVersionQueries.getChanges(dataSetVersionId),
-  );
-
-  const isDraft = dataSet?.draftVersion?.id === dataSetVersionId;
+  const isDraft = dataSetVersionChanges
+    ? dataSetVersionIsDraft(dataSetVersionChanges.dataSetVersion.status)
+    : false;
 
   const [showForm, toggleShowForm] = useToggle(false);
 
-  const dataSetVersion = isDraft
-    ? dataSet?.draftVersion
-    : dataSet?.latestLiveVersion;
-
   useEffect(() => {
-    if (isDraft && !dataSetVersion?.notes) {
+    if (isDraft && !dataSetVersionChanges?.dataSetVersion.notes) {
       toggleShowForm.on();
     }
-  }, [dataSetVersion?.notes, isDraft, toggleShowForm]);
+  }, [dataSetVersionChanges?.dataSetVersion.notes, isDraft, toggleShowForm]);
 
   const handleUpdateNotes = async ({
     notes,
@@ -55,7 +60,7 @@ export default function ReleaseApiDataSetChangelogPage() {
     await apiDataSetVersionService.updateNotes(dataSetVersionId, {
       notes,
     });
-    refetchDataSet();
+    refetchChanges();
     toggleShowForm.off();
   };
 
@@ -76,34 +81,38 @@ export default function ReleaseApiDataSetChangelogPage() {
         Back to API data set details
       </Link>
 
-      <LoadingSpinner loading={isLoadingDataSet || isLoadingChanges}>
-        {dataSet && dataSetVersion ? (
+      <LoadingSpinner loading={isLoadingChanges}>
+        {dataSetVersionChanges ? (
           <>
             <div className="govuk-grid-row">
               <div className="govuk-grid-column-three-quarters">
                 <span className="govuk-caption-l">API data set changelog</span>
-                <h2>{dataSet.title}</h2>
+                <h2>{dataSetVersionChanges.dataSet.title}</h2>
               </div>
             </div>
             <TagGroup className="govuk-!-margin-bottom-7">
               <Tag colour={isDraft ? 'green' : 'blue'}>{`${
                 isDraft ? 'Draft' : 'Published'
-              } v${dataSetVersion.version}`}</Tag>
+              } v${dataSetVersionChanges.dataSetVersion.version}`}</Tag>
               <Tag
-                colour={dataSetVersion?.type === 'Major' ? 'blue' : 'grey'}
-              >{`${dataSetVersion.type} update`}</Tag>
+                colour={
+                  dataSetVersionChanges.dataSetVersion.type === 'Major'
+                    ? 'blue'
+                    : 'grey'
+                }
+              >{`${dataSetVersionChanges.dataSetVersion.type} update`}</Tag>
             </TagGroup>
 
             {isDraft && showForm ? (
               <ApiDataSetGuidanceNotesForm
-                notes={dataSetVersion.notes}
+                notes={dataSetVersionChanges.dataSetVersion.notes}
                 onSubmit={handleUpdateNotes}
               />
             ) : (
               <>
                 <h3>Public guidance notes</h3>
                 <p>
-                  {dataSetVersion?.notes ||
+                  {dataSetVersionChanges.dataSetVersion.notes ||
                     'No notes have been added for this API data set.'}
                 </p>
                 {isDraft && (
@@ -114,11 +123,13 @@ export default function ReleaseApiDataSetChangelogPage() {
               </>
             )}
 
-            {changes ? (
+            {dataSetVersionChanges.changes ? (
               <ApiDataSetChangelog
-                majorChanges={changes.majorChanges}
-                minorChanges={changes.minorChanges}
-                version={dataSetVersion?.version ?? 'unknown'}
+                majorChanges={dataSetVersionChanges.changes.majorChanges}
+                minorChanges={dataSetVersionChanges.changes.minorChanges}
+                version={
+                  dataSetVersionChanges.dataSetVersion.version ?? 'unknown'
+                }
               />
             ) : (
               <WarningMessage>Could not load changelog</WarningMessage>

--- a/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
@@ -81,12 +81,16 @@ export interface TimePeriodRange {
 
 export type DataSetStatus = 'Draft' | 'Published' | 'Deprecated' | 'Withdrawn';
 
+export const DataSetDraftVersionStatuses = [
+  'Processing',
+  'Failed',
+  'Mapping',
+  'Draft',
+  'Cancelled',
+] as const;
+
 export type DataSetDraftVersionStatus =
-  | 'Processing'
-  | 'Failed'
-  | 'Mapping'
-  | 'Draft'
-  | 'Cancelled';
+  (typeof DataSetDraftVersionStatuses)[number];
 
 export type DataSetLiveVersionStatus = 'Published' | 'Deprecated' | 'Withdrawn';
 

--- a/src/explore-education-statistics-admin/src/services/apiDataSetVersionService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetVersionService.ts
@@ -4,10 +4,10 @@ import {
   ApiDataSetLiveVersionSummary,
   ApiDataSetVersion,
 } from '@admin/services/apiDataSetService';
-import { ApiDataSetVersionChanges } from '@common/services/types/apiDataSetChanges';
 import { PaginatedList } from '@common/services/types/pagination';
 import { Dictionary } from '@common/types';
 import { LocationLevelKey } from '@common/utils/locationLevelsMap';
+import { ApiDataSetVersionChanges } from './types/apiDataSetChanges';
 
 export type MappingType =
   | 'ManualMapped'

--- a/src/explore-education-statistics-admin/src/services/types/apiDataSetChanges.ts
+++ b/src/explore-education-statistics-admin/src/services/types/apiDataSetChanges.ts
@@ -7,8 +7,24 @@ import {
   LocationOption,
   TimePeriodOption,
 } from '@common/services/types/apiDataSetMeta';
+import { IdTitlePair } from './common';
+import { DataSetVersionStatus, DataSetVersionType } from '../apiDataSetService';
 
 export interface ApiDataSetVersionChanges {
+  dataSet: IdTitlePair;
+  dataSetVersion: DataSetVersionViewModel2;
+  changes: ApiDataSetVersionChanges2;
+}
+
+export interface DataSetVersionViewModel2 {
+  id: string;
+  version: string;
+  status: DataSetVersionStatus;
+  type: DataSetVersionType;
+  notes: string;
+}
+
+export interface ApiDataSetVersionChanges2 {
   majorChanges: ChangeSet;
   minorChanges: ChangeSet;
 }

--- a/src/explore-education-statistics-common/src/services/types/apiDataSetChanges.ts
+++ b/src/explore-education-statistics-common/src/services/types/apiDataSetChanges.ts
@@ -7,24 +7,8 @@ import {
   LocationOption,
   TimePeriodOption,
 } from '@common/services/types/apiDataSetMeta';
-import { IdTitlePair } from './common';
-import { DataSetVersionStatus, DataSetVersionType } from '../apiDataSetService';
 
 export interface ApiDataSetVersionChanges {
-  dataSet: IdTitlePair;
-  dataSetVersion: DataSetVersionViewModel2;
-  changes?: ApiDataSetVersionChanges2;
-}
-
-export interface DataSetVersionViewModel2 {
-  id: string;
-  version: string;
-  status: DataSetVersionStatus;
-  type: DataSetVersionType;
-  notes: string;
-}
-
-export interface ApiDataSetVersionChanges2 {
   majorChanges: ChangeSet;
   minorChanges: ChangeSet;
 }


### PR DESCRIPTION
Previously, when an admin visited the Public API version history page for a particular API data set, and clicked to view the changelog for versions `1.1` and above, they were sometimes displayed with the incorrect version number and version 'type' (`Major`/`Minor`).

This was because the frontend had [some logic](https://github.com/dfe-analytical-services/explore-education-statistics/pull/5700/files#:~:text=const%20dataSetVersion%20%3D,%3F.latestLiveVersion%3B) which only ever showed the version number and type for either the **latest live** version of the data set, or the current **draft** version, depending on whether or not the version you selected is the **draft** one or not. It didn't display the details for the version you have specifically requested (**caveat** - it DID do this sometimes, but only by coincidence).

For example, previously, the changelog page for the following versions showed:
- `2.0` -> Displayed `2.0` `Major` -> CORRECT (Coincidentally)
- `1.2` -> Displayed `2.0` `Major` -> INCORRECT
- `1.1` -> Displayed `2.0` `Major` -> INCORRECT
- `1.0` -> Can't access the changelog page for the first version


## Implementation

Previously, the changelog page component in the FE was retrieving the data it needs from multiple endpoints. Namely, the following endpoints in the Admin API:
- `/public-data/data-sets/{dataSetId}`
- `/public-data/data-set-versions/{dataSetVersionId}/changes`  

It was also missing some data it needs specific to the Data Set Version we're interested in.

One solution, to provide the missing information, would have been to add yet another endpoint to the BE that this component can call - one that is used to `GET` details specific to a Data Set Version. The FE component would then retrieve the data it needs from 3 different endpoints.

The alternative solution, and the one we have went with, is to refactor the `/public-data/data-set-versions/{dataSetVersionId}/changes` endpoint to retrieve **ALL** of the data that this component needs; therefore removing the need for the component to call multiple endpoints and to stitch them together.

The endpoint now returns details of:
- The Data Set
- The requested Data Set Version
- And the changelog for the Data Set Version

### Other changes

One thing to note, is that we have refactored the `PublicDataApiClient` in the BE to deserialize the Changes object it receives from the Public API into a DTO. This has a few advantages:
- We no longer have to stream the data from the Public API to the FE via the Admin API
  - And we can do this **without** pulling in the project reference to the Public API's view-models (this is similar to how you would consume other public API's, such as Google's)
- Promotes loose coupling
- We only need to expose the **required** data (which, in this case, is coincidentally all of it)

We then map this DTO onto a corresponding view-model before returning the data to the FE.

It does, however, potentially introduce the risk of deserializing and mapping the data incorrectly; and therefore losing information. So we need to make sure that we test this thoroughly.
