### PR TITLE
EES-5948 ckeditor a11y modal scroll

### DIFF
--- a/src/explore-education-statistics-admin/src/styles/_all.scss
+++ b/src/explore-education-statistics-admin/src/styles/_all.scss
@@ -4,3 +4,4 @@
 @import '~explore-education-statistics-common/src/styles/all';
 @import './variables';
 @import './layout';
+@import './ckeditor';

--- a/src/explore-education-statistics-admin/src/styles/_ckeditor.scss
+++ b/src/explore-education-statistics-admin/src/styles/_ckeditor.scss
@@ -1,0 +1,10 @@
+.ck.ck-accessibility-help-dialog {
+  --ck-accessibility-help-dialog-max-height: min(
+    400px,
+    calc(var(--ck-dialog-max-height) - var(--ck-form-header-height))
+  );
+}
+
+.ck.ck-accessibility-help-dialog .ck-accessibility-help-dialog__content {
+  overscroll-behavior-y: none;
+}

--- a/src/explore-education-statistics-admin/src/styles/_ckeditor.scss
+++ b/src/explore-education-statistics-admin/src/styles/_ckeditor.scss
@@ -1,4 +1,5 @@
 .ck.ck-accessibility-help-dialog {
+  // Dialog content was appearing too large on small viewports.
   --ck-accessibility-help-dialog-max-height: min(
     400px,
     calc(var(--ck-dialog-max-height) - var(--ck-form-header-height))
@@ -6,5 +7,6 @@
 }
 
 .ck.ck-accessibility-help-dialog .ck-accessibility-help-dialog__content {
+  // Prevent scrolling background page content after fully scrolling dialog content
   overscroll-behavior-y: none;
 }


### PR DESCRIPTION
This PR fixes some overflow issues related to the recently-added CKEditor accessibility modal.

1 - Content was overflowing the modal container on small viewports
2 - Page could be scrolled after scrolling through the modal content, which made the modal disappear.

For more context - https://dfedigital.atlassian.net/browse/EES-5948?focusedCommentId=109935