### PR TITLE
EES-5988 ckeditor insert modals focus on close

### DIFF
--- a/src/explore-education-statistics-admin/src/components/form/FormEditor.tsx
+++ b/src/explore-education-statistics-admin/src/components/form/FormEditor.tsx
@@ -156,6 +156,12 @@ const FormEditor = ({
     };
   }, [id]);
 
+  useEffect(() => {
+    if (!showFeaturedTablesModal && !showGlossaryModal) {
+      editorRef.current?.focus();
+    }
+  }, [showFeaturedTablesModal, showGlossaryModal]);
+
   const handleLabelClick = useCallback(() => {
     if (!editorRef.current) {
       return;

--- a/src/explore-education-statistics-admin/src/components/form/FormEditor.tsx
+++ b/src/explore-education-statistics-admin/src/components/form/FormEditor.tsx
@@ -158,7 +158,9 @@ const FormEditor = ({
 
   useEffect(() => {
     if (!showFeaturedTablesModal && !showGlossaryModal) {
-      editorRef.current?.focus();
+      // setTimeout seems to be necessary otherwise it doesn't focus when
+      // successfully adding a link.
+      setTimeout(() => editorRef.current?.focus(), 0);
     }
   }, [showFeaturedTablesModal, showGlossaryModal]);
 
@@ -360,7 +362,6 @@ const FormEditor = ({
                   onSubmit={item => {
                     featuredTablesPlugin.current?.addFeaturedTableLink(item);
                     toggleFeaturedTablesModal.off();
-                    editorRef.current?.focus();
                   }}
                 />
               </Modal>
@@ -375,7 +376,6 @@ const FormEditor = ({
                   onSubmit={item => {
                     glossaryPlugin.current?.addGlossaryItem(item);
                     toggleGlossaryModal.off();
-                    editorRef.current?.focus();
                   }}
                 />
               </Modal>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
@@ -330,7 +330,13 @@ export default function ChartBuilder({
           <p>Are you sure you want to delete this chart?</p>
         </ModalConfirm>
       ),
-    [initialChart, isDeleting, handleChartDelete, toggleDeleteModal],
+    [
+      initialChart,
+      isDeleting,
+      handleChartDelete,
+      toggleDeleteModal,
+      showDeleteModal,
+    ],
   );
 
   return (

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapGeoJSON.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapGeoJSON.tsx
@@ -11,7 +11,7 @@ import { Dictionary } from '@common/types';
 import formatPretty from '@common/utils/number/formatPretty';
 import { FeatureCollection } from 'geojson';
 import Leaflet, { Layer, PathOptions } from 'leaflet';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { GeoJSON, useMap } from 'react-leaflet';
 
 interface Props {
@@ -86,6 +86,8 @@ export default function MapGeoJSON({
     }
   }, [features]);
 
+  const resetZoom = useCallback(() => map.setZoom(5), [map]);
+
   useEffect(() => {
     if (!selectedFeature) {
       resetZoom();
@@ -104,9 +106,7 @@ export default function MapGeoJSON({
       // Centers the feature on the map
       map.fitBounds(layer.getBounds());
     }
-  }, [map, selectedFeature]);
-
-  const resetZoom = () => map.setZoom(5);
+  }, [map, selectedFeature, resetZoom]);
 
   // We have to assign our `onEachFeature` callback to a ref
   // as `onEachFeature` forms an internal closure which

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.tsx
@@ -1,5 +1,4 @@
 import styles from '@common/modules/find-statistics/components/KeyStatTile.module.scss';
-import formatPretty from '@common/utils/number/formatPretty';
 import React, { ReactNode } from 'react';
 
 interface Props {

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -28,7 +28,7 @@ import PublicationReleaseHeadlinesSection from '@frontend/modules/find-statistic
 import styles from '@frontend/modules/find-statistics/PublicationReleasePage.module.scss';
 import classNames from 'classnames';
 import orderBy from 'lodash/orderBy';
-import { GetServerSideProps, NextPage, Redirect } from 'next';
+import { GetServerSideProps, NextPage } from 'next';
 import React from 'react';
 
 interface Props {


### PR DESCRIPTION
This PR returns focus back to the editor when an 'add glossary link' or 'add featured table' modal is closed.

It also fixes various misc lint warnings.