### PR TITLE
Initial changes to support patch dataset creation (WIP)

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Public.Data/DataSetVersionsController.cs
@@ -10,6 +10,8 @@ using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
+using NextDataSetVersionCompleteImportRequest = GovUk.Education.ExploreEducationStatistics.Admin.Requests.Public.Data.NextDataSetVersionCompleteImportRequest;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Public.Data;
 
@@ -56,6 +58,9 @@ public class DataSetVersionsController(IDataSetVersionService dataSetVersionServ
             .CreateNextVersion(
                 releaseFileId: nextDataSetVersionCreateRequest.ReleaseFileId,
                 dataSetId: nextDataSetVersionCreateRequest.DataSetId,
+                patchVersionConfigs: nextDataSetVersionCreateRequest.SourceReleaseFileId == null ? 
+                    null : 
+                    new PatchVersionConfigs(true, nextDataSetVersionCreateRequest.SourceReleaseFileId),
                 cancellationToken: cancellationToken)
             .HandleFailuresOrOk();
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/NextDataSetVersionCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/NextDataSetVersionCreateRequest.cs
@@ -9,6 +9,8 @@ public record NextDataSetVersionCreateRequest
     public required Guid DataSetId { get; init; }
 
     public required Guid ReleaseFileId { get; init; }
+    
+    public Guid? SourceReleaseFileId { get; init; }
 
     public class Validator : AbstractValidator<NextDataSetVersionCreateRequest>
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
@@ -75,19 +75,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 metaFileName,
                 metaFileStream));
 
-            if (isReplacement)
-            {
-                var releaseFileWithApiDataSet = _context.ReleaseFiles
-                    .SingleOrDefault(rf =>
-                        rf.ReleaseVersionId == releaseVersionId
-                        && rf.Name == dataSetTitle
-                        && rf.PublicApiDataSetId != null);
-                if (releaseFileWithApiDataSet != null)
-                {
-                    errors.Add(ValidationMessages.GenerateErrorCannotReplaceDataSetWithApiDataSet(dataSetTitle));
-                }
-            }
-
             return errors;
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionMappingService.cs
@@ -28,4 +28,7 @@ public interface IDataSetVersionMappingService
         Guid nextDataSetVersionId,
         BatchFilterOptionMappingUpdatesRequest request,
         CancellationToken cancellationToken = default);
+
+     Task<MappingStatusViewModel?> GetMappingCompletionStatus(Guid targetDataSetVersionId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetVersionService.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
 using Microsoft.AspNetCore.Mvc;
 using Semver;
 
@@ -43,6 +44,7 @@ public interface IDataSetVersionService
     Task<Either<ActionResult, DataSetVersionSummaryViewModel>> CreateNextVersion(
         Guid releaseFileId,
         Guid dataSetId,
+        PatchVersionConfigs? patchVersionConfigs,
         CancellationToken cancellationToken = default);
 
     Task<Either<ActionResult, DataSetVersionSummaryViewModel>> CompleteNextVersionImport(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IProcessorClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IProcessorClient.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 
@@ -17,6 +18,7 @@ public interface IProcessorClient
     Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateNextDataSetVersionMappings(
         Guid dataSetId,
         Guid releaseFileId,
+        PatchVersionConfigs? patchVersionConfigs,
         CancellationToken cancellationToken = default);
 
     Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CompleteNextDataSetVersionImport(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
@@ -43,12 +43,14 @@ internal class ProcessorClient(
     public async Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateNextDataSetVersionMappings(
         Guid dataSetId,
         Guid releaseFileId,
+        PatchVersionConfigs? patchVersionConfigs,
         CancellationToken cancellationToken = default)
     {
         var request = new NextDataSetVersionMappingsCreateRequest
         {
             ReleaseFileId = releaseFileId,
-            DataSetId = dataSetId
+            DataSetId = dataSetId,
+            PatchVersionConfig = patchVersionConfigs
         };
 
         return await SendPost<NextDataSetVersionMappingsCreateRequest, ProcessDataSetVersionResponseViewModel>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
@@ -631,14 +631,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     var linkedApiDataSetVersionDeletionPlan = tuple.apiDataSetVersion is null
                         ? null
-                        : new DeleteApiDataSetVersionPlanViewModel
+                        : new ApiDataSetVersionPlanViewModel
                         {
                             DataSetId = tuple.apiDataSetVersion.DataSetId,
                             DataSetTitle = tuple.apiDataSetVersion.DataSet.Title,
                             Id = tuple.apiDataSetVersion.Id,
                             Version = tuple.apiDataSetVersion.PublicVersion,
                             Status = tuple.apiDataSetVersion.Status,
-                            Valid = false
+                            //Valid = false TODO: test whatever uses this...
                         };
 
                     return new DeleteDataFilePlanViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -84,6 +84,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
 using Thinktecture;
 using static GovUk.Education.ExploreEducationStatistics.Common.Utils.StartupUtils;
 using ContentGlossaryService = GovUk.Education.ExploreEducationStatistics.Content.Services.GlossaryService;
@@ -842,6 +843,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
         public Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateNextDataSetVersionMappings(
             Guid dataSetId,
             Guid releaseFileId,
+            PatchVersionConfigs? patchVersionConfigs,
             CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CompleteNextDataSetVersionImport(
@@ -897,9 +899,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             return Task.FromResult(new List<DataSetVersionStatusSummary>());
         }
 
-        public Task<Either<ActionResult, DataSetVersionSummaryViewModel>> CreateNextVersion(
-            Guid releaseFileId,
+        public Task<Either<ActionResult, DataSetVersionSummaryViewModel>> CreateNextVersion(Guid releaseFileId,
             Guid dataSetId,
+            PatchVersionConfigs? patchVersionConfigs,
             CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public Task<Either<ActionResult, DataSetVersionSummaryViewModel>> CompleteNextVersionImport(
@@ -960,6 +962,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                 BatchFilterOptionMappingUpdatesRequest request,
                 CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
+
+        public Task<MappingStatusViewModel?> GetMappingCompletionStatus(Guid targetDataSetVersionId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
     internal class NoOpPreviewTokenService : IPreviewTokenService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ApiDataSetVersionPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ApiDataSetVersionPlanViewModel.cs
@@ -1,10 +1,11 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using System;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
-public record DeleteApiDataSetVersionPlanViewModel
+public record ApiDataSetVersionPlanViewModel
 {
     public Guid DataSetId { get; init; }
 
@@ -16,5 +17,8 @@ public record DeleteApiDataSetVersionPlanViewModel
 
     public DataSetVersionStatus Status { get; init; }
 
-    public bool Valid { get; init; }
+    public MappingStatusViewModel? MappingStatus { get; init; }
+    
+    public bool Valid => MappingStatus == null 
+                         || (MappingStatus.FiltersComplete && MappingStatus.LocationsComplete);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -14,13 +14,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
     {
         public IEnumerable<DataBlockReplacementPlanViewModel> DataBlocks { get; init; } = [];
         public IEnumerable<FootnoteReplacementPlanViewModel> Footnotes { get; init; } = [];
-        public DeleteApiDataSetVersionPlanViewModel? DeleteApiDataSetVersionPlan { get; init; }
+        public ApiDataSetVersionPlanViewModel? ApiDataSetVersionPlan { get; init; }
         public Guid OriginalSubjectId { get; init; }
         public Guid ReplacementSubjectId { get; init; }
 
         public bool Valid => DataBlocks.All(info => info.Valid)
                              && Footnotes.All(info => info.Valid)
-                             && (DeleteApiDataSetVersionPlan?.Valid ?? true);
+                             && (ApiDataSetVersionPlan?.Valid ?? true);
 
         /**
          * Trimmed down version of the data replacement plan that
@@ -32,7 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
             {
                 DataBlocks = DataBlocks.Select(block => block.ToSummary()),
                 Footnotes = Footnotes.Select(footnote => footnote.ToSummary()),
-                DeleteApiDataSetVersionPlan = DeleteApiDataSetVersionPlan,
+                ApiDataSetVersionPlan = ApiDataSetVersionPlan,
                 OriginalSubjectId = OriginalSubjectId,
                 ReplacementSubjectId = ReplacementSubjectId
             };

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DeleteDataFilePlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DeleteDataFilePlanViewModel.cs
@@ -17,7 +17,7 @@ public record DeleteDataFilePlanViewModel
 
     public List<Guid> FootnoteIds { get; init; } = null!;
 
-    public DeleteApiDataSetVersionPlanViewModel? DeleteApiDataSetVersionPlan { get; init; }
+    public ApiDataSetVersionPlanViewModel? DeleteApiDataSetVersionPlan { get; init; }
 
     public bool Valid => DeleteApiDataSetVersionPlan?.Valid ?? true;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFile.cs
@@ -28,7 +28,7 @@ public class ReleaseFile
     public SemVersion? PublicApiDataSetVersion { get; set; }
 
     public string? PublicApiDataSetVersionString => PublicApiDataSetVersion is not null
-        ? $"{PublicApiDataSetVersion.Major}.{PublicApiDataSetVersion.Minor}"
+        ? $"{PublicApiDataSetVersion.Major}.{PublicApiDataSetVersion.Minor}.{PublicApiDataSetVersion.Patch}"
         : null;
 
     public List<FilterSequenceEntry>? FilterSequence { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IReleaseFileRepository.cs
@@ -44,4 +44,6 @@ public interface IReleaseFileRepository
         string? name = null,
         string? fileName = null,
         string? summary = null);
+
+    Task<ReleaseFile?> GetByIdOrDefaultAsync(Guid releaseFileId);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseFileRepository.cs
@@ -144,5 +144,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
 
             return releaseFile;
         }
+        public async Task<ReleaseFile?> GetByIdOrDefaultAsync(Guid releaseFileId)
+        {
+            return await _contentDbContext.ReleaseFiles
+            .SingleOrDefaultAsync(releaseFile => releaseFile.Id == releaseFileId);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersion.cs
@@ -80,6 +80,8 @@ public class DataSetVersion : ICreatedUpdatedTimestamps<DateTimeOffset, DateTime
     public SemVersion SemVersion() => new(major: VersionMajor, minor: VersionMinor, patch: VersionPatch);
 
     public SemVersion DefaultNextVersion() => SemVersion().WithMinor(VersionMinor + 1);
+    
+    public SemVersion NextPatchVersion() => SemVersion().WithPatch(VersionPatch + 1);
 
     public bool IsFirstVersion => VersionMajor == 1 && VersionMinor == 0 && VersionPatch == 0;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionImport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/DataSetVersionImport.cs
@@ -23,6 +23,8 @@ public class DataSetVersionImport : ICreatedUpdatedTimestamps<DateTimeOffset, Da
 
     public DateTimeOffset? Updated { get; set; }
 
+    public bool IncrementPatchNumber { get; set; } = false;
+    
     internal class Config : IEntityTypeConfiguration<DataSetVersionImport>
     {
         public void Configure(EntityTypeBuilder<DataSetVersionImport> builder)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20250320213622_EES5779_AddIncrementPatchNumberToDataSetVersionImport.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20250320213622_EES5779_AddIncrementPatchNumberToDataSetVersionImport.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
 {
     [DbContext(typeof(PublicDataDbContext))]
-    partial class PublicDataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250320213622_EES5779_AddIncrementPatchNumberToDataSetVersionImport")]
+    partial class EES5779_AddIncrementPatchNumberToDataSetVersionImport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20250320213622_EES5779_AddIncrementPatchNumberToDataSetVersionImport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Migrations/20250320213622_EES5779_AddIncrementPatchNumberToDataSetVersionImport.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class EES5779_AddIncrementPatchNumberToDataSetVersionImport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IncrementPatchNumber",
+                table: "DataSetVersionImports",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IncrementPatchNumber",
+                table: "DataSetVersionImports");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/NextDataSetVersionMappingsCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests/NextDataSetVersionMappingsCreateRequest.cs
@@ -7,7 +7,9 @@ public record NextDataSetVersionMappingsCreateRequest
     public required Guid DataSetId { get; init; }
 
     public required Guid ReleaseFileId { get; init; }
-
+    
+    public PatchVersionConfigs? PatchVersionConfig { get; init; }
+    
     public class Validator : AbstractValidator<NextDataSetVersionMappingsCreateRequest>
     {
         public Validator()
@@ -19,4 +21,11 @@ public record NextDataSetVersionMappingsCreateRequest
                 .NotEmpty();
         }
     }
+}
+
+public record PatchVersionConfigs(bool IsIncrementingPatchVersion, Guid? OldReleaseFileId)
+{
+    public Guid? SourceReleaseFileId { get; init; } = OldReleaseFileId;
+    
+    public bool IsIncrementingPatchVersion { get; set; } = IsIncrementingPatchVersion;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateNextDataSetVersionMappingsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateNextDataSetVersionMappingsFunction.cs
@@ -37,6 +37,7 @@ public class CreateNextDataSetVersionMappingsFunction(
                 dataSetId: request.DataSetId,
                 releaseFileId: request.ReleaseFileId,
                 instanceId,
+                request.PatchVersionConfig,
                 cancellationToken: cancellationToken
             ))
             .OnSuccess(async dataSetVersionId =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessNextDataSetVersionMappingsFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/ProcessNextDataSetVersionMappingsFunctions.cs
@@ -25,8 +25,8 @@ public class ProcessNextDataSetVersionMappingsFunctions(
         CancellationToken cancellationToken)
     {
         var dataSetVersionImport = await GetDataSetVersionImport(instanceId, cancellationToken);
-        await UpdateImportStage(dataSetVersionImport, DataSetVersionImportStage.AutoMapping, cancellationToken);
-        await mappingService.ApplyAutoMappings(dataSetVersionImport.DataSetVersionId, cancellationToken);
+        await UpdateImportStage(dataSetVersionImport, DataSetVersionImportStage.AutoMapping, cancellationToken); ;
+        await mappingService.ApplyAutoMappings(dataSetVersionImport.DataSetVersionId, dataSetVersionImport.IncrementPatchNumber, cancellationToken);
     }
 
     [Function(ActivityNames.CompleteNextDataSetVersionMappingProcessing)]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
@@ -99,6 +99,7 @@ internal class DataSetVersionMappingService(
 
     public async Task ApplyAutoMappings(
         Guid nextDataSetVersionId,
+        bool incrementPatchNumber = false,
         CancellationToken cancellationToken = default)
     {
         var mapping = await publicDataDbContext
@@ -129,8 +130,20 @@ internal class DataSetVersionMappingService(
 
         if (IsMajorVersionUpdate(mapping))
         {
-            mapping.TargetDataSetVersion.VersionMajor += 1;
-            mapping.TargetDataSetVersion.VersionMinor = 0;
+            if (incrementPatchNumber)
+            {
+                var doesntRequireManualMapping = mapping is { LocationMappingsComplete: true, FilterMappingsComplete: true } == false;//TODO: Need to account on whether the user has clicked finalize or not..
+
+                if (doesntRequireManualMapping)//TODO: test this unhappy path!!
+                {
+                    //throw new Exception("Major version number update is not allowed when replacement is in progress");
+                }//TODO: check that the patch number has increased?
+            }
+            else
+            {
+                mapping.TargetDataSetVersion.VersionMajor += 1;
+                mapping.TargetDataSetVersion.VersionMinor = 0;
+            }
         }
 
         publicDataDbContext.DataSetVersionMappings.Update(mapping);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/Interfaces/IDataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/Interfaces/IDataSetVersionMappingService.cs
@@ -17,5 +17,6 @@ public interface IDataSetVersionMappingService
 
     Task ApplyAutoMappings(
         Guid nextDataSetVersionId,
+        bool incrementPatchNumber = false,
         CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/Interfaces/IDataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/Interfaces/IDataSetVersionService.cs
@@ -1,4 +1,5 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Services.Interfaces;
@@ -15,6 +16,7 @@ public interface IDataSetVersionService
         Guid dataSetId,
         Guid releaseFileId,
         Guid instanceId,
+        PatchVersionConfigs? patchVersionConfig,
         CancellationToken cancellationToken = default);
 
     Task<Either<ActionResult, Unit>> BulkDeleteVersions(

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableRow.tsx
@@ -91,33 +91,6 @@ export default function DataFilesTableRow({
                     >
                       Edit title
                     </Link>
-                    {dataFile.publicApiDataSetId ? (
-                      <Modal
-                        showClose
-                        title="Cannot replace data"
-                        triggerButton={<ButtonText>Replace data</ButtonText>}
-                      >
-                        <p>
-                          This data file has an API data set linked to it.
-                          Please remove the API data set before replacing the
-                          data.
-                        </p>
-                        <p>
-                          <Link
-                            to={generatePath<ReleaseDataSetRouteParams>(
-                              releaseApiDataSetDetailsRoute.path,
-                              {
-                                publicationId,
-                                releaseVersionId,
-                                dataSetId: dataFile.publicApiDataSetId,
-                              },
-                            )}
-                          >
-                            Go to API data set
-                          </Link>
-                        </p>
-                      </Modal>
-                    ) : (
                       <Link
                         to={generatePath<ReleaseDataFileReplaceRouteParams>(
                           releaseDataFileReplaceRoute.path,
@@ -130,7 +103,6 @@ export default function DataFilesTableRow({
                       >
                         Replace data
                       </Link>
-                    )}
                   </>
                 )}
                 {dataFile.publicApiDataSetId ? (

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -1,5 +1,6 @@
 import client from '@admin/services/utils/service';
 import { Dictionary } from '@common/types';
+import { Mapping } from 'classnames';
 
 export interface TargetReplacement {
   id: string;
@@ -91,11 +92,27 @@ export interface DataBlockReplacementPlan {
   timePeriods?: TimePeriodsReplacement;
 }
 
+export interface MappingStatus {
+  locationsComplete: boolean;
+  filtersComplete: boolean;
+};
+
+export interface ApiDataSetVersionPlan {
+  id: string;
+  dataSetId: string;
+  name: string;
+  version: string;
+  status: string;
+  mappingStatus?: MappingStatus;
+  valid: boolean;
+}
+
 export interface DataReplacementPlan {
   originalSubjectId: string;
   replacementSubjectId: string;
   dataBlocks: DataBlockReplacementPlan[];
   footnotes: FootnoteReplacementPlan[];
+  apiDataSetVersionPlan: ApiDataSetVersionPlan;
   valid: boolean;
 }
 


### PR DESCRIPTION
This is a draft PR because it's still in WIP.
This commit adds changes to admin backend services such as `DataSetVersionService` & `ReplacementService` support creation of a new patch data set version and managing that new patch data set when the user is required for manual mapping. 

This also tweaks the UI of the data replacement page to display the status of the recently created patch version and to allow the user to navigate to the api data sets page in order to complete the mapping.