### PR TITLE
EES-5929 Fix latest release links within table tool final step

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/types/selectedPublication.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/types/selectedPublication.ts
@@ -5,6 +5,7 @@ export interface SelectedPublication extends PublicationTreeSummary {
   selectedRelease: SelectedRelease;
   latestRelease: {
     title: string;
+    slug: string;
   };
 }
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -351,6 +351,7 @@ export const getServerSideProps: GetServerSideProps<
           },
           latestRelease: {
             title: latestRelease.title,
+            slug: latestRelease.slug,
           },
         },
         selectedSubjectId: subjectId,
@@ -375,6 +376,7 @@ export const getServerSideProps: GetServerSideProps<
         },
         latestRelease: {
           title: latestRelease.title,
+          slug: latestRelease.slug,
         },
       },
       subjects,

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
@@ -330,6 +330,7 @@ describe('TableToolPage', () => {
     },
     latestRelease: {
       title: 'Latest Release Title',
+      slug: 'latest-release-slug',
     },
   };
 
@@ -347,6 +348,7 @@ describe('TableToolPage', () => {
     },
     latestRelease: {
       title: 'Latest Release Title',
+      slug: 'latest-release-slug',
     },
   };
 
@@ -508,7 +510,7 @@ describe('TableToolPage', () => {
 
     expect(latestDataLink).toBeInTheDocument();
     expect(latestDataLink.href).toEqual(
-      'http://localhost/find-statistics/test-publication/selected-release-slug',
+      'http://localhost/find-statistics/test-publication/latest-release-slug',
     );
     expect(latestDataLink.text).toContain('View latest data');
     expect(latestDataLink.text).toContain('Latest Release Title');

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
@@ -41,6 +41,7 @@ const TableToolFinalStep = ({
       publicationService.getLatestPublicationRelease(selectedPublication.slug),
     [selectedPublication],
   );
+
   const publication = fullPublication?.publication;
 
   const getMethodologyLinks = () => {
@@ -97,7 +98,7 @@ const TableToolFinalStep = ({
                     <Link
                       className="govuk-!-display-none-print"
                       unvisited
-                      to={`/find-statistics/${selectedPublication.slug}/${selectedPublication.selectedRelease.slug}`}
+                      to={`/find-statistics/${selectedPublication.slug}/${selectedPublication.latestRelease.slug}`}
                       testId="View latest data link"
                     >
                       View latest data:{' '}
@@ -180,9 +181,9 @@ const TableToolFinalStep = ({
         methodologyLinks={getMethodologyLinks()}
         releaseLink={
           <Link
-            to={`/find-statistics/${selectedPublication.slug}/${selectedPublication.selectedRelease.slug}`}
+            to={`/find-statistics/${selectedPublication.slug}/${selectedPublication.latestRelease.slug}`}
           >
-            {`${selectedPublication.title}, ${selectedPublication.selectedRelease.title}`}
+            {`${selectedPublication.title}, ${selectedPublication.latestRelease.title}`}
           </Link>
         }
         releaseType={selectedPublication.selectedRelease.type}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
@@ -147,11 +147,11 @@ describe('TableToolFinalStep', () => {
 
     expect(
       screen.getByRole('link', {
-        name: 'Test publication, Selected Release Title',
+        name: 'Test publication, Latest Release Title',
       }),
     ).toHaveAttribute(
       'href',
-      '/find-statistics/test-publication/selected-release-slug',
+      '/find-statistics/test-publication/latest-release-slug',
     );
   });
 
@@ -229,16 +229,16 @@ describe('TableToolFinalStep', () => {
       }),
     ).toHaveAttribute(
       'href',
-      '/find-statistics/test-publication/selected-release-slug',
+      '/find-statistics/test-publication/latest-release-slug',
     );
 
     expect(
       screen.getByRole('link', {
-        name: 'Test publication, Selected Release Title',
+        name: 'Test publication, Latest Release Title',
       }),
     ).toHaveAttribute(
       'href',
-      '/find-statistics/test-publication/selected-release-slug',
+      '/find-statistics/test-publication/latest-release-slug',
     );
   });
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__data__/tableData.ts
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__data__/tableData.ts
@@ -216,6 +216,7 @@ export const testSelectedPublicationWithLatestRelease: SelectedPublication = {
   },
   latestRelease: {
     title: 'Latest Release Title',
+    slug: 'latest-release-slug',
   },
 };
 
@@ -234,6 +235,7 @@ export const testSelectedPublicationWithNonLatestRelease: SelectedPublication =
     },
     latestRelease: {
       title: 'Latest Release Title',
+      slug: 'latest-release-slug',
     },
   };
 


### PR DESCRIPTION
This PR fixes a bug where links to 'latest release' of publications were linking to old releases, on the final step of the table tool.

We were already passing the latest release **title** through to the component, so I have just added the latest release **slug** too, to be able to render the correct link.

I've had to update tests to match this expected functionality, as they seemed to be expecting the old behaviour.