### PR TITLE
When a theme is updated, raise a ThemeUpdated event

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Moq;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
@@ -1,0 +1,28 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Moq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
+
+public class AdminEventRaiserServiceMockBuilder
+{
+    private readonly Mock<IAdminEventRaiserService> _mock = new(MockBehavior.Strict);
+    public IAdminEventRaiserService Build() => _mock.Object;
+
+    public AdminEventRaiserServiceMockBuilder()
+    {
+        _mock
+            .Setup(m => m.OnThemeUpdated(It.IsAny<Theme>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    public class Asserter(Mock<IAdminEventRaiserService> mock)
+    {
+        public void ThatOnThemeUpdatedCalled(Func<Theme, bool>? predicate = null) => 
+            mock.Verify(m => m.OnThemeUpdated(It.Is<Theme>(t => predicate == null || predicate(t))), Times.Once);
+    }
+    public Asserter Assert => new(_mock);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/ThemeBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/ThemeBuilder.cs
@@ -3,7 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 
-public class ThemeMockBuilder
+public class ThemeBuilder
 {
     public Theme Build() =>
         new()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/ThemeMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/ThemeMockBuilder.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
+
+public class ThemeMockBuilder
+{
+    public Theme Build() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Title = "Theme Title",
+            Summary = "Theme Summary",
+            Slug = "theme-slug",
+            Publications = []
+        };
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserServiceTests.cs
@@ -23,7 +23,7 @@ public class AdminEventRaiserServiceTests
         // ARRANGE
         _eventGridClientFactoryMockBuilder.WhereNoTopicConfigFound();
         var sut = GetSut();
-        var theme = new ThemeMockBuilder().Build();
+        var theme = new ThemeBuilder().Build();
         
         // ACT
         await sut.OnThemeUpdated(theme);
@@ -39,7 +39,7 @@ public class AdminEventRaiserServiceTests
     {
         // ARRANGE
         var sut = GetSut();
-        var theme = new ThemeMockBuilder().Build();
+        var theme = new ThemeBuilder().Build();
         
         // ACT
         await sut.OnThemeUpdated(theme);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Events;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Services.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserServiceTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Events;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Services.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+public class AdminEventRaiserServiceTests
+{
+    private readonly ConfiguredEventGridClientFactoryMockBuilder _eventGridClientFactoryMockBuilder = new();
+    
+    private IAdminEventRaiserService GetSut() => 
+        new AdminEventRaiserService(_eventGridClientFactoryMockBuilder.Build());
+
+    [Fact]
+    public void Can_instantiate_SUT() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task GivenNoTopicConfiguration_WhenEventRaised_ThenNothingHappens()
+    {
+        // ARRANGE
+        _eventGridClientFactoryMockBuilder.WhereNoTopicConfigFound();
+        var sut = GetSut();
+        var theme = new ThemeMockBuilder().Build();
+        
+        // ACT
+        await sut.OnThemeUpdated(theme);
+        
+        // ASSERT
+        _eventGridClientFactoryMockBuilder
+            .Client
+            .Assert.NoEventsWerePublished();
+    }
+    
+    [Fact]
+    public async Task GivenTopicConfigured_WhenOnThemeUpdated_ThenEventPublished()
+    {
+        // ARRANGE
+        var sut = GetSut();
+        var theme = new ThemeMockBuilder().Build();
+        
+        // ACT
+        await sut.OnThemeUpdated(theme);
+        
+        // ASSERT
+        var actualEvent = Assert.Single(
+            _eventGridClientFactoryMockBuilder
+                .Client
+                .Assert.EventsPublished);
+
+        var expectedEvent = new ThemeChangedEventDto(theme);
+        
+        // The theme id should be the subject
+        Assert.Equal(expectedEvent.Subject, theme.Id.ToString());
+
+        // Ensure the payload is correct
+        var actualPayload = actualEvent.Data.ToObjectFromJson<ThemeChangedEventDto.EventPayload>();
+        Assert.Equal(expectedEvent.Payload, actualPayload);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
@@ -176,7 +177,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IUserService? userService = null,
             IMethodologyService? methodologyService = null,
             IPublishingService? publishingService = null,
-            IReleaseVersionService? releaseVersionService = null)
+            IReleaseVersionService? releaseVersionService = null,
+            IAdminEventRaiserService? adminEventRaiserService = null)
         {
             var publicContext = publicDataDbContext ?? Mock.Of<PublicDataDbContext>();
             var contentContext = contentDbContext ?? Mock.Of<ContentDbContext>();
@@ -192,7 +194,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 userService ?? AlwaysTrueUserService().Object,
                 methodologyService ?? Mock.Of<IMethodologyService>(Strict),
                 publishingService ?? Mock.Of<IPublishingService>(Strict),
-                releaseVersionService ?? Mock.Of<IReleaseVersionService>(Strict)
+                releaseVersionService ?? Mock.Of<IReleaseVersionService>(Strict),
+                adminEventRaiserService ?? new AdminEventRaiserServiceMockBuilder().Build()
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Options;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -137,9 +138,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReturnsAsync(Unit.Instance);
 
                 // Arrange
+                var eventRaiser = new AdminEventRaiserServiceMockBuilder();
+                
                 var service = SetupThemeService(
                     contentDbContext: context,
-                    publishingService: publishingService.Object);
+                    publishingService: publishingService.Object,
+                    adminEventRaiserService: eventRaiser.Build());
 
                 var result = await service.UpdateTheme(
                     theme.Id,
@@ -163,6 +167,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Updated theme", savedTheme.Title);
                 Assert.Equal("updated-theme", savedTheme.Slug);
                 Assert.Equal("Updated summary", savedTheme.Summary);
+                
+                eventRaiser.Assert.ThatOnThemeUpdatedCalled(actual => actual == savedTheme);
             }
         }
 
@@ -961,6 +967,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IMethodologyService? methodologyService = null,
             IPublishingService? publishingService = null,
             IReleaseVersionService? releaseVersionService = null,
+            IAdminEventRaiserService? adminEventRaiserService = null,
             bool enableThemeDeletion = true)
         {
             contentDbContext ??= new Mock<ContentDbContext>().Object;
@@ -983,7 +990,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 userService ?? AlwaysTrueUserService().Object,
                 methodologyService ?? Mock.Of<IMethodologyService>(Strict),
                 publishingService ?? Mock.Of<IPublishingService>(Strict),
-                releaseVersionService ?? Mock.Of<IReleaseVersionService>(Strict)
+                releaseVersionService ?? Mock.Of<IReleaseVersionService>(Strict),
+                adminEventRaiserService ?? new AdminEventRaiserServiceMockBuilder().Build()
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/ThemeChangedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/ThemeChangedEventDto.cs
@@ -1,0 +1,46 @@
+﻿using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Events;
+
+public record ThemeChangedEventDto
+{
+    public ThemeChangedEventDto(Theme theme)
+    {
+        Subject = theme.Id.ToString();
+        Payload = new EventPayload
+        {
+            Title = theme.Title,
+            Summary = theme.Summary,
+            Slug = theme.Slug
+        };
+    }
+
+    // Changes to this event should also increment the version accordingly.
+    public const string DataVersion = "1.0";
+    public const string EventType = "theme-changed";
+    
+    // Which Topic endpoint to use from the appsettings
+    public const string EventTopicOptionsKey = "ThemeChangesEvent";
+
+    /// <summary>
+    /// The ReleaseVersionId is the subject
+    /// </summary>
+    public string Subject { get; init; }
+
+    /// <summary>
+    /// The event payload
+    /// </summary>
+    public EventPayload Payload { get; init; }
+    
+    public record EventPayload
+    {
+        public string Title { get; init; }
+        public string Summary { get; init; }
+        public string Slug { get; init; }
+    }
+
+    public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);
+}
+
+

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/ThemeChangedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/ThemeChangedEventDto.cs
@@ -24,14 +24,14 @@ public record ThemeChangedEventDto
     public const string EventTopicOptionsKey = "ThemeChangesEvent";
 
     /// <summary>
-    /// The ReleaseVersionId is the subject
+    /// The ThemeId is the subject
     /// </summary>
-    public string Subject { get; init; }
+    public string Subject { get; }
 
     /// <summary>
     /// The event payload
     /// </summary>
-    public EventPayload Payload { get; init; }
+    public EventPayload Payload { get; }
     
     public record EventPayload
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiserService.cs
@@ -1,17 +1,13 @@
 ﻿using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Events;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
-public interface IAdminEventRaiserService
-{
-    Task OnThemeUpdated(Theme theme);
-}
-
 /// <summary>
-/// Published events specific to the Publisher
+/// Published events specific to Admin
 /// </summary>
 /// <param name="eventGridClientFactory"></param>
 public class AdminEventRaiserService(IConfiguredEventGridClientFactory eventGridClientFactory) : IAdminEventRaiserService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiserService.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Events;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+public interface IAdminEventRaiserService
+{
+    Task OnThemeUpdated(Theme theme);
+}
+
+/// <summary>
+/// Published events specific to the Publisher
+/// </summary>
+/// <param name="eventGridClientFactory"></param>
+public class AdminEventRaiserService(IConfiguredEventGridClientFactory eventGridClientFactory) : IAdminEventRaiserService
+{
+    /// <summary>
+    /// On Theme Updated
+    /// </summary>
+    public async Task OnThemeUpdated(Theme theme)
+    {
+        if (!eventGridClientFactory.TryCreateClient(
+                ThemeChangedEventDto.EventTopicOptionsKey,
+                out var client))
+        {
+            return;
+        }
+
+        var evnt = new ThemeChangedEventDto(theme);
+        
+        await client.SendEventAsync(evnt.ToEventGridEvent());
+    }
+}
+

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiserService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+
+public interface IAdminEventRaiserService
+{
+    Task OnThemeUpdated(Theme theme);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
@@ -12,6 +12,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Secur
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -36,6 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IMethodologyService _methodologyService;
         private readonly IPublishingService _publishingService;
         private readonly IReleaseVersionService _releaseVersionService;
+        private readonly IAdminEventRaiserService _eventRaiserService;
         private readonly bool _themeDeletionAllowed;
 
         public ThemeService(
@@ -47,7 +49,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IUserService userService,
             IMethodologyService methodologyService,
             IPublishingService publishingService,
-            IReleaseVersionService releaseVersionService)
+            IReleaseVersionService releaseVersionService,
+            IAdminEventRaiserService eventRaiserService)
         {
             _contentDbContext = contentDbContext;
             _dataSetVersionRepository = dataSetVersionRepository;
@@ -57,6 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _methodologyService = methodologyService;
             _publishingService = publishingService;
             _releaseVersionService = releaseVersionService;
+            _eventRaiserService = eventRaiserService;
             _themeDeletionAllowed = appOptions.Value.EnableThemeDeletion;
         }
 
@@ -110,6 +114,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         await _contentDbContext.SaveChangesAsync();
 
                         await _publishingService.TaxonomyChanged();
+                        
+                        await _eventRaiserService.OnThemeUpdated(theme);
 
                         return await GetTheme(theme.Id);
                     }


### PR DESCRIPTION
As part of the on-going work with the new Search functionality, we need to signal whenever anything changes that affects the data that is stored and indexed by the search indexer.

The Searchable Document representation of a Release Version contains some Theme information. Therefore, if a Theme changes, we need to update any Searchable Documents that are a part of that Theme.

In this PR, we are raising an event when a Theme is updated. A future piece of work will subscribe to that event, look up the publications and therefore release versions that fall under that theme, and have the corresponding Searchable Documents updated.