### PR TITLE
EES-5952 Rename subscriptions, event type filters and a queue

### DIFF
--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -51,8 +51,8 @@ param functionAppExists bool
 @description('The name of the queue that is used when a publication is changed.')
 param publicationChangedQueueName string = 'publication-changed-queue'
 
-@description('The name of the queue that is used when the latest published release version has changed for a publication.')
-param publicationLatestPublishedReleaseVersionChangedQueueName string = 'publication-latest-published-release-version-changed-queue'
+@description('The name of the queue that is used when the latest published release of a publication changes due to reordering.')
+param publicationLatestPublishedReleaseReorderedQueueName string = 'publication-latest-published-release-reordered-queue'
 
 @description('The name of the queue that is used when a searchable document requires a refresh.')
 param refreshSearchableDocumentQueueName string = 'refresh-searchable-document-queue'
@@ -142,8 +142,8 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
         value: publicationChangedQueueName
       }
       {
-        name: 'PublicationLatestPublishedReleaseVersionChangedQueueName'
-        value: publicationLatestPublishedReleaseVersionChangedQueueName
+        name: 'PublicationLatestPublishedReleaseReorderedQueueName'
+        value: publicationLatestPublishedReleaseReorderedQueueName
       }
       {
         name: 'RefreshSearchableDocumentQueueName'
@@ -221,7 +221,7 @@ module functionAppStorageAccountQueueServiceModule '../../common/components/queu
     storageAccountName: functionAppModule.outputs.storageAccountName
     queueNames: [
       publicationChangedQueueName
-      publicationLatestPublishedReleaseVersionChangedQueueName
+      publicationLatestPublishedReleaseReorderedQueueName
       refreshSearchableDocumentQueueName
       releaseSlugChangedQueueName
       releaseVersionPublishedQueueName
@@ -236,7 +236,7 @@ output functionAppUrl string = functionAppModule.outputs.url
 output functionAppStorageAccountName string = functionAppModule.outputs.storageAccountName
 output storageQueueNames SearchStorageQueueNames = {
   publicationChangedQueueName: publicationChangedQueueName
-  publicationLatestPublishedReleaseVersionChangedQueueName: publicationLatestPublishedReleaseVersionChangedQueueName
+  publicationLatestPublishedReleaseReorderedQueueName: publicationLatestPublishedReleaseReorderedQueueName
   refreshSearchableDocumentQueueName: refreshSearchableDocumentQueueName
   releaseSlugChangedQueueName: releaseSlugChangedQueueName
   releaseVersionPublishedQueueName: releaseVersionPublishedQueueName

--- a/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
@@ -21,8 +21,8 @@ var eventGridCustomTopicSubscriptions = [
         queueName: storageQueueNames.publicationChangedQueueName
       }
       {
-        name: 'publication-latest-published-release-changed'
-        includedEventTypes: ['publication-latest-published-release-version-changed']
+        name: 'publication-latest-published-release-reordered'
+        includedEventTypes: ['publication-latest-published-release-reordered']
         queueName: storageQueueNames.publicationLatestPublishedReleaseVersionChangedQueueName
       }
     ]

--- a/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
@@ -23,7 +23,7 @@ var eventGridCustomTopicSubscriptions = [
       {
         name: 'publication-latest-published-release-reordered'
         includedEventTypes: ['publication-latest-published-release-reordered']
-        queueName: storageQueueNames.publicationLatestPublishedReleaseVersionChangedQueueName
+        queueName: storageQueueNames.publicationLatestPublishedReleaseReorderedQueueName
       }
     ]
   }

--- a/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
@@ -41,8 +41,8 @@ var eventGridCustomTopicSubscriptions = [
     topic: 'release-version-changed'
     subscriptions: [
       {
-        name: 'release-version-changed'
-        includedEventTypes: ['release-version-changed']
+        name: 'release-version-published'
+        includedEventTypes: ['release-version-published']
         queueName: storageQueueNames.releaseVersionPublishedQueueName
       }
     ]

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -20,7 +20,7 @@ type SearchServiceRole = 'Search Index Data Contributor' | 'Search Index Data Re
 @sealed()
 type SearchStorageQueueNames = {
   publicationChangedQueueName: string
-  publicationLatestPublishedReleaseVersionChangedQueueName: string
+  publicationLatestPublishedReleaseReorderedQueueName: string
   refreshSearchableDocumentQueueName: string
   releaseSlugChangedQueueName: string
   releaseVersionPublishedQueueName: string


### PR DESCRIPTION
This PR

* Corrects the name and event type filter of the `release-version-published` event queue subscription.

Corresponding with the changes in in https://github.com/dfe-analytical-services/explore-education-statistics/pull/5786:

* Renames the subscription and event type filter of the `publication-latest-published-release-changed` queue subscription to `publication-latest-published-release-reordered`.
* Renames the Search Function App's storage account queue `publication-latest-published-release-version-changed-queue` to `publication-latest-published-release-reordered-queue`.
* Changes the Search Function App's app setting `PublicationLatestPublishedReleaseVersionChangedQueueName` to `PublicationLatestPublishedReleaseReorderedQueueName`.