### PR TITLE
EES-5967 Public API data set details page - Fixing bug where empty guidance notes appears as a `0`

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileApiChangelog.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileApiChangelog.tsx
@@ -26,7 +26,7 @@ export default function DataSetFileApiChangelog({
       heading={pageSections.apiChangelog}
       id="apiChangelog"
     >
-      {guidanceNotes.length && (
+      {guidanceNotes.length > 0 && (
         <p data-testid="public-guidance-notes">{guidanceNotes}</p>
       )}
       <ApiDataSetChangelog


### PR DESCRIPTION
When no Public API dataset version 'Public guidance notes' exist, users of the public frontend will see a ‘0' in the place where guidance notes would usually appear on the API dataset details page 'API data set changelog' section.

This PR fixes this.