### PR TITLE
EES-5981 Update Renovate config to add more exclusions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,10 +48,22 @@
       "schedule": ["every 3 months"]
     },
     {
-      "description": "Pin AspectInjector version to 2.8.1 for macOS compatibility",
+      "description": "Exclude AspectInjector to pin it to version 2.8.1 for macOS compatibility",
       "matchDatasources": ["nuget"],
       "matchPackageNames": ["AspectInjector"],
-      "rangeStrategy": "pin"
+      "enabled": false
+    },
+    {
+      "description": "Exclude packages which need their major versions to be in sync with the .NET version or the EF Core version",
+      "matchDatasources": ["nuget"],
+      "matchPackagePrefixes": [
+        "Microsoft.AspNetCore",
+        "Microsoft.EntityFrameworkCore",
+        "Microsoft.Extensions",
+        "Thinktecture.EntityFrameworkCore"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     },
     {
       "matchDatasources": ["pypi"],


### PR DESCRIPTION
This PR changes the Renovate config to exclude packages which need their major versions to be in sync with the .NET version or the EF Core version.

It also attempts to fix the AspectInjector package exclude which was added by #5722.