### PR TITLE
EES-5952 Enable Event Grid events in the dev environment

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -112,9 +112,6 @@
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
-    },
-    "eventGridTopicsExist": {
-      "value": false
     }
   }
 }


### PR DESCRIPTION
This PR enables Event Grid events in the dev environment following creation and testing of the infrastructure for them in the following PR's:

- https://github.com/dfe-analytical-services/explore-education-statistics/pull/5768
- https://github.com/dfe-analytical-services/explore-education-statistics/pull/5773
- https://github.com/dfe-analytical-services/explore-education-statistics/pull/5788
- https://github.com/dfe-analytical-services/explore-education-statistics/pull/5771
- https://github.com/dfe-analytical-services/explore-education-statistics/pull/5772
- https://github.com/dfe-analytical-services/explore-education-statistics/pull/5789

The events are enabled by removing the `eventGridTopicsExist` parameter override from `dev.parameters.json` which has a default value of `true`.

This will apply the Admin and Publisher's Event Grid configuration in their app settings, causing them to begin publishing events.