### PR TITLE
EES-6044 infrastructure bicep deployments are failing due to bug in azure cli

### DIFF
--- a/infrastructure/templates/analytics/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/analytics/ci/jobs/deploy-infrastructure.yml
@@ -24,14 +24,6 @@ jobs:
             - script: az upgrade --yes
               displayName: Upgrade Azure CLI and extensions
 
-            - task: AzureCLI@2
-              displayName: Install Bicep
-              inputs:
-                azureSubscription: ${{ parameters.serviceConnection }}
-                scriptType: bash
-                scriptLocation: inlineScript
-                inlineScript: az bicep install
-
             - template: ../tasks/deploy-bicep.yml
               parameters:
                 displayName: Validate Bicep template

--- a/infrastructure/templates/analytics/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/analytics/ci/jobs/deploy-infrastructure.yml
@@ -21,6 +21,9 @@ jobs:
           steps:
             - checkout: self
 
+            - script: az upgrade --yes
+              displayName: Upgrade Azure CLI and extensions
+
             - task: AzureCLI@2
               displayName: Install Bicep
               inputs:

--- a/infrastructure/templates/analytics/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/analytics/ci/tasks/deploy-bicep.yml
@@ -26,6 +26,10 @@ steps:
       inlineScript: |
         set -e
 
+        # Workaround for AZ CLI 2.71.x breaks bicep deployments when using Azure Devops Agent
+        # See https://github.com/Azure/azure-cli/issues/31189
+        az config set bicep.use_binary_from_path=false
+
         az deployment group ${{ parameters.action }} \
           --name $(infraDeployName) \
           --resource-group $(resourceGroupName) \

--- a/infrastructure/templates/public-api/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/public-api/ci/jobs/deploy-infrastructure.yml
@@ -24,14 +24,6 @@ jobs:
             - script: az upgrade --yes
               displayName: Upgrade Azure CLI and extensions
 
-            - task: AzureCLI@2
-              displayName: Install Bicep
-              inputs:
-                azureSubscription: ${{ parameters.serviceConnection }}
-                scriptType: bash
-                scriptLocation: inlineScript
-                inlineScript: az bicep install
-
             - template: ../tasks/deploy-bicep.yml
               parameters:
                 displayName: Validate Bicep template

--- a/infrastructure/templates/public-api/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/public-api/ci/jobs/deploy-infrastructure.yml
@@ -21,6 +21,9 @@ jobs:
           steps:
             - checkout: self
 
+            - script: az upgrade --yes
+              displayName: Upgrade Azure CLI and extensions
+
             - task: AzureCLI@2
               displayName: Install Bicep
               inputs:
@@ -66,9 +69,9 @@ jobs:
                 deployAlerts: $(deployAlerts)
                 dataProcessorExists: $(dataProcessorExists)
 
-           # - template: ../tasks/assign-app-role-to-service-principal.yml
-           #   parameters:
-           #     serviceConnection: ${ {parameters.serviceConnection }}
-           #     appRoleName: Admin.Access
-           #     protectedResourceAppRegName: $(subscription)-ees-papi-ca-api-appreg
-           #     servicePrincipalName: $(subscription)-as-ees-admin
+            # - template: ../tasks/assign-app-role-to-service-principal.yml
+            #   parameters:
+            #     serviceConnection: ${ {parameters.serviceConnection }}
+            #     appRoleName: Admin.Access
+            #     protectedResourceAppRegName: $(subscription)-ees-papi-ca-api-appreg
+            #     servicePrincipalName: $(subscription)-as-ees-admin

--- a/infrastructure/templates/public-api/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/public-api/ci/tasks/deploy-bicep.yml
@@ -41,6 +41,10 @@ steps:
       inlineScript: |
         set -e
 
+        # Workaround for AZ CLI 2.71.x breaks bicep deployments when using Azure Devops Agent
+        # See https://github.com/Azure/azure-cli/issues/31189
+        az config set bicep.use_binary_from_path=false
+
         az deployment group ${{ parameters.action }} \
           --name $(infraDeployName) \
           --resource-group $(resourceGroupName) \

--- a/infrastructure/templates/screener/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/screener/ci/jobs/deploy-infrastructure.yml
@@ -24,14 +24,6 @@ jobs:
             - script: az upgrade --yes
               displayName: Upgrade Azure CLI and extensions
 
-            - task: AzureCLI@2
-              displayName: Install Bicep
-              inputs:
-                azureSubscription: ${{ parameters.serviceConnection }}
-                scriptType: bash
-                scriptLocation: inlineScript
-                inlineScript: az bicep install
-
             - template: ../tasks/deploy-bicep.yml
               parameters:
                 displayName: Validate Bicep template

--- a/infrastructure/templates/screener/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/screener/ci/jobs/deploy-infrastructure.yml
@@ -21,6 +21,9 @@ jobs:
           steps:
             - checkout: self
 
+            - script: az upgrade --yes
+              displayName: Upgrade Azure CLI and extensions
+
             - task: AzureCLI@2
               displayName: Install Bicep
               inputs:

--- a/infrastructure/templates/screener/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/screener/ci/tasks/deploy-bicep.yml
@@ -23,6 +23,10 @@ steps:
       inlineScript: |
         set -e
 
+        # Workaround for AZ CLI 2.71.x breaks bicep deployments when using Azure Devops Agent
+        # See https://github.com/Azure/azure-cli/issues/31189
+        az config set bicep.use_binary_from_path=false
+
         az deployment group ${{ parameters.action }} \
           --name $(infraDeployName) \
           --resource-group $(resourceGroupName) \


### PR DESCRIPTION
ℹ️  This applies the same changes to the Public API, Analytics, and Data Screener pipelines that were already made to the Search infrastructure pipeline by https://github.com/dfe-analytical-services/explore-education-statistics/pull/5770 ℹ️ 

This PR adds a temporary workaround to stop Bicep deployments failing due to a bug in Azure CLI 2.71.0.

The error when starting the Bicep deployment is

```
No such file or directory: '/home/vsts/work/_temp/.azclitask/bin/bicep'
```

Between 08/04/25 and 09/04/25 version 2.71.0 with the bug appears to have rolled out gradually across all agents and now it's blocking all of our infrastructure deployments. We can see the last successful run of the Bicep deployment on 08/04/25 used Azure CLI 2.70.0.

**2.71.0**:
![image (1)](https://github.com/user-attachments/assets/56b31a84-bae5-459e-95bf-78cc4b5737f4)

**2.70.0**:
![image (3)](https://github.com/user-attachments/assets/1ad02a34-36ea-43fa-a9eb-45ba2cf52d03)

## Other changes

- Add step to Upgrade Azure CLI and extensions
- Remove unnecessary 'az bicep install' command
- Formatting