### PR TITLE
Update validate snapshots cron schedule

### DIFF
--- a/.github/workflows/validate-snapshots.yml
+++ b/.github/workflows/validate-snapshots.yml
@@ -2,15 +2,18 @@ name: Validate snapshots
 on:
   workflow_dispatch:
   schedule:
-    # Actions are scheduled in UTC
+    # This action is intended to run at 9:35AM, 12:35PM & 4:35PM.
+    # Actions are scheduled in UTC.
     # Until Actions supports timezones, we need to update this cron
     # twice a year (at the start and end of daylight saving time)
     # to account for daylight saving time in the UK.
-    # Set a new reminder in the slack channel for next time to
-    # change this
-    # This action is intended to run at 9:35AM, 12:35PM & 4:35PM
+    #
+    # Set a new reminder in the Slack #snapshots channel for next time to
+    # change this.
+    #
     # March to October - cron: '35 8,11,15 * * 1-5'
-    - cron: '35 9,12,16 * * 1-5'
+    # October to March - cron: '35 9,12,16 * * 1-5'
+    - cron: '35 8,11,15 * * 1-5'
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SNAPSHOTS_WEBHOOK_URL }}

--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -28,6 +28,7 @@ trigger:
     exclude:
       - infrastructure/**
       - src/GovUk.Education.ExploreEducationStatistics.Content.Search*/**
+      - tests/robot-tests/tests/snapshots/**
       - renovate.json
 
 pr:
@@ -41,6 +42,7 @@ pr:
     exclude:
       - infrastructure/**
       - src/GovUk.Education.ExploreEducationStatistics.Content.Search*/**
+      - tests/robot-tests/tests/snapshots/**
       - renovate.json
 
 jobs:


### PR DESCRIPTION
This PR updates the validate snapshots cron schedule intended to run at 9:35AM, 12:35PM & 4:35PM in reflection of daylight saving time starting on 30/03/25.

Github Actions have no timezone support.

### Other changes

- Exclude changes to the snapshots from triggering the build pipeline.