### PR TITLE
EES-5952 Add infrastructure for Event Grid topic subscriptions

### DIFF
--- a/infrastructure/templates/common/components/event-grid/eventGridCustomTopic.bicep
+++ b/infrastructure/templates/common/components/event-grid/eventGridCustomTopic.bicep
@@ -30,7 +30,9 @@ param userAssignedIdentityName string = ''
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object
 
-var identityType = systemAssignedIdentity ? (!empty(userAssignedIdentityName) ? 'SystemAssigned, UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentityName) ? 'UserAssigned' : 'None')
+var identityType = systemAssignedIdentity
+  ? (!empty(userAssignedIdentityName) ? 'SystemAssigned, UserAssigned' : 'SystemAssigned')
+  : (!empty(userAssignedIdentityName) ? 'UserAssigned' : 'None')
 
 resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' existing = if (!empty(userAssignedIdentityName)) {
   name: userAssignedIdentityName
@@ -47,10 +49,12 @@ resource topic 'Microsoft.EventGrid/topics@2025-02-15' = {
     minimumTlsVersionAllowed: '1.2'
     inputSchema: 'EventGridSchema'
     publicNetworkAccess: publicNetworkAccess
-    inboundIpRules: [for ipRule in ipRules: {
+    inboundIpRules: [
+      for ipRule in ipRules: {
         action: 'Allow'
         ipMask: ipRule.cidr
-      }]
+      }
+    ]
     disableLocalAuth: !localAuthenticationEnabled
     dataResidencyBoundary: 'WithinRegion'
   }

--- a/infrastructure/templates/common/components/event-grid/eventGridCustomTopic.bicep
+++ b/infrastructure/templates/common/components/event-grid/eventGridCustomTopic.bicep
@@ -1,6 +1,8 @@
 import { IpRange } from '../../types.bicep'
 
 @description('The resource name.')
+@minLength(3)
+@maxLength(50)
 param name string
 
 @description('Location for all resources.')

--- a/infrastructure/templates/common/components/event-grid/eventGridCustomTopicQueueSubscription.bicep
+++ b/infrastructure/templates/common/components/event-grid/eventGridCustomTopicQueueSubscription.bicep
@@ -3,7 +3,7 @@
 @maxLength(64)
 param name string
 
-@description('The name of the parent topic.')
+@description('The Event Grid topic name associated with the subscription.')
 param topicName string
 
 @description('The name of the storage account that contains the queue that is the destination of the subscription.')

--- a/infrastructure/templates/common/components/event-grid/eventGridCustomTopicQueueSubscription.bicep
+++ b/infrastructure/templates/common/components/event-grid/eventGridCustomTopicQueueSubscription.bicep
@@ -1,0 +1,49 @@
+@description('The resource name.')
+@minLength(3)
+@maxLength(64)
+param name string
+
+@description('The name of the parent topic.')
+param topicName string
+
+@description('The name of the storage account that contains the queue that is the destination of the subscription.')
+param storageAccountName string
+
+@description('The name of the storage queue under the storage account that is the destination of the subscription.')
+param queueName string
+
+@description('A list of event types to include in the subscription. If not specified, all event types are included.')
+param includedEventTypes array = []
+
+resource topic 'Microsoft.EventGrid/topics@2025-02-15' existing = {
+  name: topicName
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+  name: storageAccountName
+}
+
+resource eventSubscription 'Microsoft.EventGrid/topics/eventSubscriptions@2025-02-15' = {
+  parent: topic
+  name: name
+  properties: {
+    destination: {
+      properties: {
+        resourceId: storageAccount.id
+        queueName: queueName
+        queueMessageTimeToLiveInSeconds: 604800
+      }
+      endpointType: 'StorageQueue'
+    }
+    filter: {
+      enableAdvancedFilteringOnArrays: true
+      includedEventTypes: length(includedEventTypes) > 0 ? includedEventTypes : null
+    }
+    labels: []
+    eventDeliverySchema: 'EventGridSchema'
+    retryPolicy: {
+      maxDeliveryAttempts: 30
+      eventTimeToLiveInMinutes: 1440
+    }
+  }
+}

--- a/infrastructure/templates/common/components/event-grid/eventGridMessaging.bicep
+++ b/infrastructure/templates/common/components/event-grid/eventGridMessaging.bicep
@@ -16,8 +16,8 @@ param tagValues object
 @description('A list of custom topic names to create.')
 param customTopicNames string[] = []
 
-module eventGridCustomTopicsModule 'eventGridCustomTopic.bicep' = [for topicName in customTopicNames: {
-  name: '${topicName}EventGridCustomTopicModuleDeploy'
+module eventGridCustomTopicModule 'eventGridCustomTopic.bicep' = [for (topicName, index) in customTopicNames: {
+  name: '${index}eventGridCustomTopicModuleDeploy'
   params: {
     name: '${resourcePrefix}-${abbreviations.eventGridTopics}-${topicName}'
     location: location

--- a/infrastructure/templates/common/components/event-grid/eventGridMessaging.bicep
+++ b/infrastructure/templates/common/components/event-grid/eventGridMessaging.bicep
@@ -14,16 +14,19 @@ param ipRules IpRange[]
 param tagValues object
 
 @description('A list of custom topic names to create.')
-param customTopicNames string[] = []
+@minLength(1)
+param customTopicNames string[]
 
-module eventGridCustomTopicModule 'eventGridCustomTopic.bicep' = [for (topicName, index) in customTopicNames: {
-  name: '${index}eventGridCustomTopicModuleDeploy'
-  params: {
-    name: '${resourcePrefix}-${abbreviations.eventGridTopics}-${topicName}'
-    location: location
-    ipRules: ipRules
-    publicNetworkAccess: 'Enabled'
-    systemAssignedIdentity: true
-    tagValues: tagValues
+module eventGridCustomTopicModule 'eventGridCustomTopic.bicep' = [
+  for (topicName, index) in customTopicNames: {
+    name: '${index}eventGridCustomTopicModuleDeploy'
+    params: {
+      name: '${resourcePrefix}-${abbreviations.eventGridTopics}-${topicName}'
+      location: location
+      ipRules: ipRules
+      publicNetworkAccess: 'Enabled'
+      systemAssignedIdentity: true
+      tagValues: tagValues
+    }
   }
-}]
+]

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -1,6 +1,6 @@
 import { abbreviations } from '../../common/abbreviations.bicep'
 import { IpRange, FirewallRule } from '../../common/types.bicep'
-import { ResourceNames, StorageQueueNamesType } from '../types.bicep'
+import { ResourceNames, SearchStorageQueueNames } from '../types.bicep'
 
 @description('The URL of the Content API.')
 param contentApiUrl string
@@ -105,7 +105,7 @@ resource searchableDocumentsContainer 'Microsoft.Storage/storageAccounts/blobSer
 }
 
 resource searchService 'Microsoft.Search/searchServices@2024-06-01-preview' existing = {
-    name: searchServiceName
+  name: searchServiceName
 }
 
 module functionAppModule '../../common/components/functionApp.bicep' = {
@@ -188,18 +188,20 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
       storageAccounts: searchDocsFunctionPrivateEndpointSubnet.id
     }
     outboundSubnetId: outboundVnetSubnet.id
-    alerts: deployAlerts ? {
-      cpuPercentage: true
-      functionAppHealth: true
-      httpErrors: true
-      memoryPercentage: true
-      storageAccountAvailability: true
-      storageLatency: false
-      fileServiceAvailability: true
-      fileServiceLatency: false
-      fileServiceCapacity: true
-      alertsGroupName: resourceNames.existingResources.alertsGroup
-    } : null
+    alerts: deployAlerts
+      ? {
+          cpuPercentage: true
+          functionAppHealth: true
+          httpErrors: true
+          memoryPercentage: true
+          storageAccountAvailability: true
+          storageLatency: false
+          fileServiceAvailability: true
+          fileServiceLatency: false
+          fileServiceCapacity: true
+          alertsGroupName: resourceNames.existingResources.alertsGroup
+        }
+      : null
     tagValues: tagValues
   }
 }
@@ -232,7 +234,7 @@ module functionAppStorageAccountQueueServiceModule '../../common/components/queu
 output functionAppName string = functionAppModule.outputs.name
 output functionAppUrl string = functionAppModule.outputs.url
 output functionAppStorageAccountName string = functionAppModule.outputs.storageAccountName
-output storageQueueNames StorageQueueNamesType = {
+output storageQueueNames SearchStorageQueueNames = {
   publicationChangedQueueName: publicationChangedQueueName
   publicationLatestPublishedReleaseVersionChangedQueueName: publicationLatestPublishedReleaseVersionChangedQueueName
   refreshSearchableDocumentQueueName: refreshSearchableDocumentQueueName

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -1,6 +1,6 @@
 import { abbreviations } from '../../common/abbreviations.bicep'
 import { IpRange, FirewallRule } from '../../common/types.bicep'
-import { ResourceNames } from '../types.bicep'
+import { ResourceNames, StorageQueueNamesType } from '../types.bicep'
 
 @description('The URL of the Content API.')
 param contentApiUrl string
@@ -231,3 +231,13 @@ module functionAppStorageAccountQueueServiceModule '../../common/components/queu
 
 output functionAppName string = functionAppModule.outputs.name
 output functionAppUrl string = functionAppModule.outputs.url
+output functionAppStorageAccountName string = functionAppModule.outputs.storageAccountName
+output storageQueueNames StorageQueueNamesType = {
+  publicationChangedQueueName: publicationChangedQueueName
+  publicationLatestPublishedReleaseVersionChangedQueueName: publicationLatestPublishedReleaseVersionChangedQueueName
+  refreshSearchableDocumentQueueName: refreshSearchableDocumentQueueName
+  releaseSlugChangedQueueName: releaseSlugChangedQueueName
+  releaseVersionPublishedQueueName: releaseVersionPublishedQueueName
+  searchableDocumentCreatedQueueName: searchableDocumentCreatedQueueName
+  themeUpdatedQueueName: themeUpdatedQueueName
+}

--- a/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
@@ -1,0 +1,77 @@
+import { abbreviations } from '../../common/abbreviations.bicep'
+import { ResourceNames, StorageQueueNamesType } from '../types.bicep'
+
+@description('Resource prefix for all resources.')
+param resourcePrefix string
+
+@description('Queue names for the Search Docs Function App used as Event Grid subscription destinations.')
+param storageQueueNames StorageQueueNamesType
+
+@description('The name of the Search Docs Function App storage account.')
+param searchDocsFunctionAppStorageAccountName string
+
+// Define each of the topics and their associated subscriptions
+var eventGridCustomTopicSubscriptions = [
+  {
+    topic: 'publication-changed'
+    subscriptions: [
+      {
+        name: 'publication-changed'
+        includedEventTypes: ['publication-changed']
+        queueName: storageQueueNames.publicationChangedQueueName
+      }
+      {
+        name: 'publication-latest-published-release-changed'
+        includedEventTypes: ['publication-latest-published-release-version-changed']
+        queueName: storageQueueNames.publicationLatestPublishedReleaseVersionChangedQueueName
+      }
+    ]
+  }
+  {
+    topic: 'release-changed'
+    subscriptions: [
+      {
+        name: 'release-slug-changed'
+        includedEventTypes: ['release-slug-changed']
+        queueName: storageQueueNames.releaseSlugChangedQueueName
+      }
+    ]
+  }
+  {
+    topic: 'release-version-changed'
+    subscriptions: [
+      {
+        name: 'release-version-changed'
+        includedEventTypes: ['release-version-changed']
+        queueName: storageQueueNames.releaseVersionPublishedQueueName
+      }
+    ]
+  }
+  {
+    topic: 'theme-changed'
+    subscriptions: [
+      {
+        name: 'theme-changed'
+        includedEventTypes: ['theme-changed']
+        queueName: storageQueueNames.themeUpdatedQueueName
+      }
+    ]
+  }
+]
+
+var subscriptions = flatten(
+  map(eventGridCustomTopicSubscriptions, item =>
+    map(item.subscriptions, subscription => { topic: item.topic, ...subscription } )))
+
+// The functions have Queue trigger bindings rather than Event Grid trigger bindings,
+// so Event Grid subscriptions are created using storage queues as destinations.
+module eventGridQueueSubscriptionModuleDeploy '../../common/components/event-grid/eventGridCustomTopicQueueSubscription.bicep' = [for (subscription, index) in subscriptions: {
+  name: '${index}eventGridQueueSubscriptionModuleDeploy'
+  params: {
+    name: '${resourcePrefix}-${abbreviations.eventGridSubscriptions}-${subscription.name}'
+    topicName: '${resourcePrefix}-${abbreviations.eventGridTopics}-${subscription.topic}'
+    includedEventTypes: subscription.includedEventTypes
+    storageAccountName: searchDocsFunctionAppStorageAccountName
+    queueName: subscription.queueName
+  }
+}]

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -132,6 +132,15 @@ module searchDocsFunctionModule 'application/searchDocsFunction.bicep' = {
   }
 }
 
+module searchDocsFunctionEventSubscriptionsModule 'application/searchDocsFunctionEventSubscriptions.bicep' = {
+  name: 'searchDocsFunctionEventSubscriptionsModule'
+  params: {
+    resourcePrefix: resourcePrefix
+    searchDocsFunctionAppStorageAccountName: searchDocsFunctionModule.outputs.functionAppStorageAccountName
+    storageQueueNames: searchDocsFunctionModule.outputs.storageQueueNames
+  }
+}
+
 module searchServiceModule 'application/searchService.bicep' = {
   name: 'searchServiceModule'
   params: {

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -17,7 +17,8 @@ type ResourceNames = {
 type SearchServiceRole = 'Search Index Data Contributor' | 'Search Index Data Reader' | 'Search Service Contributor'
 
 @export()
-type StorageQueueNamesType = {
+@sealed()
+type SearchStorageQueueNames = {
   publicationChangedQueueName: string
   publicationLatestPublishedReleaseVersionChangedQueueName: string
   refreshSearchableDocumentQueueName: string

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -15,3 +15,14 @@ type ResourceNames = {
 @export()
 // The built in Search Service roles. See https://learn.microsoft.com/en-gb/azure/role-based-access-control/built-in-roles/ai-machine-learning
 type SearchServiceRole = 'Search Index Data Contributor' | 'Search Index Data Reader' | 'Search Service Contributor'
+
+@export()
+type StorageQueueNamesType = {
+  publicationChangedQueueName: string
+  publicationLatestPublishedReleaseVersionChangedQueueName: string
+  refreshSearchableDocumentQueueName: string
+  releaseSlugChangedQueueName: string
+  releaseVersionPublishedQueueName: string
+  searchableDocumentCreatedQueueName: string
+  themeUpdatedQueueName: string
+}


### PR DESCRIPTION
This PR follows on from https://github.com/dfe-analytical-services/explore-education-statistics/pull/5768 which added Event Grid topics that the Admin and Publisher will use to publish events when certain conditions occur.

This PR subscribes the Search Function app to these topics.

Because the functions in the Search Function app have been configured to use queue trigger bindings rather than Event Grid trigger bindings, the Event Grid subscriptions are created using the storage queues as their destinations.