### PR TITLE
EES-6045 Update Azure AI Search index configuration

### DIFF
--- a/infrastructure/templates/search/application/indexes/index-1.json
+++ b/infrastructure/templates/search/application/indexes/index-1.json
@@ -1,16 +1,309 @@
 {
   "name": "index-1",
+  "defaultScoringProfile": "scoring-profile-1",
   "fields": [
     {
-      "name": "rid",
+      "name": "content",
       "type": "Edm.String",
       "searchable": true,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    },
+    {
+      "name": "releaseSlug",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "releaseType",
+      "type": "Edm.String",
+      "searchable": false,
       "filterable": true,
       "retrievable": true,
       "stored": true,
-      "sortable": true,
+      "sortable": false,
       "facetable": true,
-      "key": true
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "releaseVersionId",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "publicationSlug",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "published",
+      "type": "Edm.DateTimeOffset",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "summary",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    },
+    {
+      "name": "theme",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": true,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "title",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    },
+    {
+      "name": "typeBoost",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_storage_content_type",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_storage_size",
+      "type": "Edm.Int64",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_storage_last_modified",
+      "type": "Edm.DateTimeOffset",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_storage_content_md5",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_storage_name",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": true,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_storage_path",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_storage_file_extension",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_content_encoding",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_content_type",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_language",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "metadata_title",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
     }
-  ]
+  ],
+  "scoringProfiles": [
+    {
+      "name": "scoring-profile-1",
+      "functionAggregation": "sum",
+      "text": {
+        "weights": {
+          "title": 10,
+          "summary": 2
+        }
+      },
+      "functions": []
+    }
+  ],
+  "suggesters": [],
+  "analyzers": [],
+  "normalizers": [],
+  "tokenizers": [],
+  "tokenFilters": [],
+  "charFilters": [],
+  "similarity": {
+    "@odata.type": "#Microsoft.Azure.Search.BM25Similarity"
+  },
+  "semantic": {
+    "configurations": [
+      {
+        "name": "semantic-configuration-1",
+        "flightingOptIn": false,
+        "prioritizedFields": {
+          "titleField": {
+            "fieldName": "title"
+          },
+          "prioritizedContentFields": [
+            {
+              "fieldName": "summary"
+            },
+            {
+              "fieldName": "content"
+            }
+          ],
+          "prioritizedKeywordsFields": [
+            {
+              "fieldName": "theme"
+            }
+          ]
+        }
+      }
+    ]
+  }
 }


### PR DESCRIPTION
This PR updates the Azure AI search index configuration to add search fields to match the searchable documents in the Azure Storage blob container data source.

EES-5940 in #5733 added the infrastructure to configure the Azure AI Search instance with an index, indexer and data source. However the index that it created was an empty sample with a single key field. Attempting to use the Azure AI search endpoint up to now will yield empty results containing only two fields `@search.score` and `rid`.

With the indexer and data source configured to use the Azure Storage blob container, by default the indexer will run with a `dataToExtract` parameter of `contentAndMetadata`. This means that all metadata and textual content extracted from the blob will be indexed. This is explained in [Configure and run the blob indexer](https://learn.microsoft.com/en-us/azure/search/search-howto-indexing-azure-blob-storage#configure-and-run-the-blob-indexer).

### Index properties

Textual content of the documents is extracted by the indexer into a string field named `content`, so this field has been added.

Standard blob metadata properties and metadata specific to the content type (in our case - HTML e.g. the HTML title of the document) will be extracted to underscored `metadata_` fields in the index by the indexer. See [Indexing blob metadata](https://learn.microsoft.com/en-us/azure/search/search-howto-indexing-azure-blob-storage#indexing-blob-metadata
) for further explanation.

Custom blob metadata properties are mapped where a field in the index exists with the same name. The custom properties that we add in this PR are:

- Release slug
- Release type
- Release version Id
- Publication slug
- Published date
- Summary
- Theme
- Title
- Type boost (a numerical representation of the release type, which we aim to use to adjust search result rankings, prioritising more relevant types in search results).

Further documentation on the attributes of the search index field configuration can be found in [Create an index in Azure AI Search](https://learn.microsoft.com/en-us/azure/search/search-how-to-create-search-index).

### Scoring profile

Scoring profiles are used to boost the ranking of documents based on criteria.

The index includes a default scoring profile which uses the text-weighted fields fields. This aims to make matches found in `title` and `summary` more relevant than the same matches found in `content`.

Further documentation on the scoring profile configuration can be found in [Add scoring profiles to boost search scores](https://learn.microsoft.com/en-us/azure/search/index-add-scoring-profiles).

### Semantic ranker

The index includes a semantic configuration.  This enables semantic ranking which is a second pass during the search, iterating over the initial result set, applying an additional ranking methodology that promotes the most semantically relevant results to the top of the stack. It also provides semantic captions in search results, with highlights over the most relevant terms and phrases.

The configuration maps `title` as a title field, `summary` and `content` as content fields, and `theme` as a keyword field.

Further documentation on the semantic ranker can be found in [Configure semantic ranker and return captions in search results](https://learn.microsoft.com/en-us/azure/search/semantic-how-to-configure).