### PR TITLE
Ees 5954 On Publication Changed - Azure Function

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationChanged/OnReleaseSlugChangedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationChanged/OnReleaseSlugChangedFunctionTests.cs
@@ -1,0 +1,63 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationChanged;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationChanged.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.OnPublicationChanged;
+
+public class OnPublicationChangedFunctionTests
+{
+    private OnPublicationChangedFunction GetSut() => new(new EventGridEventHandler(new NullLogger<EventGridEventHandler>()));
+
+    [Fact]
+    public void Can_instantiate_Sut() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task GivenEvent_WhenPayloadContainsSlug_ThenRefreshSearchableDocumentMessageDtoReturned()
+    {
+        // ARRANGE
+        var payload = new PublicationChangedEventDto
+        {
+            Slug = "this-is-a-publication-slug",
+        };
+
+        var eventGridEvent = new EventGridEventBuilder()
+            .WithPayload(payload)
+            .Build();
+
+        var sut = GetSut();
+        
+        // ACT
+        var response = await sut.OnPublicationChanged(eventGridEvent, new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        var actual = Assert.Single(response);
+        Assert.NotNull(actual);
+        Assert.Equal(payload.Slug, actual.PublicationSlug);
+    }
+    
+    [Theory]
+    [InlineData((string?)null)]
+    [InlineData("")]
+    public async Task GivenEvent_WhenPayloadDoesNotContainSlug_ThenNothingIsReturned(string? blankSlug)
+    {
+        // ARRANGE
+        var payload = new PublicationChangedEventDto
+        {
+            Slug = blankSlug,
+        };
+
+        var eventGridEvent = new EventGridEventBuilder()
+            .WithPayload(payload)
+            .Build();
+
+        var sut = GetSut();
+        
+        // ACT
+        var response = await sut.OnPublicationChanged(eventGridEvent, new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        Assert.Empty(response);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
@@ -248,66 +248,26 @@ public class ProgramTests
         
         public class ResolveFunctionTests : ProgramTests
         {
-            [Fact]
-            public void Can_resolve_OnReleaseSlugChangedFunction()
+            public static TheoryData<Type> GetAzureFunctionTypes()
             {
-                // ARRANGE
-                var sut = GetSut();
-            
-                // ACT
-                var actual = ActivatorUtilities.CreateInstance<OnReleaseSlugChangedFunction>(sut.Services);
-            
-                // ASSERT
-                Assert.NotNull(actual);
-            }
-            
-            [Fact]
-            public void Can_resolve_OnReleaseVersionPublishedFunction()
-            {
-                // ARRANGE
-                var sut = GetSut();
-            
-                // ACT
-                var actual = ActivatorUtilities.CreateInstance<OnReleaseVersionPublishedFunction>(sut.Services);
-            
-                // ASSERT
-                Assert.NotNull(actual);
-            }
-            
-            [Fact]
-            public void Can_resolve_OnThemeUpdatedFunction()
-            {
-                // ARRANGE
-                var sut = GetSut();
-            
-                // ACT
-                var actual = ActivatorUtilities.CreateInstance<OnThemeUpdatedFunction>(sut.Services);
-            
-                // ASSERT
-                Assert.NotNull(actual);
+                var types = typeof(Program)
+                    .Assembly
+                    .GetTypes()
+                    .Where(type => type.Namespace?.StartsWith("GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.") == true)
+                    .Where(type => type.Name.EndsWith("Function"));
+                
+                return new TheoryData<Type>(types);
             }
 
-            [Fact]
-            public void Can_resolve_RefreshSearchableDocumentFunction()
+            [Theory]
+            [MemberData(nameof(GetAzureFunctionTypes))]
+            public void Can_resolve_AzureFunction(Type functionType)
             {
                 // ARRANGE
                 var sut = GetSut();
             
                 // ACT
-                var actual = ActivatorUtilities.CreateInstance<RefreshSearchableDocumentFunction>(sut.Services);
-            
-                // ASSERT
-                Assert.NotNull(actual);
-            }
-
-            [Fact]
-            public void Can_resolve_ReindexSearchableDocumentFunction()
-            {
-                // ARRANGE
-                var sut = GetSut();
-            
-                // ACT
-                var actual = ActivatorUtilities.CreateInstance<ReindexSearchableDocumentsFunction>(sut.Services);
+                var actual = ActivatorUtilities.CreateInstance(sut.Services, functionType);
             
                 // ASSERT
                 Assert.NotNull(actual);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
@@ -72,7 +72,6 @@ public static class HostBuilderExtension
                                 });
                             clientBuilder.UseCredential(new DefaultAzureCredential());
                         })
-                    .AddTransient<IContentApiClient, ContentApiClient>()
                     .AddHttpClient<IContentApiClient, ContentApiClient>(
                         (provider, httpClient) =>
                         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationChanged/Dtos/PublicationChangedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationChanged/Dtos/PublicationChangedEventDto.cs
@@ -1,0 +1,8 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationChanged.Dtos;
+
+public class PublicationChangedEventDto
+{
+    public string? Title { get; init; }
+    public string? Summary { get; init; }
+    public string? Slug { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationChanged/OnPublicationChangedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationChanged/OnPublicationChangedFunction.cs
@@ -1,0 +1,25 @@
+﻿using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationChanged.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RefreshSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationChanged;
+
+public class OnPublicationChangedFunction(IEventGridEventHandler eventGridEventHandler)
+{
+    [Function(nameof(OnPublicationChanged))]
+    [QueueOutput("%RefreshSearchableDocumentQueueName%")]
+    public async Task<RefreshSearchableDocumentMessageDto[]> OnPublicationChanged(
+        [QueueTrigger("%PublicationChangedQueueName%")]
+        EventGridEvent eventDto,
+        FunctionContext context) =>
+        await eventGridEventHandler.Handle<PublicationChangedEventDto, RefreshSearchableDocumentMessageDto[]>(
+            context, 
+            eventDto,
+            (payload, ct) => 
+                Task.FromResult<RefreshSearchableDocumentMessageDto[]>(
+                    string.IsNullOrEmpty(payload.Slug)
+                    ? []
+                    : [ new RefreshSearchableDocumentMessageDto { PublicationSlug = payload.Slug } ]));
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/local.settings.json
@@ -3,10 +3,11 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://data-storage",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "ReleaseVersionPublishedQueueName": "release-version-published-queue",
-    "ReleaseSlugChangedQueueName": "release-slug-changed-queue",
-    "SearchableDocumentCreatedQueueName": "search-document-created-queue",
+    "PublicationChangedQueueName": "publication-changed-queue",
     "RefreshSearchableDocumentQueueName": "refresh-searchable-document-queue",
+    "ReleaseSlugChangedQueueName": "release-slug-changed-queue",
+    "ReleaseVersionPublishedQueueName": "release-version-published-queue",
+    "SearchableDocumentCreatedQueueName": "search-document-created-queue",
     "ThemeUpdatedQueueName": "theme-updated-queue"
   },
   "Host": {


### PR DESCRIPTION
Added the event handler azure function to consume the PublicationChanged event and output a refresh searchable document command.
Also, refactored the unit test that ensures the functions can be resolved to automagically discover the functions from the assembly. This saves the developer from having to remember to manually add a corresponding test for any new functions.