### PR TITLE
EES-6026 Remove Requests from Analytics.Consumer namespace

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Functions/ConsumePublicApiQueriesFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Functions/ConsumePublicApiQueriesFunctionTests.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
-using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Functions;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Functions;
 using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using InterpolatedSql.Dapper;

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
@@ -1,4 +1,4 @@
-using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
 
 namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Functions/ConsumePublicApiQueriesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Functions/ConsumePublicApiQueriesFunction.cs
@@ -1,9 +1,9 @@
-using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Functions;
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Functions;
 
 public class ConsumePublicApiQueriesFunction(
     DuckDbConnection duckDbConnection,

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Functions/HealthCheckFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Functions/HealthCheckFunctions.cs
@@ -1,10 +1,10 @@
-using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Functions;
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Functions;
 
 // ReSharper disable once ClassNeverInstantiated.Global
 public class HealthCheckFunctions(

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RootNamespace>GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer</RootNamespace>
+    <RootNamespace>GovUk.Education.ExploreEducationStatistics.Analytics.Consumer</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.2" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Options/AnalyticsOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Options/AnalyticsOptions.cs
@@ -1,4 +1,4 @@
-namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Options;
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Options;
 
 public class AnalyticsOptions
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
@@ -1,6 +1,6 @@
-using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Options;
-using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services;
-using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Options;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
@@ -8,7 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer;
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer;
 
 public static class ProcessorHostBuilder
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Program.cs
@@ -1,4 +1,4 @@
-using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer;
 using Microsoft.Extensions.Hosting;
 
 var host = new HostBuilder()

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Properties/launchSettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer": {
+    "GovUk.Education.ExploreEducationStatistics.Analytics.Consumer": {
       "commandName": "Project",
       "commandLineArgs": "host start --pause-on-error --port 7076",
       "launchBrowser": false

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
@@ -1,11 +1,11 @@
-using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Options;
-using GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Options;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
-namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services;
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
 
 public class AnalyticsPathResolver : IAnalyticsPathResolver
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
@@ -1,4 +1,4 @@
-namespace GovUk.Education.ExploreEducationStatistics.Analytics.Requests.Consumer.Services.Interfaces;
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
 
 public interface IAnalyticsPathResolver
 {


### PR DESCRIPTION
This PR remove "Requests" from the "Analytics.Consumer" namespace, so the namespace matches the directory name for the project.