### PR TITLE
EES-6035 Attempted fix of Dev env analytics bug

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicApiQueriesProcessorServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicApiQueriesProcessorServiceTests.cs
@@ -9,14 +9,14 @@ using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests.Services;
 
-public abstract class ConsumePublicApiQueriesFunctionTests
+public abstract class ConsumePublicApiQueriesProcessorTests
 {
     private readonly string _queryResourcesPath = Path.Combine(
         Assembly.GetExecutingAssembly().GetDirectoryPath(),
         "Resources",
         "PublicApiQueries");
 
-    public class FunctionTests : ConsumePublicApiQueriesFunctionTests
+    public class ProcessTests : ConsumePublicApiQueriesProcessorTests
     {
         [Fact]
         public async Task NoSourceFolder_NoReportsProduced()

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
@@ -32,6 +32,10 @@ public class TestAnalyticsPathResolver : IAnalyticsPathResolver, IDisposable
         return Path.Combine(_basePath, "public-api", "processing");
     }
 
+    public string PublicApiQueriesFailuresDirectoryPath() {
+        return Path.Combine(_basePath, "public-api", "failures");
+    }
+
     public string PublicApiQueriesReportsDirectoryPath() {
         return Path.Combine(_basePath, "reports", "public-api", "reports");
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Functions/ConsumeAnalyticsRequestFilesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Functions/ConsumeAnalyticsRequestFilesFunction.cs
@@ -16,7 +16,17 @@ public class ConsumeAnalyticsRequestFilesFunction(
 
         foreach (var requestFileProcessor in processors)
         {
-            await requestFileProcessor.Process();
+            try
+            {
+                await requestFileProcessor.Process();
+            }
+            catch (Exception e)
+            {
+                logger.LogError(
+                    e,
+                    "Failed to process request files with processor {RequestFileProcessorType}",
+                    requestFileProcessor.GetType());
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
@@ -39,6 +39,11 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
         return Path.Combine(PublicApiQueriesDirectoryPath(), "processing");
     }
 
+    public string PublicApiQueriesFailuresDirectoryPath()
+    {
+        return Path.Combine(PublicApiQueriesDirectoryPath(), "failures");
+    }
+
     public string PublicApiQueriesReportsDirectoryPath()
     {
         return Path.Combine(ReportsDirectoryPath(), "public-api", "queries");

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
@@ -8,5 +8,7 @@ public interface IAnalyticsPathResolver
 
     string PublicApiQueriesProcessingDirectoryPath();
 
-    public string PublicApiQueriesReportsDirectoryPath();
+    string PublicApiQueriesFailuresDirectoryPath();
+
+    string PublicApiQueriesReportsDirectoryPath();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/RandomUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/RandomUtils.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
+
+public static class RandomUtils
+{
+    public static string RandomString()
+    {
+        var guidStr = Guid.NewGuid().ToString();
+        return guidStr[^5..];
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/QueryAnalyticsWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/QueryAnalyticsWriter.cs
@@ -32,7 +32,7 @@ public class QueryAnalyticsWriter(
         {
             Directory.CreateDirectory(directory);
 
-            var filename = $"{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}_{request.DataSetVersionId}_{Guid.NewGuid()}.json";
+            var filename = $"{DateTime.UtcNow:yyyyMMdd-HHmmss}_{request.DataSetVersionId}_{RandomUtils.RandomString()}.json";
 
             await File.WriteAllTextAsync(
                 Path.Combine(directory, filename),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/QueryAnalyticsWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/QueryAnalyticsWriter.cs
@@ -32,7 +32,7 @@ public class QueryAnalyticsWriter(
         {
             Directory.CreateDirectory(directory);
 
-            var filename = $"{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}_{request.DataSetVersionId}.json";
+            var filename = $"{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}_{request.DataSetVersionId}_{Guid.NewGuid()}.json";
 
             await File.WriteAllTextAsync(
                 Path.Combine(directory, filename),


### PR DESCRIPTION
This PR is hopefully a fix for an analytics bug we've seen in the Dev environment.

This bug was revealed when running the performance tests with this command:
```
pnpm --environment=dev perftest dist/publicApiDataSetQuery.test.js -e QUERY_FILES=dev/api-tests-absence-query1.json,dev/api-tests-absence-query2.json -e PROFILE=load -e MAIN_TEST_STAGE_DURATION_MINS=10 -e RPS=10
```

This would in rare instances produce request files by the Public API's `QueryAnalyticWriter#ReportDataSetVersionQuery` that ended with an extra close curly bracket. We now believe this is due to the Public API container app scaling up, and then due to a clashing filename, `WriteAllTextAsync` running twice from two different containers writing to a single file at the same time. While I feel fairly confident this is the cause, it's possible it's not.

The fix was to add a random Guid to the end of the request file's name to ensure that all filenames are unique.

To make analytics more robust, we now import the request file json into a DuckDb table one file at a time, and any file that fails will be moved to a "failures" directory. This means we don't need to manually delete any existing request files with malformed json, as they'll automatically be dealt with.