### PR TITLE
Ees 5954 On Publication Changed

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -30,6 +30,10 @@ public class AdminEventRaiserServiceMockBuilder
         _mock
             .Setup(OnReleaseSlugChanged)
             .Returns(Task.CompletedTask);
+        
+        _mock
+            .Setup(m => m.OnPublicationChanged(It.IsAny<Publication>()))
+            .Returns(Task.CompletedTask);
     }
 
     public class Asserter(Mock<IAdminEventRaiserService> mock)
@@ -51,6 +55,12 @@ public class AdminEventRaiserServiceMockBuilder
 
         public void OnReleaseSlugChangedWasNotRaised() => 
             mock.Verify(OnReleaseSlugChanged, Times.Never);
+
+        public void OnPublicationChangedWasRaised(Publication? publication = null) =>
+            mock.Verify(m => m.OnPublicationChanged(It.Is<Publication>(p => publication == null || p == publication)), Times.Once);
+
+        public void OnPublicationChangedWasNotRaised()=>
+            mock.Verify(m => m.OnPublicationChanged(It.IsAny<Publication>()), Times.Never);
     }
     public Asserter Assert => new(_mock);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Events;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Moq;
@@ -57,7 +58,7 @@ public class AdminEventRaiserServiceMockBuilder
             mock.Verify(OnReleaseSlugChanged, Times.Never);
 
         public void OnPublicationChangedWasRaised(Publication? publication = null) =>
-            mock.Verify(m => m.OnPublicationChanged(It.Is<Publication>(p => publication == null || p == publication)), Times.Once);
+            mock.Verify(m => m.OnPublicationChanged(It.Is<Publication>(p => publication == null || new PublicationChangedEventDto(p) == new PublicationChangedEventDto(publication))), Times.Once);
 
         public void OnPublicationChangedWasNotRaised()=>
             mock.Verify(m => m.OnPublicationChanged(It.IsAny<Publication>()), Times.Never);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -34,10 +34,10 @@ public class AdminEventRaiserServiceMockBuilder
 
     public class Asserter(Mock<IAdminEventRaiserService> mock)
     {
-        public void ThatOnThemeUpdatedCalled(Func<Theme, bool>? predicate = null) => 
+        public void ThatOnThemeUpdatedRaised(Func<Theme, bool>? predicate = null) => 
             mock.Verify(m => m.OnThemeUpdated(It.Is<Theme>(t => predicate == null || predicate(t))), Times.Once);
 
-        public void OnReleaseSlugChangedWasCalled(
+        public void OnReleaseSlugChangedWasRaised(
             Guid? expectedReleaseId = null,
             string? expectedNewReleaseSlug = null,
             Guid? expectedPublicationId = null,
@@ -49,7 +49,7 @@ public class AdminEventRaiserServiceMockBuilder
                 It.Is<string>(publicationSlug => expectedPublicationSlug == null || publicationSlug == expectedPublicationSlug)),
                 Times.Once);
 
-        public void OnReleaseSlugChangedWasNotCalled() => 
+        public void OnReleaseSlugChangedWasNotRaised() => 
             mock.Verify(OnReleaseSlugChanged, Times.Never);
     }
     public Asserter Assert => new(_mock);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -21,7 +21,6 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbU
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
-using IPublicationRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IPublicationRepository;
 using IReleaseVersionRepository = GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces.IReleaseVersionRepository;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -10,17 +10,19 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using Moq;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
 using IPublicationRepository = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IPublicationRepository;
+using IReleaseVersionRepository = GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces.IReleaseVersionRepository;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -629,7 +631,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IPublicationCacheService? publicationCacheService = null,
             IReleaseCacheService? releaseCacheService = null,
             IMethodologyCacheService? methodologyCacheService = null,
-            IRedirectsCacheService? redirectsCacheService = null)
+            IRedirectsCacheService? redirectsCacheService = null,
+            IAdminEventRaiserService? adminEventRaiserService = null)
         {
             context ??= Mock.Of<ContentDbContext>();
 
@@ -644,7 +647,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 publicationCacheService ?? Mock.Of<IPublicationCacheService>(Strict),
                 releaseCacheService ?? Mock.Of<IReleaseCacheService>(Strict),
                 methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
-                redirectsCacheService ?? Mock.Of<IRedirectsCacheService>(Strict));
+                redirectsCacheService ?? Mock.Of<IRedirectsCacheService>(Strict),
+                adminEventRaiserService ?? new AdminEventRaiserServiceMockBuilder().Build());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
@@ -32,864 +33,748 @@ using static Moq.MockBehavior;
 using IReleaseVersionRepository = GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces.IReleaseVersionRepository;
 using ReleaseVersionRepository = GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.ReleaseVersionRepository;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+public class PublicationServiceTests
 {
-    public class PublicationServiceTests
+    private readonly DataFixture _dataFixture = new();
+
+    [Fact]
+    public async Task ListPublications_CanViewAllPublications_Theme()
     {
-        private readonly DataFixture _dataFixture = new();
-
-        [Fact]
-        public async Task ListPublications_CanViewAllPublications_Theme()
+        var theme = new Theme
         {
-            var theme = new Theme
-            {
-                Title = "Theme title",
-            };
+            Title = "Theme title",
+        };
 
-            var publication1 = new Publication
+        var publication1 = new Publication
+        {
+            Title = "Test Publication",
+            Summary = "Test summary",
+            Slug = "test-slug",
+            Theme = theme,
+            Contact = new Contact
             {
-                Title = "Test Publication",
-                Summary = "Test summary",
-                Slug = "test-slug",
-                Theme = theme,
-                Contact = new Contact
+                ContactName = "contact name",
+                ContactTelNo = "1234",
+                TeamName = "team name",
+                TeamEmail = "team@email",
+            },
+            SupersededBy = null,
+        };
+
+        var publication2 = new Publication
+        {
+            Theme = new(),
+        };
+
+        var publication3 = new Publication
+        {
+            Theme = new(),
+        };
+
+        var userService = new Mock<IUserService>(Strict);
+
+        userService.Setup(s => s.GetUserId()).Returns(new Guid());
+        userService.Setup(s => s.MatchesPolicy(RegisteredUser)).ReturnsAsync(true);
+        userService.Setup(s => s.MatchesPolicy(CanViewAllPublications)).ReturnsAsync(true);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            await contentDbContext.Publications.AddRangeAsync(publication1, publication2, publication3);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationService = BuildPublicationService(
+                context: contentDbContext,
+                userService: userService.Object);
+
+            var result = await publicationService
+                .ListPublications(publication1.Theme.Id);
+
+            var publicationViewModelList = result.AssertRight();
+
+            var publicationViewModel = Assert.Single(publicationViewModelList);
+
+            Assert.Equal(publication1.Id, publicationViewModel.Id);
+            Assert.Equal(publication1.Title, publicationViewModel.Title);
+            Assert.Equal(publication1.Summary, publicationViewModel.Summary);
+            Assert.Equal(publication1.Slug, publicationViewModel.Slug);
+            Assert.Equal(publication1.Theme.Id, publicationViewModel.Theme.Id);
+            Assert.Equal(publication1.Theme.Title, publicationViewModel.Theme.Title);
+
+            Assert.Null(publicationViewModel.SupersededById);
+            Assert.False(publicationViewModel.IsSuperseded);
+
+            Assert.Null(publicationViewModel.Permissions);
+        }
+    }
+
+    [Fact]
+    public async Task ListPublications_CanViewAllPublications_Order()
+    {
+        var theme = new Theme();
+
+        var publication1 = new Publication
+        {
+            Title = "A",
+            Theme = theme,
+        };
+
+        var publication2 = new Publication
+        {
+            Title = "B",
+            Theme = theme,
+        };
+
+        var publication3 = new Publication
+        {
+            Title = "C",
+            Theme = theme,
+        };
+
+        var userService = new Mock<IUserService>(Strict);
+
+        userService.Setup(s => s.GetUserId()).Returns(Guid.NewGuid());
+        userService.Setup(s => s.MatchesPolicy(RegisteredUser)).ReturnsAsync(true);
+        userService.Setup(s => s.MatchesPolicy(CanViewAllPublications)).ReturnsAsync(true);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            await contentDbContext.AddRangeAsync(publication2, publication3, publication1);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationService = BuildPublicationService(
+                context: contentDbContext,
+                userService: userService.Object);
+
+            var result = await publicationService
+                .ListPublications(theme.Id);
+
+            var publicationViewModelList = result.AssertRight();
+
+            Assert.Equal(3, publicationViewModelList.Count);
+            Assert.Equal(publication1.Id, publicationViewModelList[0].Id);
+            Assert.Equal(publication1.Title, publicationViewModelList[0].Title);
+
+            Assert.Equal(publication2.Id, publicationViewModelList[1].Id);
+            Assert.Equal(publication2.Title, publicationViewModelList[1].Title);
+
+            Assert.Equal(publication3.Id, publicationViewModelList[2].Id);
+            Assert.Equal(publication3.Title, publicationViewModelList[2].Title);
+        }
+    }
+
+    [Fact]
+    public async Task ListPublications_CanViewAllPublications_NoTheme()
+    {
+        var publication1 = new Publication
+        {
+            Title = "publication1",
+            Theme = new(),
+        };
+
+        var publication2 = new Publication
+        {
+            Title = "publication2",
+            Theme = new(),
+        };
+
+        var publication3 = new Publication
+        {
+            Title = "publication3",
+            Theme = new(),
+        };
+
+        var userService = new Mock<IUserService>(Strict);
+
+        userService.Setup(s => s.GetUserId()).Returns(Guid.NewGuid());
+        userService.Setup(s => s.MatchesPolicy(RegisteredUser)).ReturnsAsync(true);
+        userService.Setup(s => s.MatchesPolicy(CanViewAllPublications)).ReturnsAsync(true);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            await contentDbContext.AddRangeAsync(publication1, publication2, publication3);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationService = BuildPublicationService(
+                context: contentDbContext,
+                userService: userService.Object);
+
+            var result = await publicationService
+                .ListPublications();
+
+            var publicationViewModelList = result.AssertRight();
+
+            Assert.Equal(3, publicationViewModelList.Count);
+            Assert.Equal(publication1.Id, publicationViewModelList[0].Id);
+            Assert.Equal(publication1.Title, publicationViewModelList[0].Title);
+            Assert.Equal(publication1.ThemeId, publicationViewModelList[0].Theme.Id);
+
+            Assert.Equal(publication2.Id, publicationViewModelList[1].Id);
+            Assert.Equal(publication2.Title, publicationViewModelList[1].Title);
+            Assert.Equal(publication2.ThemeId, publicationViewModelList[1].Theme.Id);
+
+            Assert.Equal(publication3.Id, publicationViewModelList[2].Id);
+            Assert.Equal(publication3.Title, publicationViewModelList[2].Title);
+            Assert.Equal(publication3.ThemeId, publicationViewModelList[2].Theme.Id);
+        }
+    }
+
+    [Fact]
+    public async Task ListPublications_CannotViewAllPublications()
+    {
+        var user = new User { Id = Guid.NewGuid(), };
+
+        var theme = new Theme
+        {
+            Title = "Theme title",
+        };
+
+        var publication1 = new Publication
+        {
+            Title = "Test Publication",
+            Summary = "Test summary",
+            Slug = "test-slug",
+            Theme = theme,
+            SupersededBy = null,
+        };
+
+        var publication2 = new Publication
+        {
+            Theme = new(),
+        };
+
+        var publication3 = new Publication
+        {
+            Theme = new(),
+        };
+
+        var userService = new Mock<IUserService>(Strict);
+
+        userService.Setup(s => s.GetUserId()).Returns(user.Id);
+        userService.Setup(s => s.MatchesPolicy(RegisteredUser)).ReturnsAsync(true);
+        userService.Setup(s => s.MatchesPolicy(CanViewAllPublications)).ReturnsAsync(false);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            await contentDbContext.Publications.AddRangeAsync(publication1, publication2, publication3);
+            await contentDbContext.UserPublicationRoles.AddRangeAsync(
+                new UserPublicationRole
                 {
-                    ContactName = "contact name",
-                    ContactTelNo = "1234",
-                    TeamName = "team name",
-                    TeamEmail = "team@email",
+                    User = user,
+                    Publication = publication1,
+                    Role = PublicationRole.Owner,
                 },
-                SupersededBy = null,
-            };
-
-            var publication2 = new Publication
-            {
-                Theme = new(),
-            };
-
-            var publication3 = new Publication
-            {
-                Theme = new(),
-            };
-
-            var userService = new Mock<IUserService>(Strict);
-
-            userService.Setup(s => s.GetUserId()).Returns(new Guid());
-            userService.Setup(s => s.MatchesPolicy(RegisteredUser)).ReturnsAsync(true);
-            userService.Setup(s => s.MatchesPolicy(CanViewAllPublications)).ReturnsAsync(true);
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.Publications.AddRangeAsync(publication1, publication2, publication3);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(
-                    context: contentDbContext,
-                    userService: userService.Object);
-
-                var result = await publicationService
-                    .ListPublications(publication1.Theme.Id);
-
-                var publicationViewModelList = result.AssertRight();
-
-                var publicationViewModel = Assert.Single(publicationViewModelList);
-
-                Assert.Equal(publication1.Id, publicationViewModel.Id);
-                Assert.Equal(publication1.Title, publicationViewModel.Title);
-                Assert.Equal(publication1.Summary, publicationViewModel.Summary);
-                Assert.Equal(publication1.Slug, publicationViewModel.Slug);
-                Assert.Equal(publication1.Theme.Id, publicationViewModel.Theme.Id);
-                Assert.Equal(publication1.Theme.Title, publicationViewModel.Theme.Title);
-
-                Assert.Null(publicationViewModel.SupersededById);
-                Assert.False(publicationViewModel.IsSuperseded);
-
-                Assert.Null(publicationViewModel.Permissions);
-            }
-        }
-
-        [Fact]
-        public async Task ListPublications_CanViewAllPublications_Order()
-        {
-            var theme = new Theme();
-
-            var publication1 = new Publication
-            {
-                Title = "A",
-                Theme = theme,
-            };
-
-            var publication2 = new Publication
-            {
-                Title = "B",
-                Theme = theme,
-            };
-
-            var publication3 = new Publication
-            {
-                Title = "C",
-                Theme = theme,
-            };
-
-            var userService = new Mock<IUserService>(Strict);
-
-            userService.Setup(s => s.GetUserId()).Returns(Guid.NewGuid());
-            userService.Setup(s => s.MatchesPolicy(RegisteredUser)).ReturnsAsync(true);
-            userService.Setup(s => s.MatchesPolicy(CanViewAllPublications)).ReturnsAsync(true);
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.AddRangeAsync(publication2, publication3, publication1);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(
-                    context: contentDbContext,
-                    userService: userService.Object);
-
-                var result = await publicationService
-                    .ListPublications(theme.Id);
-
-                var publicationViewModelList = result.AssertRight();
-
-                Assert.Equal(3, publicationViewModelList.Count);
-                Assert.Equal(publication1.Id, publicationViewModelList[0].Id);
-                Assert.Equal(publication1.Title, publicationViewModelList[0].Title);
-
-                Assert.Equal(publication2.Id, publicationViewModelList[1].Id);
-                Assert.Equal(publication2.Title, publicationViewModelList[1].Title);
-
-                Assert.Equal(publication3.Id, publicationViewModelList[2].Id);
-                Assert.Equal(publication3.Title, publicationViewModelList[2].Title);
-            }
-        }
-
-        [Fact]
-        public async Task ListPublications_CanViewAllPublications_NoTheme()
-        {
-            var publication1 = new Publication
-            {
-                Title = "publication1",
-                Theme = new(),
-            };
-
-            var publication2 = new Publication
-            {
-                Title = "publication2",
-                Theme = new(),
-            };
-
-            var publication3 = new Publication
-            {
-                Title = "publication3",
-                Theme = new(),
-            };
-
-            var userService = new Mock<IUserService>(Strict);
-
-            userService.Setup(s => s.GetUserId()).Returns(Guid.NewGuid());
-            userService.Setup(s => s.MatchesPolicy(RegisteredUser)).ReturnsAsync(true);
-            userService.Setup(s => s.MatchesPolicy(CanViewAllPublications)).ReturnsAsync(true);
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.AddRangeAsync(publication1, publication2, publication3);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(
-                    context: contentDbContext,
-                    userService: userService.Object);
-
-                var result = await publicationService
-                    .ListPublications();
-
-                var publicationViewModelList = result.AssertRight();
-
-                Assert.Equal(3, publicationViewModelList.Count);
-                Assert.Equal(publication1.Id, publicationViewModelList[0].Id);
-                Assert.Equal(publication1.Title, publicationViewModelList[0].Title);
-                Assert.Equal(publication1.ThemeId, publicationViewModelList[0].Theme.Id);
-
-                Assert.Equal(publication2.Id, publicationViewModelList[1].Id);
-                Assert.Equal(publication2.Title, publicationViewModelList[1].Title);
-                Assert.Equal(publication2.ThemeId, publicationViewModelList[1].Theme.Id);
-
-                Assert.Equal(publication3.Id, publicationViewModelList[2].Id);
-                Assert.Equal(publication3.Title, publicationViewModelList[2].Title);
-                Assert.Equal(publication3.ThemeId, publicationViewModelList[2].Theme.Id);
-            }
-        }
-
-        [Fact]
-        public async Task ListPublications_CannotViewAllPublications()
-        {
-            var user = new User { Id = Guid.NewGuid(), };
-
-            var theme = new Theme
-            {
-                Title = "Theme title",
-            };
-
-            var publication1 = new Publication
-            {
-                Title = "Test Publication",
-                Summary = "Test summary",
-                Slug = "test-slug",
-                Theme = theme,
-                SupersededBy = null,
-            };
-
-            var publication2 = new Publication
-            {
-                Theme = new(),
-            };
-
-            var publication3 = new Publication
-            {
-                Theme = new(),
-            };
-
-            var userService = new Mock<IUserService>(Strict);
-
-            userService.Setup(s => s.GetUserId()).Returns(user.Id);
-            userService.Setup(s => s.MatchesPolicy(RegisteredUser)).ReturnsAsync(true);
-            userService.Setup(s => s.MatchesPolicy(CanViewAllPublications)).ReturnsAsync(false);
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.Publications.AddRangeAsync(publication1, publication2, publication3);
-                await contentDbContext.UserPublicationRoles.AddRangeAsync(
-                    new UserPublicationRole
-                    {
-                        User = user,
-                        Publication = publication1,
-                        Role = PublicationRole.Owner,
-                    },
-                    new UserPublicationRole
-                    {
-                        User = user,
-                        Publication = publication2,
-                        Role = PublicationRole.Owner,
-                    },
-                    new UserPublicationRole
-                    {
-                        User = user,
-                        Publication = publication3,
-                        Role = PublicationRole.Owner,
-                    });
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(
-                    context: contentDbContext,
-                    userService: userService.Object);
-
-                var result = await publicationService
-                    .ListPublications(theme.Id);
-
-                var publicationViewModelList = result.AssertRight();
-
-                var publicationViewModel = Assert.Single(publicationViewModelList);
-
-                Assert.Equal(publication1.Id, publicationViewModel.Id);
-                Assert.Equal(publication1.Title, publicationViewModel.Title);
-                Assert.Equal(publication1.Summary, publicationViewModel.Summary);
-                Assert.Equal(publication1.Slug, publicationViewModel.Slug);
-                Assert.Equal(publication1.Theme.Id, publicationViewModel.Theme.Id);
-                Assert.Equal(publication1.Theme.Title, publicationViewModel.Theme.Title);
-
-                Assert.Null(publicationViewModel.SupersededById);
-                Assert.False(publicationViewModel.IsSuperseded);
-
-                Assert.Null(publicationViewModel.Permissions);
-            }
-        }
-
-        [Fact]
-        public async Task ListPublications_CannotViewAllPublications_Order()
-        {
-            var user = new User { Id = Guid.NewGuid(), };
-
-            var theme = new Theme();
-
-            var publication1 = new Publication
-            {
-                Title = "A",
-                Theme = theme,
-            };
-
-            var publication2 = new Publication
-            {
-                Title = "B",
-                Theme = theme,
-            };
-
-            var publication3 = new Publication
-            {
-                Title = "C",
-                Theme = theme,
-            };
-
-            var userService = new Mock<IUserService>(Strict);
-
-            userService.Setup(s => s.GetUserId()).Returns(user.Id);
-            userService.Setup(s => s.MatchesPolicy(RegisteredUser)).ReturnsAsync(true);
-            userService.Setup(s => s.MatchesPolicy(CanViewAllPublications)).ReturnsAsync(false);
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.Publications.AddRangeAsync(publication2, publication3, publication1);
-                await contentDbContext.UserPublicationRoles.AddRangeAsync(
-                    new UserPublicationRole
-                    {
-                        User = user,
-                        Publication = publication1,
-                        Role = PublicationRole.Owner,
-                    },
-                    new UserPublicationRole
-                    {
-                        User = user,
-                        Publication = publication2,
-                        Role = PublicationRole.Owner,
-                    },
-                    new UserPublicationRole
-                    {
-                        User = user,
-                        Publication = publication3,
-                        Role = PublicationRole.Owner,
-                    });
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(
-                    context: contentDbContext,
-                    userService: userService.Object);
-
-                var result = await publicationService
-                    .ListPublications(theme.Id);
-
-                var publicationViewModelList = result.AssertRight();
-
-                Assert.Equal(3, publicationViewModelList.Count);
-
-                Assert.Equal(publication1.Id, publicationViewModelList[0].Id);
-                Assert.Equal(publication1.Title, publicationViewModelList[0].Title);
-
-                Assert.Equal(publication2.Id, publicationViewModelList[1].Id);
-                Assert.Equal(publication2.Title, publicationViewModelList[1].Title);
-
-                Assert.Equal(publication3.Id, publicationViewModelList[2].Id);
-                Assert.Equal(publication3.Title, publicationViewModelList[2].Title);
-            }
-        }
-
-        [Fact]
-        public async Task ListPublications_CannotViewAllPublications_NoTheme()
-        {
-            var user = new User { Id = Guid.NewGuid(), };
-
-            var publication1 = new Publication
-            {
-                Title = "publication1",
-                Theme = new(),
-            };
-
-            var publication2 = new Publication
-            {
-                Title = "publication2",
-                Theme = new(),
-            };
-
-            var publication3 = new Publication
-            {
-                Title = "publication3",
-                Theme = new(),
-            };
-
-            var publication4 = new Publication
-            {
-                Title = "publication4",
-                Theme = new(),
-            };
-
-            var userService = new Mock<IUserService>(Strict);
-
-            userService.Setup(s => s.GetUserId()).Returns(user.Id);
-            userService.Setup(s => s.MatchesPolicy(RegisteredUser)).ReturnsAsync(true);
-            userService.Setup(s => s.MatchesPolicy(CanViewAllPublications)).ReturnsAsync(false);
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.Publications.AddRangeAsync(
-                    publication1,
-                    publication2,
-                    publication3,
-                    publication4);
-                await contentDbContext.UserPublicationRoles.AddRangeAsync(
-                    new UserPublicationRole
-                    {
-                        User = user,
-                        Publication = publication1,
-                        Role = PublicationRole.Owner,
-                    },
-                    new UserPublicationRole
-                    {
-                        User = user,
-                        Publication = publication2,
-                        Role = PublicationRole.Owner,
-                    },
-                    new UserPublicationRole
-                    {
-                        User = user,
-                        Publication = publication3,
-                        Role = PublicationRole.Owner,
-                    });
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(
-                    context: contentDbContext,
-                    userService: userService.Object);
-
-                var result = await publicationService
-                    .ListPublications();
-
-                var publicationViewModelList = result.AssertRight();
-
-                Assert.Equal(3, publicationViewModelList.Count);
-
-                Assert.Equal(publication1.Id, publicationViewModelList[0].Id);
-                Assert.Equal(publication1.Title, publicationViewModelList[0].Title);
-                Assert.Equal(publication1.ThemeId, publicationViewModelList[0].Theme.Id);
-
-                Assert.Equal(publication2.Id, publicationViewModelList[1].Id);
-                Assert.Equal(publication2.Title, publicationViewModelList[1].Title);
-                Assert.Equal(publication2.ThemeId, publicationViewModelList[1].Theme.Id);
-
-                Assert.Equal(publication3.Id, publicationViewModelList[2].Id);
-                Assert.Equal(publication3.Title, publicationViewModelList[2].Title);
-                Assert.Equal(publication3.ThemeId, publicationViewModelList[2].Theme.Id);
-            }
-        }
-
-        [Fact]
-        public async Task GetPublication()
-        {
-            var publication = new Publication
-            {
-                Title = "Test publication",
-                Summary = "Test summary",
-                Slug = "test-publication",
-                Theme = new Theme
+                new UserPublicationRole
                 {
-                    Title = "Test theme"
-                }
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.Publications.AddAsync(publication);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
-
-                var result = (await publicationService.GetPublication(publication.Id)).AssertRight();
-
-                Assert.Equal(publication.Id, result.Id);
-                Assert.Equal(publication.Title, result.Title);
-                Assert.Equal(publication.Summary, result.Summary);
-                Assert.Equal(publication.Slug, result.Slug);
-
-                Assert.Equal(publication.Theme.Id, result.Theme.Id);
-                Assert.Equal(publication.Theme.Title, result.Theme.Title);
-
-                Assert.Null(result.SupersededById);
-                Assert.False(result.IsSuperseded);
-
-                Assert.Null(result.Permissions);
-            }
-        }
-
-        [Fact]
-        public async Task GetPublication_Permissions()
-        {
-            var publication = new Publication
-            {
-                Theme = new Theme(),
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.Publications.AddAsync(publication);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var userService = new Mock<IUserService>(Strict);
-
-                userService.Setup(s => s.MatchesPolicy(
-                        It.Is<Publication>(p => p.Id == publication.Id),
-                        CanViewSpecificPublication))
-                    .ReturnsAsync(true);
-                userService.Setup(s => s.MatchesPolicy(
-                        It.Is<Publication>(p => p.Id == publication.Id),
-                        CanUpdateSpecificPublicationSummary))
-                    .ReturnsAsync(true);
-                userService.Setup(s => s.MatchesPolicy(CanUpdatePublication))
-                    .ReturnsAsync(true);
-                userService.Setup(s => s.MatchesPolicy(CanUpdateContact))
-                    .ReturnsAsync(true);
-                userService.Setup(s => s.MatchesPolicy(
-                        It.Is<Publication>(p => p.Id == publication.Id),
-                        CanCreateReleaseForSpecificPublication))
-                    .ReturnsAsync(false);
-                userService.Setup(s => s.MatchesPolicy(
-                        It.Is<Publication>(p => p.Id == publication.Id),
-                        CanAdoptMethodologyForSpecificPublication))
-                    .ReturnsAsync(false);
-                userService.Setup(s => s.MatchesPolicy(
-                        It.Is<Publication>(p => p.Id == publication.Id),
-                        CanCreateMethodologyForSpecificPublication))
-                    .ReturnsAsync(false);
-                userService.Setup(s => s.MatchesPolicy(
-                        It.Is<Publication>(p => p.Id == publication.Id),
-                        CanManageExternalMethodologyForSpecificPublication))
-                    .ReturnsAsync(false);
-                userService.Setup(s => s.MatchesPolicy(
-                        It.Is<Publication>(p => p.Id == publication.Id),
-                        CanManagePublicationReleaseSeries))
-                    .ReturnsAsync(true);
-                userService.Setup(s => s.MatchesPolicy(
-                        It.Is<Publication>(p => p.Id == publication.Id),
-                        CanUpdateContact))
-                    .ReturnsAsync(true);
-                userService.Setup(s => s.MatchesPolicy(
-                        It.Is<Tuple<Publication, ReleaseRole>>(tuple =>
-                            tuple.Item1.Id == publication.Id && tuple.Item2 == ReleaseRole.Contributor),
-                        CanUpdateSpecificReleaseRole))
-                    .ReturnsAsync(false);
-                userService.Setup(s => s.MatchesPolicy(
-                        It.Is<Publication>(p => p.Id == publication.Id),
-                        CanViewReleaseTeamAccess))
-                    .ReturnsAsync(false);
-
-                var publicationService = BuildPublicationService(context,
-                    userService: userService.Object);
-
-                var result = (await publicationService.GetPublication(publication.Id, includePermissions: true))
-                    .AssertRight();
-
-                Assert.Equal(publication.Id, result.Id);
-
-                Assert.NotNull(result.Permissions);
-                Assert.True(result.Permissions!.CanUpdatePublication);
-                Assert.True(result.Permissions.CanUpdatePublicationSummary);
-                Assert.False(result.Permissions.CanCreateReleases);
-                Assert.False(result.Permissions.CanAdoptMethodologies);
-                Assert.False(result.Permissions.CanCreateMethodologies);
-                Assert.False(result.Permissions.CanManageExternalMethodology);
-                Assert.True(result.Permissions.CanManageReleaseSeries);
-                Assert.True(result.Permissions.CanUpdateContact);
-                Assert.False(result.Permissions.CanUpdateContributorReleaseRole);
-            }
-        }
-
-        [Fact]
-        public async Task GetPublication_IsSuperseded()
-        {
-            var publication = new Publication
-            {
-                Title = "Test publication",
-                Theme = new Theme(),
-                SupersededBy = new Publication
+                    User = user,
+                    Publication = publication2,
+                    Role = PublicationRole.Owner,
+                },
+                new UserPublicationRole
                 {
-                    LatestPublishedReleaseVersionId = Guid.NewGuid()
-                }
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.Publications.AddAsync(publication);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
-
-                var result = (await publicationService.GetPublication(publication.Id, includePermissions: true))
-                    .AssertRight();
-
-                Assert.Equal(publication.Id, result.Id);
-
-                Assert.Equal(publication.SupersededById, result.SupersededById);
-                Assert.True(result.IsSuperseded);
-            }
+                    User = user,
+                    Publication = publication3,
+                    Role = PublicationRole.Owner,
+                });
+            await contentDbContext.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task GetPublication_IsSuperseded_False()
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var publication = new Publication
-            {
-                Title = "Test publication",
-                Theme = new Theme(),
-                SupersededBy = new Publication
+            var publicationService = BuildPublicationService(
+                context: contentDbContext,
+                userService: userService.Object);
+
+            var result = await publicationService
+                .ListPublications(theme.Id);
+
+            var publicationViewModelList = result.AssertRight();
+
+            var publicationViewModel = Assert.Single(publicationViewModelList);
+
+            Assert.Equal(publication1.Id, publicationViewModel.Id);
+            Assert.Equal(publication1.Title, publicationViewModel.Title);
+            Assert.Equal(publication1.Summary, publicationViewModel.Summary);
+            Assert.Equal(publication1.Slug, publicationViewModel.Slug);
+            Assert.Equal(publication1.Theme.Id, publicationViewModel.Theme.Id);
+            Assert.Equal(publication1.Theme.Title, publicationViewModel.Theme.Title);
+
+            Assert.Null(publicationViewModel.SupersededById);
+            Assert.False(publicationViewModel.IsSuperseded);
+
+            Assert.Null(publicationViewModel.Permissions);
+        }
+    }
+
+    [Fact]
+    public async Task ListPublications_CannotViewAllPublications_Order()
+    {
+        var user = new User { Id = Guid.NewGuid(), };
+
+        var theme = new Theme();
+
+        var publication1 = new Publication
+        {
+            Title = "A",
+            Theme = theme,
+        };
+
+        var publication2 = new Publication
+        {
+            Title = "B",
+            Theme = theme,
+        };
+
+        var publication3 = new Publication
+        {
+            Title = "C",
+            Theme = theme,
+        };
+
+        var userService = new Mock<IUserService>(Strict);
+
+        userService.Setup(s => s.GetUserId()).Returns(user.Id);
+        userService.Setup(s => s.MatchesPolicy(RegisteredUser)).ReturnsAsync(true);
+        userService.Setup(s => s.MatchesPolicy(CanViewAllPublications)).ReturnsAsync(false);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            await contentDbContext.Publications.AddRangeAsync(publication2, publication3, publication1);
+            await contentDbContext.UserPublicationRoles.AddRangeAsync(
+                new UserPublicationRole
                 {
-                    // Superseding publication doesn't have a published release
-                    LatestPublishedReleaseVersionId = null
-                }
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.Publications.AddAsync(publication);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
-
-                var result = (await publicationService.GetPublication(publication.Id, includePermissions: true))
-                    .AssertRight();
-
-                Assert.Equal(publication.Id, result.Id);
-
-                Assert.Equal(publication.SupersededById, result.SupersededById);
-                Assert.False(result.IsSuperseded);
-            }
+                    User = user,
+                    Publication = publication1,
+                    Role = PublicationRole.Owner,
+                },
+                new UserPublicationRole
+                {
+                    User = user,
+                    Publication = publication2,
+                    Role = PublicationRole.Owner,
+                },
+                new UserPublicationRole
+                {
+                    User = user,
+                    Publication = publication3,
+                    Role = PublicationRole.Owner,
+                });
+            await contentDbContext.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task GetPublication_NotFound()
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            await using var context = InMemoryApplicationDbContext();
+            var publicationService = BuildPublicationService(
+                context: contentDbContext,
+                userService: userService.Object);
 
+            var result = await publicationService
+                .ListPublications(theme.Id);
+
+            var publicationViewModelList = result.AssertRight();
+
+            Assert.Equal(3, publicationViewModelList.Count);
+
+            Assert.Equal(publication1.Id, publicationViewModelList[0].Id);
+            Assert.Equal(publication1.Title, publicationViewModelList[0].Title);
+
+            Assert.Equal(publication2.Id, publicationViewModelList[1].Id);
+            Assert.Equal(publication2.Title, publicationViewModelList[1].Title);
+
+            Assert.Equal(publication3.Id, publicationViewModelList[2].Id);
+            Assert.Equal(publication3.Title, publicationViewModelList[2].Title);
+        }
+    }
+
+    [Fact]
+    public async Task ListPublications_CannotViewAllPublications_NoTheme()
+    {
+        var user = new User { Id = Guid.NewGuid(), };
+
+        var publication1 = new Publication
+        {
+            Title = "publication1",
+            Theme = new(),
+        };
+
+        var publication2 = new Publication
+        {
+            Title = "publication2",
+            Theme = new(),
+        };
+
+        var publication3 = new Publication
+        {
+            Title = "publication3",
+            Theme = new(),
+        };
+
+        var publication4 = new Publication
+        {
+            Title = "publication4",
+            Theme = new(),
+        };
+
+        var userService = new Mock<IUserService>(Strict);
+
+        userService.Setup(s => s.GetUserId()).Returns(user.Id);
+        userService.Setup(s => s.MatchesPolicy(RegisteredUser)).ReturnsAsync(true);
+        userService.Setup(s => s.MatchesPolicy(CanViewAllPublications)).ReturnsAsync(false);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            await contentDbContext.Publications.AddRangeAsync(
+                publication1,
+                publication2,
+                publication3,
+                publication4);
+            await contentDbContext.UserPublicationRoles.AddRangeAsync(
+                new UserPublicationRole
+                {
+                    User = user,
+                    Publication = publication1,
+                    Role = PublicationRole.Owner,
+                },
+                new UserPublicationRole
+                {
+                    User = user,
+                    Publication = publication2,
+                    Role = PublicationRole.Owner,
+                },
+                new UserPublicationRole
+                {
+                    User = user,
+                    Publication = publication3,
+                    Role = PublicationRole.Owner,
+                });
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationService = BuildPublicationService(
+                context: contentDbContext,
+                userService: userService.Object);
+
+            var result = await publicationService
+                .ListPublications();
+
+            var publicationViewModelList = result.AssertRight();
+
+            Assert.Equal(3, publicationViewModelList.Count);
+
+            Assert.Equal(publication1.Id, publicationViewModelList[0].Id);
+            Assert.Equal(publication1.Title, publicationViewModelList[0].Title);
+            Assert.Equal(publication1.ThemeId, publicationViewModelList[0].Theme.Id);
+
+            Assert.Equal(publication2.Id, publicationViewModelList[1].Id);
+            Assert.Equal(publication2.Title, publicationViewModelList[1].Title);
+            Assert.Equal(publication2.ThemeId, publicationViewModelList[1].Theme.Id);
+
+            Assert.Equal(publication3.Id, publicationViewModelList[2].Id);
+            Assert.Equal(publication3.Title, publicationViewModelList[2].Title);
+            Assert.Equal(publication3.ThemeId, publicationViewModelList[2].Theme.Id);
+        }
+    }
+
+    [Fact]
+    public async Task GetPublication()
+    {
+        var publication = new Publication
+        {
+            Title = "Test publication",
+            Summary = "Test summary",
+            Slug = "test-publication",
+            Theme = new Theme
+            {
+                Title = "Test theme"
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddAsync(publication);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
             var publicationService = BuildPublicationService(context);
 
-            var result = await publicationService.GetPublication(Guid.NewGuid());
+            var result = (await publicationService.GetPublication(publication.Id)).AssertRight();
 
-            result.AssertNotFound();
+            Assert.Equal(publication.Id, result.Id);
+            Assert.Equal(publication.Title, result.Title);
+            Assert.Equal(publication.Summary, result.Summary);
+            Assert.Equal(publication.Slug, result.Slug);
+
+            Assert.Equal(publication.Theme.Id, result.Theme.Id);
+            Assert.Equal(publication.Theme.Title, result.Theme.Title);
+
+            Assert.Null(result.SupersededById);
+            Assert.False(result.IsSuperseded);
+
+            Assert.Null(result.Permissions);
+        }
+    }
+
+    [Fact]
+    public async Task GetPublication_Permissions()
+    {
+        var publication = new Publication
+        {
+            Theme = new Theme(),
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddAsync(publication);
+            await context.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task ListPublicationSummaries()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            var publication1 = new Publication
-            {
-                Title = "Test Publication 1"
-            };
+            var userService = new Mock<IUserService>(Strict);
 
-            var publication2 = new Publication
-            {
-                Title = "Test Publication 2"
-            };
+            userService.Setup(s => s.MatchesPolicy(
+                    It.Is<Publication>(p => p.Id == publication.Id),
+                    CanViewSpecificPublication))
+                .ReturnsAsync(true);
+            userService.Setup(s => s.MatchesPolicy(
+                    It.Is<Publication>(p => p.Id == publication.Id),
+                    CanUpdateSpecificPublicationSummary))
+                .ReturnsAsync(true);
+            userService.Setup(s => s.MatchesPolicy(CanUpdatePublication))
+                .ReturnsAsync(true);
+            userService.Setup(s => s.MatchesPolicy(CanUpdateContact))
+                .ReturnsAsync(true);
+            userService.Setup(s => s.MatchesPolicy(
+                    It.Is<Publication>(p => p.Id == publication.Id),
+                    CanCreateReleaseForSpecificPublication))
+                .ReturnsAsync(false);
+            userService.Setup(s => s.MatchesPolicy(
+                    It.Is<Publication>(p => p.Id == publication.Id),
+                    CanAdoptMethodologyForSpecificPublication))
+                .ReturnsAsync(false);
+            userService.Setup(s => s.MatchesPolicy(
+                    It.Is<Publication>(p => p.Id == publication.Id),
+                    CanCreateMethodologyForSpecificPublication))
+                .ReturnsAsync(false);
+            userService.Setup(s => s.MatchesPolicy(
+                    It.Is<Publication>(p => p.Id == publication.Id),
+                    CanManageExternalMethodologyForSpecificPublication))
+                .ReturnsAsync(false);
+            userService.Setup(s => s.MatchesPolicy(
+                    It.Is<Publication>(p => p.Id == publication.Id),
+                    CanManagePublicationReleaseSeries))
+                .ReturnsAsync(true);
+            userService.Setup(s => s.MatchesPolicy(
+                    It.Is<Publication>(p => p.Id == publication.Id),
+                    CanUpdateContact))
+                .ReturnsAsync(true);
+            userService.Setup(s => s.MatchesPolicy(
+                    It.Is<Tuple<Publication, ReleaseRole>>(tuple =>
+                        tuple.Item1.Id == publication.Id && tuple.Item2 == ReleaseRole.Contributor),
+                    CanUpdateSpecificReleaseRole))
+                .ReturnsAsync(false);
+            userService.Setup(s => s.MatchesPolicy(
+                    It.Is<Publication>(p => p.Id == publication.Id),
+                    CanViewReleaseTeamAccess))
+                .ReturnsAsync(false);
 
-            var contentDbContextId = Guid.NewGuid().ToString();
+            var publicationService = BuildPublicationService(context,
+                userService: userService.Object);
 
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            var result = (await publicationService.GetPublication(publication.Id, includePermissions: true))
+                .AssertRight();
+
+            Assert.Equal(publication.Id, result.Id);
+
+            Assert.NotNull(result.Permissions);
+            Assert.True(result.Permissions!.CanUpdatePublication);
+            Assert.True(result.Permissions.CanUpdatePublicationSummary);
+            Assert.False(result.Permissions.CanCreateReleases);
+            Assert.False(result.Permissions.CanAdoptMethodologies);
+            Assert.False(result.Permissions.CanCreateMethodologies);
+            Assert.False(result.Permissions.CanManageExternalMethodology);
+            Assert.True(result.Permissions.CanManageReleaseSeries);
+            Assert.True(result.Permissions.CanUpdateContact);
+            Assert.False(result.Permissions.CanUpdateContributorReleaseRole);
+        }
+    }
+
+    [Fact]
+    public async Task GetPublication_IsSuperseded()
+    {
+        var publication = new Publication
+        {
+            Title = "Test publication",
+            Theme = new Theme(),
+            SupersededBy = new Publication
             {
-                await contentDbContext.Publications.AddRangeAsync(publication1, publication2);
-                await contentDbContext.SaveChangesAsync();
+                LatestPublishedReleaseVersionId = Guid.NewGuid()
             }
+        };
 
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var service = BuildPublicationService(contentDbContext);
+        var contextId = Guid.NewGuid().ToString();
 
-                var result = await service.ListPublicationSummaries();
-
-                var publicationViewModels = result.AssertRight();
-                Assert.Equal(2, publicationViewModels.Count);
-
-                Assert.Equal(publication1.Id, publicationViewModels[0].Id);
-                Assert.Equal(publication1.Title, publicationViewModels[0].Title);
-
-                Assert.Equal(publication2.Id, publicationViewModels[1].Id);
-                Assert.Equal(publication2.Title, publicationViewModels[1].Title);
-            }
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddAsync(publication);
+            await context.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task ListPublicationSummaries_NoPublications()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using var contentDbContext = InMemoryApplicationDbContext(contentDbContextId);
+            var publicationService = BuildPublicationService(context);
+
+            var result = (await publicationService.GetPublication(publication.Id, includePermissions: true))
+                .AssertRight();
+
+            Assert.Equal(publication.Id, result.Id);
+
+            Assert.Equal(publication.SupersededById, result.SupersededById);
+            Assert.True(result.IsSuperseded);
+        }
+    }
+
+    [Fact]
+    public async Task GetPublication_IsSuperseded_False()
+    {
+        var publication = new Publication
+        {
+            Title = "Test publication",
+            Theme = new Theme(),
+            SupersededBy = new Publication
+            {
+                // Superseding publication doesn't have a published release
+                LatestPublishedReleaseVersionId = null
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddAsync(publication);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var publicationService = BuildPublicationService(context);
+
+            var result = (await publicationService.GetPublication(publication.Id, includePermissions: true))
+                .AssertRight();
+
+            Assert.Equal(publication.Id, result.Id);
+
+            Assert.Equal(publication.SupersededById, result.SupersededById);
+            Assert.False(result.IsSuperseded);
+        }
+    }
+
+    [Fact]
+    public async Task GetPublication_NotFound()
+    {
+        await using var context = InMemoryApplicationDbContext();
+
+        var publicationService = BuildPublicationService(context);
+
+        var result = await publicationService.GetPublication(Guid.NewGuid());
+
+        result.AssertNotFound();
+    }
+
+    [Fact]
+    public async Task ListPublicationSummaries()
+    {
+        var publication1 = new Publication
+        {
+            Title = "Test Publication 1"
+        };
+
+        var publication2 = new Publication
+        {
+            Title = "Test Publication 2"
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            await contentDbContext.Publications.AddRangeAsync(publication1, publication2);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
             var service = BuildPublicationService(contentDbContext);
 
             var result = await service.ListPublicationSummaries();
 
             var publicationViewModels = result.AssertRight();
-            Assert.Empty(publicationViewModels);
+            Assert.Equal(2, publicationViewModels.Count);
+
+            Assert.Equal(publication1.Id, publicationViewModels[0].Id);
+            Assert.Equal(publication1.Title, publicationViewModels[0].Title);
+
+            Assert.Equal(publication2.Id, publicationViewModels[1].Id);
+            Assert.Equal(publication2.Title, publicationViewModels[1].Title);
+        }
+    }
+
+    [Fact]
+    public async Task ListPublicationSummaries_NoPublications()
+    {
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using var contentDbContext = InMemoryApplicationDbContext(contentDbContextId);
+        var service = BuildPublicationService(contentDbContext);
+
+        var result = await service.ListPublicationSummaries();
+
+        var publicationViewModels = result.AssertRight();
+        Assert.Empty(publicationViewModels);
+    }
+
+    [Fact]
+    public async Task CreatePublication()
+    {
+        var theme = new Theme
+        {
+            Title = "Test theme",
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Add(theme);
+            await context.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task CreatePublication()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            var theme = new Theme
-            {
-                Title = "Test theme",
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(theme);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
-
-                // Service method under test
-                var result = await publicationService.CreatePublication(
-                    new PublicationCreateRequest
-                    {
-                        Title = "Test publication",
-                        Summary = "Test summary",
-                        Contact = new ContactSaveRequest
-                        {
-                            ContactName = "John Smith",
-                            ContactTelNo = "0123456789",
-                            TeamName = "Test team",
-                            TeamEmail = "john.smith@test.com",
-                        },
-                        ThemeId = theme.Id
-                    }
-                );
-
-                var publicationViewModel = result.AssertRight();
-                Assert.Equal("Test publication", publicationViewModel.Title);
-                Assert.Equal("Test summary", publicationViewModel.Summary);
-
-                Assert.Equal("John Smith", publicationViewModel.Contact.ContactName);
-                Assert.Equal("0123456789", publicationViewModel.Contact.ContactTelNo);
-                Assert.Equal("Test team", publicationViewModel.Contact.TeamName);
-                Assert.Equal("john.smith@test.com", publicationViewModel.Contact.TeamEmail);
-
-                Assert.Equal(theme.Id, publicationViewModel.Theme.Id);
-                Assert.Equal(theme.Title, publicationViewModel.Theme.Title);
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var createdPublication = await context.Publications
-                    .Include(p => p.Contact)
-                    .Include(p => p.Theme)
-                    .FirstAsync(p => p.Title == "Test publication");
-
-                Assert.NotNull(createdPublication);
-                Assert.False(createdPublication.Live);
-                Assert.Equal("test-publication", createdPublication.Slug);
-                Assert.False(createdPublication.Updated.HasValue);
-                Assert.Equal("Test publication", createdPublication.Title);
-                Assert.Equal("Test summary", createdPublication.Summary);
-
-                Assert.Equal("John Smith", createdPublication.Contact.ContactName);
-                Assert.Equal("0123456789", createdPublication.Contact.ContactTelNo);
-                Assert.Equal("Test team", createdPublication.Contact.TeamName);
-                Assert.Equal("john.smith@test.com", createdPublication.Contact.TeamEmail);
-
-                Assert.Equal(theme.Id, createdPublication.ThemeId);
-                Assert.Equal("Test theme", createdPublication.Theme.Title);
-            }
-        }
-
-        [Fact]
-        public async Task CreatePublication_NoContactTelNo()
-        {
-            var theme = new Theme
-            {
-                Title = "Test theme",
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(theme);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
-
-                // Service method under test
-                var result = await publicationService.CreatePublication(
-                    new PublicationCreateRequest
-                    {
-                        Title = "Test publication",
-                        Summary = "Test summary",
-                        Contact = new ContactSaveRequest
-                        {
-                            ContactName = "John Smith",
-                            ContactTelNo = "",
-                            TeamName = "Test team",
-                            TeamEmail = "john.smith@test.com",
-                        },
-                        ThemeId = theme.Id
-                    }
-                );
-
-                var publicationViewModel = result.AssertRight();
-                Assert.Equal("Test publication", publicationViewModel.Title);
-
-                Assert.Equal("John Smith", publicationViewModel.Contact.ContactName);
-                Assert.Null(publicationViewModel.Contact.ContactTelNo);
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var createdPublication = await context.Publications
-                    .Include(p => p.Contact)
-                    .FirstAsync(p =>
-                        p.Title == "Test publication");
-                Assert.Equal("John Smith", createdPublication.Contact.ContactName);
-                Assert.Null(createdPublication.Contact.ContactTelNo);
-            }
-        }
-
-        [Fact]
-        public async Task CreatePublication_FailsWithNonExistingTheme()
-        {
-            await using var context = InMemoryApplicationDbContext();
-
             var publicationService = BuildPublicationService(context);
 
             // Service method under test
@@ -897,2576 +782,2709 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 new PublicationCreateRequest
                 {
                     Title = "Test publication",
-                    ThemeId = Guid.NewGuid()
-                });
+                    Summary = "Test summary",
+                    Contact = new ContactSaveRequest
+                    {
+                        ContactName = "John Smith",
+                        ContactTelNo = "0123456789",
+                        TeamName = "Test team",
+                        TeamEmail = "john.smith@test.com",
+                    },
+                    ThemeId = theme.Id
+                }
+            );
+
+            var publicationViewModel = result.AssertRight();
+            Assert.Equal("Test publication", publicationViewModel.Title);
+            Assert.Equal("Test summary", publicationViewModel.Summary);
+
+            Assert.Equal("John Smith", publicationViewModel.Contact.ContactName);
+            Assert.Equal("0123456789", publicationViewModel.Contact.ContactTelNo);
+            Assert.Equal("Test team", publicationViewModel.Contact.TeamName);
+            Assert.Equal("john.smith@test.com", publicationViewModel.Contact.TeamEmail);
+
+            Assert.Equal(theme.Id, publicationViewModel.Theme.Id);
+            Assert.Equal(theme.Title, publicationViewModel.Theme.Title);
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var createdPublication = await context.Publications
+                .Include(p => p.Contact)
+                .Include(p => p.Theme)
+                .FirstAsync(p => p.Title == "Test publication");
+
+            Assert.NotNull(createdPublication);
+            Assert.False(createdPublication.Live);
+            Assert.Equal("test-publication", createdPublication.Slug);
+            Assert.False(createdPublication.Updated.HasValue);
+            Assert.Equal("Test publication", createdPublication.Title);
+            Assert.Equal("Test summary", createdPublication.Summary);
+
+            Assert.Equal("John Smith", createdPublication.Contact.ContactName);
+            Assert.Equal("0123456789", createdPublication.Contact.ContactTelNo);
+            Assert.Equal("Test team", createdPublication.Contact.TeamName);
+            Assert.Equal("john.smith@test.com", createdPublication.Contact.TeamEmail);
+
+            Assert.Equal(theme.Id, createdPublication.ThemeId);
+            Assert.Equal("Test theme", createdPublication.Theme.Title);
+        }
+    }
+
+    [Fact]
+    public async Task CreatePublication_NoContactTelNo()
+    {
+        var theme = new Theme
+        {
+            Title = "Test theme",
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Add(theme);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var publicationService = BuildPublicationService(context);
+
+            // Service method under test
+            var result = await publicationService.CreatePublication(
+                new PublicationCreateRequest
+                {
+                    Title = "Test publication",
+                    Summary = "Test summary",
+                    Contact = new ContactSaveRequest
+                    {
+                        ContactName = "John Smith",
+                        ContactTelNo = "",
+                        TeamName = "Test team",
+                        TeamEmail = "john.smith@test.com",
+                    },
+                    ThemeId = theme.Id
+                }
+            );
+
+            var publicationViewModel = result.AssertRight();
+            Assert.Equal("Test publication", publicationViewModel.Title);
+
+            Assert.Equal("John Smith", publicationViewModel.Contact.ContactName);
+            Assert.Null(publicationViewModel.Contact.ContactTelNo);
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var createdPublication = await context.Publications
+                .Include(p => p.Contact)
+                .FirstAsync(p =>
+                    p.Title == "Test publication");
+            Assert.Equal("John Smith", createdPublication.Contact.ContactName);
+            Assert.Null(createdPublication.Contact.ContactTelNo);
+        }
+    }
+
+    [Fact]
+    public async Task CreatePublication_FailsWithNonExistingTheme()
+    {
+        await using var context = InMemoryApplicationDbContext();
+
+        var publicationService = BuildPublicationService(context);
+
+        // Service method under test
+        var result = await publicationService.CreatePublication(
+            new PublicationCreateRequest
+            {
+                Title = "Test publication",
+                ThemeId = Guid.NewGuid()
+            });
+
+        result.AssertBadRequest(ThemeDoesNotExist);
+    }
+
+    [Fact]
+    public async Task CreatePublication_FailsWithNonUniqueSlug()
+    {
+        var theme = new Theme
+        {
+            Title = "Test theme"
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Add(theme);
+            context.Add(
+                new Publication
+                {
+                    Title = "Test publication",
+                    Slug = "test-publication"
+                }
+            );
+
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var publicationService = BuildPublicationService(context);
+
+            // Service method under test
+            var result = await publicationService.CreatePublication(
+                new PublicationCreateRequest
+                {
+                    Title = "Test publication",
+                    ThemeId = theme.Id
+                }
+            );
+
+            result.AssertBadRequest(PublicationSlugNotUnique);
+        }
+    }
+
+    [Fact]
+    public async Task UpdatePublication_NotPublished()
+    {
+        var theme = new Theme
+        {
+            Title = "New theme",
+        };
+
+        var publication = new Publication
+        {
+            Title = "Old title",
+            Summary = "Old summary",
+            Slug = "old-slug",
+            Theme = new Theme
+            {
+                Title = "Old theme"
+            },
+            Contact = new Contact
+            {
+                ContactName = "Old name",
+                ContactTelNo = "0987654321",
+                TeamName = "Old team",
+                TeamEmail = "old.smith@test.com",
+            },
+            SupersededById = Guid.NewGuid(),
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Add(theme);
+            context.Add(publication);
+
+            await context.SaveChangesAsync();
+        }
+
+        var newSupersededById = Guid.NewGuid();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var methodologyService = new Mock<IMethodologyService>(Strict);
+            methodologyService
+                .Setup(s => s.PublicationTitleOrSlugChanged(
+                    publication.Id,
+                    publication.Slug,
+                    "New title",
+                    "new-title"))
+                .Returns(Task.CompletedTask);
+
+            var publicationService = BuildPublicationService(context,
+                methodologyService: methodologyService.Object);
+
+            // Service method under test
+            var result = await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
+                {
+                    Title = "New title",
+                    Summary = "New summary",
+                    ThemeId = theme.Id,
+                    SupersededById = newSupersededById,
+                }
+            );
+
+            VerifyAllMocks(methodologyService);
+
+            var viewModel = result.AssertRight();
+
+            Assert.Equal("New title", viewModel.Title);
+            Assert.Equal("New summary", viewModel.Summary);
+
+            Assert.Equal(theme.Id, viewModel.Theme.Id);
+            Assert.Equal(theme.Title, viewModel.Theme.Title);
+
+            Assert.Equal(newSupersededById, viewModel.SupersededById);
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var updatedPublication = await context.Publications
+                .Include(p => p.Contact)
+                .Include(p => p.Theme)
+                .SingleAsync(p => p.Title == "New title");
+
+            Assert.False(updatedPublication.Live);
+            updatedPublication.Updated.AssertUtcNow();
+            Assert.Equal("new-title", updatedPublication.Slug);
+            Assert.Equal("New title", updatedPublication.Title);
+            Assert.Equal(newSupersededById, updatedPublication.SupersededById);
+
+            Assert.Equal("Old name", updatedPublication.Contact.ContactName);
+            Assert.Equal("0987654321", updatedPublication.Contact.ContactTelNo);
+            Assert.Equal("Old team", updatedPublication.Contact.TeamName);
+            Assert.Equal("old.smith@test.com", updatedPublication.Contact.TeamEmail);
+
+            Assert.Equal(theme.Id, updatedPublication.ThemeId);
+            Assert.Equal("New theme", updatedPublication.Theme.Title);
+
+            var publicationRedirects = await context.PublicationRedirects.ToListAsync();
+            Assert.Empty(publicationRedirects);
+        }
+        
+        AssertOnPublicationChangedEventNotRaised();
+    }
+
+    [Fact]
+    public async Task UpdatePublication_AlreadyPublished()
+    {
+        var theme = new Theme
+        {
+            Title = "New theme",
+        };
+
+        var supersedingPublicationToRemove = new Publication
+        {
+            Slug = "superseding-to-remove-slug",
+        };
+
+        var publication = new Publication
+        {
+            Slug = "old-title",
+            Title = "Old title",
+            Summary = "Old summary",
+            Theme = new Theme
+            {
+                Title = "Old theme"
+            },
+            Contact = new Contact
+            {
+                ContactName = "Old name",
+                ContactTelNo = "0987654321",
+                TeamName = "Old team",
+                TeamEmail = "old.smith@test.com",
+            },
+            LatestPublishedReleaseVersion = new ReleaseVersion(),
+            SupersededBy = supersedingPublicationToRemove,
+        };
+
+        var supersededPublication = new Publication
+        {
+            Slug = "superseded-slug",
+            SupersededBy = publication,
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.AddRange(theme, publication, supersedingPublicationToRemove, supersededPublication);
+            await context.SaveChangesAsync();
+        }
+
+        var newSupersededById = Guid.NewGuid();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var methodologyService = new Mock<IMethodologyService>(Strict);
+            var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
+
+            methodologyService
+                .Setup(s => s.PublicationTitleOrSlugChanged(
+                    publication.Id,
+                    publication.Slug,
+                    "New title",
+                    "new-title"))
+                .Returns(Task.CompletedTask);
+
+            methodologyCacheService.Setup(mock => mock.UpdateSummariesTree())
+                .ReturnsAsync(new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(
+                    new List<AllMethodologiesThemeViewModel>()));
+
+            publicationCacheService.Setup(mock => mock.UpdatePublication("new-title"))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            publicationCacheService.Setup(mock => mock.UpdatePublication(supersededPublication.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            publicationCacheService.Setup(mock => mock.UpdatePublicationTree())
+                .ReturnsAsync(new List<PublicationTreeThemeViewModel>());
+
+            publicationCacheService.Setup(mock => mock.RemovePublication("old-title"))
+                .ReturnsAsync(Unit.Instance);
+
+            redirectsCacheService.Setup(mock => mock.UpdateRedirects())
+                .ReturnsAsync(new RedirectsViewModel(
+                    PublicationRedirects: [],
+                    MethodologyRedirects: [],
+                    ReleaseRedirectsByPublicationSlug: []));
+
+            var publicationService = BuildPublicationService(context,
+                methodologyService: methodologyService.Object,
+                publicationCacheService: publicationCacheService.Object,
+                methodologyCacheService: methodologyCacheService.Object,
+                redirectsCacheService: redirectsCacheService.Object);
+
+            var result = await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
+                {
+                    Title = "New title",
+                    Summary = "New summary",
+                    ThemeId = theme.Id,
+                    SupersededById = newSupersededById,
+                }
+            );
+
+            VerifyAllMocks(methodologyService,
+                methodologyCacheService,
+                publicationCacheService);
+
+            var viewModel = result.AssertRight();
+
+            Assert.Equal("New title", viewModel.Title);
+            Assert.Equal("New summary", viewModel.Summary);
+
+            Assert.Equal(theme.Id, viewModel.Theme.Id);
+            Assert.Equal(theme.Title, viewModel.Theme.Title);
+
+            Assert.Equal(newSupersededById, viewModel.SupersededById);
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var updatedPublication = await context.Publications
+                .Include(p => p.Contact)
+                .Include(p => p.Theme)
+                .SingleAsync(p => p.Title == "New title");
+
+            Assert.True(updatedPublication.Live);
+            updatedPublication.Updated.AssertUtcNow();
+            Assert.Equal("New title", updatedPublication.Title);
+            Assert.Equal("new-title", updatedPublication.Slug);
+            Assert.Equal("New summary", updatedPublication.Summary);
+
+            Assert.Equal("Old name", updatedPublication.Contact.ContactName);
+            Assert.Equal("0987654321", updatedPublication.Contact.ContactTelNo);
+            Assert.Equal("Old team", updatedPublication.Contact.TeamName);
+            Assert.Equal("old.smith@test.com", updatedPublication.Contact.TeamEmail);
+
+            Assert.Equal(theme.Id, updatedPublication.ThemeId);
+            Assert.Equal("New theme", updatedPublication.Theme.Title);
+
+            Assert.Equal(newSupersededById, updatedPublication.SupersededById);
+
+            var publicationRedirects = await context.PublicationRedirects
+                .ToListAsync();
+
+            var publicationRedirect = Assert.Single(publicationRedirects);
+
+            Assert.Equal("old-title", publicationRedirect.Slug);
+            Assert.Equal(publication.Id, publicationRedirect.PublicationId);
+
+            AssertOnPublicationChangedEventRaised(updatedPublication);
+        }
+    }
+
+    [Fact]
+    public async Task UpdatePublication_TitleChangesPublicationAndMethodologySlug()
+    {
+        var publication = new Publication
+        {
+            Slug = "old-title",
+            Title = "Old title",
+            Theme = new Theme(),
+            Contact = new Contact
+            {
+                ContactName = "Old name",
+                ContactTelNo = "0987654321",
+                TeamName = "Old team",
+                TeamEmail = "old.smith@test.com",
+            },
+            LatestPublishedReleaseVersion = new ReleaseVersion(),
+        };
+
+        var methodologyVersionId = Guid.NewGuid();
+        var publicationMethodology = new PublicationMethodology
+        {
+            Publication = publication,
+            Owner = true,
+            Methodology = new Methodology
+            {
+                LatestPublishedVersionId = methodologyVersionId,
+                Versions = ListOf(new MethodologyVersion
+                {
+                    Id = methodologyVersionId,
+                }),
+                OwningPublicationTitle = "Old title",
+                OwningPublicationSlug = "old-title",
+            }
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.PublicationMethodologies.AddRange(publicationMethodology);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var methodologyService = new Mock<IMethodologyService>(Strict);
+            var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
+
+            methodologyService.Setup(mock =>
+                    mock.ValidateMethodologySlug("new-title", null, null))
+                .ReturnsAsync(Unit.Instance);
+
+            methodologyService
+                .Setup(s => s.PublicationTitleOrSlugChanged(
+                    publication.Id,
+                    publication.Slug,
+                    "New title",
+                    "new-title"))
+                .Returns(Task.CompletedTask);
+
+            methodologyCacheService.Setup(mock => mock.UpdateSummariesTree())
+                .ReturnsAsync(new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(
+                    new List<AllMethodologiesThemeViewModel>()));
+
+            publicationCacheService.Setup(mock => mock.UpdatePublication("new-title"))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            publicationCacheService.Setup(mock => mock.UpdatePublicationTree())
+                .ReturnsAsync(new List<PublicationTreeThemeViewModel>());
+
+            publicationCacheService.Setup(mock => mock.RemovePublication("old-title"))
+                .ReturnsAsync(Unit.Instance);
+
+            redirectsCacheService.Setup(mock => mock.UpdateRedirects())
+                .ReturnsAsync(new RedirectsViewModel(
+                    PublicationRedirects: [],
+                    MethodologyRedirects: [],
+                    ReleaseRedirectsByPublicationSlug: []));
+
+            var publicationService = BuildPublicationService(context,
+                methodologyService: methodologyService.Object,
+                publicationCacheService: publicationCacheService.Object,
+                methodologyCacheService: methodologyCacheService.Object,
+                redirectsCacheService: redirectsCacheService.Object);
+
+            var result = await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
+                {
+                    ThemeId = publication.ThemeId,
+                    Title = "New title",
+                    Summary = "New summary",
+                }
+            );
+
+            VerifyAllMocks(methodologyService,
+                methodologyCacheService,
+                publicationCacheService);
+
+            var viewModel = result.AssertRight();
+
+            Assert.Equal("New title", viewModel.Title);
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var updatedPublication = await context.Publications
+                .Include(p => p.Contact)
+                .Include(p => p.Theme)
+                .SingleAsync(p => p.Title == "New title");
+
+            Assert.True(updatedPublication.Live);
+            Assert.True(updatedPublication.Updated.HasValue);
+            Assert.InRange(DateTime.UtcNow.Subtract(updatedPublication.Updated!.Value).Milliseconds, 0, 1500);
+
+            Assert.Equal("new-title", updatedPublication.Slug);
+            Assert.Equal("New title", updatedPublication.Title);
+
+            // We don't check whether methodology titles/slugs have changed, because this is done by
+            // PublicationTitleOrSlugChanged, which has been mocked.
+
+            var publicationRedirects = context.PublicationRedirects.ToList();
+            var redirect = Assert.Single(publicationRedirects);
+            Assert.Equal(publication.Id, redirect.PublicationId);
+            Assert.Equal("old-title", redirect.Slug);
+            AssertOnPublicationChangedEventRaised(updatedPublication);
+        }
+    }
+
+    [Fact]
+    public async Task UpdatePublication_NoTitleOrSupersededByChange()
+    {
+        var theme = new Theme
+        {
+            Title = "theme",
+        };
+
+        var publication = new Publication
+        {
+            Title = "Old title",
+            Summary = "Old summary",
+            Slug = "old-title",
+            Theme = new Theme
+            {
+                Title = "Old theme"
+            },
+            Contact = new Contact
+            {
+                ContactName = "Old name",
+                ContactTelNo = "0987654321",
+                TeamName = "Old team",
+                TeamEmail = "old.smith@test.com",
+            },
+            SupersededById = Guid.NewGuid(),
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Add(theme);
+            context.Add(publication);
+
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            // Expect no calls to be made on this Mock as the Publication's Title and Slug haven't changed.
+            var methodologyService = new Mock<IMethodologyService>(Strict);
+
+            var publicationService = BuildPublicationService(context,
+                methodologyService: methodologyService.Object);
+
+            var result = await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
+                {
+                    Title = "Old title",
+                    Summary = "New summary",
+                    ThemeId = theme.Id,
+                    SupersededById = publication.SupersededById,
+                }
+            );
+
+            VerifyAllMocks(methodologyService);
+
+            var viewModel = result.AssertRight();
+
+            Assert.Equal("Old title", viewModel.Title);
+            Assert.Equal("New summary", viewModel.Summary);
+            Assert.Equal(publication.SupersededById, viewModel.SupersededById);
+        }
+        
+        AssertOnPublicationChangedEventNotRaised();
+    }
+
+    [Fact]
+    public async Task UpdatePublication_RemovesSupersededPublicationCacheBlobs()
+    {
+        var publication = new Publication
+        {
+            Title = "Test title",
+            Slug = "test-slug",
+            Theme = new Theme
+            {
+                Title = "Test theme",
+            },
+            LatestPublishedReleaseVersion = new ReleaseVersion()
+        };
+
+        var supersededPublication1 = new Publication
+        {
+            Title = "Superseded title 1",
+            Slug = "superseded-slug-1",
+            SupersededBy = publication,
+        };
+
+        var supersededPublication2 = new Publication
+        {
+            Title = "Superseded title 2",
+            Slug = "superseded-slug-2",
+            SupersededBy = publication,
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.AddRange(
+                publication,
+                supersededPublication1,
+                supersededPublication2);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+
+            publicationCacheService.Setup(mock =>
+                    mock.UpdatePublication(publication.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            publicationCacheService.Setup(mock =>
+                    mock.UpdatePublication(supersededPublication1.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            publicationCacheService.Setup(mock =>
+                    mock.UpdatePublication(supersededPublication2.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            publicationCacheService.Setup(mock => mock.UpdatePublicationTree())
+                .ReturnsAsync(new List<PublicationTreeThemeViewModel>());
+
+            methodologyCacheService.Setup(mock => mock.UpdateSummariesTree())
+                .ReturnsAsync(
+                    new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(
+                        new List<AllMethodologiesThemeViewModel>()));
+
+            var publicationService = BuildPublicationService(context,
+                publicationCacheService: publicationCacheService.Object,
+                methodologyCacheService: methodologyCacheService.Object);
+
+            var result = await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
+                {
+                    Title = "Test title",
+                    Slug = "test-slug",
+                    ThemeId = publication.ThemeId,
+                }
+            );
+
+            VerifyAllMocks(methodologyCacheService,
+                publicationCacheService,
+                publicationCacheService);
+
+            var viewModel = result.AssertRight();
+            Assert.Equal(publication.Id, viewModel.Id);
+            Assert.Equal("Test title", viewModel.Title);
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var updatedPublication = await context.Publications.FirstAsync(p => p.Title == "Test title");
+            Assert.NotNull(updatedPublication);
+        }
+    }
+
+    [Fact]
+    public async Task UpdatePublication_FailsWithNonExistingTheme()
+    {
+        var publication = new Publication
+        {
+            Title = "Test publication",
+            Theme = new Theme
+            {
+                Title = "Test theme"
+            },
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Add(publication);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var publicationService = BuildPublicationService(context);
+
+            // Service method under test
+            var result = await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
+                {
+                    Title = "Test publication",
+                    ThemeId = Guid.NewGuid(),
+                }
+            );
 
             result.AssertBadRequest(ThemeDoesNotExist);
         }
+        
+        AssertOnPublicationChangedEventNotRaised();
+    }
 
-        [Fact]
-        public async Task CreatePublication_FailsWithNonUniqueSlug()
+    [Fact]
+    public async Task UpdatePublication_CreateRedirectIfLiveSlugChanged()
+    {
+        var theme = new Theme
         {
-            var theme = new Theme
-            {
-                Title = "Test theme"
-            };
+            Title = "Theme title",
+        };
+        var publication = new Publication
+        {
+            Title = "Current title",
+            Slug = "current-title",
+            Theme = theme,
+            LatestPublishedReleaseVersionId = Guid.NewGuid(),
+        };
+        var olderRedirect = new PublicationRedirect
+        {
+            Publication = publication,
+            Slug = "old-title",
+        };
 
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(theme);
-                context.Add(
-                    new Publication
-                    {
-                        Title = "Test publication",
-                        Slug = "test-publication"
-                    }
-                );
-
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
-
-                // Service method under test
-                var result = await publicationService.CreatePublication(
-                    new PublicationCreateRequest
-                    {
-                        Title = "Test publication",
-                        ThemeId = theme.Id
-                    }
-                );
-
-                result.AssertBadRequest(PublicationSlugNotUnique);
-            }
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddAsync(publication);
+            await context.PublicationRedirects.AddAsync(olderRedirect);
+            await context.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task UpdatePublication_NotPublished()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            var theme = new Theme
-            {
-                Title = "New theme",
-            };
+            var methodologyService = new Mock<IMethodologyService>(Strict);
+            methodologyService.Setup(mock =>
+                    mock.ValidateMethodologySlug("new-title", null, null))
+                .ReturnsAsync(Unit.Instance);
+            methodologyService.Setup(mock =>
+                    mock.PublicationTitleOrSlugChanged(
+                        publication.Id, "current-title", "New title", "new-title"))
+                .Returns(Task.CompletedTask);
 
-            var publication = new Publication
-            {
-                Title = "Old title",
-                Summary = "Old summary",
-                Slug = "old-slug",
-                Theme = new Theme
-                {
-                    Title = "Old theme"
-                },
-                Contact = new Contact
-                {
-                    ContactName = "Old name",
-                    ContactTelNo = "0987654321",
-                    TeamName = "Old team",
-                    TeamEmail = "old.smith@test.com",
-                },
-                SupersededById = Guid.NewGuid(),
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(theme);
-                context.Add(publication);
-
-                await context.SaveChangesAsync();
-            }
-
-            var newSupersededById = Guid.NewGuid();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var methodologyService = new Mock<IMethodologyService>(Strict);
-                methodologyService
-                    .Setup(s => s.PublicationTitleOrSlugChanged(
-                        publication.Id,
-                        publication.Slug,
-                        "New title",
-                        "new-title"))
-                    .Returns(Task.CompletedTask);
-
-                var publicationService = BuildPublicationService(context,
-                    methodologyService: methodologyService.Object);
-
-                // Service method under test
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        Title = "New title",
-                        Summary = "New summary",
-                        ThemeId = theme.Id,
-                        SupersededById = newSupersededById,
-                    }
-                );
-
-                VerifyAllMocks(methodologyService);
-
-                var viewModel = result.AssertRight();
-
-                Assert.Equal("New title", viewModel.Title);
-                Assert.Equal("New summary", viewModel.Summary);
-
-                Assert.Equal(theme.Id, viewModel.Theme.Id);
-                Assert.Equal(theme.Title, viewModel.Theme.Title);
-
-                Assert.Equal(newSupersededById, viewModel.SupersededById);
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var updatedPublication = await context.Publications
-                    .Include(p => p.Contact)
-                    .Include(p => p.Theme)
-                    .SingleAsync(p => p.Title == "New title");
-
-                Assert.False(updatedPublication.Live);
-                updatedPublication.Updated.AssertUtcNow();
-                Assert.Equal("new-title", updatedPublication.Slug);
-                Assert.Equal("New title", updatedPublication.Title);
-                Assert.Equal(newSupersededById, updatedPublication.SupersededById);
-
-                Assert.Equal("Old name", updatedPublication.Contact.ContactName);
-                Assert.Equal("0987654321", updatedPublication.Contact.ContactTelNo);
-                Assert.Equal("Old team", updatedPublication.Contact.TeamName);
-                Assert.Equal("old.smith@test.com", updatedPublication.Contact.TeamEmail);
-
-                Assert.Equal(theme.Id, updatedPublication.ThemeId);
-                Assert.Equal("New theme", updatedPublication.Theme.Title);
-
-                var publicationRedirects = await context.PublicationRedirects.ToListAsync();
-                Assert.Empty(publicationRedirects);
-            }
-        }
-
-        [Fact]
-        public async Task UpdatePublication_AlreadyPublished()
-        {
-            var theme = new Theme
-            {
-                Title = "New theme",
-            };
-
-            var supersedingPublicationToRemove = new Publication
-            {
-                Slug = "superseding-to-remove-slug",
-            };
-
-            var publication = new Publication
-            {
-                Slug = "old-title",
-                Title = "Old title",
-                Summary = "Old summary",
-                Theme = new Theme
-                {
-                    Title = "Old theme"
-                },
-                Contact = new Contact
-                {
-                    ContactName = "Old name",
-                    ContactTelNo = "0987654321",
-                    TeamName = "Old team",
-                    TeamEmail = "old.smith@test.com",
-                },
-                LatestPublishedReleaseVersion = new ReleaseVersion(),
-                SupersededBy = supersedingPublicationToRemove,
-            };
-
-            var supersededPublication = new Publication
-            {
-                Slug = "superseded-slug",
-                SupersededBy = publication,
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.AddRange(theme, publication, supersedingPublicationToRemove, supersededPublication);
-                await context.SaveChangesAsync();
-            }
-
-            var newSupersededById = Guid.NewGuid();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var methodologyService = new Mock<IMethodologyService>(Strict);
-                var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
-
-                methodologyService
-                    .Setup(s => s.PublicationTitleOrSlugChanged(
-                        publication.Id,
-                        publication.Slug,
-                        "New title",
-                        "new-title"))
-                    .Returns(Task.CompletedTask);
-
-                methodologyCacheService.Setup(mock => mock.UpdateSummariesTree())
-                    .ReturnsAsync(new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(
+            var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
+            methodologyCacheService.Setup(mock => mock.UpdateSummariesTree())
+                .ReturnsAsync(
+                    new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(
                         new List<AllMethodologiesThemeViewModel>()));
 
-                publicationCacheService.Setup(mock => mock.UpdatePublication("new-title"))
-                    .ReturnsAsync(new PublicationCacheViewModel());
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(mock => mock.UpdatePublicationTree())
+                .ReturnsAsync(new List<PublicationTreeThemeViewModel>());
+            publicationCacheService.Setup(mock =>
+                    mock.UpdatePublication("new-title"))
+                .ReturnsAsync(new PublicationCacheViewModel());
+            publicationCacheService.Setup(mock => mock.RemovePublication("current-title"))
+                .ReturnsAsync(Unit.Instance);
 
-                publicationCacheService.Setup(mock => mock.UpdatePublication(supersededPublication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
+            var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
+            redirectsCacheService.Setup(mock => mock.UpdateRedirects())
+                .ReturnsAsync(new RedirectsViewModel(
+                    PublicationRedirects: [],
+                    MethodologyRedirects: [],
+                    ReleaseRedirectsByPublicationSlug: []));
 
-                publicationCacheService.Setup(mock => mock.UpdatePublicationTree())
-                    .ReturnsAsync(new List<PublicationTreeThemeViewModel>());
+            var publicationService = BuildPublicationService(context,
+                methodologyService: methodologyService.Object,
+                methodologyCacheService: methodologyCacheService.Object,
+                publicationCacheService: publicationCacheService.Object,
+                redirectsCacheService: redirectsCacheService.Object);
 
-                publicationCacheService.Setup(mock => mock.RemovePublication("old-title"))
-                    .ReturnsAsync(Unit.Instance);
+            var result = await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
+                {
+                    Title = "New title",
+                    ThemeId = theme.Id,
+                }
+            );
 
-                redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                    .ReturnsAsync(new RedirectsViewModel(
-                        PublicationRedirects: [],
-                        MethodologyRedirects: [],
-                        ReleaseRedirectsByPublicationSlug: []));
-
-                var publicationService = BuildPublicationService(context,
-                    methodologyService: methodologyService.Object,
-                    publicationCacheService: publicationCacheService.Object,
-                    methodologyCacheService: methodologyCacheService.Object,
-                    redirectsCacheService: redirectsCacheService.Object);
-
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        Title = "New title",
-                        Summary = "New summary",
-                        ThemeId = theme.Id,
-                        SupersededById = newSupersededById,
-                    }
-                );
-
-                VerifyAllMocks(methodologyService,
-                    methodologyCacheService,
-                    publicationCacheService);
-
-                var viewModel = result.AssertRight();
-
-                Assert.Equal("New title", viewModel.Title);
-                Assert.Equal("New summary", viewModel.Summary);
-
-                Assert.Equal(theme.Id, viewModel.Theme.Id);
-                Assert.Equal(theme.Title, viewModel.Theme.Title);
-
-                Assert.Equal(newSupersededById, viewModel.SupersededById);
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var updatedPublication = await context.Publications
-                    .Include(p => p.Contact)
-                    .Include(p => p.Theme)
-                    .SingleAsync(p => p.Title == "New title");
-
-                Assert.True(updatedPublication.Live);
-                updatedPublication.Updated.AssertUtcNow();
-                Assert.Equal("New title", updatedPublication.Title);
-                Assert.Equal("new-title", updatedPublication.Slug);
-                Assert.Equal("New summary", updatedPublication.Summary);
-
-                Assert.Equal("Old name", updatedPublication.Contact.ContactName);
-                Assert.Equal("0987654321", updatedPublication.Contact.ContactTelNo);
-                Assert.Equal("Old team", updatedPublication.Contact.TeamName);
-                Assert.Equal("old.smith@test.com", updatedPublication.Contact.TeamEmail);
-
-                Assert.Equal(theme.Id, updatedPublication.ThemeId);
-                Assert.Equal("New theme", updatedPublication.Theme.Title);
-
-                Assert.Equal(newSupersededById, updatedPublication.SupersededById);
-
-                var publicationRedirects = await context.PublicationRedirects
-                    .ToListAsync();
-
-                var publicationRedirect = Assert.Single(publicationRedirects);
-
-                Assert.Equal("old-title", publicationRedirect.Slug);
-                Assert.Equal(publication.Id, publicationRedirect.PublicationId);
-            }
+            var viewModel = result.AssertRight();
+            Assert.Equal("New title", viewModel.Title);
+            Assert.Equal("new-title", viewModel.Slug);
         }
 
-        [Fact]
-        public async Task UpdatePublication_TitleChangesPublicationAndMethodologySlug()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            var publication = new Publication
-            {
-                Slug = "old-title",
-                Title = "Old title",
-                Theme = new Theme(),
-                Contact = new Contact
-                {
-                    ContactName = "Old name",
-                    ContactTelNo = "0987654321",
-                    TeamName = "Old team",
-                    TeamEmail = "old.smith@test.com",
-                },
-                LatestPublishedReleaseVersion = new ReleaseVersion(),
-            };
+            var dbPublication = context.Publications
+                .Single(p => p.Id == publication.Id);
+            Assert.Equal("New title", dbPublication.Title);
+            Assert.Equal("new-title", dbPublication.Slug);
 
-            var methodologyVersionId = Guid.NewGuid();
-            var publicationMethodology = new PublicationMethodology
-            {
-                Publication = publication,
-                Owner = true,
-                Methodology = new Methodology
-                {
-                    LatestPublishedVersionId = methodologyVersionId,
-                    Versions = ListOf(new MethodologyVersion
-                    {
-                        Id = methodologyVersionId,
-                    }),
-                    OwningPublicationTitle = "Old title",
-                    OwningPublicationSlug = "old-title",
-                }
-            };
+            var publicationRedirects = context.PublicationRedirects.ToList();
+            Assert.Equal(2, publicationRedirects.Count);
 
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.PublicationMethodologies.AddRange(publicationMethodology);
-                await context.SaveChangesAsync();
-            }
+            Assert.Equal(publication.Id, publicationRedirects[0].PublicationId);
+            Assert.Equal("old-title", publicationRedirects[0].Slug);
 
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var methodologyService = new Mock<IMethodologyService>(Strict);
-                var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
+            Assert.Equal(publication.Id, publicationRedirects[1].PublicationId);
+            Assert.Equal("current-title", publicationRedirects[1].Slug);
+        }
+    }
 
-                methodologyService.Setup(mock =>
-                        mock.ValidateMethodologySlug("new-title", null, null))
-                    .ReturnsAsync(Unit.Instance);
+    [Fact]
+    public async Task UpdatePublication_ChangeBackToPreviousLiveSlug()
+    {
+        var theme = new Theme
+        {
+            Title = "Theme title",
+        };
+        var publication = new Publication
+        {
+            Title = "Title",
+            Slug = "title",
+            Theme = theme,
+            LatestPublishedReleaseVersionId = Guid.NewGuid(),
+        };
+        var olderRedirect = new PublicationRedirect
+        {
+            Publication = publication,
+            Slug = "older-title",
+        };
 
-                methodologyService
-                    .Setup(s => s.PublicationTitleOrSlugChanged(
-                        publication.Id,
-                        publication.Slug,
-                        "New title",
-                        "new-title"))
-                    .Returns(Task.CompletedTask);
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddAsync(publication);
+            await context.PublicationRedirects.AddAsync(olderRedirect);
+            await context.SaveChangesAsync();
+        }
 
-                methodologyCacheService.Setup(mock => mock.UpdateSummariesTree())
-                    .ReturnsAsync(new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var methodologyService = new Mock<IMethodologyService>(Strict);
+            methodologyService.Setup(mock =>
+                    mock.ValidateMethodologySlug("older-title", null, null))
+                .ReturnsAsync(Unit.Instance);
+            methodologyService.Setup(mock =>
+                    mock.PublicationTitleOrSlugChanged(
+                        publication.Id, "title", "Older title", "older-title"))
+                .Returns(Task.CompletedTask);
+
+            var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
+            methodologyCacheService.Setup(mock => mock.UpdateSummariesTree())
+                .ReturnsAsync(
+                    new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(
                         new List<AllMethodologiesThemeViewModel>()));
 
-                publicationCacheService.Setup(mock => mock.UpdatePublication("new-title"))
-                    .ReturnsAsync(new PublicationCacheViewModel());
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(mock => mock.UpdatePublicationTree())
+                .ReturnsAsync(new List<PublicationTreeThemeViewModel>());
+            publicationCacheService.Setup(mock =>
+                    mock.UpdatePublication("older-title"))
+                .ReturnsAsync(new PublicationCacheViewModel());
+            publicationCacheService.Setup(mock => mock.RemovePublication("title"))
+                .ReturnsAsync(Unit.Instance);
 
-                publicationCacheService.Setup(mock => mock.UpdatePublicationTree())
-                    .ReturnsAsync(new List<PublicationTreeThemeViewModel>());
+            var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
+            redirectsCacheService.Setup(mock => mock.UpdateRedirects())
+                .ReturnsAsync(new RedirectsViewModel(
+                    PublicationRedirects: [],
+                    MethodologyRedirects: [],
+                    ReleaseRedirectsByPublicationSlug: []));
 
-                publicationCacheService.Setup(mock => mock.RemovePublication("old-title"))
-                    .ReturnsAsync(Unit.Instance);
+            var publicationService = BuildPublicationService(context,
+                methodologyService: methodologyService.Object,
+                methodologyCacheService: methodologyCacheService.Object,
+                publicationCacheService: publicationCacheService.Object,
+                redirectsCacheService: redirectsCacheService.Object);
 
-                redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                    .ReturnsAsync(new RedirectsViewModel(
-                        PublicationRedirects: [],
-                        MethodologyRedirects: [],
-                        ReleaseRedirectsByPublicationSlug: []));
-
-                var publicationService = BuildPublicationService(context,
-                    methodologyService: methodologyService.Object,
-                    publicationCacheService: publicationCacheService.Object,
-                    methodologyCacheService: methodologyCacheService.Object,
-                    redirectsCacheService: redirectsCacheService.Object);
-
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        ThemeId = publication.ThemeId,
-                        Title = "New title",
-                        Summary = "New summary",
-                    }
-                );
-
-                VerifyAllMocks(methodologyService,
-                    methodologyCacheService,
-                    publicationCacheService);
-
-                var viewModel = result.AssertRight();
-
-                Assert.Equal("New title", viewModel.Title);
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var updatedPublication = await context.Publications
-                    .Include(p => p.Contact)
-                    .Include(p => p.Theme)
-                    .SingleAsync(p => p.Title == "New title");
-
-                Assert.True(updatedPublication.Live);
-                Assert.True(updatedPublication.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(updatedPublication.Updated!.Value).Milliseconds, 0, 1500);
-
-                Assert.Equal("new-title", updatedPublication.Slug);
-                Assert.Equal("New title", updatedPublication.Title);
-
-                // We don't check whether methodology titles/slugs have changed, because this is done by
-                // PublicationTitleOrSlugChanged, which has been mocked.
-
-                var publicationRedirects = context.PublicationRedirects.ToList();
-                var redirect = Assert.Single(publicationRedirects);
-                Assert.Equal(publication.Id, redirect.PublicationId);
-                Assert.Equal("old-title", redirect.Slug);
-            }
-        }
-
-        [Fact]
-        public async Task UpdatePublication_NoTitleOrSupersededByChange()
-        {
-            var theme = new Theme
-            {
-                Title = "theme",
-            };
-
-            var publication = new Publication
-            {
-                Title = "Old title",
-                Summary = "Old summary",
-                Slug = "old-title",
-                Theme = new Theme
+            var result = await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
                 {
-                    Title = "Old theme"
-                },
-                Contact = new Contact
-                {
-                    ContactName = "Old name",
-                    ContactTelNo = "0987654321",
-                    TeamName = "Old team",
-                    TeamEmail = "old.smith@test.com",
-                },
-                SupersededById = Guid.NewGuid(),
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(theme);
-                context.Add(publication);
-
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                // Expect no calls to be made on this Mock as the Publication's Title and Slug haven't changed.
-                var methodologyService = new Mock<IMethodologyService>(Strict);
-
-                var publicationService = BuildPublicationService(context,
-                    methodologyService: methodologyService.Object);
-
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        Title = "Old title",
-                        Summary = "New summary",
-                        ThemeId = theme.Id,
-                        SupersededById = publication.SupersededById,
-                    }
-                );
-
-                VerifyAllMocks(methodologyService);
-
-                var viewModel = result.AssertRight();
-
-                Assert.Equal("Old title", viewModel.Title);
-                Assert.Equal("New summary", viewModel.Summary);
-                Assert.Equal(publication.SupersededById, viewModel.SupersededById);
-            }
-        }
-
-        [Fact]
-        public async Task UpdatePublication_RemovesSupersededPublicationCacheBlobs()
-        {
-            var publication = new Publication
-            {
-                Title = "Test title",
-                Slug = "test-slug",
-                Theme = new Theme
-                {
-                    Title = "Test theme",
-                },
-                LatestPublishedReleaseVersion = new ReleaseVersion()
-            };
-
-            var supersededPublication1 = new Publication
-            {
-                Title = "Superseded title 1",
-                Slug = "superseded-slug-1",
-                SupersededBy = publication,
-            };
-
-            var supersededPublication2 = new Publication
-            {
-                Title = "Superseded title 2",
-                Slug = "superseded-slug-2",
-                SupersededBy = publication,
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.AddRange(
-                    publication,
-                    supersededPublication1,
-                    supersededPublication2);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication(supersededPublication1.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication(supersededPublication2.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                publicationCacheService.Setup(mock => mock.UpdatePublicationTree())
-                    .ReturnsAsync(new List<PublicationTreeThemeViewModel>());
-
-                methodologyCacheService.Setup(mock => mock.UpdateSummariesTree())
-                    .ReturnsAsync(
-                        new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(
-                            new List<AllMethodologiesThemeViewModel>()));
-
-                var publicationService = BuildPublicationService(context,
-                    publicationCacheService: publicationCacheService.Object,
-                    methodologyCacheService: methodologyCacheService.Object);
-
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        Title = "Test title",
-                        Slug = "test-slug",
-                        ThemeId = publication.ThemeId,
-                    }
-                );
-
-                VerifyAllMocks(methodologyCacheService,
-                    publicationCacheService,
-                    publicationCacheService);
-
-                var viewModel = result.AssertRight();
-                Assert.Equal(publication.Id, viewModel.Id);
-                Assert.Equal("Test title", viewModel.Title);
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var updatedPublication = await context.Publications.FirstAsync(p => p.Title == "Test title");
-                Assert.NotNull(updatedPublication);
-            }
-        }
-
-        [Fact]
-        public async Task UpdatePublication_FailsWithNonExistingTheme()
-        {
-            var publication = new Publication
-            {
-                Title = "Test publication",
-                Theme = new Theme
-                {
-                    Title = "Test theme"
-                },
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(publication);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
-
-                // Service method under test
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        Title = "Test publication",
-                        ThemeId = Guid.NewGuid(),
-                    }
-                );
-
-                result.AssertBadRequest(ThemeDoesNotExist);
-            }
-        }
-
-        [Fact]
-        public async Task UpdatePublication_CreateRedirectIfLiveSlugChanged()
-        {
-            var theme = new Theme
-            {
-                Title = "Theme title",
-            };
-            var publication = new Publication
-            {
-                Title = "Current title",
-                Slug = "current-title",
-                Theme = theme,
-                LatestPublishedReleaseVersionId = Guid.NewGuid(),
-            };
-            var olderRedirect = new PublicationRedirect
-            {
-                Publication = publication,
-                Slug = "old-title",
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.Publications.AddAsync(publication);
-                await context.PublicationRedirects.AddAsync(olderRedirect);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var methodologyService = new Mock<IMethodologyService>(Strict);
-                methodologyService.Setup(mock =>
-                        mock.ValidateMethodologySlug("new-title", null, null))
-                    .ReturnsAsync(Unit.Instance);
-                methodologyService.Setup(mock =>
-                        mock.PublicationTitleOrSlugChanged(
-                            publication.Id, "current-title", "New title", "new-title"))
-                    .Returns(Task.CompletedTask);
-
-                var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
-                methodologyCacheService.Setup(mock => mock.UpdateSummariesTree())
-                    .ReturnsAsync(
-                        new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(
-                            new List<AllMethodologiesThemeViewModel>()));
-
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(mock => mock.UpdatePublicationTree())
-                    .ReturnsAsync(new List<PublicationTreeThemeViewModel>());
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication("new-title"))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-                publicationCacheService.Setup(mock => mock.RemovePublication("current-title"))
-                    .ReturnsAsync(Unit.Instance);
-
-                var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
-                redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                    .ReturnsAsync(new RedirectsViewModel(
-                        PublicationRedirects: [],
-                        MethodologyRedirects: [],
-                        ReleaseRedirectsByPublicationSlug: []));
-
-                var publicationService = BuildPublicationService(context,
-                    methodologyService: methodologyService.Object,
-                    methodologyCacheService: methodologyCacheService.Object,
-                    publicationCacheService: publicationCacheService.Object,
-                    redirectsCacheService: redirectsCacheService.Object);
-
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        Title = "New title",
-                        ThemeId = theme.Id,
-                    }
-                );
-
-                var viewModel = result.AssertRight();
-                Assert.Equal("New title", viewModel.Title);
-                Assert.Equal("new-title", viewModel.Slug);
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var dbPublication = context.Publications
-                    .Single(p => p.Id == publication.Id);
-                Assert.Equal("New title", dbPublication.Title);
-                Assert.Equal("new-title", dbPublication.Slug);
-
-                var publicationRedirects = context.PublicationRedirects.ToList();
-                Assert.Equal(2, publicationRedirects.Count);
-
-                Assert.Equal(publication.Id, publicationRedirects[0].PublicationId);
-                Assert.Equal("old-title", publicationRedirects[0].Slug);
-
-                Assert.Equal(publication.Id, publicationRedirects[1].PublicationId);
-                Assert.Equal("current-title", publicationRedirects[1].Slug);
-            }
-        }
-
-        [Fact]
-        public async Task UpdatePublication_ChangeBackToPreviousLiveSlug()
-        {
-            var theme = new Theme
-            {
-                Title = "Theme title",
-            };
-            var publication = new Publication
-            {
-                Title = "Title",
-                Slug = "title",
-                Theme = theme,
-                LatestPublishedReleaseVersionId = Guid.NewGuid(),
-            };
-            var olderRedirect = new PublicationRedirect
-            {
-                Publication = publication,
-                Slug = "older-title",
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.Publications.AddAsync(publication);
-                await context.PublicationRedirects.AddAsync(olderRedirect);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var methodologyService = new Mock<IMethodologyService>(Strict);
-                methodologyService.Setup(mock =>
-                        mock.ValidateMethodologySlug("older-title", null, null))
-                    .ReturnsAsync(Unit.Instance);
-                methodologyService.Setup(mock =>
-                        mock.PublicationTitleOrSlugChanged(
-                            publication.Id, "title", "Older title", "older-title"))
-                    .Returns(Task.CompletedTask);
-
-                var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
-                methodologyCacheService.Setup(mock => mock.UpdateSummariesTree())
-                    .ReturnsAsync(
-                        new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(
-                            new List<AllMethodologiesThemeViewModel>()));
-
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(mock => mock.UpdatePublicationTree())
-                    .ReturnsAsync(new List<PublicationTreeThemeViewModel>());
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication("older-title"))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-                publicationCacheService.Setup(mock => mock.RemovePublication("title"))
-                    .ReturnsAsync(Unit.Instance);
-
-                var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
-                redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                    .ReturnsAsync(new RedirectsViewModel(
-                        PublicationRedirects: [],
-                        MethodologyRedirects: [],
-                        ReleaseRedirectsByPublicationSlug: []));
-
-                var publicationService = BuildPublicationService(context,
-                    methodologyService: methodologyService.Object,
-                    methodologyCacheService: methodologyCacheService.Object,
-                    publicationCacheService: publicationCacheService.Object,
-                    redirectsCacheService: redirectsCacheService.Object);
-
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        Title = "Older title",
-                        ThemeId = theme.Id,
-                    }
-                );
-
-                var viewModel = result.AssertRight();
-                Assert.Equal("Older title", viewModel.Title);
-                Assert.Equal("older-title", viewModel.Slug);
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var dbPublication = context.Publications
-                    .Single(p => p.Id == publication.Id);
-                Assert.Equal("Older title", dbPublication.Title);
-                Assert.Equal("older-title", dbPublication.Slug);
-
-                var publicationRedirects = context.PublicationRedirects.ToList();
-                var redirect = Assert.Single(publicationRedirects);
-
-                // As the current slug is now "older-title", the "older-title" redirect is redundant
-                // and so is removed
-
-                Assert.Equal(publication.Id, redirect.PublicationId);
-                Assert.Equal("title", redirect.Slug);
-            }
-        }
-
-        [Fact]
-        public async Task UpdatePublication_OtherPublicationHasSlug()
-        {
-            var theme = new Theme
-            {
-                Title = "Theme title"
-            };
-            var publication = new Publication
-            {
-                Title = "Test publication",
-                Slug = "test-publication",
-                Theme = theme,
-            };
-            var otherPublication = new Publication
-            {
-                Title = "Duplicated title",
-                Slug = "duplicated-title",
-                Theme = theme,
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(publication);
-                context.Add(otherPublication);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
-
-                // Service method under test
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        Title = "Duplicated title",
-                        ThemeId = theme.Id,
-                    }
-                );
-
-                result.AssertBadRequest(PublicationSlugNotUnique);
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                // check there are no changes
-                var dbPublication = context.Publications
-                    .Single(p => p.Id == publication.Id);
-                Assert.Equal("Test publication", dbPublication.Title);
-                Assert.Equal("test-publication", dbPublication.Slug);
-
-                var publicationRedirects = context.PublicationRedirects.ToList();
-                Assert.Empty(publicationRedirects);
-            }
-        }
-
-        [Fact]
-        public async Task UpdatePublication_SlugUsedByRedirect()
-        {
-            var theme = new Theme
-            {
-                Title = "Theme title"
-            };
-            var publication = new Publication
-            {
-                Title = "Test publication",
-                Slug = "test-publication",
-                Theme = theme,
-            };
-            var publicationRedirect = new PublicationRedirect
-            {
-                Slug = "duplicated-title",
-                Publication = new Publication(),
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.Publications.AddAsync(publication);
-                await context.PublicationRedirects.AddAsync(publicationRedirect);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
-
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        Title = "Duplicated title",
-                        ThemeId = theme.Id,
-                    }
-                );
-
-                result.AssertBadRequest(PublicationSlugUsedByRedirect);
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                // check there are no changes
-                var dbPublication = context.Publications
-                    .Single(p => p.Id == publication.Id);
-                Assert.Equal("Test publication", dbPublication.Title);
-                Assert.Equal("test-publication", dbPublication.Slug);
-
-                var publicationRedirects = context.PublicationRedirects.ToList();
-                var redirect = Assert.Single(publicationRedirects);
-                Assert.Equal(publicationRedirect.PublicationId, redirect.PublicationId);
-                Assert.Equal(publicationRedirect.Slug, redirect.Slug);
-            }
-        }
-
-        [Fact]
-        public async Task UpdatePublication_MethodologyInheritedNewSlugAlreadyUsed()
-        {
-            var theme = new Theme
-            {
-                Title = "Theme title"
-            };
-            var publication = new Publication
-            {
-                Title = "Test publication",
-                Slug = "test-publication",
-                Theme = theme,
-            };
-            var methodology = new Methodology
-            {
-                OwningPublicationSlug = "test-publication",
-                Versions = new List<MethodologyVersion>
-                {
-                    new()
-                    {
-                        Version = 0,
-                    }
+                    Title = "Older title",
+                    ThemeId = theme.Id,
                 }
-            };
-            var publicationMethodology = new PublicationMethodology
-            {
-                Publication = publication,
-                Methodology = methodology,
-                Owner = true,
-            };
+            );
 
-            var otherMethodology = new Methodology
-            {
-                OwningPublicationSlug = "already-used-methodology"
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.PublicationMethodologies.Add(publicationMethodology);
-                context.Methodologies.Add(otherMethodology);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var methodologyService = new Mock<IMethodologyService>(Strict);
-
-                methodologyService.Setup(mock =>
-                        mock.ValidateMethodologySlug("already-used-by-methodology", null, null))
-                    .ReturnsAsync(ValidationUtils.ValidationActionResult(MethodologySlugNotUnique));
-
-                var publicationService = BuildPublicationService(context,
-                    methodologyService: methodologyService.Object);
-
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveRequest
-                    {
-                        Title = "Already used by methodology",
-                        ThemeId = theme.Id,
-                    }
-                );
-
-                result.AssertBadRequest(MethodologySlugNotUnique);
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                // check there are no changes
-                var dbPublication = context.Publications
-                    .Single(p => p.Id == publication.Id);
-                Assert.Equal("Test publication", dbPublication.Title);
-                Assert.Equal("test-publication", dbPublication.Slug);
-
-                var publicationRedirects = context.PublicationRedirects.ToList();
-                Assert.Empty(publicationRedirects);
-
-                var dbMethodology = context.Methodologies
-                    .Include(m => m.Versions)
-                    .Single(m => m.Id == methodology.Id);
-                Assert.Equal("test-publication", dbMethodology.Versions[0].Slug);
-            }
+            var viewModel = result.AssertRight();
+            Assert.Equal("Older title", viewModel.Title);
+            Assert.Equal("older-title", viewModel.Slug);
         }
 
-        [Fact]
-        public async Task GetExternalMethodology()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            var publication = new Publication
-            {
-                ExternalMethodology = new ExternalMethodology
-                {
-                    Title = "Test external methodology",
-                    Url = "http://test.external.methodology",
-                }
-            };
+            var dbPublication = context.Publications
+                .Single(p => p.Id == publication.Id);
+            Assert.Equal("Older title", dbPublication.Title);
+            Assert.Equal("older-title", dbPublication.Slug);
 
-            var contentDbContext = InMemoryApplicationDbContext();
+            var publicationRedirects = context.PublicationRedirects.ToList();
+            var redirect = Assert.Single(publicationRedirects);
+
+            // As the current slug is now "older-title", the "older-title" redirect is redundant
+            // and so is removed
+
+            Assert.Equal(publication.Id, redirect.PublicationId);
+            Assert.Equal("title", redirect.Slug);
+        }
+    }
+
+    [Fact]
+    public async Task UpdatePublication_OtherPublicationHasSlug()
+    {
+        var theme = new Theme
+        {
+            Title = "Theme title"
+        };
+        var publication = new Publication
+        {
+            Title = "Test publication",
+            Slug = "test-publication",
+            Theme = theme,
+        };
+        var otherPublication = new Publication
+        {
+            Title = "Duplicated title",
+            Slug = "duplicated-title",
+            Theme = theme,
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Add(publication);
+            context.Add(otherPublication);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var publicationService = BuildPublicationService(context);
+
+            // Service method under test
+            var result = await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
+                {
+                    Title = "Duplicated title",
+                    ThemeId = theme.Id,
+                }
+            );
+
+            result.AssertBadRequest(PublicationSlugNotUnique);
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            // check there are no changes
+            var dbPublication = context.Publications
+                .Single(p => p.Id == publication.Id);
+            Assert.Equal("Test publication", dbPublication.Title);
+            Assert.Equal("test-publication", dbPublication.Slug);
+
+            var publicationRedirects = context.PublicationRedirects.ToList();
+            Assert.Empty(publicationRedirects);
+        }
+    }
+
+    [Fact]
+    public async Task UpdatePublication_SlugUsedByRedirect()
+    {
+        var theme = new Theme
+        {
+            Title = "Theme title"
+        };
+        var publication = new Publication
+        {
+            Title = "Test publication",
+            Slug = "test-publication",
+            Theme = theme,
+        };
+        var publicationRedirect = new PublicationRedirect
+        {
+            Slug = "duplicated-title",
+            Publication = new Publication(),
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            await context.Publications.AddAsync(publication);
+            await context.PublicationRedirects.AddAsync(publicationRedirect);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var publicationService = BuildPublicationService(context);
+
+            var result = await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
+                {
+                    Title = "Duplicated title",
+                    ThemeId = theme.Id,
+                }
+            );
+
+            result.AssertBadRequest(PublicationSlugUsedByRedirect);
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            // check there are no changes
+            var dbPublication = context.Publications
+                .Single(p => p.Id == publication.Id);
+            Assert.Equal("Test publication", dbPublication.Title);
+            Assert.Equal("test-publication", dbPublication.Slug);
+
+            var publicationRedirects = context.PublicationRedirects.ToList();
+            var redirect = Assert.Single(publicationRedirects);
+            Assert.Equal(publicationRedirect.PublicationId, redirect.PublicationId);
+            Assert.Equal(publicationRedirect.Slug, redirect.Slug);
+        }
+    }
+
+    [Fact]
+    public async Task UpdatePublication_MethodologyInheritedNewSlugAlreadyUsed()
+    {
+        var theme = new Theme
+        {
+            Title = "Theme title"
+        };
+        var publication = new Publication
+        {
+            Title = "Test publication",
+            Slug = "test-publication",
+            Theme = theme,
+        };
+        var methodology = new Methodology
+        {
+            OwningPublicationSlug = "test-publication",
+            Versions = new List<MethodologyVersion>
+            {
+                new()
+                {
+                    Version = 0,
+                }
+            }
+        };
+        var publicationMethodology = new PublicationMethodology
+        {
+            Publication = publication,
+            Methodology = methodology,
+            Owner = true,
+        };
+
+        var otherMethodology = new Methodology
+        {
+            OwningPublicationSlug = "already-used-methodology"
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.PublicationMethodologies.Add(publicationMethodology);
+            context.Methodologies.Add(otherMethodology);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var methodologyService = new Mock<IMethodologyService>(Strict);
+
+            methodologyService.Setup(mock =>
+                    mock.ValidateMethodologySlug("already-used-by-methodology", null, null))
+                .ReturnsAsync(ValidationUtils.ValidationActionResult(MethodologySlugNotUnique));
+
+            var publicationService = BuildPublicationService(context,
+                methodologyService: methodologyService.Object);
+
+            var result = await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
+                {
+                    Title = "Already used by methodology",
+                    ThemeId = theme.Id,
+                }
+            );
+
+            result.AssertBadRequest(MethodologySlugNotUnique);
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            // check there are no changes
+            var dbPublication = context.Publications
+                .Single(p => p.Id == publication.Id);
+            Assert.Equal("Test publication", dbPublication.Title);
+            Assert.Equal("test-publication", dbPublication.Slug);
+
+            var publicationRedirects = context.PublicationRedirects.ToList();
+            Assert.Empty(publicationRedirects);
+
+            var dbMethodology = context.Methodologies
+                .Include(m => m.Versions)
+                .Single(m => m.Id == methodology.Id);
+            Assert.Equal("test-publication", dbMethodology.Versions[0].Slug);
+        }
+    }
+
+    [Fact]
+    public async Task GetExternalMethodology()
+    {
+        var publication = new Publication
+        {
+            ExternalMethodology = new ExternalMethodology
+            {
+                Title = "Test external methodology",
+                Url = "http://test.external.methodology",
+            }
+        };
+
+        var contentDbContext = InMemoryApplicationDbContext();
+        await contentDbContext.Publications.AddAsync(publication);
+        await contentDbContext.SaveChangesAsync();
+
+        var service = BuildPublicationService(context: contentDbContext);
+
+        var result = await service.GetExternalMethodology(publication.Id);
+        var externalMethodology = result.AssertRight();
+
+        Assert.Equal(publication.ExternalMethodology.Title, externalMethodology.Title);
+        Assert.Equal(publication.ExternalMethodology.Url, externalMethodology.Url);
+    }
+
+    [Fact]
+    public async Task GetExternalMethodology_NoPublication()
+    {
+        var contentDbContext = InMemoryApplicationDbContext();
+
+        var service = BuildPublicationService(context: contentDbContext);
+
+        var result = await service.GetExternalMethodology(Guid.NewGuid());
+        result.AssertNotFound();
+    }
+
+    [Fact]
+    public async Task GetExternalMethodology_NoExternalMethodology()
+    {
+        var publication = new Publication
+        {
+            ExternalMethodology = null,
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
             await contentDbContext.Publications.AddAsync(publication);
             await contentDbContext.SaveChangesAsync();
+        }
 
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
             var service = BuildPublicationService(context: contentDbContext);
 
             var result = await service.GetExternalMethodology(publication.Id);
-            var externalMethodology = result.AssertRight();
-
-            Assert.Equal(publication.ExternalMethodology.Title, externalMethodology.Title);
-            Assert.Equal(publication.ExternalMethodology.Url, externalMethodology.Url);
-        }
-
-        [Fact]
-        public async Task GetExternalMethodology_NoPublication()
-        {
-            var contentDbContext = InMemoryApplicationDbContext();
-
-            var service = BuildPublicationService(context: contentDbContext);
-
-            var result = await service.GetExternalMethodology(Guid.NewGuid());
             result.AssertNotFound();
         }
+    }
 
-        [Fact]
-        public async Task GetExternalMethodology_NoExternalMethodology()
+    [Fact]
+    public async Task UpdateExternalMethodology()
+    {
+        var publication = new Publication
         {
-            var publication = new Publication
+            ExternalMethodology = new ExternalMethodology
             {
-                ExternalMethodology = null,
-            };
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.Publications.AddAsync(publication);
-                await contentDbContext.SaveChangesAsync();
+                Title = "Original external methodology",
+                Url = "http://test.external.methodology/original",
             }
+        };
 
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var service = BuildPublicationService(context: contentDbContext);
-
-                var result = await service.GetExternalMethodology(publication.Id);
-                result.AssertNotFound();
-            }
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            await contentDbContext.Publications.AddAsync(publication);
+            await contentDbContext.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task UpdateExternalMethodology()
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var publication = new Publication
-            {
-                ExternalMethodology = new ExternalMethodology
-                {
-                    Title = "Original external methodology",
-                    Url = "http://test.external.methodology/original",
-                }
-            };
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(s => s.UpdatePublication(publication.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
 
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.Publications.AddAsync(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(s => s.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var service = BuildPublicationService(context: contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
-
-                var result = await service.UpdateExternalMethodology(
-                    publication.Id,
-                    new ExternalMethodologySaveRequest
-                    {
-                        Title = "New external methodology",
-                        Url = "http://test.external.methodology/new",
-                    });
-
-                VerifyAllMocks(publicationCacheService);
-
-                var externalMethodology = result.AssertRight();
-
-                Assert.Equal("New external methodology", externalMethodology.Title);
-                Assert.Equal("http://test.external.methodology/new", externalMethodology.Url);
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var dbPublication = contentDbContext.Publications
-                    .Single(p => p.Id == publication.Id);
-
-                Assert.NotNull(dbPublication.ExternalMethodology);
-                Assert.Equal("New external methodology", dbPublication.ExternalMethodology!.Title);
-                Assert.Equal("http://test.external.methodology/new", dbPublication.ExternalMethodology.Url);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateExternalMethodology_NoPublication()
-        {
-            var contentDbContext = InMemoryApplicationDbContext();
-            var service = BuildPublicationService(context: contentDbContext);
+            var service = BuildPublicationService(context: contentDbContext,
+                publicationCacheService: publicationCacheService.Object);
 
             var result = await service.UpdateExternalMethodology(
-                publicationId: Guid.NewGuid(),
+                publication.Id,
                 new ExternalMethodologySaveRequest
                 {
                     Title = "New external methodology",
                     Url = "http://test.external.methodology/new",
                 });
 
-            result.AssertNotFound();
+            VerifyAllMocks(publicationCacheService);
+
+            var externalMethodology = result.AssertRight();
+
+            Assert.Equal("New external methodology", externalMethodology.Title);
+            Assert.Equal("http://test.external.methodology/new", externalMethodology.Url);
         }
 
-        [Fact]
-        public async Task RemoveExternalMethodology()
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var publication = new Publication
-            {
-                ExternalMethodology = new ExternalMethodology
-                {
-                    Title = "Original external methodology",
-                    Url = "http://test.external.methodology/original",
-                }
-            };
+            var dbPublication = contentDbContext.Publications
+                .Single(p => p.Id == publication.Id);
 
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.Publications.AddAsync(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(s => s.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-                var service = BuildPublicationService(context: contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
-
-                var result = await service.RemoveExternalMethodology(publication.Id);
-
-                VerifyAllMocks(publicationCacheService);
-
-                result.AssertRight();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var dbPublication = contentDbContext.Publications
-                    .Single(p => p.Id == publication.Id);
-
-                Assert.Null(dbPublication.ExternalMethodology);
-            }
+            Assert.NotNull(dbPublication.ExternalMethodology);
+            Assert.Equal("New external methodology", dbPublication.ExternalMethodology!.Title);
+            Assert.Equal("http://test.external.methodology/new", dbPublication.ExternalMethodology.Url);
         }
+    }
 
-        [Fact]
-        public async Task RemoveExternalMethodology_NoPublication()
-        {
-            var contentDbContext = InMemoryApplicationDbContext();
-            var service = BuildPublicationService(context: contentDbContext);
+    [Fact]
+    public async Task UpdateExternalMethodology_NoPublication()
+    {
+        var contentDbContext = InMemoryApplicationDbContext();
+        var service = BuildPublicationService(context: contentDbContext);
 
-            var result = await service.RemoveExternalMethodology(publicationId: Guid.NewGuid());
-
-            result.AssertNotFound();
-        }
-
-        [Fact]
-        public async Task GetContact()
-        {
-            var publication = new Publication
+        var result = await service.UpdateExternalMethodology(
+            publicationId: Guid.NewGuid(),
+            new ExternalMethodologySaveRequest
             {
-                Contact = new Contact
-                {
-                    ContactName = "contact name",
-                    ContactTelNo = "12345",
-                    TeamName = "team name",
-                    TeamEmail = "team@email.com",
-                },
-            };
+                Title = "New external methodology",
+                Url = "http://test.external.methodology/new",
+            });
 
-            var contentDbContext = InMemoryApplicationDbContext();
+        result.AssertNotFound();
+    }
+
+    [Fact]
+    public async Task RemoveExternalMethodology()
+    {
+        var publication = new Publication
+        {
+            ExternalMethodology = new ExternalMethodology
+            {
+                Title = "Original external methodology",
+                Url = "http://test.external.methodology/original",
+            }
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
             await contentDbContext.Publications.AddAsync(publication);
             await contentDbContext.SaveChangesAsync();
-
-            var service = BuildPublicationService(context: contentDbContext);
-
-            var result = await service.GetContact(publication.Id);
-            var contact = result.AssertRight();
-
-            Assert.Equal(publication.Contact.ContactName, contact.ContactName);
-            Assert.Equal(publication.Contact.ContactTelNo, contact.ContactTelNo);
-            Assert.Equal(publication.Contact.TeamName, contact.TeamName);
-            Assert.Equal(publication.Contact.TeamEmail, contact.TeamEmail);
         }
 
-        [Fact]
-        public async Task GetContact_NoContact()
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var publication = new Publication();
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(s => s.UpdatePublication(publication.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+            var service = BuildPublicationService(context: contentDbContext,
+                publicationCacheService: publicationCacheService.Object);
 
-            var contentDbContext = InMemoryApplicationDbContext();
-            await contentDbContext.Publications.AddAsync(publication);
-            await contentDbContext.SaveChangesAsync();
+            var result = await service.RemoveExternalMethodology(publication.Id);
 
-            var service = BuildPublicationService(context: contentDbContext);
+            VerifyAllMocks(publicationCacheService);
 
-            var result = await service.GetContact(publication.Id);
-            result.AssertNotFound();
+            result.AssertRight();
         }
 
-        [Fact]
-        public async Task GetContact_NoPublication()
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var contentDbContext = InMemoryApplicationDbContext();
+            var dbPublication = contentDbContext.Publications
+                .Single(p => p.Id == publication.Id);
 
-            var service = BuildPublicationService(context: contentDbContext);
-
-            var result = await service.GetContact(Guid.NewGuid());
-            result.AssertNotFound();
+            Assert.Null(dbPublication.ExternalMethodology);
         }
+    }
 
-        [Fact]
-        public async Task UpdateContact()
+    [Fact]
+    public async Task RemoveExternalMethodology_NoPublication()
+    {
+        var contentDbContext = InMemoryApplicationDbContext();
+        var service = BuildPublicationService(context: contentDbContext);
+
+        var result = await service.RemoveExternalMethodology(publicationId: Guid.NewGuid());
+
+        result.AssertNotFound();
+    }
+
+    [Fact]
+    public async Task GetContact()
+    {
+        var publication = new Publication
         {
-            var publication = new Publication
-            {
-                Contact = new Contact
-                {
-                    ContactName = "contact name",
-                    ContactTelNo = "12345",
-                    TeamName = "team name",
-                    TeamEmail = "team@email.com",
-                },
-            };
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.Publications.AddAsync(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(s => s.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var service = BuildPublicationService(context: contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
-
-                var updatedContact = new ContactSaveRequest
-                {
-                    ContactName = "new contact name",
-                    ContactTelNo = "12345 6789",
-                    TeamName = "new team name",
-                    TeamEmail = "new_team@email.com",
-                };
-
-                var result = await service.UpdateContact(publication.Id, updatedContact);
-                var contact = result.AssertRight();
-
-                Assert.Equal(updatedContact.ContactName, contact.ContactName);
-                Assert.Equal(updatedContact.ContactTelNo, contact.ContactTelNo);
-                Assert.Equal(updatedContact.TeamName, contact.TeamName);
-                Assert.Equal(updatedContact.TeamEmail, contact.TeamEmail);
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var dbPublication = await contentDbContext.Publications
-                    .Include(p => p.Contact)
-                    .SingleAsync(p => p.Id == publication.Id);
-
-                Assert.Equal("new contact name", dbPublication.Contact.ContactName);
-                Assert.Equal("12345 6789", dbPublication.Contact.ContactTelNo);
-                Assert.Equal("new team name", dbPublication.Contact.TeamName);
-                Assert.Equal("new_team@email.com", dbPublication.Contact.TeamEmail);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateContact_NoContactTelNo()
-        {
-            var publication = new Publication
-            {
-                Contact = new Contact
-                {
-                    ContactName = "contact name",
-                    ContactTelNo = "12345",
-                    TeamName = "team name",
-                    TeamEmail = "team@email.com",
-                },
-            };
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.Publications.AddAsync(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(s => s.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var service = BuildPublicationService(context: contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
-
-                var updatedContact = new ContactSaveRequest
-                {
-                    ContactName = "new contact name",
-                    ContactTelNo = "",
-                    TeamName = "new team name",
-                    TeamEmail = "new_team@email.com",
-                };
-
-                var result = await service.UpdateContact(publication.Id, updatedContact);
-                var contact = result.AssertRight();
-
-                Assert.Equal(updatedContact.ContactName, contact.ContactName);
-                Assert.Null(contact.ContactTelNo);
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var dbPublication = await contentDbContext.Publications
-                    .Include(p => p.Contact)
-                    .SingleAsync(p => p.Id == publication.Id);
-
-                Assert.Equal("new contact name", dbPublication.Contact.ContactName);
-                Assert.Null(dbPublication.Contact.ContactTelNo);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateContact_SharedContact()
-        {
-            var sharedContact = new Contact
+            Contact = new Contact
             {
                 ContactName = "contact name",
                 ContactTelNo = "12345",
                 TeamName = "team name",
                 TeamEmail = "team@email.com",
+            },
+        };
+
+        var contentDbContext = InMemoryApplicationDbContext();
+        await contentDbContext.Publications.AddAsync(publication);
+        await contentDbContext.SaveChangesAsync();
+
+        var service = BuildPublicationService(context: contentDbContext);
+
+        var result = await service.GetContact(publication.Id);
+        var contact = result.AssertRight();
+
+        Assert.Equal(publication.Contact.ContactName, contact.ContactName);
+        Assert.Equal(publication.Contact.ContactTelNo, contact.ContactTelNo);
+        Assert.Equal(publication.Contact.TeamName, contact.TeamName);
+        Assert.Equal(publication.Contact.TeamEmail, contact.TeamEmail);
+    }
+
+    [Fact]
+    public async Task GetContact_NoContact()
+    {
+        var publication = new Publication();
+
+        var contentDbContext = InMemoryApplicationDbContext();
+        await contentDbContext.Publications.AddAsync(publication);
+        await contentDbContext.SaveChangesAsync();
+
+        var service = BuildPublicationService(context: contentDbContext);
+
+        var result = await service.GetContact(publication.Id);
+        result.AssertNotFound();
+    }
+
+    [Fact]
+    public async Task GetContact_NoPublication()
+    {
+        var contentDbContext = InMemoryApplicationDbContext();
+
+        var service = BuildPublicationService(context: contentDbContext);
+
+        var result = await service.GetContact(Guid.NewGuid());
+        result.AssertNotFound();
+    }
+
+    [Fact]
+    public async Task UpdateContact()
+    {
+        var publication = new Publication
+        {
+            Contact = new Contact
+            {
+                ContactName = "contact name",
+                ContactTelNo = "12345",
+                TeamName = "team name",
+                TeamEmail = "team@email.com",
+            },
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            await contentDbContext.Publications.AddAsync(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(s => s.UpdatePublication(publication.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            var service = BuildPublicationService(context: contentDbContext,
+                publicationCacheService: publicationCacheService.Object);
+
+            var updatedContact = new ContactSaveRequest
+            {
+                ContactName = "new contact name",
+                ContactTelNo = "12345 6789",
+                TeamName = "new team name",
+                TeamEmail = "new_team@email.com",
             };
 
-            var publication1 = new Publication
+            var result = await service.UpdateContact(publication.Id, updatedContact);
+            var contact = result.AssertRight();
+
+            Assert.Equal(updatedContact.ContactName, contact.ContactName);
+            Assert.Equal(updatedContact.ContactTelNo, contact.ContactTelNo);
+            Assert.Equal(updatedContact.TeamName, contact.TeamName);
+            Assert.Equal(updatedContact.TeamEmail, contact.TeamEmail);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var dbPublication = await contentDbContext.Publications
+                .Include(p => p.Contact)
+                .SingleAsync(p => p.Id == publication.Id);
+
+            Assert.Equal("new contact name", dbPublication.Contact.ContactName);
+            Assert.Equal("12345 6789", dbPublication.Contact.ContactTelNo);
+            Assert.Equal("new team name", dbPublication.Contact.TeamName);
+            Assert.Equal("new_team@email.com", dbPublication.Contact.TeamEmail);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateContact_NoContactTelNo()
+    {
+        var publication = new Publication
+        {
+            Contact = new Contact
             {
-                Contact = sharedContact,
+                ContactName = "contact name",
+                ContactTelNo = "12345",
+                TeamName = "team name",
+                TeamEmail = "team@email.com",
+            },
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            await contentDbContext.Publications.AddAsync(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(s => s.UpdatePublication(publication.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            var service = BuildPublicationService(context: contentDbContext,
+                publicationCacheService: publicationCacheService.Object);
+
+            var updatedContact = new ContactSaveRequest
+            {
+                ContactName = "new contact name",
+                ContactTelNo = "",
+                TeamName = "new team name",
+                TeamEmail = "new_team@email.com",
             };
 
-            var publication2 = new Publication
+            var result = await service.UpdateContact(publication.Id, updatedContact);
+            var contact = result.AssertRight();
+
+            Assert.Equal(updatedContact.ContactName, contact.ContactName);
+            Assert.Null(contact.ContactTelNo);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var dbPublication = await contentDbContext.Publications
+                .Include(p => p.Contact)
+                .SingleAsync(p => p.Id == publication.Id);
+
+            Assert.Equal("new contact name", dbPublication.Contact.ContactName);
+            Assert.Null(dbPublication.Contact.ContactTelNo);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateContact_SharedContact()
+    {
+        var sharedContact = new Contact
+        {
+            ContactName = "contact name",
+            ContactTelNo = "12345",
+            TeamName = "team name",
+            TeamEmail = "team@email.com",
+        };
+
+        var publication1 = new Publication
+        {
+            Contact = sharedContact,
+        };
+
+        var publication2 = new Publication
+        {
+            Contact = sharedContact,
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            await contentDbContext.Publications.AddRangeAsync(publication1, publication2);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(s => s.UpdatePublication(publication1.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            var service = BuildPublicationService(context: contentDbContext,
+                publicationCacheService: publicationCacheService.Object);
+
+            var updatedContact = new ContactSaveRequest
             {
-                Contact = sharedContact,
+                ContactName = "new contact name",
+                ContactTelNo = "12345 6789",
+                TeamName = "new team name",
+                TeamEmail = "new_team@email.com",
             };
 
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.Publications.AddRangeAsync(publication1, publication2);
-                await contentDbContext.SaveChangesAsync();
-            }
+            var result = await service.UpdateContact(publication1.Id, updatedContact);
+            var contact = result.AssertRight();
 
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(s => s.UpdatePublication(publication1.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var service = BuildPublicationService(context: contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
-
-                var updatedContact = new ContactSaveRequest
-                {
-                    ContactName = "new contact name",
-                    ContactTelNo = "12345 6789",
-                    TeamName = "new team name",
-                    TeamEmail = "new_team@email.com",
-                };
-
-                var result = await service.UpdateContact(publication1.Id, updatedContact);
-                var contact = result.AssertRight();
-
-                Assert.Equal(updatedContact.ContactName, contact.ContactName);
-                Assert.Equal(updatedContact.ContactTelNo, contact.ContactTelNo);
-                Assert.Equal(updatedContact.TeamName, contact.TeamName);
-                Assert.Equal(updatedContact.TeamEmail, contact.TeamEmail);
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var dbPublication1 = contentDbContext.Publications
-                    .Include(p => p.Contact)
-                    .Single(p => p.Id == publication1.Id);
-
-                Assert.Equal("new contact name", dbPublication1.Contact.ContactName);
-                Assert.Equal("12345 6789", dbPublication1.Contact.ContactTelNo);
-                Assert.Equal("new team name", dbPublication1.Contact.TeamName);
-                Assert.Equal("new_team@email.com", dbPublication1.Contact.TeamEmail);
-
-                var dbPublication2 = contentDbContext.Publications
-                    .Include(p => p.Contact)
-                    .Single(p => p.Id == publication2.Id);
-
-                Assert.Equal(sharedContact.ContactName, dbPublication2.Contact.ContactName);
-                Assert.Equal(sharedContact.ContactTelNo, dbPublication2.Contact.ContactTelNo);
-                Assert.Equal(sharedContact.TeamName, dbPublication2.Contact.TeamName);
-                Assert.Equal(sharedContact.TeamEmail, dbPublication2.Contact.TeamEmail);
-            }
+            Assert.Equal(updatedContact.ContactName, contact.ContactName);
+            Assert.Equal(updatedContact.ContactTelNo, contact.ContactTelNo);
+            Assert.Equal(updatedContact.TeamName, contact.TeamName);
+            Assert.Equal(updatedContact.TeamEmail, contact.TeamEmail);
         }
 
-        [Fact]
-        public async Task UpdateContact_NoPublication()
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            var contentDbContext = InMemoryApplicationDbContext();
+            var dbPublication1 = contentDbContext.Publications
+                .Include(p => p.Contact)
+                .Single(p => p.Id == publication1.Id);
 
-            var service = BuildPublicationService(context: contentDbContext);
+            Assert.Equal("new contact name", dbPublication1.Contact.ContactName);
+            Assert.Equal("12345 6789", dbPublication1.Contact.ContactTelNo);
+            Assert.Equal("new team name", dbPublication1.Contact.TeamName);
+            Assert.Equal("new_team@email.com", dbPublication1.Contact.TeamEmail);
 
-            var result = await service.UpdateContact(
-                Guid.NewGuid(), new ContactSaveRequest());
-            result.AssertNotFound();
+            var dbPublication2 = contentDbContext.Publications
+                .Include(p => p.Contact)
+                .Single(p => p.Id == publication2.Id);
+
+            Assert.Equal(sharedContact.ContactName, dbPublication2.Contact.ContactName);
+            Assert.Equal(sharedContact.ContactTelNo, dbPublication2.Contact.ContactTelNo);
+            Assert.Equal(sharedContact.TeamName, dbPublication2.Contact.TeamName);
+            Assert.Equal(sharedContact.TeamEmail, dbPublication2.Contact.TeamEmail);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateContact_NoPublication()
+    {
+        var contentDbContext = InMemoryApplicationDbContext();
+
+        var service = BuildPublicationService(context: contentDbContext);
+
+        var result = await service.UpdateContact(
+            Guid.NewGuid(), new ContactSaveRequest());
+        result.AssertNotFound();
+    }
+
+    [Fact]
+    public async Task ListLatestReleaseVersions()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases(ListOf<Release>(
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2020),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 2, year: 2022)));
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Publications.AddRange(publication);
+            await context.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task ListLatestReleaseVersions()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases(ListOf<Release>(
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2020),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 2, year: 2022)));
+            var publicationService = BuildPublicationService(context);
 
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
+            var result = await publicationService.ListLatestReleaseVersions(
+                publication.Id);
+
+            var releases = result.AssertRight();
+
+            Assert.Equal(new[]
             {
-                context.Publications.AddRange(publication);
-                await context.SaveChangesAsync();
-            }
+                publication.Releases.Single(r => r.Year == 2022).Versions.Single(rv => rv.Version == 1).Id,
+                publication.Releases.Single(r => r.Year == 2021).Versions.Single(rv => rv.Version == 0).Id,
+                publication.Releases.Single(r => r.Year == 2020).Versions.Single(rv => rv.Version == 1).Id
+            }, releases.Select(r => r.Id).ToArray());
+        }
+    }
 
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
+    [Fact]
+    public async Task ListLatestReleaseVersions_SingleRelease()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases(_dataFixture
+                .DefaultRelease(publishedVersions: 1)
+                .Generate(1));
 
-                var result = await publicationService.ListLatestReleaseVersions(
-                    publication.Id);
+        var releaseVersion = publication.Releases.Single().Versions.Single();
 
-                var releases = result.AssertRight();
-
-                Assert.Equal(new[]
-                {
-                    publication.Releases.Single(r => r.Year == 2022).Versions.Single(rv => rv.Version == 1).Id,
-                    publication.Releases.Single(r => r.Year == 2021).Versions.Single(rv => rv.Version == 0).Id,
-                    publication.Releases.Single(r => r.Year == 2020).Versions.Single(rv => rv.Version == 1).Id
-                }, releases.Select(r => r.Id).ToArray());
-            }
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Publications.Add(publication);
+            await context.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task ListLatestReleaseVersions_SingleRelease()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases(_dataFixture
-                    .DefaultRelease(publishedVersions: 1)
-                    .Generate(1));
+            var publicationService = BuildPublicationService(context);
 
-            var releaseVersion = publication.Releases.Single().Versions.Single();
+            var result = await publicationService.ListLatestReleaseVersions(
+                publication.Id);
 
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Publications.Add(publication);
-                await context.SaveChangesAsync();
-            }
+            var releases = result.AssertRight();
 
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
+            var summaryViewModel = Assert.Single(releases);
 
-                var result = await publicationService.ListLatestReleaseVersions(
-                    publication.Id);
+            Assert.Equal(releaseVersion.Id, summaryViewModel.Id);
+            Assert.Equal(releaseVersion.Release.Title, summaryViewModel.Title);
+            Assert.Equal(releaseVersion.Release.Slug, summaryViewModel.Slug);
+            Assert.Equal(releaseVersion.Type, summaryViewModel.Type);
+            Assert.Equal(releaseVersion.Release.Year, summaryViewModel.Year);
+            Assert.Equal(releaseVersion.Release.YearTitle, summaryViewModel.YearTitle);
+            Assert.Equal(releaseVersion.Release.TimePeriodCoverage, summaryViewModel.TimePeriodCoverage);
+            Assert.Equal(releaseVersion.Published, summaryViewModel.Published);
+            Assert.Equal(releaseVersion.Live, summaryViewModel.Live);
+            Assert.Equal(releaseVersion.PublishScheduled?.ConvertUtcToUkTimeZone(), summaryViewModel.PublishScheduled);
+            Assert.Equal(releaseVersion.NextReleaseDate, summaryViewModel.NextReleaseDate);
+            Assert.Equal(releaseVersion.ApprovalStatus, summaryViewModel.ApprovalStatus);
+            Assert.Equal(releaseVersion.Amendment, summaryViewModel.Amendment);
+            Assert.Equal(releaseVersion.PreviousVersionId, summaryViewModel.PreviousVersionId);
+            Assert.Null(summaryViewModel.Permissions);
+        }
+    }
 
-                var releases = result.AssertRight();
+    [Fact]
+    public async Task ListLatestReleaseVersions_Live_True()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases(ListOf<Release>(
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2020),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 2, year: 2022)));
 
-                var summaryViewModel = Assert.Single(releases);
-
-                Assert.Equal(releaseVersion.Id, summaryViewModel.Id);
-                Assert.Equal(releaseVersion.Release.Title, summaryViewModel.Title);
-                Assert.Equal(releaseVersion.Release.Slug, summaryViewModel.Slug);
-                Assert.Equal(releaseVersion.Type, summaryViewModel.Type);
-                Assert.Equal(releaseVersion.Release.Year, summaryViewModel.Year);
-                Assert.Equal(releaseVersion.Release.YearTitle, summaryViewModel.YearTitle);
-                Assert.Equal(releaseVersion.Release.TimePeriodCoverage, summaryViewModel.TimePeriodCoverage);
-                Assert.Equal(releaseVersion.Published, summaryViewModel.Published);
-                Assert.Equal(releaseVersion.Live, summaryViewModel.Live);
-                Assert.Equal(releaseVersion.PublishScheduled?.ConvertUtcToUkTimeZone(), summaryViewModel.PublishScheduled);
-                Assert.Equal(releaseVersion.NextReleaseDate, summaryViewModel.NextReleaseDate);
-                Assert.Equal(releaseVersion.ApprovalStatus, summaryViewModel.ApprovalStatus);
-                Assert.Equal(releaseVersion.Amendment, summaryViewModel.Amendment);
-                Assert.Equal(releaseVersion.PreviousVersionId, summaryViewModel.PreviousVersionId);
-                Assert.Null(summaryViewModel.Permissions);
-            }
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Publications.Add(publication);
+            await context.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task ListLatestReleaseVersions_Live_True()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases(ListOf<Release>(
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2020),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 2, year: 2022)));
+            var publicationService = BuildPublicationService(context);
 
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
+            var result = await publicationService.ListLatestReleaseVersions(
+                publication.Id, live: true);
+
+            var releases = result.AssertRight();
+
+            Assert.Equal(new[]
             {
-                context.Publications.Add(publication);
-                await context.SaveChangesAsync();
-            }
+                publication.Releases.Single(r => r.Year == 2022).Versions.Single(rv => rv.Version == 1).Id
+            }, releases.Select(r => r.Id).ToArray());
+        }
+    }
 
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
+    [Fact]
+    public async Task ListLatestReleaseVersions_Live_False()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases(ListOf<Release>(
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2020),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 2, year: 2022)));
 
-                var result = await publicationService.ListLatestReleaseVersions(
-                    publication.Id, live: true);
-
-                var releases = result.AssertRight();
-
-                Assert.Equal(new[]
-                {
-                    publication.Releases.Single(r => r.Year == 2022).Versions.Single(rv => rv.Version == 1).Id
-                }, releases.Select(r => r.Id).ToArray());
-            }
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Publications.Add(publication);
+            await context.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task ListLatestReleaseVersions_Live_False()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases(ListOf<Release>(
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2020),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 2, year: 2022)));
+            var publicationService = BuildPublicationService(context);
 
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
+            var result = await publicationService.ListLatestReleaseVersions(
+                publication.Id, live: false);
+
+            var releases = result.AssertRight();
+
+            Assert.Equal(new[]
             {
-                context.Publications.Add(publication);
-                await context.SaveChangesAsync();
-            }
+                publication.Releases.Single(r => r.Year == 2021).Versions.Single(rv => rv.Version == 0).Id,
+                publication.Releases.Single(r => r.Year == 2020).Versions.Single(rv => rv.Version == 1).Id
+            }, releases.Select(r => r.Id).ToArray());
+        }
+    }
 
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
+    [Fact]
+    public async Task ListLatestReleaseVersions_IncludePermissions_True()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases(_dataFixture
+                .DefaultRelease(publishedVersions: 0, draftVersion: true)
+                .Generate(1));
 
-                var result = await publicationService.ListLatestReleaseVersions(
-                    publication.Id, live: false);
-
-                var releases = result.AssertRight();
-
-                Assert.Equal(new[]
-                {
-                    publication.Releases.Single(r => r.Year == 2021).Versions.Single(rv => rv.Version == 0).Id,
-                    publication.Releases.Single(r => r.Year == 2020).Versions.Single(rv => rv.Version == 1).Id
-                }, releases.Select(r => r.Id).ToArray());
-            }
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Publications.Add(publication);
+            await context.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task ListLatestReleaseVersions_IncludePermissions_True()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases(_dataFixture
-                    .DefaultRelease(publishedVersions: 0, draftVersion: true)
-                    .Generate(1));
+            var publicationService = BuildPublicationService(context);
 
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Publications.Add(publication);
-                await context.SaveChangesAsync();
-            }
+            var result = await publicationService.ListLatestReleaseVersions(
+                publication.Id, includePermissions: true);
 
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
+            var releases = result.AssertRight();
 
-                var result = await publicationService.ListLatestReleaseVersions(
-                    publication.Id, includePermissions: true);
+            var resultRelease = Assert.Single(releases);
 
-                var releases = result.AssertRight();
+            Assert.NotNull(resultRelease.Permissions);
+            Assert.True(resultRelease.Permissions!.CanDeleteRelease);
+            Assert.True(resultRelease.Permissions!.CanUpdateRelease);
+            Assert.True(resultRelease.Permissions!.CanAddPrereleaseUsers);
+            Assert.True(resultRelease.Permissions!.CanMakeAmendmentOfRelease);
+        }
+    }
 
-                var resultRelease = Assert.Single(releases);
+    [Fact]
+    public async Task ListLatestReleaseVersions_IncludePermissions_False()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases(_dataFixture
+                .DefaultRelease(publishedVersions: 0, draftVersion: true)
+                .Generate(1));
 
-                Assert.NotNull(resultRelease.Permissions);
-                Assert.True(resultRelease.Permissions!.CanDeleteRelease);
-                Assert.True(resultRelease.Permissions!.CanUpdateRelease);
-                Assert.True(resultRelease.Permissions!.CanAddPrereleaseUsers);
-                Assert.True(resultRelease.Permissions!.CanMakeAmendmentOfRelease);
-            }
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Publications.Add(publication);
+            await context.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task ListLatestReleaseVersions_IncludePermissions_False()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases(_dataFixture
-                    .DefaultRelease(publishedVersions: 0, draftVersion: true)
-                    .Generate(1));
+            var publicationService = BuildPublicationService(context);
 
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Publications.Add(publication);
-                await context.SaveChangesAsync();
-            }
+            var result = await publicationService.ListLatestReleaseVersions(
+                publication.Id, includePermissions: false);
 
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
+            var releases = result.AssertRight();
 
-                var result = await publicationService.ListLatestReleaseVersions(
-                    publication.Id, includePermissions: false);
+            var resultRelease = Assert.Single(releases);
 
-                var releases = result.AssertRight();
+            Assert.Null(resultRelease.Permissions);
+        }
+    }
 
-                var resultRelease = Assert.Single(releases);
+    [Fact]
+    public async Task ListLatestReleaseVersionsPaginated()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases(_dataFixture
+                .DefaultRelease(publishedVersions: 2)
+                .Generate(4));
 
-                Assert.Null(resultRelease.Permissions);
-            }
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Publications.Add(publication);
+            await context.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task ListLatestReleaseVersionsPaginated()
+        var expectedPagesAndYears = new Dictionary<int, int[]>
         {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases(_dataFixture
-                    .DefaultRelease(publishedVersions: 2)
-                    .Generate(4));
+            { 1, [2003, 2002] },
+            { 2, [2001, 2000] }
+        };
+        var expectedTotalPages = expectedPagesAndYears.Count;
+        var expectedTotalResults = expectedPagesAndYears.SelectMany(pair => pair.Value).Count();
+        const int pageSize = 2;
 
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Publications.Add(publication);
-                await context.SaveChangesAsync();
-            }
-
-            var expectedPagesAndYears = new Dictionary<int, int[]>
-            {
-                { 1, [2003, 2002] },
-                { 2, [2001, 2000] }
-            };
-            var expectedTotalPages = expectedPagesAndYears.Count;
-            var expectedTotalResults = expectedPagesAndYears.SelectMany(pair => pair.Value).Count();
-            const int pageSize = 2;
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context);
-
-                foreach (var (page, years) in expectedPagesAndYears)
-                {
-                    var result = await publicationService.ListLatestReleaseVersionsPaginated(
-                        publication.Id,
-                        page: page,
-                        pageSize: pageSize
-                    );
-
-                    var pagedResult = result.AssertRight();
-
-                    Assert.Equal(page, pagedResult.Paging.Page);
-                    Assert.Equal(pageSize, pagedResult.Paging.PageSize);
-                    Assert.Equal(expectedTotalPages, pagedResult.Paging.TotalPages);
-                    Assert.Equal(expectedTotalResults, pagedResult.Paging.TotalResults);
-
-                    var expectedLatestReleaseVersionIds = years.Select(year =>
-                            publication.Releases.Single(r => r.Year == year)
-                                .Versions.Single(rv => rv.Version == 1).Id)
-                        .ToArray();
-
-                    Assert.Equal(expectedLatestReleaseVersionIds, pagedResult.Results.Select(r => r.Id).ToArray());
-                }
-            }
-        }
-
-        [Fact]
-        public async Task GetReleaseSeries()
+        await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            ReleaseSeriesItem legacyLink = _dataFixture.DefaultLegacyReleaseSeriesItem();
+            var publicationService = BuildPublicationService(context);
 
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases([
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, year: 2020),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)
-                ])
-                .WithLegacyLinks([legacyLink])
-                .WithTheme(_dataFixture.DefaultTheme());
-
-            var release2020 = publication.Releases.Single(r => r.Year == 2020);
-            var release2021 = publication.Releases.Single(r => r.Year == 2021);
-            var release2022 = publication.Releases.Single(r => r.Year == 2022);
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            foreach (var (page, years) in expectedPagesAndYears)
             {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(contentDbContext);
-
-                var result = await publicationService.GetReleaseSeries(publication.Id);
-                var viewModels = result.AssertRight();
-
-                Assert.Equal(4, viewModels.Count);
-
-                Assert.False(viewModels[0].IsLegacyLink);
-                Assert.Equal(release2022.Title, viewModels[0].Description);
-                Assert.Equal(release2022.Id, viewModels[0].ReleaseId);
-                Assert.Equal(release2022.Slug, viewModels[0].ReleaseSlug);
-                Assert.True(viewModels[0].IsLatest);
-                Assert.True(viewModels[0].IsPublished);
-                Assert.Null(viewModels[0].LegacyLinkUrl);
-
-                Assert.False(viewModels[1].IsLegacyLink);
-                Assert.Equal(release2021.Title, viewModels[1].Description);
-                Assert.Equal(release2021.Id, viewModels[1].ReleaseId);
-                Assert.Equal(release2021.Slug, viewModels[1].ReleaseSlug);
-                Assert.False(viewModels[1].IsLatest);
-                Assert.False(viewModels[1].IsPublished);
-                Assert.Null(viewModels[1].LegacyLinkUrl);
-
-                Assert.False(viewModels[2].IsLegacyLink);
-                Assert.Equal(release2020.Title, viewModels[2].Description);
-                Assert.Equal(release2020.Id, viewModels[2].ReleaseId);
-                Assert.Equal(release2020.Slug, viewModels[2].ReleaseSlug);
-                Assert.False(viewModels[2].IsLatest);
-                Assert.True(viewModels[2].IsPublished);
-                Assert.Null(viewModels[2].LegacyLinkUrl);
-
-                Assert.True(viewModels[3].IsLegacyLink);
-                Assert.Equal(legacyLink.LegacyLinkDescription, viewModels[3].Description);
-                Assert.Null(viewModels[3].ReleaseId);
-                Assert.Null(viewModels[3].ReleaseSlug);
-                Assert.Null(viewModels[3].IsLatest);
-                Assert.Null(viewModels[3].IsPublished);
-                Assert.Equal(legacyLink.LegacyLinkUrl, viewModels[3].LegacyLinkUrl);
-            }
-        }
-
-        [Fact]
-        public async Task GetReleaseSeries_NoReleases()
-        {
-            var legacyLinks = _dataFixture.DefaultLegacyReleaseSeriesItem()
-                .GenerateList(2);
-
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithLegacyLinks(legacyLinks)
-                .WithTheme(_dataFixture.DefaultTheme());
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(contentDbContext);
-
-                var result = await publicationService.GetReleaseSeries(publication.Id);
-                var viewModels = result.AssertRight();
-
-                Assert.Equal(2, viewModels.Count);
-
-                Assert.True(viewModels[0].IsLegacyLink);
-                Assert.Equal(legacyLinks[0].LegacyLinkDescription, viewModels[0].Description);
-                Assert.Null(viewModels[0].ReleaseId);
-                Assert.Null(viewModels[0].ReleaseSlug);
-                Assert.Null(viewModels[0].IsLatest);
-                Assert.Null(viewModels[0].IsPublished);
-                Assert.Equal(legacyLinks[0].LegacyLinkUrl, viewModels[0].LegacyLinkUrl);
-
-                Assert.True(viewModels[1].IsLegacyLink);
-                Assert.Equal(legacyLinks[1].LegacyLinkDescription, viewModels[1].Description);
-                Assert.Null(viewModels[1].ReleaseId);
-                Assert.Null(viewModels[1].ReleaseSlug);
-                Assert.Null(viewModels[1].IsLatest);
-                Assert.Null(viewModels[1].IsPublished);
-                Assert.Equal(legacyLinks[1].LegacyLinkUrl, viewModels[1].LegacyLinkUrl);
-            }
-        }
-
-        [Fact]
-        public async Task GetReleaseSeries_Empty()
-        {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithTheme(_dataFixture.DefaultTheme());
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(contentDbContext);
-
-                var result = await publicationService.GetReleaseSeries(publication.Id);
-                var viewModels = result.AssertRight();
-
-                Assert.Empty(viewModels);
-            }
-        }
-
-        [Fact]
-        public async Task AddReleaseSeriesLegacyLink()
-        {
-            ReleaseSeriesItem legacyLink = _dataFixture.DefaultLegacyReleaseSeriesItem();
-
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
-                .WithLegacyLinks([legacyLink])
-                .WithTheme(_dataFixture.DefaultTheme());
-
-            var release = publication.Releases.Single();
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(mock => mock
-                        .UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var publicationService = BuildPublicationService(
-                    contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
-
-                var result = await publicationService.AddReleaseSeriesLegacyLink(
+                var result = await publicationService.ListLatestReleaseVersionsPaginated(
                     publication.Id,
-                    new ReleaseSeriesLegacyLinkAddRequest
-                    {
-                        Description = "New legacy link",
-                        Url = "https://test.com/new"
-                    });
+                    page: page,
+                    pageSize: pageSize
+                );
 
-                var viewModels = result.AssertRight();
-                VerifyAllMocks(publicationCacheService);
+                var pagedResult = result.AssertRight();
 
-                Assert.Equal(3, viewModels.Count);
+                Assert.Equal(page, pagedResult.Paging.Page);
+                Assert.Equal(pageSize, pagedResult.Paging.PageSize);
+                Assert.Equal(expectedTotalPages, pagedResult.Paging.TotalPages);
+                Assert.Equal(expectedTotalResults, pagedResult.Paging.TotalResults);
 
-                Assert.False(viewModels[0].IsLegacyLink);
-                Assert.Equal(release.Title, viewModels[0].Description);
-                Assert.Equal(release.Id, viewModels[0].ReleaseId);
-                Assert.Equal(release.Slug, viewModels[0].ReleaseSlug);
-                Assert.True(viewModels[0].IsLatest);
-                Assert.True(viewModels[0].IsPublished);
-                Assert.Null(viewModels[0].LegacyLinkUrl);
+                var expectedLatestReleaseVersionIds = years.Select(year =>
+                        publication.Releases.Single(r => r.Year == year)
+                            .Versions.Single(rv => rv.Version == 1).Id)
+                    .ToArray();
 
-                Assert.True(viewModels[1].IsLegacyLink);
-                Assert.Equal(legacyLink.LegacyLinkDescription, viewModels[1].Description);
-                Assert.Null(viewModels[1].ReleaseId);
-                Assert.Null(viewModels[1].ReleaseSlug);
-                Assert.Null(viewModels[1].IsLatest);
-                Assert.Null(viewModels[1].IsPublished);
-                Assert.Equal(legacyLink.LegacyLinkUrl, viewModels[1].LegacyLinkUrl);
-
-                Assert.True(viewModels[2].IsLegacyLink);
-                Assert.Equal("New legacy link", viewModels[2].Description);
-                Assert.Null(viewModels[2].ReleaseId);
-                Assert.Null(viewModels[2].ReleaseSlug);
-                Assert.Null(viewModels[2].IsLatest);
-                Assert.Null(viewModels[2].IsPublished);
-                Assert.Equal("https://test.com/new", viewModels[2].LegacyLinkUrl);
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var actualPublication = await contentDbContext.Publications
-                    .SingleAsync(p => p.Id == publication.Id);
-
-                var actualReleaseSeries = actualPublication.ReleaseSeries;
-                Assert.Equal(3, actualReleaseSeries.Count);
-
-                Assert.Equal(release.Id, actualReleaseSeries[0].ReleaseId);
-
-                Assert.Equal(legacyLink.LegacyLinkDescription, actualReleaseSeries[1].LegacyLinkDescription);
-                Assert.Equal(legacyLink.LegacyLinkUrl, actualReleaseSeries[1].LegacyLinkUrl);
-
-                Assert.Equal("New legacy link", actualReleaseSeries[2].LegacyLinkDescription);
-                Assert.Equal("https://test.com/new", actualReleaseSeries[2].LegacyLinkUrl);
+                Assert.Equal(expectedLatestReleaseVersionIds, pagedResult.Results.Select(r => r.Id).ToArray());
             }
         }
+    }
 
-        [Fact]
-        public async Task AddReleaseSeriesLegacyLink_AddToEmptySeries()
+    [Fact]
+    public async Task GetReleaseSeries()
+    {
+        ReleaseSeriesItem legacyLink = _dataFixture.DefaultLegacyReleaseSeriesItem();
+
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases([
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 1, year: 2020),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)
+            ])
+            .WithLegacyLinks([legacyLink])
+            .WithTheme(_dataFixture.DefaultTheme());
+
+        var release2020 = publication.Releases.Single(r => r.Year == 2020);
+        var release2021 = publication.Releases.Single(r => r.Year == 2021);
+        var release2022 = publication.Releases.Single(r => r.Year == 2022);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithTheme(_dataFixture.DefaultTheme());
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
 
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationService = BuildPublicationService(contentDbContext);
 
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(mock => mock
-                        .UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
+            var result = await publicationService.GetReleaseSeries(publication.Id);
+            var viewModels = result.AssertRight();
 
-                var publicationService = BuildPublicationService(
-                    contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
+            Assert.Equal(4, viewModels.Count);
 
-                var result = await publicationService.AddReleaseSeriesLegacyLink(
+            Assert.False(viewModels[0].IsLegacyLink);
+            Assert.Equal(release2022.Title, viewModels[0].Description);
+            Assert.Equal(release2022.Id, viewModels[0].ReleaseId);
+            Assert.Equal(release2022.Slug, viewModels[0].ReleaseSlug);
+            Assert.True(viewModels[0].IsLatest);
+            Assert.True(viewModels[0].IsPublished);
+            Assert.Null(viewModels[0].LegacyLinkUrl);
+
+            Assert.False(viewModels[1].IsLegacyLink);
+            Assert.Equal(release2021.Title, viewModels[1].Description);
+            Assert.Equal(release2021.Id, viewModels[1].ReleaseId);
+            Assert.Equal(release2021.Slug, viewModels[1].ReleaseSlug);
+            Assert.False(viewModels[1].IsLatest);
+            Assert.False(viewModels[1].IsPublished);
+            Assert.Null(viewModels[1].LegacyLinkUrl);
+
+            Assert.False(viewModels[2].IsLegacyLink);
+            Assert.Equal(release2020.Title, viewModels[2].Description);
+            Assert.Equal(release2020.Id, viewModels[2].ReleaseId);
+            Assert.Equal(release2020.Slug, viewModels[2].ReleaseSlug);
+            Assert.False(viewModels[2].IsLatest);
+            Assert.True(viewModels[2].IsPublished);
+            Assert.Null(viewModels[2].LegacyLinkUrl);
+
+            Assert.True(viewModels[3].IsLegacyLink);
+            Assert.Equal(legacyLink.LegacyLinkDescription, viewModels[3].Description);
+            Assert.Null(viewModels[3].ReleaseId);
+            Assert.Null(viewModels[3].ReleaseSlug);
+            Assert.Null(viewModels[3].IsLatest);
+            Assert.Null(viewModels[3].IsPublished);
+            Assert.Equal(legacyLink.LegacyLinkUrl, viewModels[3].LegacyLinkUrl);
+        }
+    }
+
+    [Fact]
+    public async Task GetReleaseSeries_NoReleases()
+    {
+        var legacyLinks = _dataFixture.DefaultLegacyReleaseSeriesItem()
+            .GenerateList(2);
+
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithLegacyLinks(legacyLinks)
+            .WithTheme(_dataFixture.DefaultTheme());
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationService = BuildPublicationService(contentDbContext);
+
+            var result = await publicationService.GetReleaseSeries(publication.Id);
+            var viewModels = result.AssertRight();
+
+            Assert.Equal(2, viewModels.Count);
+
+            Assert.True(viewModels[0].IsLegacyLink);
+            Assert.Equal(legacyLinks[0].LegacyLinkDescription, viewModels[0].Description);
+            Assert.Null(viewModels[0].ReleaseId);
+            Assert.Null(viewModels[0].ReleaseSlug);
+            Assert.Null(viewModels[0].IsLatest);
+            Assert.Null(viewModels[0].IsPublished);
+            Assert.Equal(legacyLinks[0].LegacyLinkUrl, viewModels[0].LegacyLinkUrl);
+
+            Assert.True(viewModels[1].IsLegacyLink);
+            Assert.Equal(legacyLinks[1].LegacyLinkDescription, viewModels[1].Description);
+            Assert.Null(viewModels[1].ReleaseId);
+            Assert.Null(viewModels[1].ReleaseSlug);
+            Assert.Null(viewModels[1].IsLatest);
+            Assert.Null(viewModels[1].IsPublished);
+            Assert.Equal(legacyLinks[1].LegacyLinkUrl, viewModels[1].LegacyLinkUrl);
+        }
+    }
+
+    [Fact]
+    public async Task GetReleaseSeries_Empty()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithTheme(_dataFixture.DefaultTheme());
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationService = BuildPublicationService(contentDbContext);
+
+            var result = await publicationService.GetReleaseSeries(publication.Id);
+            var viewModels = result.AssertRight();
+
+            Assert.Empty(viewModels);
+        }
+    }
+
+    [Fact]
+    public async Task AddReleaseSeriesLegacyLink()
+    {
+        ReleaseSeriesItem legacyLink = _dataFixture.DefaultLegacyReleaseSeriesItem();
+
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
+            .WithLegacyLinks([legacyLink])
+            .WithTheme(_dataFixture.DefaultTheme());
+
+        var release = publication.Releases.Single();
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(mock => mock
+                    .UpdatePublication(publication.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            var publicationService = BuildPublicationService(
+                contentDbContext,
+                publicationCacheService: publicationCacheService.Object);
+
+            var result = await publicationService.AddReleaseSeriesLegacyLink(
+                publication.Id,
+                new ReleaseSeriesLegacyLinkAddRequest
+                {
+                    Description = "New legacy link",
+                    Url = "https://test.com/new"
+                });
+
+            var viewModels = result.AssertRight();
+            VerifyAllMocks(publicationCacheService);
+
+            Assert.Equal(3, viewModels.Count);
+
+            Assert.False(viewModels[0].IsLegacyLink);
+            Assert.Equal(release.Title, viewModels[0].Description);
+            Assert.Equal(release.Id, viewModels[0].ReleaseId);
+            Assert.Equal(release.Slug, viewModels[0].ReleaseSlug);
+            Assert.True(viewModels[0].IsLatest);
+            Assert.True(viewModels[0].IsPublished);
+            Assert.Null(viewModels[0].LegacyLinkUrl);
+
+            Assert.True(viewModels[1].IsLegacyLink);
+            Assert.Equal(legacyLink.LegacyLinkDescription, viewModels[1].Description);
+            Assert.Null(viewModels[1].ReleaseId);
+            Assert.Null(viewModels[1].ReleaseSlug);
+            Assert.Null(viewModels[1].IsLatest);
+            Assert.Null(viewModels[1].IsPublished);
+            Assert.Equal(legacyLink.LegacyLinkUrl, viewModels[1].LegacyLinkUrl);
+
+            Assert.True(viewModels[2].IsLegacyLink);
+            Assert.Equal("New legacy link", viewModels[2].Description);
+            Assert.Null(viewModels[2].ReleaseId);
+            Assert.Null(viewModels[2].ReleaseSlug);
+            Assert.Null(viewModels[2].IsLatest);
+            Assert.Null(viewModels[2].IsPublished);
+            Assert.Equal("https://test.com/new", viewModels[2].LegacyLinkUrl);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var actualPublication = await contentDbContext.Publications
+                .SingleAsync(p => p.Id == publication.Id);
+
+            var actualReleaseSeries = actualPublication.ReleaseSeries;
+            Assert.Equal(3, actualReleaseSeries.Count);
+
+            Assert.Equal(release.Id, actualReleaseSeries[0].ReleaseId);
+
+            Assert.Equal(legacyLink.LegacyLinkDescription, actualReleaseSeries[1].LegacyLinkDescription);
+            Assert.Equal(legacyLink.LegacyLinkUrl, actualReleaseSeries[1].LegacyLinkUrl);
+
+            Assert.Equal("New legacy link", actualReleaseSeries[2].LegacyLinkDescription);
+            Assert.Equal("https://test.com/new", actualReleaseSeries[2].LegacyLinkUrl);
+        }
+    }
+
+    [Fact]
+    public async Task AddReleaseSeriesLegacyLink_AddToEmptySeries()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithTheme(_dataFixture.DefaultTheme());
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(mock => mock
+                    .UpdatePublication(publication.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            var publicationService = BuildPublicationService(
+                contentDbContext,
+                publicationCacheService: publicationCacheService.Object);
+
+            var result = await publicationService.AddReleaseSeriesLegacyLink(
+                publication.Id,
+                new ReleaseSeriesLegacyLinkAddRequest
+                {
+                    Description = "New legacy link",
+                    Url = "https://test.com/new"
+                });
+
+            VerifyAllMocks(publicationCacheService);
+
+            var viewModels = result.AssertRight();
+
+            var newSeriesItem = Assert.Single(viewModels);
+            Assert.True(newSeriesItem.IsLegacyLink);
+            Assert.Equal("New legacy link", newSeriesItem.Description);
+            Assert.Null(newSeriesItem.ReleaseId);
+            Assert.Null(newSeriesItem.ReleaseSlug);
+            Assert.Null(newSeriesItem.IsLatest);
+            Assert.Null(newSeriesItem.IsPublished);
+            Assert.Equal("https://test.com/new", newSeriesItem.LegacyLinkUrl);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var actualPublication = await contentDbContext.Publications
+                .SingleAsync(p => p.Id == publication.Id);
+
+            var actualReleaseSeriesItem = Assert.Single(actualPublication.ReleaseSeries);
+
+            Assert.Equal("New legacy link", actualReleaseSeriesItem.LegacyLinkDescription);
+            Assert.Equal("https://test.com/new", actualReleaseSeriesItem.LegacyLinkUrl);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateReleaseSeries()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases([
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 1, year: 2020),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2021),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)
+            ])
+            .WithLegacyLinks([_dataFixture.DefaultLegacyReleaseSeriesItem()])
+            .WithTheme(_dataFixture.DefaultTheme());
+
+        var release2020 = publication.Releases.Single(r => r.Year == 2020);
+        var release2021 = publication.Releases.Single(r => r.Year == 2021);
+        var release2022 = publication.Releases.Single(r => r.Year == 2022);
+
+        // Check the publication's latest published release version in the generated test data setup
+        Assert.Equal(release2022.Versions[1].Id, publication.LatestPublishedReleaseVersionId);
+
+        // Check the expected order of the release series items in the generated test data setup
+        Assert.Equal(4, publication.ReleaseSeries.Count);
+        Assert.Equal(release2022.Id, publication.ReleaseSeries[0].ReleaseId);
+        Assert.Equal(release2021.Id, publication.ReleaseSeries[1].ReleaseId);
+        Assert.Equal(release2020.Id, publication.ReleaseSeries[2].ReleaseId);
+        Assert.True(publication.ReleaseSeries[3].IsLegacyLink);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(mock =>
+                    mock.UpdatePublication(publication.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            var publicationService = BuildPublicationService(
+                contentDbContext,
+                publicationCacheService: publicationCacheService.Object);
+
+            var result = await publicationService.UpdateReleaseSeries(
+                publication.Id,
+                updatedReleaseSeriesItems:
+                [
+                    new ReleaseSeriesItemUpdateRequest
+                    {
+                        LegacyLinkDescription = "Legacy link new",
+                        LegacyLinkUrl = "https://test.com/new"
+                    },
+                    new ReleaseSeriesItemUpdateRequest { ReleaseId = release2022.Id },
+                    new ReleaseSeriesItemUpdateRequest { ReleaseId = release2020.Id },
+                    new ReleaseSeriesItemUpdateRequest { ReleaseId = release2021.Id }
+                ]);
+
+            VerifyAllMocks(publicationCacheService);
+
+            var viewModels = result.AssertRight();
+            Assert.Equal(4, viewModels.Count);
+
+            Assert.True(viewModels[0].IsLegacyLink);
+            Assert.Equal("Legacy link new", viewModels[0].Description);
+            Assert.Null(viewModels[0].ReleaseId);
+            Assert.Null(viewModels[0].ReleaseSlug);
+            Assert.Null(viewModels[0].IsLatest);
+            Assert.Null(viewModels[0].IsPublished);
+            Assert.Equal("https://test.com/new", viewModels[0].LegacyLinkUrl);
+
+            Assert.False(viewModels[1].IsLegacyLink);
+            Assert.Equal(release2022.Title, viewModels[1].Description);
+            Assert.Equal(release2022.Id, viewModels[1].ReleaseId);
+            Assert.Equal(release2022.Slug, viewModels[1].ReleaseSlug);
+            Assert.True(viewModels[1].IsLatest);
+            Assert.True(viewModels[1].IsPublished);
+            Assert.Null(viewModels[1].LegacyLinkUrl);
+
+            Assert.False(viewModels[2].IsLegacyLink);
+            Assert.Equal(release2020.Title, viewModels[2].Description);
+            Assert.Equal(release2020.Id, viewModels[2].ReleaseId);
+            Assert.Equal(release2020.Slug, viewModels[2].ReleaseSlug);
+            Assert.False(viewModels[2].IsLatest);
+            Assert.True(viewModels[2].IsPublished);
+            Assert.Null(viewModels[2].LegacyLinkUrl);
+
+            Assert.False(viewModels[3].IsLegacyLink);
+            Assert.Equal(release2021.Title, viewModels[3].Description);
+            Assert.Equal(release2021.Id, viewModels[3].ReleaseId);
+            Assert.Equal(release2021.Slug, viewModels[3].ReleaseSlug);
+            Assert.False(viewModels[3].IsLatest);
+            Assert.True(viewModels[3].IsPublished);
+            Assert.Null(viewModels[3].LegacyLinkUrl);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var actualPublication = await contentDbContext.Publications
+                .SingleAsync(p => p.Id == publication.Id);
+
+            var actualReleaseSeries = actualPublication.ReleaseSeries;
+            Assert.Equal(4, actualReleaseSeries.Count);
+
+            Assert.Equal("Legacy link new", actualReleaseSeries[0].LegacyLinkDescription);
+            Assert.Equal("https://test.com/new", actualReleaseSeries[0].LegacyLinkUrl);
+
+            Assert.Equal(release2022.Id, actualReleaseSeries[1].ReleaseId);
+            Assert.Equal(release2020.Id, actualReleaseSeries[2].ReleaseId);
+            Assert.Equal(release2021.Id, actualReleaseSeries[3].ReleaseId);
+
+            // The publication's latest published release version should be unchanged as 2022 was positioned
+            // as the first release after the legacy link
+            Assert.Equal(release2022.Versions[1].Id, actualPublication.LatestPublishedReleaseVersionId);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateReleaseSeries_UpdatesLatestPublishedReleaseVersion()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases([
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 1, year: 2020),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2021),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)
+            ])
+            .WithTheme(_dataFixture.DefaultTheme());
+
+        var release2020 = publication.Releases.Single(r => r.Year == 2020);
+        var release2021 = publication.Releases.Single(r => r.Year == 2021);
+        var release2022 = publication.Releases.Single(r => r.Year == 2022);
+
+        var expectedLatestPublishedReleaseVersionId = release2021.Versions[0].Id;
+
+        // Check the publication's latest published release version in the generated test data setup
+        Assert.Equal(release2022.Versions[1].Id, publication.LatestPublishedReleaseVersionId);
+
+        // Check the expected order of the release series items in the generated test data setup
+        Assert.Equal(3, publication.ReleaseSeries.Count);
+        Assert.Equal(release2022.Id, publication.ReleaseSeries[0].ReleaseId);
+        Assert.Equal(release2021.Id, publication.ReleaseSeries[1].ReleaseId);
+        Assert.Equal(release2020.Id, publication.ReleaseSeries[2].ReleaseId);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(mock =>
+                    mock.UpdatePublication(publication.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            var releaseCacheService = new Mock<IReleaseCacheService>(Strict);
+            releaseCacheService.Setup(mock => mock.UpdateRelease(
+                    expectedLatestPublishedReleaseVersionId,
+                    publication.Slug,
+                    null))
+                .ReturnsAsync(new ReleaseCacheViewModel(expectedLatestPublishedReleaseVersionId));
+
+            var publicationService = BuildPublicationService(
+                contentDbContext,
+                publicationCacheService: publicationCacheService.Object,
+                releaseCacheService: releaseCacheService.Object);
+
+            var result = await publicationService.UpdateReleaseSeries(
+                publication.Id,
+                updatedReleaseSeriesItems:
+                [
+                    new ReleaseSeriesItemUpdateRequest { ReleaseId = release2021.Id },
+                    new ReleaseSeriesItemUpdateRequest { ReleaseId = release2020.Id },
+                    new ReleaseSeriesItemUpdateRequest { ReleaseId = release2022.Id }
+                ]);
+
+            VerifyAllMocks(publicationCacheService, releaseCacheService);
+
+            var viewModels = result.AssertRight();
+            Assert.Equal(3, viewModels.Count);
+
+            Assert.Equal(release2021.Id, viewModels[0].ReleaseId);
+            Assert.True(viewModels[0].IsLatest);
+            Assert.True(viewModels[0].IsPublished);
+
+            Assert.Equal(release2020.Id, viewModels[1].ReleaseId);
+            Assert.False(viewModels[1].IsLatest);
+            Assert.True(viewModels[1].IsPublished);
+
+            Assert.Equal(release2022.Id, viewModels[2].ReleaseId);
+            Assert.False(viewModels[2].IsLatest);
+            Assert.True(viewModels[2].IsPublished);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var actualPublication = await contentDbContext.Publications
+                .SingleAsync(p => p.Id == publication.Id);
+
+            var actualReleaseSeries = actualPublication.ReleaseSeries;
+            Assert.Equal(3, actualReleaseSeries.Count);
+
+            Assert.Equal(release2021.Id, actualReleaseSeries[0].ReleaseId);
+            Assert.Equal(release2020.Id, actualReleaseSeries[1].ReleaseId);
+            Assert.Equal(release2022.Id, actualReleaseSeries[2].ReleaseId);
+
+            // The latest published version of 2021 should now be the publication's latest published release
+            // version since it was positioned as the first release
+            Assert.Equal(expectedLatestPublishedReleaseVersionId,
+                actualPublication.LatestPublishedReleaseVersionId);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateReleaseSeries_UpdatesLatestPublishedReleaseVersion_SkipsUnpublishedReleases()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases([
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 1, year: 2020),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
+                _dataFixture
+                    .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)
+            ])
+            .WithTheme(_dataFixture.DefaultTheme());
+
+        var release2020 = publication.Releases.Single(r => r.Year == 2020);
+        var release2021 = publication.Releases.Single(r => r.Year == 2021);
+        var release2022 = publication.Releases.Single(r => r.Year == 2022);
+
+        var expectedLatestPublishedReleaseVersionId = release2020.Versions[0].Id;
+
+        // Check the publication's latest published release version in the generated test data setup
+        Assert.Equal(release2022.Versions[1].Id, publication.LatestPublishedReleaseVersionId);
+
+        // Check the expected order of the release series items in the generated test data setup
+        Assert.Equal(3, publication.ReleaseSeries.Count);
+        Assert.Equal(release2022.Id, publication.ReleaseSeries[0].ReleaseId);
+        Assert.Equal(release2021.Id, publication.ReleaseSeries[1].ReleaseId);
+        Assert.Equal(release2020.Id, publication.ReleaseSeries[2].ReleaseId);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(mock =>
+                    mock.UpdatePublication(publication.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            var releaseCacheService = new Mock<IReleaseCacheService>(Strict);
+            releaseCacheService.Setup(mock => mock.UpdateRelease(
+                    expectedLatestPublishedReleaseVersionId,
+                    publication.Slug,
+                    null))
+                .ReturnsAsync(new ReleaseCacheViewModel(expectedLatestPublishedReleaseVersionId));
+
+            var publicationService = BuildPublicationService(
+                contentDbContext,
+                publicationCacheService: publicationCacheService.Object,
+                releaseCacheService: releaseCacheService.Object);
+
+            var result = await publicationService.UpdateReleaseSeries(
+                publication.Id,
+                updatedReleaseSeriesItems:
+                [
+                    new ReleaseSeriesItemUpdateRequest { ReleaseId = release2021.Id }, // Unpublished
+                    new ReleaseSeriesItemUpdateRequest { ReleaseId = release2020.Id },
+                    new ReleaseSeriesItemUpdateRequest { ReleaseId = release2022.Id }
+                ]);
+
+            VerifyAllMocks(publicationCacheService, releaseCacheService);
+
+            var viewModels = result.AssertRight();
+            Assert.Equal(3, viewModels.Count);
+
+            Assert.Equal(release2021.Id, viewModels[0].ReleaseId);
+            Assert.False(viewModels[0].IsLatest);
+            Assert.False(viewModels[0].IsPublished);
+
+            Assert.Equal(release2020.Id, viewModels[1].ReleaseId);
+            Assert.True(viewModels[1].IsLatest);
+            Assert.True(viewModels[1].IsPublished);
+
+            Assert.Equal(release2022.Id, viewModels[2].ReleaseId);
+            Assert.False(viewModels[2].IsLatest);
+            Assert.True(viewModels[2].IsPublished);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var actualPublication = await contentDbContext.Publications
+                .SingleAsync(p => p.Id == publication.Id);
+
+            var actualReleaseSeries = actualPublication.ReleaseSeries;
+            Assert.Equal(3, actualReleaseSeries.Count);
+
+            Assert.Equal(release2021.Id, actualReleaseSeries[0].ReleaseId);
+            Assert.Equal(release2020.Id, actualReleaseSeries[1].ReleaseId);
+            Assert.Equal(release2022.Id, actualReleaseSeries[2].ReleaseId);
+
+            // The latest published version of 2020 should now be the publication's latest published release
+            // version since it was positioned as the next release after 2021 which is unpublished
+            Assert.Equal(expectedLatestPublishedReleaseVersionId,
+                actualPublication.LatestPublishedReleaseVersionId);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateReleaseSeries_SetEmpty()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithLegacyLinks([_dataFixture.DefaultLegacyReleaseSeriesItem()])
+            .WithTheme(_dataFixture.DefaultTheme());
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(mock =>
+                    mock.UpdatePublication(publication.Slug))
+                .ReturnsAsync(new PublicationCacheViewModel());
+
+            var publicationService = BuildPublicationService(
+                contentDbContext,
+                publicationCacheService: publicationCacheService.Object);
+
+            var result = await publicationService.UpdateReleaseSeries(
+                publication.Id,
+                updatedReleaseSeriesItems: []);
+
+            VerifyAllMocks(publicationCacheService);
+
+            var viewModels = result.AssertRight();
+
+            Assert.Empty(viewModels);
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var actualPublication = await contentDbContext.Publications
+                .SingleAsync(p => p.Id == publication.Id);
+
+            Assert.Empty(actualPublication.ReleaseSeries);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateReleaseSeries_UnsetRelease()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
+            .WithTheme(_dataFixture.DefaultTheme());
+
+        var release = publication.Releases.Single();
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationService = BuildPublicationService(contentDbContext);
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+                publicationService.UpdateReleaseSeries(
                     publication.Id,
-                    new ReleaseSeriesLegacyLinkAddRequest
-                    {
-                        Description = "New legacy link",
-                        Url = "https://test.com/new"
-                    });
+                    updatedReleaseSeriesItems: []));
 
-                VerifyAllMocks(publicationCacheService);
+            Assert.Equal($"Missing or duplicate release in new release series. Expected ReleaseIds: {release.Id}",
+                exception.Message);
+        }
+    }
 
-                var viewModels = result.AssertRight();
+    [Fact]
+    public async Task UpdateReleaseSeries_SetDuplicateRelease()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
+            .WithTheme(_dataFixture.DefaultTheme());
 
-                var newSeriesItem = Assert.Single(viewModels);
-                Assert.True(newSeriesItem.IsLegacyLink);
-                Assert.Equal("New legacy link", newSeriesItem.Description);
-                Assert.Null(newSeriesItem.ReleaseId);
-                Assert.Null(newSeriesItem.ReleaseSlug);
-                Assert.Null(newSeriesItem.IsLatest);
-                Assert.Null(newSeriesItem.IsPublished);
-                Assert.Equal("https://test.com/new", newSeriesItem.LegacyLinkUrl);
-            }
+        var release = publication.Releases.Single();
 
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var actualPublication = await contentDbContext.Publications
-                    .SingleAsync(p => p.Id == publication.Id);
-
-                var actualReleaseSeriesItem = Assert.Single(actualPublication.ReleaseSeries);
-
-                Assert.Equal("New legacy link", actualReleaseSeriesItem.LegacyLinkDescription);
-                Assert.Equal("https://test.com/new", actualReleaseSeriesItem.LegacyLinkUrl);
-            }
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
         }
 
-        [Fact]
-        public async Task UpdateReleaseSeries()
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
         {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases([
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, year: 2020),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2021),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)
-                ])
-                .WithLegacyLinks([_dataFixture.DefaultLegacyReleaseSeriesItem()])
-                .WithTheme(_dataFixture.DefaultTheme());
+            var publicationService = BuildPublicationService(contentDbContext);
 
-            var release2020 = publication.Releases.Single(r => r.Year == 2020);
-            var release2021 = publication.Releases.Single(r => r.Year == 2021);
-            var release2022 = publication.Releases.Single(r => r.Year == 2022);
-
-            // Check the publication's latest published release version in the generated test data setup
-            Assert.Equal(release2022.Versions[1].Id, publication.LatestPublishedReleaseVersionId);
-
-            // Check the expected order of the release series items in the generated test data setup
-            Assert.Equal(4, publication.ReleaseSeries.Count);
-            Assert.Equal(release2022.Id, publication.ReleaseSeries[0].ReleaseId);
-            Assert.Equal(release2021.Id, publication.ReleaseSeries[1].ReleaseId);
-            Assert.Equal(release2020.Id, publication.ReleaseSeries[2].ReleaseId);
-            Assert.True(publication.ReleaseSeries[3].IsLegacyLink);
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var publicationService = BuildPublicationService(
-                    contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
-
-                var result = await publicationService.UpdateReleaseSeries(
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+                publicationService.UpdateReleaseSeries(
                     publication.Id,
                     updatedReleaseSeriesItems:
+                    [
+                        new ReleaseSeriesItemUpdateRequest { ReleaseId = release.Id },
+                        new ReleaseSeriesItemUpdateRequest { ReleaseId = release.Id }
+                    ]));
+
+            Assert.Equal($"Missing or duplicate release in new release series. Expected ReleaseIds: {release.Id}",
+                exception.Message);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateReleaseSeries_InvalidSeriesItem1()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
+            .WithTheme(_dataFixture.DefaultTheme());
+
+        var release = publication.Releases.Single();
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationService = BuildPublicationService(contentDbContext);
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+                publicationService.UpdateReleaseSeries(
+                    publication.Id,
                     [
                         new ReleaseSeriesItemUpdateRequest
                         {
-                            LegacyLinkDescription = "Legacy link new",
-                            LegacyLinkUrl = "https://test.com/new"
-                        },
-                        new ReleaseSeriesItemUpdateRequest { ReleaseId = release2022.Id },
-                        new ReleaseSeriesItemUpdateRequest { ReleaseId = release2020.Id },
-                        new ReleaseSeriesItemUpdateRequest { ReleaseId = release2021.Id }
-                    ]);
-
-                VerifyAllMocks(publicationCacheService);
-
-                var viewModels = result.AssertRight();
-                Assert.Equal(4, viewModels.Count);
-
-                Assert.True(viewModels[0].IsLegacyLink);
-                Assert.Equal("Legacy link new", viewModels[0].Description);
-                Assert.Null(viewModels[0].ReleaseId);
-                Assert.Null(viewModels[0].ReleaseSlug);
-                Assert.Null(viewModels[0].IsLatest);
-                Assert.Null(viewModels[0].IsPublished);
-                Assert.Equal("https://test.com/new", viewModels[0].LegacyLinkUrl);
-
-                Assert.False(viewModels[1].IsLegacyLink);
-                Assert.Equal(release2022.Title, viewModels[1].Description);
-                Assert.Equal(release2022.Id, viewModels[1].ReleaseId);
-                Assert.Equal(release2022.Slug, viewModels[1].ReleaseSlug);
-                Assert.True(viewModels[1].IsLatest);
-                Assert.True(viewModels[1].IsPublished);
-                Assert.Null(viewModels[1].LegacyLinkUrl);
-
-                Assert.False(viewModels[2].IsLegacyLink);
-                Assert.Equal(release2020.Title, viewModels[2].Description);
-                Assert.Equal(release2020.Id, viewModels[2].ReleaseId);
-                Assert.Equal(release2020.Slug, viewModels[2].ReleaseSlug);
-                Assert.False(viewModels[2].IsLatest);
-                Assert.True(viewModels[2].IsPublished);
-                Assert.Null(viewModels[2].LegacyLinkUrl);
-
-                Assert.False(viewModels[3].IsLegacyLink);
-                Assert.Equal(release2021.Title, viewModels[3].Description);
-                Assert.Equal(release2021.Id, viewModels[3].ReleaseId);
-                Assert.Equal(release2021.Slug, viewModels[3].ReleaseSlug);
-                Assert.False(viewModels[3].IsLatest);
-                Assert.True(viewModels[3].IsPublished);
-                Assert.Null(viewModels[3].LegacyLinkUrl);
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var actualPublication = await contentDbContext.Publications
-                    .SingleAsync(p => p.Id == publication.Id);
-
-                var actualReleaseSeries = actualPublication.ReleaseSeries;
-                Assert.Equal(4, actualReleaseSeries.Count);
-
-                Assert.Equal("Legacy link new", actualReleaseSeries[0].LegacyLinkDescription);
-                Assert.Equal("https://test.com/new", actualReleaseSeries[0].LegacyLinkUrl);
-
-                Assert.Equal(release2022.Id, actualReleaseSeries[1].ReleaseId);
-                Assert.Equal(release2020.Id, actualReleaseSeries[2].ReleaseId);
-                Assert.Equal(release2021.Id, actualReleaseSeries[3].ReleaseId);
-
-                // The publication's latest published release version should be unchanged as 2022 was positioned
-                // as the first release after the legacy link
-                Assert.Equal(release2022.Versions[1].Id, actualPublication.LatestPublishedReleaseVersionId);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateReleaseSeries_UpdatesLatestPublishedReleaseVersion()
-        {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases([
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, year: 2020),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, draftVersion: true, year: 2021),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)
-                ])
-                .WithTheme(_dataFixture.DefaultTheme());
-
-            var release2020 = publication.Releases.Single(r => r.Year == 2020);
-            var release2021 = publication.Releases.Single(r => r.Year == 2021);
-            var release2022 = publication.Releases.Single(r => r.Year == 2022);
-
-            var expectedLatestPublishedReleaseVersionId = release2021.Versions[0].Id;
-
-            // Check the publication's latest published release version in the generated test data setup
-            Assert.Equal(release2022.Versions[1].Id, publication.LatestPublishedReleaseVersionId);
-
-            // Check the expected order of the release series items in the generated test data setup
-            Assert.Equal(3, publication.ReleaseSeries.Count);
-            Assert.Equal(release2022.Id, publication.ReleaseSeries[0].ReleaseId);
-            Assert.Equal(release2021.Id, publication.ReleaseSeries[1].ReleaseId);
-            Assert.Equal(release2020.Id, publication.ReleaseSeries[2].ReleaseId);
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var releaseCacheService = new Mock<IReleaseCacheService>(Strict);
-                releaseCacheService.Setup(mock => mock.UpdateRelease(
-                        expectedLatestPublishedReleaseVersionId,
-                        publication.Slug,
-                        null))
-                    .ReturnsAsync(new ReleaseCacheViewModel(expectedLatestPublishedReleaseVersionId));
-
-                var publicationService = BuildPublicationService(
-                    contentDbContext,
-                    publicationCacheService: publicationCacheService.Object,
-                    releaseCacheService: releaseCacheService.Object);
-
-                var result = await publicationService.UpdateReleaseSeries(
-                    publication.Id,
-                    updatedReleaseSeriesItems:
-                    [
-                        new ReleaseSeriesItemUpdateRequest { ReleaseId = release2021.Id },
-                        new ReleaseSeriesItemUpdateRequest { ReleaseId = release2020.Id },
-                        new ReleaseSeriesItemUpdateRequest { ReleaseId = release2022.Id }
-                    ]);
-
-                VerifyAllMocks(publicationCacheService, releaseCacheService);
-
-                var viewModels = result.AssertRight();
-                Assert.Equal(3, viewModels.Count);
-
-                Assert.Equal(release2021.Id, viewModels[0].ReleaseId);
-                Assert.True(viewModels[0].IsLatest);
-                Assert.True(viewModels[0].IsPublished);
-
-                Assert.Equal(release2020.Id, viewModels[1].ReleaseId);
-                Assert.False(viewModels[1].IsLatest);
-                Assert.True(viewModels[1].IsPublished);
-
-                Assert.Equal(release2022.Id, viewModels[2].ReleaseId);
-                Assert.False(viewModels[2].IsLatest);
-                Assert.True(viewModels[2].IsPublished);
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var actualPublication = await contentDbContext.Publications
-                    .SingleAsync(p => p.Id == publication.Id);
-
-                var actualReleaseSeries = actualPublication.ReleaseSeries;
-                Assert.Equal(3, actualReleaseSeries.Count);
-
-                Assert.Equal(release2021.Id, actualReleaseSeries[0].ReleaseId);
-                Assert.Equal(release2020.Id, actualReleaseSeries[1].ReleaseId);
-                Assert.Equal(release2022.Id, actualReleaseSeries[2].ReleaseId);
-
-                // The latest published version of 2021 should now be the publication's latest published release
-                // version since it was positioned as the first release
-                Assert.Equal(expectedLatestPublishedReleaseVersionId,
-                    actualPublication.LatestPublishedReleaseVersionId);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateReleaseSeries_UpdatesLatestPublishedReleaseVersion_SkipsUnpublishedReleases()
-        {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases([
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 1, year: 2020),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 0, draftVersion: true, year: 2021),
-                    _dataFixture
-                        .DefaultRelease(publishedVersions: 2, draftVersion: true, year: 2022)
-                ])
-                .WithTheme(_dataFixture.DefaultTheme());
-
-            var release2020 = publication.Releases.Single(r => r.Year == 2020);
-            var release2021 = publication.Releases.Single(r => r.Year == 2021);
-            var release2022 = publication.Releases.Single(r => r.Year == 2022);
-
-            var expectedLatestPublishedReleaseVersionId = release2020.Versions[0].Id;
-
-            // Check the publication's latest published release version in the generated test data setup
-            Assert.Equal(release2022.Versions[1].Id, publication.LatestPublishedReleaseVersionId);
-
-            // Check the expected order of the release series items in the generated test data setup
-            Assert.Equal(3, publication.ReleaseSeries.Count);
-            Assert.Equal(release2022.Id, publication.ReleaseSeries[0].ReleaseId);
-            Assert.Equal(release2021.Id, publication.ReleaseSeries[1].ReleaseId);
-            Assert.Equal(release2020.Id, publication.ReleaseSeries[2].ReleaseId);
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var releaseCacheService = new Mock<IReleaseCacheService>(Strict);
-                releaseCacheService.Setup(mock => mock.UpdateRelease(
-                        expectedLatestPublishedReleaseVersionId,
-                        publication.Slug,
-                        null))
-                    .ReturnsAsync(new ReleaseCacheViewModel(expectedLatestPublishedReleaseVersionId));
-
-                var publicationService = BuildPublicationService(
-                    contentDbContext,
-                    publicationCacheService: publicationCacheService.Object,
-                    releaseCacheService: releaseCacheService.Object);
-
-                var result = await publicationService.UpdateReleaseSeries(
-                    publication.Id,
-                    updatedReleaseSeriesItems:
-                    [
-                        new ReleaseSeriesItemUpdateRequest { ReleaseId = release2021.Id }, // Unpublished
-                        new ReleaseSeriesItemUpdateRequest { ReleaseId = release2020.Id },
-                        new ReleaseSeriesItemUpdateRequest { ReleaseId = release2022.Id }
-                    ]);
-
-                VerifyAllMocks(publicationCacheService, releaseCacheService);
-
-                var viewModels = result.AssertRight();
-                Assert.Equal(3, viewModels.Count);
-
-                Assert.Equal(release2021.Id, viewModels[0].ReleaseId);
-                Assert.False(viewModels[0].IsLatest);
-                Assert.False(viewModels[0].IsPublished);
-
-                Assert.Equal(release2020.Id, viewModels[1].ReleaseId);
-                Assert.True(viewModels[1].IsLatest);
-                Assert.True(viewModels[1].IsPublished);
-
-                Assert.Equal(release2022.Id, viewModels[2].ReleaseId);
-                Assert.False(viewModels[2].IsLatest);
-                Assert.True(viewModels[2].IsPublished);
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var actualPublication = await contentDbContext.Publications
-                    .SingleAsync(p => p.Id == publication.Id);
-
-                var actualReleaseSeries = actualPublication.ReleaseSeries;
-                Assert.Equal(3, actualReleaseSeries.Count);
-
-                Assert.Equal(release2021.Id, actualReleaseSeries[0].ReleaseId);
-                Assert.Equal(release2020.Id, actualReleaseSeries[1].ReleaseId);
-                Assert.Equal(release2022.Id, actualReleaseSeries[2].ReleaseId);
-
-                // The latest published version of 2020 should now be the publication's latest published release
-                // version since it was positioned as the next release after 2021 which is unpublished
-                Assert.Equal(expectedLatestPublishedReleaseVersionId,
-                    actualPublication.LatestPublishedReleaseVersionId);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateReleaseSeries_SetEmpty()
-        {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithLegacyLinks([_dataFixture.DefaultLegacyReleaseSeriesItem()])
-                .WithTheme(_dataFixture.DefaultTheme());
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-                publicationCacheService.Setup(mock =>
-                        mock.UpdatePublication(publication.Slug))
-                    .ReturnsAsync(new PublicationCacheViewModel());
-
-                var publicationService = BuildPublicationService(
-                    contentDbContext,
-                    publicationCacheService: publicationCacheService.Object);
-
-                var result = await publicationService.UpdateReleaseSeries(
-                    publication.Id,
-                    updatedReleaseSeriesItems: []);
-
-                VerifyAllMocks(publicationCacheService);
-
-                var viewModels = result.AssertRight();
-
-                Assert.Empty(viewModels);
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var actualPublication = await contentDbContext.Publications
-                    .SingleAsync(p => p.Id == publication.Id);
-
-                Assert.Empty(actualPublication.ReleaseSeries);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateReleaseSeries_UnsetRelease()
-        {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
-                .WithTheme(_dataFixture.DefaultTheme());
-
-            var release = publication.Releases.Single();
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(contentDbContext);
-
-                var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-                    publicationService.UpdateReleaseSeries(
-                        publication.Id,
-                        updatedReleaseSeriesItems: []));
-
-                Assert.Equal($"Missing or duplicate release in new release series. Expected ReleaseIds: {release.Id}",
-                    exception.Message);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateReleaseSeries_SetDuplicateRelease()
-        {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
-                .WithTheme(_dataFixture.DefaultTheme());
-
-            var release = publication.Releases.Single();
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(contentDbContext);
-
-                var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-                    publicationService.UpdateReleaseSeries(
-                        publication.Id,
-                        updatedReleaseSeriesItems:
-                        [
-                            new ReleaseSeriesItemUpdateRequest { ReleaseId = release.Id },
-                            new ReleaseSeriesItemUpdateRequest { ReleaseId = release.Id }
-                        ]));
-
-                Assert.Equal($"Missing or duplicate release in new release series. Expected ReleaseIds: {release.Id}",
-                    exception.Message);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateReleaseSeries_InvalidSeriesItem1()
-        {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1)])
-                .WithTheme(_dataFixture.DefaultTheme());
-
-            var release = publication.Releases.Single();
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(contentDbContext);
-
-                var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-                    publicationService.UpdateReleaseSeries(
-                        publication.Id,
-                        [
-                            new ReleaseSeriesItemUpdateRequest
-                            {
-                                ReleaseId = release.Id,
-                                LegacyLinkDescription = "this should be null",
-                                LegacyLinkUrl = "https://should.be/null",
-                            }
-                        ]));
-
-                Assert.Equal("LegacyLink details shouldn't be set if ReleaseId is set.", exception.Message);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateReleaseSeries_InvalidSeriesItem2()
-        {
-            Publication publication = _dataFixture
-                .DefaultPublication()
-                .WithTheme(_dataFixture.DefaultTheme());
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                contentDbContext.Publications.Add(publication);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationService = BuildPublicationService(contentDbContext);
-
-                var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-                    publicationService.UpdateReleaseSeries(
-                        publication.Id,
-                        [
-                            new ReleaseSeriesItemUpdateRequest
-                            {
-                                ReleaseId = null,
-                                LegacyLinkDescription = null,
-                                LegacyLinkUrl = null,
-                            }
-                        ]));
-
-                Assert.Equal("LegacyLink details should be set if ReleaseId is null.", exception.Message);
-            }
-        }
-
-        private static PublicationService BuildPublicationService(
-            ContentDbContext context,
-            IUserService? userService = null,
-            IPublicationRepository? publicationRepository = null,
-            IReleaseVersionRepository? releaseVersionRepository = null,
-            IMethodologyService? methodologyService = null,
-            IPublicationCacheService? publicationCacheService = null,
-            IReleaseCacheService? releaseCacheService = null,
-            IMethodologyCacheService? methodologyCacheService = null,
-            IRedirectsCacheService? redirectsCacheService = null)
-        {
-            return new(
-                context,
-                AdminMapper(),
-                new PersistenceHelper<ContentDbContext>(context),
-                userService ?? AlwaysTrueUserService().Object,
-                publicationRepository ?? new PublicationRepository(context),
-                releaseVersionRepository ?? new ReleaseVersionRepository(context),
-                methodologyService ?? Mock.Of<IMethodologyService>(Strict),
-                publicationCacheService ?? Mock.Of<IPublicationCacheService>(Strict),
-                releaseCacheService ?? Mock.Of<IReleaseCacheService>(Strict),
-                methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
-                redirectsCacheService ?? Mock.Of<IRedirectsCacheService>(Strict));
+                            ReleaseId = release.Id,
+                            LegacyLinkDescription = "this should be null",
+                            LegacyLinkUrl = "https://should.be/null",
+                        }
+                    ]));
+
+            Assert.Equal("LegacyLink details shouldn't be set if ReleaseId is set.", exception.Message);
         }
     }
+
+    [Fact]
+    public async Task UpdateReleaseSeries_InvalidSeriesItem2()
+    {
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithTheme(_dataFixture.DefaultTheme());
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.Publications.Add(publication);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var publicationService = BuildPublicationService(contentDbContext);
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+                publicationService.UpdateReleaseSeries(
+                    publication.Id,
+                    [
+                        new ReleaseSeriesItemUpdateRequest
+                        {
+                            ReleaseId = null,
+                            LegacyLinkDescription = null,
+                            LegacyLinkUrl = null,
+                        }
+                    ]));
+
+            Assert.Equal("LegacyLink details should be set if ReleaseId is null.", exception.Message);
+        }
+    }
+
+    private PublicationService BuildPublicationService(
+        ContentDbContext context,
+        IUserService? userService = null,
+        IPublicationRepository? publicationRepository = null,
+        IReleaseVersionRepository? releaseVersionRepository = null,
+        IMethodologyService? methodologyService = null,
+        IPublicationCacheService? publicationCacheService = null,
+        IReleaseCacheService? releaseCacheService = null,
+        IMethodologyCacheService? methodologyCacheService = null,
+        IRedirectsCacheService? redirectsCacheService = null)
+    {
+        return new(
+            context,
+            AdminMapper(),
+            new PersistenceHelper<ContentDbContext>(context),
+            userService ?? AlwaysTrueUserService().Object,
+            publicationRepository ?? new PublicationRepository(context),
+            releaseVersionRepository ?? new ReleaseVersionRepository(context),
+            methodologyService ?? Mock.Of<IMethodologyService>(Strict),
+            publicationCacheService ?? Mock.Of<IPublicationCacheService>(Strict),
+            releaseCacheService ?? Mock.Of<IReleaseCacheService>(Strict),
+            methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
+            redirectsCacheService ?? Mock.Of<IRedirectsCacheService>(Strict),
+            _adminEventRaiserServiceMockBuilder.Build());
+    }
+
+    private readonly AdminEventRaiserServiceMockBuilder _adminEventRaiserServiceMockBuilder = new();
+
+    private void AssertOnPublicationChangedEventRaised(Publication? publication = null) =>
+        _adminEventRaiserServiceMockBuilder.Assert.OnPublicationChangedWasRaised(publication);
+    
+    private void AssertOnPublicationChangedEventNotRaised() =>
+        _adminEventRaiserServiceMockBuilder.Assert.OnPublicationChangedWasNotRaised();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -331,7 +331,7 @@ public abstract class ReleaseServiceTests
             output.WriteLine($"Expected Publication Id: {expectedPublicationId}");
             output.WriteLine($"Expected Publication Slug: {expectedPublicationSlug}");
             
-            adminEventRaiserService.Assert.OnReleaseSlugChangedWasCalled(
+            adminEventRaiserService.Assert.OnReleaseSlugChangedWasRaised(
                 expectedReleaseId,
                 expectedNewReleaseSlug,
                 expectedPublicationId,
@@ -406,7 +406,7 @@ public abstract class ReleaseServiceTests
             var newReleaseSlug = NamingUtils.CreateReleaseSlug(year, timePeriod, label);
             Assert.NotEqual(currentReleaseSlug, newReleaseSlug);
             
-            adminEventRaiserService.Assert.OnReleaseSlugChangedWasNotCalled();
+            adminEventRaiserService.Assert.OnReleaseSlugChangedWasNotRaised();
         }
         
         [Fact]
@@ -473,7 +473,7 @@ public abstract class ReleaseServiceTests
             
             // ASSERT
             result.AssertRight();
-            adminEventRaiserService.Assert.OnReleaseSlugChangedWasNotCalled();
+            adminEventRaiserService.Assert.OnReleaseSlugChangedWasNotRaised();
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -168,7 +168,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("updated-theme", savedTheme.Slug);
                 Assert.Equal("Updated summary", savedTheme.Summary);
                 
-                eventRaiser.Assert.ThatOnThemeUpdatedCalled(actual => actual == savedTheme);
+                eventRaiser.Assert.ThatOnThemeUpdatedRaised(actual => actual == savedTheme);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationChangedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationChangedEventDto.cs
@@ -1,0 +1,44 @@
+﻿using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Events;
+
+public record PublicationChangedEventDto
+{
+    public PublicationChangedEventDto(Publication publication)
+    {
+        Subject = publication.Id.ToString();
+        Payload = new EventPayload
+        {
+            Title = publication.Title,
+            Summary = publication.Summary,
+            Slug = publication.Slug
+        };
+    }
+
+    // Changes to this event should also increment the version accordingly.
+    private const string DataVersion = "1.0";
+    private const string EventType = "publication-changed";
+    
+    // Which Topic endpoint to use from the appsettings
+    public const string EventTopicOptionsKey = "PublicationChangedEvent";
+
+    /// <summary>
+    /// The ThemeId is the subject
+    /// </summary>
+    public string Subject { get; }
+
+    /// <summary>
+    /// The event payload
+    /// </summary>
+    public EventPayload Payload { get; }
+    
+    public record EventPayload
+    {
+        public string Title { get; init; }
+        public string Summary { get; init; }
+        public string Slug { get; init; }
+    }
+
+    public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationChangedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationChangedEventDto.cs
@@ -24,7 +24,7 @@ public record PublicationChangedEventDto
     public const string EventTopicOptionsKey = "PublicationChangedEvent";
 
     /// <summary>
-    /// The ThemeId is the subject
+    /// The PublicationId is the subject
     /// </summary>
     public string Subject { get; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/ReleaseSlugChangedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/ReleaseSlugChangedEventDto.cs
@@ -21,7 +21,7 @@ public record ReleaseSlugChangedEventDto
     private const string EventType = "release-slug-changed";
     
     // Which Topic endpoint to use from the appsettings
-    public const string EventTopicOptionsKey = "ReleaseChangesEvent";
+    public const string EventTopicOptionsKey = "ReleaseChangedEvent";
 
     /// <summary>
     /// The ThemeId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/ThemeChangedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/ThemeChangedEventDto.cs
@@ -21,7 +21,7 @@ public record ThemeChangedEventDto
     private const string EventType = "theme-changed";
     
     // Which Topic endpoint to use from the appsettings
-    public const string EventTopicOptionsKey = "ThemeChangesEvent";
+    public const string EventTopicOptionsKey = "ThemeChangedEvent";
 
     /// <summary>
     /// The ThemeId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiserService.cs
@@ -45,5 +45,22 @@ public class AdminEventRaiserService(IConfiguredEventGridClientFactory eventGrid
         var eventDto = new ReleaseSlugChangedEventDto(releaseId, newReleaseSlug, publicationId, publicationSlug);
         await client.SendEventAsync(eventDto.ToEventGridEvent());
     }
+
+    /// <summary>
+    /// On Publication Changed
+    /// </summary>
+    public async Task OnPublicationChanged(Publication publication)
+    {
+        if (!eventGridClientFactory.TryCreateClient(
+                PublicationChangedEventDto.EventTopicOptionsKey,
+                out var client))
+        {
+            return;
+        }
+
+        var eventDto = new PublicationChangedEventDto(publication);
+        
+        await client.SendEventAsync(eventDto.ToEventGridEvent());
+    }
 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiserService.cs
@@ -8,4 +8,5 @@ public interface IAdminEventRaiserService
 {
     Task OnThemeUpdated(Theme theme);
     Task OnReleaseSlugChanged(Guid releaseId, string newReleaseSlug, Guid publicationId, string publicationSlug);
+    Task OnPublicationChanged(Publication publication);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -29,629 +29,636 @@ using IReleaseVersionRepository = GovUk.Education.ExploreEducationStatistics.Con
 using PublicationViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.PublicationViewModel;
 using ReleaseVersionSummaryViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ReleaseVersionSummaryViewModel;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+public class PublicationService(
+    ContentDbContext context,
+    IMapper mapper,
+    IPersistenceHelper<ContentDbContext> persistenceHelper,
+    IUserService userService,
+    IPublicationRepository publicationRepository,
+    IReleaseVersionRepository releaseVersionRepository,
+    IMethodologyService methodologyService,
+    IPublicationCacheService publicationCacheService,
+    IReleaseCacheService releaseCacheService,
+    IMethodologyCacheService methodologyCacheService,
+    IRedirectsCacheService redirectsCacheService,
+    IAdminEventRaiserService adminEventRaiserService)
+    : IPublicationService
 {
-    public class PublicationService(
-        ContentDbContext context,
-        IMapper mapper,
-        IPersistenceHelper<ContentDbContext> persistenceHelper,
-        IUserService userService,
-        IPublicationRepository publicationRepository,
-        IReleaseVersionRepository releaseVersionRepository,
-        IMethodologyService methodologyService,
-        IPublicationCacheService publicationCacheService,
-        IReleaseCacheService releaseCacheService,
-        IMethodologyCacheService methodologyCacheService,
-        IRedirectsCacheService redirectsCacheService)
-        : IPublicationService
+    public async Task<Either<ActionResult, List<PublicationViewModel>>> ListPublications(
+        Guid? themeId = null)
     {
-        public async Task<Either<ActionResult, List<PublicationViewModel>>> ListPublications(
-            Guid? themeId = null)
-        {
-            return await userService
-                .CheckCanAccessSystem()
-                .OnSuccess(_ => userService.CheckCanViewAllPublications()
-                    .OnSuccess(async () =>
-                    {
-                        var hydratedPublication = HydratePublication(
-                            publicationRepository.QueryPublicationsForTheme(themeId));
-                        return await hydratedPublication.ToListAsync();
-                    })
-                    .OrElse(() =>
-                    {
-                        var userId = userService.GetUserId();
-                        return publicationRepository.ListPublicationsForUser(userId, themeId);
-                    })
-                )
-                .OnSuccess(async publications =>
+        return await userService
+            .CheckCanAccessSystem()
+            .OnSuccess(_ => userService.CheckCanViewAllPublications()
+                .OnSuccess(async () =>
                 {
-                    return await publications
-                        .ToAsyncEnumerable()
-                        .SelectAwait(async publication => await GeneratePublicationViewModel(publication))
-                        .OrderBy(publicationViewModel => publicationViewModel.Title)
+                    var hydratedPublication = HydratePublication(
+                        publicationRepository.QueryPublicationsForTheme(themeId));
+                    return await hydratedPublication.ToListAsync();
+                })
+                .OrElse(() =>
+                {
+                    var userId = userService.GetUserId();
+                    return publicationRepository.ListPublicationsForUser(userId, themeId);
+                })
+            )
+            .OnSuccess(async publications =>
+            {
+                return await publications
+                    .ToAsyncEnumerable()
+                    .SelectAwait(async publication => await GeneratePublicationViewModel(publication))
+                    .OrderBy(publicationViewModel => publicationViewModel.Title)
+                    .ToListAsync();
+            });
+    }
+
+    public async Task<Either<ActionResult, List<PublicationSummaryViewModel>>> ListPublicationSummaries()
+    {
+        return await userService
+            .CheckCanViewAllPublications()
+            .OnSuccess(_ =>
+            {
+                return context.Publications
+                    .Select(publication => new PublicationSummaryViewModel(publication))
+                    .ToList();
+            });
+    }
+
+    public async Task<Either<ActionResult, PublicationCreateViewModel>> CreatePublication(
+        PublicationCreateRequest publication)
+    {
+        return await ValidateSelectedTheme(publication.ThemeId)
+            .OnSuccess(_ => ValidatePublicationSlug(publication.Slug))
+            .OnSuccess(async _ =>
+            {
+                var contact = await context.Contacts.AddAsync(new Contact
+                {
+                    ContactName = publication.Contact.ContactName,
+                    ContactTelNo = string.IsNullOrWhiteSpace(publication.Contact.ContactTelNo)
+                        ? null
+                        : publication.Contact.ContactTelNo,
+                    TeamName = publication.Contact.TeamName,
+                    TeamEmail = publication.Contact.TeamEmail
+                });
+
+                var saved = await context.Publications.AddAsync(new Publication
+                {
+                    Contact = contact.Entity,
+                    Title = publication.Title,
+                    Summary = publication.Summary,
+                    ThemeId = publication.ThemeId,
+                    Slug = publication.Slug,
+                });
+
+                await context.SaveChangesAsync();
+
+                return await persistenceHelper
+                    .CheckEntityExists<Publication>(saved.Entity.Id, HydratePublication)
+                    .OnSuccess(GeneratePublicationCreateViewModel);
+            });
+    }
+
+    public async Task<Either<ActionResult, PublicationViewModel>> UpdatePublication(
+        Guid publicationId,
+        PublicationSaveRequest updatedPublication)
+    {
+        return await persistenceHelper
+            .CheckEntityExists<Publication>(publicationId)
+            .OnSuccess(userService.CheckCanUpdatePublicationSummary)
+            .OnSuccessDo(async publication =>
+            {
+                if (publication.Title != updatedPublication.Title)
+                {
+                    return await userService.CheckCanUpdatePublication();
+                }
+
+                return Unit.Instance;
+            })
+            .OnSuccessDo(async publication =>
+            {
+                if (publication.SupersededById != updatedPublication.SupersededById)
+                {
+                    return await userService.CheckCanUpdatePublication();
+                }
+
+                return Unit.Instance;
+            })
+            .OnSuccessDo(async publication =>
+            {
+                if (publication.ThemeId != updatedPublication.ThemeId)
+                {
+                    return await ValidateSelectedTheme(updatedPublication.ThemeId);
+                }
+
+                return Unit.Instance;
+            })
+            .OnSuccessDo(async publication =>
+            {
+                if (publication.ThemeId != updatedPublication.ThemeId)
+                {
+                    return await userService.CheckCanUpdatePublication();
+                }
+
+                return Unit.Instance;
+            })
+            .OnSuccess(async publication =>
+            {
+                var originalTitle = publication.Title;
+                var originalSlug = publication.Slug;
+                var originalSummary = publication.Summary;
+
+                var titleChanged = originalTitle != updatedPublication.Title;
+                var slugChanged = originalSlug != updatedPublication.Slug;
+                var summaryChanged = originalSummary != updatedPublication.Summary;
+
+                if (slugChanged)
+                {
+                    var slugValidation =
+                        await ValidatePublicationSlug(updatedPublication.Slug, publication.Id);
+
+                    if (slugValidation.IsLeft)
+                    {
+                        return new Either<ActionResult, PublicationViewModel>(slugValidation.Left);
+                    }
+
+                    publication.Slug = updatedPublication.Slug;
+
+                    if (publication.Live
+                        && context.PublicationRedirects.All(pr =>
+                            !(pr.PublicationId == publicationId && pr.Slug == originalSlug))) // don't create duplicate redirect
+                    {
+                        var publicationRedirect = new PublicationRedirect
+                        {
+                            Slug = originalSlug,
+                            Publication = publication,
+                            PublicationId = publication.Id,
+                        };
+                        context.PublicationRedirects.Add(publicationRedirect);
+                    }
+
+                    // If there is an existing redirects for the new slug, they're redundant. Remove them
+                    var redundantRedirects = await context.PublicationRedirects
+                        .Where(pr => pr.Slug == updatedPublication.Slug)
                         .ToListAsync();
-                });
-        }
-
-        public async Task<Either<ActionResult, List<PublicationSummaryViewModel>>> ListPublicationSummaries()
-        {
-            return await userService
-                .CheckCanViewAllPublications()
-                .OnSuccess(_ =>
-                {
-                    return context.Publications
-                        .Select(publication => new PublicationSummaryViewModel(publication))
-                        .ToList();
-                });
-        }
-
-        public async Task<Either<ActionResult, PublicationCreateViewModel>> CreatePublication(
-            PublicationCreateRequest publication)
-        {
-            return await ValidateSelectedTheme(publication.ThemeId)
-                .OnSuccess(_ => ValidatePublicationSlug(publication.Slug))
-                .OnSuccess(async _ =>
-                {
-                    var contact = await context.Contacts.AddAsync(new Contact
+                    if (redundantRedirects.Count > 0)
                     {
-                        ContactName = publication.Contact.ContactName,
-                        ContactTelNo = string.IsNullOrWhiteSpace(publication.Contact.ContactTelNo)
-                            ? null
-                            : publication.Contact.ContactTelNo,
-                        TeamName = publication.Contact.TeamName,
-                        TeamEmail = publication.Contact.TeamEmail
-                    });
-
-                    var saved = await context.Publications.AddAsync(new Publication
-                    {
-                        Contact = contact.Entity,
-                        Title = publication.Title,
-                        Summary = publication.Summary,
-                        ThemeId = publication.ThemeId,
-                        Slug = publication.Slug,
-                    });
-
-                    await context.SaveChangesAsync();
-
-                    return await persistenceHelper
-                        .CheckEntityExists<Publication>(saved.Entity.Id, HydratePublication)
-                        .OnSuccess(GeneratePublicationCreateViewModel);
-                });
-        }
-
-        public async Task<Either<ActionResult, PublicationViewModel>> UpdatePublication(
-            Guid publicationId,
-            PublicationSaveRequest updatedPublication)
-        {
-            return await persistenceHelper
-                .CheckEntityExists<Publication>(publicationId)
-                .OnSuccess(userService.CheckCanUpdatePublicationSummary)
-                .OnSuccessDo(async publication =>
-                {
-                    if (publication.Title != updatedPublication.Title)
-                    {
-                        return await userService.CheckCanUpdatePublication();
+                        context.PublicationRedirects.RemoveRange(redundantRedirects);
                     }
+                }
 
-                    return Unit.Instance;
-                })
-                .OnSuccessDo(async publication =>
+                publication.Title = updatedPublication.Title;
+                publication.Summary = updatedPublication.Summary;
+                publication.ThemeId = updatedPublication.ThemeId;
+                publication.Updated = DateTime.UtcNow;
+                publication.SupersededById = updatedPublication.SupersededById;
+
+                context.Publications.Update(publication);
+
+                await context.SaveChangesAsync();
+
+                if (titleChanged || slugChanged)
                 {
-                    if (publication.SupersededById != updatedPublication.SupersededById)
-                    {
-                        return await userService.CheckCanUpdatePublication();
-                    }
+                    await methodologyService.PublicationTitleOrSlugChanged(publicationId,
+                        originalSlug,
+                        publication.Title,
+                        publication.Slug);
+                }
 
-                    return Unit.Instance;
-                })
-                .OnSuccessDo(async publication =>
+                if (publication.Live)
                 {
-                    if (publication.ThemeId != updatedPublication.ThemeId)
-                    {
-                        return await ValidateSelectedTheme(updatedPublication.ThemeId);
-                    }
-
-                    return Unit.Instance;
-                })
-                .OnSuccessDo(async publication =>
-                {
-                    if (publication.ThemeId != updatedPublication.ThemeId)
-                    {
-                        return await userService.CheckCanUpdatePublication();
-                    }
-
-                    return Unit.Instance;
-                })
-                .OnSuccess(async publication =>
-                {
-                    var originalTitle = publication.Title;
-                    var originalSlug = publication.Slug;
-
-                    var titleChanged = originalTitle != updatedPublication.Title;
-                    var slugChanged = originalSlug != updatedPublication.Slug;
+                    await methodologyCacheService.UpdateSummariesTree();
+                    await publicationCacheService.UpdatePublicationTree();
+                    await publicationCacheService.UpdatePublication(publication.Slug);
 
                     if (slugChanged)
                     {
-                        var slugValidation =
-                            await ValidatePublicationSlug(updatedPublication.Slug, publication.Id);
-
-                        if (slugValidation.IsLeft)
-                        {
-                            return new Either<ActionResult, PublicationViewModel>(slugValidation.Left);
-                        }
-
-                        publication.Slug = updatedPublication.Slug;
-
-                        if (publication.Live
-                            && context.PublicationRedirects.All(pr =>
-                                !(pr.PublicationId == publicationId && pr.Slug == originalSlug))) // don't create duplicate redirect
-                        {
-                            var publicationRedirect = new PublicationRedirect
-                            {
-                                Slug = originalSlug,
-                                Publication = publication,
-                                PublicationId = publication.Id,
-                            };
-                            context.PublicationRedirects.Add(publicationRedirect);
-                        }
-
-                        // If there is an existing redirects for the new slug, they're redundant. Remove them
-                        var redundantRedirects = await context.PublicationRedirects
-                            .Where(pr => pr.Slug == updatedPublication.Slug)
-                            .ToListAsync();
-                        if (redundantRedirects.Count > 0)
-                        {
-                            context.PublicationRedirects.RemoveRange(redundantRedirects);
-                        }
+                        await publicationCacheService.RemovePublication(originalSlug);
+                        await redirectsCacheService.UpdateRedirects();
                     }
 
-                    publication.Title = updatedPublication.Title;
-                    publication.Summary = updatedPublication.Summary;
-                    publication.ThemeId = updatedPublication.ThemeId;
-                    publication.Updated = DateTime.UtcNow;
-                    publication.SupersededById = updatedPublication.SupersededById;
+                    await UpdateCachedSupersededPublications(publication);
+                }
 
-                    context.Publications.Update(publication);
+                if (publication.Live && (titleChanged || slugChanged || summaryChanged))
+                {
+                    await adminEventRaiserService.OnPublicationChanged(publication);
+                }
+                
+                return await GetPublication(publication.Id);
+            });
+    }
 
-                    await context.SaveChangesAsync();
+    private async Task UpdateCachedSupersededPublications(Publication publication)
+    {
+        // NOTE: When a publication is updated, any publication that is superseded by it can be affected, so
+        // update any superseded publications that are cached
+        var supersededPublications = await context.Publications
+            .Where(p => p.SupersededById == publication.Id)
+            .ToListAsync();
 
-                    if (titleChanged || slugChanged)
-                    {
-                        await methodologyService.PublicationTitleOrSlugChanged(publicationId,
-                            originalSlug,
-                            publication.Title,
-                            publication.Slug);
-                    }
+        await supersededPublications
+            .ToAsyncEnumerable()
+            .ForEachAwaitAsync(p => publicationCacheService.UpdatePublication(p.Slug));
+    }
 
-                    if (publication.Live)
-                    {
-                        await methodologyCacheService.UpdateSummariesTree();
-                        await publicationCacheService.UpdatePublicationTree();
-                        await publicationCacheService.UpdatePublication(publication.Slug);
+    private async Task<Either<ActionResult, Unit>> ValidateSelectedTheme(Guid themeId)
+    {
+        var theme = await context.Themes.FindAsync(themeId);
 
-                        if (slugChanged)
-                        {
-                            await publicationCacheService.RemovePublication(originalSlug);
-                            await redirectsCacheService.UpdateRedirects();
-                        }
-
-                        await UpdateCachedSupersededPublications(publication);
-                    }
-
-                    return await GetPublication(publication.Id);
-                });
+        if (theme is null)
+        {
+            return ValidationActionResult(ThemeDoesNotExist);
         }
 
-        private async Task UpdateCachedSupersededPublications(Publication publication)
-        {
-            // NOTE: When a publication is updated, any publication that is superseded by it can be affected, so
-            // update any superseded publications that are cached
-            var supersededPublications = await context.Publications
-                .Where(p => p.SupersededById == publication.Id)
-                .ToListAsync();
+        return await userService.CheckCanCreatePublicationForTheme(theme)
+            .OnSuccess(_ => Unit.Instance);
+    }
 
-            await supersededPublications
-                .ToAsyncEnumerable()
-                .ForEachAwaitAsync(p => publicationCacheService.UpdatePublication(p.Slug));
-        }
+    public async Task<Either<ActionResult, PublicationViewModel>> GetPublication(
+        Guid publicationId, bool includePermissions = false)
+    {
+        return await persistenceHelper
+            .CheckEntityExists<Publication>(publicationId, HydratePublication)
+            .OnSuccess(userService.CheckCanViewPublication)
+            .OnSuccess(publication => GeneratePublicationViewModel(publication, includePermissions));
+    }
 
-        private async Task<Either<ActionResult, Unit>> ValidateSelectedTheme(Guid themeId)
-        {
-            var theme = await context.Themes.FindAsync(themeId);
+    public async Task<Either<ActionResult, ExternalMethodologyViewModel>> GetExternalMethodology(Guid publicationId)
+    {
+        return await persistenceHelper
+            .CheckEntityExists<Publication>(publicationId)
+            .OnSuccessDo(userService.CheckCanViewPublication)
+            .OnSuccess(publication => publication.ExternalMethodology != null
+                ? new ExternalMethodologyViewModel(publication.ExternalMethodology)
+                : NotFound<ExternalMethodologyViewModel>());
+    }
 
-            if (theme is null)
+    public async Task<Either<ActionResult, ExternalMethodologyViewModel>> UpdateExternalMethodology(
+        Guid publicationId, ExternalMethodologySaveRequest updatedExternalMethodology)
+    {
+        return await persistenceHelper
+            .CheckEntityExists<Publication>(publicationId)
+            .OnSuccessDo(userService.CheckCanManageExternalMethodologyForPublication)
+            .OnSuccess(async publication =>
             {
-                return ValidationActionResult(ThemeDoesNotExist);
-            }
+                context.Update(publication);
+                publication.ExternalMethodology ??= new ExternalMethodology();
+                publication.ExternalMethodology.Title = updatedExternalMethodology.Title;
+                publication.ExternalMethodology.Url = updatedExternalMethodology.Url;
+                await context.SaveChangesAsync();
 
-            return await userService.CheckCanCreatePublicationForTheme(theme)
-                .OnSuccess(_ => Unit.Instance);
-        }
+                // Update publication cache because ExternalMethodology is in Content.Services.ViewModels.PublicationViewModel
+                await publicationCacheService.UpdatePublication(publication.Slug);
 
-        public async Task<Either<ActionResult, PublicationViewModel>> GetPublication(
-            Guid publicationId, bool includePermissions = false)
-        {
-            return await persistenceHelper
-                .CheckEntityExists<Publication>(publicationId, HydratePublication)
-                .OnSuccess(userService.CheckCanViewPublication)
-                .OnSuccess(publication => GeneratePublicationViewModel(publication, includePermissions));
-        }
+                return new ExternalMethodologyViewModel(publication.ExternalMethodology);
+            });
+    }
 
-        public async Task<Either<ActionResult, ExternalMethodologyViewModel>> GetExternalMethodology(Guid publicationId)
-        {
-            return await persistenceHelper
-                .CheckEntityExists<Publication>(publicationId)
-                .OnSuccessDo(userService.CheckCanViewPublication)
-                .OnSuccess(publication => publication.ExternalMethodology != null
-                    ? new ExternalMethodologyViewModel(publication.ExternalMethodology)
-                    : NotFound<ExternalMethodologyViewModel>());
-        }
+    public async Task<Either<ActionResult, Unit>> RemoveExternalMethodology(
+        Guid publicationId)
+    {
+        return await persistenceHelper
+            .CheckEntityExists<Publication>(publicationId)
+            .OnSuccessDo(userService.CheckCanManageExternalMethodologyForPublication)
+            .OnSuccess(async publication =>
+            {
+                context.Update(publication);
+                publication.ExternalMethodology = null;
+                await context.SaveChangesAsync();
 
-        public async Task<Either<ActionResult, ExternalMethodologyViewModel>> UpdateExternalMethodology(
-            Guid publicationId, ExternalMethodologySaveRequest updatedExternalMethodology)
-        {
-            return await persistenceHelper
-                .CheckEntityExists<Publication>(publicationId)
-                .OnSuccessDo(userService.CheckCanManageExternalMethodologyForPublication)
-                .OnSuccess(async publication =>
+                // Clear cache because ExternalMethodology is in Content.Services.ViewModels.PublicationViewModel
+                await publicationCacheService.UpdatePublication(publication.Slug);
+
+                return Unit.Instance;
+            });
+    }
+
+    public async Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId)
+    {
+        return await persistenceHelper
+            .CheckEntityExists<Publication>(publicationId, query =>
+                query.Include(p => p.Contact))
+            .OnSuccessDo(userService.CheckCanViewPublication)
+            .OnSuccess(publication => mapper.Map<ContactViewModel>(publication.Contact));
+    }
+
+    public async Task<Either<ActionResult, ContactViewModel>> UpdateContact(Guid publicationId, ContactSaveRequest updatedContact)
+    {
+        return await persistenceHelper
+            .CheckEntityExists<Publication>(publicationId, query =>
+                query.Include(p => p.Contact))
+            .OnSuccessDo(userService.CheckCanUpdateContact)
+            .OnSuccess(async publication =>
+            {
+                // Replace existing contact that is shared with another publication with a new
+                // contact, as we want each publication to have its own contact.
+                if (context.Publications
+                    .Any(p => p.ContactId == publication.ContactId && p.Id != publication.Id))
                 {
-                    context.Update(publication);
-                    publication.ExternalMethodology ??= new ExternalMethodology();
-                    publication.ExternalMethodology.Title = updatedExternalMethodology.Title;
-                    publication.ExternalMethodology.Url = updatedExternalMethodology.Url;
-                    await context.SaveChangesAsync();
+                    publication.Contact = new Contact();
+                }
 
-                    // Update publication cache because ExternalMethodology is in Content.Services.ViewModels.PublicationViewModel
-                    await publicationCacheService.UpdatePublication(publication.Slug);
+                publication.Contact.ContactName = updatedContact.ContactName;
+                publication.Contact.ContactTelNo = string.IsNullOrWhiteSpace(updatedContact.ContactTelNo)
+                    ? null
+                    : updatedContact.ContactTelNo;
+                publication.Contact.TeamName = updatedContact.TeamName;
+                publication.Contact.TeamEmail = updatedContact.TeamEmail;
+                await context.SaveChangesAsync();
 
-                    return new ExternalMethodologyViewModel(publication.ExternalMethodology);
-                });
-        }
+                // Clear cache because Contact is in Content.Services.ViewModels.PublicationViewModel
+                await publicationCacheService.UpdatePublication(publication.Slug);
 
-        public async Task<Either<ActionResult, Unit>> RemoveExternalMethodology(
-            Guid publicationId)
-        {
-            return await persistenceHelper
-                .CheckEntityExists<Publication>(publicationId)
-                .OnSuccessDo(userService.CheckCanManageExternalMethodologyForPublication)
-                .OnSuccess(async publication =>
-                {
-                    context.Update(publication);
-                    publication.ExternalMethodology = null;
-                    await context.SaveChangesAsync();
+                return mapper.Map<ContactViewModel>(publication.Contact);
+            });
+    }
 
-                    // Clear cache because ExternalMethodology is in Content.Services.ViewModels.PublicationViewModel
-                    await publicationCacheService.UpdatePublication(publication.Slug);
-
-                    return Unit.Instance;
-                });
-        }
-
-        public async Task<Either<ActionResult, ContactViewModel>> GetContact(Guid publicationId)
-        {
-            return await persistenceHelper
-                .CheckEntityExists<Publication>(publicationId, query =>
-                    query.Include(p => p.Contact))
-                .OnSuccessDo(userService.CheckCanViewPublication)
-                .OnSuccess(publication => mapper.Map<ContactViewModel>(publication.Contact));
-        }
-
-        public async Task<Either<ActionResult, ContactViewModel>> UpdateContact(Guid publicationId, ContactSaveRequest updatedContact)
-        {
-            return await persistenceHelper
-                .CheckEntityExists<Publication>(publicationId, query =>
-                    query.Include(p => p.Contact))
-                .OnSuccessDo(userService.CheckCanUpdateContact)
-                .OnSuccess(async publication =>
-                {
-                    // Replace existing contact that is shared with another publication with a new
-                    // contact, as we want each publication to have its own contact.
-                    if (context.Publications
-                        .Any(p => p.ContactId == publication.ContactId && p.Id != publication.Id))
-                    {
-                        publication.Contact = new Contact();
-                    }
-
-                    publication.Contact.ContactName = updatedContact.ContactName;
-                    publication.Contact.ContactTelNo = string.IsNullOrWhiteSpace(updatedContact.ContactTelNo)
-                        ? null
-                        : updatedContact.ContactTelNo;
-                    publication.Contact.TeamName = updatedContact.TeamName;
-                    publication.Contact.TeamEmail = updatedContact.TeamEmail;
-                    await context.SaveChangesAsync();
-
-                    // Clear cache because Contact is in Content.Services.ViewModels.PublicationViewModel
-                    await publicationCacheService.UpdatePublication(publication.Slug);
-
-                    return mapper.Map<ContactViewModel>(publication.Contact);
-                });
-        }
-
-        public async Task<Either<ActionResult, PaginatedListViewModel<ReleaseVersionSummaryViewModel>>>
-            ListLatestReleaseVersionsPaginated(
-                Guid publicationId,
-                int page = 1,
-                int pageSize = 5,
-                bool? live = null,
-                bool includePermissions = false)
-        {
-            return await ListLatestReleaseVersions(publicationId, live, includePermissions)
-                .OnSuccess(
-                    releases =>
-                        // This is not ideal - we should paginate results in the database, however,
-                        // this is not possible as we need to iterate over all releases to get the
-                        // latest/active versions of releases. Ideally, we should be able to
-                        // pagination entirely in the database, but this requires re-modelling of releases.
-                        // TODO: EES-3663 Use database pagination when ReleaseVersions are introduced
-                        PaginatedListViewModel<ReleaseVersionSummaryViewModel>.Paginate(releases, page, pageSize)
-                );
-        }
-
-        public async Task<Either<ActionResult, List<ReleaseVersionSummaryViewModel>>> ListLatestReleaseVersions(
+    public async Task<Either<ActionResult, PaginatedListViewModel<ReleaseVersionSummaryViewModel>>>
+        ListLatestReleaseVersionsPaginated(
             Guid publicationId,
+            int page = 1,
+            int pageSize = 5,
             bool? live = null,
             bool includePermissions = false)
-        {
-            return await persistenceHelper
-                .CheckEntityExists<Publication>(publicationId)
-                .OnSuccess(userService.CheckCanViewPublication)
-                .OnSuccess(async () =>
-                {
-                    // Note the 'live' filter is applied after the latest release versions are retrieved.
-                    // A published release with a current draft version is deliberately not returned when 'live' is true.
-                    var releaseVersions = (await releaseVersionRepository.ListLatestReleaseVersions(publicationId))
-                        .Where(rv => live == null || rv.Live == live)
-                        .ToList();
+    {
+        return await ListLatestReleaseVersions(publicationId, live, includePermissions)
+            .OnSuccess(
+                releases =>
+                    // This is not ideal - we should paginate results in the database, however,
+                    // this is not possible as we need to iterate over all releases to get the
+                    // latest/active versions of releases. Ideally, we should be able to
+                    // pagination entirely in the database, but this requires re-modelling of releases.
+                    // TODO: EES-3663 Use database pagination when ReleaseVersions are introduced
+                    PaginatedListViewModel<ReleaseVersionSummaryViewModel>.Paginate(releases, page, pageSize)
+            );
+    }
 
-                    return await releaseVersions
-                        .ToAsyncEnumerable()
-                        .SelectAwait(async releaseVersion =>
-                        {
-                            await context.ReleaseVersions
-                                .Entry(releaseVersion)
-                                .Reference(rv => rv.Release)
-                                .LoadAsync();
+    public async Task<Either<ActionResult, List<ReleaseVersionSummaryViewModel>>> ListLatestReleaseVersions(
+        Guid publicationId,
+        bool? live = null,
+        bool includePermissions = false)
+    {
+        return await persistenceHelper
+            .CheckEntityExists<Publication>(publicationId)
+            .OnSuccess(userService.CheckCanViewPublication)
+            .OnSuccess(async () =>
+            {
+                // Note the 'live' filter is applied after the latest release versions are retrieved.
+                // A published release with a current draft version is deliberately not returned when 'live' is true.
+                var releaseVersions = (await releaseVersionRepository.ListLatestReleaseVersions(publicationId))
+                    .Where(rv => live == null || rv.Live == live)
+                    .ToList();
 
-                            return mapper.Map<ReleaseVersionSummaryViewModel>(releaseVersion) with
-                            {
-                                Permissions = includePermissions
-                                    ? await PermissionsUtils.GetReleasePermissions(userService, releaseVersion)
-                                    : null
-                            };
-                        })
-                        .ToListAsync();
-                });
-        }
-
-        public async Task<Either<ActionResult, List<ReleaseSeriesTableEntryViewModel>>> GetReleaseSeries(
-            Guid publicationId)
-        {
-            return await context.Publications
-                .FirstOrNotFoundAsync(p => p.Id == publicationId)
-                .OnSuccess(userService.CheckCanViewPublication)
-                .OnSuccess(async publication =>
-                {
-                    var result = new List<ReleaseSeriesTableEntryViewModel>();
-                    foreach (var seriesItem in publication.ReleaseSeries)
+                return await releaseVersions
+                    .ToAsyncEnumerable()
+                    .SelectAwait(async releaseVersion =>
                     {
-                        if (seriesItem.IsLegacyLink)
-                        {
-                            result.Add(new ReleaseSeriesTableEntryViewModel
-                            {
-                                Id = seriesItem.Id,
-                                Description = seriesItem.LegacyLinkDescription!,
-                                LegacyLinkUrl = seriesItem.LegacyLinkUrl,
-                            });
-                        }
-                        else
-                        {
-                            var release = await context.Releases
-                                .SingleAsync(r => r.Id == seriesItem.ReleaseId);
+                        await context.ReleaseVersions
+                            .Entry(releaseVersion)
+                            .Reference(rv => rv.Release)
+                            .LoadAsync();
 
-                            var latestPublishedReleaseVersion = await context.ReleaseVersions
-                                .LatestReleaseVersion(releaseId: seriesItem.ReleaseId!.Value, publishedOnly: true)
-                                .SingleOrDefaultAsync();
+                        return mapper.Map<ReleaseVersionSummaryViewModel>(releaseVersion) with
+                        {
+                            Permissions = includePermissions
+                                ? await PermissionsUtils.GetReleasePermissions(userService, releaseVersion)
+                                : null
+                        };
+                    })
+                    .ToListAsync();
+            });
+    }
 
-                            result.Add(new ReleaseSeriesTableEntryViewModel
-                            {
-                                Id = seriesItem.Id,
-                                ReleaseId = release.Id,
-                                Description = release.Title,
-                                ReleaseSlug = release.Slug,
-                                IsLatest = publication.LatestPublishedReleaseVersionId != null &&
-                                           latestPublishedReleaseVersion?.Id == publication.LatestPublishedReleaseVersionId,
-                                IsPublished = latestPublishedReleaseVersion != null
-                            });
-                        }
+    public async Task<Either<ActionResult, List<ReleaseSeriesTableEntryViewModel>>> GetReleaseSeries(
+        Guid publicationId)
+    {
+        return await context.Publications
+            .FirstOrNotFoundAsync(p => p.Id == publicationId)
+            .OnSuccess(userService.CheckCanViewPublication)
+            .OnSuccess(async publication =>
+            {
+                var result = new List<ReleaseSeriesTableEntryViewModel>();
+                foreach (var seriesItem in publication.ReleaseSeries)
+                {
+                    if (seriesItem.IsLegacyLink)
+                    {
+                        result.Add(new ReleaseSeriesTableEntryViewModel
+                        {
+                            Id = seriesItem.Id,
+                            Description = seriesItem.LegacyLinkDescription!,
+                            LegacyLinkUrl = seriesItem.LegacyLinkUrl,
+                        });
+                    }
+                    else
+                    {
+                        var release = await context.Releases
+                            .SingleAsync(r => r.Id == seriesItem.ReleaseId);
+
+                        var latestPublishedReleaseVersion = await context.ReleaseVersions
+                            .LatestReleaseVersion(releaseId: seriesItem.ReleaseId!.Value, publishedOnly: true)
+                            .SingleOrDefaultAsync();
+
+                        result.Add(new ReleaseSeriesTableEntryViewModel
+                        {
+                            Id = seriesItem.Id,
+                            ReleaseId = release.Id,
+                            Description = release.Title,
+                            ReleaseSlug = release.Slug,
+                            IsLatest = publication.LatestPublishedReleaseVersionId != null &&
+                                       latestPublishedReleaseVersion?.Id == publication.LatestPublishedReleaseVersionId,
+                            IsPublished = latestPublishedReleaseVersion != null
+                        });
+                    }
+                }
+
+                return result;
+            });
+    }
+
+    public async Task<Either<ActionResult, List<ReleaseSeriesTableEntryViewModel>>> AddReleaseSeriesLegacyLink(
+        Guid publicationId,
+        ReleaseSeriesLegacyLinkAddRequest newLegacyLink)
+    {
+        return await context.Publications
+            .FirstOrNotFoundAsync(p => p.Id == publicationId)
+            .OnSuccess(userService.CheckCanManageReleaseSeries)
+            .OnSuccess(async publication =>
+            {
+                publication.ReleaseSeries.Add(new ReleaseSeriesItem
+                {
+                    Id = Guid.NewGuid(),
+                    LegacyLinkDescription = newLegacyLink.Description,
+                    LegacyLinkUrl = newLegacyLink.Url,
+                });
+
+                context.Publications.Update(publication);
+                await context.SaveChangesAsync();
+
+                await publicationCacheService.UpdatePublication(publication.Slug);
+
+                return await GetReleaseSeries(publication.Id);
+            });
+    }
+
+    public async Task<Either<ActionResult, List<ReleaseSeriesTableEntryViewModel>>> UpdateReleaseSeries(
+        Guid publicationId,
+        List<ReleaseSeriesItemUpdateRequest> updatedReleaseSeriesItems)
+    {
+        return await context.Publications
+            .FirstOrNotFoundAsync(p => p.Id == publicationId)
+            .OnSuccess(userService.CheckCanManageReleaseSeries)
+            .OnSuccess(async publication =>
+            {
+                // Check new series items details are correct
+                foreach (var seriesItem in updatedReleaseSeriesItems)
+                {
+                    if (seriesItem.ReleaseId != null && (
+                            seriesItem.LegacyLinkDescription != null || seriesItem.LegacyLinkUrl != null))
+                    {
+                        throw new ArgumentException("LegacyLink details shouldn't be set if ReleaseId is set.");
                     }
 
-                    return result;
-                });
-        }
+                    if (seriesItem.ReleaseId == null && (
+                            seriesItem.LegacyLinkDescription == null || seriesItem.LegacyLinkUrl == null))
+                    {
+                        throw new ArgumentException("LegacyLink details should be set if ReleaseId is null.");
+                    }
+                }
 
-        public async Task<Either<ActionResult, List<ReleaseSeriesTableEntryViewModel>>> AddReleaseSeriesLegacyLink(
-            Guid publicationId,
-            ReleaseSeriesLegacyLinkAddRequest newLegacyLink)
-        {
-            return await context.Publications
-                .FirstOrNotFoundAsync(p => p.Id == publicationId)
-                .OnSuccess(userService.CheckCanManageReleaseSeries)
-                .OnSuccess(async publication =>
+                // Check all publication releases are included in updatedReleaseSeriesItems
+                var publicationReleaseIds = await context.Releases
+                    .Where(r => r.PublicationId == publicationId)
+                    .Select(r => r.Id)
+                    .ToListAsync();
+
+                var updatedSeriesReleaseIds = updatedReleaseSeriesItems
+                    .Where(rsi => rsi.ReleaseId.HasValue)
+                    .Select(rsi => rsi.ReleaseId!.Value)
+                    .ToList();
+
+                if (!ComparerUtils.SequencesAreEqualIgnoringOrder(publicationReleaseIds, updatedSeriesReleaseIds))
                 {
-                    publication.ReleaseSeries.Add(new ReleaseSeriesItem
+                    throw new ArgumentException(
+                        "Missing or duplicate release in new release series. Expected ReleaseIds: " +
+                        publicationReleaseIds.JoinToString(","));
+                }
+
+                // Work out the publication's new latest published release version (if any).
+                // This is the latest published version of the first release which has a published version 
+                Guid? latestPublishedReleaseVersionId = null;
+                foreach (var releaseId in updatedSeriesReleaseIds)
+                {
+                    latestPublishedReleaseVersionId = (await context.ReleaseVersions
+                        .LatestReleaseVersion(releaseId: releaseId, publishedOnly: true)
+                        .SingleOrDefaultAsync())?.Id;
+
+                    if (latestPublishedReleaseVersionId != null)
+                    {
+                        break;
+                    }
+                }
+
+                var oldLatestPublishedReleaseVersionId = publication.LatestPublishedReleaseVersionId;
+                publication.LatestPublishedReleaseVersionId = latestPublishedReleaseVersionId;
+
+                publication.ReleaseSeries = updatedReleaseSeriesItems
+                    .Select(request => new ReleaseSeriesItem
                     {
                         Id = Guid.NewGuid(),
-                        LegacyLinkDescription = newLegacyLink.Description,
-                        LegacyLinkUrl = newLegacyLink.Url,
-                    });
+                        ReleaseId = request.ReleaseId,
+                        LegacyLinkDescription = request.LegacyLinkDescription,
+                        LegacyLinkUrl = request.LegacyLinkUrl,
+                    }).ToList();
 
-                    context.Publications.Update(publication);
-                    await context.SaveChangesAsync();
+                await context.SaveChangesAsync();
 
-                    await publicationCacheService.UpdatePublication(publication.Slug);
+                // Update the cached publication
+                await publicationCacheService.UpdatePublication(publication.Slug);
 
-                    return await GetReleaseSeries(publication.Id);
-                });
-        }
-
-        public async Task<Either<ActionResult, List<ReleaseSeriesTableEntryViewModel>>> UpdateReleaseSeries(
-            Guid publicationId,
-            List<ReleaseSeriesItemUpdateRequest> updatedReleaseSeriesItems)
-        {
-            return await context.Publications
-                .FirstOrNotFoundAsync(p => p.Id == publicationId)
-                .OnSuccess(userService.CheckCanManageReleaseSeries)
-                .OnSuccess(async publication =>
+                // If the publication's latest published release version has changed,
+                // update the publication's cached latest release version
+                if (oldLatestPublishedReleaseVersionId != latestPublishedReleaseVersionId &&
+                    latestPublishedReleaseVersionId.HasValue)
                 {
-                    // Check new series items details are correct
-                    foreach (var seriesItem in updatedReleaseSeriesItems)
-                    {
-                        if (seriesItem.ReleaseId != null && (
-                                seriesItem.LegacyLinkDescription != null || seriesItem.LegacyLinkUrl != null))
-                        {
-                            throw new ArgumentException("LegacyLink details shouldn't be set if ReleaseId is set.");
-                        }
-
-                        if (seriesItem.ReleaseId == null && (
-                                seriesItem.LegacyLinkDescription == null || seriesItem.LegacyLinkUrl == null))
-                        {
-                            throw new ArgumentException("LegacyLink details should be set if ReleaseId is null.");
-                        }
-                    }
-
-                    // Check all publication releases are included in updatedReleaseSeriesItems
-                    var publicationReleaseIds = await context.Releases
-                        .Where(r => r.PublicationId == publicationId)
-                        .Select(r => r.Id)
-                        .ToListAsync();
-
-                    var updatedSeriesReleaseIds = updatedReleaseSeriesItems
-                        .Where(rsi => rsi.ReleaseId.HasValue)
-                        .Select(rsi => rsi.ReleaseId!.Value)
-                        .ToList();
-
-                    if (!ComparerUtils.SequencesAreEqualIgnoringOrder(publicationReleaseIds, updatedSeriesReleaseIds))
-                    {
-                        throw new ArgumentException(
-                            "Missing or duplicate release in new release series. Expected ReleaseIds: " +
-                            publicationReleaseIds.JoinToString(","));
-                    }
-
-                    // Work out the publication's new latest published release version (if any).
-                    // This is the latest published version of the first release which has a published version 
-                    Guid? latestPublishedReleaseVersionId = null;
-                    foreach (var releaseId in updatedSeriesReleaseIds)
-                    {
-                        latestPublishedReleaseVersionId = (await context.ReleaseVersions
-                            .LatestReleaseVersion(releaseId: releaseId, publishedOnly: true)
-                            .SingleOrDefaultAsync())?.Id;
-
-                        if (latestPublishedReleaseVersionId != null)
-                        {
-                            break;
-                        }
-                    }
-
-                    var oldLatestPublishedReleaseVersionId = publication.LatestPublishedReleaseVersionId;
-                    publication.LatestPublishedReleaseVersionId = latestPublishedReleaseVersionId;
-
-                    publication.ReleaseSeries = updatedReleaseSeriesItems
-                        .Select(request => new ReleaseSeriesItem
-                        {
-                            Id = Guid.NewGuid(),
-                            ReleaseId = request.ReleaseId,
-                            LegacyLinkDescription = request.LegacyLinkDescription,
-                            LegacyLinkUrl = request.LegacyLinkUrl,
-                        }).ToList();
-
-                    await context.SaveChangesAsync();
-
-                    // Update the cached publication
-                    await publicationCacheService.UpdatePublication(publication.Slug);
-
-                    // If the publication's latest published release version has changed,
-                    // update the publication's cached latest release version
-                    if (oldLatestPublishedReleaseVersionId != latestPublishedReleaseVersionId &&
-                        latestPublishedReleaseVersionId.HasValue)
-                    {
-                        await releaseCacheService.UpdateRelease(releaseVersionId: latestPublishedReleaseVersionId.Value,
-                            publicationSlug: publication.Slug);
-                    }
-
-                    return await GetReleaseSeries(publication.Id);
-                });
-        }
-
-        private async Task<Either<ActionResult, Unit>> ValidatePublicationSlug(
-            string newSlug, Guid? publicationId = null)
-        {
-            if (await context.Publications
-                    .AnyAsync(publication =>
-                        publication.Id != publicationId
-                        && publication.Slug == newSlug))
-            {
-                return ValidationActionResult(PublicationSlugNotUnique);
-            }
-
-            var hasRedirect = await context.PublicationRedirects
-                .AnyAsync(pr =>
-                    pr.PublicationId != publicationId // If publication previously used this slug, can change it back
-                    && pr.Slug == newSlug);
-
-            if (hasRedirect)
-            {
-                return ValidationActionResult(PublicationSlugUsedByRedirect);
-            }
-
-            if (publicationId.HasValue &&
-                context.PublicationMethodologies.Any(pm =>
-                    pm.Publication.Id == publicationId
-                    && pm.Owner)
-                // Strictly, we should also check whether the owned methodology inherits the publication slug - we don't
-                // need to validate the new slug against methodologies if it isn't changing the methodology slug - but
-                // this check is expensive and an unlikely edge case, so doesn't seem worth it.
-                )
-            {
-                var methodologySlugValidation = await methodologyService
-                    .ValidateMethodologySlug(newSlug);
-                if (methodologySlugValidation.IsLeft)
-                {
-                    return methodologySlugValidation.Left;
+                    await releaseCacheService.UpdateRelease(releaseVersionId: latestPublishedReleaseVersionId.Value,
+                        publicationSlug: publication.Slug);
                 }
-            }
 
-            return Unit.Instance;
+                return await GetReleaseSeries(publication.Id);
+            });
+    }
+
+    private async Task<Either<ActionResult, Unit>> ValidatePublicationSlug(
+        string newSlug, Guid? publicationId = null)
+    {
+        if (await context.Publications
+                .AnyAsync(publication =>
+                    publication.Id != publicationId
+                    && publication.Slug == newSlug))
+        {
+            return ValidationActionResult(PublicationSlugNotUnique);
         }
 
-        public static IQueryable<Publication> HydratePublication(IQueryable<Publication> values)
+        var hasRedirect = await context.PublicationRedirects
+            .AnyAsync(pr =>
+                pr.PublicationId != publicationId // If publication previously used this slug, can change it back
+                && pr.Slug == newSlug);
+
+        if (hasRedirect)
         {
-            return values
-                .Include(p => p.Theme);
+            return ValidationActionResult(PublicationSlugUsedByRedirect);
         }
 
-        private async Task<PublicationViewModel> GeneratePublicationViewModel(Publication publication,
-            bool includePermissions = false)
+        if (publicationId.HasValue &&
+            context.PublicationMethodologies.Any(pm =>
+                pm.Publication.Id == publicationId
+                && pm.Owner)
+            // Strictly, we should also check whether the owned methodology inherits the publication slug - we don't
+            // need to validate the new slug against methodologies if it isn't changing the methodology slug - but
+            // this check is expensive and an unlikely edge case, so doesn't seem worth it.
+            )
         {
-            var publicationViewModel = mapper.Map<PublicationViewModel>(publication);
-
-            publicationViewModel.IsSuperseded = await publicationRepository.IsSuperseded(publication.Id);
-
-            if (includePermissions)
+            var methodologySlugValidation = await methodologyService
+                .ValidateMethodologySlug(newSlug);
+            if (methodologySlugValidation.IsLeft)
             {
-                publicationViewModel.Permissions =
-                    await PermissionsUtils.GetPublicationPermissions(userService, publication);
+                return methodologySlugValidation.Left;
             }
-
-            return publicationViewModel;
         }
 
-        private async Task<PublicationCreateViewModel> GeneratePublicationCreateViewModel(Publication publication)
+        return Unit.Instance;
+    }
+
+    public static IQueryable<Publication> HydratePublication(IQueryable<Publication> values)
+    {
+        return values
+            .Include(p => p.Theme);
+    }
+
+    private async Task<PublicationViewModel> GeneratePublicationViewModel(Publication publication,
+        bool includePermissions = false)
+    {
+        var publicationViewModel = mapper.Map<PublicationViewModel>(publication);
+
+        publicationViewModel.IsSuperseded = await publicationRepository.IsSuperseded(publication.Id);
+
+        if (includePermissions)
         {
-            var publicationCreateViewModel = mapper.Map<PublicationCreateViewModel>(publication);
-
-            publicationCreateViewModel.IsSuperseded = await publicationRepository.IsSuperseded(publication.Id);
-
-            return publicationCreateViewModel;
+            publicationViewModel.Permissions =
+                await PermissionsUtils.GetPublicationPermissions(userService, publication);
         }
+
+        return publicationViewModel;
+    }
+
+    private async Task<PublicationCreateViewModel> GeneratePublicationCreateViewModel(Publication publication)
+    {
+        var publicationCreateViewModel = mapper.Map<PublicationCreateViewModel>(publication);
+
+        publicationCreateViewModel.IsSuperseded = await publicationRepository.IsSuperseded(publication.Id);
+
+        return publicationCreateViewModel;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -59,7 +59,7 @@
     "EventTopics":
     [
       {
-        "Key":"ThemeChangesEvent",
+        "Key":"ThemeChangedEvent",
         "TopicEndpoint":"",
         "TopicAccessKey":""
       }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Events/ReleaseVersionPublishedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Events/ReleaseVersionPublishedEventDto.cs
@@ -10,7 +10,7 @@ public record ReleaseVersionPublishedEventDto(Guid ReleaseVersionId, ReleaseVers
     public const string EventType = "release-version-published";
     
     // Which Topic endpoint to use from the appsettings
-    public const string EventTopicOptionsKey = "ReleaseVersionChangesEvent";
+    public const string EventTopicOptionsKey = "ReleaseVersionChangedEvent";
     
     /// <summary>
     /// The ReleaseVersionId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/appsettings.example.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/appsettings.example.json
@@ -4,7 +4,7 @@
     "EventTopics":
     [
       {
-        "Key":"ReleaseVersionChangesEvent",
+        "Key":"ReleaseVersionChangedEvent",
         "TopicEndpoint":"https://release-version-changes-topic.uksouth-1.eventgrid.azure.net/api/events",
         "TopicAccessKey":""
       }


### PR DESCRIPTION
Note: There are 4 steps to this PR which I have left as easy to understand separate commits

1. Renamed Mock Builder asserts from xxCalled to xxRaised to refer to the events instead of the methods

2. Very subtle change: I had originally named the Topics xxxChanges to signify that it was a stream of changes. But it's too easy to transpose xxxChanged which is the name of the events and event handler etc

3. Add new Event Raiser function - to raise a Publication Changed event

4. Utilise the new event in Publication Service. Update some tests to also check for the events (or lack of them where appropriate).
