### PR TITLE
Fix PublicDataDb hack

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -242,7 +242,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             {
                 var publicDataDbConnectionString = configuration.GetConnectionString("PublicDataDb")!;
                 // TODO EES-5073 Remove this check when the Public Data db is available in all Azure environments.
-                if (publicDataDbExists)
+                if (publicDataDbExists && !string.IsNullOrWhiteSpace(publicDataDbConnectionString))
                 {
                     services.AddPsqlDbContext<PublicDataDbContext>(publicDataDbConnectionString, hostEnvironment);
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
@@ -172,7 +172,7 @@ public static class PublisherHostBuilderExtensions
                 if (!hostEnvironment.IsIntegrationTest())
                 {
                     var connectionString = ConnectionUtils.GetPostgreSqlConnectionString("PublicDataDb")!;
-                    if (publicDataDbExists)
+                    if (publicDataDbExists && !string.IsNullOrWhiteSpace(connectionString))
                     {
                         services.AddFunctionAppPsqlDbContext<PublicDataDbContext>(connectionString, hostContext);
                     }


### PR DESCRIPTION
Admin and Publisher, when starting up, look for the existence of a PublicDataDb flag to know whether to setup the PsqlDbContext. However, it does not check whether the connection string it uses has a value. This has led to issues where the flag is true but the connection string is null.
