### PR TITLE
EES-6050 - increasing Pre-Prods statistics db capacity from 250GB to 350GB

### DIFF
--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -87,7 +87,7 @@
       "value": 1073741824
     },
     "maxStatsDbSizeBytes": {
-      "value": 268435456000
+      "value": 375809638400
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true


### PR DESCRIPTION
This PR increases the capacity of the statistics and replica DBs on Pre-Prod, from 250GB to 350GB.

This is in response to capacity alerts showing that Pre-Prod's statistics dbs are now at 95% capacity.