### PR TITLE
EES-5969 SEO noindex for query params

### DIFF
--- a/src/explore-education-statistics-frontend/src/middleware.ts
+++ b/src/explore-education-statistics-frontend/src/middleware.ts
@@ -1,8 +1,9 @@
 import redirectPages from '@frontend/middleware/pages/redirectPages';
 import chain from './middleware/pages/chain';
 import rewritePaths from './middleware/pages/rewritePaths';
+import noIndexPagesWithParams from './middleware/pages/noIndexPagesWithParams';
 
-export default chain([rewritePaths, redirectPages]);
+export default chain([rewritePaths, redirectPages, noIndexPagesWithParams]);
 
 // Only run the middleware on the specified paths below.
 // Ideally we'd just exclude build files and run it on all routes,
@@ -13,7 +14,7 @@ export const config = {
   matcher: [
     '/cookies/:path*',
     '/find-statistics/:path*/:path*',
-    '/data-tables',
+    '/data-tables/:path*/:path*',
     '/data-catalogue',
     '/data-catalogue/data-set/:dataSetFileId/csv',
     '/methodology/:path*',

--- a/src/explore-education-statistics-frontend/src/middleware/pages/noIndexPagesWithParams.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/noIndexPagesWithParams.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export default function noIndexPagesWithParams(request: NextRequest) {
+  const response = NextResponse.next();
+
+  const reqUrl = new URL(request.url);
+  const params = new URLSearchParams(reqUrl.search);
+  const numParams = params.size;
+
+  // Only allow indexing of pages without query params, or if the only param is 'page'
+  if (numParams > 1 || (numParams === 1 && !params.has('page'))) {
+    response.headers.set('X-Robots-Tag', 'noindex, nofollow');
+  }
+
+  return response;
+}


### PR DESCRIPTION
This PR adds middleware for the frontend site to prevent duplicate indexing of pages with different query params.
We check if there are query params present in the request, and add a `noindex` header to the response if there are, unless the only query param is `page`, which we still want to be indexed.

I considered adding a noindex meta tag to the document `head` as an alternative, but this would need to be done in multiple templates in `getServerSideProps` and didn't seem as clean or global as a solution.