### PR TITLE
Implement reindexer function

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/EventGridEventBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/EventGridEventBuilder.cs
@@ -1,0 +1,23 @@
+using Azure.Messaging.EventGrid;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+
+public class EventGridEventBuilder
+{
+    private object _payload = new();
+    
+    public EventGridEvent Build()
+    {
+        return new EventGridEvent(
+            "Event Subject",
+            "Event Type",
+            "1.1",
+            _payload);
+    }
+
+    public EventGridEventBuilder WithPayload(object payload)
+    {
+        _payload = payload;
+        return this;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/FunctionContextBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/FunctionContextBuilder.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Immutable;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+
+public class FunctionContextBuilder
+{
+    private string _functionName = "Mock Function Name";
+
+    public class MockFunctionContext(FunctionDefinition functionDefinition) : FunctionContext
+    {
+        public override string InvocationId { get; } = string.Empty;
+        public override string FunctionId { get; } = string.Empty;
+        public override TraceContext TraceContext { get; } = null!;
+        public override BindingContext BindingContext { get; } = null!;
+        public override RetryContext RetryContext { get; } = null!;
+        public override IServiceProvider InstanceServices { get; set; } = null!;
+        public override FunctionDefinition FunctionDefinition => functionDefinition; 
+        public override IDictionary<object, object> Items { get; set; } = null!;
+        public override IInvocationFeatures Features { get; } = null!;
+    }
+
+    public class MockFunctionDefinition(string name) : FunctionDefinition
+    {
+        public override ImmutableArray<FunctionParameter> Parameters { get; } = ImmutableArray<FunctionParameter>.Empty;
+        public override string PathToAssembly { get; } = string.Empty;
+        public override string EntryPoint { get; } = string.Empty;
+        public override string Id { get; } = string.Empty;
+        public override string Name => name;
+        public override IImmutableDictionary<string, BindingMetadata> InputBindings { get; } = ImmutableDictionary<string, BindingMetadata>.Empty;
+        public override IImmutableDictionary<string, BindingMetadata> OutputBindings { get; } = ImmutableDictionary<string, BindingMetadata>.Empty;
+    }
+
+    public FunctionContext Build() => 
+        new MockFunctionContext(
+            new MockFunctionDefinition(
+                name: _functionName));
+
+    public FunctionContextBuilder ForFunctionName(string functionName)
+    {
+        _functionName = functionName;
+        return this;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/HeathCheckStrategyBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/HeathCheckStrategyBuilder.cs
@@ -7,7 +7,7 @@ public class HealthCheckStrategyBuilder
 {
     private readonly Mock<IHealthCheckStrategy> _mock = new(MockBehavior.Strict);
     private bool _healthCheckIsSuccessful = true;
-    private string? _healthCheckMessage = string.Empty;
+    private string _healthCheckMessage = string.Empty;
     
     public IHealthCheckStrategy Build()
     {
@@ -21,21 +21,21 @@ public class HealthCheckStrategyBuilder
     public HealthCheckStrategyBuilder WhereResultIsHealthy(string? message = null)
     {
         _healthCheckIsSuccessful = true;
-        _healthCheckMessage = message;
+        _healthCheckMessage = message ?? "Everything is OK";
         return this;
     }
 
     public HealthCheckStrategyBuilder WhereIsHealthyResultIs(bool isHealthy, string? message = null)
     {
         _healthCheckIsSuccessful = isHealthy;
-        _healthCheckMessage = message;
+        _healthCheckMessage = message ?? "Everything is OK";
         return this;
     }
 
     public HealthCheckStrategyBuilder WhereResultIsUnhealthy(string? message = null)
     {
         _healthCheckIsSuccessful = false;
-        _healthCheckMessage = message;
+        _healthCheckMessage = message ?? "Boo. It didn't work.";
         return this;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/LoggerBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/LoggerBuilder.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+
+/// <summary>
+/// Use this builder to construct an implementation of <summary cref="ILogger{T}" /> where
+/// the log statements are recorded and can be asserted.
+/// </summary>
+public class LoggerBuilder<T>
+{
+    private MockLogger? _logger;
+    
+    /// <summary>
+    /// Build the <summary cref="ILogger{T}" /> instance. Pass in the instance of <summary cref="ITestOutputHelper" /> injected into the xunit test class. 
+    /// </summary>
+    public ILogger<T> Build() => _logger = new MockLogger();
+
+    private class MockLogger() : ILogger<T>
+    {
+        public List<LogItem> LogItems { get; } = new();
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => throw new NotImplementedException();
+
+        public bool IsEnabled(LogLevel logLevel) => throw new NotImplementedException();
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            LogItems.Add(new LogItem(logLevel, formatter(state, exception)));
+        }
+    }
+    
+    public record LogItem(LogLevel LogLevel, string Message);
+
+    public Asserter Assert => new(_logger?.LogItems ?? throw new InvalidOperationException("Do not attempt to assert on this builder before it has been built"));
+    public class Asserter(List<LogItem> logItems)
+    {
+        public void LoggedErrorContains(string errorMessage)
+        {
+            var errors = logItems.Where(l => l.LogLevel == LogLevel.Error);
+            var errorsWithMessage = errors.Where(l => l.Message.Contains(errorMessage));
+            Xunit.Assert.NotEmpty(errorsWithMessage);
+        }
+        
+        public void LoggedInfoContains(string message)
+        {
+            var infos = logItems.Where(l => l.LogLevel == LogLevel.Information);
+            var infosWithMessage = infos.Where(l => l.Message.Contains(message));
+            Xunit.Assert.NotEmpty(infosWithMessage);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Clients/AzureSearch/SearchIndexClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Clients/AzureSearch/SearchIndexClientTests.cs
@@ -1,0 +1,77 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
+using SearchIndexClient = GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch.SearchIndexClient;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Clients.AzureSearch;
+
+public class SearchIndexClientTests
+{
+    private AzureSearchOptions AzureSearchOptions => new()
+    {
+        SearchServiceEndpoint = _searchServiceEndpoint,
+        SearchServiceAccessKey = _searchServiceAccessKey,
+        IndexName = _indexName
+    };
+
+
+    private string _searchServiceEndpoint = "https://example.search.windows.net/";
+    private string? _searchServiceAccessKey = "my-access-key";
+    private string _indexName = "my-index-name";
+
+    private ISearchIndexClient GetSut()
+    {
+        return new SearchIndexClient(
+            new AzureSearchIndexerClientFactory(
+                Microsoft.Extensions.Options.Options.Create(AzureSearchOptions)),
+            Microsoft.Extensions.Options.Options.Create(AzureSearchOptions));
+    }
+
+    public class BasicTests : SearchIndexClientTests
+    {
+        [Fact]
+        public void Can_Instantiate_SUT() => Assert.NotNull(GetSut());
+    }
+
+    public class IntegrationTests : SearchIndexClientTests
+    {
+        public IntegrationTests()
+        {
+            var searchServiceName = "-- insert search service name here --";
+            _searchServiceAccessKey = "-- insert search service access key here --";
+            _indexName = "-- insert search index name here --";
+
+            _searchServiceEndpoint = $"https://{searchServiceName}.search.windows.net/";
+        }
+        
+        [Fact(Skip = "Integration test is disabled")]
+        public async Task Trigger_reindex()
+        {
+            // ARRANGE
+            var sut = GetSut();
+
+            // ACT
+            await sut.RunIndexer();
+        }
+        
+        [Fact(Skip = "Integration test is disabled")]
+        public async Task Can_ping_indexer()
+        {
+            // ARRANGE
+            var sut = GetSut();
+
+            // ACT
+            Assert.True(await sut.IndexerExists());
+        }
+        
+        [Fact(Skip = "Integration test is disabled")]
+        public async Task Can_not_ping_unknown_indexer()
+        {
+            // ARRANGE
+            _indexName = "not-a-real-indexer";
+            var sut = GetSut();
+
+            // ACT
+            Assert.False(await sut.IndexerExists());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/HealthChecks/HealthCheckFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/HealthChecks/HealthCheckFunctionTests.cs
@@ -75,7 +75,7 @@ public class HealthCheckFunctionTests
         [
             new HealthCheckStrategyBuilder().WhereResultIsHealthy("Result one").Build(),
             new HealthCheckStrategyBuilder().WhereResultIsUnhealthy("Result two").Build(),
-            new HealthCheckStrategyBuilder().WhereResultIsHealthy(null).Build()
+            new HealthCheckStrategyBuilder().WhereResultIsHealthy("Result three").Build()
         ];
         var sut = GetSut(strategies);
         
@@ -90,7 +90,7 @@ public class HealthCheckFunctionTests
         {
             new HealthCheckResult(true, "Result one"),
             new HealthCheckResult(false, "Result two"),
-            new HealthCheckResult(true, null)
+            new HealthCheckResult(true, "Result three")
         };
         Assert.Equal(expectedResults, healthCheckResult.Results);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.csproj
@@ -14,11 +14,17 @@
   </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="Moq" Version="4.20.70" />
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
@@ -4,7 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clie
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CreateSearchableReleaseDocuments;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.ReindexSearchDocuments;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.ReindexSearchableDocuments;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Extensions;
@@ -200,16 +200,16 @@ public class ProgramTests
             }
         }
         
-        public class ReindexSearchDocumentsFunctionTests : ProgramTests
+        public class ReindexSearchableDocumentsFunctionTests : ProgramTests
         {
             [Fact]
-            public void Should_resolve_ReindexSearchDocumentsFunction()
+            public void Should_resolve_ReindexSearchableDocumentsFunction()
             {
                 // ARRANGE
                 var sut = GetSut();
             
                 // ACT
-                var actual = ActivatorUtilities.CreateInstance<ReindexSearchDocumentsFunction>(sut.Services);
+                var actual = ActivatorUtilities.CreateInstance<ReindexSearchableDocumentsFunction>(sut.Services);
             
                 // ASSERT
                 Assert.NotNull(actual);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
@@ -3,6 +3,8 @@ using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clie
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CreateSearchableReleaseDocuments;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.ReindexSearchDocuments;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Extensions;
@@ -195,6 +197,38 @@ public class ProgramTests
                 // ASSERT
                 var options = host.Services.GetRequiredService<IOptions<AppOptions>>();
                 Assert.NotNull(options);
+            }
+        }
+        
+        public class ReindexSearchDocumentsFunctionTests : ProgramTests
+        {
+            [Fact]
+            public void Should_resolve_ReindexSearchDocumentsFunction()
+            {
+                // ARRANGE
+                var sut = GetSut();
+            
+                // ACT
+                var actual = ActivatorUtilities.CreateInstance<ReindexSearchDocumentsFunction>(sut.Services);
+            
+                // ASSERT
+                Assert.NotNull(actual);
+            }
+        }
+        
+        public class CreateSearchableReleaseDocumentInAzureStorageFunctionTests : ProgramTests
+        {
+            [Fact]
+            public void Should_resolve_CreateSearchableReleaseDocumentInAzureStorageFunction()
+            {
+                // ARRANGE
+                var sut = GetSut();
+            
+                // ACT
+                var actual = ActivatorUtilities.CreateInstance<CreateSearchableReleaseDocumentInAzureStorageFunction>(sut.Services);
+            
+                // ASSERT
+                Assert.NotNull(actual);
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
@@ -214,6 +214,35 @@ public class ProgramTests
                 // ASSERT
                 Assert.NotNull(actual);
             }
+            
+            [Fact]
+            public void GivenNotConfigured_WhenResolvingReindexSearchableDocumentsFunction_ThenShouldResolve()
+            {
+                // ARRANGE
+                var sut = GetSutWithConfig("{}");
+            
+                // ACT
+                var actual = sut.Services.GetRequiredService<IOptions<ReindexSearchableDocumentsFunction>>();
+                
+                // ASSERT
+                Assert.NotNull(actual);
+            }
+            
+            [Fact]
+            public void GivenNotConfigured_WhenResolvingAzureSearchOptions_ThenShouldResolve()
+            {
+                // ARRANGE
+                var sut = GetSutWithConfig("{}");
+            
+                // ACT
+                var options = sut.Services.GetRequiredService<IOptions<AzureSearchOptions>>();
+                
+                // ASSERT
+                Assert.NotNull(options.Value);
+                Assert.Equal(string.Empty, options.Value.SearchServiceEndpoint);
+                Assert.Null(options.Value.SearchServiceAccessKey);
+                Assert.Equal(string.Empty, options.Value.IndexName);
+            }
         }
         
         public class CreateSearchableReleaseDocumentInAzureStorageFunctionTests : ProgramTests

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/EventGridEventHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/EventGridEventHandlerTests.cs
@@ -1,0 +1,163 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Services;
+
+public class EventGridEventHandlerTests
+{
+    private readonly FunctionContextBuilder _functionContextBuilder = new();
+    private readonly EventGridEventBuilder _eventGridEventBuilder = new();
+    private readonly LoggerBuilder<EventGridEventHandler> _loggerBuilder = new();
+
+    private EventGridEventHandler GetSut() => new(_loggerBuilder.Build());
+    
+    [Fact]
+    public void Can_instantiate_SUT() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task GivenEvent_WhenHasPayload_ThenHandlerIsCalledWithPayload()
+    {
+        // ARRANGE
+        var expectedPayload = new MockPayloadClass { Messaage = "This is the payload" };
+        _eventGridEventBuilder.WithPayload(expectedPayload);
+        var sut = GetSut();
+
+        MockPayloadClass? actualPayload = null;
+        
+        Task<MockResponse> Handler(MockPayloadClass payload, CancellationToken cancellationToken = default)
+        {
+            actualPayload = payload;
+            return Task.FromResult(new MockResponse());            
+        }
+        
+        // ACT
+        await sut.Handle<MockPayloadClass, MockResponse>(_functionContextBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
+        
+        // ASSERT
+        Assert.NotNull(actualPayload);
+        Assert.Equal(expectedPayload.Messaage, actualPayload.Messaage);
+    }
+    
+    [Fact]
+    public async Task GivenEvent_WhenHasRecordPayload_ThenHandlerIsCalledWithPayload()
+    {
+        // ARRANGE
+        var expectedPayload = new MockPayloadRecord { Messaage = "This is the payload" };
+        _eventGridEventBuilder.WithPayload(expectedPayload);
+        var sut = GetSut();
+
+        MockPayloadRecord? actualPayload = null;
+        
+        Task<MockResponse> Handler(MockPayloadRecord payload, CancellationToken cancellationToken = default)
+        {
+            actualPayload = payload;
+            return Task.FromResult(new MockResponse());            
+        }
+        
+        // ACT
+        await sut.Handle<MockPayloadRecord, MockResponse>(_functionContextBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
+        
+        // ASSERT
+        Assert.Equal(expectedPayload, actualPayload);
+    }
+    
+    [Fact]
+    public async Task GivenEvent_WhenEventHandled_ThenHandlerLogs()
+    {
+        // ARRANGE
+        _functionContextBuilder.ForFunctionName("FUNCTION_NAME_123");
+        var sut = GetSut();
+
+        Task<MockResponse> Handler(MockPayloadRecord payload, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new MockResponse());            
+        }
+        
+        // ACT
+        await sut.Handle<MockPayloadRecord, MockResponse>(_functionContextBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
+        
+        // ASSERT
+        _loggerBuilder.Assert.LoggedInfoContains("FUNCTION_NAME_123");
+    }
+
+    [Fact]
+    public async Task GivenEvent_WhenHasNoPayload_ThenHandlerIsCalledWithDefaultPayload()
+    {
+        // ARRANGE
+        _eventGridEventBuilder.WithPayload(new object());
+        var sut = GetSut();
+
+        MockPayloadClass? actualPayload = null;
+        
+        Task<MockResponse> Handler(MockPayloadClass payload, CancellationToken cancellationToken = default)
+        {
+            actualPayload = payload;
+            return Task.FromResult(new MockResponse());            
+        }
+        
+        // ACT
+        await sut.Handle<MockPayloadClass, MockResponse>(_functionContextBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
+        
+        // ASSERT
+        Assert.NotNull(actualPayload);
+        Assert.Null(actualPayload.Messaage);
+    }
+    
+    [Fact]
+    public async Task GivenEvent_WhenHasNoRecordPayload_ThenHandlerIsCalledWithDefaultPayload()
+    {
+        // ARRANGE
+        _eventGridEventBuilder.WithPayload(new object());
+        var sut = GetSut();
+
+        MockPayloadRecord? actualPayload = null;
+        
+        Task<MockResponse> Handler(MockPayloadRecord payload, CancellationToken cancellationToken = default)
+        {
+            actualPayload = payload;
+            return Task.FromResult(new MockResponse());            
+        }
+        
+        // ACT
+        await sut.Handle<MockPayloadRecord, MockResponse>(_functionContextBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
+        
+        // ASSERT
+        var expectedPayload = new MockPayloadRecord();
+        Assert.Equal(expectedPayload, actualPayload);
+    }
+    
+    
+    [Fact]
+    public async Task GivenHandlerCalled_WhenHandlerReturnsResponse_ThenSUTReturnsResponse()
+    {
+        // ARRANGE
+        var sut = GetSut();
+
+        var expectedResponse = new MockResponse();
+        
+        Task<MockResponse> Handler(MockPayloadClass payload, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(expectedResponse);
+        }
+        
+        // ACT
+        var actualReponse = await sut.Handle<MockPayloadClass, MockResponse>(_functionContextBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
+
+        // ASSERT
+        Assert.NotNull(actualReponse);
+        Assert.Equal(expectedResponse, actualReponse);
+    }
+
+    public class MockPayloadClass
+    {
+        public string? Messaage { get; init; }
+    }
+    
+    public record MockPayloadRecord
+    {
+        public string? Messaage { get; init; }
+    }
+
+    public record MockResponse { }
+}
+

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/AzureSearchIndexerClientFactory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/AzureSearchIndexerClientFactory.cs
@@ -1,0 +1,24 @@
+﻿using Azure;
+using Azure.Identity;
+using Azure.Search.Documents.Indexes;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
+using Microsoft.Extensions.Options;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
+
+/// <summary>
+/// Factory creates the appropriate instance of SearchIndexerClient
+/// (depending on whether an access key has been configured)
+/// and wraps it in a AzureSearchIndexerClientWrapper
+/// </summary>
+public class AzureSearchIndexerClientFactory(IOptions<AzureSearchOptions> options) : IAzureSearchIndexerClientFactory
+{
+    private readonly string _searchServiceEndpoint = options.Value.SearchServiceEndpoint;
+    private readonly string? _accessKey = options.Value.SearchServiceAccessKey;
+
+    public IAzureSearchIndexerClient Create() =>
+        new AzureSearchIndexerClientWrapper(
+            string.IsNullOrEmpty(_accessKey)
+                ? new SearchIndexerClient(new Uri(_searchServiceEndpoint), new DefaultAzureCredential())
+                : new SearchIndexerClient(new Uri(_searchServiceEndpoint), new AzureKeyCredential(_accessKey)));
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/AzureSearchIndexerClientWrapper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/AzureSearchIndexerClientWrapper.cs
@@ -1,0 +1,24 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
+
+/// <summary>
+/// A thin wrapper around Azure's SearchIndexerClient to allow it to be mocked
+/// </summary>
+/// <param name="azureSearchIndexerClient">A real SearchIndexerClient instance</param>
+public class AzureSearchIndexerClientWrapper(Azure.Search.Documents.Indexes.SearchIndexerClient azureSearchIndexerClient) : IAzureSearchIndexerClient
+{
+    public async Task ResetIndexerAsync(string indexName, CancellationToken cancellationToken) => await azureSearchIndexerClient.ResetIndexerAsync(indexName, cancellationToken);
+
+    public async Task RunIndexerAsync(string indexName, CancellationToken cancellationToken) => await azureSearchIndexerClient.RunIndexerAsync(indexName, cancellationToken);
+    public async Task<bool> IndexerExists(string indexName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await azureSearchIndexerClient.GetIndexerAsync(indexName, cancellationToken);
+            return response.HasValue;
+        }
+        catch (Azure.RequestFailedException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/AzureSearchIndexerClientWrapper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/AzureSearchIndexerClientWrapper.cs
@@ -4,11 +4,15 @@
 /// A thin wrapper around Azure's SearchIndexerClient to allow it to be mocked
 /// </summary>
 /// <param name="azureSearchIndexerClient">A real SearchIndexerClient instance</param>
-public class AzureSearchIndexerClientWrapper(Azure.Search.Documents.Indexes.SearchIndexerClient azureSearchIndexerClient) : IAzureSearchIndexerClient
+public class AzureSearchIndexerClientWrapper(
+    Azure.Search.Documents.Indexes.SearchIndexerClient azureSearchIndexerClient) 
+    : IAzureSearchIndexerClient
 {
-    public async Task ResetIndexerAsync(string indexName, CancellationToken cancellationToken) => await azureSearchIndexerClient.ResetIndexerAsync(indexName, cancellationToken);
+    public async Task ResetIndexerAsync(string indexName, CancellationToken cancellationToken) =>
+        await azureSearchIndexerClient.ResetIndexerAsync(indexName, cancellationToken);
 
-    public async Task RunIndexerAsync(string indexName, CancellationToken cancellationToken) => await azureSearchIndexerClient.RunIndexerAsync(indexName, cancellationToken);
+    public async Task RunIndexerAsync(string indexName, CancellationToken cancellationToken) => 
+        await azureSearchIndexerClient.RunIndexerAsync(indexName, cancellationToken);
     
     public async Task<bool> IndexerExists(string indexName, CancellationToken cancellationToken)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/AzureSearchIndexerClientWrapper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/AzureSearchIndexerClientWrapper.cs
@@ -9,6 +9,7 @@ public class AzureSearchIndexerClientWrapper(Azure.Search.Documents.Indexes.Sear
     public async Task ResetIndexerAsync(string indexName, CancellationToken cancellationToken) => await azureSearchIndexerClient.ResetIndexerAsync(indexName, cancellationToken);
 
     public async Task RunIndexerAsync(string indexName, CancellationToken cancellationToken) => await azureSearchIndexerClient.RunIndexerAsync(indexName, cancellationToken);
+    
     public async Task<bool> IndexerExists(string indexName, CancellationToken cancellationToken)
     {
         try

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/IAzureSearchIndexerClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/IAzureSearchIndexerClient.cs
@@ -1,0 +1,11 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
+
+/// <summary>
+/// Interface around Microsoft's Azure SearchIndexerClient
+/// </summary>
+public interface IAzureSearchIndexerClient
+{
+    Task ResetIndexerAsync(string indexName, CancellationToken cancellationToken);
+    Task RunIndexerAsync(string indexName, CancellationToken cancellationToken);
+    Task<bool> IndexerExists(string indexName, CancellationToken cancellationToken);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/IAzureSearchIndexerClientFactory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/IAzureSearchIndexerClientFactory.cs
@@ -1,0 +1,6 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
+
+public interface IAzureSearchIndexerClientFactory
+{
+    IAzureSearchIndexerClient Create();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/ISearchIndexClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/ISearchIndexClient.cs
@@ -1,0 +1,8 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
+
+public interface ISearchIndexClient
+{
+    Task RunIndexer(CancellationToken cancellationToken = default);
+    Task ResetIndexer(CancellationToken cancellationToken = default);
+    Task<bool> IndexerExists(CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/SearchIndexClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/SearchIndexClient.cs
@@ -1,0 +1,33 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
+using Microsoft.Extensions.Options;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
+
+/// <summary>
+/// Client for calling the configured Azure Search Indexer
+/// </summary>
+public class SearchIndexClient(
+    IAzureSearchIndexerClientFactory azureSearchIndexerClientFactory,
+    IOptions<AzureSearchOptions> searchOptions)
+    : ISearchIndexClient
+{
+    private readonly string _indexName = searchOptions.Value.IndexName;
+
+    public async Task RunIndexer(CancellationToken cancellationToken = default)
+    {
+        var client = azureSearchIndexerClientFactory.Create();
+        await client.RunIndexerAsync(_indexName, cancellationToken);
+    }
+
+    public async Task ResetIndexer(CancellationToken cancellationToken = default)
+    {
+        var client = azureSearchIndexerClientFactory.Create();
+        await client.ResetIndexerAsync(_indexName, cancellationToken);
+    }
+    
+    public async Task<bool> IndexerExists(CancellationToken cancellationToken = default)
+    {
+        var client = azureSearchIndexerClientFactory.Create();
+        return await client.IndexerExists(_indexName, cancellationToken);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
@@ -1,7 +1,9 @@
 ﻿using Azure.Identity;
 using Azure.Storage.Blobs;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CreateSearchableReleaseDocuments;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using Microsoft.Azure.Functions.Worker;
@@ -32,8 +34,10 @@ public static class HostBuilderExtension
                 services
                     .AddApplicationInsightsTelemetryWorkerService()
                     .ConfigureFunctionsApplicationInsights()
+                    .AddTransient<EventGridEventHandler>()
                     .Configure<AppOptions>(context.Configuration.GetSection(AppOptions.Section))
                     .Configure<ContentApiOptions>(context.Configuration.GetSection(ContentApiOptions.Section))
+                    .Configure<AzureSearchOptions>(context.Configuration.GetSection(AzureSearchOptions.Section))
                     .Configure<LoggerFilterOptions>(options =>
                     {
                         // The Application Insights SDK adds a default logging filter that instructs ILogger to capture
@@ -52,6 +56,8 @@ public static class HostBuilderExtension
                     .AddTransient<IContentApiClient, ContentApiClient>()
                     .AddTransient<IAzureBlobStorageClient, AzureBlobStorageClient>()
                     .AddTransient<ISearchableDocumentCreator, SearchableDocumentCreator>()
+                    .AddTransient<ISearchIndexClient, SearchIndexClient>()
+                    .AddTransient<IAzureSearchIndexerClientFactory, AzureSearchIndexerClientFactory>()
                     .AddHealthChecks()
                     .AddAzureClientsInline(
                         clientBuilder =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ObjectExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ObjectExtensions.cs
@@ -1,0 +1,8 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
+
+public static class ObjectExtensions
+{
+    public static bool IsDefault<T>([NotNullWhen(false)] this T obj) => EqualityComparer<T>.Default.Equals(obj, default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ObjectExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ObjectExtensions.cs
@@ -1,8 +1,0 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
-
-public static class ObjectExtensions
-{
-    public static bool IsDefault<T>([NotNullWhen(false)] this T obj) => EqualityComparer<T>.Default.Equals(obj, default);
-}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ public static class ServiceCollectionExtensions
         serviceCollection
             .AddTransient<IHealthCheckStrategy, ContentApiHealthCheckStrategy>()
             .AddTransient<IHealthCheckStrategy, AzureBlobStorageHealthCheckStrategy>()
-            .AddTransient<IHealthCheckStrategy, AzureSearchHealthCheckStrategy>()
+            // .AddTransient<IHealthCheckStrategy, AzureSearchHealthCheckStrategy>() // TODO: Comment this back in once the infrastructure and config for Azure Search are added. 
             // Factories to allow Healthcheck to evaluate config before attempting to instantiate clients
             .AddTransient<Func<IContentApiClient>>(sp => sp.GetRequiredService<IContentApiClient>) 
             .AddTransient<Func<IAzureBlobStorageClient>>(sp => sp.GetRequiredService<IAzureBlobStorageClient>)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks.Strategies;
 using Microsoft.Extensions.Azure;
@@ -20,7 +21,10 @@ public static class ServiceCollectionExtensions
         serviceCollection
             .AddTransient<IHealthCheckStrategy, ContentApiHealthCheckStrategy>()
             .AddTransient<IHealthCheckStrategy, AzureBlobStorageHealthCheckStrategy>()
+            .AddTransient<IHealthCheckStrategy, AzureSearchHealthCheckStrategy>()
             // Factories to allow Healthcheck to evaluate config before attempting to instantiate clients
             .AddTransient<Func<IContentApiClient>>(sp => sp.GetRequiredService<IContentApiClient>) 
-            .AddTransient<Func<IAzureBlobStorageClient>>(sp => sp.GetRequiredService<IAzureBlobStorageClient>);
+            .AddTransient<Func<IAzureBlobStorageClient>>(sp => sp.GetRequiredService<IAzureBlobStorageClient>)
+            .AddTransient<Func<ISearchIndexClient>>(sp => sp.GetRequiredService<ISearchIndexClient>)
+        ;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/CreateSearchableReleaseDocumentInAzureStorageFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/CreateSearchableReleaseDocumentInAzureStorageFunction.cs
@@ -11,18 +11,18 @@ public class CreateSearchableReleaseDocumentInAzureStorageFunction(
 {
     [Function("CreateSearchableReleaseDocument")]
     [QueueOutput("%SearchableDocumentCreatedQueueName%")]
-    public async Task<SearchDocumentCreatedMessageDto> CreateSearchableReleaseDocumentInAzureStorage(
+    public async Task<SearchableDocumentCreatedMessageDto> CreateSearchableReleaseDocumentInAzureStorage(
         [QueueTrigger("%ReleaseVersionPublishedQueueName%")]
         EventGridEvent eventDto,
         FunctionContext context) =>
-        await eventGridEventHandler.Handle<ReleaseVersionPublishedEventDto, SearchDocumentCreatedMessageDto>(
+        await eventGridEventHandler.Handle<ReleaseVersionPublishedEventDto, SearchableDocumentCreatedMessageDto>(
             context, 
             eventDto,
             async (payload, ct) =>
             {
                 var request = new CreatePublicationLatestReleaseSearchableDocumentRequest{ PublicationSlug = payload.PublicationSlug };
                 var response = await searchableDocumentCreator.CreatePublicationLatestReleaseSearchableDocument(request, ct);
-                return new SearchDocumentCreatedMessageDto
+                return new SearchableDocumentCreatedMessageDto
                 {
                     PublicationId = payload.PublicationId,
                     PublicationSlug = response.PublicationSlug,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/CreateSearchableReleaseDocumentInAzureStorageFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/CreateSearchableReleaseDocumentInAzureStorageFunction.cs
@@ -30,7 +30,7 @@ public class CreateSearchableReleaseDocumentInAzureStorageFunction(
                     ReleaseSlug = payload.ReleaseSlug,
                     ReleaseVersionId = response.ReleaseVersionId,
                     BlobName = response.BlobName,
-                    PublicationLatestReleaseVersionId = payload.PublicationLatestReleaseVersionId
+                    PublicationLatestPublishedReleaseVersionId = payload.PublicationLatestPublishedReleaseVersionId
                 };
             });
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/CreateSearchableReleaseDocumentInAzureStorageFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/CreateSearchableReleaseDocumentInAzureStorageFunction.cs
@@ -1,34 +1,36 @@
+using Azure.Messaging.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CreateSearchableReleaseDocuments.Dtos;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CreateSearchableReleaseDocuments;
 
 public class CreateSearchableReleaseDocumentInAzureStorageFunction(
-    ILogger<CreateSearchableReleaseDocumentInAzureStorageFunction> logger,
+    EventGridEventHandler eventGridEventHandler,
     ISearchableDocumentCreator searchableDocumentCreator)
 {
     [Function("CreateSearchableReleaseDocument")]
     [QueueOutput("%SearchableDocumentCreatedQueueName%")]
-    public async Task<SearchDocumentCreatedMessage> CreateSearchableReleaseDocumentInAzureStorage(
+    public async Task<SearchDocumentCreatedMessageDto> CreateSearchableReleaseDocumentInAzureStorage(
         [QueueTrigger("%ReleaseVersionPublishedQueueName%")]
-        ReleasePublishedMessage message,
-        FunctionContext context,
-        CancellationToken cancellationToken)
-    {
-        logger.LogInformation("{FunctionName} triggered: {Request}", context.FunctionDefinition.Name, message);
-
-        var request = new CreatePublicationLatestReleaseSearchableDocumentRequest{ PublicationSlug = message.PublicationSlug };
-        var response = await searchableDocumentCreator.CreatePublicationLatestReleaseSearchableDocument(request, cancellationToken);
-        var searchDocumentCreatedMessage = new SearchDocumentCreatedMessage
-        {
-            PublicationSlug = response.PublicationSlug,
-            BlobName = response.BlobName,
-            ReleaseVersionId = response.ReleaseVersionId
-        };
-
-        logger.LogInformation("{FunctionName} completed. {Response}", context.FunctionDefinition.Name, searchDocumentCreatedMessage);
-        return searchDocumentCreatedMessage;
-    }
+        EventGridEvent eventDto,
+        FunctionContext context) =>
+        await eventGridEventHandler.Handle<ReleaseVersionPublishedEventDto, SearchDocumentCreatedMessageDto>(
+            context, 
+            eventDto,
+            async (payload, ct) =>
+            {
+                var request = new CreatePublicationLatestReleaseSearchableDocumentRequest{ PublicationSlug = payload.PublicationSlug };
+                var response = await searchableDocumentCreator.CreatePublicationLatestReleaseSearchableDocument(request, ct);
+                return new SearchDocumentCreatedMessageDto
+                {
+                    PublicationId = payload.PublicationId,
+                    PublicationSlug = response.PublicationSlug,
+                    ReleaseId = payload.ReleaseId,
+                    ReleaseSlug = payload.ReleaseSlug,
+                    ReleaseVersionId = response.ReleaseVersionId,
+                    BlobName = response.BlobName,
+                    PublicationLatestReleaseVersionId = payload.PublicationLatestReleaseVersionId
+                };
+            });
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/ReleasePublishedMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/ReleasePublishedMessage.cs
@@ -1,3 +1,0 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CreateSearchableReleaseDocuments.Dtos;
-
-public record ReleasePublishedMessage(string PublicationSlug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/ReleaseVersionPublishedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/ReleaseVersionPublishedEventDto.cs
@@ -1,0 +1,10 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CreateSearchableReleaseDocuments.Dtos;
+
+public record ReleaseVersionPublishedEventDto
+{
+    public required Guid ReleaseId {get;init;}
+    public required string ReleaseSlug { get; init; }
+    public required Guid PublicationId { get; init; }
+    public required string PublicationSlug { get; init; }
+    public required Guid PublicationLatestReleaseVersionId { get; init; }   
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/ReleaseVersionPublishedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/ReleaseVersionPublishedEventDto.cs
@@ -6,5 +6,5 @@ public record ReleaseVersionPublishedEventDto
     public required string ReleaseSlug { get; init; }
     public required Guid PublicationId { get; init; }
     public required string PublicationSlug { get; init; }
-    public required Guid PublicationLatestReleaseVersionId { get; init; }   
+    public required Guid PublicationLatestPublishedReleaseVersionId { get; init; }   
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/SearchDocumentCreatedMessageDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/SearchDocumentCreatedMessageDto.cs
@@ -1,8 +1,15 @@
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CreateSearchableReleaseDocuments.Dtos;
 
-public record SearchDocumentCreatedMessage
+public record SearchDocumentCreatedMessageDto
 {
+    public required Guid PublicationId { get; init; }
     public required string PublicationSlug { get; init; }
+
+    public required Guid ReleaseId {get;init;}
+    public required string ReleaseSlug { get; init; }
+    
     public required Guid ReleaseVersionId { get; init; }
     public required string BlobName { get; init; }
+    
+    public required Guid PublicationLatestReleaseVersionId { get; init; }  
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/SearchDocumentCreatedMessageDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/SearchDocumentCreatedMessageDto.cs
@@ -11,5 +11,5 @@ public record SearchDocumentCreatedMessageDto
     public required Guid ReleaseVersionId { get; init; }
     public required string BlobName { get; init; }
     
-    public required Guid PublicationLatestReleaseVersionId { get; init; }  
+    public required Guid PublicationLatestPublishedReleaseVersionId { get; init; }  
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/SearchableDocumentCreatedMessageDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CreateSearchableReleaseDocuments/Dtos/SearchableDocumentCreatedMessageDto.cs
@@ -1,6 +1,6 @@
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CreateSearchableReleaseDocuments.Dtos;
 
-public record SearchDocumentCreatedMessageDto
+public record SearchableDocumentCreatedMessageDto
 {
     public required Guid PublicationId { get; init; }
     public required string PublicationSlug { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureSearchHealthCheckStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureSearchHealthCheckStrategy.cs
@@ -1,0 +1,34 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
+using Microsoft.Extensions.Options;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks.Strategies;
+
+internal class AzureSearchHealthCheckStrategy(
+    Func<ISearchIndexClient> searchIndexClientFactory,
+    IOptions<AzureSearchOptions> azureSearchOptions) : IHealthCheckStrategy
+{
+    public async Task<HealthCheckResult> Run(CancellationToken cancellationToken)
+    {
+        if (!azureSearchOptions.Value.IsValid(out var errorMessage))
+        {
+            return new HealthCheckResult(false,  errorMessage);
+        }
+        
+        try
+        {
+            var client = searchIndexClientFactory();
+            if (!await client.IndexerExists(cancellationToken))
+            {
+                return new HealthCheckResult(false, $"Azure Search Indexer is not found");
+            }
+
+        }
+        catch (Exception e)
+        {
+            return new HealthCheckResult(false, $"Error occurred whilst trying to run healthcheck for Azure Search Indexer: {e.Message}");
+        }
+        
+        return new HealthCheckResult(true, "Connection to Azure Search Indexer:OK");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/ReindexSearchDocuments/ReindexSearchDocumentsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/ReindexSearchDocuments/ReindexSearchDocumentsFunction.cs
@@ -1,0 +1,24 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CreateSearchableReleaseDocuments.Dtos;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.ReindexSearchDocuments;
+
+public class ReindexSearchDocumentsFunction(
+    ILogger<ReindexSearchDocumentsFunction> logger,
+    ISearchIndexClient searchIndexClient)
+{
+    [Function("ReindexNewlyCreatedSearchableDocument")]
+    public async Task ReindexNewlyCreatedSearchableDocument(
+        [QueueTrigger("%SearchableDocumentCreatedQueueName%")]
+        SearchDocumentCreatedMessageDto messageDto,
+        FunctionContext context)
+    {
+        logger.LogInformation("{FunctionName} triggered: {@Request}", context.FunctionDefinition.Name, messageDto);
+
+        await searchIndexClient.RunIndexer(context.CancellationToken);
+        
+        logger.LogInformation("{FunctionName} completed.", context.FunctionDefinition.Name);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/ReindexSearchableDocuments/ReindexSearchableDocumentsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/ReindexSearchableDocuments/ReindexSearchableDocumentsFunction.cs
@@ -9,10 +9,10 @@ public class ReindexSearchableDocumentsFunction(
     ILogger<ReindexSearchableDocumentsFunction> logger,
     ISearchIndexClient searchIndexClient)
 {
-    [Function("ReindexNewlyCreatedSearchableDocument")]
-    public async Task ReindexNewlyCreatedSearchableDocument(
+    [Function("ReindexSearchableDocuments")]
+    public async Task ReindexSearchableDocuments(
         [QueueTrigger("%SearchableDocumentCreatedQueueName%")]
-        SearchDocumentCreatedMessageDto messageDto,
+        SearchableDocumentCreatedMessageDto messageDto,
         FunctionContext context)
     {
         logger.LogInformation("{FunctionName} triggered: {@Request}", context.FunctionDefinition.Name, messageDto);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/ReindexSearchableDocuments/ReindexSearchableDocumentsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/ReindexSearchableDocuments/ReindexSearchableDocumentsFunction.cs
@@ -3,10 +3,10 @@ using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Func
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.ReindexSearchDocuments;
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.ReindexSearchableDocuments;
 
-public class ReindexSearchDocumentsFunction(
-    ILogger<ReindexSearchDocumentsFunction> logger,
+public class ReindexSearchableDocumentsFunction(
+    ILogger<ReindexSearchableDocumentsFunction> logger,
     ISearchIndexClient searchIndexClient)
 {
     [Function("ReindexNewlyCreatedSearchableDocument")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
@@ -9,20 +9,22 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.30.0" />
+    <PackageReference Include="Azure.Search.Documents" Version="11.6.0" />
     <PackageReference Include="Generator.Equals" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.6.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.4.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
     
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
 
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
     
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Options/AzureSearchOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Options/AzureSearchOptions.cs
@@ -1,0 +1,35 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
+
+public class AzureSearchOptions
+{
+    public const string Section = "AzureSearch";
+    
+    /// <summary>
+    /// Url of the search service endpoint. Likely to be similar to:
+    /// https://{search_service}.search.windows.net
+    /// </summary>
+    public string SearchServiceEndpoint { get; init; } = string.Empty;
+    public string? SearchServiceAccessKey { get; init; }
+    
+    public string IndexName { get; init; } = string.Empty;
+    
+    public bool IsValid([NotNullWhen(false)] out string? errorMessage)
+    {
+        if (string.IsNullOrWhiteSpace(SearchServiceEndpoint))
+        {
+            errorMessage = $"Azure Search Endpoint is not configured. Ensure the {Section}:{nameof(SearchServiceEndpoint)} is set.";
+            return false;
+        }
+                
+        if (string.IsNullOrWhiteSpace(IndexName))
+        {
+            errorMessage = $"Azure Search Index Name is not configured. Ensure the {Section}:{nameof(IndexName)} is set.";
+            return false;
+        }
+        
+        errorMessage = null;
+        return true;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Options/AzureSearchOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Options/AzureSearchOptions.cs
@@ -11,6 +11,7 @@ public class AzureSearchOptions
     /// https://{search_service}.search.windows.net
     /// </summary>
     public string SearchServiceEndpoint { get; init; } = string.Empty;
+    
     public string? SearchServiceAccessKey { get; init; }
     
     public string IndexName { get; init; } = string.Empty;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/EventGridEventHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/EventGridEventHandler.cs
@@ -1,0 +1,29 @@
+﻿using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+
+public class EventGridEventHandler(ILogger<EventGridEventHandler> logger)
+{
+    public async Task<TResponse> Handle<TPayload, TResponse>(
+        FunctionContext context,
+        EventGridEvent eventGridEvent,
+        Func<TPayload, CancellationToken, Task<TResponse>> handler)
+    {
+        logger.LogInformation("{FunctionName} triggered: {Request}", context.FunctionDefinition.Name, eventGridEvent);
+        
+        var payload = eventGridEvent.Data.ToObjectFromJson<TPayload>();
+        if (payload.IsDefault())
+        {
+            throw new Exception(
+                $"Unable to deserialise the payload of event into type {typeof(TPayload).Name}");
+        }
+        
+        var response = await handler(payload, context.CancellationToken);
+
+        logger.LogInformation("{FunctionName} completed. {Response}", context.FunctionDefinition.Name, response);
+        return response;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/EventGridEventHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/EventGridEventHandler.cs
@@ -14,12 +14,9 @@ public class EventGridEventHandler(ILogger<EventGridEventHandler> logger)
     {
         logger.LogInformation("{FunctionName} triggered: {Request}", context.FunctionDefinition.Name, eventGridEvent);
         
-        var payload = eventGridEvent.Data.ToObjectFromJson<TPayload>();
-        if (payload.IsDefault())
-        {
-            throw new Exception(
-                $"Unable to deserialise the payload of event into type {typeof(TPayload).Name}");
-        }
+        var payload = eventGridEvent.Data.ToObjectFromJson<TPayload>() 
+                      ?? throw new Exception(
+                          $"Unable to deserialise the payload of event into type {typeof(TPayload).Name}");
         
         var response = await handler(payload, context.CancellationToken);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
@@ -12,5 +12,10 @@
   },
   "ContentApi": {
     "Url": "http://localhost:5010"
+  },
+  "AzureSearch": {
+    "SearchServiceEndpoint": "-- insert search service endpoint here e.g. https://xxxxx.search.windows.net/ --",
+    "SearchServiceAccessKey" : "-- insert search service access key here --",
+    "IndexName": "-- insert index name here --"
   }
 }


### PR DESCRIPTION
The publisher raises an event signalling that a new release version has been published.
This event is subscribed to and queues for processing by a Function App.
That function creates the searchable document in Azure and then places its own message into a new queue signalling that a new document has been created in Azure storage.
This work is to implement the next part of the process, which is to consume that message and trigger a reindex.

Note that I needed to correct the dto of the message arriving from the publisher since I forgot that it would of course be a payload wrapped in an event envelope.

I also added another healthcheck strategy which reports back on whether the indexer is configured and can be reached.