### PR TITLE
EES-5934 Fixing Admin Public API Data Set Changelog page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
@@ -33,6 +33,19 @@ public class DataSetVersionsController(IDataSetVersionService dataSetVersionServ
             .HandleFailuresOrOk();
     }
 
+    [HttpGet("{dataSetVersionId:guid}")]
+    [Produces("application/json")]
+    public async Task<ActionResult<DataSetVersionInfoViewModel>> GetDataSetVersion(
+        Guid dataSetVersionId,
+        CancellationToken cancellationToken)
+    {
+        return await dataSetVersionService
+            .GetDataSetVersion(
+                dataSetVersionId: dataSetVersionId,
+                cancellationToken: cancellationToken)
+            .HandleFailuresOrOk();
+    }
+
     [HttpPost]
     [Produces("application/json")]
     public async Task<ActionResult<DataSetVersionSummaryViewModel>> CreateNextVersion(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -2,11 +2,13 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Mappings;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using System;
 using System.Collections.Generic;
@@ -211,6 +213,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                         methodologyVersion.Notes.OrderByDescending(note => note.DisplayDate)));
 
             CreateMap<ReleaseVersion, ReleasePublicationStatusViewModel>();
+
+            CreateMap<DataSetVersion, DataSetVersionInfoViewModel>()
+                .ForMember(dest => dest.Version,
+                    m => m.MapFrom(dataSetVersion =>
+                        dataSetVersion.PublicVersion))
+                .ForMember(dest => dest.Type,
+                    m => m.MapFrom(dataSetVersion =>
+                        dataSetVersion.VersionType));
         }
 
         private void CreateContentBlockMap()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
@@ -23,13 +23,17 @@ public interface IDataSetVersionService
         int pageSize,
         CancellationToken cancellationToken = default);
 
-    Task<List<DataSetVersionStatusSummary>> GetStatusesForReleaseVersion(
-        Guid releaseVersionId,
+    Task<Either<ActionResult, DataSetVersionInfoViewModel>> GetDataSetVersion(
+        Guid dataSetVersionId,
         CancellationToken cancellationToken = default);
 
     Task<Either<ActionResult, DataSetVersion>> GetDataSetVersion(
         Guid dataSetId,
         SemVersion version,
+        CancellationToken cancellationToken = default);
+
+    Task<List<DataSetVersionStatusSummary>> GetStatusesForReleaseVersion(
+        Guid releaseVersionId,
         CancellationToken cancellationToken = default);
 
     Task<Either<ActionResult, Unit>> DeleteVersion(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -872,11 +872,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             return Task.FromResult(PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>.Paginate([], 1, 10));
         }
 
-        public Task<List<DataSetVersionStatusSummary>> GetStatusesForReleaseVersion(
-            Guid releaseVersionId,
+        public Task<Either<ActionResult, DataSetVersionInfoViewModel>> GetDataSetVersion(
+            Guid dataSetVersionIdId,
             CancellationToken cancellationToken = default)
         {
-            return Task.FromResult(new List<DataSetVersionStatusSummary>());
+            return Task.FromResult(new Either<ActionResult, DataSetVersionInfoViewModel>(new NotFoundResult()));
         }
 
         public Task<Either<ActionResult, DataSetVersion>> GetDataSetVersion(
@@ -885,6 +885,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new Either<ActionResult, DataSetVersion>(new NotFoundResult()));
+        }
+
+        public Task<List<DataSetVersionStatusSummary>> GetStatusesForReleaseVersion(
+            Guid releaseVersionId,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new List<DataSetVersionStatusSummary>());
         }
 
         public Task<Either<ActionResult, DataSetVersionSummaryViewModel>> CreateNextVersion(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Public.Data/DataSetVersionViewModels.cs
@@ -85,3 +85,18 @@ public record MappingStatusViewModel
     
     public required bool FiltersComplete { get; init; }
 }
+
+public record DataSetVersionInfoViewModel 
+{
+    public required Guid Id { get; init; }
+
+    public required string Version { get; init; }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public required DataSetVersionStatus Status { get; init; }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public required DataSetVersionType Type { get; init; }
+
+    public required string Notes { get; init; }
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetChangelogPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetChangelogPage.tsx
@@ -20,6 +20,10 @@ import { useQuery } from '@tanstack/react-query';
 import { generatePath, useParams } from 'react-router-dom';
 import React, { useEffect } from 'react';
 import WarningMessage from '@common/components/WarningMessage';
+import { DataSetVersionStatus } from '@admin/services/apiDataSetService';
+
+const dataSetVersionIsDraft = (dataSetVersionStatus: DataSetVersionStatus) =>
+  dataSetVersionStatus === 'Draft';
 
 export default function ReleaseApiDataSetChangelogPage() {
   const { dataSetId, dataSetVersionId, releaseVersionId, publicationId } =
@@ -31,17 +35,19 @@ export default function ReleaseApiDataSetChangelogPage() {
     refetch: refetchDataSet,
   } = useQuery(apiDataSetQueries.get(dataSetId));
 
+  const { data: dataSetVersion, isLoading: isLoadingDataSetVersion } = useQuery(
+    apiDataSetVersionQueries.getVersion(dataSetVersionId),
+  );
+
   const { data: changes, isLoading: isLoadingChanges } = useQuery(
     apiDataSetVersionQueries.getChanges(dataSetVersionId),
   );
 
-  const isDraft = dataSet?.draftVersion?.id === dataSetVersionId;
+  const isDraft = dataSetVersion
+    ? dataSetVersionIsDraft(dataSetVersion.status)
+    : false;
 
   const [showForm, toggleShowForm] = useToggle(false);
-
-  const dataSetVersion = isDraft
-    ? dataSet?.draftVersion
-    : dataSet?.latestLiveVersion;
 
   useEffect(() => {
     if (isDraft && !dataSetVersion?.notes) {
@@ -76,7 +82,11 @@ export default function ReleaseApiDataSetChangelogPage() {
         Back to API data set details
       </Link>
 
-      <LoadingSpinner loading={isLoadingDataSet || isLoadingChanges}>
+      <LoadingSpinner
+        loading={
+          isLoadingDataSet || isLoadingDataSetVersion || isLoadingChanges
+        }
+      >
         {dataSet && dataSetVersion ? (
           <>
             <div className="govuk-grid-row">

--- a/src/explore-education-statistics-admin/src/queries/apiDataSetVersionQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/apiDataSetVersionQueries.ts
@@ -10,6 +10,12 @@ const apiDataSetVersionQueries = createQueryKeys('apiDataSetVersionQueries', {
       queryFn: () => apiDataSetVersionService.listVersions(query),
     };
   },
+  getVersion(dataSetVersionId: string) {
+    return {
+      queryKey: [dataSetVersionId],
+      queryFn: () => apiDataSetVersionService.getVersion(dataSetVersionId),
+    };
+  },
   getFiltersMapping(dataSetVersionId: string) {
     return {
       queryKey: [dataSetVersionId],

--- a/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetService.ts
@@ -13,6 +13,14 @@ export interface ApiDataSetSummary {
   previousReleaseIds: string[];
 }
 
+export interface ApiDataSetVersionInfo {
+  id: string;
+  version: string;
+  status: DataSetVersionStatus;
+  type: DataSetVersionType;
+  notes: string;
+}
+
 export interface ApiDataSetVersionSummary {
   id: string;
   version: string;

--- a/src/explore-education-statistics-admin/src/services/apiDataSetVersionService.ts
+++ b/src/explore-education-statistics-admin/src/services/apiDataSetVersionService.ts
@@ -3,6 +3,7 @@ import {
   ApiDataSet,
   ApiDataSetLiveVersionSummary,
   ApiDataSetVersion,
+  ApiDataSetVersionInfo,
 } from '@admin/services/apiDataSetService';
 import { ApiDataSetVersionChanges } from '@common/services/types/apiDataSetChanges';
 import { PaginatedList } from '@common/services/types/pagination';
@@ -129,6 +130,9 @@ const apiDataSetVersionService = {
     return client.get(`/public-data/data-set-versions`, {
       params,
     });
+  },
+  getVersion(dataSetVersionId: string): Promise<ApiDataSetVersionInfo> {
+    return client.get(`/public-data/data-set-versions/${dataSetVersionId}`);
   },
   getFiltersMapping(dataSetVersionId: string): Promise<FiltersMapping> {
     return client.get(


### PR DESCRIPTION
Previously, when an admin visited the Public API version history page for a particular API data set, and clicked to view the changelog for versions `1.1` and above, they were sometimes displayed with the incorrect version number and version 'type' (`Major`/`Minor`).

This was because the frontend had [some logic](https://github.com/dfe-analytical-services/explore-education-statistics/pull/5700/files#:~:text=const%20dataSetVersion%20%3D,%3F.latestLiveVersion%3B) which only ever showed the version number and type for either the **latest live** version of the data set, or the current **draft** version, depending on whether or not the version you selected is the **draft** one or not. It didn't display the details for the version you have specifically requested (**caveat** - it DID do this sometimes, but only by coincidence).

For example, previously, the changelog page for the following versions showed:
- `2.0` -> Displayed `2.0` `Major` -> CORRECT (Coincidentally)
- `1.2` -> Displayed `2.0` `Major` -> INCORRECT
- `1.1` -> Displayed `2.0` `Major` -> INCORRECT
- `1.0` -> Can't access the changelog page for the first version


This PR makes the changes necessary for the page to retrieve the data it needs specific to the **requested** data set version. We have introduced a new Admin API `GET` endpoint for this, for the Data Set Version.