### PR TITLE
EES-6029 Update robot test after ck editor version update

### DIFF
--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -666,7 +666,7 @@ get editor toolbar
 
 get editor
     [Arguments]    ${block}
-    ${editor}=    lookup or return webelement    css:[aria-label="Editor editing area: main"]    ${block}
+    ${editor}=    lookup or return webelement    css:[aria-label^="Editor editing area: main"]    ${block}
     [Return]    ${editor}
 
 get comments sidebar


### PR DESCRIPTION
CK Editor version was recently updated, which updated the aria-label of the editor element.
Our robot test `get editor` selector was using the old label, so I have updated the selector to match the new one.

Old aria-label: `Editor editing area: main`
New aria-label: `Editor editing area: main. Press Alt+0 for help.`

The new selector should cover cases if ever the a11y help plugin is not present for the editor, too.