### PR TITLE
Cleaning up unit tests

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/EventGrid/ConfiguredEventGridClientFactoryMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/EventGrid/ConfiguredEventGridClientFactoryMockBuilder.cs
@@ -4,7 +4,7 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services.EventGrid;
 
-public class ConfiguredEventGridClientFactoryBuilder
+public class ConfiguredEventGridClientFactoryMockBuilder
 {
     private readonly Mock<IConfiguredEventGridClientFactory> _mock = new(MockBehavior.Strict);
     private bool _topicConfigFound = true;
@@ -27,9 +27,9 @@ public class ConfiguredEventGridClientFactoryBuilder
         return _mock.Object;
     }
 
-    public EventGridClientBuilder Client { get; } = new();
+    public EventGridClientMockBuilder Client { get; } = new();
 
-    public ConfiguredEventGridClientFactoryBuilder WhereNoTopicConfigFound()
+    public ConfiguredEventGridClientFactoryMockBuilder WhereNoTopicConfigFound()
     {
         _topicConfigFound = false;
         return this;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/EventGrid/EventGridClientMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/EventGrid/EventGridClientMockBuilder.cs
@@ -8,7 +8,7 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services.EventGrid;
 
-public class EventGridClientBuilder
+public class EventGridClientMockBuilder
 {
     private readonly Mock<IEventGridClient> _mock = new(MockBehavior.Strict);
     private readonly List<EventGridEvent> _eventsPublished = new();
@@ -36,13 +36,13 @@ public class EventGridClientBuilder
         return _mock.Object;
     }
 
-    public EventGridClientBuilder WhereResponseIs(HttpStatusCode statusCode)
+    public EventGridClientMockBuilder WhereResponseIs(HttpStatusCode statusCode)
     {
         _httpStatusCode = statusCode;
         return this;
     }
 
-    public EventGridClientBuilder WhereSendEventAsyncThrows(Exception exception)
+    public EventGridClientMockBuilder WhereSendEventAsyncThrows(Exception exception)
     {
         _sendEventAsyncException = exception;
         return this;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Models/ReleaseVersionBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Models/ReleaseVersionBuilder.cs
@@ -3,17 +3,18 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Models;
 
-public class ReleaseVersionBuilder(Guid releaseVersionId)
+public class ReleaseVersionBuilder(Guid? releaseVersionId = null)
 {
     private readonly ReleaseBuilder _releaseBuilder = new();
     private Guid _publicationId; // remove this line when EES-5818 removes ReleaseVersion.PublicationId
+    private Release? _release;
 
     public ReleaseVersion Build()
     {
         var releaseVersion = new ReleaseVersion
         {
-            Id = releaseVersionId,
-            Release = _releaseBuilder.Build(),
+            Id = releaseVersionId ?? Guid.NewGuid(),
+            Release = _release ?? _releaseBuilder.Build(),
             PublicationId = _publicationId // remove this line when EES-5818 removes ReleaseVersion.PublicationId
         };
         return releaseVersion;
@@ -29,6 +30,13 @@ public class ReleaseVersionBuilder(Guid releaseVersionId)
     public ReleaseVersionBuilder ForRelease(Func<ReleaseBuilder, ReleaseBuilder> modifyRelease)
     {
         modifyRelease(_releaseBuilder);
+        return this;
+    }
+    
+    public ReleaseVersionBuilder ForRelease(Release release)
+    {
+        _release = release;
+        _publicationId = release.PublicationId;
         return this;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ContentDbContextMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ContentDbContextMockBuilder.cs
@@ -7,7 +7,7 @@ using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Services;
 
-public class ContentDbContextBuilder
+public class ContentDbContextMockBuilder
 {
     private readonly ContentDbContext _inMemoryContentDbContext = ContentDbUtils.InMemoryContentDbContext();
 
@@ -17,14 +17,14 @@ public class ContentDbContextBuilder
         return _inMemoryContentDbContext;
     }
 
-    public ContentDbContextBuilder With(ReleaseVersion releaseVersion)
+    public ContentDbContextMockBuilder With(ReleaseVersion releaseVersion)
     {
         _inMemoryContentDbContext.ReleaseVersions.Add(releaseVersion);
         _inMemoryContentDbContext.SaveChanges();
         return this;
     }
 
-    public ContentDbContextBuilder With(Publication publication)
+    public ContentDbContextMockBuilder With(Publication publication)
     {
         _inMemoryContentDbContext.Publications.Add(publication);
         _inMemoryContentDbContext.SaveChanges();

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ContentServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ContentServiceMockBuilder.cs
@@ -7,14 +7,14 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Services;
 
-public class ContentServiceBuilder
+public class ContentServiceMockBuilder
 {
     private readonly Mock<IContentService> _mock = new(MockBehavior.Strict);
     public Asserter Assert => new(_mock);
 
     public IContentService Build() => _mock.Object;
 
-    public ContentServiceBuilder()
+    public ContentServiceMockBuilder()
     {
         _mock
             .Setup(m => m.DeletePreviousVersionsDownloadFiles(It.IsAny<IReadOnlyList<Guid>>()))

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/DataSetPublishingServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/DataSetPublishingServiceMockBuilder.cs
@@ -6,12 +6,12 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Services;
 
-public class DataSetPublishingServiceBuilder
+public class DataSetPublishingServiceMockBuilder
 {
     private readonly Mock<IDataSetPublishingService> _mock = new(MockBehavior.Strict);
     public IDataSetPublishingService Build() => _mock.Object;
     public Asserter Assert => new(_mock);
-    public DataSetPublishingServiceBuilder()
+    public DataSetPublishingServiceMockBuilder()
     {
         _mock
             .Setup(m => m.PublishDataSets(It.IsAny<Guid[]>()))

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/EventRaiserServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/EventRaiserServiceMockBuilder.cs
@@ -8,12 +8,12 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Services;
 
-public class EventRaiserServiceBuilder
+public class EventRaiserServiceMockBuilder
 {
     private readonly Mock<IPublisherEventRaiserService> _mock = new(MockBehavior.Strict);
     public IPublisherEventRaiserService Build() => _mock.Object;
     public Asserter Assert => new(_mock);
-    public EventRaiserServiceBuilder()
+    public EventRaiserServiceMockBuilder()
     {
         _mock
             .Setup(m => m.RaiseReleaseVersionPublishedEvents(It.IsAny<IList<PublishingCompletionService.PublishedReleaseVersionInfo>>()))

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/MethodologyServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/MethodologyServiceMockBuilder.cs
@@ -6,14 +6,22 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Services;
 
-public class MethodologyServiceBuilder
+public class MethodologyServiceMockBuilder
 {
     private readonly Mock<IMethodologyService> _mock = new(MockBehavior.Strict);
     public Asserter Assert => new(_mock);
 
+    public MethodologyServiceMockBuilder()
+    {
+        // By default, no methodologies for any release version
+        _mock
+            .Setup(m => m.GetLatestVersionByRelease(It.IsAny<ReleaseVersion>()))
+            .ReturnsAsync([]);
+    }
+    
     public IMethodologyService Build() => _mock.Object;
 
-    public MethodologyServiceBuilder WhereGetLatestVersionByReleaseReturns(
+    public MethodologyServiceMockBuilder WhereGetLatestVersionByReleaseReturns(
         ReleaseVersion releaseVersion,
         params MethodologyVersion[] methodologyVersions)
     {
@@ -28,7 +36,7 @@ public class MethodologyServiceBuilder
         return this;
     }
     
-    public MethodologyServiceBuilder WhereGetLatestVersionByReleaseReturnsNoMethodologies(ReleaseVersion releaseVersion)
+    public MethodologyServiceMockBuilder WhereGetLatestVersionByReleaseReturnsNoMethodologies(ReleaseVersion releaseVersion)
     {
         _mock
             .Setup(m => m.GetLatestVersionByRelease(releaseVersion))
@@ -37,7 +45,7 @@ public class MethodologyServiceBuilder
         return this;
     }
 
-    public MethodologyServiceBuilder WhereIsBeingPublishedAlongsideRelease(MethodologyVersion methodologyVersion, ReleaseVersion releaseVersion)
+    public MethodologyServiceMockBuilder WhereIsBeingPublishedAlongsideRelease(MethodologyVersion methodologyVersion, ReleaseVersion releaseVersion)
     {
         _mock
             .Setup(m => m.IsBeingPublishedAlongsideRelease(methodologyVersion, releaseVersion))
@@ -45,7 +53,7 @@ public class MethodologyServiceBuilder
         
         return this;
     }
-    public MethodologyServiceBuilder WhereIsNotBeingPublishedAlongsideRelease(MethodologyVersion methodologyVersion, ReleaseVersion releaseVersion)
+    public MethodologyServiceMockBuilder WhereIsNotBeingPublishedAlongsideRelease(MethodologyVersion methodologyVersion, ReleaseVersion releaseVersion)
     {
         _mock
             .Setup(m => m.IsBeingPublishedAlongsideRelease(methodologyVersion, releaseVersion))

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/NotificationsServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/NotificationsServiceMockBuilder.cs
@@ -7,13 +7,13 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Services;
 
-public class NotificationsServiceBuilder
+public class NotificationsServiceMockBuilder
 {
     private readonly Mock<INotificationsService> _mock = new(MockBehavior.Strict);
     public INotificationsService Build() => _mock.Object;
     public Asserter Assert => new(_mock);
 
-    public NotificationsServiceBuilder()
+    public NotificationsServiceMockBuilder()
     {
         _mock
             .Setup(m => m.NotifySubscribersIfApplicable(It.IsAny<IReadOnlyList<Guid>>()))

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/PublicationCacheServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/PublicationCacheServiceMockBuilder.cs
@@ -6,14 +6,14 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Services;
 
-public class PublicationCacheServiceBuilder
+public class PublicationCacheServiceMockBuilder
 {
     private readonly Mock<IPublicationCacheService> _mock = new(MockBehavior.Strict);
     public Asserter Assert => new(_mock);
 
     public IPublicationCacheService Build() => _mock.Object;
 
-    public PublicationCacheServiceBuilder()
+    public PublicationCacheServiceMockBuilder()
     {
         _mock
             .Setup(m => m.UpdatePublication(It.IsAny<string>()))

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/RedirectsCacheServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/RedirectsCacheServiceMockBuilder.cs
@@ -6,14 +6,14 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Services;
 
-public class RedirectsCacheServiceBuilder
+public class RedirectsCacheServiceMockBuilder
 {
     private readonly Mock<IRedirectsCacheService> _mock = new(MockBehavior.Strict);
     public IRedirectsCacheService Build() => _mock.Object;
     
     public Asserter Assert => new(_mock);
 
-    public RedirectsCacheServiceBuilder()
+    public RedirectsCacheServiceMockBuilder()
     {
         _mock
             .Setup(m => m.UpdateRedirects())

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ReleasePublishingStatusServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ReleasePublishingStatusServiceMockBuilder.cs
@@ -5,14 +5,14 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Services;
 
-public class ReleasePublishingStatusServiceBuilder
+public class ReleasePublishingStatusServiceMockBuilder
 {
     private readonly Mock<IReleasePublishingStatusService> _mock = new(MockBehavior.Strict);
     public Asserter Assert => new(_mock);
 
     public IReleasePublishingStatusService Build() => _mock.Object;
 
-    public ReleasePublishingStatusServiceBuilder()
+    public ReleasePublishingStatusServiceMockBuilder()
     {
         _mock
             .Setup(
@@ -24,7 +24,7 @@ public class ReleasePublishingStatusServiceBuilder
 
     }
     
-    public ReleasePublishingStatusServiceBuilder WhereGetReturns(
+    public ReleasePublishingStatusServiceMockBuilder WhereGetReturns(
         ReleasePublishingKey releasePublishingKey,
         ReleasePublishingStatus releasePublishingStatus)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ReleaseServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ReleaseServiceMockBuilder.cs
@@ -7,30 +7,30 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Services;
 
-public class ReleaseServiceBuilder
+public class ReleaseServiceMockBuilder
 {
     private readonly Mock<IReleaseService> _mock = new(MockBehavior.Strict);
     public Asserter Assert => new(_mock);
 
     public IReleaseService Build() => _mock.Object;
 
-    public ReleaseServiceBuilder()
+    public ReleaseServiceMockBuilder()
     {
         _mock
             .Setup(m => m.CompletePublishing(It.IsAny<Guid>(), It.IsAny<DateTime>()))
             .Returns(Task.CompletedTask);
     }
 
-    public ReleaseServiceBuilder WhereGetReturns(Guid releaseVersionId, ReleaseVersion releaseVersion)
+    public ReleaseServiceMockBuilder WhereGetReturns(ReleaseVersion releaseVersion)
     {
         _mock
-            .Setup(m => m.Get(releaseVersionId))
+            .Setup(m => m.Get(releaseVersion.Id))
             .ReturnsAsync(releaseVersion);
         
         return this;
     }
 
-    public ReleaseServiceBuilder WherePublicationLatestPublishedReleaseVersionIs(
+    public ReleaseServiceMockBuilder WherePublicationLatestPublishedReleaseVersionIs(
         Guid publicationId,
         ReleaseVersion latestPublishedReleaseVersion)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserServiceTests.cs
@@ -21,10 +21,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services;
 
 public class PublisherEventRaiserServiceTests
 {
-    private readonly ConfiguredEventGridClientFactoryBuilder _eventGridClientBuilder = new();
+    private readonly ConfiguredEventGridClientFactoryMockBuilder _eventGridClient = new();
 
     private IPublisherEventRaiserService GetSut(IConfiguredEventGridClientFactory? eventGridClientFactory = null) => 
-        new PublisherEventRaiserService(eventGridClientFactory ?? _eventGridClientBuilder.Build());
+        new PublisherEventRaiserService(eventGridClientFactory ?? _eventGridClient.Build());
 
     public class BasicTests : PublisherEventRaiserServiceTests
     {
@@ -38,7 +38,7 @@ public class PublisherEventRaiserServiceTests
         public async Task GivenNotConfigured_WhenPublishedReleaseVersionInfoSpecified_ThenNoEventRaised()
         {
             // ARRANGE
-            _eventGridClientBuilder.WhereNoTopicConfigFound();
+            _eventGridClient.WhereNoTopicConfigFound();
             
             var sut = GetSut();
             var publishedReleaseVersionInfo = new PublishingCompletionService.PublishedReleaseVersionInfo();
@@ -47,7 +47,7 @@ public class PublisherEventRaiserServiceTests
             await sut.RaiseReleaseVersionPublishedEvents([publishedReleaseVersionInfo]);
 
             // ASSERT
-            _eventGridClientBuilder
+            _eventGridClient
                 .Client
                 .Assert.NoEventsWerePublished();
         }
@@ -71,7 +71,7 @@ public class PublisherEventRaiserServiceTests
             await sut.RaiseReleaseVersionPublishedEvents([info]);
 
             // ASSERT
-            var eventGridEvent = Assert.Single(_eventGridClientBuilder.Client.Assert.EventsPublished);
+            var eventGridEvent = Assert.Single(_eventGridClient.Client.Assert.EventsPublished);
             Assert.NotNull(eventGridEvent);
             Assert.Equal(info.ReleaseVersionId.ToString(), eventGridEvent.Subject);
             Assert.Equal(ReleaseVersionPublishedEventDto.EventType, eventGridEvent.EventType);
@@ -110,7 +110,7 @@ public class PublisherEventRaiserServiceTests
             await sut.RaiseReleaseVersionPublishedEvents(infos);
 
             // ASSERT
-            Assert.Equal(numberOfEvents, _eventGridClientBuilder.Client.Assert.EventsPublished.Count());
+            Assert.Equal(numberOfEvents, _eventGridClient.Client.Assert.EventsPublished.Count());
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
@@ -73,7 +73,7 @@ public class PublishingCompletionServiceTests
                     .WhereFilesStatusIs(ReleasePublishingStatusFilesStage.NotStarted)
                     .Build();
                 
-                var readyKeys = new List<ReleasePublishingKey>()
+                var notReadyKeys = new List<ReleasePublishingKey>()
                 {
                     releasePublishingKey1, 
                     releasePublishingKey2
@@ -86,7 +86,7 @@ public class PublishingCompletionServiceTests
                 var sut = GetSut();
 
                 // ACT
-                await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
+                await sut.CompletePublishingIfAllPriorStagesComplete(notReadyKeys);
 
                 // ASSERT
                 _releasePublishingStatusService.Assert.UpdatePublishingStageWasNotCalled();
@@ -120,14 +120,12 @@ public class PublishingCompletionServiceTests
                 _releaseVersion1 = new ReleaseVersionBuilder()
                     .WithPublicationId(PublicationId1)
                     .ForRelease(release => release
-                        .WithReleaseId(Guid.NewGuid())
                         .WithReleaseSlug("release-slug-1"))
                     .Build();
 
                 _releaseVersion2 = new ReleaseVersionBuilder()
                     .WithPublicationId(PublicationId2)
                     .ForRelease(release => release
-                        .WithReleaseId(Guid.NewGuid())
                         .WithReleaseSlug("release-slug-2"))
                     .Build();
                 


### PR DESCRIPTION
Renamed xxxBuilder to xxxMockBuilder - but removed MockBuilder suffix from usages - since all dependencies in the unit tests are mocks so seems superfluous to keep stating it.

Cleaned up PublishingCompletionServiceTests