### PR TITLE
EES-5986 Ensure focus is returned to modal trigger for publish date modal

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -362,28 +362,60 @@ const ReleaseStatusForm = ({
               />
 
               <ButtonGroup>
-                <Button
-                  type="submit"
-                  disabled={formState.isSubmitting}
-                  onClick={async e => {
-                    e.preventDefault();
-
-                    if (
-                      approvalStatus === 'Approved' &&
-                      getValues('publishMethod') === 'Scheduled' &&
-                      getValues('publishScheduled')
-                    ) {
-                      if (formState.isValid) {
-                        toggleConfirmScheduleModal.on();
-                        return;
-                      }
-                    }
-
+                <ModalConfirm
+                  title="Confirm publish date"
+                  open={showConfirmScheduleModal}
+                  onConfirm={async () => {
                     await handleSubmit(handleSubmitForm)();
+                    toggleConfirmScheduleModal.off();
                   }}
+                  onCancel={toggleConfirmScheduleModal.off}
+                  onExit={toggleConfirmScheduleModal.off}
+                  triggerButton={
+                    <Button
+                      type="submit"
+                      disabled={formState.isSubmitting}
+                      onClick={async e => {
+                        e.preventDefault();
+
+                        if (
+                          approvalStatus === 'Approved' &&
+                          getValues('publishMethod') === 'Scheduled' &&
+                          getValues('publishScheduled')
+                        ) {
+                          if (formState.isValid) {
+                            toggleConfirmScheduleModal.on();
+                            return;
+                          }
+                        }
+
+                        await handleSubmit(handleSubmitForm)();
+                      }}
+                    >
+                      Update status
+                    </Button>
+                  }
                 >
-                  Update status
-                </Button>
+                  <p>
+                    This release will be published at 09:30 on{' '}
+                    <FormattedDate format="EEEE d MMMM yyyy">
+                      {getValues('publishScheduled') || ''}
+                    </FormattedDate>
+                    .
+                  </p>
+                  <p>
+                    Once confirmed, if you need to change or cancel the
+                    publishing for any reason, you must come back to this page
+                    to change it yourself. If you need any support, please
+                    contact{' '}
+                    <a href="mailto:explore.statistics@education.gov.uk">
+                      explore.statistics@education.gov.uk
+                    </a>
+                    .
+                  </p>
+                  <p>Are you sure?</p>
+                </ModalConfirm>
+
                 <ButtonText
                   onClick={() => {
                     reset();
@@ -394,33 +426,6 @@ const ReleaseStatusForm = ({
                 </ButtonText>
               </ButtonGroup>
             </Form>
-            <ModalConfirm
-              title="Confirm publish date"
-              open={showConfirmScheduleModal}
-              onConfirm={async () => {
-                await handleSubmit(handleSubmitForm)();
-                toggleConfirmScheduleModal.off();
-              }}
-              onExit={toggleConfirmScheduleModal.off}
-            >
-              <p>
-                This release will be published at 09:30 on{' '}
-                <FormattedDate format="EEEE d MMMM yyyy">
-                  {getValues('publishScheduled') || ''}
-                </FormattedDate>
-                .
-              </p>
-              <p>
-                Once confirmed, if you need to change or cancel the publishing
-                for any reason, you must come back to this page to change it
-                yourself. If you need any support, please contact{' '}
-                <a href="mailto:explore.statistics@education.gov.uk">
-                  explore.statistics@education.gov.uk
-                </a>
-                .
-              </p>
-              <p>Are you sure?</p>
-            </ModalConfirm>
 
             <ModalConfirm
               title="Publish date cannot be scheduled"

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseUserAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseUserAccessForm.tsx
@@ -16,7 +16,13 @@ import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import useToggle from '@common/hooks/useToggle';
 import { mapFieldErrors } from '@common/validation/serverValidations';
 import Yup from '@common/validation/yup';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { ObjectSchema } from 'yup';
 
 interface FormValues {
@@ -61,6 +67,13 @@ export default function PreReleaseUserAccessForm({
   );
 
   const [invitePlan, setInvitePlan] = useState<PreReleaseInvitePlan>();
+  const submitButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!invitePlan) {
+      submitButtonRef.current?.focus();
+    }
+  }, [invitePlan]);
 
   const splitAndTrimLines = (input: string) =>
     input
@@ -171,6 +184,7 @@ export default function PreReleaseUserAccessForm({
                   <Button
                     type="submit"
                     disabled={formState.isSubmitting || isRemoving}
+                    ref={submitButtonRef}
                   >
                     {formState.isSubmitting
                       ? 'Inviting new users'


### PR DESCRIPTION
Fix focus issue - when closing the 'update status' modal (for scheduling publishing of a release), focus is now returned to the trigger button.
Also addresses EES-5989 - Returning focus to PreRelease User Access Modal trigger button when modal closes.