### PR TITLE
EES-XXXX - breaking out separate ConfigureServices method and supplying in-memory configuration with PublicDataDbExists flag set to false for simplicity

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -240,10 +240,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             // cause the data source builder to throw a host exception.
             if (!hostEnvironment.IsIntegrationTest())
             {
-                var publicDataDbConnectionString = configuration.GetConnectionString("PublicDataDb")!;
                 // TODO EES-5073 Remove this check when the Public Data db is available in all Azure environments.
-                if (publicDataDbExists && !string.IsNullOrWhiteSpace(publicDataDbConnectionString))
+                if (publicDataDbExists)
                 {
+                    var publicDataDbConnectionString = configuration.GetConnectionString("PublicDataDb")!;
                     services.AddPsqlDbContext<PublicDataDbContext>(publicDataDbConnectionString, hostEnvironment);
                 }
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/HostBuilderTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/HostBuilderTestExtensions.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests;
+
+public static class HostBuilderTestExtensions
+{
+    private const string StorageConnectionString = 
+        "DefaultEndpointsProtocol=http;AccountName=account;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;";
+
+    public static IHostBuilder ConfigureTestAppConfiguration(this IHostBuilder hostBuilder)
+    {
+        return hostBuilder.ConfigureAppConfiguration(s =>
+        {
+            var configuration = new Dictionary<string, string>
+            {
+                { "PublicDataDbExists", "false" },
+                { "App:PrivateStorageConnectionString", StorageConnectionString },
+                { "App:NotifierStorageConnectionString", StorageConnectionString },
+                { "App:PublicStorageConnectionString", StorageConnectionString },
+                { "App:PublisherStorageConnectionString", StorageConnectionString },
+            };
+
+            s.AddInMemoryCollection(configuration!).Build();
+        });
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/HostBuilderTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/HostBuilderTestExtensions.cs
@@ -6,7 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests;
 
 public static class HostBuilderTestExtensions
 {
-    private const string StorageConnectionString = 
+    private const string DevelopmentStorageConnectionString = 
         "DefaultEndpointsProtocol=http;AccountName=account;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;";
 
     public static IHostBuilder ConfigureTestAppConfiguration(this IHostBuilder hostBuilder)
@@ -16,10 +16,10 @@ public static class HostBuilderTestExtensions
             var configuration = new Dictionary<string, string>
             {
                 { "PublicDataDbExists", "false" },
-                { "App:PrivateStorageConnectionString", StorageConnectionString },
-                { "App:NotifierStorageConnectionString", StorageConnectionString },
-                { "App:PublicStorageConnectionString", StorageConnectionString },
-                { "App:PublisherStorageConnectionString", StorageConnectionString },
+                { "App:PrivateStorageConnectionString", DevelopmentStorageConnectionString },
+                { "App:NotifierStorageConnectionString", DevelopmentStorageConnectionString },
+                { "App:PublicStorageConnectionString", DevelopmentStorageConnectionString },
+                { "App:PublisherStorageConnectionString", DevelopmentStorageConnectionString },
             };
 
             s.AddInMemoryCollection(configuration!).Build();

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
@@ -91,7 +90,10 @@ public class PublisherEventRaiserTests
         public void WhenResolvedFromContainer_ThenEventRaiserIsReturned()
         {
             // ARRANGE
-            var host = new HostBuilder().ConfigurePublisherHostBuilder().Build();
+            var host = new HostBuilder()
+                .ConfigureTestAppConfiguration()
+                .ConfigureServices()
+                .Build();
             
             // ACT
             var eventRaiser = host.Services.GetRequiredService<IPublisherEventRaiser>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
@@ -50,7 +50,11 @@ public class PublishingCompletionServiceTests
         [Fact]
         public void EnsureSUTCanBeResolved()
         {
-            var host = new HostBuilder().ConfigurePublisherHostBuilder().Build();
+            var host = new HostBuilder()
+                .ConfigureTestAppConfiguration()
+                .ConfigureServices()
+                .Build();
+            
             ActivatorUtilities.CreateInstance<PublishingCompletionService>(host.Services);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/PublisherHostBuilderExtensions.cs
@@ -62,6 +62,12 @@ public static class PublisherHostBuilderExtensions
                 // TODO EES-5013 Why can't this be controlled through application settings?
                 logging.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Warning);
             })
+            .ConfigureServices();
+    }
+    
+    public static IHostBuilder ConfigureServices(this IHostBuilder hostBuilder)
+    {
+        return hostBuilder
             .ConfigureServices((hostContext, services) =>
             {
                 var configuration = hostContext.Configuration;
@@ -171,9 +177,9 @@ public static class PublisherHostBuilderExtensions
                 // cause the data source builder to throw a host exception.
                 if (!hostEnvironment.IsIntegrationTest())
                 {
-                    var connectionString = ConnectionUtils.GetPostgreSqlConnectionString("PublicDataDb")!;
-                    if (publicDataDbExists && !string.IsNullOrWhiteSpace(connectionString))
+                    if (publicDataDbExists)
                     {
+                        var connectionString = ConnectionUtils.GetPostgreSqlConnectionString("PublicDataDb")!;
                         services.AddFunctionAppPsqlDbContext<PublicDataDbContext>(connectionString, hostContext);
                     }
                 }


### PR DESCRIPTION
This PR:
- fixes an issue whereby the `PublishingCompletionServiceTests.EnsureSUTCanBeResolved` test was failing when the PublicDataDbExists flag was set to true in peoples' `appsettings.Local.json` files, as this resulted in no PublicDataDbContext being registered but subsequent dependencies needing one to be available.

We now provide explicit configuration to this test's HostBuilder and call `ConfigureServices()` directly without needing to rely on prior configuration from `ConfigureAppConfiguration()`.  