### PR TITLE
EES-5940 Add infrastructure to deploy an Azure AI Search data source, index and indexer

### DIFF
--- a/infrastructure/templates/public-api/components/storageAccount.bicep
+++ b/infrastructure/templates/public-api/components/storageAccount.bicep
@@ -181,6 +181,7 @@ module storeAccessKeyToKeyVault './keyVaultSecret.bicep' = {
   }
 }
 
+output storageAccountId string = storageAccount.id
 output storageAccountName string = storageAccount.name
 output connectionStringSecretName string = connectionStringSecretName
 output accessKeySecretName string = accessKeySecretName

--- a/infrastructure/templates/search/application/indexes/index-1.json
+++ b/infrastructure/templates/search/application/indexes/index-1.json
@@ -1,0 +1,16 @@
+{
+  "name": "index-1",
+  "fields": [
+    {
+      "name": "rid",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": true,
+      "facetable": true,
+      "key": true
+    }
+  ]
+}

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -21,7 +21,7 @@ param searchableDocumentsContainerName string
 @description('The IP address ranges that can access the Search Docs Function App storage accounts.')
 param storageFirewallRules IpRange[]
 
-@description('Whether to create or update Azure Monitor alerts during this deploy')
+@description('Whether to create/update Azure Monitor alerts during this deploy.')
 param deployAlerts bool
 
 @description('Specifies common resource naming variables.')

--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -2,8 +2,11 @@ import { abbreviations } from '../../common/abbreviations.bicep'
 import { IpRange } from '../../common/types.bicep'
 import { ResourceNames } from '../types.bicep'
 
-@description('Whether to create or update Azure Monitor alerts during this deploy')
+@description('Whether to create/update Azure Monitor alerts during this deploy.')
 param deployAlerts bool
+
+@description('Whether to deploy the Search service configuration to create/update the data source, index and indexer.')
+param deploySearchConfig bool
 
 @description('Resource prefix for all resources.')
 param resourcePrefix string
@@ -14,11 +17,29 @@ param resourceNames ResourceNames
 @description('Location for all resources.')
 param location string
 
+@description('Specifies the name of the index to create/update.')
+param indexName string
+
+@description('Specifies the file containing the JSON definition of the index to create/update.')
+param indexDefinitionFilename string = '${indexName}.json'
+
+@description('Specifies the base path for the index definitions.')
+param indexDefinitionsBasePath string = 'infrastructure/templates/search/application/indexes'
+
+@description('Specifies the name of the indexer to create/update.')
+param indexerName string = '${indexName}-indexer'
+
 @description('Name of the searchable documents container in the Search storage account.')
 param searchableDocumentsContainerName string = 'searchable-documents'
 
-@description('Storage account firewall rules.')
-param storageFirewallRules IpRange[]
+@description('A list IP network rules to allow access to the Search Service from specific public internet IP address ranges.')
+param searchServiceIpRules IpRange[] = []
+
+@description('A list IP network rules to allow access to the Search storage account from specific public internet IP address ranges.')
+param storageIpRules IpRange[]
+
+@description('The branch, tag or commit of the source code from which the deployment is triggered.')
+param githubSourceRef string
 
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
@@ -36,12 +57,17 @@ resource searchStoragePrivateEndpointSubnet 'Microsoft.Network/virtualNetworks/s
   parent: vNet
 }
 
+var searchServiceName = '${resourcePrefix}-${abbreviations.searchSearchServices}'
+
 module searchServiceModule '../components/searchService.bicep' = {
   name: 'searchServiceModuleDeploy'
   params: {
-    name: '${resourcePrefix}-${abbreviations.searchSearchServices}'
+    name: searchServiceName
     location: location
-    sku: 'free'
+    ipRules: [] // TODO EES-5940 - Should be searchServiceIpRules
+    publicNetworkAccess: 'Enabled'
+    sku: 'basic'
+    systemAssignedIdentity: true
     tagValues: tagValues
   }
 }
@@ -52,7 +78,7 @@ module searchStorageAccountModule '../../public-api/components/storageAccount.bi
     location: location
     storageAccountName: '${replace(resourcePrefix, '-', '')}${abbreviations.storageStorageAccounts}search'
     publicNetworkAccessEnabled: false
-    firewallRules: storageFirewallRules
+    firewallRules: storageIpRules
     sku: 'Standard_LRS'
     kind: 'StorageV2'
     keyVaultName: keyVault.name
@@ -74,6 +100,33 @@ module blobServiceModule '../../common/components/blobService.bicep' = {
     storageAccountName: searchStorageAccountModule.outputs.storageAccountName
     containerNames: [searchableDocumentsContainerName]
   }
+}
+
+module searchServiceBlobRoleAssignmentModule '../../common/components/storageAccountRoleAssignment.bicep' = {
+  name: '${searchServiceName}BlobRoleAssignmentModuleDeploy'
+  params: {
+    principalIds: [searchServiceModule.outputs.searchServiceIdentityPrincipalId]
+    storageAccountName: searchStorageAccountModule.outputs.storageAccountName
+    role: 'Storage Blob Data Reader'
+  }
+}
+
+var gitHubRawContentBaseUrl = 'https://raw.githubusercontent.com/dfe-analytical-services/explore-education-statistics'
+
+module searchServiceConfigModule '../components/searchServiceConfig.bicep' = if (deploySearchConfig) {
+  name: 'searchServiceConfigModuleDeploy'
+  params: {
+    dataSourceName: 'azureblob-${searchableDocumentsContainerName}-datasource'
+    dataSourceConnectionString: 'ResourceId=${searchStorageAccountModule.outputs.storageAccountId};'
+    dataSourceContainerName: searchableDocumentsContainerName
+    dataSourceType: 'azureblob'
+    indexerName: indexerName
+    indexDefinitionUri: '${gitHubRawContentBaseUrl}/${githubSourceRef}/${indexDefinitionsBasePath}/${indexDefinitionFilename}'
+    indexerScheduleInterval: 'PT5M'
+    searchServiceName: searchServiceModule.outputs.searchServiceName
+    location: location
+  }
+  dependsOn: [blobServiceModule] // Ensures the searchable documents container exists
 }
 
 output searchableDocumentsContainerName string = searchableDocumentsContainerName

--- a/infrastructure/templates/search/ci/azure-pipelines.yml
+++ b/infrastructure/templates/search/ci/azure-pipelines.yml
@@ -13,7 +13,14 @@ pr: none
 
 parameters:
   - name: deployAlerts
-    displayName: Do the Azure Monitor alerts need creating or updating?
+    displayName: Do the Azure Monitor alerts need creating/updating?
+    type: string
+    values:
+      - Yes
+      - No
+    default: No
+  - name: deploySearchConfig
+    displayName: Does the Azure Search configuration need creating/updating?
     type: string
     values:
       - Yes
@@ -55,6 +62,8 @@ variables:
     value: ubuntu-latest
   - name: deployAlerts
     value: ${{ iif(eq(parameters.deployAlerts, 'Yes'), true, false) }}
+  - name: deploySearchConfig
+    value: ${{ iif(eq(parameters.deploySearchConfig, 'Yes'), true, false) }}
 
 pool:
   vmImage: $(vmImageName)

--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -36,6 +36,9 @@ jobs:
                 action: validate
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
+                deployAlerts: false
+                deploySearchConfig: false
+                githubSourceRef: $(Build.SourceBranch)
                 searchDocsFunctionAppExists: false
 
             - template: ../../../public-api/ci/tasks/check-function-app-exists.yml
@@ -51,4 +54,7 @@ jobs:
                 action: create
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
+                deployAlerts: $(deployAlerts)
+                deploySearchConfig: $(deploySearchConfig)
+                githubSourceRef: $(Build.SourceBranch)
                 searchDocsFunctionAppExists: $(searchDocsFunctionAppExists)

--- a/infrastructure/templates/search/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/search/ci/tasks/deploy-bicep.yml
@@ -11,6 +11,12 @@ parameters:
     type: string
   - name: parameterFile
     type: string
+  - name: deployAlerts
+    type: string
+  - name: deploySearchConfig
+    type: string
+  - name: githubSourceRef
+    type: string
   - name: searchDocsFunctionAppExists
     type: string
     default: true
@@ -35,4 +41,7 @@ steps:
               subscription='$(subscription)' \
               resourceTags='$(resourceTags)' \
               maintenanceIpRanges='$(maintenanceFirewallRules)' \
+              deployAlerts=${{ parameters.deployAlerts }} \
+              deploySearchConfig=${{ parameters.deploySearchConfig }} \
+              githubSourceRef=${{ parameters.githubSourceRef }} \
               searchDocsFunctionAppExists=${{ parameters.searchDocsFunctionAppExists }}

--- a/infrastructure/templates/search/components/searchServiceConfig.bicep
+++ b/infrastructure/templates/search/components/searchServiceConfig.bicep
@@ -1,0 +1,97 @@
+@description('Specifies the Search Service name.')
+param searchServiceName string
+
+@description('Specifies the name of the data source to create/update.')
+param dataSourceName string
+
+@description('Specifies the connection string to use to connect to the data source. The format of the connection string depends on the data source type.')
+param dataSourceConnectionString string = ''
+
+@description('Specifies the name of the table, view, collection, or blob container containing data to index.')
+param dataSourceContainerName string = ''
+
+@description('Specifies a query to use to filter the data source.')
+param dataSourceContainerQuery string = ''
+
+@description('Specifies the data source type to use for the Search Service. Must be one of the supported data source types.')
+@allowed([
+  'azuresql'
+  'cosmosdb'
+  'azureblob'
+  'adlsgen2'
+  'azuretable'
+  'azurefile'
+  'mysql'
+  'sharepoint'
+])
+param dataSourceType string
+
+@description('Specifies the URI of a file containing the JSON definition of the index to create/update.')
+param indexDefinitionUri string
+
+@description('Specifies the name of the indexer to create/update.')
+param indexerName string
+
+@description('Specifies whether the indexer is disabled. Set this property if you want to create the indexer definition without immediately running it.')
+param indexerDisabled bool = false
+
+@description('Specifies the interval at which the indexer should run. The format is an \'XSD\' xs:dayTimeDuration e.g. \'PT2H\' for every 2 hours. Optional, but runs once immediately if unspecified and not disabled.')
+param indexerScheduleInterval string = ''
+
+@description('Specifies the location for all resources.')
+param location string
+
+resource searchService 'Microsoft.Search/searchServices@2022-09-01' existing = {
+  name: searchServiceName
+}
+
+// A user-assigned managed identity to give the deployment script the required access to complete operations in the script
+resource scriptIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: '${searchService.name}-script-identity'
+  location: location
+}
+
+// The built-in Search Service Contributor role. See https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#search-service-contributor')
+resource searchServiceContributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: subscription()
+  name: '7ca78c08-252a-4471-8644-bb5ff32d4ba0'
+}
+
+// Assign the Search Service Contributor role to the deployment script identity
+resource scriptIdentityRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: searchService
+  name: guid(searchService.id, scriptIdentity.id, searchServiceContributorRoleDefinition.id)
+  properties: {
+    roleDefinitionId: searchServiceContributorRoleDefinition.id
+    principalId: scriptIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+var indexDefinitionFilename = substring(indexDefinitionUri, lastIndexOf(indexDefinitionUri, '/') + 1)
+
+resource deploymentScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+  name: '${searchService.name}-deployment-script'
+  location: location
+  kind: 'AzurePowerShell'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${scriptIdentity.id}': {}
+    }
+  }
+  properties: {
+    azPowerShellVersion: '13.2'
+    arguments: '-searchServiceName \\"${searchService.name}\\" -indexDefinitionFilename \\"${indexDefinitionFilename}\\" -indexerName \\"${indexerName}\\" -indexerDisabled \\"${indexerDisabled}\\" -indexerScheduleInterval \\"${indexerScheduleInterval}\\" -dataSourceName \\"${dataSourceName}\\" -dataSourceType \\"${dataSourceType}\\" -dataSourceConnectionString \\"${dataSourceConnectionString}\\" -dataSourceContainerName \\"${dataSourceContainerName}\\" -dataSourceContainerQuery \\"${dataSourceContainerQuery}\\"'
+    scriptContent: loadTextContent('../scripts/SetupSearchService.ps1')
+    supportingScriptUris: [
+      indexDefinitionUri
+    ]
+    cleanupPreference: 'OnExpiration'
+    retentionInterval: 'PT1H'
+    timeout: 'PT5M'
+  }
+  dependsOn: [scriptIdentityRoleAssignment]
+}
+
+output indexName string = deploymentScript.properties.outputs.indexName

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -23,8 +23,11 @@ param resourceTags {
 @description('Tagging : Date Provisioned. Used for tagging resources created by this infrastructure pipeline.')
 param dateProvisioned string = utcNow('u')
 
-@description('Do Azure Monitor alerts need creating or updating?')
+@description('Whether to create/update Azure Monitor alerts during this deploy.')
 param deployAlerts bool = false
+
+@description('Whether to deploy the Search service configuration to create/update the data source, index and indexer.')
+param deploySearchConfig bool = false
 
 @description('The URL of the Content API.')
 param contentApiUrl string
@@ -34,6 +37,9 @@ param searchDocsFunctionAppExists bool = true
 
 @description('Provides access to resources for specific IP address ranges used for service maintenance.')
 param maintenanceIpRanges IpRange[] = []
+
+@description('The branch, tag or commit of the source code from which the deployment is triggered.')
+param githubSourceRef string = 'refs/heads/dev'
 
 var tagValues = union(resourceTags ?? {}, {
   Environment: environmentName
@@ -108,10 +114,14 @@ module searchServiceModule 'application/searchService.bicep' = {
   name: 'searchServiceModule'
   params: {
     location: location
+    githubSourceRef: githubSourceRef
+    indexName: 'index-1'
     resourceNames: resourceNames
     resourcePrefix: resourcePrefix
-    storageFirewallRules: maintenanceIpRanges
+    searchServiceIpRules: maintenanceIpRanges
+    storageIpRules: maintenanceIpRanges
     deployAlerts: deployAlerts
+    deploySearchConfig: deploySearchConfig
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/search/scripts/SetupSearchService.ps1
+++ b/infrastructure/templates/search/scripts/SetupSearchService.ps1
@@ -1,0 +1,91 @@
+param(
+    [string] [Parameter(Mandatory=$true)] $searchServiceName,
+    [string] [Parameter(Mandatory=$true)] $indexDefinitionFilename,
+    [string] [Parameter(Mandatory=$true)] $indexerName,
+    [string] [Parameter(Mandatory=$true)] [AllowEmptyString()] $indexerScheduleInterval,
+    [string] [Parameter(Mandatory=$true)] $dataSourceName,
+    [string] [Parameter(Mandatory=$true)] $dataSourceType,
+    [string] [Parameter(Mandatory=$true)] [AllowEmptyString()] $dataSourceConnectionString,
+    [string] [Parameter(Mandatory=$true)] [AllowEmptyString()] $dataSourceContainerName,
+    [string] [Parameter(Mandatory=$true)] [AllowEmptyString()] $dataSourceContainerQuery,
+    [string] $indexerDisabled
+)
+
+# Change the ErrorActionPreference to 'Stop'
+$ErrorActionPreference = 'Stop'
+
+$apiVersion = '2024-07-01'
+$token = (ConvertFrom-SecureString (Get-AzAccessToken -ResourceUrl https://search.azure.com -AsSecureString).Token -AsPlainText)
+$headers = @{ 'Authorization' = "Bearer $token"; 'Content-Type' = 'application/json'; }
+$uri = "https://$searchServiceName.search.windows.net"
+$dataSourceDefinition = $null
+$indexDefinitionPath = Join-Path -Path ${Env:AZ_SCRIPTS_PATH_INPUT_DIRECTORY} -ChildPath $indexDefinitionFilename
+$indexDefinition = Get-Content -Path $indexDefinitionPath -Raw | ConvertFrom-Json
+$indexerDefinition = $null
+
+# Use this variable to store output values which can then be referenced by the deployment template.
+# Outputs can also be viewed under Details of the Deployment Script resource in Azure Portal after deployment
+$DeploymentScriptOutputs = @{}
+$DeploymentScriptOutputs['indexName'] = $indexDefinition.name
+
+# Create the data source and indexer definitions
+switch ($dataSourceType)
+{
+    "azureblob" {
+        $dataSourceDefinition = @{
+            'name' = $dataSourceName;
+            'type' = $dataSourceType;
+            'container' = @{
+                'name' = $dataSourceContainerName;
+                'query' = $dataSourceContainerQuery;
+            };
+            'credentials' = @{
+                'connectionString' = $dataSourceConnectionString;
+            };
+            'dataDeletionDetectionPolicy' = @{
+                '@odata.type' = '#Microsoft.Azure.Search.NativeBlobSoftDeleteDeletionDetectionPolicy';
+            };
+        }
+        $indexerDefinition = @{
+            'name' = $indexerName;
+            'disabled' = $indexerDisabled -eq 'true';
+            'targetIndexName' = $indexDefinition.name;
+            'dataSourceName' = $dataSourceName;
+            'schedule' = $indexerScheduleInterval.Length -gt 0 ? @{ 'interval' = $indexerScheduleInterval } : $null;
+        }
+    }
+    default {
+        throw "Unsupported data source type $dataSourceType"
+    }
+}
+
+try {
+    # https://learn.microsoft.com/rest/api/searchservice/create-index
+    # Note: This will fail to update an index if attempting to remove fields, as they are locked for the index's lifetime
+    Invoke-WebRequest `
+        -Method 'PUT' `
+        -Uri "$uri/indexes/$($indexDefinition.name)?api-version=$apiVersion" `
+        -Headers  $headers `
+        -Body (ConvertTo-Json $indexDefinition)
+
+    if ($dataSourceContainerName.Length -gt 0 -and $dataSourceConnectionString.Length -gt 0)
+    {
+        # https://learn.microsoft.com/rest/api/searchservice/create-data-source
+        Invoke-WebRequest `
+            -Method 'PUT' `
+            -Uri "$uri/datasources/$($dataSourceDefinition['name'])?api-version=$apiVersion" `
+            -Headers $headers `
+            -Body (ConvertTo-Json $dataSourceDefinition)
+
+        # https://learn.microsoft.com/rest/api/searchservice/create-indexer
+        Invoke-WebRequest `
+            -Method 'PUT' `
+            -Uri "$uri/indexers/$($indexerDefinition['name'])?api-version=$apiVersion" `
+            -Headers $headers `
+            -Body (ConvertTo-Json $indexerDefinition)
+    }
+    $DeploymentScriptOutputs['result'] = 'Success'
+} catch {
+    Write-Error $_.ErrorDetails.Message
+    throw
+}


### PR DESCRIPTION
This PR adds the Bicep infrastructure to create or update a Azure AI Search data source, index and indexer. The result of this is that we now have an Azure AI Search API endpoint that we can run search queries against.

It builds on #5668 which added the infrastructure to create the Azure AI Search Service and Search Storage account/container but did not go as far as configuring the Storage container as a data source within the Azure AI Search, or define the index or indexer.

### Deployment Script resource

There's no Bicep template support for Azure AI Search data plane operations like creating an data source or an index.

Instead, we create an Azure Deployment Script resource to use data plane operations of the Azure AI Search REST API. The Deployment Script uses a Container Instance to execute a Powershell script from a temporary Storage Account created during the deploy. To allow for debugging the script output, the account has been configured with a retention period of 1 hour and will be deleted on expiration.

See [Use deployment scripts in Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deployment-script-bicep) to learn more about using Deployment Script resources.

The deployment script has been set up with a managed identity and been assigned the Search Service Contributor role on the Azure AI Search service. This uses Microsoft Entra ID authentication and RBAC to provide a bearer token in the authorization header of API requests.

This script code was originally based off the Quickstart [Bicep deployment of Azure Cognitive Search](https://github.com/Azure-Samples/azure-search-deployment-template) template. I have adapted this to add additional naming and schedule parameters and make it so the indexer can be disabled by default if necessary.

The Powershell script has been written to support containers using multiple types of data source but for now only Azure Blob Storage is supported.

In order to make the 'searchServiceConfig' Bicep template a reusable component with a configurable index definition I replaced the hardcoded Powershell object definition of the index with a supporting script file. This uses the Deployment Script  `supportingScriptUris` property to supply the file in a relative directory to the primary script. See [Develop a deployment script in Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deployment-script-develop) to learn more about the script properties and arguments.

### Prerequisites for creating Deployment Script resources

Creating an Azure Deployment Script resource requires the Azure Storage and Azure Container Instances resource providers to be registered.

In our case the `Microsoft.ContainerInstance` resource provider was not registered on the subscription.

![image (3)](https://github.com/user-attachments/assets/a8b36a71-dd85-4ec4-b5b2-6bb30100d66f)

Registering the resource provider at subscription level is a manual step that needs to be done before attempting the deploy in other environments.

### Data source

![image](https://github.com/user-attachments/assets/8be6aeb4-bb73-440e-8c74-201c34dd958d)

The data source is configured for the 'searchable documents' container in the Search Storage Account blob service.

Making this accessible required ensuring the Azure AI Search service has a managed identity and assigning it the role 'Storage Blob Data Reader' on the Storage Account. It has the name `azureblob-${searchableDocumentsContainerName}-datasource`.

Since it uses RBAC with a managed identity it allows us to configure the data source with a credential-less connection string with no account key or password. See [Connect to Azure Storage using a managed identity](https://learn.microsoft.com/en-us/azure/search/search-howto-managed-identities-storage).

It is configured with the native soft deletion detection policy which should work since the Search Storage account has already been set up with soft delete for blobs enabled.

### Search index

![image (1)](https://github.com/user-attachments/assets/7fa86219-9bc9-4259-b65a-fd3234ea3ea9)

The index named `index-1` is created from the JSON definition provided in the base definitions directory. The index provided with this change is only an example with a single field. See `infrastructure/templates/search/application/indexes/index-1.json`.

This definition will be updated by future work.

### Indexer

![image (2)](https://github.com/user-attachments/assets/6e24c2ea-e3c6-4334-88d4-724b5e217c5b)

The indexer is configured for the data source, targeting the search index. It has a default name of `${indexName}-indexer`.

The [Change and delete detection using indexers for Azure Storage in Azure AI Search](https://learn.microsoft.com/en-us/azure/search/search-howto-index-changed-deleted-blobs) documentation says:

> For indexed content that originates from Azure Storage, change detection occurs automatically because indexers keep track of the last update using the built-in timestamps on objects and files in Azure Storage.

I wasn't sure if this happens automatically even if the indexer is only run once so for now it has been configured with a schedule of PT5M (every five minutes).