### PR TITLE
Add a 'wait' argument to 'waits until modal is visible' keyword

### DIFF
--- a/tests/robot-tests/tests/admin/bau/delete_subject.robot
+++ b/tests/robot-tests/tests/admin/bau/delete_subject.robot
@@ -157,7 +157,7 @@ Delete UI test subject
     user waits until data upload is completed    UI test subject
     user clicks button    Delete files
 
-    user waits until h2 is visible    Confirm deletion of selected data files    %{WAIT_SMALL}
+    user waits until modal is visible    Confirm deletion of selected data files    wait=%{WAIT_MEDIUM}
     user checks page contains    4 footnotes will be removed or updated.
     user checks page contains    The following data blocks will also be deleted:
     user checks page contains    UI test table name

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -831,10 +831,13 @@ user waits until modal is visible
     [Arguments]
     ...    ${modal_title}
     ...    ${modal_text}=${EMPTY}
+    ...    ${wait}=${timeout}
 
     user waits until parent contains element    css:[role="dialog"]    xpath://h2[.="${modal_title}"]
+    ...    timeout=${wait}
     IF    "${modal_text}" != "${EMPTY}"
         user waits until parent contains element    css:[role="dialog"]    xpath://*[.="${modal_text}"]
+        ...    timeout=${wait}
     END
     ${modal_element}=    get webelement    css:[role="dialog"]
     [Return]    ${modal_element}


### PR DESCRIPTION
This PR: 
- adds a 'wait' argument to 'waits until modal is visible' keyword
- increases the wait time for delete files modal UI test to fix the failing test