### PR TITLE
EES-7733 (DRAFT) Export table functionality

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -4,10 +4,11 @@ import isErrorLike from '@common/utils/error/isErrorLike';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 import { ReleaseTableDataQuery } from '@common/services/tableBuilderService';
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, RefObject } from 'react';
 import DataTableCaption from '@common/modules/table-tool/components/DataTableCaption';
 import FixedMultiHeaderDataTable from '@common/modules/table-tool/components/FixedMultiHeaderDataTable';
 import mapTableToJson from '@common/modules/table-tool/utils/mapTableToJson';
+import ExportTableButton from '@common/table/components/TableExportButton';
 
 interface Props {
   captionTitle?: string;
@@ -66,6 +67,18 @@ const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
               Some rows and columns are not shown in this table as the data does
               not exist in the underlying file.
             </WarningMessage>
+          )}
+          {/* query in props is defined at first render then undefined.
+              Can potentially use that for the CSV stuff. Also this doesn't
+              render when editing a draft release currently due to dataBlockId
+          */}
+          {dataBlockId && (
+            <ExportTableButton 
+              fileName={captionTitle} 
+              fullTable={fullTable} 
+              title={captionTitle} 
+              tableRef={dataTableRef as RefObject<HTMLElement>}
+            />
           )}
           <FixedMultiHeaderDataTable
             caption={

--- a/src/explore-education-statistics-common/src/table/components/ExportTableButton.module.scss
+++ b/src/explore-education-statistics-common/src/table/components/ExportTableButton.module.scss
@@ -1,0 +1,32 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.exportCloseButton {
+  margin-top: govuk-spacing(6);
+}
+
+.exportMenuList {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.exportMenu {
+  display: grid;
+  justify-content: start;
+  margin: 0;
+  padding: govuk-spacing(2);
+  padding-top: govuk-spacing(0);
+
+  :global(.govuk-details__text) {
+    background: govuk-colour('white');
+    border: 2px solid govuk-colour('black');
+    border-top: 0;
+    position: absolute;
+    z-index: 10;
+    padding-right: govuk-spacing(4);
+  }
+}
+
+.exportMenu button {
+  padding: govuk-spacing(1);
+}

--- a/src/explore-education-statistics-common/src/table/components/TableExportButton.tsx
+++ b/src/explore-education-statistics-common/src/table/components/TableExportButton.tsx
@@ -1,0 +1,82 @@
+import ButtonText from '@common/components/ButtonText';
+import Details from '@common/components/Details';
+import useToggle from '@common/hooks/useToggle';
+import React, { RefObject } from 'react';
+import { Footnote } from '@common/services/types/footnotes';
+import downloadTableOdsFile from '@common/modules/table-tool/components/utils/downloadTableOdsFile';
+import { FullTable } from '@common/modules/table-tool/types/fullTable';
+import styles from './ExportTableButton.module.scss';
+
+interface ExportTableButtonProps {
+    fileName?: string | undefined,
+    footnotes?: Footnote[];
+    fullTable?: FullTable,
+    tableRef: RefObject<HTMLElement>,
+    title?: string | undefined,
+}
+
+const ExportTableButton: React.FC<ExportTableButtonProps> = ({
+    fileName,
+    footnotes = [],
+    fullTable,
+    title,
+    tableRef,
+ }) => {
+    const [isOpen, toggleOpened] = useToggle(false);
+
+    const tableFootnotes = fullTable
+    ? fullTable.subjectMeta.footnotes
+    : footnotes;
+
+    const copyTableToClipboard = () => {
+        if (!tableRef.current) return;
+        
+        const clipboardItem = new ClipboardItem({
+          "text/plain": new Blob(
+            [tableRef.current.innerText],
+            { type: "text/plain" }
+          ),
+          "text/html": new Blob(
+            [tableRef.current.outerHTML],
+            { type: "text/html" }
+          ),
+        });
+    
+        navigator.clipboard.write([clipboardItem]);
+      }
+
+    const exportToOds = () => {
+        downloadTableOdsFile(fileName ?? "table", tableFootnotes, tableRef, title ?? "table")
+    };
+
+    return (
+        <Details
+            summary="Export options"
+            hiddenText="Export options for table"
+            open={isOpen}
+            onToggle={toggleOpened}
+            className={styles.exportMenu}
+        >
+        {isOpen && (
+            <ul
+                className={`${styles.exportMenuList} govuk-!-font-size-16`}
+                role="menu"
+            >
+                <li role="menuitem">
+                    <ButtonText onClick={exportToOds}>
+                        Download table as ODS
+                    </ButtonText>
+                </li>
+                <li role="menuitem">
+                    <ButtonText onClick={copyTableToClipboard}>
+                        Copy table to clipboard
+                    </ButtonText>
+                </li>
+                {/* need to add CSV functionality here but seems we need access to release table query */}
+            </ul>
+        )}
+    </Details>
+    );
+};
+
+export default ExportTableButton;


### PR DESCRIPTION
DRAFT

changes:
Added initial functionality to export table via data blocks (clipboarding and ODS)

Points:
- current CSV functionality requires a table query, looking at the investigation ticket for this it wasn't mentioned how we'd want to implement this unless I missed something.
- Is there a way to determine we are only rendering a table on a datablock? dataBlockId is undefined when editing a draft release
- Export table button is currently placed on the left hand side vs the right unlike the chart export, as the rearrange table button makes it look a bit weird on the right. open to suggestions.

![download table](https://github.com/user-attachments/assets/8712e85f-3719-4596-a9df-14fb18b3cbfb)

![table clipboard](https://github.com/user-attachments/assets/c3dbbe91-eaff-43ae-88e0-4627a13db784)

