### PR TITLE
EES-6000 show single item filters in tables

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/getDefaultTableHeadersConfig.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/getDefaultTableHeadersConfig.test.ts
@@ -338,7 +338,7 @@ describe('getDefaultTableHeadersConfig', () => {
     expect(rows[1].label).toBe('Number of authorised absence sessions');
   });
 
-  test('returns correct config with siblingless filters removed when one option for every filter type', () => {
+  test('does not remove siblingless non-default filters', () => {
     const testTableDataSiblingless: TableDataResponse = {
       ...testTableData,
       subjectMeta: {
@@ -409,10 +409,93 @@ describe('getDefaultTableHeadersConfig', () => {
     const { rows, rowGroups, columns, columnGroups } =
       getDefaultTableHeaderConfig(testSubjectMeta);
 
-    // Should only have indicators and time periods
-    // when all other filter types are siblingless
     expect(columnGroups).toHaveLength(0);
-    expect(rowGroups).toHaveLength(0);
+    expect(rowGroups).toHaveLength(2);
+    expect(rowGroups[0][0].label).toBe('State-funded secondary');
+    expect(rowGroups[1][0].label).toBe('Ethnicity Major Black Total');
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].label).toBe('Number of overall absence sessions');
+
+    expect(columns).toHaveLength(1);
+    expect(columns[0].label).toBe('2014/15');
+  });
+
+  test('removes siblingless default filters', () => {
+    const testTableDataSiblingless: TableDataResponse = {
+      ...testTableData,
+      subjectMeta: {
+        ...testTableData.subjectMeta,
+        filters: {
+          ...testTableData.subjectMeta.filters,
+          Characteristic: {
+            ...testTableData.subjectMeta.filters.Characteristic,
+            autoSelectFilterItemId: 'ethnicity-major-black-total',
+            options: {
+              EthnicGroupMajor: {
+                id: 'ethnic-group-major',
+                label: 'Ethnic group major',
+                options: [
+                  {
+                    label: 'Ethnicity Major Black Total',
+                    value: 'ethnicity-major-black-total',
+                  },
+                ],
+                order: 0,
+              },
+            },
+          },
+          SchoolType: {
+            ...testTableData.subjectMeta.filters.SchoolType,
+            options: {
+              Default: {
+                id: 'default',
+                label: 'Default',
+                options: [
+                  {
+                    label: 'State-funded secondary',
+                    value: 'state-funded-secondary',
+                  },
+                ],
+                order: 0,
+              },
+            },
+          },
+        },
+        indicators: [
+          {
+            value: 'overall-absence-sessions',
+            label: 'Number of overall absence sessions',
+            unit: '',
+            name: 'sess_overall',
+            decimalPlaces: 2,
+          },
+        ],
+        locations: {
+          localAuthority: [
+            { id: 'barnsley', value: 'barnsley', label: 'Barnsley' },
+          ],
+        },
+      },
+      results: [
+        {
+          filters: [],
+          geographicLevel: '',
+          locationId: '',
+          measures: {},
+          timePeriod: '2014_AY',
+        },
+      ],
+    };
+
+    const testSubjectMeta = mapFullTable(testTableDataSiblingless);
+
+    const { rows, rowGroups, columns, columnGroups } =
+      getDefaultTableHeaderConfig(testSubjectMeta);
+
+    expect(columnGroups).toHaveLength(0);
+    expect(rowGroups).toHaveLength(1);
+    expect(rowGroups[0][0].label).toBe('State-funded secondary');
 
     expect(rows).toHaveLength(1);
     expect(rows[0].label).toBe('Number of overall absence sessions');

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/getDefaultTableHeadersConfig.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/getDefaultTableHeadersConfig.ts
@@ -1,4 +1,5 @@
 import {
+  CategoryFilter,
   Filter,
   TimePeriodFilter,
 } from '@common/modules/table-tool/types/filters';
@@ -11,7 +12,13 @@ import last from 'lodash/last';
 import orderBy from 'lodash/orderBy';
 
 const removeSingleOptionFilterGroups = (filters: Filter[][]): Filter[][] => {
-  return filters.filter(filterGroup => filterGroup.length > 1);
+  return filters.filter(
+    filterGroup =>
+      filterGroup.length > 1 ||
+      (filterGroup[0] instanceof CategoryFilter &&
+        filterGroup.length === 1 &&
+        !filterGroup[0].isAutoSelect),
+  );
 };
 
 /**
@@ -29,7 +36,12 @@ function getSortedRowColGroups(
     options => options.reduce((acc, option) => acc + option.label.length, 0),
   ]);
 
-  const halfwayIndex = Math.floor(sortedFilters.length / 2);
+  // Adjust the halfwayIndex if we have a single filter option in the table
+  // to keep it in the rows.
+  const halfwayIndex =
+    sortedFilters.length > 1 && sortedFilters[0].length === 1
+      ? Math.floor(sortedFilters.length / 2) - 1
+      : Math.floor(sortedFilters.length / 2);
 
   // Re-sort by number of options. We want to avoid cases where groups
   // with small number of options repeat many times, causing the


### PR DESCRIPTION
Previously single filters were hidden in table tool tables, which could cause some confusion. Now they are shown unless they are the default, usually 'Total', for the filter / filter group.

## Some examples:

### 1
Before:
![Screenshot 2025-04-17 162327](https://github.com/user-attachments/assets/4cc22df2-b60f-4dad-89c3-e895515538f8)
After:
![Screenshot 2025-04-17 162317](https://github.com/user-attachments/assets/6ca33521-cbfa-40a3-9ab2-c621192524ca)

### 2
Before:
![Screenshot 2025-04-17 162239](https://github.com/user-attachments/assets/5d46990d-5f57-47a6-a58f-08e007177a1c)
After:
![Screenshot 2025-04-17 162248](https://github.com/user-attachments/assets/d7e960bf-f3c4-4d37-8029-bac1d9fac297)

### 3 
Before:
![Screenshot 2025-04-17 155920](https://github.com/user-attachments/assets/aa516eb1-ee94-4a4a-a948-eeb1d2e592de)
After: 
![Screenshot 2025-04-17 155932](https://github.com/user-attachments/assets/5a2a588d-9e7e-42b5-993d-ef439b8e4917)

