### PR TITLE
EES-5974 infrastructure changes for search function app related to EES-5875

### DIFF
--- a/infrastructure/templates/common/components/functionApp.bicep
+++ b/infrastructure/templates/common/components/functionApp.bicep
@@ -77,12 +77,8 @@ param allowedOrigins array = []
 @description('Specifies an optional URL for Azure to use to monitor the health of this resource')
 param healthCheckPath string?
 
-@description('An existing Managed Identity\'s Resource Id with which to associate this Function App.')
-param userAssignedManagedIdentityParams {
-  id: string
-  name: string
-  principalId: string
-}?
+@description('The name of a user-assigned managed identity to assign to the Function App.')
+param userAssignedIdentityName string = ''
 
 @description('Specifies the SKU for the Function App hosting plan.')
 param sku object
@@ -126,17 +122,6 @@ var firewallRules = [
   }
 ]
 
-var identity = userAssignedManagedIdentityParams != null
-  ? {
-      type: 'UserAssigned'
-      userAssignedIdentities: {
-        '${userAssignedManagedIdentityParams!.id}': {}
-      }
-    }
-  : {
-      type: 'SystemAssigned'
-    }
-
 var storageAlerts = alerts != null
   ? {
       availability: alerts!.storageAccountAvailability
@@ -156,6 +141,12 @@ var fileServiceAlerts = alerts != null
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
+}
+
+var identityType = !empty(userAssignedIdentityName) ? 'SystemAssigned, UserAssigned' : 'SystemAssigned'
+
+resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' existing = if (!empty(userAssignedIdentityName)) {
+  name: userAssignedIdentityName
 }
 
 module appServicePlanModule '../../public-api/components/appServicePlan.bicep' = {
@@ -210,7 +201,10 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
   name: functionAppName
   location: location
   kind: (operatingSystem == 'Linux' ? 'functionapp,linux' : 'functionapp')
-  identity: identity
+  identity: {
+    type: identityType
+    userAssignedIdentities: !empty(userAssignedIdentityName) ? { '${userAssignedIdentity.id}': {} } : null
+  }
   properties: {
     containerSize: instanceMemoryMB
     reserved: operatingSystem == 'Linux'
@@ -313,7 +307,7 @@ resource azureStorageAccountsConfig 'Microsoft.Web/sites/config@2023-12-01' = if
 module keyVaultRoleAssignmentModule '../../public-api/components/keyVaultRoleAssignment.bicep' = {
   name: '${functionAppName}KeyVaultRoleAssignmentModuleDeploy'
   params: {
-    principalIds: userAssignedManagedIdentityParams != null ? [userAssignedManagedIdentityParams!.principalId] : [functionApp.identity.principalId]
+    principalIds: [functionApp.identity.principalId]
     keyVaultName: keyVault.name
     role: 'Secrets User'
   }
@@ -411,3 +405,4 @@ module expectedHttpStatusCodeAlerts '../../public-api/components/alerts/dynamicM
 
 output name string = functionApp.name
 output url string = 'https://${functionApp.name}.azurewebsites.net'
+output functionAppIdentityPrincipalId string = functionApp.identity.principalId

--- a/infrastructure/templates/common/components/storageAccountRoleAssignment.bicep
+++ b/infrastructure/templates/common/components/storageAccountRoleAssignment.bicep
@@ -27,7 +27,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing 
 // Create the role assignment. Note that this is dependent on the deploying service principal having
 // "Microsoft.Authorization/roleAssignments/write" permissions on the Storage Account via an appropriate
 // role.
-resource keyVaultRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {
+resource storageAccountRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {
   scope: storageAccount
   name: guid(storageAccount.id, principalId, rolesToRoleIds[role])
   properties: {

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -8,6 +8,12 @@ param contentApiUrl string
 @description('The IP address ranges that can access the Search Docs Function App endpoints.')
 param functionAppFirewallRules FirewallRule[]
 
+@description('Specifies the base URL of the Search Service endpoint for interacting with the data plane REST API. For example: https://[search-service-name].search.windows.net')
+param searchServiceEndpoint string
+
+@description('Specifies the Search Service indexer name.')
+param searchServiceIndexerName string
+
 @description('Name of the Search storage account.')
 param searchStorageAccountName string
 
@@ -95,6 +101,14 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
       {
         name: 'App__SearchableDocumentsContainerName'
         value: searchableDocumentsContainer.name
+      }
+      {
+        name: 'AzureSearch__SearchServiceEndpoint'
+        value: searchServiceEndpoint
+      }
+      {
+        name: 'AzureSearch__IndexerName'
+        value: searchServiceIndexerName
       }
       {
         name: 'ContentApi__Url'

--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -131,6 +131,8 @@ module searchServiceConfigModule '../components/searchServiceConfig.bicep' = if 
 
 output searchableDocumentsContainerName string = searchableDocumentsContainerName
 output searchServiceEndpoint string = searchServiceModule.outputs.searchServiceEndpoint
+output searchServiceIndexName string = indexName
+output searchServiceIndexerName string = indexerName
 output searchServiceName string = searchServiceModule.outputs.searchServiceName
 output searchStorageAccountConnectionStringSecretName string = searchStorageAccountModule.outputs.connectionStringSecretName
 output searchStorageAccountName string = searchStorageAccountModule.outputs.storageAccountName

--- a/infrastructure/templates/search/components/searchServiceConfig.bicep
+++ b/infrastructure/templates/search/components/searchServiceConfig.bicep
@@ -51,7 +51,7 @@ resource scriptIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-1
   location: location
 }
 
-// The built-in Search Service Contributor role. See https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#search-service-contributor')
+// The built-in Search Service Contributor role. See https://learn.microsoft.com/en-gb/azure/role-based-access-control/built-in-roles/ai-machine-learning#search-service-contributor')
 resource searchServiceContributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
   scope: subscription()
   name: '7ca78c08-252a-4471-8644-bb5ff32d4ba0'

--- a/infrastructure/templates/search/components/searchServiceRoleAssignment.bicep
+++ b/infrastructure/templates/search/components/searchServiceRoleAssignment.bicep
@@ -1,0 +1,37 @@
+import { SearchServiceRole } from '../types.bicep'
+
+@description('Specifies the name of the Search Service.')
+param searchServiceName string
+
+@description('Specifies the ids of the service principals that are being assigned the role')
+param principalIds string[]
+
+// A subset of allowed roles is supported here in accordance with role assignment conditions.
+// See https://docs.microsoft.com/azure/role-based-access-control/built-in-roles for possible
+// roles to support here, in conjunction with the limited set of roles that the deploying service
+// principal is allowed to assign.
+@description('Specifies the role to assign to the service principals')
+param role SearchServiceRole
+
+var rolesToRoleIds = {
+  'Search Index Data Contributor': '8ebe5a00-799e-43f5-93ac-243d3dce84a7'
+  'Search Index Data Reader': '1407120a-92aa-4202-b7e9-c0e197c71c8f'
+  'Search Service Contributor': '7ca78c08-252a-4471-8644-bb5ff32d4ba0'
+}
+
+resource searchService 'Microsoft.Search/searchServices@2024-06-01-preview' existing = {
+  name: searchServiceName
+}
+
+// Create the role assignment. Note that this is dependent on the deploying service principal having
+// "Microsoft.Authorization/roleAssignments/write" permissions on the Search Service via an appropriate
+// role.
+resource searchServiceRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {
+  scope: searchService
+  name: guid(searchService.id, principalId, rolesToRoleIds[role])
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', rolesToRoleIds[role])
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}]

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -102,6 +102,7 @@ module searchDocsFunctionModule 'application/searchDocsFunction.bicep' = {
     )
     searchServiceEndpoint: searchServiceModule.outputs.searchServiceEndpoint
     searchServiceIndexerName: searchServiceModule.outputs.searchServiceIndexerName
+    searchServiceName: searchServiceModule.outputs.searchServiceName
     searchStorageAccountName: searchServiceModule.outputs.searchStorageAccountName
     searchStorageAccountConnectionStringSecretName: searchServiceModule.outputs.searchStorageAccountConnectionStringSecretName
     searchableDocumentsContainerName: searchServiceModule.outputs.searchableDocumentsContainerName

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -100,6 +100,8 @@ module searchDocsFunctionModule 'application/searchDocsFunction.bicep' = {
       ],
       maintenanceFirewallRules
     )
+    searchServiceEndpoint: searchServiceModule.outputs.searchServiceEndpoint
+    searchServiceIndexerName: searchServiceModule.outputs.searchServiceIndexerName
     searchStorageAccountName: searchServiceModule.outputs.searchStorageAccountName
     searchStorageAccountConnectionStringSecretName: searchServiceModule.outputs.searchStorageAccountConnectionStringSecretName
     searchableDocumentsContainerName: searchServiceModule.outputs.searchableDocumentsContainerName

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -11,3 +11,7 @@ type ResourceNames = {
     }
   }
 }
+
+@export()
+// The built in Search Service roles. See https://learn.microsoft.com/en-gb/azure/role-based-access-control/built-in-roles/ai-machine-learning
+type SearchServiceRole = 'Search Index Data Contributor' | 'Search Index Data Reader' | 'Search Service Contributor'

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Clients/AzureSearch/SearchIndexClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Clients/AzureSearch/SearchIndexClientTests.cs
@@ -10,13 +10,13 @@ public class SearchIndexClientTests
     {
         SearchServiceEndpoint = _searchServiceEndpoint,
         SearchServiceAccessKey = _searchServiceAccessKey,
-        IndexName = _indexName
+        IndexerName = _indexerName
     };
 
 
     private string _searchServiceEndpoint = "https://example.search.windows.net/";
     private string? _searchServiceAccessKey = "my-access-key";
-    private string _indexName = "my-index-name";
+    private string _indexerName = "my-indexer-name";
 
     private ISearchIndexClient GetSut()
     {
@@ -38,7 +38,7 @@ public class SearchIndexClientTests
         {
             var searchServiceName = "-- insert search service name here --";
             _searchServiceAccessKey = "-- insert search service access key here --";
-            _indexName = "-- insert search index name here --";
+            _indexerName = "-- insert search indexer name here --";
 
             _searchServiceEndpoint = $"https://{searchServiceName}.search.windows.net/";
         }
@@ -67,7 +67,7 @@ public class SearchIndexClientTests
         public async Task Can_not_ping_unknown_indexer()
         {
             // ARRANGE
-            _indexName = "not-a-real-indexer";
+            _indexerName = "not-a-real-indexer";
             var sut = GetSut();
 
             // ACT

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Configuration;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CreateSearchableReleaseDocuments;
@@ -241,7 +239,7 @@ public class ProgramTests
                 Assert.NotNull(options.Value);
                 Assert.Equal(string.Empty, options.Value.SearchServiceEndpoint);
                 Assert.Null(options.Value.SearchServiceAccessKey);
-                Assert.Equal(string.Empty, options.Value.IndexName);
+                Assert.Equal(string.Empty, options.Value.IndexerName);
             }
         }
         

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/AzureSearchIndexerClientWrapper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/AzureSearchIndexerClientWrapper.cs
@@ -5,20 +5,20 @@
 /// </summary>
 /// <param name="azureSearchIndexerClient">A real SearchIndexerClient instance</param>
 public class AzureSearchIndexerClientWrapper(
-    Azure.Search.Documents.Indexes.SearchIndexerClient azureSearchIndexerClient) 
+    Azure.Search.Documents.Indexes.SearchIndexerClient azureSearchIndexerClient)
     : IAzureSearchIndexerClient
 {
-    public async Task ResetIndexerAsync(string indexName, CancellationToken cancellationToken) =>
-        await azureSearchIndexerClient.ResetIndexerAsync(indexName, cancellationToken);
+    public async Task ResetIndexerAsync(string indexerName, CancellationToken cancellationToken) =>
+        await azureSearchIndexerClient.ResetIndexerAsync(indexerName, cancellationToken);
 
-    public async Task RunIndexerAsync(string indexName, CancellationToken cancellationToken) => 
-        await azureSearchIndexerClient.RunIndexerAsync(indexName, cancellationToken);
-    
-    public async Task<bool> IndexerExists(string indexName, CancellationToken cancellationToken)
+    public async Task RunIndexerAsync(string indexerName, CancellationToken cancellationToken) =>
+        await azureSearchIndexerClient.RunIndexerAsync(indexerName, cancellationToken);
+
+    public async Task<bool> IndexerExists(string indexerName, CancellationToken cancellationToken)
     {
         try
         {
-            var response = await azureSearchIndexerClient.GetIndexerAsync(indexName, cancellationToken);
+            var response = await azureSearchIndexerClient.GetIndexerAsync(indexerName, cancellationToken);
             return response.HasValue;
         }
         catch (Azure.RequestFailedException)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/IAzureSearchIndexerClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/IAzureSearchIndexerClient.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public interface IAzureSearchIndexerClient
 {
-    Task ResetIndexerAsync(string indexName, CancellationToken cancellationToken);
-    Task RunIndexerAsync(string indexName, CancellationToken cancellationToken);
-    Task<bool> IndexerExists(string indexName, CancellationToken cancellationToken);
+    Task ResetIndexerAsync(string indexerName, CancellationToken cancellationToken);
+    Task RunIndexerAsync(string indexerName, CancellationToken cancellationToken);
+    Task<bool> IndexerExists(string indexerName, CancellationToken cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/SearchIndexClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureSearch/SearchIndexClient.cs
@@ -11,23 +11,23 @@ public class SearchIndexClient(
     IOptions<AzureSearchOptions> searchOptions)
     : ISearchIndexClient
 {
-    private readonly string _indexName = searchOptions.Value.IndexName;
+    private readonly string _indexerName = searchOptions.Value.IndexerName;
 
     public async Task RunIndexer(CancellationToken cancellationToken = default)
     {
         var client = azureSearchIndexerClientFactory.Create();
-        await client.RunIndexerAsync(_indexName, cancellationToken);
+        await client.RunIndexerAsync(_indexerName, cancellationToken);
     }
 
     public async Task ResetIndexer(CancellationToken cancellationToken = default)
     {
         var client = azureSearchIndexerClientFactory.Create();
-        await client.ResetIndexerAsync(_indexName, cancellationToken);
+        await client.ResetIndexerAsync(_indexerName, cancellationToken);
     }
     
     public async Task<bool> IndexerExists(CancellationToken cancellationToken = default)
     {
         var client = azureSearchIndexerClientFactory.Create();
-        return await client.IndexerExists(_indexName, cancellationToken);
+        return await client.IndexerExists(_indexerName, cancellationToken);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ServiceCollectionExtensions.cs
@@ -21,10 +21,9 @@ public static class ServiceCollectionExtensions
         serviceCollection
             .AddTransient<IHealthCheckStrategy, ContentApiHealthCheckStrategy>()
             .AddTransient<IHealthCheckStrategy, AzureBlobStorageHealthCheckStrategy>()
-            // .AddTransient<IHealthCheckStrategy, AzureSearchHealthCheckStrategy>() // TODO: Comment this back in once the infrastructure and config for Azure Search are added. 
+            .AddTransient<IHealthCheckStrategy, AzureSearchHealthCheckStrategy>()
             // Factories to allow Healthcheck to evaluate config before attempting to instantiate clients
-            .AddTransient<Func<IContentApiClient>>(sp => sp.GetRequiredService<IContentApiClient>) 
+            .AddTransient<Func<IContentApiClient>>(sp => sp.GetRequiredService<IContentApiClient>)
             .AddTransient<Func<IAzureBlobStorageClient>>(sp => sp.GetRequiredService<IAzureBlobStorageClient>)
-            .AddTransient<Func<ISearchIndexClient>>(sp => sp.GetRequiredService<ISearchIndexClient>)
-        ;
+            .AddTransient<Func<ISearchIndexClient>>(sp => sp.GetRequiredService<ISearchIndexClient>);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureSearchHealthCheckStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureSearchHealthCheckStrategy.cs
@@ -12,9 +12,9 @@ internal class AzureSearchHealthCheckStrategy(
     {
         if (!azureSearchOptions.Value.IsValid(out var errorMessage))
         {
-            return new HealthCheckResult(false,  errorMessage);
+            return new HealthCheckResult(false, errorMessage);
         }
-        
+
         try
         {
             var client = searchIndexClientFactory();
@@ -22,13 +22,12 @@ internal class AzureSearchHealthCheckStrategy(
             {
                 return new HealthCheckResult(false, $"Azure Search Indexer is not found");
             }
-
         }
         catch (Exception e)
         {
             return new HealthCheckResult(false, $"Error occurred whilst trying to run healthcheck for Azure Search Indexer: {e.Message}");
         }
-        
+
         return new HealthCheckResult(true, "Connection to Azure Search Indexer:OK");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Options/AzureSearchOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Options/AzureSearchOptions.cs
@@ -5,17 +5,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 public class AzureSearchOptions
 {
     public const string Section = "AzureSearch";
-    
+
     /// <summary>
     /// Url of the search service endpoint. Likely to be similar to:
     /// https://{search_service}.search.windows.net
     /// </summary>
     public string SearchServiceEndpoint { get; init; } = string.Empty;
-    
+
     public string? SearchServiceAccessKey { get; init; }
-    
-    public string IndexName { get; init; } = string.Empty;
-    
+
+    public string IndexerName { get; init; } = string.Empty;
+
     public bool IsValid([NotNullWhen(false)] out string? errorMessage)
     {
         if (string.IsNullOrWhiteSpace(SearchServiceEndpoint))
@@ -23,13 +23,14 @@ public class AzureSearchOptions
             errorMessage = $"Azure Search Endpoint is not configured. Ensure the {Section}:{nameof(SearchServiceEndpoint)} is set.";
             return false;
         }
-                
-        if (string.IsNullOrWhiteSpace(IndexName))
+
+        if (string.IsNullOrWhiteSpace(IndexerName))
         {
-            errorMessage = $"Azure Search Index Name is not configured. Ensure the {Section}:{nameof(IndexName)} is set.";
+            errorMessage =
+                $"Azure Search Indexer Name is not configured. Ensure the {Section}:{nameof(IndexerName)} is set.";
             return false;
         }
-        
+
         errorMessage = null;
         return true;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
@@ -16,6 +16,6 @@
   "AzureSearch": {
     "SearchServiceEndpoint": "-- insert search service endpoint here e.g. https://xxxxx.search.windows.net/ --",
     "SearchServiceAccessKey" : "-- insert search service access key here --",
-    "IndexName": "-- insert index name here --"
+    "IndexerName": "-- insert indexer name here --"
   }
 }


### PR DESCRIPTION
This PR makes infrastructure changes for the Search Azure Function App to support changes made to it in EES-5875 by #5703. These changes are possible now that the configuration for the Azure AI Search resource was added by #5733.

- Rename the `indexName` app setting and parameter names to `indexerName` to match Azure's SearchIndexerClient class since the operation to retrieve indexer information requires the indexer name rather than the index name.
- Configure the app with the Azure AI search REST API endpoint.
- Configure the app with the Azure AI search indexer name.
- Enable the app's search indexer health check by uncommenting `AzureSearchHealthCheckStrategy`.
- Assign the app's system managed identity the 'Search Service Contributor' role required to list indexers.
- Break out a new `searchServiceRoleAssignment` template and refactor `searchServiceConfig` to use it.

Updated health check response after deploying these changes:

![image](https://github.com/user-attachments/assets/048ea5f4-510a-4f2a-b62b-e305cca0fe0a)
