### PR TITLE
EES-5962 On Release Slug changed - Event Handler Function

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/AzureBlobStorageClientMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/AzureBlobStorageClientMockBuilder.cs
@@ -5,11 +5,11 @@ using Blob = GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionA
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
 
-internal class AzureBlobStorageClientBuilder
+internal class AzureBlobStorageClientMockBuilder
 {
     private readonly Mock<IAzureBlobStorageClient> _mock = new(MockBehavior.Strict);
 
-    public AzureBlobStorageClientBuilder()
+    public AzureBlobStorageClientMockBuilder()
     {
         Assert = new(_mock);
         

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/ContentApiClientMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/ContentApiClientMockBuilder.cs
@@ -5,19 +5,24 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
 
-internal class ContentApiClientBuilder
+internal class ContentApiClientMockBuilder
 {
-    private readonly Mock<IContentApiClient> _mock = new Mock<IContentApiClient>(MockBehavior.Strict);
+    private readonly Mock<IContentApiClient> _mock = new(MockBehavior.Strict);
     private readonly ReleaseSearchableDocumentBuilder _releaseSearchableDocumentBuilder = new();
     private ReleaseSearchableDocument? _releaseSearchableDocument;
+    private PublicationInfo[]? _publicationsForTheme;
 
-    public ContentApiClientBuilder()
+    public ContentApiClientMockBuilder()
     {
         Assert = new Asserter(_mock);
         
         _mock
             .Setup(m => m.GetPublicationLatestReleaseSearchableDocument(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_releaseSearchableDocument ?? _releaseSearchableDocumentBuilder.Build());
+
+        _mock
+            .Setup(m => m.GetPublicationsForTheme(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _publicationsForTheme ?? []);
     }
 
     public IContentApiClient Build()
@@ -25,15 +30,21 @@ internal class ContentApiClientBuilder
         return _mock.Object;
     }
 
-    public ContentApiClientBuilder WhereReleaseSearchViewModelIs(ReleaseSearchableDocument releaseSearchableDocument)
+    public ContentApiClientMockBuilder WhereReleaseSearchViewModelIs(ReleaseSearchableDocument releaseSearchableDocument)
     {
         _releaseSearchableDocument = releaseSearchableDocument;
         return this;
     }
     
-    public ContentApiClientBuilder WhereReleaseSearchViewModelIs(Func<ReleaseSearchableDocumentBuilder, ReleaseSearchableDocumentBuilder> modifyReleaseSearchViewModel)
+    public ContentApiClientMockBuilder WhereReleaseSearchViewModelIs(Func<ReleaseSearchableDocumentBuilder, ReleaseSearchableDocumentBuilder> modifyReleaseSearchViewModel)
     {
         modifyReleaseSearchViewModel(_releaseSearchableDocumentBuilder);
+        return this;
+    }
+
+    public ContentApiClientMockBuilder WhereThemeHasPublications(params PublicationInfo[] publications)
+    {
+        _publicationsForTheme = publications;
         return this;
     }
 
@@ -43,6 +54,11 @@ internal class ContentApiClientBuilder
         public void ContentWasLoadedFor(string publicationSlug)
         {
             mock.Verify(m => m.GetPublicationLatestReleaseSearchableDocument(publicationSlug, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        public void PublicationsRequestedForThemeId(Guid expectedThemeId)
+        {
+            mock.Verify(m => m.GetPublicationsForTheme(expectedThemeId, It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/EventGridEventBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/EventGridEventBuilder.cs
@@ -5,11 +5,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 public class EventGridEventBuilder
 {
     private object _payload = new();
-    
+    private string? _subject;
+
     public EventGridEvent Build()
     {
         return new EventGridEvent(
-            "Event Subject",
+            _subject ?? "Event Subject",
             "Event Type",
             "1.1",
             _payload);
@@ -18,6 +19,12 @@ public class EventGridEventBuilder
     public EventGridEventBuilder WithPayload(object payload)
     {
         _payload = payload;
+        return this;
+    }
+
+    public EventGridEventBuilder WithSubject(string subject)
+    {
+        _subject = subject;
         return this;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/FunctionContextMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/FunctionContextMockBuilder.cs
@@ -3,11 +3,11 @@ using Microsoft.Azure.Functions.Worker;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
 
-public class FunctionContextBuilder
+public class FunctionContextMockBuilder
 {
     private string _functionName = "Mock Function Name";
 
-    public class MockFunctionContext(FunctionDefinition functionDefinition) : FunctionContext
+    private class MockFunctionContext(FunctionDefinition functionDefinition) : FunctionContext
     {
         public override string InvocationId { get; } = string.Empty;
         public override string FunctionId { get; } = string.Empty;
@@ -20,7 +20,7 @@ public class FunctionContextBuilder
         public override IInvocationFeatures Features { get; } = null!;
     }
 
-    public class MockFunctionDefinition(string name) : FunctionDefinition
+    private class MockFunctionDefinition(string name) : FunctionDefinition
     {
         public override ImmutableArray<FunctionParameter> Parameters { get; } = ImmutableArray<FunctionParameter>.Empty;
         public override string PathToAssembly { get; } = string.Empty;
@@ -36,7 +36,7 @@ public class FunctionContextBuilder
             new MockFunctionDefinition(
                 name: _functionName));
 
-    public FunctionContextBuilder ForFunctionName(string functionName)
+    public FunctionContextMockBuilder ForFunctionName(string functionName)
     {
         _functionName = functionName;
         return this;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/HeathCheckStrategyBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/HeathCheckStrategyBuilder.cs
@@ -3,7 +3,7 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
 
-public class HealthCheckStrategyBuilder
+public class HealthCheckStrategyMockBuilder
 {
     private readonly Mock<IHealthCheckStrategy> _mock = new(MockBehavior.Strict);
     private bool _healthCheckIsSuccessful = true;
@@ -18,21 +18,21 @@ public class HealthCheckStrategyBuilder
         return _mock.Object;
     }
 
-    public HealthCheckStrategyBuilder WhereResultIsHealthy(string? message = null)
+    public HealthCheckStrategyMockBuilder WhereResultIsHealthy(string? message = null)
     {
         _healthCheckIsSuccessful = true;
         _healthCheckMessage = message ?? "Everything is OK";
         return this;
     }
 
-    public HealthCheckStrategyBuilder WhereIsHealthyResultIs(bool isHealthy, string? message = null)
+    public HealthCheckStrategyMockBuilder WhereIsHealthyResultIs(bool isHealthy, string? message = null)
     {
         _healthCheckIsSuccessful = isHealthy;
         _healthCheckMessage = message ?? "Everything is OK";
         return this;
     }
 
-    public HealthCheckStrategyBuilder WhereResultIsUnhealthy(string? message = null)
+    public HealthCheckStrategyMockBuilder WhereResultIsUnhealthy(string? message = null)
     {
         _healthCheckIsSuccessful = false;
         _healthCheckMessage = message ?? "Boo. It didn't work.";

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/LoggerMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/LoggerMockBuilder.cs
@@ -47,5 +47,12 @@ public class LoggerMockBuilder<T>
             var infosWithMessage = infos.Where(l => l.Message.Contains(message));
             Xunit.Assert.NotEmpty(infosWithMessage);
         }
+        
+        public void LoggedDebugContains(string message)
+        {
+            var infos = logItems.Where(l => l.LogLevel == LogLevel.Debug);
+            var infosWithMessage = infos.Where(l => l.Message.Contains(message));
+            Xunit.Assert.NotEmpty(infosWithMessage);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/LoggerMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/LoggerMockBuilder.cs
@@ -7,7 +7,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 /// Use this builder to construct an implementation of <summary cref="ILogger{T}" /> where
 /// the log statements are recorded and can be asserted.
 /// </summary>
-public class LoggerBuilder<T>
+public class LoggerMockBuilder<T>
 {
     private MockLogger? _logger;
     

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/SearchIndexClientMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/SearchIndexClientMockBuilder.cs
@@ -1,0 +1,23 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
+using Moq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+
+public class SearchIndexClientMockBuilder
+{
+    private readonly Mock<ISearchIndexClient> _mock = new(MockBehavior.Strict);
+    public ISearchIndexClient Build()
+    {
+        _mock
+            .Setup(m => m.RunIndexer(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        
+        return _mock.Object;
+    }
+
+    public Asserter Assert => new Asserter(_mock);
+    public class Asserter(Mock<ISearchIndexClient> mock)
+    {
+        public void IndexerRun() => mock.Verify(m => m.RunIndexer(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/SearchableDocumentCreatorMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/SearchableDocumentCreatorMockBuilder.cs
@@ -1,0 +1,69 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using Moq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+
+public class SearchableDocumentCreatorMockBuilder
+{
+    private readonly Mock<ISearchableDocumentCreator> _mock = new(MockBehavior.Strict);
+    private CreatePublicationLatestReleaseSearchableDocumentResponse? _response;
+
+    public ISearchableDocumentCreator Build()
+    {
+        _mock
+            .Setup(
+                m =>
+                    m.CreatePublicationLatestReleaseSearchableDocument(
+                        It.IsAny<CreatePublicationLatestReleaseSearchableDocumentRequest>(),
+                        It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                (CreatePublicationLatestReleaseSearchableDocumentRequest req, CancellationToken _) =>
+                    _response ??
+                    new CreatePublicationLatestReleaseSearchableDocumentResponse
+                    {
+                        PublicationSlug = req.PublicationSlug,
+                        ReleaseId = Guid.NewGuid(),
+                        ReleaseSlug = "release-slug",
+                        ReleaseVersionId = Guid.NewGuid(),
+                        BlobName = "blob name"
+                    });
+
+        return _mock.Object;
+    }
+
+    public SearchableDocumentCreatorMockBuilder WhereResponseIs(
+        CreatePublicationLatestReleaseSearchableDocumentResponse response)
+    {
+        _response = response;
+        return this;
+    }
+
+public Asserter Assert => new(_mock);
+
+    public class Asserter(Mock<ISearchableDocumentCreator> mock)
+    {
+        public void CreateSearchableDocumentCalledFor(string expectedPublicationSlug)
+        {
+            mock
+                .Verify(
+                    m =>
+                        m.CreatePublicationLatestReleaseSearchableDocument(
+                            It.Is<CreatePublicationLatestReleaseSearchableDocumentRequest>(
+                                req => 
+                                    req.PublicationSlug == expectedPublicationSlug),
+                    It.IsAny<CancellationToken>()),
+                    Times.Once);
+        }
+
+        public void CreateSearchableDocumentNotCalled()
+        {
+            mock
+                .Verify(
+                    m =>
+                        m.CreatePublicationLatestReleaseSearchableDocument(
+                            It.IsAny<CreatePublicationLatestReleaseSearchableDocumentRequest>(),
+                            It.IsAny<CancellationToken>()),
+                    Times.Never);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/HealthChecks/HealthCheckFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/HealthChecks/HealthCheckFunctionTests.cs
@@ -20,9 +20,9 @@ public class HealthCheckFunctionTests
         // ARRANGE
         IHealthCheckStrategy[] strategies =
         [
-            new HealthCheckStrategyBuilder().WhereResultIsHealthy().Build(),
-            new HealthCheckStrategyBuilder().WhereResultIsHealthy().Build(),
-            new HealthCheckStrategyBuilder().WhereResultIsHealthy().Build()
+            new HealthCheckStrategyMockBuilder().WhereResultIsHealthy().Build(),
+            new HealthCheckStrategyMockBuilder().WhereResultIsHealthy().Build(),
+            new HealthCheckStrategyMockBuilder().WhereResultIsHealthy().Build()
         ];
         var sut = GetSut(strategies);
         
@@ -50,9 +50,9 @@ public class HealthCheckFunctionTests
         // ARRANGE
         IHealthCheckStrategy[] strategies =
         [
-            new HealthCheckStrategyBuilder().WhereIsHealthyResultIs(isHealthy1).Build(),
-            new HealthCheckStrategyBuilder().WhereIsHealthyResultIs(isHealthy2).Build(),
-            new HealthCheckStrategyBuilder().WhereIsHealthyResultIs(isHealthy3).Build(),
+            new HealthCheckStrategyMockBuilder().WhereIsHealthyResultIs(isHealthy1).Build(),
+            new HealthCheckStrategyMockBuilder().WhereIsHealthyResultIs(isHealthy2).Build(),
+            new HealthCheckStrategyMockBuilder().WhereIsHealthyResultIs(isHealthy3).Build(),
         ];
         var sut = GetSut(strategies);
         
@@ -73,9 +73,9 @@ public class HealthCheckFunctionTests
         // ARRANGE
         IHealthCheckStrategy[] strategies =
         [
-            new HealthCheckStrategyBuilder().WhereResultIsHealthy("Result one").Build(),
-            new HealthCheckStrategyBuilder().WhereResultIsUnhealthy("Result two").Build(),
-            new HealthCheckStrategyBuilder().WhereResultIsHealthy("Result three").Build()
+            new HealthCheckStrategyMockBuilder().WhereResultIsHealthy("Result one").Build(),
+            new HealthCheckStrategyMockBuilder().WhereResultIsUnhealthy("Result two").Build(),
+            new HealthCheckStrategyMockBuilder().WhereResultIsHealthy("Result three").Build()
         ];
         var sut = GetSut(strategies);
         

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseSlugChanged/OnReleaseSlugChangedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseSlugChanged/OnReleaseSlugChangedFunctionTests.cs
@@ -1,0 +1,63 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseSlugChanged;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseSlugChanged.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.OnReleaseSlugChanged;
+
+public class OnReleaseSlugChangedFunctionTests
+{
+    private OnReleaseSlugChangedFunction GetSut() => new(new EventGridEventHandler(new NullLogger<EventGridEventHandler>()));
+
+    [Fact]
+    public void Can_instantiate_Sut() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task GivenEvent_WhenPayloadContainsPublicationSlug_ThenRefreshSearchableDocumentMessageDtoReturned()
+    {
+        // ARRANGE
+        var payload = new ReleaseSlugChangedEventDto
+        {
+            PublicationSlug = "this-is-a-publication-slug",
+        };
+
+        var eventGridEvent = new EventGridEventBuilder()
+            .WithPayload(payload)
+            .Build();
+
+        var sut = GetSut();
+        
+        // ACT
+        var response = await sut.OnReleaseSlugChangedEvent(eventGridEvent, new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        var actual = Assert.Single(response);
+        Assert.NotNull(actual);
+        Assert.Equal(payload.PublicationSlug, actual.PublicationSlug);
+    }
+    
+    [Theory]
+    [InlineData((string?)null)]
+    [InlineData("")]
+    public async Task GivenEvent_WhenPayloadDoesNotContainPublicationSlug_ThenNothingIsReturned(string? blankPublicationSlug)
+    {
+        // ARRANGE
+        var payload = new ReleaseSlugChangedEventDto
+        {
+            PublicationSlug = blankPublicationSlug,
+        };
+
+        var eventGridEvent = new EventGridEventBuilder()
+            .WithPayload(payload)
+            .Build();
+
+        var sut = GetSut();
+        
+        // ACT
+        var response = await sut.OnReleaseSlugChangedEvent(eventGridEvent, new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        Assert.Empty(response);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseVersionPublished/OnReleaseVersionPublishedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseVersionPublished/OnReleaseVersionPublishedFunctionTests.cs
@@ -1,0 +1,65 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseVersionPublished;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseVersionPublished.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.OnReleaseVersionPublished;
+
+public class OnReleaseVersionPublishedFunctionTests
+{
+    private OnReleaseVersionPublishedFunction GetSut() => new(new EventGridEventHandler(new NullLogger<EventGridEventHandler>()));
+
+    [Fact]
+    public void Can_instantiate_Sut() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task GivenEvent_WhenPayloadContainsPublicationSlug_ThenRefreshSearchableDocumentMessageDtoReturned()
+    {
+        // ARRANGE
+        var payload = new ReleaseVersionPublishedEventDto
+        {
+            PublicationSlug = "this-is-a-publication-slug",
+        };
+
+        var eventGridEvent = new EventGridEventBuilder()
+            .WithPayload(payload)
+            .Build();
+
+        var sut = GetSut();
+        
+        // ACT
+        var response = await sut.OnReleaseVersionPublished(eventGridEvent, new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        var actual = Assert.Single(response);
+        Assert.NotNull(actual);
+        Assert.Equal(payload.PublicationSlug, actual.PublicationSlug);
+    }
+    
+    [Theory]
+    [InlineData((string?)null)]
+    [InlineData("")]
+    public async Task GivenEvent_WhenPayloadDoesNotContainPublicationSlug_ThenNothingIsReturned(string? blankPublicationSlug)
+    {
+        // ARRANGE
+        var payload = new ReleaseVersionPublishedEventDto
+        {
+            PublicationSlug = blankPublicationSlug,
+        };
+
+        var eventGridEvent = new EventGridEventBuilder()
+            .WithPayload(payload)
+            .Build();
+
+        var sut = GetSut();
+        
+        // ACT
+        var response = await sut.OnReleaseVersionPublished(eventGridEvent, new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        Assert.Empty(response);
+    }
+
+
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnThemeUpdated/OnThemeUpdatedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnThemeUpdated/OnThemeUpdatedFunctionTests.cs
@@ -1,0 +1,50 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Domain;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnThemeUpdated;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.OnThemeUpdated;
+
+public class OnThemeUpdatedFunctionTests
+{
+    private readonly ContentApiClientMockBuilder _contentApiMockBuilder = new();
+
+    private OnThemeUpdatedFunction GetSut() => new(
+        new EventGridEventHandler(new NullLogger<EventGridEventHandler>()),
+        _contentApiMockBuilder.Build(),
+        new NullLogger<OnThemeUpdatedFunction>()
+    );
+
+    [Fact]
+    public void Can_instantiate_SUT() => Assert.NotNull(GetSut());
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(10)]
+    public async Task GivenEvent_WhenThemeContainsNPublications_ThenNMessagesReturned(int numberOfPublications)
+    {
+        // ARRANGE
+        var themeId = Guid.NewGuid();
+        var eventDto = new EventGridEventBuilder()
+            .WithSubject(themeId.ToString())
+            .Build();
+        var sut = GetSut();
+        var publicationSlugs = Enumerable.Range(0, numberOfPublications)
+            .Select(i => $"publication-slug-{i}")
+            .ToArray();
+        var publications = publicationSlugs.Select(slug => new PublicationInfo{ PublicationSlug = slug }).ToArray(); 
+        
+        _contentApiMockBuilder.WhereThemeHasPublications(publications);
+        
+        // ACT
+        var response = await sut.OnThemeUpdated(eventDto, new FunctionContextMockBuilder().Build());
+
+        // ASSERT
+        _contentApiMockBuilder.Assert.PublicationsRequestedForThemeId(themeId);
+        Assert.Equal(numberOfPublications, response.Length);
+        Assert.Equal(publicationSlugs, response.Select(message => message.PublicationSlug));
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RefreshSearchableDocument/RefreshSearchableDocumentFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RefreshSearchableDocument/RefreshSearchableDocumentFunctionTests.cs
@@ -1,0 +1,88 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RefreshSearchableDocument;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RefreshSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.RefreshSearchableDocument;
+
+public class RefreshSearchableDocumentFunctionTests
+{
+    private readonly SearchableDocumentCreatorMockBuilder _searchableDocumentCreatorMockBuilder = new();
+    
+    private RefreshSearchableDocumentFunction GetSut() => new(_searchableDocumentCreatorMockBuilder.Build());
+    
+    [Fact]
+    public void Can_instantiate_SUT() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task WhenMessageWithPublicationSlug_ThenDocumentCreatorCalled()
+    {
+        // ARRANGE
+        var sut = GetSut();
+        var publicationSlug = "publication-slug";
+        var command = new RefreshSearchableDocumentMessageDto
+        {
+            PublicationSlug = publicationSlug
+        };
+        
+        // ACT
+        await sut.RefreshSearchableDocument(command, new FunctionContextMockBuilder().Build());
+
+        // ASSERT
+        _searchableDocumentCreatorMockBuilder.Assert.CreateSearchableDocumentCalledFor(publicationSlug);
+    }
+    
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task WhenMessageHasNoPublicationSlug_ThenDocumentCreatorNotCalled(string? blankPublicationSlug)
+    {
+        // ARRANGE
+        var sut = GetSut();
+        var command = new RefreshSearchableDocumentMessageDto
+        {
+            PublicationSlug = blankPublicationSlug
+        };
+        
+        // ACT
+        var response = await sut.RefreshSearchableDocument(command, new FunctionContextMockBuilder().Build());
+
+        // ASSERT
+        _searchableDocumentCreatorMockBuilder.Assert.CreateSearchableDocumentNotCalled();
+    }
+    
+    
+    [Fact]
+    public async Task GivenMessageWithPublicationSlug_WhenDocumentCreatorCalled_ThenResponseDataIsReturned()
+    {
+        // ARRANGE
+        var sut = GetSut();
+        var publicationSlug = "publication-slug";
+        var command = new RefreshSearchableDocumentMessageDto
+        {
+            PublicationSlug = publicationSlug
+        };
+        var expectedResponse = new CreatePublicationLatestReleaseSearchableDocumentResponse
+        {
+            PublicationSlug = publicationSlug,
+            ReleaseId = Guid.NewGuid(),
+            ReleaseSlug = "release-slug",
+            ReleaseVersionId = Guid.NewGuid(),
+            BlobName = "blob name"
+        };
+        _searchableDocumentCreatorMockBuilder.WhereResponseIs(expectedResponse);
+        
+        // ACT
+        var response = await sut.RefreshSearchableDocument(command, new FunctionContextMockBuilder().Build());
+
+        // ASSERT
+        Assert.NotNull(response);
+        var actual = Assert.Single(response);
+        Assert.NotNull(actual);
+        Assert.Equal(expectedResponse.PublicationSlug, publicationSlug);
+        Assert.Equal(expectedResponse.ReleaseId, actual.ReleaseId);
+        Assert.Equal(expectedResponse.ReleaseSlug, actual.ReleaseSlug);
+        Assert.Equal(expectedResponse.ReleaseVersionId, actual.ReleaseVersionId);
+        Assert.Equal(expectedResponse.BlobName, actual.BlobName);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/ReindexSearchableDocuments/ReindexSearchableDocumentsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/ReindexSearchableDocuments/ReindexSearchableDocumentsFunctionTests.cs
@@ -1,0 +1,31 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RefreshSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.ReindexSearchableDocuments;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.ReindexSearchableDocuments;
+
+public class ReindexSearchableDocumentsFunctionTests
+{
+    private readonly SearchIndexClientMockBuilder _searchIndexClientMockBuilder = new();
+    
+    private ReindexSearchableDocumentsFunction GetSut() => new(new NullLogger<ReindexSearchableDocumentsFunction>(),
+                                                               _searchIndexClientMockBuilder.Build());
+    
+    [Fact]
+    public void Can_instantiate_SUT() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task WhenMessageReceived_ThenIndexerRun()
+    {
+        // ARRANGE
+        var sut = GetSut();
+        var message = new SearchableDocumentCreatedMessageDto();
+
+        // ACT
+        await sut.ReindexSearchableDocuments(message, new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        _searchIndexClientMockBuilder.Assert.IndexerRun();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
@@ -1,6 +1,7 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseSlugChanged;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseVersionPublished;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnThemeUpdated;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RefreshSearchableDocument;
@@ -247,6 +248,19 @@ public class ProgramTests
         
         public class ResolveFunctionTests : ProgramTests
         {
+            [Fact]
+            public void Can_resolve_OnReleaseSlugChangedFunction()
+            {
+                // ARRANGE
+                var sut = GetSut();
+            
+                // ACT
+                var actual = ActivatorUtilities.CreateInstance<OnReleaseSlugChangedFunction>(sut.Services);
+            
+                // ASSERT
+                Assert.NotNull(actual);
+            }
+            
             [Fact]
             public void Can_resolve_OnReleaseVersionPublishedFunction()
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/EventGridEventHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/EventGridEventHandlerTests.cs
@@ -5,11 +5,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 
 public class EventGridEventHandlerTests
 {
-    private readonly FunctionContextBuilder _functionContextBuilder = new();
+    private readonly FunctionContextMockBuilder _functionContextMockBuilder = new();
     private readonly EventGridEventBuilder _eventGridEventBuilder = new();
-    private readonly LoggerBuilder<EventGridEventHandler> _loggerBuilder = new();
+    private readonly LoggerMockBuilder<EventGridEventHandler> _loggerMockBuilder = new();
 
-    private EventGridEventHandler GetSut() => new(_loggerBuilder.Build());
+    private EventGridEventHandler GetSut() => new(_loggerMockBuilder.Build());
     
     [Fact]
     public void Can_instantiate_SUT() => Assert.NotNull(GetSut());
@@ -31,7 +31,7 @@ public class EventGridEventHandlerTests
         }
         
         // ACT
-        await sut.Handle<MockPayloadClass, MockResponse>(_functionContextBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
+        await sut.Handle<MockPayloadClass, MockResponse>(_functionContextMockBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
         
         // ASSERT
         Assert.NotNull(actualPayload);
@@ -55,7 +55,7 @@ public class EventGridEventHandlerTests
         }
         
         // ACT
-        await sut.Handle<MockPayloadRecord, MockResponse>(_functionContextBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
+        await sut.Handle<MockPayloadRecord, MockResponse>(_functionContextMockBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
         
         // ASSERT
         Assert.Equal(expectedPayload, actualPayload);
@@ -65,7 +65,7 @@ public class EventGridEventHandlerTests
     public async Task GivenEvent_WhenEventHandled_ThenHandlerLogs()
     {
         // ARRANGE
-        _functionContextBuilder.ForFunctionName("FUNCTION_NAME_123");
+        _functionContextMockBuilder.ForFunctionName("FUNCTION_NAME_123");
         var sut = GetSut();
 
         Task<MockResponse> Handler(MockPayloadRecord payload, CancellationToken cancellationToken = default)
@@ -74,10 +74,10 @@ public class EventGridEventHandlerTests
         }
         
         // ACT
-        await sut.Handle<MockPayloadRecord, MockResponse>(_functionContextBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
+        await sut.Handle<MockPayloadRecord, MockResponse>(_functionContextMockBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
         
         // ASSERT
-        _loggerBuilder.Assert.LoggedInfoContains("FUNCTION_NAME_123");
+        _loggerMockBuilder.Assert.LoggedInfoContains("FUNCTION_NAME_123");
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class EventGridEventHandlerTests
         }
         
         // ACT
-        await sut.Handle<MockPayloadClass, MockResponse>(_functionContextBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
+        await sut.Handle<MockPayloadClass, MockResponse>(_functionContextMockBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
         
         // ASSERT
         Assert.NotNull(actualPayload);
@@ -119,7 +119,7 @@ public class EventGridEventHandlerTests
         }
         
         // ACT
-        await sut.Handle<MockPayloadRecord, MockResponse>(_functionContextBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
+        await sut.Handle<MockPayloadRecord, MockResponse>(_functionContextMockBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
         
         // ASSERT
         var expectedPayload = new MockPayloadRecord();
@@ -141,7 +141,7 @@ public class EventGridEventHandlerTests
         }
         
         // ACT
-        var actualReponse = await sut.Handle<MockPayloadClass, MockResponse>(_functionContextBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
+        var actualReponse = await sut.Handle<MockPayloadClass, MockResponse>(_functionContextMockBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
 
         // ASSERT
         Assert.NotNull(actualReponse);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/EventGridEventHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/EventGridEventHandlerTests.cs
@@ -77,7 +77,7 @@ public class EventGridEventHandlerTests
         await sut.Handle<MockPayloadRecord, MockResponse>(_functionContextMockBuilder.Build(), _eventGridEventBuilder.Build(), Handler);
         
         // ASSERT
-        _loggerMockBuilder.Assert.LoggedInfoContains("FUNCTION_NAME_123");
+        _loggerMockBuilder.Assert.LoggedDebugContains("FUNCTION_NAME_123");
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/SearchableDocumentCreatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/SearchableDocumentCreatorTests.cs
@@ -9,13 +9,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 
 public class SearchableDocumentCreatorTests
 {
-    private readonly ContentApiClientBuilder _contentApiClientBuilder = new();
-    private readonly AzureBlobStorageClientBuilder _azureBlobStorageClientBuilder = new();
+    private readonly ContentApiClientMockBuilder _contentApiClientMockBuilder = new();
+    private readonly AzureBlobStorageClientMockBuilder _azureBlobStorageClientMockBuilder = new();
     private AppOptions _appOptions = new();
     
     private SearchableDocumentCreator GetSut() => new(
-        _contentApiClientBuilder.Build(), 
-        _azureBlobStorageClientBuilder.Build(), 
+        _contentApiClientMockBuilder.Build(), 
+        _azureBlobStorageClientMockBuilder.Build(), 
         Microsoft.Extensions.Options.Options.Create(_appOptions));
 
     public class BasicTests : SearchableDocumentCreatorTests
@@ -36,7 +36,7 @@ public class SearchableDocumentCreatorTests
             await sut.CreatePublicationLatestReleaseSearchableDocument(new CreatePublicationLatestReleaseSearchableDocumentRequest { PublicationSlug = "publication-slug" });
             
             // ASSERT
-            _contentApiClientBuilder.Assert.ContentWasLoadedFor("publication-slug");
+            _contentApiClientMockBuilder.Assert.ContentWasLoadedFor("publication-slug");
         }
 
         [Fact]
@@ -55,7 +55,7 @@ public class SearchableDocumentCreatorTests
             await sut.CreatePublicationLatestReleaseSearchableDocument(new CreatePublicationLatestReleaseSearchableDocumentRequest { PublicationSlug = "publication-slug" });
             
             // ASSERT
-            _azureBlobStorageClientBuilder.Assert.BlobWasUploaded(containerName: _appOptions.SearchableDocumentsContainerName);
+            _azureBlobStorageClientMockBuilder.Assert.BlobWasUploaded(containerName: _appOptions.SearchableDocumentsContainerName);
         }
         
         [Fact]
@@ -63,7 +63,7 @@ public class SearchableDocumentCreatorTests
         {
             // ARRANGE
             var releaseId = new Guid("11223344-5566-7788-9900-123456789abc");
-            _contentApiClientBuilder.WhereReleaseSearchViewModelIs(builder => builder.WithReleaseId(releaseId));
+            _contentApiClientMockBuilder.WhereReleaseSearchViewModelIs(builder => builder.WithReleaseId(releaseId));
             
             var sut = GetSut();
             
@@ -71,7 +71,7 @@ public class SearchableDocumentCreatorTests
             await sut.CreatePublicationLatestReleaseSearchableDocument(new CreatePublicationLatestReleaseSearchableDocumentRequest { PublicationSlug = "publication-slug" });
             
             // ASSERT
-            _azureBlobStorageClientBuilder.Assert.BlobWasUploaded(blobName: releaseId.ToString());
+            _azureBlobStorageClientMockBuilder.Assert.BlobWasUploaded(blobName: releaseId.ToString());
         }
         
         [Fact]
@@ -79,7 +79,7 @@ public class SearchableDocumentCreatorTests
         {
             // ARRANGE
             var releaseSearchableDocument = new ReleaseSearchableDocumentBuilder().Build();
-            _contentApiClientBuilder.WhereReleaseSearchViewModelIs(releaseSearchableDocument);
+            _contentApiClientMockBuilder.WhereReleaseSearchViewModelIs(releaseSearchableDocument);
             var sut = GetSut();
             
             // ACT
@@ -87,7 +87,7 @@ public class SearchableDocumentCreatorTests
             
             // ASSERT
             var expected = new Blob(releaseSearchableDocument.HtmlContent, releaseSearchableDocument.BuildMetadata());
-            _azureBlobStorageClientBuilder.Assert.BlobWasUploaded(whereBlob: blob => blob == expected);
+            _azureBlobStorageClientMockBuilder.Assert.BlobWasUploaded(whereBlob: blob => blob == expected);
         }
         
         [Fact]
@@ -95,7 +95,7 @@ public class SearchableDocumentCreatorTests
         {
             // ARRANGE
             var releaseSearchableDocument = new ReleaseSearchableDocumentBuilder().Build();
-            _contentApiClientBuilder.WhereReleaseSearchViewModelIs(releaseSearchableDocument);
+            _contentApiClientMockBuilder.WhereReleaseSearchViewModelIs(releaseSearchableDocument);
             var sut = GetSut();
             
             // ACT

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/ContentApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/ContentApiClient.cs
@@ -93,9 +93,10 @@ internal class ContentApiClient(HttpClient httpClient) : IContentApiClient
     {
         var publicationDtos = await GetAllPaginatedItems<PublicationDto>(page => BuildGetPublicationsByThemePageEndpoint(themeId, page), cancellationToken);
         return publicationDtos
+            .Where(dto => !string.IsNullOrEmpty(dto.Slug))
             .Select(dto => new PublicationInfo
             {
-                PublicationSlug = dto.Slug
+                PublicationSlug = dto.Slug!
             })
             .ToArray();
     }
@@ -121,6 +122,12 @@ internal class ContentApiClient(HttpClient httpClient) : IContentApiClient
             // Store the latest page of results and if there are more to retrieve, loop around
             if (getResponse is GetResponse<PaginatedResultDto<TResponse>>.Success success)
             {
+                if (success.Result.Paging is null)
+                    throw new GetPaginatedItemsException("Paginated response did not contain the expected page information.");
+                
+                if (success.Result.Results is null)
+                    throw new GetPaginatedItemsException("Paginated response did not contain any data.");
+                        
                 items.AddRange(success.Result.Results);
                 morePagesToGet = success.Result.Paging.Page < success.Result.Paging.TotalPages;
                 page++;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/ContentApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/ContentApiClient.cs
@@ -123,11 +123,15 @@ internal class ContentApiClient(HttpClient httpClient) : IContentApiClient
             if (getResponse is GetResponse<PaginatedResultDto<TResponse>>.Success success)
             {
                 if (success.Result.Paging is null)
+                {
                     throw new GetPaginatedItemsException("Paginated response did not contain the expected page information.");
-                
+                }
+
                 if (success.Result.Results is null)
+                {
                     throw new GetPaginatedItemsException("Paginated response did not contain any data.");
-                        
+                }
+
                 items.AddRange(success.Result.Results);
                 morePagesToGet = success.Result.Paging.Page < success.Result.Paging.TotalPages;
                 page++;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/Dtos/PaginatedResultDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/Dtos/PaginatedResultDto.cs
@@ -1,7 +1,9 @@
+// ReSharper disable CollectionNeverUpdated.Global
+// ReSharper disable ClassNeverInstantiated.Global
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi.Dtos;
 
 public record PaginatedResultDto<T>
 {
-    public List<T> Results { get; init; }
-    public PagingDto Paging { get; init; }
+    public List<T>? Results { get; init; }
+    public PagingDto? Paging { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/Dtos/PagingDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/Dtos/PagingDto.cs
@@ -1,3 +1,4 @@
+// ReSharper disable ClassNeverInstantiated.Global
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi.Dtos;
 
 public record PagingDto

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/Dtos/PublicationDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/Dtos/PublicationDto.cs
@@ -1,4 +1,5 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi.Dtos;
+﻿// ReSharper disable ClassNeverInstantiated.Global
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi.Dtos;
 
 public record PublicationDto
 {
@@ -7,10 +8,10 @@ public record PublicationDto
     /// <summary>
     /// Publication Slug
     /// </summary>
-    public string Slug { get; init; } = string.Empty;
-    public required string LatestReleaseSlug { get; init; }
-    public string Summary { get; init; } = string.Empty;
-    public string Title { get; init; } = string.Empty;
-    public string Theme { get; init; } = string.Empty;
-    public DateTimeOffset Published { get; init; }
+    public string? Slug { get; init; }
+    public string? LatestReleaseSlug { get; init; }
+    public string? Summary { get; init; }
+    public string? Title { get; init; }
+    public string? Theme { get; init; }
+    public DateTimeOffset? Published { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
@@ -33,7 +33,7 @@ public static class HostBuilderExtension
                 services
                     .AddApplicationInsightsTelemetryWorkerService()
                     .ConfigureFunctionsApplicationInsights()
-                    .AddTransient<EventGridEventHandler>()
+                    // Config
                     .Configure<AppOptions>(context.Configuration.GetSection(AppOptions.Section))
                     .Configure<ContentApiOptions>(context.Configuration.GetSection(ContentApiOptions.Section))
                     .Configure<AzureSearchOptions>(context.Configuration.GetSection(AzureSearchOptions.Section))
@@ -52,12 +52,15 @@ public static class HostBuilderExtension
                             options.Rules.Remove(toRemove);
                         }
                     })
-                    .AddTransient<IContentApiClient, ContentApiClient>()
-                    .AddTransient<IAzureBlobStorageClient, AzureBlobStorageClient>()
+                    // Services
                     .AddTransient<ISearchableDocumentCreator, SearchableDocumentCreator>()
+                    // Functions
+                    .AddTransient<IEventGridEventHandler, EventGridEventHandler>()
+                    .AddHealthChecks()
+                    // Clients
                     .AddTransient<ISearchIndexClient, SearchIndexClient>()
                     .AddTransient<IAzureSearchIndexerClientFactory, AzureSearchIndexerClientFactory>()
-                    .AddHealthChecks()
+                    .AddTransient<IAzureBlobStorageClient, AzureBlobStorageClient>()
                     .AddAzureClientsInline(
                         clientBuilder =>
                         {
@@ -69,6 +72,7 @@ public static class HostBuilderExtension
                                 });
                             clientBuilder.UseCredential(new DefaultAzureCredential());
                         })
+                    .AddTransient<IContentApiClient, ContentApiClient>()
                     .AddHttpClient<IContentApiClient, ContentApiClient>(
                         (provider, httpClient) =>
                         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnReleaseSlugChanged/Dtos/ReleaseSlugChangedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnReleaseSlugChanged/Dtos/ReleaseSlugChangedEventDto.cs
@@ -1,0 +1,8 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseSlugChanged.Dtos;
+
+public class ReleaseSlugChangedEventDto
+{
+    public string? NewReleaseSlug { get; init; }
+    public string? PublicationId { get; init; }
+    public string? PublicationSlug { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnReleaseSlugChanged/OnReleaseSlugChangedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnReleaseSlugChanged/OnReleaseSlugChangedFunction.cs
@@ -1,0 +1,31 @@
+using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseSlugChanged.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RefreshSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseSlugChanged;
+
+public class OnReleaseSlugChangedFunction(IEventGridEventHandler eventGridEventHandler)
+{
+    [Function(nameof(OnReleaseSlugChangedEvent))]
+    [QueueOutput("%RefreshSearchableDocumentQueueName%")]
+    public async Task<RefreshSearchableDocumentMessageDto[]> OnReleaseSlugChangedEvent(
+        [QueueTrigger("%ReleaseSlugChangedQueueName%")]
+        EventGridEvent eventDto,
+        FunctionContext context) =>
+        await eventGridEventHandler.Handle<ReleaseSlugChangedEventDto, RefreshSearchableDocumentMessageDto[]>(
+            context, 
+            eventDto,
+            (payload, _) =>
+                Task.FromResult(
+                    string.IsNullOrEmpty(payload.PublicationSlug)
+                    ? []
+                    : new []
+                    {
+                        new RefreshSearchableDocumentMessageDto
+                        {
+                            PublicationSlug = payload.PublicationSlug
+                        }
+                    }));
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnReleaseVersionPublished/Dtos/ReleaseVersionPublishedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnReleaseVersionPublished/Dtos/ReleaseVersionPublishedEventDto.cs
@@ -1,10 +1,11 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseVersionPublished.Dtos;
+﻿// ReSharper disable ClassNeverInstantiated.Global
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseVersionPublished.Dtos;
 
 public record ReleaseVersionPublishedEventDto
 {
-    public required Guid ReleaseId {get;init;}
-    public required string ReleaseSlug { get; init; }
-    public required Guid PublicationId { get; init; }
-    public required string PublicationSlug { get; init; }
-    public required Guid PublicationLatestPublishedReleaseVersionId { get; init; }   
+    public Guid? ReleaseId {get;init;}
+    public string? ReleaseSlug { get; init; }
+    public Guid? PublicationId { get; init; }
+    public string? PublicationSlug { get; init; }
+    public Guid? PublicationLatestPublishedReleaseVersionId { get; init; }   
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnReleaseVersionPublished/Dtos/ReleaseVersionPublishedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnReleaseVersionPublished/Dtos/ReleaseVersionPublishedEventDto.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable ClassNeverInstantiated.Global
-namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseVersionPublished.Dtos;
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseVersionPublished.Dtos;
 
 public record ReleaseVersionPublishedEventDto
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnReleaseVersionPublished/OnReleaseVersionPublishedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnReleaseVersionPublished/OnReleaseVersionPublishedFunction.cs
@@ -6,7 +6,7 @@ using Microsoft.Azure.Functions.Worker;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseVersionPublished;
 
-public class OnReleaseVersionPublishedFunction(EventGridEventHandler eventGridEventHandler)
+public class OnReleaseVersionPublishedFunction(IEventGridEventHandler eventGridEventHandler)
 {
     [Function(nameof(OnReleaseVersionPublished))]
     [QueueOutput("%RefreshSearchableDocumentQueueName%")]
@@ -15,17 +15,16 @@ public class OnReleaseVersionPublishedFunction(EventGridEventHandler eventGridEv
         EventGridEvent eventDto,
         FunctionContext context) =>
         await eventGridEventHandler.Handle<ReleaseVersionPublishedEventDto, RefreshSearchableDocumentMessageDto[]>(
-            context, 
+            context,
             eventDto,
-            (payload, _) => 
+            (payload, _) =>
                 Task.FromResult(
                     // TODO: Detect whether this is the latest published release version.
-                    // If not, we don't need to refresh the Searchable Document (which is only for the latest release version) so return empty. 
-                    new []
-                    {
-                        new RefreshSearchableDocumentMessageDto
+                    // If not, we don't need to refresh the Searchable Document (which is only for the latest release version) so return empty.
+                    string.IsNullOrEmpty(payload.PublicationSlug)
+                        ? []
+                        : new[]
                         {
-                            PublicationSlug = payload.PublicationSlug
-                        }
-                    }));
+                            new RefreshSearchableDocumentMessageDto { PublicationSlug = payload.PublicationSlug }
+                        }));
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnThemeUpdated/Dtos/ThemeUpdatedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnThemeUpdated/Dtos/ThemeUpdatedEventDto.cs
@@ -1,8 +1,9 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnThemeUpdated.Dtos;
+﻿// ReSharper disable ClassNeverInstantiated.Global
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnThemeUpdated.Dtos;
 
 public class ThemeUpdatedEventDto
 {
-    public required string Title { get; init; }
-    public required string Summary { get; init; }
-    public required string Slug { get; init; }
+    public string? Title { get; init; }
+    public string? Summary { get; init; }
+    public string? Slug { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnThemeUpdated/OnThemeUpdatedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnThemeUpdated/OnThemeUpdatedFunction.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnThemeUpdated;
 
 public class OnThemeUpdatedFunction(
-    EventGridEventHandler eventGridEventHandler,
+    IEventGridEventHandler eventGridEventHandler,
     IContentApiClient contentApiClient,
     ILogger<OnThemeUpdatedFunction> logger)
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RefreshSearchableDocument/Dto/RefreshSearchableDocumentMessageDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RefreshSearchableDocument/Dto/RefreshSearchableDocumentMessageDto.cs
@@ -2,5 +2,5 @@
 
 public class RefreshSearchableDocumentMessageDto
 {
-    public required string PublicationSlug { get; init; }
+    public string? PublicationSlug { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RefreshSearchableDocument/Dto/SearchableDocumentCreatedMessageDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RefreshSearchableDocument/Dto/SearchableDocumentCreatedMessageDto.cs
@@ -2,9 +2,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 
 public record SearchableDocumentCreatedMessageDto
 {
-    public required string PublicationSlug { get; init; }
-    public required Guid ReleaseId {get;init;}
-    public required string ReleaseSlug { get; init; }
-    public required Guid ReleaseVersionId { get; init; }
-    public required string BlobName { get; init; }
+    public string? PublicationSlug { get; init; }
+    public Guid? ReleaseId {get;init;}
+    public string? ReleaseSlug { get; init; }
+    public Guid? ReleaseVersionId { get; init; }
+    public string? BlobName { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RefreshSearchableDocument/RefreshSearchableDocumentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RefreshSearchableDocument/RefreshSearchableDocumentFunction.cs
@@ -14,8 +14,10 @@ public class RefreshSearchableDocumentFunction(ISearchableDocumentCreator search
         FunctionContext context)
     {
         if (string.IsNullOrEmpty(message.PublicationSlug))
+        {
             return [];
-        
+        }
+
         // Create Searchable Document
         var request = new CreatePublicationLatestReleaseSearchableDocumentRequest
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RefreshSearchableDocument/RefreshSearchableDocumentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RefreshSearchableDocument/RefreshSearchableDocumentFunction.cs
@@ -8,26 +8,35 @@ public class RefreshSearchableDocumentFunction(ISearchableDocumentCreator search
 {
     [Function(nameof(RefreshSearchableDocument))]
     [QueueOutput("%SearchableDocumentCreatedQueueName%")]
-    public async Task<SearchableDocumentCreatedMessageDto> RefreshSearchableDocument(
+    public async Task<SearchableDocumentCreatedMessageDto[]> RefreshSearchableDocument(
         [QueueTrigger("%RefreshSearchableDocumentQueueName%")]
         RefreshSearchableDocumentMessageDto message,
         FunctionContext context)
     {
+        if (string.IsNullOrEmpty(message.PublicationSlug))
+            return [];
+        
         // Create Searchable Document
         var request = new CreatePublicationLatestReleaseSearchableDocumentRequest
-            {
-                PublicationSlug = message.PublicationSlug
-            };
-        
-        var response = await searchableDocumentCreator.CreatePublicationLatestReleaseSearchableDocument(request, context.CancellationToken);
-        
-        return new SearchableDocumentCreatedMessageDto
         {
-            PublicationSlug = response.PublicationSlug,
-            ReleaseId = response.ReleaseId,
-            ReleaseSlug = response.ReleaseSlug,
-            ReleaseVersionId = response.ReleaseVersionId,
-            BlobName = response.BlobName,
+            PublicationSlug = message.PublicationSlug
         };
+
+        var response =
+            await searchableDocumentCreator.CreatePublicationLatestReleaseSearchableDocument(
+                request,
+                context.CancellationToken);
+
+        return
+        [
+            new SearchableDocumentCreatedMessageDto
+            {
+                PublicationSlug = response.PublicationSlug,
+                ReleaseId = response.ReleaseId,
+                ReleaseSlug = response.ReleaseSlug,
+                ReleaseVersionId = response.ReleaseVersionId,
+                BlobName = response.BlobName,
+            }
+        ];
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
@@ -43,7 +43,4 @@
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
-  </ItemGroup>
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
@@ -7,6 +7,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
+  </ItemGroup>
+  
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.30.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/EventGridEventHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/EventGridEventHandler.cs
@@ -11,7 +11,7 @@ public class EventGridEventHandler(ILogger<EventGridEventHandler> logger) : IEve
         EventGridEvent eventGridEvent,
         Func<TPayload, CancellationToken, Task<TResponse>> handler)
     {
-        logger.LogInformation("{FunctionName} triggered: {Request}", context.FunctionDefinition.Name, eventGridEvent);
+        logger.LogDebug("{FunctionName} triggered: {@EventGridEvent}", context.FunctionDefinition.Name, eventGridEvent);
         
         var payload = eventGridEvent.Data.ToObjectFromJson<TPayload>() 
                       ?? throw new Exception(
@@ -20,12 +20,12 @@ public class EventGridEventHandler(ILogger<EventGridEventHandler> logger) : IEve
         try
         {
             var response = await handler(payload, context.CancellationToken);
-            logger.LogInformation("{FunctionName} completed. {Response}", context.FunctionDefinition.Name, response);
+            logger.LogDebug("{FunctionName} completed. {Response}", context.FunctionDefinition.Name, response);
             return response;
         }
         catch (Exception e)
         {
-            logger.LogError(e, "{FunctionName} errored processing {Request}.", context.FunctionDefinition.Name, eventGridEvent);
+            logger.LogError(e, "{FunctionName} errored processing {@EventGridEvent}.", context.FunctionDefinition.Name, eventGridEvent);
             throw;
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/EventGridEventHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/EventGridEventHandler.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 
-public class EventGridEventHandler(ILogger<EventGridEventHandler> logger)
+public class EventGridEventHandler(ILogger<EventGridEventHandler> logger) : IEventGridEventHandler
 {
     public async Task<TResponse> Handle<TPayload, TResponse>(
         FunctionContext context,
@@ -16,10 +16,17 @@ public class EventGridEventHandler(ILogger<EventGridEventHandler> logger)
         var payload = eventGridEvent.Data.ToObjectFromJson<TPayload>() 
                       ?? throw new Exception(
                           $"Unable to deserialise the payload of event into type {typeof(TPayload).Name}");
-        
-        var response = await handler(payload, context.CancellationToken);
 
-        logger.LogInformation("{FunctionName} completed. {Response}", context.FunctionDefinition.Name, response);
-        return response;
+        try
+        {
+            var response = await handler(payload, context.CancellationToken);
+            logger.LogInformation("{FunctionName} completed. {Response}", context.FunctionDefinition.Name, response);
+            return response;
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "{FunctionName} errored processing {Request}.", context.FunctionDefinition.Name, eventGridEvent);
+            throw;
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/IEventGridEventHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/IEventGridEventHandler.cs
@@ -1,0 +1,12 @@
+﻿using Azure.Messaging.EventGrid;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+
+public interface IEventGridEventHandler
+{
+    Task<TResponse> Handle<TPayload, TResponse>(
+        FunctionContext context,
+        EventGridEvent eventGridEvent,
+        Func<TPayload, CancellationToken, Task<TResponse>> handler);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/local.settings.json
@@ -4,6 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://data-storage",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "ReleaseVersionPublishedQueueName": "release-version-published-queue",
+    "ReleaseSlugChangedQueueName": "release-slug-changed-queue",
     "SearchableDocumentCreatedQueueName": "search-document-created-queue",
     "RefreshSearchableDocumentQueueName": "refresh-searchable-document-queue",
     "ThemeUpdatedQueueName": "theme-updated-queue"


### PR DESCRIPTION
For the final part of this ticket, added a new event handler function app for receiving and handling OnReleaseSlugChanged events.

Added On Release Slug changed event handler function. 
Added event handler OnReleaseSlugChanged.
Made all properties for the dtos nullable since the serialiser will not respect the "required" keyword. 
Added null guards where appropriate
Added Tests for all of the functions.
