### PR TITLE
EES-5938 Add skip links to bypass map regions

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
@@ -82,7 +82,7 @@ const DataBlockPageReadOnlyTabs = ({ releaseVersionId, dataBlock }: Props) => {
                 >
                   {chart && (
                     <ChartRenderer
-                      id="dataBlockTabs-chart"
+                      id={`dataBlockTabs-chart-${dataBlock.id}`}
                       source={dataBlock.source}
                       chart={chart}
                     />

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
@@ -282,6 +282,13 @@ export default function MapBlock({
             },
           )}
         >
+          <a
+            id={`map-start-${id}`}
+            href={`#map-end-${id}`}
+            className="govuk-skip-link"
+          >
+            Skip to end of map
+          </a>
           <MapContainer
             style={{
               width: (width && `${width}px`) || '100%',
@@ -310,6 +317,13 @@ export default function MapBlock({
             hideText
             alert
           />
+          <a
+            id={`map-end-${id}`}
+            href={`#map-start-${id}`}
+            className="govuk-skip-link"
+          >
+            Back to start of map
+          </a>
         </div>
 
         {selectedDataSetConfig && (

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -82,7 +82,7 @@ const DataBlockTabs = ({
               <ErrorBoundary fallback={errorMessage}>
                 {chart && (
                   <ChartRenderer
-                    id="dataBlockTabs-chart"
+                    id={`dataBlockTabs-chart-${dataBlock.id}`}
                     source={dataBlock.source}
                     chart={chart}
                   />


### PR DESCRIPTION
This allows keyboard users to skip to/from the end of the map to/from the beginning, so they don't have to tab through all of the map regions to proceed down the page
