### PR TITLE
Ees 6048 hotfix revert duckdb dependency version

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/GovUk.Education.ExploreEducationStatistics.Common.DuckDb.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.DuckDb/GovUk.Education.ExploreEducationStatistics.Common.DuckDb.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.1.66" />
-      <PackageReference Include="DuckDB.NET.Data.Full" Version="1.2.1" />
+      <PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.2" />
       <PackageReference Include="InterpolatedSql.Dapper" Version="2.3.0" />
       <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
     </ItemGroup>


### PR DESCRIPTION
This PR:
* fixes the import of CSVs with quote-escaped cells (e.g. "Kingston upon Hull, City of") by reverting to the previously-used version of DuckDB.
* The change to the new version of Duck would, without further explicit configuration, result in the following errors when attempting to read form such a CSV:

```
Message: Invalid Input Error: CSV Error on Line: 34226
Original Line: 2024,Week 37,Monday,Local...authority,E92000001,England,E12000003,Yorkshire and The Humber,E06000010,"Kingston upon Hull, City of",810,2024-09-09,Primary,Attendance,Present,All present,37020,x,x
Expected Number of Columns:...
```

This is likely due to a change in DuckDB's default CSV behaviour since version 1.2.0 (we previously used 1.0.2 and the upgrades set the new version to 1.2.1). From the DuckDB v1.2.0 README:

```
By default, DuckDB now parses CSVs in so-called strict mode (strict_mode = true)
```

This hotfix will likely be a temporary stopgap. This long term fix will be to:
* Upgrade to the latest DuckDB version.
* Ensure that any reading of CSVs is done with either QUOTE set to " or strict_mode set to false.
* Add tests to handle CSVs with quote-escaped cells in both the initial import of a data set and a "next" import as well.