### PR TITLE
EES-6020 sanitise download file names

### DIFF
--- a/src/explore-education-statistics-common/src/utils/file/__tests__/sanitiseFileName.test.ts
+++ b/src/explore-education-statistics-common/src/utils/file/__tests__/sanitiseFileName.test.ts
@@ -1,0 +1,13 @@
+import sanitiseFileName from '../sanitiseFileName';
+
+describe('sanitiseFileName', () => {
+  test('removes disallowed characters from the file name', () => {
+    // eslint-disable-next-line no-useless-escape
+    expect(sanitiseFileName(`file<>:"/\|?.*name`)).toBe('filename');
+  });
+
+  test('trims the file name', () => {
+    // eslint-disable-next-line no-useless-escape
+    expect(sanitiseFileName(` file<>:"/\|?*.name `)).toBe('filename');
+  });
+});

--- a/src/explore-education-statistics-common/src/utils/file/downloadFile.ts
+++ b/src/explore-education-statistics-common/src/utils/file/downloadFile.ts
@@ -1,3 +1,5 @@
+import sanitiseFileName from './sanitiseFileName';
+
 /**
  * Start downloading a {@param file} onto the client's disk.
  *
@@ -16,7 +18,7 @@ export default function downloadFile(file: Blob | string, fileName?: string) {
   link.href = url;
 
   if (fileName) {
-    link.setAttribute('download', fileName);
+    link.setAttribute('download', sanitiseFileName(fileName));
   }
 
   document.body.appendChild(link);

--- a/src/explore-education-statistics-common/src/utils/file/sanitiseFileName.ts
+++ b/src/explore-education-statistics-common/src/utils/file/sanitiseFileName.ts
@@ -1,0 +1,4 @@
+// Remove characters not permitted in file names.
+export default function sanitiseFileName(fileName: string) {
+  return fileName.replace(/[|*?"/<>:.]/g, '').trim();
+}


### PR DESCRIPTION
Removes disallowed characters from the file names for downloads. This fixes a bug when exporting charts with titles containing special characters.