### PR TITLE
EES-6021 Search infrastructure Bicep deployments are failing caused by bug in Azure CLI

### DIFF
--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -25,14 +25,6 @@ jobs:
             - script: az upgrade --yes
               displayName: Upgrade Azure CLI and extensions
 
-            - task: AzureCLI@2
-              displayName: Install Bicep
-              inputs:
-                azureSubscription: ${{ parameters.serviceConnection }}
-                scriptType: bash
-                scriptLocation: inlineScript
-                inlineScript: az bicep install
-
             - template: ../tasks/deploy-bicep.yml
               parameters:
                 displayName: Validate Bicep template

--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -22,6 +22,9 @@ jobs:
             - checkout: self
             - download: none
 
+            - script: az upgrade --yes
+              displayName: Upgrade Azure CLI and extensions
+
             - task: AzureCLI@2
               displayName: Install Bicep
               inputs:

--- a/infrastructure/templates/search/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/search/ci/tasks/deploy-bicep.yml
@@ -32,6 +32,10 @@ steps:
       inlineScript: |
         set -e
 
+        # Workaround for AZ CLI 2.71.x breaks bicep deployments when using Azure Devops Agent
+        # See https://github.com/Azure/azure-cli/issues/31189
+        az config set bicep.use_binary_from_path=false
+
         az deployment group ${{ parameters.action }} \
           --name $(infraDeployName) \
           --resource-group $(resourceGroupName) \


### PR DESCRIPTION
This PR adds a temporary workaround to stop Bicep deployments failing due to a bug in Azure CLI 2.71.0.

The error when starting the Bicep deployment is

```
No such file or directory: '/home/vsts/work/_temp/.azclitask/bin/bicep'
```

Between 08/04/25 and 09/04/25 version 2.71.0 with the bug appears to have rolled out gradually across all agents and now it's blocking all of our infrastructure deployments. We can see the last successful run of the Bicep deployment on 08/04/25 used Azure CLI 2.70.0.

It's likely that we will have to apply the same workaround to our other infrastructure pipelines if this is not resolved quickly.

**2.71.0**:
![image (1)](https://github.com/user-attachments/assets/56b31a84-bae5-459e-95bf-78cc4b5737f4)

**2.70.0**:
![image (3)](https://github.com/user-attachments/assets/1ad02a34-36ea-43fa-a9eb-45ba2cf52d03)

## Other changes

- Add step to Upgrade Azure CLI and extensions
- Remove unnecessary 'az bicep install' command