### PR TITLE
EES-6000 fix table rendering issue and update ui tests

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/getDefaultTableHeadersConfig.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/getDefaultTableHeadersConfig.ts
@@ -70,7 +70,6 @@ function getFixedTimePeriodAndIndicatorTableHeadersConfig(
   filteredTimePeriodRange: TimePeriodFilter[],
 ): TableHeadersConfig {
   const { indicators, filters, locations } = fullTableMeta;
-
   const { columnGroups, rowGroups } = getSortedRowColGroups(
     removeSingleOptionFilterGroups([
       ...Object.values(filters).map(group => group.options),
@@ -130,6 +129,12 @@ export default function getDefaultTableHeaderConfig(
     filteredTimePeriodRange,
     indicators,
   ]);
+
+  // Make sure there's always something in the columns
+  if (!columnGroups.length) {
+    columnGroups.push(rowGroups[0]);
+    rowGroups.shift();
+  }
 
   return {
     columnGroups: columnGroups.length > 1 ? columnGroups.slice(0, -1) : [],

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -654,7 +654,7 @@ Select featured table from subjects step
     ...    xpath://*[@data-testid="dataTableCaption" and text()="Admission Numbers for '${SUBJECT_2_NAME}' for Not specified in Bolton 001, Bolton 004, Nailsea Youngwood and Syon between 2005 and 2017"]
 
 Validate table column headings for featured table
-    user checks table column heading contains    1    1    Admission Numbers
+    user checks table column heading contains    1    1    Not specified
 
 Validate table rows for featured table
     ${row}=    user gets row number with heading    Bolton 001

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -171,7 +171,7 @@ user creates key stats data block for dates csv
     user waits until results table appears    %{WAIT_LONG}
 
     user checks table column heading contains    1    1    2020 Week 13
-    user checks headed table body row cell contains    ${indicator_name}    1    ${expected_indicator_value}
+    user checks headed table body row cell contains    23/03/2020    1    ${expected_indicator_value}
 
     user enters text into element    id:dataBlockDetailsForm-name    ${datablock_name}
     user enters text into element    id:dataBlockDetailsForm-heading    ${datablock_title}


### PR DESCRIPTION
Fixes an issue caused by https://github.com/dfe-analytical-services/explore-education-statistics/pull/5812 where tables with no filters didn't render.

Also updates a couple of UI tests to expect tables to show single filters.