### PR TITLE
Ees 5951 redirect publication to latest release

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -591,7 +591,7 @@ export const getServerSideProps: GetServerSideProps<Dictionary<unknown>> =
       return {
         redirect: {
           destination: `/find-statistics/${publicationSlug}/${releaseVersion.slug}`,
-          permanent: false,
+          permanent: true,
         } as Redirect,
       };
     }

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -28,7 +28,7 @@ import PublicationReleaseHeadlinesSection from '@frontend/modules/find-statistic
 import styles from '@frontend/modules/find-statistics/PublicationReleasePage.module.scss';
 import classNames from 'classnames';
 import orderBy from 'lodash/orderBy';
-import { GetServerSideProps, NextPage } from 'next';
+import { GetServerSideProps, NextPage, Redirect } from 'next';
 import React from 'react';
 
 interface Props {
@@ -577,8 +577,8 @@ const PublicationReleasePage: NextPage<Props> = ({ releaseVersion }) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Props> = withAxiosHandler(
-  async ({ query }) => {
+export const getServerSideProps: GetServerSideProps<Dictionary<unknown>> =
+  withAxiosHandler(async ({ query }) => {
     const { publication: publicationSlug, release: releaseSlug } =
       query as Dictionary<string>;
 
@@ -586,12 +586,21 @@ export const getServerSideProps: GetServerSideProps<Props> = withAxiosHandler(
       ? publicationService.getPublicationRelease(publicationSlug, releaseSlug)
       : publicationService.getLatestPublicationRelease(publicationSlug));
 
+    // EES-5951 Redirect to latest release URL if the requested URL is for the publication base
+    if (!releaseSlug) {
+      return {
+        redirect: {
+          destination: `/find-statistics/${publicationSlug}/${releaseVersion.slug}`,
+          permanent: false,
+        } as Redirect,
+      };
+    }
+
     return {
       props: {
         releaseVersion,
       },
     };
-  },
-);
+  });
 
 export default PublicationReleasePage;

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -577,8 +577,8 @@ const PublicationReleasePage: NextPage<Props> = ({ releaseVersion }) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps<Dictionary<unknown>> =
-  withAxiosHandler(async ({ query }) => {
+export const getServerSideProps: GetServerSideProps = withAxiosHandler(
+  async ({ query }) => {
     const { publication: publicationSlug, release: releaseSlug } =
       query as Dictionary<string>;
 
@@ -586,13 +586,12 @@ export const getServerSideProps: GetServerSideProps<Dictionary<unknown>> =
       ? publicationService.getPublicationRelease(publicationSlug, releaseSlug)
       : publicationService.getLatestPublicationRelease(publicationSlug));
 
-    // EES-5951 Redirect to latest release URL if the requested URL is for the publication base
     if (!releaseSlug) {
       return {
         redirect: {
           destination: `/find-statistics/${publicationSlug}/${releaseVersion.slug}`,
           permanent: true,
-        } as Redirect,
+        },
       };
     }
 
@@ -601,6 +600,7 @@ export const getServerSideProps: GetServerSideProps<Dictionary<unknown>> =
         releaseVersion,
       },
     };
-  });
+  },
+);
 
 export default PublicationReleasePage;


### PR DESCRIPTION
This PR ensures that if a user visits a base publication URL they will be redirected to the latest release URL for that publication.
E.g. if user visits `https://base/find-statistics/[publication-slug]` they will be redirected to `https://base/find-statistics/[publication-slug]/[latest-release-slug]`.

N.B I had to change the type on L580 from `Props` as the TS compiler was complaining.
- it wouldn't complain if `getServerSideProps` wasn't wrapped with the `withAxiosHandler` HOC
- it wouldn't complain if we didn't return a redirect.
- it wouldn't complain if I amended the withAxiosHandler type annotations, but this would have wider effects on the codebase which I didn't want to introduce!

Any solution or alternative, let me know.
