### PR TITLE
Ees 5955 - On release series change

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
@@ -40,14 +40,14 @@ public class AdminEventRaiserServiceMockBuilder
         _mock
             .Setup(m => m.OnPublicationLatestPublishedReleaseVersionChanged(
                 It.IsAny<Publication>(),
-                It.IsAny<Guid?>()))
-            .Callback((Publication publication, Guid? oldLatestPublishedReleaseVersionId) => 
+                It.IsAny<Guid>()))
+            .Callback((Publication publication, Guid oldLatestPublishedReleaseVersionId) => 
                 _onPublicationLatestPublishedReleaseVersionChangedInvocations
                     .Add(new OnPublicationLatestPublishedReleaseVersionChangedArgs(publication, oldLatestPublishedReleaseVersionId)))
             .Returns(Task.CompletedTask);
     }
 
-    private record OnPublicationLatestPublishedReleaseVersionChangedArgs(Publication Publication, Guid? OldLatestPublishedReleaseVersionId);
+    private record OnPublicationLatestPublishedReleaseVersionChangedArgs(Publication Publication, Guid OldLatestPublishedReleaseVersionId);
     
     public class Asserter(AdminEventRaiserServiceMockBuilder mockBuilder)
     {
@@ -75,8 +75,8 @@ public class AdminEventRaiserServiceMockBuilder
                 || new PublicationChangedEventDto(p) == new PublicationChangedEventDto(publication))), Times.Once);
 
         public void OnPublicationLatestPublishedReleaseVersionChangedWasRaised(
-            Publication? publication = null,
-            Guid? previousReleaseVersionId = null)
+            Publication publication,
+            Guid previousReleaseVersionId)
         {
             var expectedEvent = new PublicationLatestPublishedReleaseVersionChangedEventDto(
                 publication, 
@@ -97,7 +97,7 @@ public class AdminEventRaiserServiceMockBuilder
             mockBuilder._mock.Verify(m => m.OnPublicationChanged(It.IsAny<Publication>()), Times.Never);
             mockBuilder._mock.Verify(m => m.OnPublicationLatestPublishedReleaseVersionChanged(
                 It.IsAny<Publication>(),
-                It.IsAny<Guid?>()), 
+                It.IsAny<Guid>()), 
                 Times.Never);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserServiceMockBuilder.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Events;
@@ -12,7 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 public class AdminEventRaiserServiceMockBuilder
 {
     private readonly Mock<IAdminEventRaiserService> _mock = new(MockBehavior.Strict);
-    
+    private readonly List<OnPublicationLatestPublishedReleaseVersionChangedArgs> _onPublicationLatestPublishedReleaseVersionChangedInvocations = new();
     private static readonly Expression<Func<IAdminEventRaiserService, Task>> OnReleaseSlugChanged =  
         m => m.OnReleaseSlugChanged(
             It.IsAny<Guid>(), 
@@ -35,19 +36,30 @@ public class AdminEventRaiserServiceMockBuilder
         _mock
             .Setup(m => m.OnPublicationChanged(It.IsAny<Publication>()))
             .Returns(Task.CompletedTask);
+        
+        _mock
+            .Setup(m => m.OnPublicationLatestPublishedReleaseVersionChanged(
+                It.IsAny<Publication>(),
+                It.IsAny<Guid?>()))
+            .Callback((Publication publication, Guid? oldLatestPublishedReleaseVersionId) => 
+                _onPublicationLatestPublishedReleaseVersionChangedInvocations
+                    .Add(new OnPublicationLatestPublishedReleaseVersionChangedArgs(publication, oldLatestPublishedReleaseVersionId)))
+            .Returns(Task.CompletedTask);
     }
 
-    public class Asserter(Mock<IAdminEventRaiserService> mock)
+    private record OnPublicationLatestPublishedReleaseVersionChangedArgs(Publication Publication, Guid? OldLatestPublishedReleaseVersionId);
+    
+    public class Asserter(AdminEventRaiserServiceMockBuilder mockBuilder)
     {
         public void ThatOnThemeUpdatedRaised(Func<Theme, bool>? predicate = null) => 
-            mock.Verify(m => m.OnThemeUpdated(It.Is<Theme>(t => predicate == null || predicate(t))), Times.Once);
+            mockBuilder._mock.Verify(m => m.OnThemeUpdated(It.Is<Theme>(t => predicate == null || predicate(t))), Times.Once);
 
         public void OnReleaseSlugChangedWasRaised(
             Guid? expectedReleaseId = null,
             string? expectedNewReleaseSlug = null,
             Guid? expectedPublicationId = null,
             string? expectedPublicationSlug = null) => 
-            mock.Verify(m => m.OnReleaseSlugChanged(
+            mockBuilder._mock.Verify(m => m.OnReleaseSlugChanged(
                 It.Is<Guid>(releaseId => expectedReleaseId == null || releaseId == expectedReleaseId), 
                 It.Is<string>(newReleaseSlug => expectedNewReleaseSlug == null || newReleaseSlug == expectedNewReleaseSlug), 
                 It.Is<Guid>(publicationId => expectedPublicationId == null || publicationId == expectedPublicationId), 
@@ -55,13 +67,39 @@ public class AdminEventRaiserServiceMockBuilder
                 Times.Once);
 
         public void OnReleaseSlugChangedWasNotRaised() => 
-            mock.Verify(OnReleaseSlugChanged, Times.Never);
+            mockBuilder._mock.Verify(OnReleaseSlugChanged, Times.Never);
 
         public void OnPublicationChangedWasRaised(Publication? publication = null) =>
-            mock.Verify(m => m.OnPublicationChanged(It.Is<Publication>(p => publication == null || new PublicationChangedEventDto(p) == new PublicationChangedEventDto(publication))), Times.Once);
+            mockBuilder._mock.Verify(m => m.OnPublicationChanged(It.Is<Publication>(p => 
+                publication == null 
+                || new PublicationChangedEventDto(p) == new PublicationChangedEventDto(publication))), Times.Once);
 
-        public void OnPublicationChangedWasNotRaised()=>
-            mock.Verify(m => m.OnPublicationChanged(It.IsAny<Publication>()), Times.Never);
+        public void OnPublicationLatestPublishedReleaseVersionChangedWasRaised(
+            Publication? publication = null,
+            Guid? previousReleaseVersionId = null)
+        {
+            var expectedEvent = new PublicationLatestPublishedReleaseVersionChangedEventDto(
+                publication, 
+                previousReleaseVersionId);
+
+            Xunit.Assert.Single(
+                mockBuilder._onPublicationLatestPublishedReleaseVersionChangedInvocations, 
+                inv =>
+                    new PublicationLatestPublishedReleaseVersionChangedEventDto(
+                        inv.Publication,
+                        inv.OldLatestPublishedReleaseVersionId)
+                    == expectedEvent);
+        }
+            
+
+        public void OnPublicationChangedWasNotRaised()
+        {
+            mockBuilder._mock.Verify(m => m.OnPublicationChanged(It.IsAny<Publication>()), Times.Never);
+            mockBuilder._mock.Verify(m => m.OnPublicationLatestPublishedReleaseVersionChanged(
+                It.IsAny<Publication>(),
+                It.IsAny<Guid?>()), 
+                Times.Never);
+        }
     }
-    public Asserter Assert => new(_mock);
+    public Asserter Assert => new(this);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -3502,8 +3502,8 @@ public class PublicationServiceTests
         _adminEventRaiserServiceMockBuilder.Assert.OnPublicationChangedWasRaised(publication);
     
     private void AssertOnPublicationLatestPublishedReleaseVersionChangedWasRaised(
-        Publication? publication = null,
-        Guid? previousReleaseVersionId = null) =>
+        Publication publication,
+        Guid previousReleaseVersionId) =>
         _adminEventRaiserServiceMockBuilder.Assert.OnPublicationLatestPublishedReleaseVersionChangedWasRaised(
             publication,
             previousReleaseVersionId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -2994,6 +2994,7 @@ public class PublicationServiceTests
                 contentDbContext,
                 publicationCacheService: publicationCacheService.Object);
 
+            // Let's swap the order of the oldest two releases to 2022, 2020, 2021 and insert a legacy link.
             var result = await publicationService.UpdateReleaseSeries(
                 publication.Id,
                 updatedReleaseSeriesItems:
@@ -3065,6 +3066,9 @@ public class PublicationServiceTests
             // as the first release after the legacy link
             Assert.Equal(release2022.Versions[1].Id, actualPublication.LatestPublishedReleaseVersionId);
         }
+        
+        // The latest release is unchanged so no event should have been raised
+        AssertOnPublicationChangedEventNotRaised();
     }
 
     [Fact]
@@ -3166,6 +3170,8 @@ public class PublicationServiceTests
             // version since it was positioned as the first release
             Assert.Equal(expectedLatestPublishedReleaseVersionId,
                 actualPublication.LatestPublishedReleaseVersionId);
+            
+            AssertOnPublicationChangedEventRaised(actualPublication);
         }
     }
 
@@ -3268,6 +3274,8 @@ public class PublicationServiceTests
             // version since it was positioned as the next release after 2021 which is unpublished
             Assert.Equal(expectedLatestPublishedReleaseVersionId,
                 actualPublication.LatestPublishedReleaseVersionId);
+
+            AssertOnPublicationChangedEventRaised(actualPublication);
         }
     }
 
@@ -3315,6 +3323,8 @@ public class PublicationServiceTests
 
             Assert.Empty(actualPublication.ReleaseSeries);
         }
+        
+        AssertOnPublicationChangedEventNotRaised();
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -3090,10 +3090,11 @@ public class PublicationServiceTests
         var release2021 = publication.Releases.Single(r => r.Year == 2021);
         var release2022 = publication.Releases.Single(r => r.Year == 2022);
 
+        var originalLatestPublishedReleaseVersionId = release2022.Versions[1].Id;
         var expectedLatestPublishedReleaseVersionId = release2021.Versions[0].Id;
 
         // Check the publication's latest published release version in the generated test data setup
-        Assert.Equal(release2022.Versions[1].Id, publication.LatestPublishedReleaseVersionId);
+        Assert.Equal(originalLatestPublishedReleaseVersionId, publication.LatestPublishedReleaseVersionId);
 
         // Check the expected order of the release series items in the generated test data setup
         Assert.Equal(3, publication.ReleaseSeries.Count);
@@ -3171,7 +3172,9 @@ public class PublicationServiceTests
             Assert.Equal(expectedLatestPublishedReleaseVersionId,
                 actualPublication.LatestPublishedReleaseVersionId);
             
-            AssertOnPublicationChangedEventRaised(actualPublication);
+            AssertOnPublicationLatestPublishedReleaseVersionChangedWasRaised(
+                actualPublication,
+                originalLatestPublishedReleaseVersionId);
         }
     }
 
@@ -3194,10 +3197,11 @@ public class PublicationServiceTests
         var release2021 = publication.Releases.Single(r => r.Year == 2021);
         var release2022 = publication.Releases.Single(r => r.Year == 2022);
 
+        var originalLatestPublishedReleaseVersionId = release2022.Versions[1].Id;
         var expectedLatestPublishedReleaseVersionId = release2020.Versions[0].Id;
 
         // Check the publication's latest published release version in the generated test data setup
-        Assert.Equal(release2022.Versions[1].Id, publication.LatestPublishedReleaseVersionId);
+        Assert.Equal(originalLatestPublishedReleaseVersionId, publication.LatestPublishedReleaseVersionId);
 
         // Check the expected order of the release series items in the generated test data setup
         Assert.Equal(3, publication.ReleaseSeries.Count);
@@ -3275,7 +3279,9 @@ public class PublicationServiceTests
             Assert.Equal(expectedLatestPublishedReleaseVersionId,
                 actualPublication.LatestPublishedReleaseVersionId);
 
-            AssertOnPublicationChangedEventRaised(actualPublication);
+            AssertOnPublicationLatestPublishedReleaseVersionChangedWasRaised(
+                actualPublication,
+                originalLatestPublishedReleaseVersionId);
         }
     }
 
@@ -3494,6 +3500,13 @@ public class PublicationServiceTests
 
     private void AssertOnPublicationChangedEventRaised(Publication? publication = null) =>
         _adminEventRaiserServiceMockBuilder.Assert.OnPublicationChangedWasRaised(publication);
+    
+    private void AssertOnPublicationLatestPublishedReleaseVersionChangedWasRaised(
+        Publication? publication = null,
+        Guid? previousReleaseVersionId = null) =>
+        _adminEventRaiserServiceMockBuilder.Assert.OnPublicationLatestPublishedReleaseVersionChangedWasRaised(
+            publication,
+            previousReleaseVersionId);
     
     private void AssertOnPublicationChangedEventNotRaised() =>
         _adminEventRaiserServiceMockBuilder.Assert.OnPublicationChangedWasNotRaised();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationLatestPublishedReleaseVersionChangedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationLatestPublishedReleaseVersionChangedEventDto.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Events;
+
+public record PublicationLatestPublishedReleaseVersionChangedEventDto
+{
+    public PublicationLatestPublishedReleaseVersionChangedEventDto(
+        Publication publication,
+        Guid? previousReleaseVersionId)
+    {
+        Subject = publication.Id.ToString();
+        Payload = new EventPayload
+        {
+            Title = publication.Title,
+            Slug = publication.Slug,
+            LatestPublishedReleaseVersionId = publication.LatestPublishedReleaseVersionId,
+            PreviousReleaseVersionId = previousReleaseVersionId
+        };
+    }
+
+    // Changes to this event should also increment the version accordingly.
+    private const string DataVersion = "1.0";
+    private const string EventType = "publication-latest-publised-release-version-changed";
+    
+    // Which Topic endpoint to use from the appsettings
+    public const string EventTopicOptionsKey = "PublicationChangedEvent";
+
+    /// <summary>
+    /// The PublicationId is the subject
+    /// </summary>
+    public string Subject { get; }
+
+    /// <summary>
+    /// The event payload
+    /// </summary>
+    public EventPayload Payload { get; }
+    
+    public record EventPayload
+    {
+        public string Title { get; init; }
+        public string Slug { get; init; }
+        public Guid? LatestPublishedReleaseVersionId { get; init; }
+        public Guid? PreviousReleaseVersionId { get; init; }
+    }
+
+    public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationLatestPublishedReleaseVersionChangedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationLatestPublishedReleaseVersionChangedEventDto.cs
@@ -8,14 +8,14 @@ public record PublicationLatestPublishedReleaseVersionChangedEventDto
 {
     public PublicationLatestPublishedReleaseVersionChangedEventDto(
         Publication publication,
-        Guid? previousReleaseVersionId)
+        Guid previousReleaseVersionId)
     {
         Subject = publication.Id.ToString();
         Payload = new EventPayload
         {
             Title = publication.Title,
             Slug = publication.Slug,
-            LatestPublishedReleaseVersionId = publication.LatestPublishedReleaseVersionId,
+            LatestPublishedReleaseVersionId = publication.LatestPublishedReleaseVersionId ?? throw new ArgumentNullException(nameof(publication.LatestPublishedReleaseVersionId)),
             PreviousReleaseVersionId = previousReleaseVersionId
         };
     }
@@ -41,8 +41,8 @@ public record PublicationLatestPublishedReleaseVersionChangedEventDto
     {
         public string Title { get; init; }
         public string Slug { get; init; }
-        public Guid? LatestPublishedReleaseVersionId { get; init; }
-        public Guid? PreviousReleaseVersionId { get; init; }
+        public Guid LatestPublishedReleaseVersionId { get; init; }
+        public Guid PreviousReleaseVersionId { get; init; }
     }
 
     public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiserService.cs
@@ -62,5 +62,22 @@ public class AdminEventRaiserService(IConfiguredEventGridClientFactory eventGrid
         
         await client.SendEventAsync(eventDto.ToEventGridEvent());
     }
+    
+    /// <summary>
+    /// On Publication Latest Published Release Version changed
+    /// </summary>
+    public async Task OnPublicationLatestPublishedReleaseVersionChanged(Publication publication, Guid? previousReleaseVersionId)
+    {
+        if (!eventGridClientFactory.TryCreateClient(
+                PublicationLatestPublishedReleaseVersionChangedEventDto.EventTopicOptionsKey,
+                out var client))
+        {
+            return;
+        }
+
+        var eventDto = new PublicationLatestPublishedReleaseVersionChangedEventDto(publication, previousReleaseVersionId);
+        
+        await client.SendEventAsync(eventDto.ToEventGridEvent());
+    }
 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiserService.cs
@@ -64,9 +64,11 @@ public class AdminEventRaiserService(IConfiguredEventGridClientFactory eventGrid
     }
     
     /// <summary>
-    /// On Publication Latest Published Release Version changed
+    /// On Publication Latest Published Release Version changed.
+    /// It is assumed that the publication LatestPublishedReleaseVersionId has a value assigned to it.
+    /// If it is null, then no event will be raised.
     /// </summary>
-    public async Task OnPublicationLatestPublishedReleaseVersionChanged(Publication publication, Guid? previousReleaseVersionId)
+    public async Task OnPublicationLatestPublishedReleaseVersionChanged(Publication publication, Guid previousLatestPublishedReleaseVersionId)
     {
         if (!eventGridClientFactory.TryCreateClient(
                 PublicationLatestPublishedReleaseVersionChangedEventDto.EventTopicOptionsKey,
@@ -75,7 +77,13 @@ public class AdminEventRaiserService(IConfiguredEventGridClientFactory eventGrid
             return;
         }
 
-        var eventDto = new PublicationLatestPublishedReleaseVersionChangedEventDto(publication, previousReleaseVersionId);
+        // Should the publication not have a latest published release version for some reason, do nothing.
+        if (publication.LatestPublishedReleaseVersionId is null)
+        {
+            return;
+        }
+
+        var eventDto = new PublicationLatestPublishedReleaseVersionChangedEventDto(publication, previousLatestPublishedReleaseVersionId);
         
         await client.SendEventAsync(eventDto.ToEventGridEvent());
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiserService.cs
@@ -9,4 +9,5 @@ public interface IAdminEventRaiserService
     Task OnThemeUpdated(Theme theme);
     Task OnReleaseSlugChanged(Guid releaseId, string newReleaseSlug, Guid publicationId, string publicationSlug);
     Task OnPublicationChanged(Publication publication);
+    Task OnPublicationLatestPublishedReleaseVersionChanged(Publication publication, Guid? previousReleaseVersionId);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiserService.cs
@@ -9,5 +9,5 @@ public interface IAdminEventRaiserService
     Task OnThemeUpdated(Theme theme);
     Task OnReleaseSlugChanged(Guid releaseId, string newReleaseSlug, Guid publicationId, string publicationSlug);
     Task OnPublicationChanged(Publication publication);
-    Task OnPublicationLatestPublishedReleaseVersionChanged(Publication publication, Guid? previousReleaseVersionId);
+    Task OnPublicationLatestPublishedReleaseVersionChanged(Publication publication, Guid previousLatestPublishedReleaseVersionId);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -585,10 +585,9 @@ public class PublicationService(
                     await releaseCacheService.UpdateRelease(releaseVersionId: latestPublishedReleaseVersionId.Value,
                         publicationSlug: publication.Slug);
 
-                    // Arguably, we should always be raising a publication changed event and
-                    // detailing what has changed. The event subscriber should be deciding
-                    // whether to react or not.
-                    await adminEventRaiserService.OnPublicationChanged(publication);
+                    await adminEventRaiserService.OnPublicationLatestPublishedReleaseVersionChanged(
+                        publication, 
+                        oldLatestPublishedReleaseVersionId);
                 }
 
                 return await GetReleaseSeries(publication.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -585,9 +585,14 @@ public class PublicationService(
                     await releaseCacheService.UpdateRelease(releaseVersionId: latestPublishedReleaseVersionId.Value,
                         publicationSlug: publication.Slug);
 
-                    await adminEventRaiserService.OnPublicationLatestPublishedReleaseVersionChanged(
-                        publication, 
-                        oldLatestPublishedReleaseVersionId);
+                    // The reordering of the series implies that there was already a published release version,
+                    // therefore, this should always have a value
+                    if (oldLatestPublishedReleaseVersionId.HasValue)
+                    {
+                        await adminEventRaiserService.OnPublicationLatestPublishedReleaseVersionChanged(
+                            publication,
+                            oldLatestPublishedReleaseVersionId.Value);
+                    }
                 }
 
                 return await GetReleaseSeries(publication.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -584,6 +584,11 @@ public class PublicationService(
                 {
                     await releaseCacheService.UpdateRelease(releaseVersionId: latestPublishedReleaseVersionId.Value,
                         publicationSlug: publication.Slug);
+
+                    // Arguably, we should always be raising a publication changed event and
+                    // detailing what has changed. The event subscriber should be deciding
+                    // whether to react or not.
+                    await adminEventRaiserService.OnPublicationChanged(publication);
                 }
 
                 return await GetReleaseSeries(publication.Id);


### PR DESCRIPTION
The new search is based on the latest release of a publication. In our continuing adventures of event raising, another way in which the latest release can change is if the releases are reordered. This would mean that the search would need to pick up the new latest release if it has changed.

As part of this, I've made the event more specific to "publication latest release changed" instead of a generic "publication changed" which would indicate that anything had changed.