### PR TITLE
EES-5954 Only validate date input field changes after form is submitted

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormFieldDateInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldDateInput.tsx
@@ -41,7 +41,7 @@ export default function FormFieldDateInput<TFormValues extends FieldValues>({
   const id = fieldId(name as string, customId);
 
   const {
-    formState: { errors },
+    formState: { errors, isSubmitted },
     setValue,
     trigger,
   } = useFormContext<TFormValues>();
@@ -107,9 +107,11 @@ export default function FormFieldDateInput<TFormValues extends FieldValues>({
         [key]: inputValue,
       });
 
-      trigger(name);
+      if (isSubmitted) {
+        trigger(name);
+      }
     },
-    [name, setValue, trigger, type, values],
+    [name, isSubmitted, setValue, trigger, type, values],
   );
 
   return (

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldDateInput.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldDateInput.test.tsx
@@ -7,6 +7,7 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import noop from 'lodash/noop';
 import React from 'react';
+import Button from '@common/components/Button';
 
 describe('FormFieldDateInput', () => {
   test('renders correctly', () => {
@@ -31,27 +32,30 @@ describe('FormFieldDateInput', () => {
           startDate: Yup.date().required('Select a date'),
         })}
       >
-        <FormFieldDateInput
-          legend="Start date"
-          id="startDate"
-          name="startDate"
-        />
+        <Form id="testForm" onSubmit={noop} visuallyHiddenErrorSummary>
+          <FormFieldDateInput
+            legend="Start date"
+            id="startDate"
+            name="startDate"
+          />
+          <Button type="submit">Submit</Button>
+        </Form>
       </FormProvider>,
     );
 
-    await userEvent.tab();
-    await userEvent.tab();
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
+    const group = within(screen.getByRole('group'));
     await waitFor(() => {
-      expect(screen.getByText('Select a date')).toHaveAttribute(
+      expect(group.getByText('Select a date')).toHaveAttribute(
         'id',
-        'startDate-error',
+        'testForm-startDate-error',
       );
     });
 
     expect(screen.getByRole('group')).toHaveAttribute(
       'aria-describedby',
-      'startDate-error',
+      'testForm-startDate-error',
     );
   });
 
@@ -91,6 +95,7 @@ describe('FormFieldDateInput', () => {
             hint="Test hint"
             name="startDate"
           />
+          <Button type="submit">Submit</Button>
         </Form>
       </FormProvider>,
     );
@@ -115,57 +120,12 @@ describe('FormFieldDateInput', () => {
       'testForm-startDate-year',
     );
 
-    await userEvent.tab();
-    await userEvent.tab();
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(group.getByText('Select a date')).toHaveAttribute(
         'id',
         'testForm-startDate-error',
-      );
-    });
-  });
-
-  test('renders with correct defaults ids without form', async () => {
-    render(
-      <FormProvider
-        initialValues={{}}
-        validationSchema={Yup.object({
-          startDate: Yup.date().required('Select a date'),
-        })}
-      >
-        <FormFieldDateInput
-          legend="Start date"
-          hint="Test hint"
-          name="startDate"
-        />
-      </FormProvider>,
-    );
-
-    const group = within(screen.getByRole('group'));
-
-    expect(group.getByText('Test hint')).toHaveAttribute(
-      'id',
-      'startDate-hint',
-    );
-
-    expect(group.getByLabelText('Day')).toHaveAttribute('id', 'startDate-day');
-    expect(group.getByLabelText('Month')).toHaveAttribute(
-      'id',
-      'startDate-month',
-    );
-    expect(group.getByLabelText('Year')).toHaveAttribute(
-      'id',
-      'startDate-year',
-    );
-
-    await userEvent.tab();
-    await userEvent.tab();
-
-    await waitFor(() => {
-      expect(group.getByText('Select a date')).toHaveAttribute(
-        'id',
-        'startDate-error',
       );
     });
   });
@@ -185,6 +145,7 @@ describe('FormFieldDateInput', () => {
             name="startDate"
             id="customId"
           />
+          <Button type="submit">Submit</Button>
         </Form>
       </FormProvider>,
     );
@@ -209,50 +170,12 @@ describe('FormFieldDateInput', () => {
       'testForm-customId-year',
     );
 
-    await userEvent.tab();
-    await userEvent.tab();
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() => {
       expect(group.getByText('Select a date')).toHaveAttribute(
         'id',
         'testForm-customId-error',
-      );
-    });
-  });
-
-  test('renders with correct custom ids without form', async () => {
-    render(
-      <FormProvider
-        initialValues={{}}
-        validationSchema={Yup.object({
-          startDate: Yup.date().required('Select a date'),
-        })}
-      >
-        <FormFieldDateInput
-          legend="Start date"
-          hint="Test hint"
-          name="startDate"
-          id="customId"
-        />
-      </FormProvider>,
-    );
-
-    const group = within(screen.getByRole('group'));
-
-    expect(group.getByLabelText('Day')).toHaveAttribute('id', 'customId-day');
-    expect(group.getByLabelText('Month')).toHaveAttribute(
-      'id',
-      'customId-month',
-    );
-    expect(group.getByLabelText('Year')).toHaveAttribute('id', 'customId-year');
-
-    await userEvent.tab();
-    await userEvent.tab();
-
-    await waitFor(() => {
-      expect(group.getByText('Select a date')).toHaveAttribute(
-        'id',
-        'customId-error',
       );
     });
   });


### PR DESCRIPTION
This PR changed the `FormFieldDateInput` component to only validate onChange input **after** the form has been submitted.
This prevents annoying inline validation when tabbing through the different date input text fields before the form has been submitted. 

It also amends the release status form, to separate out logic for actually submitting the release status form vs showing the confirm modal.

A side effect of this amend was to have to not use the form's submit button as the confirm modal trigger, as it was preventing form validation on click.
As a result I've had to amend how we handle returning focus when the modal is closed - this is by imperatively calling 'focus()' after a timeout (necessary as without a timeout the focus() call doesn't work).
**I couldn't use the `useEffect` method from other examples as it was focussing the submit button as soon as the form was mounted.**


I also had to amend the dateinput field tests, to not expect errors after simply tabbing through the different fields.