### PR TITLE
EES-5981 Update Dotnet SDK version

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "8.0.7",
+      "version": "9.0.3",
       "commands": [
         "dotnet-ef"
       ],

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.402",
+    "version": "8.0.407",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
This PR updates the minimum Dotnet SDK version from 8.0.402 to 8.0.407.

It also updates to use the latest Entity Framework Core Tools (which should always be safe to update to the latest version because it is backwards compatible).