### PR TITLE
EES-5912 Prevent screenreader announcing unavailable after button click

### DIFF
--- a/src/explore-education-statistics-common/src/components/__tests__/Button.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Button.test.tsx
@@ -1,7 +1,7 @@
 import delay from '@common/utils/delay';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import Button from '../Button';
 
 describe('Button', () => {
@@ -47,25 +47,20 @@ describe('Button', () => {
     expect(button).toBeAriaDisabled();
   });
 
-  test('aria-disabled if current `onClick` handler is processing', async () => {
+  test('calls `onClick` handler once when clicking twice, if `preventDoubleClick` is true', async () => {
     const handleClick = jest.fn(async () => delay(100));
 
     render(<Button onClick={handleClick}>Test button</Button>);
 
     const button = screen.getByRole('button', { name: 'Test button' });
 
-    expect(button).not.toBeAriaDisabled();
-    expect(button).toBeEnabled();
-
+    await userEvent.click(button);
     await userEvent.click(button);
 
     expect(handleClick).toHaveBeenCalledTimes(1);
-
-    expect(button).toBeAriaDisabled();
-    expect(button).toBeEnabled();
   });
 
-  test('not aria-disabled if current `onClick` handler is processing and `preventDoubleClick` is false', async () => {
+  test('calls `onClick` handler twice when clicking twice, if `preventDoubleClick` is false', async () => {
     const handleClick = jest.fn(async () => delay(100));
 
     render(
@@ -76,38 +71,9 @@ describe('Button', () => {
 
     const button = screen.getByRole('button', { name: 'Test button' });
 
-    expect(button).not.toBeAriaDisabled();
-    expect(button).toBeEnabled();
-
+    await userEvent.click(button);
     await userEvent.click(button);
 
-    expect(handleClick).toHaveBeenCalledTimes(1);
-
-    expect(button).not.toBeAriaDisabled();
-    expect(button).toBeEnabled();
-  });
-
-  test('not aria-disabled once the current `onClick` handler has finished', async () => {
-    const handleClick = jest.fn(async () => delay(100));
-
-    render(<Button onClick={handleClick}>Test button</Button>);
-
-    const button = screen.getByRole('button', { name: 'Test button' });
-
-    expect(button).not.toBeAriaDisabled();
-    expect(button).toBeEnabled();
-
-    await userEvent.click(button);
-
-    expect(handleClick).toHaveBeenCalledTimes(1);
-
-    expect(button).toBeAriaDisabled();
-    expect(button).toBeEnabled();
-
-    // Task has completed, so button is now enabled
-    await waitFor(() => {
-      expect(button).not.toBeAriaDisabled();
-      expect(button).toBeEnabled();
-    });
+    expect(handleClick).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/explore-education-statistics-common/src/components/__tests__/ButtonText.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ButtonText.test.tsx
@@ -1,7 +1,7 @@
 import delay from '@common/utils/delay';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import ButtonText from '../ButtonText';
 
 describe('ButtonText', () => {
@@ -47,25 +47,20 @@ describe('ButtonText', () => {
     expect(button).toBeAriaDisabled();
   });
 
-  test('aria-disabled if current `onClick` handler is processing', async () => {
+  test('calls `onClick` handler once when clicking twice, if `preventDoubleClick` is true', async () => {
     const handleClick = jest.fn(async () => delay(100));
 
     render(<ButtonText onClick={handleClick}>Test button</ButtonText>);
 
     const button = screen.getByRole('button', { name: 'Test button' });
 
-    expect(button).not.toBeAriaDisabled();
-    expect(button).toBeEnabled();
-
+    await userEvent.click(button);
     await userEvent.click(button);
 
     expect(handleClick).toHaveBeenCalledTimes(1);
-
-    expect(button).toBeAriaDisabled();
-    expect(button).toBeEnabled();
   });
 
-  test('not aria-disabled if current `onClick` handler is processing and `preventDoubleClick` is false', async () => {
+  test('calls `onClick` handler twice when clicking twice, if `preventDoubleClick` is false', async () => {
     const handleClick = jest.fn(async () => delay(100));
 
     render(
@@ -76,38 +71,9 @@ describe('ButtonText', () => {
 
     const button = screen.getByRole('button', { name: 'Test button' });
 
-    expect(button).not.toBeAriaDisabled();
-    expect(button).toBeEnabled();
-
+    await userEvent.click(button);
     await userEvent.click(button);
 
-    expect(handleClick).toHaveBeenCalledTimes(1);
-
-    expect(button).not.toBeAriaDisabled();
-    expect(button).toBeEnabled();
-  });
-
-  test('not aria-disabled once the current `onClick` handler has finished', async () => {
-    const handleClick = jest.fn(async () => delay(100));
-
-    render(<ButtonText onClick={handleClick}>Test button</ButtonText>);
-
-    const button = screen.getByRole('button', { name: 'Test button' });
-
-    expect(button).not.toBeAriaDisabled();
-    expect(button).toBeEnabled();
-
-    await userEvent.click(button);
-
-    expect(handleClick).toHaveBeenCalledTimes(1);
-
-    expect(button).toBeAriaDisabled();
-    expect(button).toBeEnabled();
-
-    // Task has completed, so button is now enabled
-    await waitFor(() => {
-      expect(button).not.toBeAriaDisabled();
-      expect(button).toBeEnabled();
-    });
+    expect(handleClick).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/explore-education-statistics-common/src/components/__tests__/ModalConfirm.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ModalConfirm.test.tsx
@@ -30,9 +30,6 @@ describe('ModalConfirm', () => {
 
       await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
-      expect(
-        screen.getByRole('button', { name: 'Confirm' }),
-      ).toBeAriaDisabled();
       expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
 
       expect(screen.getByTestId('loadingSpinner')).toBeInTheDocument();
@@ -110,9 +107,6 @@ describe('ModalConfirm', () => {
 
       await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
-      expect(
-        screen.getByRole('button', { name: 'Confirm' }),
-      ).toBeAriaDisabled();
       expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
 
       await waitFor(() => {
@@ -195,7 +189,6 @@ describe('ModalConfirm', () => {
       await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
       expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
-      expect(screen.getByRole('button', { name: 'Cancel' })).toBeAriaDisabled();
 
       expect(screen.getByTestId('loadingSpinner')).toBeInTheDocument();
     });
@@ -272,7 +265,6 @@ describe('ModalConfirm', () => {
       await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
       expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
-      expect(screen.getByRole('button', { name: 'Cancel' })).toBeAriaDisabled();
 
       await waitFor(() => {
         expect(screen.queryByText('Confirm')).not.toBeInTheDocument();

--- a/src/explore-education-statistics-common/src/hooks/useButton.ts
+++ b/src/explore-education-statistics-common/src/hooks/useButton.ts
@@ -67,7 +67,7 @@ export default function useButton({
   return {
     'aria-controls': ariaControls,
     'aria-current': ariaCurrent,
-    'aria-disabled': ariaDisabled || disabled,
+    'aria-disabled': !!(ariaDisabled || disabled),
     'aria-expanded': ariaExpanded,
     'aria-label': ariaLabel,
     children,

--- a/src/explore-education-statistics-common/src/hooks/useButton.ts
+++ b/src/explore-education-statistics-common/src/hooks/useButton.ts
@@ -36,11 +36,11 @@ export default function useButton({
   const [isClicking, toggleClicking] = useToggle(false);
   const isMountedRef = useMountedRef();
 
-  const isDisabled = ariaDisabled || disabled || isClicking;
+  const isClickDisabled = ariaDisabled || disabled || isClicking;
 
   const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
     async event => {
-      if (isDisabled) {
+      if (isClickDisabled) {
         event.preventDefault();
         return;
       }
@@ -55,13 +55,19 @@ export default function useButton({
         toggleClicking.off();
       }
     },
-    [isDisabled, preventDoubleClick, onClick, isMountedRef, toggleClicking],
+    [
+      isClickDisabled,
+      preventDoubleClick,
+      onClick,
+      isMountedRef,
+      toggleClicking,
+    ],
   );
 
   return {
     'aria-controls': ariaControls,
     'aria-current': ariaCurrent,
-    'aria-disabled': isDisabled,
+    'aria-disabled': ariaDisabled || disabled,
     'aria-expanded': ariaExpanded,
     'aria-label': ariaLabel,
     children,


### PR DESCRIPTION
Don't set aria-disabled to true during 'double click prevention' phase, as this causes screen readers to announce 'unavailable' immediately on button click.
`aria-disabled` can still be passed in as a prop, as well as `disabled`