### PR TITLE
EES-5962 - Remove the unused and broken ThemeViewModel.Publications

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -222,28 +222,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "Test theme",
                 Slug = "test-theme",
-                Summary = "Test summary",
-                Publications =
-                [
-                    new()
-                    {
-                        Title = "Test publication 1",
-                        Slug = "test-publication-1"
-                    },
-                    new()
-                    {
-                        Title = "Test publication 2",
-                        Slug = "test-publication-2",
-                    }
-                ]
-            };
-
-            // This publication should not be included with
-            // the theme as it is unrelated.
-            var unrelatedTheme = new Publication
-            {
-                Title = "Unrelated publication",
-                Slug = "unrelated-publication"
+                Summary = "Test summary"
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -251,8 +230,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 context.Add(theme);
-                context.Add(unrelatedTheme);
-
                 await context.SaveChangesAsync();
             }
 
@@ -266,13 +243,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test theme", viewModel.Title);
                 Assert.Equal("test-theme", viewModel.Slug);
                 Assert.Equal("Test summary", viewModel.Summary);
-
-                Assert.Equal(2, theme.Publications.Count);
-                Assert.Equal("Test publication 1", theme.Publications[0].Title);
-                Assert.Equal("test-publication-1", theme.Publications[0].Slug);
-
-                Assert.Equal("Test publication 2", theme.Publications[1].Title);
-                Assert.Equal("test-publication-2", theme.Publications[1].Slug);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -131,8 +131,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
             CreateMap<FeaturedTable, FeaturedTableViewModel>();
             CreateMap<FeaturedTableCreateRequest, FeaturedTable>();
 
-            CreateMap<Theme, ThemeViewModel>()
-                .ForMember(theme => theme.Publications, m => m.MapFrom(t => t.Publications.OrderBy(publication => publication.Title)));
+            CreateMap<Theme, ThemeViewModel>();
 
             CreateMap<ContentSection, ContentSectionViewModel>().ForMember(dest => dest.Content,
                 m => m.MapFrom(section => section.Content.OrderBy(contentBlock => contentBlock.Order)));

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ThemeViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ThemeViewModels.cs
@@ -1,31 +1,28 @@
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+
+public class ThemeViewModel
 {
-    public class ThemeViewModel
+    public Guid Id { get; set; }
+    public string Slug { get; set; }
+    public string Title { get; set; }
+    public string Summary { get; set; }
+}
+
+public class ThemeSaveViewModel
+{
+    private string _slug;
+
+    public string Slug
     {
-        public Guid Id { get; set; }
-        public string Slug { get; set; }
-        public string Title { get; set; }
-        public string Summary { get; set; }
-        public List<PublicationViewModel> Publications { get; set; }
+        get => string.IsNullOrEmpty(_slug) ? NamingUtils.SlugFromTitle(Title) : _slug;
+        set => _slug = value;
     }
 
-    public class ThemeSaveViewModel
-    {
-        private string _slug;
+    public string Summary { get; set; }
 
-        public string Slug
-        {
-            get => string.IsNullOrEmpty(_slug) ? NamingUtils.SlugFromTitle(Title) : _slug;
-            set => _slug = value;
-        }
-
-        public string Summary { get; set; }
-
-        [Required] public string Title { get; set; }
-    }
+    [Required] public string Title { get; set; }
 }


### PR DESCRIPTION
ThemeViewModel has a Publications property that was not being populated. Furthermore, inspection of the usage of ThemeViewModel reveals that we do not want the list of publications being returned under each themeViewModel instance, increasing the response size considerably.