### PR TITLE
EES-6049 - Public API wildcard data set versions try to access unpublished data bug fix

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/TheoryDataExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/TheoryDataExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+
+public static class TheoryDataExtensions
+{
+    public static TheoryData<T1, T2> Cross<T1, T2>(
+        this TheoryData<T1, T2> theoryData,
+        IEnumerable<T1> testDataCollection1,
+        IEnumerable<T2> testDataCollection2)
+    {
+        foreach (var testDataParameter1 in testDataCollection1)
+        {
+            foreach (var testDataParameter2 in testDataCollection2)
+            {
+                theoryData.Add(testDataParameter1, testDataParameter2);
+            }
+        }
+
+        return theoryData;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/DataSetVersionNumberTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/DataSetVersionNumberTest.cs
@@ -125,7 +125,7 @@ public static class DataSetVersionNumberTest
         [InlineData("*")]
         public void PassedWildcard_ExpectsIsWildcardToReturnTrue(string versionString)
         {
-            DataSetVersionNumber.TryParse(versionString, out var version);
+            Assert.True(DataSetVersionNumber.TryParse(versionString, out var version));
             Assert.True(version.IsWildcard);
         }
         
@@ -135,7 +135,7 @@ public static class DataSetVersionNumberTest
         [InlineData("1")]
         public void PassedNonWildcard_ExpectsIsWildcardToReturnFalse(string versionString)
         {
-            DataSetVersionNumber.TryParse(versionString, out var version);
+            Assert.True(DataSetVersionNumber.TryParse(versionString, out var version));
             Assert.False(version.IsWildcard);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/DataSetVersionNumberTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/DataSetVersionNumberTest.cs
@@ -118,5 +118,25 @@ public static class DataSetVersionNumberTest
         {
             Assert.False(DataSetVersionNumber.TryParse(versionString, out _));
         }
+
+        [Theory]
+        [InlineData("1.*")]
+        [InlineData("1.1.*")]
+        [InlineData("*")]
+        public void PassedWildcard_ExpectsIsWildcardToReturnTrue(string versionString)
+        {
+            DataSetVersionNumber.TryParse(versionString, out var version);
+            Assert.True(version.IsWildcard);
+        }
+        
+        [Theory]
+        [InlineData("1.1")]
+        [InlineData("1.1.1")]
+        [InlineData("1")]
+        public void PassedNonWildcard_ExpectsIsWildcardToReturnFalse(string versionString)
+        {
+            DataSetVersionNumber.TryParse(versionString, out var version);
+            Assert.False(version.IsWildcard);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/DataSetVersionNumber.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/DataSetVersionNumber.cs
@@ -8,7 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
 
 public record DataSetVersionNumber(int? Major, int? Minor, int? Patch)
 {
-    public bool IsWildcard { get; set; }
+    public bool IsWildcard { get; init; }
 
     public static bool TryParse(string versionString, [NotNullWhen(true)] out DataSetVersionNumber? version)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/DataSetVersionNumber.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/DataSetVersionNumber.cs
@@ -8,7 +8,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils;
 
 public record DataSetVersionNumber(int? Major, int? Minor, int? Patch)
 {
-    public static bool TryParse(string versionString, out DataSetVersionNumber? version)
+    public bool IsWildcard { get; set; }
+
+    public static bool TryParse(string versionString, [NotNullWhen(true)] out DataSetVersionNumber? version)
     {
         version = null;
         if (versionString.Contains('*'))
@@ -27,8 +29,12 @@ public record DataSetVersionNumber(int? Major, int? Minor, int? Patch)
         {
             return false;
         }
-
-        version = new DataSetVersionNumber(sv.Major, sv.Minor, sv.Patch);
+        
+        version = new DataSetVersionNumber(sv.Major, sv.Minor, sv.Patch)
+        {
+            IsWildcard = false
+        };
+        
         return successful;
     }
 
@@ -59,7 +65,11 @@ public record DataSetVersionNumber(int? Major, int? Minor, int? Patch)
 
         version = new DataSetVersionNumber(parts[0],
             parts.Length > 1 ? parts[1] : null,
-            parts.Length > 2 ? parts[2] : null);
+            parts.Length > 2 ? parts[2] : null)
+        {
+            IsWildcard = true
+        };
+
         return true;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
@@ -1869,8 +1869,10 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
                     dsv.SetVersionNumber(2, 1);
                 })
                 .GenerateList();
+        
+        var version = versionStatus == DataSetVersionStatus.Published ? "2.1" : "1.2";
 
-        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == "1.2");
+        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == version);
         dataSet.Versions = dataSetVersion;
 
         await TestApp.AddTestData<PublicDataDbContext>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
@@ -18,7 +18,7 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Controllers;
 
-public abstract class DataSetVersionsControllerTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+public abstract class DataSetVersionsControllerTests(TestApplicationFactory testApp) : IntegrationTestFixtureWithCommonTestDataSetup(testApp)
 {
     private const string BaseUrl = "v1/data-sets";
 
@@ -1830,61 +1830,6 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
         }
     }
 
-    private async Task<(DataSet, List<DataSetVersion>)> SetupDataSetWithSpecifiedVersionStatuses(
-        DataSetVersionStatus versionStatus)
-    {
-        DataSet dataSet = DataFixture
-            .DefaultDataSet()
-            .WithStatusPublished();
-
-        await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
-
-        var dataSetVersion = DataFixture
-                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 3)
-                .WithStatusPublished()
-                .WithDataSetId(dataSet.Id)
-                .WithMetaSummary(
-                    DataFixture.DefaultDataSetVersionMetaSummary()
-                        .WithGeographicLevels(
-                            [
-                                GeographicLevel.Country,
-                                GeographicLevel.LocalAuthority,
-                                GeographicLevel.Region,
-                                GeographicLevel.School
-                            ]
-                        )
-                )
-                .WithPreviewTokens(() => [DataFixture.DefaultPreviewToken()])
-                .ForIndex(1, dsv => dsv.SetVersionNumber(1, 1))
-                .ForIndex(2, dsv => dsv.SetVersionNumber(1, 2))
-                .ForIndex(3, dsv =>
-                {
-                    dsv.SetStatus(versionStatus);
-                    dsv.SetVersionNumber(2, 0);
-                    
-                })
-                .ForIndex(4, dsv =>
-                {
-                    dsv.SetStatus(versionStatus);
-                    dsv.SetVersionNumber(2, 1);
-                })
-                .GenerateList();
-        
-        var version = versionStatus == DataSetVersionStatus.Published ? "2.1" : "1.2";
-
-        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == version);
-        dataSet.Versions = dataSetVersion;
-
-        await TestApp.AddTestData<PublicDataDbContext>(
-            context =>
-            {
-                context.DataSetVersions.AddRange(dataSetVersion);
-                context.DataSets.Update(dataSet);
-            }
-        );
-
-        return (dataSet, dataSetVersion);
-    }
     private WebApplicationFactory<Startup> BuildApp(
         IContentApiClient? contentApiClient = null,
         ClaimsPrincipal? user = null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
@@ -30,7 +30,7 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockU
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Controllers;
 
-public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory testApp) : IntegrationTestFixtureWithCommonTestDataSetup(testApp)
 {
     private const string BaseUrl = "v1/data-sets";
 
@@ -3171,62 +3171,7 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
 
         return dataSetVersion;
     }
-    
-    private async Task<(DataSet, List<DataSetVersion>)> SetupDataSetWithSpecifiedVersionStatuses(
-        DataSetVersionStatus versionStatus)
-    {
-        DataSet dataSet = DataFixture
-            .DefaultDataSet()
-            .WithStatusPublished();
 
-        await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
-
-        var dataSetVersion = DataFixture
-                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 3)
-                .WithStatusPublished()
-                .WithDataSetId(dataSet.Id)
-                .WithMetaSummary(
-                    DataFixture.DefaultDataSetVersionMetaSummary()
-                        .WithGeographicLevels(
-                            [
-                                GeographicLevel.Country,
-                                GeographicLevel.LocalAuthority,
-                                GeographicLevel.Region,
-                                GeographicLevel.School
-                            ]
-                        )
-                )
-                .WithPreviewTokens(() => [DataFixture.DefaultPreviewToken()])
-                .ForIndex(1, dsv => dsv.SetVersionNumber(1, 1))
-                .ForIndex(2, dsv => dsv.SetVersionNumber(1, 2))
-                .ForIndex(3, dsv =>
-                {
-                    dsv.SetStatus(versionStatus);
-                    dsv.SetVersionNumber(2, 0);
-                    
-                })
-                .ForIndex(4, dsv =>
-                {
-                    dsv.SetStatus(versionStatus);
-                    dsv.SetVersionNumber(2, 1);
-                })
-                .GenerateList();
-
-        var version = versionStatus == DataSetVersionStatus.Published ? "2.1" : "1.2";
-
-        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == version);
-        dataSet.Versions = dataSetVersion;
-
-        await TestApp.AddTestData<PublicDataDbContext>(
-            context =>
-            {
-                context.DataSetVersions.AddRange(dataSetVersion);
-                context.DataSets.Update(dataSet);
-            }
-        );
-
-        return (dataSet, dataSetVersion);
-    }
 
     private WebApplicationFactory<Startup> BuildApp()
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
@@ -3212,7 +3212,9 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
                 })
                 .GenerateList();
 
-        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == "1.2");
+        var version = versionStatus == DataSetVersionStatus.Published ? "2.1" : "1.2";
+
+        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == version);
         dataSet.Versions = dataSetVersion;
 
         await TestApp.AddTestData<PublicDataDbContext>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
@@ -105,6 +105,45 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
 
             response.AssertNotFound();
         }
+        
+        [Theory]
+        [MemberData(nameof(DataSetVersionStatusQueryTheoryData.NonPublishedStatus),
+            MemberType = typeof(DataSetVersionStatusQueryTheoryData))]
+        public async Task WildCardSpecified_RequestsNonPublishedVersion_Returns404(DataSetVersionStatus versionStatus)
+        {
+            var (dataSet, versions) = await SetupDataSetWithSpecifiedVersionStatuses(versionStatus);
+            
+            var response = await QueryDataSet(
+                dataSetId: dataSet.Id,
+                dataSetVersion: "2.*",
+                previewTokenId: versions.Last().PreviewTokens[0].Id,
+                indicators: [AbsenceSchoolData.IndicatorSessAuthorised]);
+
+            response.AssertNotFound();
+        }
+        
+        [Fact]
+        public async Task WildCardSpecified_RequestsPublishedVersion_Returns200()
+        {
+            var (dataSet, versions) = await SetupDataSetWithSpecifiedVersionStatuses(DataSetVersionStatus.Published);
+            
+            var response = await QueryDataSet(
+                dataSetId: dataSet.Id,
+                dataSetVersion: "2.*",
+                previewTokenId: versions.Last().PreviewTokens[0].Id,
+                indicators: [AbsenceSchoolData.IndicatorSessAuthorised]);
+
+            response.AssertOk();
+            
+            var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
+            Assert.Equal(1, viewModel.Paging.Page);
+            Assert.Equal(1, viewModel.Paging.TotalPages);
+            Assert.Equal(216, viewModel.Paging.TotalResults);
+
+            Assert.Empty(viewModel.Warnings);
+
+            Assert.Equal(216, viewModel.Results.Count);
+        }
     }
 
     public class PreviewTokenTests(TestApplicationFactory testApp) : DataSetsControllerGetQueryTests(testApp)
@@ -3131,6 +3170,60 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
         );
 
         return dataSetVersion;
+    }
+    
+    private async Task<(DataSet, List<DataSetVersion>)> SetupDataSetWithSpecifiedVersionStatuses(
+        DataSetVersionStatus versionStatus)
+    {
+        DataSet dataSet = DataFixture
+            .DefaultDataSet()
+            .WithStatusPublished();
+
+        await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+        var dataSetVersion = DataFixture
+                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 3)
+                .WithStatusPublished()
+                .WithDataSetId(dataSet.Id)
+                .WithMetaSummary(
+                    DataFixture.DefaultDataSetVersionMetaSummary()
+                        .WithGeographicLevels(
+                            [
+                                GeographicLevel.Country,
+                                GeographicLevel.LocalAuthority,
+                                GeographicLevel.Region,
+                                GeographicLevel.School
+                            ]
+                        )
+                )
+                .WithPreviewTokens(() => [DataFixture.DefaultPreviewToken()])
+                .ForIndex(1, dsv => dsv.SetVersionNumber(1, 1))
+                .ForIndex(2, dsv => dsv.SetVersionNumber(1, 2))
+                .ForIndex(3, dsv =>
+                {
+                    dsv.SetStatus(versionStatus);
+                    dsv.SetVersionNumber(2, 0);
+                    
+                })
+                .ForIndex(4, dsv =>
+                {
+                    dsv.SetStatus(versionStatus);
+                    dsv.SetVersionNumber(2, 1);
+                })
+                .GenerateList();
+
+        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == "1.2");
+        dataSet.Versions = dataSetVersion;
+
+        await TestApp.AddTestData<PublicDataDbContext>(
+            context =>
+            {
+                context.DataSetVersions.AddRange(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            }
+        );
+
+        return (dataSet, dataSetVersion);
     }
 
     private WebApplicationFactory<Startup> BuildApp()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
@@ -30,7 +30,7 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockU
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Controllers;
 
-public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory testApp) : IntegrationTestFixtureWithCommonTestDataSetup(testApp)
 {
     private const string BaseUrl = "v1/data-sets";
 
@@ -4143,62 +4143,6 @@ public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory te
         return dataSetVersion;
     }
 
-    private async Task<(DataSet, List<DataSetVersion>)> SetupDataSetWithSpecifiedVersionStatuses(
-        DataSetVersionStatus versionStatus)
-    {
-        DataSet dataSet = DataFixture
-            .DefaultDataSet()
-            .WithStatusPublished();
-
-        await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
-
-        var dataSetVersion = DataFixture
-                .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 3)
-                .WithStatusPublished()
-                .WithDataSetId(dataSet.Id)
-                .WithMetaSummary(
-                    DataFixture.DefaultDataSetVersionMetaSummary()
-                        .WithGeographicLevels(
-                            [
-                                GeographicLevel.Country,
-                                GeographicLevel.LocalAuthority,
-                                GeographicLevel.Region,
-                                GeographicLevel.School
-                            ]
-                        )
-                )
-                .WithPreviewTokens(() => [DataFixture.DefaultPreviewToken()])
-                .ForIndex(1, dsv => dsv.SetVersionNumber(1, 1))
-                .ForIndex(2, dsv => dsv.SetVersionNumber(1, 2))
-                .ForIndex(3, dsv =>
-                {
-                    dsv.SetStatus(versionStatus);
-                    dsv.SetVersionNumber(2, 0);
-                    
-                })
-                .ForIndex(4, dsv =>
-                {
-                    dsv.SetStatus(versionStatus);
-                    dsv.SetVersionNumber(2, 1);
-                })
-                .GenerateList();
-
-        var version = versionStatus == DataSetVersionStatus.Published ? "2.1" : "1.2";
-
-        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == version);
-        dataSet.Versions = dataSetVersion;
-
-        await TestApp.AddTestData<PublicDataDbContext>(
-            context =>
-            {
-                context.DataSetVersions.AddRange(dataSetVersion);
-                context.DataSets.Update(dataSet);
-            }
-        );
-
-        return (dataSet, dataSetVersion);
-    }
-    
     private WebApplicationFactory<Startup> BuildApp()
     {
         return TestApp

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
@@ -4183,7 +4183,9 @@ public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory te
                 })
                 .GenerateList();
 
-        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == "1.2");
+        var version = versionStatus == DataSetVersionStatus.Published ? "2.1" : "1.2";
+
+        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == version);
         dataSet.Versions = dataSetVersion;
 
         await TestApp.AddTestData<PublicDataDbContext>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -23,7 +23,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Controllers;
 
-public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : IntegrationTestFixtureWithCommonTestDataSetup(testApp)
 {
     private const string BaseUrl = "v1/data-sets";
 
@@ -1964,62 +1964,6 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
         }
     }
 
-    private async Task<(DataSet, List<DataSetVersion>)> SetupDataSetWithSpecifiedVersionStatuses(
-        DataSetVersionStatus versionStatus)
-    {
-        DataSet dataSet = DataFixture
-            .DefaultDataSet()
-            .WithStatusPublished();
-
-        await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
-
-        var dataSetVersion = DataFixture
-            .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 3)
-            .WithStatusPublished()
-            .WithDataSetId(dataSet.Id)
-            .WithMetaSummary(
-                DataFixture.DefaultDataSetVersionMetaSummary()
-                    .WithGeographicLevels(
-                        [
-                            GeographicLevel.Country,
-                            GeographicLevel.LocalAuthority,
-                            GeographicLevel.Region,
-                            GeographicLevel.School
-                        ]
-                    )
-            )
-            .WithPreviewTokens(() => [DataFixture.DefaultPreviewToken()])
-            .ForIndex(1, dsv => dsv.SetVersionNumber(1, 1))
-            .ForIndex(2, dsv => dsv.SetVersionNumber(1, 2))
-            .ForIndex(3, dsv =>
-            {
-                dsv.SetStatus(versionStatus);
-                dsv.SetVersionNumber(2, 0);
-                
-            })
-            .ForIndex(4, dsv =>
-            {
-                dsv.SetStatus(versionStatus);
-                dsv.SetVersionNumber(2, 1);
-            })
-            .GenerateList();
-
-        var version = versionStatus == DataSetVersionStatus.Published ? "2.1" : "1.2";
-
-        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == version);
-        dataSet.Versions = dataSetVersion;
-
-        await TestApp.AddTestData<PublicDataDbContext>(
-            context =>
-            {
-                context.DataSetVersions.AddRange(dataSetVersion);
-                context.DataSets.Update(dataSet);
-            }
-        );
-
-        return (dataSet, dataSetVersion);
-    }
-    
     private WebApplicationFactory<Startup> BuildApp()
     {
         return TestApp;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -2004,7 +2004,9 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
             })
             .GenerateList();
 
-        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == "1.2");
+        var version = versionStatus == DataSetVersionStatus.Published ? "2.1" : "1.2";
+
+        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == version);
         dataSet.Versions = dataSetVersion;
 
         await TestApp.AddTestData<PublicDataDbContext>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Fixture/IntegrationTestFixtureWithCommonTestDataSetup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Fixture/IntegrationTestFixtureWithCommonTestDataSetup.cs
@@ -1,0 +1,65 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Fixture;
+
+public abstract class IntegrationTestFixtureWithCommonTestDataSetup(TestApplicationFactory testApp) : IntegrationTestFixture(testApp)
+{
+    protected async Task<(DataSet, List<DataSetVersion>)> SetupDataSetWithSpecifiedVersionStatuses(
+        DataSetVersionStatus versionStatus)
+    {
+        DataSet dataSet = DataFixture
+            .DefaultDataSet()
+            .WithStatusPublished();
+
+        await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+        var dataSetVersion = DataFixture
+            .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 3)
+            .WithStatusPublished()
+            .WithDataSetId(dataSet.Id)
+            .WithMetaSummary(
+                DataFixture.DefaultDataSetVersionMetaSummary()
+                    .WithGeographicLevels(
+                        [
+                            GeographicLevel.Country,
+                            GeographicLevel.LocalAuthority,
+                            GeographicLevel.Region,
+                            GeographicLevel.School
+                        ]
+                    )
+            )
+            .WithPreviewTokens(() => [DataFixture.DefaultPreviewToken()])
+            .ForIndex(1, dsv => dsv.SetVersionNumber(1, 1))
+            .ForIndex(2, dsv => dsv.SetVersionNumber(1, 2))
+            .ForIndex(3, dsv =>
+            {
+                dsv.SetStatus(versionStatus);
+                dsv.SetVersionNumber(2, 0);
+                
+            })
+            .ForIndex(4, dsv =>
+            {
+                dsv.SetStatus(versionStatus);
+                dsv.SetVersionNumber(2, 1);
+            })
+            .GenerateList();
+
+        var version = versionStatus == DataSetVersionStatus.Published ? "2.1" : "1.2";
+
+        dataSet.LatestLiveVersion = dataSetVersion.FirstOrDefault(dsv => dsv.PublicVersion == version);
+        dataSet.Versions = dataSetVersion;
+
+        await TestApp.AddTestData<PublicDataDbContext>(
+            context =>
+            {
+                context.DataSetVersions.AddRange(dataSetVersion);
+                context.DataSets.Update(dataSet);
+            }
+        );
+
+        return (dataSet, dataSetVersion);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/TheoryData/DataSetVersionStatusTheoryData.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/TheoryData/DataSetVersionStatusTheoryData.cs
@@ -21,6 +21,9 @@ public static class DataSetVersionStatusQueryTheoryData
 
     public static readonly TheoryData<DataSetVersionStatus> UnavailableStatusesExceptDraft = new(
         EnumUtil.GetEnums<DataSetVersionStatus>().Except([.. AvailableStatusesList, DataSetVersionStatus.Draft]));
+    
+    public static readonly TheoryData<DataSetVersionStatus> NonPublishedStatus = new(
+        EnumUtil.GetEnums<DataSetVersionStatus>().Except([DataSetVersionStatus.Published]));
 }
 
 public static class DataSetVersionStatusViewTheoryData
@@ -46,4 +49,7 @@ public static class DataSetVersionStatusViewTheoryData
 
     public static readonly TheoryData<DataSetVersionStatus> UnavailableStatusesExceptDraft = new(
         EnumUtil.GetEnums<DataSetVersionStatus>().Except([.. AvailableStatusesList, DataSetVersionStatus.Draft]));
+    
+    public static readonly TheoryData<DataSetVersionStatus> NonPublishedStatus = new(
+        EnumUtil.GetEnums<DataSetVersionStatus>().Except([DataSetVersionStatus.Published]));
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
@@ -133,7 +133,7 @@ internal class DataSetQueryService(
             .DataSetVersions
             .AsNoTracking()
             .Include(dsv => dsv.DataSet)
-            .FindByVersion(dataSetId, dataSetVersion, cancellationToken);
+            .FindByVersion(dataSetId, dataSetVersion, true, cancellationToken);
     }
     
     private async Task<Either<ActionResult, DataSetQueryPaginatedResultsViewModel>> RunQueryWithAnalytics(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
@@ -133,7 +133,11 @@ internal class DataSetQueryService(
             .DataSetVersions
             .AsNoTracking()
             .Include(dsv => dsv.DataSet)
-            .FindByVersion(dataSetId, dataSetVersion, true, cancellationToken);
+            .FindByVersion(
+                dataSetId: dataSetId, 
+                version: dataSetVersion,
+                publicOnly: true, 
+                cancellationToken);
     }
     
     private async Task<Either<ActionResult, DataSetQueryPaginatedResultsViewModel>> RunQueryWithAnalytics(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
@@ -117,29 +117,35 @@ internal class DataSetQueryService(
         using var _ = MiniProfiler.Current
             .Step($"{nameof(DataSetQueryService)}.{nameof(FindDataSetVersion)}");
 
-        if (dataSetVersion is null)
-        {
-            return await publicDataDbContext
+        return dataSetVersion is null or "*"
+            ? await publicDataDbContext
                 .DataSets
                 .AsNoTracking()
                 .Include(ds => ds.LatestLiveVersion)
                 .ThenInclude(dsv => dsv != null ? dsv.DataSet : null)
                 .Where(ds => ds.Id == dataSetId)
                 .Select(ds => ds.LatestLiveVersion!)
-                .SingleOrNotFoundAsync(cancellationToken);
-        }
-
-        return await publicDataDbContext
-            .DataSetVersions
-            .AsNoTracking()
-            .Include(dsv => dsv.DataSet)
-            .FindByVersion(
-                dataSetId: dataSetId, 
-                version: dataSetVersion,
-                publicOnly: true, 
-                cancellationToken);
+                .SingleOrNotFoundAsync(cancellationToken)
+            : dataSetVersion.Contains('*')
+                ? await publicDataDbContext
+                    .DataSetVersions
+                    .AsNoTracking()
+                    .Include(dsv => dsv.DataSet)
+                    .WherePublishedStatus()
+                    .FindByVersion(
+                        dataSetId: dataSetId,
+                        version: dataSetVersion,
+                        cancellationToken)
+                : await publicDataDbContext
+                    .DataSetVersions
+                    .AsNoTracking()
+                    .Include(dsv => dsv.DataSet)
+                    .FindByVersion(
+                        dataSetId: dataSetId,
+                        version: dataSetVersion,
+                        cancellationToken);
     }
-    
+
     private async Task<Either<ActionResult, DataSetQueryPaginatedResultsViewModel>> RunQueryWithAnalytics(
         DataSetVersion dataSetVersion,
         DataSetQueryRequest query,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetQueryService.cs
@@ -126,24 +126,14 @@ internal class DataSetQueryService(
                 .Where(ds => ds.Id == dataSetId)
                 .Select(ds => ds.LatestLiveVersion!)
                 .SingleOrNotFoundAsync(cancellationToken)
-            : dataSetVersion.Contains('*')
-                ? await publicDataDbContext
-                    .DataSetVersions
-                    .AsNoTracking()
-                    .Include(dsv => dsv.DataSet)
-                    .WherePublishedStatus()
-                    .FindByVersion(
-                        dataSetId: dataSetId,
-                        version: dataSetVersion,
-                        cancellationToken)
-                : await publicDataDbContext
-                    .DataSetVersions
-                    .AsNoTracking()
-                    .Include(dsv => dsv.DataSet)
-                    .FindByVersion(
-                        dataSetId: dataSetId,
-                        version: dataSetVersion,
-                        cancellationToken);
+            : await publicDataDbContext
+                .DataSetVersions
+                .AsNoTracking()
+                .Include(dsv => dsv.DataSet)
+                .FindByVersion(
+                    dataSetId: dataSetId,
+                    version: dataSetVersion,
+                    cancellationToken);
     }
 
     private async Task<Either<ActionResult, DataSetQueryPaginatedResultsViewModel>> RunQueryWithAnalytics(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -101,6 +101,7 @@ internal class DataSetService(
             .FindByVersion(
                 dataSetId: dataSetId,
                 version: dataSetVersion,
+                publicOnly: true,
                 cancellationToken: cancellationToken)
             .OnSuccessDo(userService.CheckCanViewDataSetVersion)
             .OnSuccess(MapDataSetVersion);
@@ -258,6 +259,7 @@ internal class DataSetService(
             .AsNoTracking()
             .FindByVersion(
                 dataSetId: dataSetId,
+                publicOnly: true,
                 version: dataSetVersion,
                 cancellationToken: cancellationToken);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -96,17 +96,7 @@ internal class DataSetService(
         string dataSetVersion,
         CancellationToken cancellationToken = default)
     {
-        return dataSetVersion.Contains('*')
-            ? await publicDataDbContext.DataSetVersions
-                .AsNoTracking()
-                .WherePublishedStatus()
-                .FindByVersion(
-                    dataSetId: dataSetId,
-                    version: dataSetVersion,
-                    cancellationToken: cancellationToken)
-                .OnSuccessDo(userService.CheckCanViewDataSetVersion)
-                .OnSuccess(MapDataSetVersion)
-            : await publicDataDbContext.DataSetVersions
+        return await publicDataDbContext.DataSetVersions
             .AsNoTracking()
             .FindByVersion(
                 dataSetId: dataSetId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetVersionChangeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetVersionChangeService.cs
@@ -27,6 +27,7 @@ public class DataSetVersionChangeService(
             .FindByVersion(
                 dataSetId: dataSetId,
                 version: dataSetVersion,
+                publicOnly: true,
                 cancellationToken: cancellationToken)
             .OnSuccessDo(userService.CheckCanViewDataSetVersion)
             .OnSuccess(dsv => LoadChanges(dsv, cancellationToken))

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetVersionChangeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetVersionChangeService.cs
@@ -22,18 +22,7 @@ public class DataSetVersionChangeService(
         string dataSetVersion,
         CancellationToken cancellationToken = default)
     {
-        return dataSetVersion.Contains('*')
-            ? publicDataDbContext.DataSetVersions
-                .AsNoTracking()
-                .WherePublishedStatus()
-                .FindByVersion(
-                    dataSetId: dataSetId,
-                    version: dataSetVersion,
-                    cancellationToken: cancellationToken)
-                .OnSuccessDo(userService.CheckCanViewDataSetVersion)
-                .OnSuccess(dsv => LoadChanges(dsv, cancellationToken))
-                .OnSuccess(MapChanges)
-            : publicDataDbContext.DataSetVersions
+        return publicDataDbContext.DataSetVersions
             .AsNoTracking()
             .FindByVersion(
                 dataSetId: dataSetId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Extensions/DataSetVersionQueryableExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Extensions/DataSetVersionQueryableExtensionsTests.cs
@@ -27,7 +27,7 @@ public class DataSetVersionQueryableExtensionsTests
             var queryable = SetupDataSetVersions(out dataSetId);
 
             // Act 
-            var actualResult = await queryable.FindByVersion(dataSetId, versionString, false, CancellationToken.None);
+            var actualResult = await queryable.WherePublishedStatus().FindByVersion(dataSetId, versionString, CancellationToken.None);
 
             // Assert
             Assert.True(actualResult.IsRight);
@@ -62,7 +62,7 @@ public class DataSetVersionQueryableExtensionsTests
             var queryable = SetupDataSetVersions(out dataSetId);
 
             // Act 
-            var actualResult = await queryable.FindByVersion(dataSetId, versionString, false, CancellationToken.None);
+            var actualResult = await queryable.WherePublishedStatus().FindByVersion(dataSetId, versionString, CancellationToken.None);
 
             // Assert
             actualResult.AssertNotFound();
@@ -107,7 +107,7 @@ public class DataSetVersionQueryableExtensionsTests
             var queryable = publicDataDbContextMock.Object.DataSetVersions.AsNoTracking();
 
             // Act 
-            var actualResult = await queryable.FindByVersion(dataSet.Id, versionString, true, CancellationToken.None);
+            var actualResult = await queryable.WherePublishedStatus().FindByVersion(dataSet.Id, versionString, CancellationToken.None);
 
             // Assert
             actualResult.AssertNotFound();
@@ -156,7 +156,7 @@ public class DataSetVersionQueryableExtensionsTests
             var queryable = publicDataDbContextMock.Object.DataSetVersions.AsNoTracking();
 
             // Act 
-            var actualResult = await queryable.FindByVersion(dataSet.Id, versionString, true, CancellationToken.None);
+            var actualResult = await queryable.WherePublishedStatus().FindByVersion(dataSet.Id, versionString, CancellationToken.None);
 
             // Assert
             Assert.Equal(1, actualResult.Right.VersionMajor);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Extensions/DataSetVersionQueryableExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Extensions/DataSetVersionQueryableExtensionsTests.cs
@@ -249,24 +249,10 @@ public class DataSetVersionQueryableExtensionsTests
             {"v*", 5, 0, 0}
         };
         
-        public static TheoryData<DataSetVersionStatus, string> NonPublishedStatusWithVersionStringTheoryData
-        {
-            get
-            {
-                var data = new TheoryData<DataSetVersionStatus, string>();
-                var statuses = EnumUtil.GetEnums<DataSetVersionStatus>()
-                    .Except([DataSetVersionStatus.Published]);
-                string[] versions = ["1.*", "*", "v1.*", "v*"];
-                foreach (var status in statuses)
-                {
-                    foreach (var version in versions)
-                    {
-                        data.Add(status, version);
-                    }
-                }
-
-                return data;
-            }
-        }
+        public static TheoryData<DataSetVersionStatus, string> NonPublishedStatusWithVersionStringTheoryData =>
+            new TheoryData<DataSetVersionStatus, string>()
+                .Cross(
+                    Enum.GetValues<DataSetVersionStatus>().Except([DataSetVersionStatus.Published]),
+                    ["1.*", "*", "v1.*", "v*"]);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionAuthExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionAuthExtensions.cs
@@ -24,6 +24,9 @@ public static class DataSetVersionAuthExtensions
     public static IQueryable<DataSetVersion> WherePublicStatus(this IQueryable<DataSetVersion> queryable)
         => queryable.Where(IsPublicStatus());
 
+    public static IQueryable<DataSetVersion> WherePublishedStatus(this IQueryable<DataSetVersion> queryable)
+        => queryable.Where(dv => dv.Status == DataSetVersionStatus.Published);
+    
     private static Expression<Func<DataSetVersion, bool>> IsPublicStatus()
         => dataSetVersion => PublicStatuses.Contains(dataSetVersion.Status);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionQueryableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionQueryableExtensions.cs
@@ -34,7 +34,6 @@ public static class DataSetVersionQueryableExtensions
         }
 
         return await query
-            .Where(dsv => dsv.DataSetId == dataSetId)
             .Where(v =>
                 (!parsedVersion.Major.HasValue || v.VersionMajor == parsedVersion.Major) &&
                 (!parsedVersion.Minor.HasValue || v.VersionMinor == parsedVersion.Minor) &&

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionQueryableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionQueryableExtensions.cs
@@ -12,7 +12,7 @@ public static class DataSetVersionQueryableExtensions
     /// </summary>
     /// <param name="version">Data set version which can contain a wildcard</param>
     /// <param name="publicOnly">Specifies whether this method should return versions that are not
-    /// "Published", "Depreciated" or "Withdrawn".
+    /// "Published".
     /// </param>
     public static async Task<Either<ActionResult, DataSetVersion>> FindByVersion(
         this IQueryable<DataSetVersion> queryable,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionQueryableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionQueryableExtensions.cs
@@ -31,10 +31,7 @@ public static class DataSetVersionQueryableExtensions
 
         if (publicOnly)
         {
-            query = query.Where(dsv => new[]
-            {
-                DataSetVersionStatus.Published, DataSetVersionStatus.Withdrawn, DataSetVersionStatus.Deprecated
-            }.Contains(dsv.Status));
+            query = query.Where(dsv => dsv.Status == DataSetVersionStatus.Published);
         }
 
         return await query.Where(v =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionQueryableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model/Extensions/DataSetVersionQueryableExtensions.cs
@@ -8,7 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Extension
 public static class DataSetVersionQueryableExtensions
 {
     /// <summary>
-    /// Returns specified data set version, if a wildcard is specified, the latest version of a data set based on a major/minor/patch level that's being wildcarded (i.e., substituted with '*') is returned.
+    /// Returns specified data set version. If a wildcard is specified, the latest version of a data set based on a major/minor/patch level that's being wildcarded (i.e., substituted with '*') is returned.
     /// </summary>
     /// <param name="queryable">The queryable collection of <see cref="DataSetVersion"/> objects.</param>
     /// <param name="version">Data set version which can contain a wildcard</param>
@@ -19,13 +19,21 @@ public static class DataSetVersionQueryableExtensions
         Guid dataSetId,
         string version,
         CancellationToken cancellationToken = default)
-    {
+    { 
         if (!DataSetVersionNumber.TryParse(version, out var parsedVersion))
         {
             return new NotFoundResult();
         }
 
-        return await queryable
+        var query = queryable
+            .Where(dsv => dsv.DataSetId == dataSetId);
+
+        if (parsedVersion.IsWildcard)
+        {
+            query = query.WherePublishedStatus();
+        }
+
+        return await query
             .Where(dsv => dsv.DataSetId == dataSetId)
             .Where(v =>
                 (!parsedVersion.Major.HasValue || v.VersionMajor == parsedVersion.Major) &&


### PR DESCRIPTION
### Summary
This Pull Request fixes functionality that handles requests to the Public API with wildcard versions (e.g., 2.*) that was previously returning unpublished data set versions.

It tweaks logic of Public API endpoints that accept data set version that user specifies, that if the user a wildcard dataset version, that only published dataset versions are returned. 

### Main Changes
Ensure that for wildcard data set version - only published data set versions are returned if present. 
Ensures 404 response if a non-published version exists and has been requested using wildcard parameter.

### Updates to tests:
Added or updated test coverage for controllers handling wildcard dataset version queries.
Extended existing tests to check the behavior for both published and non-published versions.
Introduced a new method WherePublishedStatus in dataset version query extension to filter only published versions.

