### PR TITLE
EES-5949 Fix fieldset id to match error target id

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -168,7 +168,7 @@ const LocationFiltersForm = ({
             onSubmit={handleSubmit}
           >
             <FormFieldset
-              id="levels"
+              id="locations"
               legend={stepHeading}
               hint="Select at least one"
               error={


### PR DESCRIPTION
This PR fixes the id of the 'locations' fieldset, so that the related error message links to the correct fieldset.