### PR TITLE
EES-6033 content section focus handling

### DIFF
--- a/src/explore-education-statistics-admin/src/components/FormModal.tsx
+++ b/src/explore-education-statistics-admin/src/components/FormModal.tsx
@@ -100,7 +100,6 @@ export default function FormModal<TFormValues extends FieldValues>({
     [
       onSubmit,
       isMounted,
-      toggleConfirmationWarning,
       formHasConfirmationWarning,
       showConfirmationWarning,
       isSubmitting,

--- a/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.tsx
@@ -116,6 +116,7 @@ const EditableAccordion = (props: EditableAccordionProps) => {
             onClick={onAddSection}
             className={styles.addSectionButton}
             disabled={isReordering}
+            id="editable-accordion-add-section-button"
           >
             Add new section
           </Button>

--- a/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.tsx
@@ -116,7 +116,7 @@ const EditableAccordion = (props: EditableAccordionProps) => {
             onClick={onAddSection}
             className={styles.addSectionButton}
             disabled={isReordering}
-            id="editable-accordion-add-section-button"
+            id={`add-section-button-${id}`}
           >
             Add new section
           </Button>

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordion.tsx
@@ -101,7 +101,7 @@ const MethodologyAccordion = ({
         buttonToFocus?.focus();
       }, 100);
     },
-    [removeContentSection, id, methodology.id, methodology.content],
+    [removeContentSection, id, methodology.id, methodology.content, sectionKey],
   );
 
   if (

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
@@ -10,7 +10,8 @@ import { Dictionary } from '@common/types';
 import MethodologyBlock from '@admin/pages/methodology/components/MethodologyBlock';
 import { ContentSectionKeys } from '@admin/pages/methodology/edit-methodology/content/context/MethodologyContentContextActionTypes';
 import useMethodologyContentActions from '@admin/pages/methodology/edit-methodology/content/context/useMethodologyContentActions';
-import React, { memo, useCallback, useEffect, useState } from 'react';
+import focusAddedSectionBlockButton from '@admin/utils/focus/focusAddedSectionBlockButton';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 interface MethodologyAccordionSectionProps {
   id: string;
@@ -43,6 +44,8 @@ const MethodologyAccordionSection = ({
   const [isReordering, setIsReordering] = useState(false);
   const [blocks, setBlocks] = useState<EditableContentBlock[]>(sectionContent);
 
+  const addTextBlockButton = useRef<HTMLButtonElement>(null);
+
   useEffect(() => {
     setBlocks(sectionContent);
   }, [sectionContent]);
@@ -59,17 +62,7 @@ const MethodologyAccordionSection = ({
       sectionKey,
     });
 
-    setTimeout(() => {
-      const newBlockEl = document.querySelector(
-        `#editableSectionBlocks-${newBlock.id}`,
-      );
-      const newBlockButton = newBlockEl?.querySelector(
-        'button.govuk-button--secondary',
-      ) as HTMLButtonElement;
-      if (newBlockButton) {
-        newBlockButton.focus();
-      }
-    }, 100);
+    focusAddedSectionBlockButton(newBlock.id);
   }, [
     addContentSectionBlock,
     methodologyId,
@@ -91,15 +84,29 @@ const MethodologyAccordionSection = ({
     [methodologyId, sectionId, sectionKey, updateContentSectionBlock],
   );
 
+  const onAfterDeleteBlock = () => {
+    setTimeout(() => {
+      addTextBlockButton.current?.focus();
+    }, 100);
+  };
+
   const removeBlockFromAccordionSection = useCallback(
-    (blockId: string) =>
+    (blockId: string) => {
       deleteContentSectionBlock({
         methodologyId,
         sectionId,
         blockId,
         sectionKey,
-      }),
-    [deleteContentSectionBlock, methodologyId, sectionId, sectionKey],
+      });
+      onAfterDeleteBlock();
+    },
+    [
+      deleteContentSectionBlock,
+      onAfterDeleteBlock,
+      methodologyId,
+      sectionId,
+      sectionKey,
+    ],
   );
 
   const reorderBlocksInAccordionSection = useCallback(async () => {
@@ -176,7 +183,11 @@ const MethodologyAccordionSection = ({
       />
       {editingMode === 'edit' && !isReordering && (
         <div className="govuk-!-margin-bottom-8 govuk-!-text-align-centre">
-          <Button variant="secondary" onClick={addBlockToAccordionSection}>
+          <Button
+            variant="secondary"
+            onClick={addBlockToAccordionSection}
+            ref={addTextBlockButton}
+          >
             Add text block
           </Button>
         </div>

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
@@ -84,12 +84,6 @@ const MethodologyAccordionSection = ({
     [methodologyId, sectionId, sectionKey, updateContentSectionBlock],
   );
 
-  const onAfterDeleteBlock = () => {
-    setTimeout(() => {
-      addTextBlockButton.current?.focus();
-    }, 100);
-  };
-
   const removeBlockFromAccordionSection = useCallback(
     (blockId: string) => {
       deleteContentSectionBlock({
@@ -98,11 +92,14 @@ const MethodologyAccordionSection = ({
         blockId,
         sectionKey,
       });
-      onAfterDeleteBlock();
+
+      setTimeout(() => {
+        addTextBlockButton.current?.focus();
+      }, 100);
     },
     [
       deleteContentSectionBlock,
-      onAfterDeleteBlock,
+      addTextBlockButton,
       methodologyId,
       sectionId,
       sectionKey,

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyAccordionSection.tsx
@@ -18,6 +18,7 @@ interface MethodologyAccordionSectionProps {
   sectionKey: ContentSectionKeys;
   methodologyId: string;
   methodologySlug: string;
+  onRemoveSection: (sectionId: string) => void;
 }
 
 const MethodologyAccordionSection = ({
@@ -25,6 +26,7 @@ const MethodologyAccordionSection = ({
   section: { id: sectionId, caption, heading, content: sectionContent = [] },
   methodologyId,
   methodologySlug,
+  onRemoveSection,
   ...props
 }: MethodologyAccordionSectionProps) => {
   const { editingMode } = useEditingContext();
@@ -36,7 +38,6 @@ const MethodologyAccordionSection = ({
     updateContentSectionBlock,
     updateSectionBlockOrder,
     updateContentSectionHeading,
-    removeContentSection,
   } = useMethodologyContentActions();
 
   const [isReordering, setIsReordering] = useState(false);
@@ -126,16 +127,6 @@ const MethodologyAccordionSection = ({
     [methodologyId, sectionId, sectionKey, updateContentSectionHeading],
   );
 
-  const handleRemoveSection = useCallback(
-    () =>
-      removeContentSection({
-        methodologyId,
-        sectionId,
-        sectionKey,
-      }),
-    [methodologyId, removeContentSection, sectionId, sectionKey],
-  );
-
   return (
     <EditableAccordionSection
       {...props}
@@ -163,7 +154,7 @@ const MethodologyAccordionSection = ({
         </Button>
       }
       onHeadingChange={handleHeadingChange}
-      onRemoveSection={handleRemoveSection}
+      onRemoveSection={() => onRemoveSection(sectionId)}
     >
       <EditableSectionBlocks<EditableContentBlock>
         blocks={blocks}

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/context/useMethodologyContentActions.ts
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/context/useMethodologyContentActions.ts
@@ -193,6 +193,8 @@ export default function useMethodologyContentActions() {
         sectionKey,
       },
     });
+
+    return content;
   }
 
   async function updateContentSectionHeading({

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -20,6 +20,7 @@ import {
 } from '@admin/routes/routes';
 import releaseDataFileService from '@admin/services/releaseDataFileService';
 import releaseFileService from '@admin/services/releaseFileService';
+import focusAddedSectionBlockButton from '@admin/utils/focus/focusAddedSectionBlockButton';
 import Button from '@common/components/Button';
 import ButtonText from '@common/components/ButtonText';
 import Details from '@common/components/Details';
@@ -30,7 +31,7 @@ import Tag from '@common/components/Tag';
 import ReleaseSummarySection from '@common/modules/release/components/ReleaseSummarySection';
 import ReleaseDataAndFiles from '@common/modules/release/components/ReleaseDataAndFiles';
 import useDebouncedCallback from '@common/hooks/useDebouncedCallback';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { generatePath, useLocation } from 'react-router';
 import { useConfig } from '@admin/contexts/ConfigContext';
 
@@ -56,6 +57,8 @@ const ReleaseContent = ({
   const { release } = useReleaseContentState();
   const { addContentSectionBlock } = useReleaseContentActions();
 
+  const addSummaryBlockButton = useRef<HTMLButtonElement>(null);
+
   const blockRouteChange = useMemo(() => {
     if (unsavedBlocks.length > 0) {
       return true;
@@ -69,7 +72,7 @@ const ReleaseContent = ({
   }, [unsavedBlocks, unsavedCommentDeletions]);
 
   const addSummaryBlock = useCallback(async () => {
-    await addContentSectionBlock({
+    const newBlock = await addContentSectionBlock({
       releaseVersionId: release.id,
       sectionId: release.summarySection.id,
       sectionKey: 'summarySection',
@@ -79,6 +82,8 @@ const ReleaseContent = ({
         body: '',
       },
     });
+
+    focusAddedSectionBlockButton(newBlock.id);
   }, [addContentSectionBlock, release.id, release.summarySection.id]);
 
   const addRelatedDashboardsBlock = useCallback(async () => {
@@ -154,6 +159,12 @@ const ReleaseContent = ({
     };
   }, [handleScroll]);
 
+  const onAfterDeleteSummaryBlock = () => {
+    setTimeout(() => {
+      addSummaryBlockButton.current?.focus();
+    }, 100);
+  };
+
   return (
     <>
       <RouteLeavingGuard
@@ -219,13 +230,18 @@ const ReleaseContent = ({
                       releaseVersionId={release.id}
                       sectionId={release.summarySection.id}
                       sectionKey="summarySection"
+                      onAfterDeleteBlock={onAfterDeleteSummaryBlock}
                     />
                   )}
                 />
                 {editingMode === 'edit' &&
                   release.summarySection.content?.length === 0 && (
                     <div className="govuk-!-margin-bottom-8 govuk-!-text-align-centre">
-                      <Button variant="secondary" onClick={addSummaryBlock}>
+                      <Button
+                        variant="secondary"
+                        onClick={addSummaryBlock}
+                        ref={addSummaryBlockButton}
+                      >
                         Add a summary text block
                       </Button>
                     </div>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordion.tsx
@@ -61,7 +61,7 @@ const ReleaseContentAccordion = ({
       // otherwise to the 'add section' button
       setTimeout(() => {
         let buttonToFocus = document.querySelector(
-          '#editable-accordion-add-section-button',
+          `#add-section-button-${id}`,
         ) as HTMLButtonElement;
 
         if (updatedContent.length > 0) {

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -11,6 +11,7 @@ import ReleaseEditableBlock from '@admin/pages/release/content/components/Releas
 import { useReleaseContentState } from '@admin/pages/release/content/contexts/ReleaseContentContext';
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
 import { EditableBlock } from '@admin/services/types/content';
+import focusAddedSectionBlockButton from '@admin/utils/focus/focusAddedSectionBlockButton';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import Modal from '@common/components/Modal';
@@ -19,7 +20,14 @@ import useToggle from '@common/hooks/useToggle';
 import { ContentSection } from '@common/services/publicationService';
 import { Dictionary } from '@common/types';
 import { isFuture } from 'date-fns';
-import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 export interface ReleaseContentAccordionSectionProps {
   id: string;
@@ -50,6 +58,8 @@ const ReleaseContentAccordionSection = ({
 
   const [blocks, setBlocks] = useState<EditableBlock[]>(sectionContent);
 
+  const addTextBlockButton = useRef<HTMLButtonElement>(null);
+
   useEffect(() => {
     setBlocks(sectionContent);
   }, [sectionContent]);
@@ -79,17 +89,7 @@ const ReleaseContentAccordionSection = ({
       },
     });
 
-    setTimeout(() => {
-      const newBlockEl = document.querySelector(
-        `#editableSectionBlocks-${newBlock.id}`,
-      );
-      const newBlockButton = newBlockEl?.querySelector(
-        'button.govuk-button--secondary',
-      ) as HTMLButtonElement;
-      if (newBlockButton) {
-        newBlockButton.focus();
-      }
-    }, 100);
+    focusAddedSectionBlockButton(newBlock.id);
   }, [actions, release.id, sectionId, sectionContent.length]);
 
   const addEmbedBlock = useCallback(
@@ -147,6 +147,12 @@ const ReleaseContentAccordionSection = ({
     },
     [actions, sectionId, release.id],
   );
+
+  const onAfterDeleteBlock = () => {
+    setTimeout(() => {
+      addTextBlockButton.current?.focus();
+    }, 100);
+  };
 
   const hasLockedBlocks = blocks.some(
     block => block.lockedUntil && isFuture(new Date(block.lockedUntil)),
@@ -214,6 +220,7 @@ const ReleaseContentAccordionSection = ({
                 publicationId={release.publication.id}
                 releaseVersionId={release.id}
                 visible={open}
+                onAfterDeleteBlock={onAfterDeleteBlock}
               />
             )}
           />
@@ -233,7 +240,11 @@ const ReleaseContentAccordionSection = ({
               )}
 
               <ButtonGroup className="govuk-!-margin-bottom-8 dfe-justify-content--center">
-                <Button variant="secondary" onClick={addBlock}>
+                <Button
+                  variant="secondary"
+                  onClick={addBlock}
+                  ref={addTextBlockButton}
+                >
                   Add text block
                 </Button>
                 {!showDataBlockForm && (

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -24,11 +24,13 @@ import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 export interface ReleaseContentAccordionSectionProps {
   id: string;
   section: ContentSection<EditableBlock>;
+  onRemoveSection: (sectionId: string) => void;
   transformFeaturedTableLinks?: (url: string, text: string) => void;
 }
 
 const ReleaseContentAccordionSection = ({
   section,
+  onRemoveSection,
   transformFeaturedTableLinks,
   ...props
 }: ReleaseContentAccordionSectionProps) => {
@@ -146,13 +148,6 @@ const ReleaseContentAccordionSection = ({
     [actions, sectionId, release.id],
   );
 
-  const handleRemoveSection = useCallback(async () => {
-    await actions.removeContentSection({
-      sectionId,
-      releaseVersionId: release.id,
-    });
-  }, [actions, sectionId, release.id]);
-
   const hasLockedBlocks = blocks.some(
     block => block.lockedUntil && isFuture(new Date(block.lockedUntil)),
   );
@@ -168,7 +163,7 @@ const ReleaseContentAccordionSection = ({
       }
       caption={caption}
       onHeadingChange={handleHeadingChange}
-      onRemoveSection={handleRemoveSection}
+      onRemoveSection={() => onRemoveSection(sectionId)}
       headerButtons={
         <Tooltip
           text="This section is being edited and cannot be reordered"

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseEditableBlock.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseEditableBlock.tsx
@@ -38,6 +38,7 @@ interface Props {
   sectionId: string;
   sectionKey: ContentSectionKeys;
   visible?: boolean;
+  onAfterDeleteBlock?: () => void;
 }
 
 const ReleaseEditableBlock = ({
@@ -50,6 +51,7 @@ const ReleaseEditableBlock = ({
   sectionId,
   sectionKey,
   visible,
+  onAfterDeleteBlock,
 }: Props) => {
   const {
     addUnsavedBlock,
@@ -202,9 +204,12 @@ const ReleaseEditableBlock = ({
       sectionKey,
       blockId: block.id,
     });
+
+    onAfterDeleteBlock?.();
   }, [
     block.id,
     deleteContentSectionBlock,
+    onAfterDeleteBlock,
     releaseVersionId,
     sectionId,
     sectionKey,

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
@@ -6,11 +6,12 @@ import ReleaseBlock from '@admin/pages/release/content/components/ReleaseBlock';
 import ReleaseEditableBlock from '@admin/pages/release/content/components/ReleaseEditableBlock';
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
 import { EditableRelease } from '@admin/services/releaseContentService';
+import focusAddedSectionBlockButton from '@admin/utils/focus/focusAddedSectionBlockButton';
 import Button from '@common/components/Button';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
 import DataBlockTabs from '@common/modules/find-statistics/components/DataBlockTabs';
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import AddSecondaryStats from './AddSecondaryStats';
 
 interface Props {
@@ -22,10 +23,12 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
   const { editingMode } = useEditingContext();
   const actions = useReleaseContentActions();
 
+  const addHeadlinesBlockButton = useRef<HTMLButtonElement>(null);
+
   const getChartFile = useGetChartFile(release.id);
 
   const addBlock = useCallback(async () => {
-    await actions.addContentSectionBlock({
+    const newBlock = await actions.addContentSectionBlock({
       releaseVersionId: release.id,
       sectionId: release.headlinesSection.id,
       sectionKey: 'headlinesSection',
@@ -35,7 +38,15 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
         body: '',
       },
     });
+
+    focusAddedSectionBlockButton(newBlock.id);
   }, [actions, release.id, release.headlinesSection.id]);
+
+  const onAfterDeleteHeadlinesBlock = () => {
+    setTimeout(() => {
+      addHeadlinesBlockButton.current?.focus();
+    }, 100);
+  };
 
   const headlinesTab = (
     <TabsSection title="Summary">
@@ -60,6 +71,7 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
               releaseVersionId={release.id}
               sectionId={release.headlinesSection.id}
               sectionKey="headlinesSection"
+              onAfterDeleteBlock={onAfterDeleteHeadlinesBlock}
             />
           )}
         />
@@ -67,7 +79,11 @@ const ReleaseHeadlines = ({ release, transformFeaturedTableLinks }: Props) => {
         {editingMode === 'edit' &&
           release.headlinesSection.content?.length === 0 && (
             <div className="govuk-!-margin-bottom-8 govuk-!-text-align-centre">
-              <Button variant="secondary" onClick={addBlock}>
+              <Button
+                variant="secondary"
+                onClick={addBlock}
+                ref={addHeadlinesBlockButton}
+              >
                 Add a headlines text block
               </Button>
             </div>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseContentAccordionSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseContentAccordionSection.test.tsx
@@ -42,6 +42,7 @@ describe('ReleaseContentAccordionSection', () => {
               <ReleaseContentAccordionSection
                 id="test-section-1"
                 section={testReleaseContent.release.content[0]}
+                onRemoveSection={() => {}}
               />
             </EditableAccordion>
           </ReleaseContentHubContextProvider>
@@ -99,6 +100,7 @@ describe('ReleaseContentAccordionSection', () => {
                 <ReleaseContentAccordionSection
                   id="test-section-1"
                   section={testReleaseContent.release.content[0]}
+                  onRemoveSection={() => {}}
                 />
               </EditableAccordion>
             </ReleaseContentHubContextProvider>
@@ -148,6 +150,7 @@ describe('ReleaseContentAccordionSection', () => {
               <ReleaseContentAccordionSection
                 id="test-section-1"
                 section={testReleaseContent.release.content[0]}
+                onRemoveSection={() => {}}
               />
             </EditableAccordion>
           </ReleaseContentHubContextProvider>
@@ -199,6 +202,7 @@ describe('ReleaseContentAccordionSection', () => {
               <ReleaseContentAccordionSection
                 id="test-section-1"
                 section={testReleaseContent.release.content[0]}
+                onRemoveSection={() => {}}
               />
             </EditableAccordion>
           </ReleaseContentHubContextProvider>
@@ -238,6 +242,7 @@ describe('ReleaseContentAccordionSection', () => {
               <ReleaseContentAccordionSection
                 id="test-section-1"
                 section={testReleaseContent.release.content[0]}
+                onRemoveSection={() => {}}
               />
             </EditableAccordion>
           </ReleaseContentHubContextProvider>
@@ -293,6 +298,7 @@ describe('ReleaseContentAccordionSection', () => {
               <ReleaseContentAccordionSection
                 id="test-section-1"
                 section={testSectionWithLockedBlock}
+                onRemoveSection={() => {}}
               />
             </EditableAccordion>
           </ReleaseContentHubContextProvider>

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/useReleaseContentActions.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/useReleaseContentActions.ts
@@ -418,6 +418,8 @@ export default function useReleaseContentActions() {
           content,
         },
       });
+
+      return content;
     },
     [dispatch],
   );

--- a/src/explore-education-statistics-admin/src/utils/focus/focusAddedSectionBlockButton.ts
+++ b/src/explore-education-statistics-admin/src/utils/focus/focusAddedSectionBlockButton.ts
@@ -1,0 +1,14 @@
+/**
+ * Focus the 'Edit block' button after a new content section block is added.
+ */
+export default function focusAddedSectionBlockButton(id: string) {
+  setTimeout(() => {
+    const newBlockEl = document.querySelector(`#editableSectionBlocks-${id}`);
+    const newBlockButton = newBlockEl?.querySelector(
+      'button.govuk-button--secondary',
+    ) as HTMLButtonElement;
+    if (newBlockButton) {
+      newBlockButton.focus();
+    }
+  }, 100);
+}


### PR DESCRIPTION
This PR handles many cases of focussing elements after content blocks and sections are added or removed.
Existing behaviour is that focus 'disappears' after removing (or sometimes adding) blocks/sections, so the user would have to tab all the way back to there point of interest in the page.

- When a **section** is removed, focus on the previous section if it exists, otherwise on the 'add section' button.
- When a content **block** is removed, focus on the applicable 'add' button.
- Similar for particular release content blocks, e.g. adding and removing **headlines block** and **release summary block** 