### PR TITLE
EES-5956 Add ReleaseId to ReleaseSummaryViewModel for use by Search Function App

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseSummaryViewModel.cs
@@ -8,7 +8,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 
 public record ReleaseSummaryViewModel
 {
+    /// <summary>
+    /// The ReleaseVersion id
+    /// </summary>
     public required Guid Id { get; init; }
+
+    public required Guid ReleaseId { get; init; }
 
     public required string Title { get; init; }
 
@@ -38,6 +43,7 @@ public record ReleaseSummaryViewModel
     public ReleaseSummaryViewModel(ReleaseCacheViewModel release, PublicationCacheViewModel publication)
     {
         Id = release.Id;
+        ReleaseId = release.ReleaseId;
         Title = release.Title;
         Slug = release.Slug;
         YearTitle = release.YearTitle;
@@ -53,6 +59,7 @@ public record ReleaseSummaryViewModel
     public ReleaseSummaryViewModel(ReleaseVersion releaseVersion, bool latestPublishedRelease)
     {
         Id = releaseVersion.Id;
+        ReleaseId = releaseVersion.Release.Id;
         Title = releaseVersion.Release.Title;
         Slug = releaseVersion.Release.Slug;
         YearTitle = releaseVersion.Release.YearTitle;


### PR DESCRIPTION
This PR adds `ReleaseId` to `ReleaseSummaryViewModel` in the Content API.

The `ReleaseSummaryViewModel` type is returned in requests to list all releases by publication slug.

```http
GET /api/publications/{publicationSlug}/releases
````

This is being added for use by the Search Function App which will query the list of all releases by publication slug on archiving of a  publication in order to know which searchable documents to remove. `ReleaseId` is used in the naming of searchable document blobs.