### PR TITLE
EES-5741 - Filter Hierarchies UI & Layout

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormCheckbox.module.scss
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckbox.module.scss
@@ -1,0 +1,3 @@
+.label::before {
+  background: #fff;
+}

--- a/src/explore-education-statistics-common/src/components/form/FormCheckbox.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckbox.tsx
@@ -7,6 +7,7 @@ import React, {
   ReactNode,
   Ref,
 } from 'react';
+import styles from './FormCheckbox.module.scss';
 
 export type OtherCheckboxChangeProps = Pick<FormCheckboxProps, 'label'>;
 
@@ -81,10 +82,14 @@ const FormCheckbox = ({
           value={value}
         />
         <label
-          className={classNames('govuk-label govuk-checkboxes__label', {
-            'govuk-!-font-weight-bold': boldLabel,
-            'govuk-!-padding-bottom-1': hintSmall,
-          })}
+          className={classNames(
+            'govuk-label govuk-checkboxes__label',
+            styles.label,
+            {
+              'govuk-!-font-weight-bold': boldLabel,
+              'govuk-!-padding-bottom-1': hintSmall,
+            },
+          )}
           htmlFor={id}
         >
           {label}

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckbox.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckbox.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`FormCheckbox does not render conditional content when not checked 1`] =
          value="true"
          aria-controls="test-checkbox-conditional"
   >
-  <label class="govuk-label govuk-checkboxes__label"
+  <label class="govuk-label govuk-checkboxes__label label"
          for="test-checkbox"
   >
     Test checkbox
@@ -39,7 +39,7 @@ exports[`FormCheckbox renders conditional content when checked 1`] = `
          aria-controls="test-checkbox-conditional"
          aria-expanded="true"
   >
-  <label class="govuk-label govuk-checkboxes__label"
+  <label class="govuk-label govuk-checkboxes__label label"
          for="test-checkbox"
   >
     Test checkbox
@@ -65,7 +65,7 @@ exports[`FormCheckbox renders correctly when \`hint\` is provided 1`] = `
          type="checkbox"
          value="true"
   >
-  <label class="govuk-label govuk-checkboxes__label"
+  <label class="govuk-label govuk-checkboxes__label label"
          for="test-checkbox"
   >
     Test checkbox
@@ -88,7 +88,7 @@ exports[`FormCheckbox renders correctly with required props 1`] = `
          type="checkbox"
          value="true"
   >
-  <label class="govuk-label govuk-checkboxes__label"
+  <label class="govuk-label govuk-checkboxes__label label"
          for="test-checkbox"
   >
     Test checkbox

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxGroup.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`FormCheckboxGroup renders checkboxes with some pre-checked 1`] = `
                type="checkbox"
                value="1"
         >
-        <label class="govuk-label govuk-checkboxes__label"
+        <label class="govuk-label govuk-checkboxes__label label"
                for="test-checkboxes-checkbox-1"
         >
           Test checkbox 1
@@ -34,7 +34,7 @@ exports[`FormCheckboxGroup renders checkboxes with some pre-checked 1`] = `
                value="2"
                checked
         >
-        <label class="govuk-label govuk-checkboxes__label"
+        <label class="govuk-label govuk-checkboxes__label label"
                for="test-checkboxes-checkbox-2"
         >
           Test checkbox 2
@@ -49,7 +49,7 @@ exports[`FormCheckboxGroup renders checkboxes with some pre-checked 1`] = `
                type="checkbox"
                value="3"
         >
-        <label class="govuk-label govuk-checkboxes__label"
+        <label class="govuk-label govuk-checkboxes__label label"
                for="test-checkboxes-checkbox-3"
         >
           Test checkbox 3
@@ -78,7 +78,7 @@ exports[`FormCheckboxGroup renders correctly with legend 1`] = `
                type="checkbox"
                value="1"
         >
-        <label class="govuk-label govuk-checkboxes__label"
+        <label class="govuk-label govuk-checkboxes__label label"
                for="test-checkboxes-checkbox-1"
         >
           Test checkbox 1
@@ -118,7 +118,7 @@ exports[`FormCheckboxGroup renders correctly with small size variants 1`] = `
             value="1"
           />
           <label
-            class="govuk-label govuk-checkboxes__label"
+            class="govuk-label govuk-checkboxes__label label"
             for="test-checkboxes-checkbox-1"
           >
             Test checkbox 1
@@ -148,7 +148,7 @@ exports[`FormCheckboxGroup renders list of checkboxes in correct order 1`] = `
                type="checkbox"
                value="1"
         >
-        <label class="govuk-label govuk-checkboxes__label"
+        <label class="govuk-label govuk-checkboxes__label label"
                for="test-checkboxes-checkbox-1"
         >
           Test checkbox 1
@@ -163,7 +163,7 @@ exports[`FormCheckboxGroup renders list of checkboxes in correct order 1`] = `
                type="checkbox"
                value="2"
         >
-        <label class="govuk-label govuk-checkboxes__label"
+        <label class="govuk-label govuk-checkboxes__label label"
                for="test-checkboxes-checkbox-2"
         >
           Test checkbox 2
@@ -178,7 +178,7 @@ exports[`FormCheckboxGroup renders list of checkboxes in correct order 1`] = `
                type="checkbox"
                value="3"
         >
-        <label class="govuk-label govuk-checkboxes__label"
+        <label class="govuk-label govuk-checkboxes__label label"
                for="test-checkboxes-checkbox-3"
         >
           Test checkbox 3
@@ -209,7 +209,7 @@ exports[`FormCheckboxGroup renders option with conditional contents 1`] = `
                aria-controls="test-checkboxes-checkbox-1-conditional"
                aria-expanded="false"
         >
-        <label class="govuk-label govuk-checkboxes__label"
+        <label class="govuk-label govuk-checkboxes__label label"
                for="test-checkboxes-checkbox-1"
         >
           Test checkbox 1
@@ -234,7 +234,7 @@ exports[`FormCheckboxGroup renders option with conditional contents 1`] = `
                aria-controls="test-checkboxes-checkbox-2-conditional"
                aria-expanded="true"
         >
-        <label class="govuk-label govuk-checkboxes__label"
+        <label class="govuk-label govuk-checkboxes__label label"
                for="test-checkboxes-checkbox-2"
         >
           Test checkbox 2
@@ -258,7 +258,7 @@ exports[`FormCheckboxGroup renders option with conditional contents 1`] = `
                aria-controls="test-checkboxes-checkbox-3-conditional"
                aria-expanded="false"
         >
-        <label class="govuk-label govuk-checkboxes__label"
+        <label class="govuk-label govuk-checkboxes__label label"
                for="test-checkboxes-checkbox-3"
         >
           Test checkbox 3

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchGroup.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`FormCheckboxSearchGroup without searchOnly renders list of checkboxes i
                  type="checkbox"
                  value="1"
           >
-          <label class="govuk-label govuk-checkboxes__label"
+          <label class="govuk-label govuk-checkboxes__label label"
                  for="test-checkboxes-options-1"
           >
             Test checkbox 1
@@ -51,7 +51,7 @@ exports[`FormCheckboxSearchGroup without searchOnly renders list of checkboxes i
                  type="checkbox"
                  value="2"
           >
-          <label class="govuk-label govuk-checkboxes__label"
+          <label class="govuk-label govuk-checkboxes__label label"
                  for="test-checkboxes-options-2"
           >
             Test checkbox 2
@@ -66,7 +66,7 @@ exports[`FormCheckboxSearchGroup without searchOnly renders list of checkboxes i
                  type="checkbox"
                  value="3"
           >
-          <label class="govuk-label govuk-checkboxes__label"
+          <label class="govuk-label govuk-checkboxes__label label"
                  for="test-checkboxes-options-3"
           >
             Test checkbox 3

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchSubGroups.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchSubGroups.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`FormCheckboxSearchSubGroups renders groups of checkboxes in correct ord
                      type="checkbox"
                      value="1"
               >
-              <label class="govuk-label govuk-checkboxes__label"
+              <label class="govuk-label govuk-checkboxes__label label"
                      for="test-checkboxes-options-1-1"
               >
                 Checkbox 1
@@ -71,7 +71,7 @@ exports[`FormCheckboxSearchSubGroups renders groups of checkboxes in correct ord
                      type="checkbox"
                      value="2"
               >
-              <label class="govuk-label govuk-checkboxes__label"
+              <label class="govuk-label govuk-checkboxes__label label"
                      for="test-checkboxes-options-1-2"
               >
                 Checkbox 2
@@ -107,7 +107,7 @@ exports[`FormCheckboxSearchSubGroups renders groups of checkboxes in correct ord
                      type="checkbox"
                      value="3"
               >
-              <label class="govuk-label govuk-checkboxes__label"
+              <label class="govuk-label govuk-checkboxes__label label"
                      for="test-checkboxes-options-2-3"
               >
                 Checkbox 3
@@ -122,7 +122,7 @@ exports[`FormCheckboxSearchSubGroups renders groups of checkboxes in correct ord
                      type="checkbox"
                      value="4"
               >
-              <label class="govuk-label govuk-checkboxes__label"
+              <label class="govuk-label govuk-checkboxes__label label"
                      for="test-checkboxes-options-2-4"
               >
                 Checkbox 4
@@ -175,7 +175,7 @@ exports[`FormCheckboxSearchSubGroups renders single group of checkboxes correctl
                  type="checkbox"
                  value="1"
           >
-          <label class="govuk-label govuk-checkboxes__label"
+          <label class="govuk-label govuk-checkboxes__label label"
                  for="test-checkboxes-1-1"
           >
             Checkbox 1
@@ -190,7 +190,7 @@ exports[`FormCheckboxSearchSubGroups renders single group of checkboxes correctl
                  type="checkbox"
                  value="2"
           >
-          <label class="govuk-label govuk-checkboxes__label"
+          <label class="govuk-label govuk-checkboxes__label label"
                  for="test-checkboxes-1-2"
           >
             Checkbox 2

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldCheckboxGroupsMenu.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldCheckboxGroupsMenu.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
               value="1"
             />
             <label
-              class="govuk-label govuk-checkboxes__label"
+              class="govuk-label govuk-checkboxes__label label"
               for="test-options-1-1"
             >
               Option 1
@@ -93,7 +93,7 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
               value="2"
             />
             <label
-              class="govuk-label govuk-checkboxes__label"
+              class="govuk-label govuk-checkboxes__label label"
               for="test-options-1-2"
             >
               Option 2
@@ -142,7 +142,7 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
               value="3"
             />
             <label
-              class="govuk-label govuk-checkboxes__label"
+              class="govuk-label govuk-checkboxes__label label"
               for="test-options-2-3"
             >
               Option 3
@@ -160,7 +160,7 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
               value="4"
             />
             <label
-              class="govuk-label govuk-checkboxes__label"
+              class="govuk-label govuk-checkboxes__label label"
               for="test-options-2-4"
             >
               Option 4
@@ -223,7 +223,7 @@ exports[`FormFieldCheckboxGroupsMenu renders single checkbox group with search i
           value="1"
         />
         <label
-          class="govuk-label govuk-checkboxes__label"
+          class="govuk-label govuk-checkboxes__label label"
           for="test-1-1"
         >
           Option 1
@@ -241,7 +241,7 @@ exports[`FormFieldCheckboxGroupsMenu renders single checkbox group with search i
           value="2"
         />
         <label
-          class="govuk-label govuk-checkboxes__label"
+          class="govuk-label govuk-checkboxes__label label"
           for="test-1-2"
         >
           Option 2
@@ -281,7 +281,7 @@ exports[`FormFieldCheckboxGroupsMenu renders single checkbox group with single c
           value="1"
         />
         <label
-          class="govuk-label govuk-checkboxes__label"
+          class="govuk-label govuk-checkboxes__label label"
           for="test-1-1"
         >
           Option 1

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.module.scss
@@ -1,4 +1,23 @@
-.fhList {
-  margin: 0;
-  padding: 0;
+@import '~govuk-frontend/dist/govuk/base';
+
+.tier {
+  background: govuk-colour('light-grey');
+  padding: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.subTier {
+  position: relative;
+  margin-top: 3rem;
+
+  &::before {
+    content: '';
+    border-top: 1.2rem solid govuk-colour('blue');
+    border-left: 3rem solid transparent;
+    border-right: 3rem solid transparent;
+    left: 50%;
+    position: absolute;
+    top: -1.5rem;
+    transform: translate(-50%, -50%);
+  }
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.module.scss
@@ -2,22 +2,22 @@
 
 .tier {
   background: govuk-colour('light-grey');
-  padding: 0.5rem;
-  margin-bottom: 1.5rem;
+  padding: govuk-spacing(2);
+  margin-bottom: govuk-spacing(5);
 }
 
 .subTier {
   position: relative;
-  margin-top: 3rem;
+  margin-top: govuk-spacing(8);
 
   &::before {
     content: '';
-    border-top: 1.2rem solid govuk-colour('blue');
-    border-left: 3rem solid transparent;
-    border-right: 3rem solid transparent;
+    border-top: govuk-spacing(4) solid govuk-colour('blue');
+    border-left: govuk-spacing(8) solid transparent;
+    border-right: govuk-spacing(8) solid transparent;
     left: 50%;
     position: absolute;
-    top: -1.5rem;
+    top: govuk-spacing(-5);
     transform: translate(-50%, -50%);
   }
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.module.scss
@@ -1,0 +1,4 @@
+.fhList {
+  margin: 0;
+  padding: 0;
+}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
@@ -1,16 +1,19 @@
+import ButtonText from '@common/components/ButtonText';
 import DetailsMenu from '@common/components/DetailsMenu';
 import { FormFieldset } from '@common/components/form';
 import { useFormIdContext } from '@common/components/form/contexts/FormIdContext';
 import FormCheckboxSelectedCount from '@common/components/form/FormCheckboxSelectedCount';
+import Modal from '@common/components/Modal';
 import { SubjectMetaFilterHierarchy } from '@common/services/tableBuilderService';
+import classNames from 'classnames';
 import get from 'lodash/get';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
+import styles from './FilterHierarchy.module.scss';
 import FilterHierarchyOptions, {
   FilterHierarchyOption,
 } from './FilterHierarchyOptions';
 import { OptionLabelsMap } from './utils/getFilterHierarchyLabelsMap';
-import styles from './FilterHierarchy.module.scss';
 
 export interface FilterHierarchyProps {
   optionLabelsMap: OptionLabelsMap;
@@ -20,6 +23,144 @@ export interface FilterHierarchyProps {
   name: string;
   open?: boolean;
   onToggle?: (isOpen: boolean) => void;
+}
+
+function FilterHierarchy({
+  optionLabelsMap,
+  filterHierarchy,
+  id: customId,
+  name,
+  disabled,
+  open,
+  onToggle,
+}: FilterHierarchyProps) {
+  const tiersTotal = filterHierarchy.length + 1;
+
+  const filterLabels: string[] = [
+    ...filterHierarchy.map(({ filterId }) => optionLabelsMap[filterId ?? '']),
+    optionLabelsMap[filterHierarchy.at(-1)?.childFilterId ?? ''],
+  ].filter(label => label !== undefined);
+
+  const legend = filterLabels.at(-1) ?? '';
+
+  const rootOptionTrees = useMemo(
+    () => getRootOptionTrees(filterHierarchy, optionLabelsMap),
+    [filterHierarchy, optionLabelsMap],
+  );
+
+  const selectedValues = useWatch({ name });
+  const {
+    formState: { errors },
+  } = useFormContext();
+
+  const { fieldId } = useFormIdContext();
+  const id = fieldId(name);
+  const errorMessage = get(errors, name)?.message;
+
+  const [expandedOptionsList, setExpandedOptionsList] = useState<string[]>([]);
+  const toggleOptions = useCallback(
+    (optionId: string) => {
+      if (expandedOptionsList.includes(optionId)) {
+        return setExpandedOptionsList(
+          expandedOptionsList.filter(expandedId => expandedId !== optionId),
+        );
+      }
+      return setExpandedOptionsList([...expandedOptionsList, optionId]);
+    },
+    [setExpandedOptionsList, expandedOptionsList],
+  );
+
+  return (
+    <DetailsMenu
+      id={`details-${customId ?? id}`}
+      open={open}
+      jsRequired
+      preventToggle={!!errorMessage}
+      summary={`${legend}${tiersTotal > 1 ? ` (${tiersTotal} tiers)` : ''}`}
+      summaryAfter={<FormCheckboxSelectedCount name={name} />}
+      onToggle={onToggle}
+    >
+      <FormFieldset
+        id={name}
+        legend={`Search all tiers and ${legend.toLowerCase()}`}
+        legendSize="s"
+        useFormId
+        error={errorMessage?.toString()}
+      >
+        <Modal
+          title={`${legend} tiers`}
+          triggerButton={
+            <ButtonText>
+              What are {legend.toLocaleLowerCase()} tiers?
+            </ButtonText>
+          }
+          showClose
+          closeText="Close"
+        >
+          {filterLabels.map((filterLabel, index) => {
+            const isFirst = index === 0;
+            const isLast = index + 1 === filterLabels.length;
+
+            return (
+              <div
+                key={filterLabel}
+                className={classNames(styles.tier, {
+                  [styles.subTier]: !isFirst,
+                })}
+              >
+                <h3 className="govuk-heading-s">
+                  {filterLabel} (tier {index + 1})
+                </h3>
+                {isFirst && !isLast && (
+                  <>
+                    <p>This is a top level category.</p>
+                    <p>
+                      Selecting a tier 1 option provides a total value for all
+                      sub categories associated to this area
+                    </p>
+                  </>
+                )}
+                {!isFirst && !isLast && (
+                  <>
+                    <p>This is a sub category of tier {index}.</p>
+                    <p>
+                      Selected a tier {index + 1} option provides a total value
+                      for all {filterLabels[index + 1].toLowerCase()} options
+                      associated to this area
+                    </p>
+                  </>
+                )}
+                {isLast && (
+                  <>
+                    <p>These are the individual {filterLabel.toLowerCase()}</p>
+                    <p>
+                      If you're not sure about a specific{' '}
+                      {filterLabel.toLowerCase()} options, then you can also use
+                      the browse feature to find via related parent tiers
+                    </p>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </Modal>
+        {rootOptionTrees.map(optionTree => {
+          return (
+            <FilterHierarchyOptions
+              key={optionTree.value}
+              optionTree={optionTree}
+              name={name}
+              disabled={disabled}
+              selectedValues={selectedValues}
+              level={0}
+              toggleOptions={toggleOptions}
+              expandedOptionsList={expandedOptionsList}
+            />
+          );
+        })}
+      </FormFieldset>
+    </DetailsMenu>
+  );
 }
 
 function sortAlphabeticalTotalsFirst(a: string, b: string) {
@@ -81,89 +222,6 @@ function mapOptionTreesRecursively(
       option => tier === 0 || option.label.toLocaleLowerCase() !== 'total',
     )
     .sort((a, b) => sortAlphabeticalTotalsFirst(a.label, b.label));
-}
-
-function FilterHierarchy({
-  optionLabelsMap,
-  filterHierarchy,
-  id: customId,
-  name,
-  disabled,
-  open,
-  onToggle,
-}: FilterHierarchyProps) {
-  const tiersTotal = filterHierarchy.length + 1;
-
-  const filterLabels: string[] = [
-    ...filterHierarchy.map(({ filterId }) => optionLabelsMap[filterId ?? '']),
-    optionLabelsMap[filterHierarchy.at(-1)?.childFilterId ?? ''],
-  ].filter(label => label !== undefined);
-
-  const legend = filterLabels.at(-1) ?? '';
-
-  const rootOptionTrees = useMemo(
-    () => getRootOptionTrees(filterHierarchy, optionLabelsMap),
-    [filterHierarchy, optionLabelsMap],
-  );
-
-  const selectedValues = useWatch({ name });
-  const {
-    formState: { errors },
-  } = useFormContext();
-
-  const { fieldId } = useFormIdContext();
-  const id = fieldId(name);
-  const errorMessage = get(errors, name)?.message;
-
-  const [expandedOptionsList, setExpandedOptionsList] = useState<string[]>([]);
-  const toggleOptions = useCallback(
-    (optionId: string) => {
-      if (expandedOptionsList.includes(optionId)) {
-        return setExpandedOptionsList(
-          expandedOptionsList.filter(expandedId => expandedId !== optionId),
-        );
-      }
-      return setExpandedOptionsList([...expandedOptionsList, optionId]);
-    },
-    [setExpandedOptionsList, expandedOptionsList],
-  );
-
-  return (
-    <DetailsMenu
-      id={`details-${customId ?? id}`}
-      open={open}
-      jsRequired
-      preventToggle={!!errorMessage}
-      summary={`${legend}${tiersTotal > 1 ? ` (${tiersTotal} tiers)` : ''}`}
-      summaryAfter={<FormCheckboxSelectedCount name={name} />}
-      onToggle={onToggle}
-    >
-      <ul id={id} className={styles.fhList}>
-        <FormFieldset
-          id={name}
-          legend={`Search tiered options of ${legend.toLowerCase()}`}
-          legendSize="s"
-          useFormId
-          error={errorMessage?.toString()}
-        >
-          {rootOptionTrees.map(optionTree => {
-            return (
-              <FilterHierarchyOptions
-                key={optionTree.value}
-                optionTree={optionTree}
-                name={name}
-                disabled={disabled}
-                selectedValues={selectedValues}
-                level={0}
-                toggleOptions={toggleOptions}
-                expandedOptionsList={expandedOptionsList}
-              />
-            );
-          })}
-        </FormFieldset>
-      </ul>
-    </DetailsMenu>
-  );
 }
 
 export default memo(FilterHierarchy);

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
@@ -5,6 +5,7 @@ import { useFormIdContext } from '@common/components/form/contexts/FormIdContext
 import FormCheckboxSelectedCount from '@common/components/form/FormCheckboxSelectedCount';
 import Modal from '@common/components/Modal';
 import { SubjectMetaFilterHierarchy } from '@common/services/tableBuilderService';
+import sortAlphabeticalTotalsFirst from '@common/utils/sortAlphabeticalTotalsFirst';
 import classNames from 'classnames';
 import get from 'lodash/get';
 import React, { memo, useCallback, useMemo, useState } from 'react';
@@ -161,22 +162,6 @@ function FilterHierarchy({
       </FormFieldset>
     </DetailsMenu>
   );
-}
-
-function sortAlphabeticalTotalsFirst(a: string, b: string) {
-  if (a.toLocaleLowerCase() === 'total') {
-    return -1;
-  }
-  if (b.toLocaleLowerCase() === 'total') {
-    return 1;
-  }
-  if (a < b) {
-    return -1;
-  }
-  if (a > b) {
-    return 1;
-  }
-  return 0;
 }
 
 function getRootOptionTrees(

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.module.scss
@@ -1,0 +1,44 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.option {
+  display: block;
+  padding: 0.5rem 4px;
+
+  @include govuk-media-query($from: tablet) {
+    padding: 0.5rem !important;
+  }
+
+  &__expanded {
+    background: #f3f2f1;
+    margin-bottom: 1rem;
+  }
+}
+
+.detailsMenu {
+  margin-bottom: 0;
+
+  > summary {
+    margin-left: 44px;
+  }
+}
+
+.detailsMenu > div {
+  background: #fff !important;
+  box-shadow: inset 0 -3px 1px -1px #ccc;
+  padding: 0.5rem 0 0.5rem 4px !important;
+
+  @include govuk-media-query($from: tablet) {
+    box-shadow: none;
+    padding: 0.5rem !important;
+  }
+
+  > ul {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+.checkbox {
+  padding-left: 0.5rem;
+  padding-bottom: 0.5rem;
+}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.module.scss
@@ -5,11 +5,11 @@
   padding: 0.5rem 4px;
 
   @include govuk-media-query($from: tablet) {
-    padding: 0.5rem !important;
+    padding: 0.5rem;
   }
 
   &__expanded {
-    background: #f3f2f1;
+    background: govuk-colour('light-grey');
     margin-bottom: 1rem;
   }
 }
@@ -23,22 +23,25 @@
 }
 
 .detailsMenu > div {
-  background: #fff !important;
+  background: #fff;
   box-shadow: inset 0 -3px 1px -1px #ccc;
-  padding: 0.5rem 0 0.5rem 4px !important;
+  padding: 0.5rem 4px !important;
 
   @include govuk-media-query($from: tablet) {
     box-shadow: none;
-    padding: 0.5rem !important;
-  }
-
-  > ul {
-    margin: 0;
-    padding: 0;
+    padding: 1rem 0.5rem 1rem 2rem !important;
   }
 }
 
 .checkbox {
   padding-left: 0.5rem;
   padding-bottom: 0.5rem;
+}
+
+.search {
+  margin: 0.5rem;
+}
+
+.selectAllButton {
+  margin: 0.5rem;
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.module.scss
@@ -2,15 +2,15 @@
 
 .option {
   display: block;
-  padding: 0.5rem 4px;
+  padding: govuk-spacing(2) govuk-spacing(1);
 
   @include govuk-media-query($from: tablet) {
-    padding: 0.5rem;
+    padding: govuk-spacing(2);
   }
 
   &__expanded {
     background: govuk-colour('light-grey');
-    margin-bottom: 1rem;
+    margin-bottom: govuk-spacing(4);
   }
 }
 
@@ -25,23 +25,23 @@
 .detailsMenu > div {
   background: #fff;
   box-shadow: inset 0 -3px 1px -1px #ccc;
-  padding: 0.5rem 4px !important;
+  padding: govuk-spacing(2) govuk-spacing(1) !important;
 
   @include govuk-media-query($from: tablet) {
     box-shadow: none;
-    padding: 1rem 0.5rem 1rem 2rem !important;
+    padding: govuk-spacing(4) govuk-spacing(2) govuk-spacing(4) govuk-spacing(8) !important;
   }
 }
 
-.checkbox {
-  padding-left: 0.5rem;
-  padding-bottom: 0.5rem;
+.checkboxContainer {
+  padding-left: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
 }
 
 .search {
-  margin: 0.5rem;
+  margin: govuk-spacing(2);
 }
 
 .selectAllButton {
-  margin: 0.5rem;
+  margin: govuk-spacing(2);
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.tsx
@@ -1,7 +1,7 @@
 import ButtonText from '@common/components/ButtonText';
 import DetailsMenu from '@common/components/DetailsMenu';
 import { FormCheckbox, FormTextSearchInput } from '@common/components/form';
-import FormField from '@common/components/form/FormField';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 import classNames from 'classnames';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
@@ -55,7 +55,8 @@ function FilterHierarchyOptions({
   }, [selectedValues, filteredOptions]);
 
   const isExpanded = expandedOptionsList.includes(optionTree.value);
-  const { setValue } = useFormContext();
+  const { setValue, register } = useFormContext();
+  const { ref: inputRef, ...field } = register(name);
 
   const toggleSelectAll = useCallback(() => {
     if (hasAllSelected) {
@@ -83,17 +84,17 @@ function FilterHierarchyOptions({
         },
       )}
     >
-      <div className={styles.checkbox}>
-        <FormField
-          hint={optionTree.filterLabel}
-          label={optionTree.label}
+      <div className={styles.checkboxContainer}>
+        <FormCheckbox
+          {...field}
+          inputRef={inputRef}
+          key={optionTree.label}
           id={`${name}-${optionTree.value}`}
-          // @ts-expect-error  `value` required to make checkboxes unique
+          label={optionTree.label}
           value={optionTree.value}
-          name={name}
-          as={FormCheckbox}
-          checked={selectedValues.includes(optionTree.value)}
+          hint={optionTree.filterLabel}
           disabled={disabled}
+          checked={selectedValues.includes(optionTree.value)}
         />
       </div>
       {!!optionTree.options?.length && (
@@ -101,52 +102,56 @@ function FilterHierarchyOptions({
           summary={`${
             isExpanded ? 'Close' : 'Show'
           } ${optionTree.childFilterLabel?.toLocaleLowerCase()}`}
+          hiddenText={`options for ${optionTree.label.toLocaleLowerCase()}`}
           open={isExpanded}
           onToggle={() => toggleOptions(optionTree.value)}
           className={styles.detailsMenu}
         >
-          <div>
-            {optionTree.options.length > 6 && (
-              <div className={styles.search}>
-                <FormTextSearchInput
-                  id={`${name}-search`}
-                  name={`${name}-search`}
-                  label={`Search ${
-                    optionTree.label
-                  } (${optionTree.childFilterLabel?.toLocaleLowerCase()})`}
-                  width={20}
-                  onChange={event => setSearchTerm(event.target.value)}
-                  onKeyPress={event => {
-                    if (event.key === 'Enter') {
-                      event.preventDefault();
-                    }
-                  }}
-                />
-              </div>
-            )}
-            <div>
-              {filteredOptions.length > 1 && (
-                <ButtonText
-                  className={styles.selectAllButton}
-                  onClick={toggleSelectAll}
-                >
-                  {hasAllSelected ? 'Unselect' : 'Select'} all{' '}
-                  {filteredOptions.length} options
-                </ButtonText>
-              )}
-              {filteredOptions?.map(childOptionTree => (
-                <FilterHierarchyOptions
-                  toggleOptions={toggleOptions}
-                  expandedOptionsList={expandedOptionsList}
-                  optionTree={childOptionTree}
-                  key={childOptionTree.value}
-                  name={name}
-                  disabled={disabled}
-                  selectedValues={selectedValues}
-                  level={level + 1}
-                />
-              ))}
+          {optionTree.options.length > 6 && (
+            <div className={styles.search}>
+              <FormTextSearchInput
+                id={`${name}-search`}
+                name={`${name}-search`}
+                label={`Search ${
+                  optionTree.label
+                } (${optionTree.childFilterLabel?.toLocaleLowerCase()})`}
+                width={20}
+                onChange={event => setSearchTerm(event.target.value)}
+                onKeyPress={event => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                  }
+                }}
+              />
             </div>
+          )}
+          <div>
+            {filteredOptions.length > 1 && (
+              <ButtonText
+                className={styles.selectAllButton}
+                onClick={toggleSelectAll}
+              >
+                {hasAllSelected ? 'Unselect' : 'Select'} all{' '}
+                {filteredOptions.length} <span aria-hidden>options</span>
+                <VisuallyHidden>
+                  {' '}
+                  {optionTree.childFilterLabel!.toLowerCase()} options for{' '}
+                  {optionTree.label.toLocaleLowerCase()}
+                </VisuallyHidden>
+              </ButtonText>
+            )}
+            {filteredOptions?.map(childOptionTree => (
+              <FilterHierarchyOptions
+                toggleOptions={toggleOptions}
+                expandedOptionsList={expandedOptionsList}
+                optionTree={childOptionTree}
+                key={childOptionTree.value}
+                name={name}
+                disabled={disabled}
+                selectedValues={selectedValues}
+                level={level + 1}
+              />
+            ))}
           </div>
         </DetailsMenu>
       )}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -78,7 +78,7 @@ export default function FiltersForm({
   showTableQueryErrorDownload = true,
   onSubmit,
   onTableQueryError,
-  hideFilterHierarchies = true, // hierarchies feature flag
+  hideFilterHierarchies = false, // hierarchies feature flag
   ...stepProps
 }: Props) {
   const { goToNextStep, isActive } = stepProps;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -286,12 +286,11 @@ export default function FiltersForm({
       initialValues={initialFormValues}
       validationSchema={validationSchema}
     >
-      {({ formState, getValues, reset, setValue, watch }) => {
+      {({ formState, getValues, reset, setValue }) => {
         const { getError } = createErrorHelper({
           errors: formState.errors,
           touchedFields: formState.touchedFields,
         });
-        const values = watch();
 
         if (isActive) {
           return (
@@ -455,7 +454,7 @@ export default function FiltersForm({
             </Form>
           );
         }
-        // const values = getValues();
+        const values = getValues();
 
         return (
           <WizardStepSummary {...stepProps} goToButtonText="Edit filters">

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -307,34 +307,38 @@ export default function FiltersForm({
 
               {stepHeading}
 
-              <FormFieldCheckboxSearchSubGroups
-                disabled={formState.isSubmitting}
-                groupLabel="Indicators"
-                hint="Select at least one indicator below"
-                legend={
-                  <>
-                    Indicators
-                    <FormCheckboxSelectedCount name="indicators" />
-                  </>
-                }
-                legendSize="m"
-                name="indicators"
-                options={orderedIndicators.map(group => ({
-                  legend: group.label,
-                  options: group.options,
-                }))}
-                order={[]}
-              />
+              <div className="govuk-grid-row">
+                <div className="govuk-grid-column govuk-!-margin-bottom-6">
+                  <FormFieldCheckboxSearchSubGroups
+                    disabled={formState.isSubmitting}
+                    groupLabel="Indicators"
+                    hint="Select at least one indicator below"
+                    legend={
+                      <>
+                        Indicators
+                        <FormCheckboxSelectedCount name="indicators" />
+                      </>
+                    }
+                    legendSize="m"
+                    name="indicators"
+                    options={orderedIndicators.map(group => ({
+                      legend: group.label,
+                      options: group.options,
+                    }))}
+                    order={[]}
+                  />
 
-              {standardFilters.length + hierarchiedFilterIds.length > 0 && (
-                <FormFieldset
-                  error={getError('filters') ?? getError('filterHierarchies')}
-                  hint={
-                    <div className="dfe-flex dfe-justify-content--space-between dfe-flex-wrap dfe-align-items-start">
-                      <span
-                        className={`govuk-!-margin-bottom-2 ${styles.hintText}`}
-                      >
-                        {`Select at least one option from all categories.
+                  {standardFilters.length + hierarchiedFilterIds.length > 0 && (
+                    <FormFieldset
+                      error={
+                        getError('filters') ?? getError('filterHierarchies')
+                      }
+                      hint={
+                        <div className="dfe-flex dfe-justify-content--space-between dfe-flex-wrap dfe-align-items-start">
+                          <span
+                            className={`govuk-!-margin-bottom-2 ${styles.hintText}`}
+                          >
+                            {`Select at least one option from all categories.
                             ${
                               filtersIncludeTotal
                                 ? ` If no options are selected from a category then
@@ -344,82 +348,86 @@ export default function FiltersForm({
                                 other options within a category.`
                                 : ''
                             }`}
-                      </span>
-                      {standardFilters.length > 1 && (
-                        <ButtonText
-                          ariaExpanded={allFiltersOpen}
-                          ariaControls="filterGroups"
-                          className="govuk-!-margin-bottom-2"
-                          onClick={() => {
-                            setOpenFilterGroups(
-                              allFiltersOpen ? [] : allFilterGroupKeys,
-                            );
-                          }}
-                        >
-                          {allFiltersOpen ? 'Collapse all' : 'Expand all'}
-                          <VisuallyHidden> categories</VisuallyHidden>
-                        </ButtonText>
-                      )}
-                    </div>
-                  }
-                  id="filters"
-                  legend="Categories"
-                  legendSize="m"
-                >
-                  {filterHierarchies.map(filterHierarchy => {
-                    if (filterHierarchy.length === 0) return null;
+                          </span>
+                          {standardFilters.length > 1 && (
+                            <ButtonText
+                              ariaExpanded={allFiltersOpen}
+                              ariaControls="filterGroups"
+                              className="govuk-!-margin-bottom-2"
+                              onClick={() => {
+                                setOpenFilterGroups(
+                                  allFiltersOpen ? [] : allFilterGroupKeys,
+                                );
+                              }}
+                            >
+                              {allFiltersOpen ? 'Collapse all' : 'Expand all'}
+                              <VisuallyHidden> categories</VisuallyHidden>
+                            </ButtonText>
+                          )}
+                        </div>
+                      }
+                      id="filters"
+                      legend="Categories"
+                      legendSize="m"
+                    >
+                      {filterHierarchies.map(filterHierarchy => {
+                        if (filterHierarchy.length === 0) return null;
 
-                    const hierarchyName = `filterHierarchies.${camelCase(
-                      optionLabelsMap[
-                        filterHierarchy.at(-1)?.childFilterId ?? ''
-                      ],
-                    )}`;
+                        const hierarchyName = `filterHierarchies.${camelCase(
+                          optionLabelsMap[
+                            filterHierarchy.at(-1)?.childFilterId ?? ''
+                          ],
+                        )}`;
 
-                    return (
-                      <FilterHierarchy
-                        filterHierarchy={filterHierarchy}
-                        optionLabelsMap={optionLabelsMap}
-                        disabled={formState.isSubmitting}
-                        key={hierarchyName}
-                        name={hierarchyName}
-                      />
-                    );
-                  })}
-                  <div id="filterGroups">
-                    {standardFilters.map(([filterKey, filterGroup]) => {
-                      const filterName = `filters.${filterKey}`;
-                      const orderedFilterGroupOptions = orderBy(
-                        Object.values(filterGroup.options),
-                        'order',
-                      );
+                        return (
+                          <FilterHierarchy
+                            filterHierarchy={filterHierarchy}
+                            optionLabelsMap={optionLabelsMap}
+                            disabled={formState.isSubmitting}
+                            key={hierarchyName}
+                            name={hierarchyName}
+                          />
+                        );
+                      })}
+                      <div id="filterGroups">
+                        {standardFilters.map(([filterKey, filterGroup]) => {
+                          const filterName = `filters.${filterKey}`;
+                          const orderedFilterGroupOptions = orderBy(
+                            Object.values(filterGroup.options),
+                            'order',
+                          );
 
-                      return (
-                        <FormFieldCheckboxGroupsMenu
-                          disabled={formState.isSubmitting}
-                          groupLabel={filterGroup.legend}
-                          hint={filterGroup.hint}
-                          key={filterKey}
-                          legend={filterGroup.legend}
-                          name={filterName}
-                          open={openFilterGroups.includes(filterKey)}
-                          options={orderedFilterGroupOptions.map(group => ({
-                            legend: group.label,
-                            options: group.options,
-                          }))}
-                          order={[]}
-                          onToggle={isOpen => {
-                            setOpenFilterGroups(groups =>
-                              isOpen
-                                ? [...groups, filterKey]
-                                : groups.filter(group => group !== filterKey),
-                            );
-                          }}
-                        />
-                      );
-                    })}
-                  </div>
-                </FormFieldset>
-              )}
+                          return (
+                            <FormFieldCheckboxGroupsMenu
+                              disabled={formState.isSubmitting}
+                              groupLabel={filterGroup.legend}
+                              hint={filterGroup.hint}
+                              key={filterKey}
+                              legend={filterGroup.legend}
+                              name={filterName}
+                              open={openFilterGroups.includes(filterKey)}
+                              options={orderedFilterGroupOptions.map(group => ({
+                                legend: group.label,
+                                options: group.options,
+                              }))}
+                              order={[]}
+                              onToggle={isOpen => {
+                                setOpenFilterGroups(groups =>
+                                  isOpen
+                                    ? [...groups, filterKey]
+                                    : groups.filter(
+                                        group => group !== filterKey,
+                                      ),
+                                );
+                              }}
+                            />
+                          );
+                        })}
+                      </div>
+                    </FormFieldset>
+                  )}
+                </div>
+              </div>
 
               <WizardStepFormActions
                 {...stepProps}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -66,7 +66,7 @@ interface Props extends InjectedWizardProps {
     publicationTitle: string,
     subjectName: string,
   ) => void;
-  hideFilterHierarchies?: boolean;
+  showFilterHierarchies?: boolean;
 }
 
 export default function FiltersForm({
@@ -78,7 +78,7 @@ export default function FiltersForm({
   showTableQueryErrorDownload = true,
   onSubmit,
   onTableQueryError,
-  hideFilterHierarchies = false, // hierarchies feature flag
+  showFilterHierarchies = false, // hierarchies feature flag
   ...stepProps
 }: Props) {
   const { goToNextStep, isActive } = stepProps;
@@ -88,14 +88,14 @@ export default function FiltersForm({
   const [openFilterGroups, setOpenFilterGroups] = useState<string[]>([]);
 
   const filterHierarchies = useMemo(() => {
-    if (hideFilterHierarchies) {
+    if (!showFilterHierarchies) {
       return [];
     }
     return subjectMeta.filterHierarchies ?? [];
-  }, [subjectMeta, hideFilterHierarchies]);
+  }, [subjectMeta, showFilterHierarchies]);
 
   const hierarchiedFilterIds = useMemo(() => {
-    if (hideFilterHierarchies) return [];
+    if (!showFilterHierarchies) return [];
 
     return (
       filterHierarchies.flatMap(hierarchy => {
@@ -105,7 +105,7 @@ export default function FiltersForm({
         ];
       }) ?? []
     );
-  }, [filterHierarchies, hideFilterHierarchies]);
+  }, [filterHierarchies, showFilterHierarchies]);
 
   const standardFilters = useMemo(() => {
     return orderBy(

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -307,38 +307,34 @@ export default function FiltersForm({
 
               {stepHeading}
 
-              <div className="govuk-grid-row">
-                <div className="govuk-grid-column govuk-!-margin-bottom-6">
-                  <FormFieldCheckboxSearchSubGroups
-                    disabled={formState.isSubmitting}
-                    groupLabel="Indicators"
-                    hint="Select at least one indicator below"
-                    legend={
-                      <>
-                        Indicators
-                        <FormCheckboxSelectedCount name="indicators" />
-                      </>
-                    }
-                    legendSize="m"
-                    name="indicators"
-                    options={orderedIndicators.map(group => ({
-                      legend: group.label,
-                      options: group.options,
-                    }))}
-                    order={[]}
-                  />
+              <FormFieldCheckboxSearchSubGroups
+                disabled={formState.isSubmitting}
+                groupLabel="Indicators"
+                hint="Select at least one indicator below"
+                legend={
+                  <>
+                    Indicators
+                    <FormCheckboxSelectedCount name="indicators" />
+                  </>
+                }
+                legendSize="m"
+                name="indicators"
+                options={orderedIndicators.map(group => ({
+                  legend: group.label,
+                  options: group.options,
+                }))}
+                order={[]}
+              />
 
-                  {standardFilters.length + hierarchiedFilterIds.length > 0 && (
-                    <FormFieldset
-                      error={
-                        getError('filters') ?? getError('filterHierarchies')
-                      }
-                      hint={
-                        <div className="dfe-flex dfe-justify-content--space-between dfe-flex-wrap dfe-align-items-start">
-                          <span
-                            className={`govuk-!-margin-bottom-2 ${styles.hintText}`}
-                          >
-                            {`Select at least one option from all categories.
+              {standardFilters.length + hierarchiedFilterIds.length > 0 && (
+                <FormFieldset
+                  error={getError('filters') ?? getError('filterHierarchies')}
+                  hint={
+                    <div className="dfe-flex dfe-justify-content--space-between dfe-flex-wrap dfe-align-items-start">
+                      <span
+                        className={`govuk-!-margin-bottom-2 ${styles.hintText}`}
+                      >
+                        {`Select at least one option from all categories.
                             ${
                               filtersIncludeTotal
                                 ? ` If no options are selected from a category then
@@ -348,86 +344,82 @@ export default function FiltersForm({
                                 other options within a category.`
                                 : ''
                             }`}
-                          </span>
-                          {standardFilters.length > 1 && (
-                            <ButtonText
-                              ariaExpanded={allFiltersOpen}
-                              ariaControls="filterGroups"
-                              className="govuk-!-margin-bottom-2"
-                              onClick={() => {
-                                setOpenFilterGroups(
-                                  allFiltersOpen ? [] : allFilterGroupKeys,
-                                );
-                              }}
-                            >
-                              {allFiltersOpen ? 'Collapse all' : 'Expand all'}
-                              <VisuallyHidden> categories</VisuallyHidden>
-                            </ButtonText>
-                          )}
-                        </div>
-                      }
-                      id="filters"
-                      legend="Categories"
-                      legendSize="m"
-                    >
-                      {filterHierarchies.map(filterHierarchy => {
-                        if (filterHierarchy.length === 0) return null;
+                      </span>
+                      {standardFilters.length > 1 && (
+                        <ButtonText
+                          ariaExpanded={allFiltersOpen}
+                          ariaControls="filterGroups"
+                          className="govuk-!-margin-bottom-2"
+                          onClick={() => {
+                            setOpenFilterGroups(
+                              allFiltersOpen ? [] : allFilterGroupKeys,
+                            );
+                          }}
+                        >
+                          {allFiltersOpen ? 'Collapse all' : 'Expand all'}
+                          <VisuallyHidden> categories</VisuallyHidden>
+                        </ButtonText>
+                      )}
+                    </div>
+                  }
+                  id="filters"
+                  legend="Categories"
+                  legendSize="m"
+                >
+                  {filterHierarchies.map(filterHierarchy => {
+                    if (filterHierarchy.length === 0) return null;
 
-                        const hierarchyName = `filterHierarchies.${camelCase(
-                          optionLabelsMap[
-                            filterHierarchy.at(-1)?.childFilterId ?? ''
-                          ],
-                        )}`;
+                    const hierarchyName = `filterHierarchies.${camelCase(
+                      optionLabelsMap[
+                        filterHierarchy.at(-1)?.childFilterId ?? ''
+                      ],
+                    )}`;
 
-                        return (
-                          <FilterHierarchy
-                            filterHierarchy={filterHierarchy}
-                            optionLabelsMap={optionLabelsMap}
-                            disabled={formState.isSubmitting}
-                            key={hierarchyName}
-                            name={hierarchyName}
-                          />
-                        );
-                      })}
-                      <div id="filterGroups">
-                        {standardFilters.map(([filterKey, filterGroup]) => {
-                          const filterName = `filters.${filterKey}`;
-                          const orderedFilterGroupOptions = orderBy(
-                            Object.values(filterGroup.options),
-                            'order',
-                          );
+                    return (
+                      <FilterHierarchy
+                        filterHierarchy={filterHierarchy}
+                        optionLabelsMap={optionLabelsMap}
+                        disabled={formState.isSubmitting}
+                        key={hierarchyName}
+                        name={hierarchyName}
+                      />
+                    );
+                  })}
+                  <div id="filterGroups">
+                    {standardFilters.map(([filterKey, filterGroup]) => {
+                      const filterName = `filters.${filterKey}`;
+                      const orderedFilterGroupOptions = orderBy(
+                        Object.values(filterGroup.options),
+                        'order',
+                      );
 
-                          return (
-                            <FormFieldCheckboxGroupsMenu
-                              disabled={formState.isSubmitting}
-                              groupLabel={filterGroup.legend}
-                              hint={filterGroup.hint}
-                              key={filterKey}
-                              legend={filterGroup.legend}
-                              name={filterName}
-                              open={openFilterGroups.includes(filterKey)}
-                              options={orderedFilterGroupOptions.map(group => ({
-                                legend: group.label,
-                                options: group.options,
-                              }))}
-                              order={[]}
-                              onToggle={isOpen => {
-                                setOpenFilterGroups(groups =>
-                                  isOpen
-                                    ? [...groups, filterKey]
-                                    : groups.filter(
-                                        group => group !== filterKey,
-                                      ),
-                                );
-                              }}
-                            />
-                          );
-                        })}
-                      </div>
-                    </FormFieldset>
-                  )}
-                </div>
-              </div>
+                      return (
+                        <FormFieldCheckboxGroupsMenu
+                          disabled={formState.isSubmitting}
+                          groupLabel={filterGroup.legend}
+                          hint={filterGroup.hint}
+                          key={filterKey}
+                          legend={filterGroup.legend}
+                          name={filterName}
+                          open={openFilterGroups.includes(filterKey)}
+                          options={orderedFilterGroupOptions.map(group => ({
+                            legend: group.label,
+                            options: group.options,
+                          }))}
+                          order={[]}
+                          onToggle={isOpen => {
+                            setOpenFilterGroups(groups =>
+                              isOpen
+                                ? [...groups, filterKey]
+                                : groups.filter(group => group !== filterKey),
+                            );
+                          }}
+                        />
+                      );
+                    })}
+                  </div>
+                </FormFieldset>
+              )}
 
               <WizardStepFormActions
                 {...stepProps}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -307,7 +307,7 @@ export default function FiltersForm({
 
               {stepHeading}
 
-              <div className="govuk-grid-row">
+              <div>
                 <div className="govuk-grid-column govuk-!-margin-bottom-6">
                   <FormFieldCheckboxSearchSubGroups
                     disabled={formState.isSubmitting}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -612,7 +612,7 @@ export default function TableToolWizard({
                   showTableQueryErrorDownload={showTableQueryErrorDownload}
                   onTableQueryError={onTableQueryError}
                   onSubmit={handleFiltersFormSubmit}
-                  hideFilterHierarchies={!showFilterHierachies}
+                  showFilterHierarchies={showFilterHierachies}
                 />
               )}
             </WizardStep>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -109,6 +109,7 @@ export interface TableToolWizardProps {
     publicationTitle: string,
     subjectName: string,
   ) => void;
+  showFilterHierachies?: boolean;
 }
 
 export default function TableToolWizard({
@@ -129,6 +130,7 @@ export default function TableToolWizard({
   onSubjectStepBack,
   onSubmit,
   onTableQueryError,
+  showFilterHierachies,
 }: TableToolWizardProps) {
   const [state, updateState] = useImmer<TableToolState>({
     initialStep: 1,
@@ -610,6 +612,7 @@ export default function TableToolWizard({
                   showTableQueryErrorDownload={showTableQueryErrorDownload}
                   onTableQueryError={onTableQueryError}
                   onSubmit={handleFiltersFormSubmit}
+                  hideFilterHierarchies={!showFilterHierachies}
                 />
               )}
             </WizardStep>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -48,6 +48,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
   themeMeta,
 }) => {
   const router = useRouter();
+  const showFilterHierachies = !!router.query.fh;
   const [loadingFastTrack, setLoadingFastTrack] = useState(false);
   const [currentStep, setCurrentStep] = useState<number | undefined>(undefined);
   const [pageTitle, setPageTitle] = useState<string>(defaultPageTitle);
@@ -160,6 +161,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
       </p>
 
       <TableToolWizard
+        showFilterHierachies={showFilterHierachies}
         key={fastTrack?.id}
         scrollOnMount
         themeMeta={themeMeta}


### PR DESCRIPTION
Takes the Filter Hierarchy work further with UI layout bells & whistles.
Notable changes:
- includes feature flag search param `fh` appending `?subjectId=....&fh=true` will show filter hierarchies (when hierarchied data is used in the table tool)
- UI dropdowns & modal with associated styling
- Sub category tier level search for tiers with 7 or more options to filter long option lists
- Refactor / reverted option render method to go for a option tree generation first approach to cater for upcoming search (option tree filtering) functionality


![image](https://github.com/user-attachments/assets/3be70041-64fe-4eb9-aa8e-e9c041bcf9b9)
![image](https://github.com/user-attachments/assets/5b96b20c-548e-450a-b872-f60971058488)
