### PR TITLE
EES-5791 Event Grid Events

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Events;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Services.EventGrid;
 using Xunit.Abstractions;
 
@@ -13,69 +14,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 
 public class AdminEventRaiserTests(ITestOutputHelper output)
 {
-    private readonly ConfiguredEventGridClientFactoryMockBuilder _eventGridClientFactoryMockBuilder = new();
-    
-    private IAdminEventRaiser GetSut() => 
-        new AdminEventRaiser(_eventGridClientFactoryMockBuilder.Build());
+    private readonly EventRaiserMockBuilder _eventRaiserMockBuilder = new();
+
+    private IAdminEventRaiser GetSut() =>
+        new AdminEventRaiser(_eventRaiserMockBuilder.Build());
 
     [Fact]
     public void Can_instantiate_SUT() => Assert.NotNull(GetSut());
 
-    [Fact]
-    public async Task GivenNoTopicConfiguration_WhenEventRaised_ThenNothingHappens()
-    {
-        // ARRANGE
-        _eventGridClientFactoryMockBuilder.WhereNoTopicConfigFound();
-        var sut = GetSut();
-        var theme = new ThemeBuilder().Build();
-        
-        // ACT
-        await sut.OnThemeUpdated(theme);
-        
-        // ASSERT
-        _eventGridClientFactoryMockBuilder
-            .Client
-            .Assert.NoEventsWerePublished();
-    }
-    
     [Fact]
     public async Task GivenTopicConfigured_WhenOnThemeUpdated_ThenEventPublished()
     {
         // ARRANGE
         var sut = GetSut();
         var theme = new ThemeBuilder().Build();
-        
+
         // ACT
         await sut.OnThemeUpdated(theme);
-        
+
         // ASSERT
-        var actualEvent = Assert.Single(
-            _eventGridClientFactoryMockBuilder
-                .Client
-                .Assert.EventsPublished);
-
         var expectedEvent = new ThemeChangedEvent(theme);
-        var expectedPayload = new ThemeChangedEvent.EventPayload
-        {
-            Title = theme.Title,
-            Summary = theme.Summary,
-            Slug = theme.Slug
-        };
-        // The theme id should be the subject
-        Assert.Equal(expectedEvent.Subject, theme.Id.ToString());
-
-        // Ensure the payload is correct
-        var actualPayload = actualEvent.Data.ToObjectFromJson<ThemeChangedEvent.EventPayload>();
-        Assert.Equal(expectedPayload, actualPayload);
-
-        // Output the EventGridEvent - useful for adding to a function app processing queue in Microsoft Azure Storage Explorer 
-        PrintJson(actualEvent);
-    }
-    
-    private void Print(string s) => output.WriteLine(s);
-    private void PrintJson<T>(T o)
-    {
-        var s= JsonSerializer.Serialize(o);
-        Print(s);
+        _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserTests.cs
@@ -1,18 +1,15 @@
 using System;
-using System.Text.Json;
-using System.Text.Json.Serialization.Metadata;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Events;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Services.EventGrid;
-using Xunit.Abstractions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 
-public class AdminEventRaiserTests(ITestOutputHelper output)
+public class AdminEventRaiserTests
 {
     private readonly EventRaiserMockBuilder _eventRaiserMockBuilder = new();
 
@@ -23,7 +20,7 @@ public class AdminEventRaiserTests(ITestOutputHelper output)
     public void Can_instantiate_SUT() => Assert.NotNull(GetSut());
 
     [Fact]
-    public async Task GivenTopicConfigured_WhenOnThemeUpdated_ThenEventPublished()
+    public async Task WhenOnThemeUpdated_ThenEventPublished()
     {
         // ARRANGE
         var sut = GetSut();
@@ -35,5 +32,107 @@ public class AdminEventRaiserTests(ITestOutputHelper output)
         // ASSERT
         var expectedEvent = new ThemeChangedEvent(theme);
         _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
+    }
+    
+    [Fact]
+    public async Task WhenOnReleaseSlugChanged_ThenEventPublished()
+    {
+        // ARRANGE
+        var releaseId = Guid.NewGuid();
+        var newReleaseSlug = "new-release-slug";
+        var publicationId = Guid.NewGuid();
+        var publicationSlug = "publication-slug";
+        
+        var sut = GetSut();
+
+        // ACT
+        await sut.OnReleaseSlugChanged(
+            releaseId,
+            newReleaseSlug,
+            publicationId,
+            publicationSlug);
+
+        // ASSERT
+        var expectedEvent = new ReleaseSlugChangedEvent(
+            releaseId,
+            newReleaseSlug,
+            publicationId,
+            publicationSlug);
+        _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
+    }
+    
+    [Fact]
+    public async Task WhenOnPublicationChanged_ThenEventPublished()
+    {
+        // ARRANGE
+        var publication = new Publication
+        {
+            Id = Guid.NewGuid(),
+            Title = "Publication title",
+            Summary = "This is the publication summary",
+            Slug = "publication-slug"
+        };
+        
+        var sut = GetSut();
+
+        // ACT
+        await sut.OnPublicationChanged(publication);
+
+        // ASSERT
+        var expectedEvent = new PublicationChangedEvent(publication);
+        _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
+    }
+    
+    [Fact]
+    public async Task WhenOnPublicationLatestPublishedReleaseReordered_ThenEventPublished()
+    {
+        // ARRANGE
+        var publication = new Publication
+        {
+            Id = Guid.NewGuid(),
+            Title = "Publication title",
+            Summary = "This is the publication summary",
+            Slug = "publication-slug",
+            LatestPublishedReleaseVersionId = Guid.NewGuid()
+        };
+        var previousLatestPublishedReleaseVersionId = Guid.NewGuid();
+        
+        var sut = GetSut();
+
+        // ACT
+        await sut.OnPublicationLatestPublishedReleaseReordered(
+            publication, 
+            previousLatestPublishedReleaseVersionId);
+
+        // ASSERT
+        var expectedEvent = new PublicationLatestPublishedReleaseReorderedEvent(
+            publication, 
+            previousLatestPublishedReleaseVersionId);
+        _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
+    }
+    
+    [Fact]
+    public async Task GivenPublicationLatestPublishedReleaseVersionIdIsNull_WhenOnPublicationLatestPublishedReleaseReordered_ThenNoEventPublished()
+    {
+        // ARRANGE
+        var publication = new Publication
+        {
+            Id = Guid.NewGuid(),
+            Title = "Publication title",
+            Summary = "This is the publication summary",
+            Slug = "publication-slug",
+            LatestPublishedReleaseVersionId = null
+        };
+        var previousLatestPublishedReleaseVersionId = Guid.NewGuid();
+        
+        var sut = GetSut();
+
+        // ACT
+        await sut.OnPublicationLatestPublishedReleaseReordered(
+            publication, 
+            previousLatestPublishedReleaseVersionId);
+
+        // ASSERT
+        _eventRaiserMockBuilder.Assert.NoEventRaised();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationChangedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationChangedEvent.cs
@@ -1,9 +1,10 @@
-﻿using Azure.Messaging.EventGrid;
+using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Events;
 
-public record PublicationChangedEvent
+public record PublicationChangedEvent : IEvent
 {
     public PublicationChangedEvent(Publication publication)
     {
@@ -21,7 +22,7 @@ public record PublicationChangedEvent
     private const string EventType = "publication-changed";
     
     // Which Topic endpoint to use from the appsettings
-    public const string EventTopicOptionsKey = "PublicationChangedEvent";
+    public static string EventTopicOptionsKey => "PublicationChangedEvent";
 
     /// <summary>
     /// The PublicationId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationLatestPublishedReleaseReorderedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationLatestPublishedReleaseReorderedEvent.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Events;
 
-public record PublicationLatestPublishedReleaseReorderedEvent
+public record PublicationLatestPublishedReleaseReorderedEvent : IEvent
 {
     public PublicationLatestPublishedReleaseReorderedEvent(
         Publication publication,
@@ -25,7 +26,7 @@ public record PublicationLatestPublishedReleaseReorderedEvent
     private const string EventType = "publication-latest-published-release-reordered";
     
     // Which Topic endpoint to use from the appsettings
-    public const string EventTopicOptionsKey = "PublicationChangedEvent";
+    public static string EventTopicOptionsKey => "PublicationChangedEvent";
 
     /// <summary>
     /// The PublicationId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/ReleaseSlugChangedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/ReleaseSlugChangedEvent.cs
@@ -1,9 +1,10 @@
 using System;
 using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Events;
 
-public record ReleaseSlugChangedEvent
+public record ReleaseSlugChangedEvent : IEvent
 {
     public ReleaseSlugChangedEvent(Guid releaseId, string newReleaseSlug, Guid publicationId, string publicationSlug)
     {
@@ -21,7 +22,7 @@ public record ReleaseSlugChangedEvent
     private const string EventType = "release-slug-changed";
     
     // Which Topic endpoint to use from the appsettings
-    public const string EventTopicOptionsKey = "ReleaseChangedEvent";
+    public static string EventTopicOptionsKey => "ReleaseChangedEvent";
 
     /// <summary>
     /// The ThemeId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/ThemeChangedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/ThemeChangedEvent.cs
@@ -1,9 +1,10 @@
 using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Events;
 
-public record ThemeChangedEvent
+public record ThemeChangedEvent : IEvent
 {
     public ThemeChangedEvent(Theme theme)
     {
@@ -21,7 +22,7 @@ public record ThemeChangedEvent
     private const string EventType = "theme-changed";
     
     // Which Topic endpoint to use from the appsettings
-    public const string EventTopicOptionsKey = "ThemeChangedEvent";
+    public static string EventTopicOptionsKey => "ThemeChangedEvent";
 
     /// <summary>
     /// The ThemeId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiser.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Admin.Events;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
@@ -10,82 +12,49 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 /// <summary>
 /// Publish events specific to Admin
 /// </summary>
-/// <param name="eventGridClientFactory"></param>
-public class AdminEventRaiser(IConfiguredEventGridClientFactory eventGridClientFactory) : IAdminEventRaiser
+public class AdminEventRaiser(IEventRaiser eventRaiser) : IAdminEventRaiser
 {
     /// <summary>
     /// On Theme Updated
     /// </summary>
-    public async Task OnThemeUpdated(Theme theme)
-    {
-        if (!eventGridClientFactory.TryCreateClient(
-                ThemeChangedEvent.EventTopicOptionsKey,
-                out var client))
-        {
-            return;
-        }
-
-        var evnt = new ThemeChangedEvent(theme);
-        
-        await client.SendEventAsync(evnt.ToEventGridEvent());
-    }
+    public async Task OnThemeUpdated(Theme theme) => 
+        await eventRaiser.RaiseEvent(new ThemeChangedEvent(theme));
 
     /// <summary>
     /// On Release Slug changed
     /// </summary>
-    public async Task OnReleaseSlugChanged(Guid releaseId, string newReleaseSlug, Guid publicationId, string publicationSlug)
-    {
-        if (!eventGridClientFactory.TryCreateClient(
-                ReleaseSlugChangedEvent.EventTopicOptionsKey,
-                out var client))
-        {
-            return;
-        }
-
-        var evnt = new ReleaseSlugChangedEvent(releaseId, newReleaseSlug, publicationId, publicationSlug);
-        await client.SendEventAsync(evnt.ToEventGridEvent());
-    }
+    public async Task OnReleaseSlugChanged(
+        Guid releaseId,
+        string newReleaseSlug,
+        Guid publicationId,
+        string publicationSlug) =>
+        await eventRaiser.RaiseEvent(new ReleaseSlugChangedEvent(releaseId, newReleaseSlug, publicationId, publicationSlug));
 
     /// <summary>
     /// On Publication Changed
     /// </summary>
-    public async Task OnPublicationChanged(Publication publication)
-    {
-        if (!eventGridClientFactory.TryCreateClient(
-                PublicationChangedEvent.EventTopicOptionsKey,
-                out var client))
-        {
-            return;
-        }
+    public async Task OnPublicationChanged(Publication publication) =>
+        await eventRaiser.RaiseEvent(new PublicationChangedEvent(publication));
 
-        var evnt = new PublicationChangedEvent(publication);
-        
-        await client.SendEventAsync(evnt.ToEventGridEvent());
-    }
-    
     /// <summary>
     /// On Publication Latest Published Release Reordered.
     /// It is assumed that the publication LatestPublishedReleaseVersionId has a value assigned to it.
     /// If it is null, then no event will be raised.
     /// </summary>
-    public async Task OnPublicationLatestPublishedReleaseReordered(Publication publication, Guid previousLatestPublishedReleaseVersionId)
+    public async Task OnPublicationLatestPublishedReleaseReordered(
+        Publication publication,
+        Guid previousLatestPublishedReleaseVersionId)
     {
-        if (!eventGridClientFactory.TryCreateClient(
-                PublicationLatestPublishedReleaseReorderedEvent.EventTopicOptionsKey,
-                out var client))
-        {
-            return;
-        }
-
         // Should the publication not have a latest published release version for some reason, do nothing.
         if (publication.LatestPublishedReleaseVersionId is null)
         {
             return;
         }
 
-        var evnt = new PublicationLatestPublishedReleaseReorderedEvent(publication, previousLatestPublishedReleaseVersionId);
-        
-        await client.SendEventAsync(evnt.ToEventGridEvent());
+        await eventRaiser.RaiseEvent(
+            new PublicationLatestPublishedReleaseReorderedEvent(
+                publication,
+                previousLatestPublishedReleaseVersionId));
     }
 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiser.cs
@@ -1,7 +1,6 @@
+#nullable enable
 using System;
-using System.Threading;
 using System.Threading.Tasks;
-using Azure.Messaging.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Admin.Events;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/EventGrid/EventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/EventGrid/EventRaiserMockBuilder.cs
@@ -21,6 +21,9 @@ public class EventRaiserMockBuilder
         public void EventsRaised<TEventBuilder>(IEnumerable<TEventBuilder> expectedEvents) 
             where TEventBuilder : IEvent
             => Xunit.Assert.All(expectedEvents, e => Xunit.Assert.True( parent._mock.EventWasRaised(e)));
+
+        public void NoEventRaised() 
+            => Xunit.Assert.False(parent._mock.EventWasRaised());
     }
 
     private class MockEventRaiser : IEventRaiser
@@ -40,6 +43,8 @@ public class EventRaiserMockBuilder
 
         public bool EventWasRaised<TEventBuilder>(TEventBuilder expectedEvent) => 
             _events.OfType<TEventBuilder>().Any(actual => actual.Equals(expectedEvent));
+
+        public bool EventWasRaised() => _events.Any();
 
         public Task RaiseEvent<TEventBuilder>(TEventBuilder eventBuilder, CancellationToken cancellationToken = default) 
             where TEventBuilder : IEvent => 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/EventGrid/EventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/EventGrid/EventRaiserMockBuilder.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services.EventGrid;
+
+public class EventRaiserMockBuilder
+{
+    private readonly MockEventRaiser _mock = new();
+    public IEventRaiser Build() => _mock;
+    public Asserter Assert => new(this);
+
+    public class Asserter(EventRaiserMockBuilder parent)
+    {
+        public void EventRaised<TEventBuilder>(TEventBuilder expectedEvent) 
+            where TEventBuilder : IEvent
+            => Xunit.Assert.True(parent._mock.EventWasRaised(expectedEvent));
+
+        public void EventsRaised<TEventBuilder>(IEnumerable<TEventBuilder> expectedEvents) 
+            where TEventBuilder : IEvent
+            => Xunit.Assert.All(expectedEvents, e => Xunit.Assert.True( parent._mock.EventWasRaised(e)));
+    }
+
+    private class MockEventRaiser : IEventRaiser
+    {
+        private readonly List<object> _events = new();
+
+        private Task AddEvent<TEventBuilder>(TEventBuilder @event)
+        {
+            _events.Add(@event);
+            return Task.CompletedTask;
+        }
+        private Task AddEvents<TEventBuilder>(IEnumerable<TEventBuilder> @events)
+        {
+            _events.AddRange(@events.Cast<object>());
+            return Task.CompletedTask;
+        }
+
+        public bool EventWasRaised<TEventBuilder>(TEventBuilder expectedEvent) => 
+            _events.OfType<TEventBuilder>().Any(actual => actual.Equals(expectedEvent));
+
+        public Task RaiseEvent<TEventBuilder>(TEventBuilder eventBuilder, CancellationToken cancellationToken = default) 
+            where TEventBuilder : IEvent => 
+            AddEvent(eventBuilder);
+
+        public Task RaiseEvents<TEventBuilder>(IEnumerable<TEventBuilder> eventBuilders, CancellationToken cancellationToken = default) 
+            where TEventBuilder : IEvent => 
+            AddEvents(eventBuilders);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/EventGrid/EventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/EventGrid/EventRaiserTests.cs
@@ -1,0 +1,70 @@
+﻿using System.Threading.Tasks;
+using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services.EventGrid;
+
+public class EventRaiserTests
+{
+    private readonly ConfiguredEventGridClientFactoryMockBuilder _eventGridClientFactoryMockBuilder = new();
+
+    private IEventRaiser GetSut() => 
+        new EventRaiser(_eventGridClientFactoryMockBuilder.Build());
+
+    private class TestEvent : IEvent
+    {
+        public string Subject => "subject";
+        public string EventType => "event type";
+        public string DataVersion => "version";
+        public object Payload => "payload";
+        public static string EventTopicOptionsKey => "TestEventTopicOptionsKey";
+        public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);
+    }
+    
+    [Fact]
+    public void Can_instantiate_SUT() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task GivenNoTopicConfiguration_WhenEventRaised_ThenNothingHappens()
+    {
+        // ARRANGE
+        _eventGridClientFactoryMockBuilder.WhereNoTopicConfigFound();
+        var sut = GetSut();
+        
+        // ACT
+        await sut.RaiseEvent(new TestEvent());
+        
+        // ASSERT
+        _eventGridClientFactoryMockBuilder
+            .Client
+            .Assert.NoEventsWerePublished();
+    }
+    
+    [Fact]
+    public async Task GivenTopicConfigured_WhenOnThemeUpdated_ThenEventPublished()
+    {
+        // ARRANGE
+        var sut = GetSut();
+        
+        // ACT
+        var testEvent = new TestEvent();
+        await sut.RaiseEvent(testEvent);
+        
+        // ASSERT
+        var actualEvent = Assert.Single(
+            _eventGridClientFactoryMockBuilder
+                .Client
+                .Assert.EventsPublished);
+
+        var expectedEvent = testEvent;
+        var expectedPayload = testEvent.Payload;
+        
+        Assert.Equal(expectedEvent.Subject, actualEvent.Subject);
+        Assert.Equal(expectedEvent.EventType, actualEvent.EventType);
+        Assert.Equal(expectedEvent.DataVersion, actualEvent.DataVersion);
+
+        var actualPayload = actualEvent.Data.ToObjectFromJson<string>();
+        Assert.Equal(expectedPayload, actualPayload);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/EventGrid/EventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/EventGrid/EventRaiserTests.cs
@@ -42,7 +42,7 @@ public class EventRaiserTests
     }
     
     [Fact]
-    public async Task GivenTopicConfigured_WhenOnThemeUpdated_ThenEventPublished()
+    public async Task GivenTopicConfigured_WhenTestEventRaised_ThenEventPublished()
     {
         // ARRANGE
         var sut = GetSut();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ServiceCollectionExtensions.cs
@@ -130,6 +130,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddEventGridClient(this IServiceCollection services, IConfiguration configuration) =>
         services
             .AddTransient<IEventGridClientFactory, EventGridClientFactory>()
+            .AddTransient<IEventRaiser, EventRaiser>()
             .AddTransient<IConfiguredEventGridClientFactory, ConfiguredEventGridClientFactory>()
             .AddTransient(typeof(Func<ILogger<SafeEventGridClient>>), sp => sp.GetRequiredService<ILogger<SafeEventGridClient>>)
             .Configure<EventGridOptions>(configuration.GetSection(EventGridOptions.Section))

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/EventGrid/EventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/EventGrid/EventRaiser.cs
@@ -1,0 +1,32 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
+
+public class EventRaiser(IConfiguredEventGridClientFactory eventGridClientFactory) : IEventRaiser
+{
+    public async Task RaiseEvent<TEventBuilder>(TEventBuilder eventBuilder, CancellationToken cancellationToken = default)
+        where TEventBuilder : IEvent
+    {
+        // Try to obtain an event grid client, configured using the configuration keyed on EventTopicOptionsKey 
+        if (!eventGridClientFactory.TryCreateClient(
+                TEventBuilder.EventTopicOptionsKey,
+                out var client))
+        {
+            return;
+        }
+        
+        await client.SendEventAsync(eventBuilder.ToEventGridEvent(), cancellationToken);
+    }
+
+    public async Task RaiseEvents<TEventBuilder>(IEnumerable<TEventBuilder> eventBuilders, CancellationToken cancellationToken = default)
+        where TEventBuilder : IEvent
+    {
+        foreach (var eventBuilder in eventBuilders)
+        {
+            await RaiseEvent(eventBuilder, cancellationToken);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/EventGrid/IEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/EventGrid/IEvent.cs
@@ -1,0 +1,9 @@
+﻿using Azure.Messaging.EventGrid;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
+
+public interface IEvent
+{
+    static abstract string EventTopicOptionsKey { get; }
+    EventGridEvent ToEventGridEvent();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/EventGrid/IEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/EventGrid/IEventRaiser.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
+
+public interface IEventRaiser
+{
+    Task RaiseEvent<TEventBuilder>(TEventBuilder eventBuilder, CancellationToken cancellationToken = default)
+        where TEventBuilder : IEvent;
+    
+    Task RaiseEvents<TEventBuilder>(IEnumerable<TEventBuilder> eventBuilders, CancellationToken cancellationToken = default)
+        where TEventBuilder : IEvent;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/PublisherEventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/PublisherEventRaiserMockBuilder.cs
@@ -8,12 +8,12 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Services;
 
-public class EventRaiserMockBuilder
+public class PublisherEventRaiserMockBuilder
 {
     private readonly Mock<IPublisherEventRaiser> _mock = new(MockBehavior.Strict);
     public IPublisherEventRaiser Build() => _mock.Object;
     public Asserter Assert => new(_mock);
-    public EventRaiserMockBuilder()
+    public PublisherEventRaiserMockBuilder()
     {
         _mock
             .Setup(m => m.RaiseReleaseVersionPublishedEvents(It.IsAny<IList<PublishingCompletionService.PublishedReleaseVersionInfo>>()))

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
@@ -24,7 +24,7 @@ public class PublishingCompletionServiceTests
     private readonly ReleaseServiceMockBuilder _releaseService = new();
     private readonly RedirectsCacheServiceMockBuilder _redirectsCacheService = new();
     private readonly DataSetPublishingServiceMockBuilder _dataSetPublishingService = new();
-    private readonly EventRaiserMockBuilder _eventRaiser = new();
+    private readonly PublisherEventRaiserMockBuilder _publisherEventRaiser = new();
 
     private PublishingCompletionService GetSut() =>
         new(
@@ -37,7 +37,7 @@ public class PublishingCompletionServiceTests
             _releaseService.Build(),
             _redirectsCacheService.Build(),
             _dataSetPublishingService.Build(),
-            _eventRaiser.Build());
+            _publisherEventRaiser.Build());
 
     public class BasicTests : PublishingCompletionServiceTests
     {
@@ -568,7 +568,7 @@ public class PublishingCompletionServiceTests
                         PublicationSlug = _releaseVersion1.Release.Publication.Slug,
                         PublicationLatestPublishedReleaseVersionId = _releaseVersion1.Id
                     };
-                    _eventRaiser.Assert.EventWasRaised(evt => evt == expectedInfo); 
+                    _publisherEventRaiser.Assert.EventWasRaised(evt => evt == expectedInfo); 
                 }
                 
                 [Fact]
@@ -600,7 +600,7 @@ public class PublishingCompletionServiceTests
                         PublicationSlug = _releaseVersion1.Release.Publication.Slug,
                         PublicationLatestPublishedReleaseVersionId = releaseVersionId1V2 // Assert latest release is different
                     };
-                    _eventRaiser.Assert.EventWasRaised(evt => evt == expectedInfo); 
+                    _publisherEventRaiser.Assert.EventWasRaised(evt => evt == expectedInfo); 
                 }
             }
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Events/ReleaseVersionPublishedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Events/ReleaseVersionPublishedEvent.cs
@@ -30,7 +30,7 @@ public record ReleaseVersionPublishedEvent : IEvent
     /// <summary>
     /// The ReleaseVersionId is the subject
     /// </summary>
-    public string Subject { get; init; }
+    public string Subject { get; }
 
     /// <summary>
     /// The event payload
@@ -43,7 +43,7 @@ public record ReleaseVersionPublishedEvent : IEvent
         public required string PublicationSlug { get; init; }
         public required Guid PublicationLatestPublishedReleaseVersionId { get; init; }    
     }
-    public EventPayload Payload { get; init; }
+    public EventPayload Payload { get; }
     
     public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Events/ReleaseVersionPublishedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Events/ReleaseVersionPublishedEvent.cs
@@ -1,21 +1,36 @@
-﻿using System;
+using System;
 using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Events;
 
-public record ReleaseVersionPublishedEvent(Guid ReleaseVersionId, ReleaseVersionPublishedEvent.EventPayload Payload)
+public record ReleaseVersionPublishedEvent : IEvent
 {
+    public ReleaseVersionPublishedEvent(PublishingCompletionService.PublishedReleaseVersionInfo publishedReleaseVersion)
+    {
+        Subject = publishedReleaseVersion.ReleaseVersionId.ToString();
+        Payload = new()
+        {
+            ReleaseId = publishedReleaseVersion.ReleaseId,
+            ReleaseSlug = publishedReleaseVersion.ReleaseSlug,
+            PublicationId = publishedReleaseVersion.PublicationId,
+            PublicationSlug = publishedReleaseVersion.PublicationSlug,
+            PublicationLatestPublishedReleaseVersionId = publishedReleaseVersion.PublicationLatestPublishedReleaseVersionId,
+        };
+    }
+
     // Changes to this event should also increment the version accordingly.
     public const string DataVersion = "1.0";
     public const string EventType = "release-version-published";
     
     // Which Topic endpoint to use from the appsettings
-    public const string EventTopicOptionsKey = "ReleaseVersionChangedEvent";
+    public static string EventTopicOptionsKey => "ReleaseVersionChangedEvent";
     
     /// <summary>
     /// The ReleaseVersionId is the subject
     /// </summary>
-    public string Subject => ReleaseVersionId.ToString();
+    public string Subject { get; init; }
 
     /// <summary>
     /// The event payload
@@ -28,6 +43,7 @@ public record ReleaseVersionPublishedEvent(Guid ReleaseVersionId, ReleaseVersion
         public required string PublicationSlug { get; init; }
         public required Guid PublicationLatestPublishedReleaseVersionId { get; init; }    
     }
+    public EventPayload Payload { get; init; }
     
     public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublisherEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublisherEventRaiser.cs
@@ -6,5 +6,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 public interface IPublisherEventRaiser
 {
     Task RaiseReleaseVersionPublishedEvents(
-        IList<PublishingCompletionService.PublishedReleaseVersionInfo> publishedReleaseVersionInfos);
+        IEnumerable<PublishingCompletionService.PublishedReleaseVersionInfo> publishedReleaseVersionInfos);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
@@ -10,42 +10,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 /// <summary>
 /// Publish events specific to the Publisher
 /// </summary>
-/// <param name="eventGridClientFactory"></param>
-public class PublisherEventRaiser(
-    IConfiguredEventGridClientFactory eventGridClientFactory)
-    : IPublisherEventRaiser
+public class PublisherEventRaiser(IEventRaiser eventRaiser) : IPublisherEventRaiser
 {
     /// <summary>
     /// On Release Version Published
     /// </summary>
     /// <param name="publishedReleaseVersionInfos">information about the one or more release versions that have been published</param>
     public async Task RaiseReleaseVersionPublishedEvents(
-        IList<PublishingCompletionService.PublishedReleaseVersionInfo> publishedReleaseVersionInfos)
-    {
-        if (!eventGridClientFactory.TryCreateClient(
-                ReleaseVersionPublishedEvent.EventTopicOptionsKey,
-                out var client))
-        {
-            return;
-        }
-
-        var releaseVersionPublishedEvents = 
-            publishedReleaseVersionInfos.Select(info => 
-                new ReleaseVersionPublishedEvent(
-                        info.ReleaseVersionId,
-                        new ReleaseVersionPublishedEvent.EventPayload
-                        {
-                            ReleaseId = info.ReleaseId,
-                            ReleaseSlug = info.ReleaseSlug,
-                            PublicationId = info.PublicationId,
-                            PublicationSlug = info.PublicationSlug,
-                            PublicationLatestPublishedReleaseVersionId = info.PublicationLatestPublishedReleaseVersionId,
-                        })
-                .ToEventGridEvent());
-
-        foreach (var evnt in releaseVersionPublishedEvents)
-        {
-            await client.SendEventAsync(evnt);
-        }
-    }
+        IEnumerable<PublishingCompletionService.PublishedReleaseVersionInfo> publishedReleaseVersionInfos) =>
+        await eventRaiser.RaiseEvents(
+            publishedReleaseVersionInfos.Select(info => new ReleaseVersionPublishedEvent(info)));
 }


### PR DESCRIPTION
As part of writing up my documentation on using and raising Event Grid Events, I realised it could be simplified even further. Hence this refactor, which strips out everything from the specific AdminEventRaiser and PublisherEventRaiser into a common IEventRaiser dependency. The specific event raisers now simply create the event and pass it to the new IEventRaiser. Super simple.