### PR TITLE
EES-6045 Fix failing Search infrastructure deploy

### DIFF
--- a/infrastructure/templates/search/scripts/SetupSearchService.ps1
+++ b/infrastructure/templates/search/scripts/SetupSearchService.ps1
@@ -66,7 +66,7 @@ try {
         -Method 'PUT' `
         -Uri "$uri/indexes/$($indexDefinition.name)?api-version=$apiVersion" `
         -Headers  $headers `
-        -Body (ConvertTo-Json $indexDefinition)
+        -Body (ConvertTo-Json -Compress -Depth 100 $indexDefinition)
 
     if ($dataSourceContainerName.Length -gt 0 -and $dataSourceConnectionString.Length -gt 0)
     {
@@ -75,14 +75,14 @@ try {
             -Method 'PUT' `
             -Uri "$uri/datasources/$($dataSourceDefinition['name'])?api-version=$apiVersion" `
             -Headers $headers `
-            -Body (ConvertTo-Json $dataSourceDefinition)
+            -Body (ConvertTo-Json -Compress -Depth 100 $dataSourceDefinition)
 
         # https://learn.microsoft.com/rest/api/searchservice/create-indexer
         Invoke-WebRequest `
             -Method 'PUT' `
             -Uri "$uri/indexers/$($indexerDefinition['name'])?api-version=$apiVersion" `
             -Headers $headers `
-            -Body (ConvertTo-Json $indexerDefinition)
+            -Body (ConvertTo-Json -Compress -Depth 100 $indexerDefinition)
     }
     $DeploymentScriptOutputs['result'] = 'Success'
 } catch {


### PR DESCRIPTION
This PR fixes the failing Azure AI Search configuration deployment script in the Search infrastructure deploy.

It sets the `Depth` parameter of `ConvertTo-Json` used in the HTTP requests to the max possible value (100) to prevent unwanted data loss when converting objects to JSON.

### Other changes

- Adds the `Compress` parameter to `ConvertTo-Json` to omit white space and indented formatting in JSON used in HTTP requests.