### PR TITLE
EES-5960 update publication modal focus close fix

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
@@ -13,7 +13,7 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import useToggle from '@common/hooks/useToggle';
 import Yup from '@common/validation/yup';
-import React, { useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { ObjectSchema } from 'yup';
 import PublicationUpdateConfirmModal from '@admin/pages/publication/components/PublicationUpdateConfirmModal';
 
@@ -48,6 +48,12 @@ export default function PublicationDetailsForm({
   const [showConfirmModal, toggleConfirmModal] = useToggle(false);
   const submitButtonRef = useRef<HTMLButtonElement>(null);
 
+  useEffect(() => {
+    if (showConfirmModal === false) {
+      submitButtonRef.current?.focus();
+    }
+  }, [showConfirmModal]);
+
   const { value, isLoading } = useAsyncHandledRetry(async () => {
     const themes = await themeService.getThemes();
     if (!canUpdatePublication) {
@@ -70,15 +76,6 @@ export default function PublicationDetailsForm({
       ...values,
     });
     onSubmit();
-  };
-
-  const cancelConfirmModal = () => {
-    toggleConfirmModal.off();
-    // This setTimeout is needed because the focus() fn needs to be called
-    // on the next tick. Without it, the button doesn't focus.
-    // I think the modal tries to handle the focus on close, which prevents
-    // our custom focus handling from working at that point.
-    setTimeout(() => submitButtonRef.current?.focus(), 0);
   };
 
   const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
@@ -183,8 +180,8 @@ export default function PublicationDetailsForm({
                   onConfirm={async () => {
                     await form.handleSubmit(handleSubmit)();
                   }}
-                  onExit={cancelConfirmModal}
-                  onCancel={cancelConfirmModal}
+                  onExit={toggleConfirmModal.off}
+                  onCancel={toggleConfirmModal.off}
                 />
               )}
             </>

--- a/src/explore-education-statistics-admin/src/queries/releaseDataFileQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/releaseDataFileQueries.ts
@@ -1,7 +1,5 @@
 import { createQueryKeys } from '@lukemorales/query-key-factory';
-import releaseDataFileService, {
-  DataFile,
-} from '@admin/services/releaseDataFileService';
+import releaseDataFileService from '@admin/services/releaseDataFileService';
 
 const releaseDataFileQueries = createQueryKeys('releaseDataFile', {
   list(releaseId: string) {


### PR DESCRIPTION
This PR fixes focus restoration when the 'edit publication' modal is closed in the admin site - returning focus to the modal trigger button.


Instead of refactoring to use 'triggerButton' like we do on other modals, we handle focus manually by focussing the button via a ref.

This is to keep the form validation/submit behaviour working as it currently does.