### PR TITLE
EES-5981 Update Renovate config to pin AspectInjector version

### DIFF
--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -28,6 +28,7 @@ trigger:
     exclude:
       - infrastructure/**
       - src/GovUk.Education.ExploreEducationStatistics.Content.Search*/**
+      - renovate.json
 
 pr:
   branches:
@@ -40,6 +41,7 @@ pr:
     exclude:
       - infrastructure/**
       - src/GovUk.Education.ExploreEducationStatistics.Content.Search*/**
+      - renovate.json
 
 jobs:
   - job: BackendVerify

--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,12 @@
       "schedule": ["every 3 months"]
     },
     {
+      "description": "Pin AspectInjector version to 2.8.1 for macOS compatibility",
+      "matchDatasources": ["nuget"],
+      "matchPackageNames": ["AspectInjector"],
+      "rangeStrategy": "pin"
+    },
+    {
       "matchDatasources": ["pypi"],
       "groupName": "Python dependencies",
       "enabled": false


### PR DESCRIPTION
This PR updates the Renovate config to pin AspectInjector version to 2.8.1 for macOS compatibility.

It also excludes the renovate.json from the DevOps build pipeline CI and PR triggers.