### PR TITLE
EES-5973 Infrastructure changes for Publisher related to EES-5908

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1244,6 +1244,7 @@
     "publicDataStorageAccountName": "[concat(parameters('subscription'), 'eespapisa')]",
     "eventGridTopicNamePublicationChanged": "[concat(parameters('subscription'), '-', parameters('environment'), '-evgt-publication-changed')]",
     "eventGridTopicNameReleaseChanged": "[concat(parameters('subscription'), '-', parameters('environment'), '-evgt-release-changed')]",
+    "eventGridTopicNameReleaseVersionChanged": "[concat(parameters('subscription'), '-', parameters('environment'), '-evgt-release-version-changed')]",
     "eventGridTopicNameThemeChanged": "[concat(parameters('subscription'), '-', parameters('environment'), '-evgt-theme-changed')]"
   },
   "resources": [
@@ -3378,7 +3379,7 @@
         "App__PublisherStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher')).secretUriWithVersion, ')')]",
         "DataFiles__BasePath": "[variables('publicDataFileShareMountPathWindows')]",
         "EventGrid__EventTopics__0__Key": "ReleaseVersionChangedEvent",
-        "EventGrid__EventTopics__0__TopicEndpoint": "",
+        "EventGrid__EventTopics__0__TopicEndpoint": "[if(parameters('eventGridTopicsExist'), reference(resourceId('Microsoft.EventGrid/topics', variables('eventGridTopicNameReleaseVersionChanged')), '2025-02-15').endpoint, '')]",
         "PublicDataDbExists": "[parameters('publicDataDbExists')]"
       }
     },

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -3377,6 +3377,8 @@
         "App__PublicStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-public')).secretUriWithVersion, ')')]",
         "App__PublisherStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher')).secretUriWithVersion, ')')]",
         "DataFiles__BasePath": "[variables('publicDataFileShareMountPathWindows')]",
+        "EventGrid__EventTopics__0__Key": "ReleaseVersionChangedEvent",
+        "EventGrid__EventTopics__0__TopicEndpoint": "",
         "PublicDataDbExists": "[parameters('publicDataDbExists')]"
       }
     },


### PR DESCRIPTION
This PR makes an infrastructure change to the Publisher function app settings to support changes made to it in EES-5908 by #5694 and #5754. These added the ability to publish events to an Event Grid custom topic.

This PR adds the following app settings:
- `EventGrid__EventTopics__0__Key` - `ReleaseVersionChangedEvent`
- `EventGrid__EventTopics__0__TopicEndpoint` - `<Event Grid custom topic endpoint>`

The endpoint value references the endpoint of the `s101[d|t|p][01|02]-ees-evgt-release-version-changed` topic resource. It is set conditionally depending on whether the topic exists, since it is not deployed to all environments yet.