### PR TITLE
EES-5939 'add block/section' button focus behaviour

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordion.tsx
@@ -26,15 +26,22 @@ const MethodologyAccordion = ({
   const { addContentSection, updateContentSectionsOrder } =
     useMethodologyContentActions();
 
-  const onAddSection = useCallback(
-    () =>
-      addContentSection({
-        methodologyId: methodology.id,
-        order: methodology[sectionKey].length,
-        sectionKey,
-      }),
-    [addContentSection, methodology, sectionKey],
-  );
+  const onAddSection = useCallback(async () => {
+    const newSection = await addContentSection({
+      methodologyId: methodology.id,
+      order: methodology[sectionKey].length,
+      sectionKey,
+    });
+
+    setTimeout(() => {
+      const newSectionButton = document.querySelector(
+        `#${id}-${newSection.id}-heading`,
+      ) as HTMLButtonElement;
+      if (newSectionButton) {
+        newSectionButton.focus();
+      }
+    }, 100);
+  }, [addContentSection, methodology, sectionKey]);
 
   const reorderAccordionSections = useCallback(
     async (ids: string[]) => {

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordion.tsx
@@ -41,7 +41,7 @@ const MethodologyAccordion = ({
         newSectionButton.focus();
       }
     }, 100);
-  }, [addContentSection, methodology, sectionKey]);
+  }, [addContentSection, methodology, sectionKey, id]);
 
   const reorderAccordionSections = useCallback(
     async (ids: string[]) => {

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
@@ -47,7 +47,7 @@ const MethodologyAccordionSection = ({
   }, [sectionContent]);
 
   const addBlockToAccordionSection = useCallback(async () => {
-    await addContentSectionBlock({
+    const newBlock = await addContentSectionBlock({
       methodologyId,
       sectionId,
       block: {
@@ -57,6 +57,18 @@ const MethodologyAccordionSection = ({
       },
       sectionKey,
     });
+
+    setTimeout(() => {
+      const newBlockEl = document.querySelector(
+        `#editableSectionBlocks-${newBlock.id}`,
+      );
+      const newBlockButton = newBlockEl?.querySelector(
+        'button.govuk-button--secondary',
+      ) as HTMLButtonElement;
+      if (newBlockButton) {
+        newBlockButton.focus();
+      }
+    }, 100);
   }, [
     addContentSectionBlock,
     methodologyId,

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/context/useMethodologyContentActions.ts
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/context/useMethodologyContentActions.ts
@@ -95,6 +95,7 @@ export default function useMethodologyContentActions() {
         block: newBlock,
       },
     });
+    return newBlock;
   }
 
   async function updateSectionBlockOrder({

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/context/useMethodologyContentActions.ts
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/context/useMethodologyContentActions.ts
@@ -145,6 +145,7 @@ export default function useMethodologyContentActions() {
         section: newSection,
       },
     });
+    return newSection;
   }
 
   async function updateContentSectionsOrder({

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/DataBlockSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/DataBlockSelectForm.tsx
@@ -54,6 +54,7 @@ const DataBlockSelectForm = ({
   return (
     <form className="govuk-!-text-align-left" id={id}>
       <FormSelect
+        autoFocus
         className="govuk-!-margin-right-1"
         id={`${id}-selectedDataBlock`}
         name="selectedDataBlock"

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordion.tsx
@@ -25,10 +25,19 @@ const ReleaseContentAccordion = ({
     useReleaseContentActions();
 
   const addAccordionSection = useCallback(async () => {
-    await addContentSection({
+    const newSection = await addContentSection({
       releaseVersionId: release.id,
       order: release.content.length,
     });
+
+    setTimeout(() => {
+      const newSectionButton = document.querySelector(
+        `#${id}-${newSection.id}-heading`,
+      ) as HTMLButtonElement;
+      if (newSectionButton) {
+        newSectionButton.focus();
+      }
+    }, 100);
   }, [release.id, release.content.length, addContentSection]);
 
   const reorderAccordionSections = useCallback(

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordion.tsx
@@ -38,7 +38,7 @@ const ReleaseContentAccordion = ({
         newSectionButton.focus();
       }
     }, 100);
-  }, [release.id, release.content.length, addContentSection]);
+  }, [release.id, release.content.length, addContentSection, id]);
 
   const reorderAccordionSections = useCallback(
     async (ids: string[]) => {

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -235,33 +235,31 @@ const ReleaseContentAccordionSection = ({
                   </Button>
                 )}
                 {user?.permissions.isBauUser && (
-                  <>
-                    {!showEmbedDashboardForm && (
+                  <Modal
+                    title="Embed a URL"
+                    open={showEmbedDashboardForm}
+                    onExit={toggleEmbedDashboardForm.off}
+                    triggerButton={
                       <Button
                         variant="secondary"
                         onClick={toggleEmbedDashboardForm.on}
                       >
                         Embed a URL
                       </Button>
-                    )}
-                  </>
+                    }
+                  >
+                    <EditableEmbedForm
+                      onCancel={toggleEmbedDashboardForm.off}
+                      onSubmit={async embedBlock => {
+                        await addEmbedBlock(embedBlock);
+                        toggleEmbedDashboardForm.off();
+                      }}
+                    />
+                  </Modal>
                 )}
               </ButtonGroup>
             </>
           )}
-          <Modal
-            title="Embed a URL"
-            open={showEmbedDashboardForm}
-            onExit={toggleEmbedDashboardForm.off}
-          >
-            <EditableEmbedForm
-              onCancel={toggleEmbedDashboardForm.off}
-              onSubmit={async embedBlock => {
-                await addEmbedBlock(embedBlock);
-                toggleEmbedDashboardForm.off();
-              }}
-            />
-          </Modal>
         </>
       )}
     </EditableAccordionSection>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -66,7 +66,7 @@ const ReleaseContentAccordionSection = ({
   }, [blocks, section, unsavedBlocks, unsavedCommentDeletions]);
 
   const addBlock = useCallback(async () => {
-    await actions.addContentSectionBlock({
+    const newBlock = await actions.addContentSectionBlock({
       releaseVersionId: release.id,
       sectionId,
       sectionKey: 'content',
@@ -76,6 +76,18 @@ const ReleaseContentAccordionSection = ({
         body: '',
       },
     });
+
+    setTimeout(() => {
+      const newBlockEl = document.querySelector(
+        `#editableSectionBlocks-${newBlock.id}`,
+      );
+      const newBlockButton = newBlockEl?.querySelector(
+        'button.govuk-button--secondary',
+      ) as HTMLButtonElement;
+      if (newBlockButton) {
+        newBlockButton.focus();
+      }
+    }, 100);
   }, [actions, release.id, sectionId, sectionContent.length]);
 
   const addEmbedBlock = useCallback(

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/useReleaseContentActions.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/useReleaseContentActions.ts
@@ -369,6 +369,7 @@ export default function useReleaseContentActions() {
           section: newSection,
         },
       });
+      return newSection;
     },
     [dispatch],
   );

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/useReleaseContentActions.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/useReleaseContentActions.ts
@@ -209,6 +209,8 @@ export default function useReleaseContentActions() {
       });
 
       await updateUnattachedDataBlocks({ releaseVersionId });
+
+      return newBlock;
     },
     [dispatch, updateUnattachedDataBlocks],
   );

--- a/src/explore-education-statistics-common/src/components/form/FormSelect.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormSelect.tsx
@@ -22,6 +22,7 @@ export interface SelectOption<Value = string | number> {
 
 export interface FormSelectProps
   extends Pick<FormLabelProps, 'hideLabel' | 'label'> {
+  autoFocus?: boolean;
   className?: string;
   disabled?: boolean;
   error?: string;
@@ -53,6 +54,7 @@ export interface FormSelectProps
 }
 
 const FormSelect = ({
+  autoFocus,
   className,
   disabled,
   error,
@@ -109,6 +111,8 @@ const FormSelect = ({
           className={classNames('govuk-select', className, {
             'govuk-select--error': !!error,
           })}
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus={autoFocus}
           id={id}
           name={name}
           disabled={disabled}


### PR DESCRIPTION
This PR fixes multiple focus-related issues for the release and methodology content pages. 

Currently, many buttons which add items or show/close modals don't move the focus, so screen reader users can't see any change has happened, and keyboard users have to tab to access the next logical action.

- When adding a new content **section**, move focus to the added section accordion item, ready to expand it.
- When adding a **data block** to a section, move focus to the newly-appeared data block select (this change affects more places but all with this desired behaviour)
- When closing the **embed URL modal** on cancel or escape, move focus back to the 'Embed a URL' button
- When adding a new **text block**, move focus to the added block's 'Edit block' button, ready to edit the new block.