### PR TITLE
EES-5956 Add event handling to Search function app for publication archiving events

### DIFF
--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -50,15 +50,15 @@ param functionAppExists bool
 
 @description('Specifies the names of the storage queues that trigger functions within the Search Docs Function App.')
 param storageQueueNames SearchStorageQueueNames = {
-  publicationArchivedQueueName: 'publication-archived-queue'
-  publicationChangedQueueName: 'publication-changed-queue'
-  publicationLatestPublishedReleaseReorderedQueueName: 'publication-latest-published-release-reordered-queue'
-  refreshSearchableDocumentQueueName: 'refresh-searchable-document-queue'
-  releaseSlugChangedQueueName: 'release-slug-changed-queue'
-  releaseVersionPublishedQueueName: 'release-version-published-queue'
-  removePublicationSearchableDocumentsQueueName: 'remove-publication-searchable-documents-queue'
-  searchableDocumentCreatedQueueName: 'search-document-created-queue'
-  themeUpdatedQueueName: 'theme-updated-queue'
+  publicationArchived: 'publication-archived-queue'
+  publicationChanged: 'publication-changed-queue'
+  publicationLatestPublishedReleaseReordered: 'publication-latest-published-release-reordered-queue'
+  refreshSearchableDocument: 'refresh-searchable-document-queue'
+  releaseSlugChanged: 'release-slug-changed-queue'
+  releaseVersionPublished: 'release-version-published-queue'
+  removePublicationSearchableDocuments: 'remove-publication-searchable-documents-queue'
+  searchableDocumentCreated: 'search-document-created-queue'
+  themeUpdated: 'theme-updated-queue'
 }
 
 @description('Specifies a set of tags with which to tag the resource in Azure.')
@@ -131,39 +131,39 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
       }
       {
         name: 'PublicationArchivedQueueName'
-        value: storageQueueNames.publicationArchivedQueueName
+        value: storageQueueNames.publicationArchived
       }
       {
         name: 'PublicationChangedQueueName'
-        value: storageQueueNames.publicationChangedQueueName
+        value: storageQueueNames.publicationChanged
       }
       {
         name: 'PublicationLatestPublishedReleaseReorderedQueueName'
-        value: storageQueueNames.publicationLatestPublishedReleaseReorderedQueueName
+        value: storageQueueNames.publicationLatestPublishedReleaseReordered
       }
       {
         name: 'RefreshSearchableDocumentQueueName'
-        value: storageQueueNames.refreshSearchableDocumentQueueName
+        value: storageQueueNames.refreshSearchableDocument
       }
       {
         name: 'ReleaseSlugChangedQueueName'
-        value: storageQueueNames.releaseSlugChangedQueueName
+        value: storageQueueNames.releaseSlugChanged
       }
       {
         name: 'ReleaseVersionPublishedQueueName'
-        value: storageQueueNames.releaseVersionPublishedQueueName
+        value: storageQueueNames.releaseVersionPublished
       }
       {
         name: 'RemovePublicationSearchableDocumentsQueueName'
-        value: storageQueueNames.removePublicationSearchableDocumentsQueueName
+        value: storageQueueNames.removePublicationSearchableDocuments
       }
       {
         name: 'SearchableDocumentCreatedQueueName'
-        value: storageQueueNames.searchableDocumentCreatedQueueName
+        value: storageQueueNames.searchableDocumentCreated
       }
       {
         name: 'ThemeUpdatedQueueName'
-        value: storageQueueNames.themeUpdatedQueueName
+        value: storageQueueNames.themeUpdated
       }
     ]
     functionAppExists: functionAppExists

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -48,26 +48,18 @@ param applicationInsightsConnectionString string = ''
 @description('Specifies whether or not the Search Docs Function App already exists.')
 param functionAppExists bool
 
-@description('The name of the queue that is used when a publication is changed.')
-param publicationChangedQueueName string = 'publication-changed-queue'
-
-@description('The name of the queue that is used when the latest published release of a publication changes due to reordering.')
-param publicationLatestPublishedReleaseReorderedQueueName string = 'publication-latest-published-release-reordered-queue'
-
-@description('The name of the queue that is used when a searchable document requires a refresh.')
-param refreshSearchableDocumentQueueName string = 'refresh-searchable-document-queue'
-
-@description('The name of the queue that is used when a release slug is changed.')
-param releaseSlugChangedQueueName string = 'release-slug-changed-queue'
-
-@description('The name of the queue that is used when a release version is published.')
-param releaseVersionPublishedQueueName string = 'release-version-published-queue'
-
-@description('The name of the queue that is used when a searchable document is created.')
-param searchableDocumentCreatedQueueName string = 'search-document-created-queue'
-
-@description('The name of the queue that is used when a theme is updated.')
-param themeUpdatedQueueName string = 'theme-updated-queue'
+@description('Specifies the names of the storage queues that trigger functions within the Search Docs Function App.')
+param storageQueueNames SearchStorageQueueNames = {
+  publicationArchivedQueueName: 'publication-archived-queue'
+  publicationChangedQueueName: 'publication-changed-queue'
+  publicationLatestPublishedReleaseReorderedQueueName: 'publication-latest-published-release-reordered-queue'
+  refreshSearchableDocumentQueueName: 'refresh-searchable-document-queue'
+  releaseSlugChangedQueueName: 'release-slug-changed-queue'
+  releaseVersionPublishedQueueName: 'release-version-published-queue'
+  removePublicationSearchableDocumentsQueueName: 'remove-publication-searchable-documents-queue'
+  searchableDocumentCreatedQueueName: 'search-document-created-queue'
+  themeUpdatedQueueName: 'theme-updated-queue'
+}
 
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
@@ -138,32 +130,40 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
         value: contentApiUrl
       }
       {
+        name: 'PublicationArchivedQueueName'
+        value: storageQueueNames.publicationArchivedQueueName
+      }
+      {
         name: 'PublicationChangedQueueName'
-        value: publicationChangedQueueName
+        value: storageQueueNames.publicationChangedQueueName
       }
       {
         name: 'PublicationLatestPublishedReleaseReorderedQueueName'
-        value: publicationLatestPublishedReleaseReorderedQueueName
+        value: storageQueueNames.publicationLatestPublishedReleaseReorderedQueueName
       }
       {
         name: 'RefreshSearchableDocumentQueueName'
-        value: refreshSearchableDocumentQueueName
+        value: storageQueueNames.refreshSearchableDocumentQueueName
       }
       {
         name: 'ReleaseSlugChangedQueueName'
-        value: releaseSlugChangedQueueName
+        value: storageQueueNames.releaseSlugChangedQueueName
       }
       {
         name: 'ReleaseVersionPublishedQueueName'
-        value: releaseVersionPublishedQueueName
+        value: storageQueueNames.releaseVersionPublishedQueueName
+      }
+      {
+        name: 'RemovePublicationSearchableDocumentsQueueName'
+        value: storageQueueNames.removePublicationSearchableDocumentsQueueName
       }
       {
         name: 'SearchableDocumentCreatedQueueName'
-        value: searchableDocumentCreatedQueueName
+        value: storageQueueNames.searchableDocumentCreatedQueueName
       }
       {
         name: 'ThemeUpdatedQueueName'
-        value: themeUpdatedQueueName
+        value: storageQueueNames.themeUpdatedQueueName
       }
     ]
     functionAppExists: functionAppExists
@@ -219,27 +219,11 @@ module functionAppStorageAccountQueueServiceModule '../../common/components/queu
   name: 'searchDocsFunctionAppStorageAccountQueueServiceModuleDeploy'
   params: {
     storageAccountName: functionAppModule.outputs.storageAccountName
-    queueNames: [
-      publicationChangedQueueName
-      publicationLatestPublishedReleaseReorderedQueueName
-      refreshSearchableDocumentQueueName
-      releaseSlugChangedQueueName
-      releaseVersionPublishedQueueName
-      searchableDocumentCreatedQueueName
-      themeUpdatedQueueName
-    ]
+    queueNames: map(items(storageQueueNames), item => item.value)
   }
 }
 
 output functionAppName string = functionAppModule.outputs.name
 output functionAppUrl string = functionAppModule.outputs.url
 output functionAppStorageAccountName string = functionAppModule.outputs.storageAccountName
-output storageQueueNames SearchStorageQueueNames = {
-  publicationChangedQueueName: publicationChangedQueueName
-  publicationLatestPublishedReleaseReorderedQueueName: publicationLatestPublishedReleaseReorderedQueueName
-  refreshSearchableDocumentQueueName: refreshSearchableDocumentQueueName
-  releaseSlugChangedQueueName: releaseSlugChangedQueueName
-  releaseVersionPublishedQueueName: releaseVersionPublishedQueueName
-  searchableDocumentCreatedQueueName: searchableDocumentCreatedQueueName
-  themeUpdatedQueueName: themeUpdatedQueueName
-}
+output storageQueueNames SearchStorageQueueNames = storageQueueNames

--- a/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
@@ -20,12 +20,12 @@ var eventGridCustomTopicSubscriptions = [
       {
         name: 'publication-changed'
         includedEventTypes: ['publication-changed']
-        queueName: storageQueueNames.publicationChangedQueueName
+        queueName: storageQueueNames.publicationChanged
       }
       {
         name: 'publication-latest-published-release-reordered'
         includedEventTypes: ['publication-latest-published-release-reordered']
-        queueName: storageQueueNames.publicationLatestPublishedReleaseReorderedQueueName
+        queueName: storageQueueNames.publicationLatestPublishedReleaseReordered
       }
     ]
   }
@@ -35,7 +35,7 @@ var eventGridCustomTopicSubscriptions = [
       {
         name: 'release-slug-changed'
         includedEventTypes: ['release-slug-changed']
-        queueName: storageQueueNames.releaseSlugChangedQueueName
+        queueName: storageQueueNames.releaseSlugChanged
       }
     ]
   }
@@ -45,7 +45,7 @@ var eventGridCustomTopicSubscriptions = [
       {
         name: 'release-version-published'
         includedEventTypes: ['release-version-published']
-        queueName: storageQueueNames.releaseVersionPublishedQueueName
+        queueName: storageQueueNames.releaseVersionPublished
       }
     ]
   }
@@ -55,7 +55,7 @@ var eventGridCustomTopicSubscriptions = [
       {
         name: 'theme-changed'
         includedEventTypes: ['theme-changed']
-        queueName: storageQueueNames.themeUpdatedQueueName
+        queueName: storageQueueNames.themeUpdated
       }
     ]
   }

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -22,21 +22,21 @@ type SearchServiceRole = 'Search Index Data Contributor' | 'Search Index Data Re
 @sealed()
 type SearchStorageQueueNames = {
   @description('The name of the queue used when a publication is archived.')
-  publicationArchivedQueueName: string
+  publicationArchived: string
   @description('The name of the queue used when a publication is changed.')
-  publicationChangedQueueName: string
+  publicationChanged: string
   @description('The name of the queue used when the latest published release of a publication changes due to reordering.')
-  publicationLatestPublishedReleaseReorderedQueueName: string
+  publicationLatestPublishedReleaseReordered: string
   @description('The name of the queue used when a searchable document requires a refresh.')
-  refreshSearchableDocumentQueueName: string
+  refreshSearchableDocument: string
   @description('The name of the queue used when a release slug is changed.')
-  releaseSlugChangedQueueName: string
+  releaseSlugChanged: string
   @description('The name of the queue used when a release version is published.')
-  releaseVersionPublishedQueueName: string
+  releaseVersionPublished: string
   @description('The name of the queue used for removing searchable documents associated with a publication.')
-  removePublicationSearchableDocumentsQueueName: string
+  removePublicationSearchableDocuments: string
   @description('The name of the queue used when a searchable document is created.')
-  searchableDocumentCreatedQueueName: string
+  searchableDocumentCreated: string
   @description('The name of the queue used when a theme is updated.')
-  themeUpdatedQueueName: string
+  themeUpdated: string
 }

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -21,11 +21,22 @@ type SearchServiceRole = 'Search Index Data Contributor' | 'Search Index Data Re
 @export()
 @sealed()
 type SearchStorageQueueNames = {
+  @description('The name of the queue used when a publication is archived.')
+  publicationArchivedQueueName: string
+  @description('The name of the queue used when a publication is changed.')
   publicationChangedQueueName: string
+  @description('The name of the queue used when the latest published release of a publication changes due to reordering.')
   publicationLatestPublishedReleaseReorderedQueueName: string
+  @description('The name of the queue used when a searchable document requires a refresh.')
   refreshSearchableDocumentQueueName: string
+  @description('The name of the queue used when a release slug is changed.')
   releaseSlugChangedQueueName: string
+  @description('The name of the queue used when a release version is published.')
   releaseVersionPublishedQueueName: string
+  @description('The name of the queue used for removing searchable documents associated with a publication.')
+  removePublicationSearchableDocumentsQueueName: string
+  @description('The name of the queue used when a searchable document is created.')
   searchableDocumentCreatedQueueName: string
+  @description('The name of the queue used when a theme is updated.')
   themeUpdatedQueueName: string
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/AzureBlobStorageClientMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/AzureBlobStorageClientMockBuilder.cs
@@ -1,5 +1,4 @@
-﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
 using Moq;
 using Blob = GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage.Blob;
 
@@ -8,34 +7,70 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 internal class AzureBlobStorageClientMockBuilder
 {
     private readonly Mock<IAzureBlobStorageClient> _mock = new(MockBehavior.Strict);
+    private bool _deleteBlobIfExistsIsSuccessful = true;
 
     public AzureBlobStorageClientMockBuilder()
     {
-        Assert = new(_mock);
-        
+        Assert = new Asserter(_mock);
+
+        _mock.Setup(mock => mock.DeleteBlobIfExists(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _deleteBlobIfExistsIsSuccessful);
+
         _mock.Setup(mock => mock.UploadBlob(
-            It.IsAny<string>(), 
-            It.IsAny<string>(), 
-            It.IsAny<Blob>(), 
-            It.IsAny<CancellationToken>()))
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<Blob>(),
+                It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
     }
-    
+
     public IAzureBlobStorageClient Build() => _mock.Object;
 
+    public AzureBlobStorageClientMockBuilder WhereDeleteBlobIfExistsIsSuccessful(bool isSuccessful)
+    {
+        _deleteBlobIfExistsIsSuccessful = isSuccessful;
+        return this;
+    }
+
     public Asserter Assert { get; }
+
     public class Asserter(Mock<IAzureBlobStorageClient> mock)
     {
+        public void BlobWasDeletedIfExists(
+            string? containerName = null,
+            string? blobName = null)
+        {
+            mock.Verify(m => m.DeleteBlobIfExists(
+                    It.Is<string>(actualContainerName => containerName == null || actualContainerName == containerName),
+                    It.Is<string>(actualBlobName => blobName == null || actualBlobName == blobName),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        public void NoBlobsDeleted()
+        {
+            mock
+                .Verify(m => m.DeleteBlobIfExists(
+                            It.IsAny<string>(),
+                            It.IsAny<string>(),
+                            It.IsAny<CancellationToken>()),
+                    Times.Never);
+        }
+
         public void BlobWasUploaded(
             string? containerName = null,
-            string? blobName = null, 
+            string? blobName = null,
             Func<Blob, bool>? whereBlob = null)
         {
             mock.Verify(m => m.UploadBlob(
-                It.Is<string>(actualContainerName => containerName == null || actualContainerName == containerName),
-                It.Is<string>(actualBlobName => blobName == null || actualBlobName == blobName),
-                It.Is<Blob>(blob => whereBlob == null || whereBlob(blob)), 
-                It.IsAny<CancellationToken>()), Times.Once);
+                    It.Is<string>(actualContainerName => containerName == null || actualContainerName == containerName),
+                    It.Is<string>(actualBlobName => blobName == null || actualBlobName == blobName),
+                    It.Is<Blob>(blob => whereBlob == null || whereBlob(blob)),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/SearchableDocumentRemoverMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/SearchableDocumentRemoverMockBuilder.cs
@@ -1,0 +1,56 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using Moq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+
+public class SearchableDocumentRemoverMockBuilder
+{
+    private readonly Mock<ISearchableDocumentRemover> _mock = new(MockBehavior.Strict);
+    private RemovePublicationSearchableDocumentsResponse? _response;
+
+    public SearchableDocumentRemoverMockBuilder()
+    {
+        Assert = new Asserter(_mock);
+
+        _mock
+            .Setup(m => m.RemovePublicationSearchableDocuments(
+                It.IsAny<RemovePublicationSearchableDocumentsRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_response ?? new RemovePublicationSearchableDocumentsResponse());
+    }
+
+    public ISearchableDocumentRemover Build()
+    {
+        return _mock.Object;
+    }
+
+    public SearchableDocumentRemoverMockBuilder WhereResponseIs(RemovePublicationSearchableDocumentsResponse response)
+    {
+        _response = response;
+        return this;
+    }
+
+    public Asserter Assert { get; }
+
+    public class Asserter(Mock<ISearchableDocumentRemover> mock)
+    {
+        public void RemovePublicationSearchableDocumentsCalledFor(string publicationSlug)
+        {
+            mock
+                .Verify(m => m.RemovePublicationSearchableDocuments(
+                        It.Is<RemovePublicationSearchableDocumentsRequest>(
+                            req =>
+                                req.PublicationSlug == publicationSlug),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+        }
+
+        public void RemovePublicationSearchableDocumentsNotCalled()
+        {
+            mock.Verify(m => m.RemovePublicationSearchableDocuments(
+                    It.IsAny<RemovePublicationSearchableDocumentsRequest>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/SearchableDocumentRemoverMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/SearchableDocumentRemoverMockBuilder.cs
@@ -16,7 +16,7 @@ public class SearchableDocumentRemoverMockBuilder
             .Setup(m => m.RemovePublicationSearchableDocuments(
                 It.IsAny<RemovePublicationSearchableDocumentsRequest>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(_response ?? new RemovePublicationSearchableDocumentsResponse());
+            .ReturnsAsync(_response ?? new RemovePublicationSearchableDocumentsResponse(new Dictionary<Guid, bool>()));
     }
 
     public ISearchableDocumentRemover Build()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Clients/ContentApi/ContentApiClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Clients/ContentApi/ContentApiClientTests.cs
@@ -16,7 +16,7 @@ public class ContentApiClientTests(ITestOutputHelper output)
     }
 
     protected void Print(string s) => output.WriteLine(s);
-    
+
     /// <summary>
     /// Separately assert that each of the public properties of two instances of an object are equal.
     /// This provides a finer grained explanation of where two objects differ in equality.  
@@ -54,16 +54,16 @@ public class ContentApiClientTests(ITestOutputHelper output)
                 // ARRANGE
                 var sut = GetSut();
                 var publicationSlug = "seed-publication-permanent-and-fixed-period-exclusions-in-england";
-                
+
                 // ACT
                 var actual = await sut.GetPublicationLatestReleaseSearchableDocument(publicationSlug);
-                
+
                 // ASSERT
                 Assert.NotNull(actual);
                 var expected = new ReleaseSearchableDocument
                 {
                     ReleaseVersionId = new Guid("46c5d916-ee40-49bd-cfdc-08dc1c5c621e"),
-                    Published = DateTimeOffset.Parse("2018-07-18T23:00:00Z"), 
+                    Published = DateTimeOffset.Parse("2018-07-18T23:00:00Z"),
                     PublicationTitle = "Seed publication - Permanent and fixed-period exclusions in England",
                     Summary = "Read national statistical summaries, view charts and tables and download data files.",
                     Theme = "Seed theme - Pupils and schools",
@@ -98,7 +98,6 @@ public class ContentApiClientTests(ITestOutputHelper output)
                     Assert.Contains(publicationSlug, unableToGetPublicationLatestReleaseSearchViewModelException.Message);
                 }
             }
-        
     }
 
     public class IntegrationTests(ITestOutputHelper output) : ContentApiClientTests(output)
@@ -111,7 +110,7 @@ public class ContentApiClientTests(ITestOutputHelper output)
                 httpClient.BaseAddress = new Uri(ContentApiBaseAddress);
             });
 
-        [Fact(Skip="Call Content API to get publications for a specified theme id")]
+        [Fact(Skip = "Call Content API to get publications for a specified theme id")]
         public async Task GetPublicationsForTheme()
         {
             var sut = GetSut();
@@ -123,5 +122,16 @@ public class ContentApiClientTests(ITestOutputHelper output)
             }
         }
 
+        [Fact(Skip = "Call Content API to get releases for a specified publication slug")]
+        public async Task GetReleasesForPublication()
+        {
+            var sut = GetSut();
+            const string publicationSlug = "seed-publication-pupil-absence-in-schools-in-england";
+            var releases = await sut.GetReleasesForPublication(publicationSlug);
+            foreach (var release in releases)
+            {
+                Print(release.ReleaseId.ToString());
+            }
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationArchived/OnPublicationArchivedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationArchived/OnPublicationArchivedFunctionTests.cs
@@ -1,0 +1,42 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationArchived;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationArchived.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationChanged.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.OnPublicationArchived;
+
+public class OnPublicationArchivedFunctionTests
+{
+    private OnPublicationArchivedFunction GetSut() => new(
+        new EventGridEventHandler(new NullLogger<EventGridEventHandler>()));
+
+    [Fact]
+    public void CanInstantiateSut() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task GivenEvent_WhenPayloadContainsSlug_ReturnsExpectedDto()
+    {
+        var payload = new PublicationChangedEventDto { Slug = "publication-slug" };
+        var eventGridEvent = new EventGridEventBuilder().WithPayload(payload).Build();
+
+        var response = await GetSut().OnPublicationArchived(eventGridEvent, new FunctionContextMockBuilder().Build());
+
+        var actual = Assert.Single(response);
+        Assert.Equal(payload.Slug, actual.PublicationSlug);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task GivenEvent_WhenPayloadDoesNotContainSlug_ThenNothingIsReturned(string? blankSlug)
+    {
+        var payload = new PublicationArchivedEventDto { Slug = blankSlug };
+        var eventGridEvent = new EventGridEventBuilder().WithPayload(payload).Build();
+
+        var response = await GetSut().OnPublicationArchived(eventGridEvent, new FunctionContextMockBuilder().Build());
+
+        Assert.Empty(response);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsTests.cs
@@ -1,0 +1,42 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.
+    RemovePublicationSearchableDocuments;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.
+    RemovePublicationSearchableDocuments.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.
+    RemovePublicationSearchableDocuments;
+
+public class RemovePublicationSearchableDocumentsTests
+{
+    private readonly SearchableDocumentRemoverMockBuilder _searchableDocumentRemoverMockBuilder = new();
+
+    private RemovePublicationSearchableDocumentsFunction GetSut() => new(
+        _searchableDocumentRemoverMockBuilder.Build());
+
+    [Fact]
+    public void CanInstantiateSut() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task WhenMessageContainsSlug_ThenDocumentRemoverCalled()
+    {
+        var command = new RemovePublicationSearchableDocumentsDto { PublicationSlug = "publication-slug" };
+
+        await GetSut().RemovePublicationSearchableDocuments(command, new FunctionContextMockBuilder().Build());
+
+        _searchableDocumentRemoverMockBuilder.Assert.RemovePublicationSearchableDocumentsCalledFor(
+            command.PublicationSlug);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task WhenMessageDoesNotContainSlug_ThenDocumentRemoverNotCalled(string? publicationSlug)
+    {
+        var command = new RemovePublicationSearchableDocumentsDto { PublicationSlug = publicationSlug };
+
+        await GetSut().RemovePublicationSearchableDocuments(command, new FunctionContextMockBuilder().Build());
+
+        _searchableDocumentRemoverMockBuilder.Assert.RemovePublicationSearchableDocumentsNotCalled();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsTests.cs
@@ -3,6 +3,7 @@
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.
     RemovePublicationSearchableDocuments.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.
     RemovePublicationSearchableDocuments;
@@ -12,6 +13,7 @@ public class RemovePublicationSearchableDocumentsTests
     private readonly SearchableDocumentRemoverMockBuilder _searchableDocumentRemoverMockBuilder = new();
 
     private RemovePublicationSearchableDocumentsFunction GetSut() => new(
+        new NullLogger<RemovePublicationSearchableDocumentsFunction>(),
         _searchableDocumentRemoverMockBuilder.Build());
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
@@ -1,10 +1,6 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseSlugChanged;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseVersionPublished;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnThemeUpdated;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RefreshSearchableDocument;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.ReindexSearchableDocuments;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
@@ -31,7 +27,7 @@ public class ProgramTests
 
     private IHost GetSut() => GetSutWithConfig(FullConfig);
 
-    private IHost GetSutWithConfig(params string[] jsonConfig) => GetSut(builder => 
+    private IHost GetSutWithConfig(params string[] jsonConfig) => GetSut(builder =>
         builder.ConfigureAppConfiguration((_, configurationBuilder) =>
         {
             foreach (var s in jsonConfig)
@@ -39,8 +35,9 @@ public class ProgramTests
                 configurationBuilder.AddJsonString(s);
             }
         }));
-    
-    private IHost GetSut(Func<IHostBuilder, IHostBuilder> modifyHostBuilder) => modifyHostBuilder(new HostBuilder()).BuildHost();
+
+    private IHost GetSut(Func<IHostBuilder, IHostBuilder> modifyHostBuilder) =>
+        modifyHostBuilder(new HostBuilder()).BuildHost();
 
     public class BasicTests : ProgramTests
     {
@@ -57,7 +54,7 @@ public class ProgramTests
             {
                 // ARRANGE
                 var sut = GetSut();
-                
+
                 // ACT
                 var httpClient = sut.Services.GetRequiredService<System.Net.Http.HttpClient>();
 
@@ -65,7 +62,7 @@ public class ProgramTests
                 Assert.NotNull(httpClient);
             }
         }
-        
+
         public class SearchableDocumentCreatorTests : ProgramTests
         {
             [Fact]
@@ -73,16 +70,33 @@ public class ProgramTests
             {
                 // ARRANGE
                 var sut = GetSut();
-            
+
                 // ACT
                 var actual = sut.Services.GetRequiredService<ISearchableDocumentCreator>();
-            
+
                 // ASSERT
                 Assert.NotNull(actual);
                 Assert.IsType<SearchableDocumentCreator>(actual);
             }
         }
-        
+
+        public class SearchableDocumentRemoverTests : ProgramTests
+        {
+            [Fact]
+            public void Should_resolve_ISearchableDocumentRemover()
+            {
+                // ARRANGE
+                var sut = GetSut();
+
+                // ACT
+                var actual = sut.Services.GetRequiredService<ISearchableDocumentRemover>();
+
+                // ASSERT
+                Assert.NotNull(actual);
+                Assert.IsType<SearchableDocumentRemover>(actual);
+            }
+        }
+
         public class ClientApiTests : GivenConfiguredHostTests
         {
             [Fact]
@@ -97,7 +111,7 @@ public class ProgramTests
                      }
                     }
                     """);
-                
+
                 // ACT
                 var actual = sut.Services.GetRequiredService<IContentApiClient>();
 
@@ -106,7 +120,7 @@ public class ProgramTests
                 var contentApiClient = Assert.IsType<ContentApiClient>(actual);
                 Assert.Equal("http://my.test.url:123/", contentApiClient.HttpClient.BaseAddress?.ToString());
             }
-            
+
             [Fact]
             public void WhenBaseAddressIsNotConfiguredShouldThrowOnStartup()
             {
@@ -128,7 +142,7 @@ public class ProgramTests
                 Assert.NotNull(options);
             }
         }
-        
+
         public class AzureBlobStorageClientApiTests : GivenConfiguredHostTests
         {
             [Fact]
@@ -155,7 +169,7 @@ public class ProgramTests
                 Assert.Equal("https://mystorageaccount.blob.core.windows.net/", blobServiceClient.Uri.ToString());
                 Assert.Equal("mystorageaccount", blobServiceClient.AccountName);
             }
-            
+
             [Fact]
             public void WhenConnectionStringNotConfiguredShouldNotThrowOnStartUp()
             {
@@ -177,7 +191,7 @@ public class ProgramTests
                 var options = host.Services.GetRequiredService<IOptions<ContentApiOptions>>();
                 Assert.NotNull(options);
             }
-            
+
             [Fact]
             public void WhenContainerNameNotConfiguredShouldNotThrowOnStartup()
             {
@@ -200,7 +214,7 @@ public class ProgramTests
                 Assert.NotNull(options);
             }
         }
-        
+
         public class ReindexSearchableDocumentsFunctionTests : ProgramTests
         {
             [Fact]
@@ -208,36 +222,36 @@ public class ProgramTests
             {
                 // ARRANGE
                 var sut = GetSut();
-            
+
                 // ACT
                 var actual = ActivatorUtilities.CreateInstance<ReindexSearchableDocumentsFunction>(sut.Services);
-            
+
                 // ASSERT
                 Assert.NotNull(actual);
             }
-            
+
             [Fact]
             public void GivenNotConfigured_WhenResolvingReindexSearchableDocumentsFunction_ThenShouldResolve()
             {
                 // ARRANGE
                 var sut = GetSutWithConfig("{}");
-            
+
                 // ACT
                 var actual = sut.Services.GetRequiredService<IOptions<ReindexSearchableDocumentsFunction>>();
-                
+
                 // ASSERT
                 Assert.NotNull(actual);
             }
-            
+
             [Fact]
             public void GivenNotConfigured_WhenResolvingAzureSearchOptions_ThenShouldResolve()
             {
                 // ARRANGE
                 var sut = GetSutWithConfig("{}");
-            
+
                 // ACT
                 var options = sut.Services.GetRequiredService<IOptions<AzureSearchOptions>>();
-                
+
                 // ASSERT
                 Assert.NotNull(options.Value);
                 Assert.Equal(string.Empty, options.Value.SearchServiceEndpoint);
@@ -245,7 +259,7 @@ public class ProgramTests
                 Assert.Equal(string.Empty, options.Value.IndexerName);
             }
         }
-        
+
         public class ResolveFunctionTests : ProgramTests
         {
             public static TheoryData<Type> GetAzureFunctionTypes()
@@ -253,9 +267,10 @@ public class ProgramTests
                 var types = typeof(Program)
                     .Assembly
                     .GetTypes()
-                    .Where(type => type.Namespace?.StartsWith("GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.") == true)
+                    .Where(type => type.Namespace?.StartsWith(
+                            "GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.") == true)
                     .Where(type => type.Name.EndsWith("Function"));
-                
+
                 return new TheoryData<Type>(types);
             }
 
@@ -265,10 +280,10 @@ public class ProgramTests
             {
                 // ARRANGE
                 var sut = GetSut();
-            
+
                 // ACT
                 var actual = ActivatorUtilities.CreateInstance(sut.Services, functionType);
-            
+
                 // ASSERT
                 Assert.NotNull(actual);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/SearchableDocumentRemoverTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/SearchableDocumentRemoverTests.cs
@@ -1,0 +1,109 @@
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Domain;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Services;
+
+public class SearchableDocumentRemoverTests
+{
+    private readonly ContentApiClientMockBuilder _contentApiClientMockBuilder = new();
+    private readonly AzureBlobStorageClientMockBuilder _azureBlobStorageClientMockBuilder = new();
+    private AppOptions _appOptions = new();
+
+    private SearchableDocumentRemover GetSut() => new(
+        _contentApiClientMockBuilder.Build(),
+        _azureBlobStorageClientMockBuilder.Build(),
+        Microsoft.Extensions.Options.Options.Create(_appOptions));
+
+    public class BasicTests : SearchableDocumentRemoverTests
+    {
+        [Fact]
+        public void CanInstantiateSut() => Assert.NotNull(GetSut());
+    }
+
+    public class RemovePublicationSearchableDocumentsTests : SearchableDocumentRemoverTests
+    {
+        [Fact]
+        public async Task ShouldRequestReleasesForPublicationFromContentApi()
+        {
+            var request = new RemovePublicationSearchableDocumentsRequest { PublicationSlug = "publication-slug" };
+
+            await GetSut().RemovePublicationSearchableDocuments(request);
+
+            _contentApiClientMockBuilder.Assert.ReleasesRequestedForPublication("publication-slug");
+        }
+
+        [Fact]
+        public async Task ShouldNotDeleteBlobsIfNoReleasesFound()
+        {
+            ReleaseInfo[] releases = [];
+            var request = new RemovePublicationSearchableDocumentsRequest { PublicationSlug = "publication-slug" };
+            _contentApiClientMockBuilder.WherePublicationHasReleases(releases);
+
+            await GetSut().RemovePublicationSearchableDocuments(request);
+
+            _azureBlobStorageClientMockBuilder.Assert.NoBlobsDeleted();
+        }
+
+        [Fact]
+        public async Task ShouldDeleteBlobsFromExpectedStorageContainer()
+        {
+            _appOptions = new AppOptions
+            {
+                SearchStorageConnectionString = "azure storage connection string",
+                SearchableDocumentsContainerName = "searchable-documents-container-name"
+            };
+
+            ReleaseInfo[] releases =
+            [
+                new() { ReleaseId = Guid.NewGuid() }
+            ];
+            var request = new RemovePublicationSearchableDocumentsRequest { PublicationSlug = "publication-slug" };
+            _contentApiClientMockBuilder.WherePublicationHasReleases(releases);
+
+            await GetSut().RemovePublicationSearchableDocuments(request);
+
+            _azureBlobStorageClientMockBuilder.Assert.BlobWasDeletedIfExists(
+                containerName: _appOptions.SearchableDocumentsContainerName);
+        }
+
+        [Fact]
+        public async Task ShouldDeleteBlobsForReleases()
+        {
+            ReleaseInfo[] releases =
+            [
+                new() { ReleaseId = Guid.NewGuid() },
+                new() { ReleaseId = Guid.NewGuid() }
+            ];
+            var request = new RemovePublicationSearchableDocumentsRequest { PublicationSlug = "publication-slug" };
+            _contentApiClientMockBuilder.WherePublicationHasReleases(releases);
+
+            await GetSut().RemovePublicationSearchableDocuments(request);
+
+            _azureBlobStorageClientMockBuilder.Assert.BlobWasDeletedIfExists(
+                blobName: releases[0].ReleaseId.ToString());
+            _azureBlobStorageClientMockBuilder.Assert.BlobWasDeletedIfExists(
+                blobName: releases[1].ReleaseId.ToString());
+        }
+
+        [Fact]
+        public async Task ShouldReturnDeletionResultInResponse()
+        {
+            ReleaseInfo[] releases =
+            [
+                new() { ReleaseId = Guid.NewGuid() },
+                new() { ReleaseId = Guid.NewGuid() }
+            ];
+            var request = new RemovePublicationSearchableDocumentsRequest { PublicationSlug = "publication-slug" };
+            _contentApiClientMockBuilder.WherePublicationHasReleases(releases);
+            _azureBlobStorageClientMockBuilder.WhereDeleteBlobIfExistsIsSuccessful(false);
+
+            var response = await GetSut().RemovePublicationSearchableDocuments(request);
+
+            Assert.Equal(2, response.ReleaseIdToDeletionResult.Count);
+            Assert.False(response.ReleaseIdToDeletionResult[releases[0].ReleaseId]);
+            Assert.False(response.ReleaseIdToDeletionResult[releases[1].ReleaseId]);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/SearchableDocumentRemoverTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/SearchableDocumentRemoverTests.cs
@@ -64,7 +64,7 @@ public class SearchableDocumentRemoverTests
 
             await GetSut().RemovePublicationSearchableDocuments(request);
 
-            _azureBlobStorageClientMockBuilder.Assert.BlobWasDeletedIfExists(
+            _azureBlobStorageClientMockBuilder.Assert.BlobWasDeleted(
                 containerName: _appOptions.SearchableDocumentsContainerName);
         }
 
@@ -81,9 +81,9 @@ public class SearchableDocumentRemoverTests
 
             await GetSut().RemovePublicationSearchableDocuments(request);
 
-            _azureBlobStorageClientMockBuilder.Assert.BlobWasDeletedIfExists(
+            _azureBlobStorageClientMockBuilder.Assert.BlobWasDeleted(
                 blobName: releases[0].ReleaseId.ToString());
-            _azureBlobStorageClientMockBuilder.Assert.BlobWasDeletedIfExists(
+            _azureBlobStorageClientMockBuilder.Assert.BlobWasDeleted(
                 blobName: releases[1].ReleaseId.ToString());
         }
 
@@ -97,13 +97,13 @@ public class SearchableDocumentRemoverTests
             ];
             var request = new RemovePublicationSearchableDocumentsRequest { PublicationSlug = "publication-slug" };
             _contentApiClientMockBuilder.WherePublicationHasReleases(releases);
-            _azureBlobStorageClientMockBuilder.WhereDeleteBlobIfExistsIsSuccessful(false);
+            _azureBlobStorageClientMockBuilder.WhereDeleteBlobFailsFor(releases[0].ReleaseId.ToString());
 
             var response = await GetSut().RemovePublicationSearchableDocuments(request);
 
             Assert.Equal(2, response.ReleaseIdToDeletionResult.Count);
             Assert.False(response.ReleaseIdToDeletionResult[releases[0].ReleaseId]);
-            Assert.False(response.ReleaseIdToDeletionResult[releases[1].ReleaseId]);
+            Assert.True(response.ReleaseIdToDeletionResult[releases[1].ReleaseId]);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureBlobStorage/AzureBlobStorageClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureBlobStorage/AzureBlobStorageClient.cs
@@ -12,6 +12,24 @@ public class AzureBlobStorageClient(
 {
     internal BlobServiceClient BlobServiceClient { get; } = blobServiceClient;
 
+    public async Task<bool> DeleteBlobIfExists(
+        string containerName,
+        string blobName,
+        CancellationToken cancellationToken = default)
+    {
+        var blobContainerClient = BlobServiceClient.GetBlobContainerClient(containerName);
+        var blobClient = blobContainerClient.GetBlobClient(blobName);
+        try
+        {
+            return await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to delete blob {ContainerName}/{BlobName}", containerName, blobName);
+            throw;
+        }
+    }
+
     public async Task UploadBlob(
         string containerName,
         string blobName,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureBlobStorage/IAzureBlobStorageClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureBlobStorage/IAzureBlobStorageClient.cs
@@ -3,6 +3,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 public interface IAzureBlobStorageClient
 {
     /// <summary>
+    /// Deletes a blob from the specified container if it exists.
+    /// </summary>
+    /// <param name="containerName">The name of the storage account container</param>
+    /// <param name="blobName">The name of the blob to delete.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>
+    /// A a boolean indicating whether the blob was successfully deleted or did not exist.
+    /// </returns>
+    Task<bool> DeleteBlobIfExists(string containerName, string blobName, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Upload a Blob to our configured Azure Blob storage account
     /// </summary>
     /// <param name="containerName">The name of the storage account container</param>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/Dtos/ReleaseSearchViewModelDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/Dtos/ReleaseSearchViewModelDto.cs
@@ -1,6 +1,6 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Domain;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi.Dtos;
 
 internal record ReleaseSearchViewModelDto
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/Dtos/ReleaseSummaryViewModelDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/Dtos/ReleaseSummaryViewModelDto.cs
@@ -1,0 +1,6 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi.Dtos;
+
+public record ReleaseSummaryViewModelDto
+{
+    public required Guid ReleaseId { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/IContentApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/IContentApiClient.cs
@@ -26,4 +26,14 @@ public interface IContentApiClient
     /// Given a Theme, get the Publications
     /// </summary>
     Task<PublicationInfo[]> GetPublicationsForTheme(Guid themeId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the releases for the specified publication.
+    /// </summary>
+    /// <param name="publicationSlug">the publication slug</param>
+    /// <param name="cancellationToken">cancellation token</param>
+    /// <returns> An array of releases for the specified publication.</returns>
+    Task<ReleaseInfo[]> GetReleasesForPublication(
+        string publicationSlug,
+        CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Domain/ReleaseInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Domain/ReleaseInfo.cs
@@ -1,0 +1,6 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Domain;
+
+public record ReleaseInfo
+{
+    public required Guid ReleaseId { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Exceptions/UnableToGetReleasesForPublicationException.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Exceptions/UnableToGetReleasesForPublicationException.cs
@@ -1,0 +1,8 @@
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Exceptions;
+
+/// <summary>
+/// Exception thrown when the call to the Content API to retrieve the releases for a publication fails.
+/// </summary>
+public class UnableToGetReleasesForPublicationException(string publicationSlug, string? errorMessage)
+    : Exception($"Unable to get releases for publication \"{publicationSlug}\". Error: \"{errorMessage}\"");
+

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
@@ -54,6 +54,7 @@ public static class HostBuilderExtension
                     })
                     // Services
                     .AddTransient<ISearchableDocumentCreator, SearchableDocumentCreator>()
+                    .AddTransient<ISearchableDocumentRemover, SearchableDocumentRemover>()
                     // Functions
                     .AddTransient<IEventGridEventHandler, EventGridEventHandler>()
                     .AddHealthChecks()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationArchived/Dtos/PublicationArchivedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationArchived/Dtos/PublicationArchivedEventDto.cs
@@ -1,0 +1,6 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationArchived.Dtos;
+
+public class PublicationArchivedEventDto
+{
+    public string? Slug { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationArchived/OnPublicationArchivedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationArchived/OnPublicationArchivedFunction.cs
@@ -1,0 +1,24 @@
+﻿using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationArchived.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemovePublicationSearchableDocuments.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationArchived;
+
+public class OnPublicationArchivedFunction(IEventGridEventHandler eventGridEventHandler)
+{
+    [Function(nameof(OnPublicationArchived))]
+    [QueueOutput("%RemovePublicationSearchableDocumentsQueueName%")]
+    public async Task<RemovePublicationSearchableDocumentsDto[]> OnPublicationArchived(
+        [QueueTrigger("%PublicationArchivedQueueName%")] EventGridEvent eventDto,
+        FunctionContext context) =>
+        await eventGridEventHandler.Handle<PublicationArchivedEventDto, RemovePublicationSearchableDocumentsDto[]>(
+            context,
+            eventDto,
+            (payload, _) =>
+                Task.FromResult<RemovePublicationSearchableDocumentsDto[]>(
+                    string.IsNullOrEmpty(payload.Slug)
+                        ? []
+                        : [new RemovePublicationSearchableDocumentsDto { PublicationSlug = payload.Slug }]));
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RemovePublicationSearchableDocuments/Dto/RemovePublicationSearchableDocumentsDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RemovePublicationSearchableDocuments/Dto/RemovePublicationSearchableDocumentsDto.cs
@@ -1,0 +1,7 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.
+    RemovePublicationSearchableDocuments.Dto;
+
+public class RemovePublicationSearchableDocumentsDto
+{
+    public string? PublicationSlug { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsFunction.cs
@@ -2,11 +2,14 @@
     RemovePublicationSearchableDocuments.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.
     RemovePublicationSearchableDocuments;
 
-public class RemovePublicationSearchableDocumentsFunction(ISearchableDocumentRemover searchableDocumentRemover)
+public class RemovePublicationSearchableDocumentsFunction(
+    ILogger<RemovePublicationSearchableDocumentsFunction> logger,
+    ISearchableDocumentRemover searchableDocumentRemover)
 {
     [Function(nameof(RemovePublicationSearchableDocuments))]
     public async Task RemovePublicationSearchableDocuments(
@@ -18,8 +21,11 @@ public class RemovePublicationSearchableDocumentsFunction(ISearchableDocumentRem
             return;
         }
 
-        await searchableDocumentRemover.RemovePublicationSearchableDocuments(
+        var response = await searchableDocumentRemover.RemovePublicationSearchableDocuments(
             new RemovePublicationSearchableDocumentsRequest { PublicationSlug = message.PublicationSlug },
             context.CancellationToken);
+
+        logger.LogInformation(
+            "Removed searchable documents for publication \"{PublicationSlug}\". Response: {@response}", message.PublicationSlug, response);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsFunction.cs
@@ -1,0 +1,25 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.
+    RemovePublicationSearchableDocuments.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.
+    RemovePublicationSearchableDocuments;
+
+public class RemovePublicationSearchableDocumentsFunction(ISearchableDocumentRemover searchableDocumentRemover)
+{
+    [Function(nameof(RemovePublicationSearchableDocuments))]
+    public async Task RemovePublicationSearchableDocuments(
+        [QueueTrigger("%RemovePublicationSearchableDocumentsQueueName%")] RemovePublicationSearchableDocumentsDto message,
+        FunctionContext context)
+    {
+        if (string.IsNullOrEmpty(message.PublicationSlug))
+        {
+            return;
+        }
+
+        await searchableDocumentRemover.RemovePublicationSearchableDocuments(
+            new RemovePublicationSearchableDocumentsRequest { PublicationSlug = message.PublicationSlug },
+            context.CancellationToken);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/ISearchableDocumentRemover.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/ISearchableDocumentRemover.cs
@@ -1,0 +1,8 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+
+public interface ISearchableDocumentRemover
+{
+    Task<RemovePublicationSearchableDocumentsResponse> RemovePublicationSearchableDocuments(
+        RemovePublicationSearchableDocumentsRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/RemovePublicationSearchableDocumentsRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/RemovePublicationSearchableDocumentsRequest.cs
@@ -1,0 +1,6 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+
+public record RemovePublicationSearchableDocumentsRequest
+{
+    public required string PublicationSlug { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/RemovePublicationSearchableDocumentsResponse.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/RemovePublicationSearchableDocumentsResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+
+public class RemovePublicationSearchableDocumentsResponse
+{
+    public Dictionary<Guid, bool> ReleaseIdToDeletionResult { get; } = [];
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/RemovePublicationSearchableDocumentsResponse.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/RemovePublicationSearchableDocumentsResponse.cs
@@ -1,6 +1,3 @@
 ﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 
-public class RemovePublicationSearchableDocumentsResponse
-{
-    public Dictionary<Guid, bool> ReleaseIdToDeletionResult { get; } = [];
-}
+public record RemovePublicationSearchableDocumentsResponse(IReadOnlyDictionary<Guid, bool> ReleaseIdToDeletionResult);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/SearchableDocumentRemover.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/SearchableDocumentRemover.cs
@@ -21,18 +21,18 @@ internal class SearchableDocumentRemover(
             request.PublicationSlug,
             cancellationToken);
 
-        var response = new RemovePublicationSearchableDocumentsResponse();
+        var results = new Dictionary<Guid, bool>();
 
         foreach (var releaseInfo in releaseInfos)
         {
             var blobName = releaseInfo.ReleaseId.ToString();
-            response.ReleaseIdToDeletionResult[releaseInfo.ReleaseId] =
+            results[releaseInfo.ReleaseId] =
                 await azureBlobStorageClient.DeleteBlobIfExists(
                     appOptions.Value.SearchableDocumentsContainerName,
                     blobName,
                     cancellationToken);
         }
 
-        return response;
+        return new RemovePublicationSearchableDocumentsResponse(results);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/SearchableDocumentRemover.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/SearchableDocumentRemover.cs
@@ -1,0 +1,38 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
+using Microsoft.Extensions.Options;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+
+/// <summary>
+/// This service provides a way of deleting all searchable documents that may exist for a publication.
+/// </summary>
+internal class SearchableDocumentRemover(
+    IContentApiClient contentApiClient,
+    IAzureBlobStorageClient azureBlobStorageClient,
+    IOptions<AppOptions> appOptions) : ISearchableDocumentRemover
+{
+    public async Task<RemovePublicationSearchableDocumentsResponse> RemovePublicationSearchableDocuments(
+        RemovePublicationSearchableDocumentsRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var releaseInfos = await contentApiClient.GetReleasesForPublication(
+            request.PublicationSlug,
+            cancellationToken);
+
+        var response = new RemovePublicationSearchableDocumentsResponse();
+
+        foreach (var releaseInfo in releaseInfos)
+        {
+            var blobName = releaseInfo.ReleaseId.ToString();
+            response.ReleaseIdToDeletionResult[releaseInfo.ReleaseId] =
+                await azureBlobStorageClient.DeleteBlobIfExists(
+                    appOptions.Value.SearchableDocumentsContainerName,
+                    blobName,
+                    cancellationToken);
+        }
+
+        return response;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/local.settings.json
@@ -3,11 +3,13 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://data-storage",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "PublicationArchivedQueueName": "publication-archived-queue",
     "PublicationChangedQueueName": "publication-changed-queue",
     "PublicationLatestPublishedReleaseReorderedQueueName" : "publication-latest-published-release-reordered-queue",
     "RefreshSearchableDocumentQueueName": "refresh-searchable-document-queue",
     "ReleaseSlugChangedQueueName": "release-slug-changed-queue",
     "ReleaseVersionPublishedQueueName": "release-version-published-queue",
+    "RemovePublicationSearchableDocumentsQueueName": "remove-publication-searchable-documents-queue",
     "SearchableDocumentCreatedQueueName": "search-document-created-queue",
     "ThemeUpdatedQueueName": "theme-updated-queue"
   },

--- a/src/GovUk.Education.ExploreEducationStatistics.Search.sln.DotSettings
+++ b/src/GovUk.Education.ExploreEducationStatistics.Search.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=dtos/@EntryIndexedValue">True</s:Boolean>
+</wpf:ResourceDictionary>


### PR DESCRIPTION
This PR adds event handling to the Search Function App for publication archiving events.

When subscribed to publication archiving events, on archiving of a publication the Search Function App will remove searchable documents from the Search blob storage account for any published releases of the publication.

It does this by making a call to the Content API to retrieve all published releases for the publication. Using the release id's it removes searchable documents from the Search blob storage account for any blobs matching the release id, if they exist.