### PR TITLE
EES-5974 Infrastructure changes for search function app related to EES-5954 and EES-5955

### DIFF
--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -48,6 +48,9 @@ param applicationInsightsConnectionString string = ''
 @description('Specifies whether or not the Search Docs Function App already exists.')
 param functionAppExists bool
 
+@description('The name of the queue that is used when a publication is changed.')
+param publicationChangedQueueName string = 'publication-changed-queue'
+
 @description('The name of the queue that is used when a searchable document requires a refresh.')
 param refreshSearchableDocumentQueueName string = 'refresh-searchable-document-queue'
 
@@ -135,6 +138,10 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
         value: contentApiUrl
       }
       {
+        name: 'PublicationChangedQueueName'
+        value: publicationChangedQueueName
+      }
+      {
         name: 'RefreshSearchableDocumentQueueName'
         value: refreshSearchableDocumentQueueName
       }
@@ -207,6 +214,7 @@ module functionAppStorageAccountQueueServiceModule '../../common/components/queu
   params: {
     storageAccountName: functionAppStorageAccountName
     queueNames: [
+      publicationChangedQueueName
       refreshSearchableDocumentQueueName
       releaseSlugChangedQueueName
       releaseVersionPublishedQueueName

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -51,6 +51,9 @@ param functionAppExists bool
 @description('The name of the queue that is used when a publication is changed.')
 param publicationChangedQueueName string = 'publication-changed-queue'
 
+@description('The name of the queue that is used when the latest published release version has changed for a publication.')
+param publicationLatestPublishedReleaseVersionChangedQueueName string = 'publication-latest-published-release-version-changed-queue'
+
 @description('The name of the queue that is used when a searchable document requires a refresh.')
 param refreshSearchableDocumentQueueName string = 'refresh-searchable-document-queue'
 
@@ -142,6 +145,10 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
         value: publicationChangedQueueName
       }
       {
+        name: 'PublicationLatestPublishedReleaseVersionChangedQueueName'
+        value: publicationLatestPublishedReleaseVersionChangedQueueName
+      }
+      {
         name: 'RefreshSearchableDocumentQueueName'
         value: refreshSearchableDocumentQueueName
       }
@@ -215,6 +222,7 @@ module functionAppStorageAccountQueueServiceModule '../../common/components/queu
     storageAccountName: functionAppStorageAccountName
     queueNames: [
       publicationChangedQueueName
+      publicationLatestPublishedReleaseVersionChangedQueueName
       refreshSearchableDocumentQueueName
       releaseSlugChangedQueueName
       releaseVersionPublishedQueueName


### PR DESCRIPTION
This PR follows on from https://github.com/dfe-analytical-services/explore-education-statistics/pull/5748 by making an infrastructure change to the Search Azure Function App to support changes made to it in EES-5954 by https://github.com/dfe-analytical-services/explore-education-statistics/pull/5756 and EES-5955 by https://github.com/dfe-analytical-services/explore-education-statistics/pull/5766.

This change adds `PublicationChangedQueueName` and `PublicationLatestPublishedReleaseVersionChangedQueueName` to the app settings, and creates the queues `publication-changed-queue` and `publication-latest-published-release-version-changed-queue` in the app's dedicated storage account queue service.