### PR TITLE
EES-6032 safari copy chart clipboard bug

### DIFF
--- a/src/explore-education-statistics-common/src/components/ExportMenu.module.scss
+++ b/src/explore-education-statistics-common/src/components/ExportMenu.module.scss
@@ -30,6 +30,10 @@
   button {
     padding: govuk-spacing(1);
   }
+
+  > summary {
+    margin-left: auto;
+  }
 }
 
 .exportMenu[open] {

--- a/src/explore-education-statistics-common/src/modules/charts/components/ChartExportMenu.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/ChartExportMenu.tsx
@@ -21,18 +21,29 @@ export default function ChartExportMenu({ chartRef, chartTitle }: Props) {
   }, [chartTitle, getClipboardPng]);
 
   const handleCopyToClipboard = useCallback(async () => {
-    await getClipboardPng(async blob => {
-      try {
-        if (blob) {
-          const clipboardItems: ClipboardItem[] = [];
-          const clipboardItem = new ClipboardItem({ [blob.type]: blob });
-          clipboardItems.push(clipboardItem);
-          await navigator.clipboard.write(clipboardItems);
-        }
-      } catch (error) {
-        logger.error(error);
-      }
-    });
+    try {
+      await navigator.clipboard.write([
+        // EES-6032 Safari requires the clipboard item value be returned from a promise
+        // https://web.dev/articles/async-clipboard#write
+        new ClipboardItem({
+          // eslint-disable-next-line no-async-promise-executor
+          'image/png': new Promise(async (resolve, reject) => {
+            try {
+              await getClipboardPng(blob => {
+                if (!blob) {
+                  throw new Error("Couldn't create blob");
+                }
+                resolve(blob);
+              });
+            } catch (err) {
+              reject(err);
+            }
+          }),
+        }),
+      ]);
+    } catch (error) {
+      logger.error(error);
+    }
   }, [getClipboardPng]);
 
   return (

--- a/src/explore-education-statistics-common/src/modules/charts/components/ChartExportMenu.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/ChartExportMenu.tsx
@@ -58,7 +58,7 @@ export default function ChartExportMenu({ chartRef, chartTitle }: Props) {
     } catch (error) {
       logger.error(error);
     }
-  }, [getClipboardPng]);
+  }, [getClipboardPng, setCopySuccess]);
 
   return (
     <ExportMenu title={chartTitle || 'chart'}>

--- a/src/explore-education-statistics-common/src/modules/charts/components/ChartExportMenu.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/ChartExportMenu.tsx
@@ -1,9 +1,10 @@
-import React, { RefObject, useCallback } from 'react';
+import React, { RefObject, useCallback, useEffect } from 'react';
 import downloadFile from '@common/utils/file/downloadFile';
 import logger from '@common/services/logger';
 import useCurrentPng from '@common/components/ChartsToPNG';
 import ButtonText from '@common/components/ButtonText';
 import ExportMenu from '@common/components/ExportMenu';
+import useToggle from '@common/hooks/useToggle';
 
 interface Props {
   chartRef: RefObject<HTMLElement>;
@@ -12,6 +13,17 @@ interface Props {
 
 export default function ChartExportMenu({ chartRef, chartTitle }: Props) {
   const [getClipboardPng] = useCurrentPng({ ref: chartRef });
+  const [copySuccess, setCopySuccess] = useToggle(false);
+
+  useEffect(() => {
+    const resetTimeout = setTimeout(setCopySuccess.off, 5000);
+
+    return () => {
+      if (copySuccess) {
+        clearTimeout(resetTimeout);
+      }
+    };
+  }, [copySuccess, setCopySuccess]);
 
   const handlePngDownload = useCallback(async () => {
     const png = await getClipboardPng();
@@ -41,6 +53,8 @@ export default function ChartExportMenu({ chartRef, chartTitle }: Props) {
           }),
         }),
       ]);
+
+      setCopySuccess.on();
     } catch (error) {
       logger.error(error);
     }
@@ -55,7 +69,7 @@ export default function ChartExportMenu({ chartRef, chartTitle }: Props) {
       </li>
       <li role="menuitem">
         <ButtonText onClick={handleCopyToClipboard}>
-          Copy chart to clipboard
+          {copySuccess ? 'Copied' : 'Copy chart to clipboard'}
         </ButtonText>
       </li>
     </ExportMenu>


### PR DESCRIPTION
This PR fixes an issue where 'Copy to Clipboard' functionality didn't work on Safari.

After some research it seems Safari requires the blob value to be returned from a promise.

It also
- Fixes style issue of the export menu to display on the right (it was showing on the left on Safari and Firefox)
- Changes the button text to 'Copied' temporarily on copy success, in line with other copy functionality on the site.

References for the Safari issue:

- https://web.dev/articles/async-clipboard#demos:~:text=Warning%3A%20Safari,type%3A%20%27foo/bar%27%20%7D))%3B%20%7D)%2C%20%7D)
- https://www.bigbinary.com/blog/copy-generated-image-clipboard-javascript
- https://stackoverflow.com/questions/65356108/how-to-use-clipboard-api-to-write-image-to-clipboard-in-safari
- https://wolfgangrittner.dev/how-to-use-clipboard-api-in-firefox/