### PR TITLE
EES-5955 - On publication latest published release version changed function

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationLatestPublishedReleaseVersionChanged/OnPublicationLatestPublishedReleaseVersionChangedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationLatestPublishedReleaseVersionChanged/OnPublicationLatestPublishedReleaseVersionChangedFunctionTests.cs
@@ -1,0 +1,68 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationChanged.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationLatestPublishedReleaseVersionChanged;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationLatestPublishedReleaseVersionChanged.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.OnPublicationLatestPublishedReleaseVersionChanged;
+
+public class OnPublicationLatestPublishedReleaseVersionChangedFunctionTests
+{
+    private OnPublicationLatestPublishedReleaseVersionChangedFunction GetSut() => new(new EventGridEventHandler(new NullLogger<EventGridEventHandler>()));
+
+    [Fact]
+    public void Can_instantiate_Sut() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task GivenEvent_WhenPayloadContainsSlug_ThenRefreshSearchableDocumentMessageDtoReturned()
+    {
+        // ARRANGE
+        var payload = new PublicationLatestPublishedReleaseVersionChangedEventDto
+        {
+            Slug = "this-is-a-publication-slug",
+        };
+
+        var eventGridEvent = new EventGridEventBuilder()
+            .WithPayload(payload)
+            .Build();
+
+        var sut = GetSut();
+        
+        // ACT
+        var response = await sut.OnPublicationLatestPublishedReleaseVersionChanged(
+            eventGridEvent, 
+            new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        var actual = Assert.Single(response);
+        Assert.NotNull(actual);
+        Assert.Equal(payload.Slug, actual.PublicationSlug);
+    }
+    
+    [Theory]
+    [InlineData((string?)null)]
+    [InlineData("")]
+    public async Task GivenEvent_WhenPayloadDoesNotContainSlug_ThenNothingIsReturned(string? blankSlug)
+    {
+        // ARRANGE
+        var payload = new PublicationLatestPublishedReleaseVersionChangedEventDto
+        {
+            Slug = blankSlug,
+        };
+
+        var eventGridEvent = new EventGridEventBuilder()
+            .WithPayload(payload)
+            .Build();
+
+        var sut = GetSut();
+        
+        // ACT
+        var response = await sut.OnPublicationLatestPublishedReleaseVersionChanged(
+            eventGridEvent, 
+            new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        Assert.Empty(response);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationLatestPublishedReleaseVersionChanged/Dtos/PublicationLatestPublishedReleaseVersionChangedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationLatestPublishedReleaseVersionChanged/Dtos/PublicationLatestPublishedReleaseVersionChangedEventDto.cs
@@ -1,0 +1,9 @@
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationLatestPublishedReleaseVersionChanged.Dtos;
+
+public class PublicationLatestPublishedReleaseVersionChangedEventDto
+{
+    public string? Title { get; init; }
+    public string? Slug { get; init; }
+    public Guid? LatestPublishedReleaseVersionId { get; init; }
+    public Guid? PreviousReleaseVersionId { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationLatestPublishedReleaseVersionChanged/OnPublicationLatestPublishedReleaseVersionChangedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationLatestPublishedReleaseVersionChanged/OnPublicationLatestPublishedReleaseVersionChangedFunction.cs
@@ -1,0 +1,25 @@
+using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationLatestPublishedReleaseVersionChanged.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RefreshSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationLatestPublishedReleaseVersionChanged;
+
+public class OnPublicationLatestPublishedReleaseVersionChangedFunction(IEventGridEventHandler eventGridEventHandler)
+{
+    [Function(nameof(OnPublicationChanged))]
+    [QueueOutput("%RefreshSearchableDocumentQueueName%")]
+    public async Task<RefreshSearchableDocumentMessageDto[]> OnPublicationLatestPublishedReleaseVersionChanged(
+        [QueueTrigger("%PublicationLatestPublishedReleaseVersionChangedQueueName%")]
+        EventGridEvent eventDto,
+        FunctionContext context) =>
+        await eventGridEventHandler.Handle<PublicationLatestPublishedReleaseVersionChangedEventDto, RefreshSearchableDocumentMessageDto[]>(
+            context, 
+            eventDto,
+            (payload, ct) => 
+                Task.FromResult<RefreshSearchableDocumentMessageDto[]>(
+                    string.IsNullOrEmpty(payload.Slug)
+                        ? []
+                        : [ new RefreshSearchableDocumentMessageDto { PublicationSlug = payload.Slug } ]));
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationLatestPublishedReleaseVersionChanged/OnPublicationLatestPublishedReleaseVersionChangedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationLatestPublishedReleaseVersionChanged/OnPublicationLatestPublishedReleaseVersionChangedFunction.cs
@@ -8,7 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 
 public class OnPublicationLatestPublishedReleaseVersionChangedFunction(IEventGridEventHandler eventGridEventHandler)
 {
-    [Function(nameof(OnPublicationChanged))]
+    [Function(nameof(OnPublicationLatestPublishedReleaseVersionChanged))]
     [QueueOutput("%RefreshSearchableDocumentQueueName%")]
     public async Task<RefreshSearchableDocumentMessageDto[]> OnPublicationLatestPublishedReleaseVersionChanged(
         [QueueTrigger("%PublicationLatestPublishedReleaseVersionChangedQueueName%")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/local.settings.json
@@ -4,6 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://data-storage",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "PublicationChangedQueueName": "publication-changed-queue",
+    "PublicationLatestPublishedReleaseVersionChangedQueueName" : "publication-latest-published-release-version-changed-queue",
     "RefreshSearchableDocumentQueueName": "refresh-searchable-document-queue",
     "ReleaseSlugChangedQueueName": "release-slug-changed-queue",
     "ReleaseVersionPublishedQueueName": "release-version-published-queue",


### PR DESCRIPTION
Another event being raised by the admin system to catch. This time, the event is for when the latest published release version has changed for a publication.