### PR TITLE
EES-5977 Add analytics for zip downloads

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -750,6 +750,20 @@
       "metadata": {
         "description": "The Client ID of a manually-created App Registration that represents the Public API Container App in Entra ID"
       }
+    },
+    "analyticsEnabled": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Whether analytics is enabled"
+      }
+    },
+    "analyticsFileShareMountPath": {
+      "type": "string",
+      "defaultValue": "\\mounts\\analytics",
+      "metadata": {
+        "description": "Where analytics request files are saved before being processed"
+      }
     }
   },
   "variables": {
@@ -1242,6 +1256,8 @@
     "publicDataFileShareMountPathWindows": "\\mounts\\public-api-data",
     "publicDataFileShareName": "[concat(parameters('subscription'), '-ees-papi-share-data')]",
     "publicDataStorageAccountName": "[concat(parameters('subscription'), 'eespapisa')]",
+    "analyticsFileShareName": "[concat(parameters('subscription'), '-ees-share-anlyt')]",
+    "analyticsStorageAccountName": "[concat(parameters('subscription'), 'eessaanlyt')]",
     "eventGridTopicNamePublicationChanged": "[concat(parameters('subscription'), '-', parameters('environment'), '-evgt-publication-changed')]",
     "eventGridTopicNameReleaseChanged": "[concat(parameters('subscription'), '-', parameters('environment'), '-evgt-release-changed')]",
     "eventGridTopicNameReleaseVersionChanged": "[concat(parameters('subscription'), '-', parameters('environment'), '-evgt-release-version-changed')]",
@@ -1576,7 +1592,29 @@
         "WEBSITE_NODE_DEFAULT_VERSION": "20.16.0",
         "WEBSITE_RUN_FROM_PACKAGE": "1",
         "PublicStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-public'), '2018-02-14').secretUriWithVersion, ')')]",
-        "enableSwagger": "[parameters('enableSwagger')]"
+        "enableSwagger": "[parameters('enableSwagger')]",
+        "Analytics__Enabled": "[parameters('analyticsEnabled')]",
+        "Analytics__BasePath": "[parameters('analyticsFileShareMountPath')]"
+      }
+    },
+    {
+      "condition": "[parameters('analyticsEnabled')]",
+      "name": "[concat(variables('contentAppName'), '/azurestorageaccounts')]",
+      "type": "Microsoft.Web/sites/config",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2019-08-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', variables('contentAppName'))]"
+      ],
+      "properties": {
+        "[variables('analyticsFileShareName')]": {
+          "type": "AzureFiles",
+          "accountName": "[variables('analyticsStorageAccountName')]",
+          "accessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('analyticsStorageAccountName')), '2018-02-01').keys[0].value]",
+          "shareName": "[variables('analyticsFileShareName')]",
+          "mountPath": "[variables('analyticsFileShareMountPath')]",
+          "protocol": "Smb"
+        }
       }
     },
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicZipDownloads/ZipDownloadRequestFile_NoSubjectId.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicZipDownloads/ZipDownloadRequestFile_NoSubjectId.json
@@ -1,0 +1,6 @@
+{
+  "publicationName": "publication name",
+  "releaseLabel": "release label",
+  "releaseName": "release name",
+  "releaseVersionId": "319750f6-4c33-476c-9e6d-3da7a403201d"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicZipDownloads/ZipDownloadRequestFile_WithSubjectId.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicZipDownloads/ZipDownloadRequestFile_WithSubjectId.json
@@ -1,5 +1,5 @@
 {
-  "dataSetName": "data set name 2",
+  "dataSetTitle": "data set title 2",
   "publicationName": "publication name 2",
   "releaseLabel": "release label 2",
   "releaseName": "release name 2",

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicZipDownloads/ZipDownloadRequestFile_WithSubjectId.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicZipDownloads/ZipDownloadRequestFile_WithSubjectId.json
@@ -1,0 +1,8 @@
+{
+  "dataSetName": "data set name 2",
+  "publicationName": "publication name 2",
+  "releaseLabel": "release label 2",
+  "releaseName": "release name 2",
+  "releaseVersionId": "72a6856c-8d7b-4ad9-b533-2066d171d146",
+  "subjectId": "66c5eb5f-a85b-4586-bae8-dc3504d3042f"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicZipDownloads/ZipDownloadRequestFile_WithSubjectId_Copy.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicZipDownloads/ZipDownloadRequestFile_WithSubjectId_Copy.json
@@ -1,5 +1,5 @@
 {
-  "dataSetName": "data set name 2",
+  "dataSetTitle": "data set title 2",
   "publicationName": "publication name 2",
   "releaseLabel": "release label 2",
   "releaseName": "release name 2",

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicZipDownloads/ZipDownloadRequestFile_WithSubjectId_Copy.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicZipDownloads/ZipDownloadRequestFile_WithSubjectId_Copy.json
@@ -1,0 +1,8 @@
+{
+  "dataSetName": "data set name 2",
+  "publicationName": "publication name 2",
+  "releaseLabel": "release label 2",
+  "releaseName": "release name 2",
+  "releaseVersionId": "72a6856c-8d7b-4ad9-b533-2066d171d146",
+  "subjectId": "66c5eb5f-a85b-4586-bae8-dc3504d3042f"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicApiQueriesProcessorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicApiQueriesProcessorTests.cs
@@ -9,14 +9,14 @@ using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests.Services;
 
-public abstract class ConsumePublicApiQueriesProcessorTests
+public abstract class PublicApiQueriesProcessorTests
 {
     private readonly string _queryResourcesPath = Path.Combine(
         Assembly.GetExecutingAssembly().GetDirectoryPath(),
         "Resources",
         "PublicApiQueries");
 
-    public class ProcessTests : ConsumePublicApiQueriesProcessorTests
+    public class ProcessTests : PublicApiQueriesProcessorTests
     {
         [Fact]
         public async Task NoSourceFolder_NoReportsProduced()

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicApiQueriesProcessorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicApiQueriesProcessorTests.cs
@@ -21,7 +21,7 @@ public abstract class PublicApiQueriesProcessorTests
         [Fact]
         public async Task NoSourceFolder_NoReportsProduced()
         {
-            var pathResolver = new TestAnalyticsPathResolver();
+            using var pathResolver = new TestAnalyticsPathResolver();
 
             var service = BuildService(
                 pathResolver: pathResolver);
@@ -34,7 +34,7 @@ public abstract class PublicApiQueriesProcessorTests
         [Fact]
         public async Task NoSourceQueriesToConsume_NoReportsProduced()
         {
-            var pathResolver = new TestAnalyticsPathResolver();
+            using var pathResolver = new TestAnalyticsPathResolver();
 
             Directory.CreateDirectory(pathResolver.PublicApiQueriesDirectoryPath());
 
@@ -51,7 +51,7 @@ public abstract class PublicApiQueriesProcessorTests
         [Fact]
         public async Task SingleSourceQuery_ProducesOneReportRow()
         {
-            var pathResolver = new TestAnalyticsPathResolver();
+            using var pathResolver = new TestAnalyticsPathResolver();
             SetupQueryRequest(pathResolver, "Query1Request.json");
 
             var service = BuildService(
@@ -111,7 +111,7 @@ public abstract class PublicApiQueriesProcessorTests
         [Fact]
         public async Task TwoDifferentSourceQueries_ProduceTwoDistinctReportRows()
         {
-            var pathResolver = new TestAnalyticsPathResolver();
+            using var pathResolver = new TestAnalyticsPathResolver();
 
             SetupQueryRequest(pathResolver, "Query1Request.json");
             SetupQueryRequest(pathResolver, "Query2Request1.json");
@@ -139,29 +139,29 @@ public abstract class PublicApiQueriesProcessorTests
 
             var queryReportRow1 = queryReportRows[0];
 
-            Assert.Equal("b856e997ec5d2c7b445c71ff14859be7", queryReportRow1.QueryVersionHash);
-            Assert.Equal("7145877f51cbcab16411b8a1a7bac4c3", queryReportRow1.QueryHash);
-            Assert.Equal(Guid.Parse("8b9da0ae-80e4-43e8-9f39-4f670fd1a45a"), queryReportRow1.DataSetId);
-            Assert.Equal(Guid.Parse("5ed5053d-92fc-49a1-b0b1-4c11f3b2c538"), queryReportRow1.DataSetVersionId);
-            Assert.Equal("2.1.0", queryReportRow1.DataSetVersion);
-            Assert.Equal("Data Set 2", queryReportRow1.DataSetTitle);
-            Assert.Equal(20, queryReportRow1.ResultsCount);
-            Assert.Equal(23, queryReportRow1.TotalRowsCount);
+            Assert.Equal("f89944c2ee4284894962724bc68a1c8e", queryReportRow1.QueryVersionHash);
+            Assert.Equal("a992584964c8051b6e1b167a0a8dd4e0", queryReportRow1.QueryHash);
+            Assert.Equal(Guid.Parse("01d29401-7274-a871-a8db-d4bc4e98c324"), queryReportRow1.DataSetId);
+            Assert.Equal(Guid.Parse("01d29401-7974-1276-a06b-b28a6a5385c6"), queryReportRow1.DataSetVersionId);
+            Assert.Equal("1.2.0", queryReportRow1.DataSetVersion);
+            Assert.Equal("Data Set 1", queryReportRow1.DataSetTitle);
+            Assert.Equal(44, queryReportRow1.ResultsCount);
+            Assert.Equal(800, queryReportRow1.TotalRowsCount);
             Assert.Equal(1, queryReportRow1.QueryExecutions);
-            Assert.StartsWith("{\"criteria\":{\"filters\":{\"in\":[\"qOnjG\"", queryReportRow1.Query);
+            Assert.StartsWith("{\"criteria\":{\"filters\":{\"eq\":\"qOnjG\"}", queryReportRow1.Query);
 
             var queryReportRow2 = queryReportRows[1];
 
-            Assert.Equal("f89944c2ee4284894962724bc68a1c8e", queryReportRow2.QueryVersionHash);
-            Assert.Equal("a992584964c8051b6e1b167a0a8dd4e0", queryReportRow2.QueryHash);
-            Assert.Equal(Guid.Parse("01d29401-7274-a871-a8db-d4bc4e98c324"), queryReportRow2.DataSetId);
-            Assert.Equal(Guid.Parse("01d29401-7974-1276-a06b-b28a6a5385c6"), queryReportRow2.DataSetVersionId);
-            Assert.Equal("1.2.0", queryReportRow2.DataSetVersion);
-            Assert.Equal("Data Set 1", queryReportRow2.DataSetTitle);
-            Assert.Equal(44, queryReportRow2.ResultsCount);
-            Assert.Equal(800, queryReportRow2.TotalRowsCount);
+            Assert.Equal("b856e997ec5d2c7b445c71ff14859be7", queryReportRow2.QueryVersionHash);
+            Assert.Equal("7145877f51cbcab16411b8a1a7bac4c3", queryReportRow2.QueryHash);
+            Assert.Equal(Guid.Parse("8b9da0ae-80e4-43e8-9f39-4f670fd1a45a"), queryReportRow2.DataSetId);
+            Assert.Equal(Guid.Parse("5ed5053d-92fc-49a1-b0b1-4c11f3b2c538"), queryReportRow2.DataSetVersionId);
+            Assert.Equal("2.1.0", queryReportRow2.DataSetVersion);
+            Assert.Equal("Data Set 2", queryReportRow2.DataSetTitle);
+            Assert.Equal(20, queryReportRow2.ResultsCount);
+            Assert.Equal(23, queryReportRow2.TotalRowsCount);
             Assert.Equal(1, queryReportRow2.QueryExecutions);
-            Assert.StartsWith("{\"criteria\":{\"filters\":{\"eq\":\"qOnjG\"}", queryReportRow2.Query);
+            Assert.StartsWith("{\"criteria\":{\"filters\":{\"in\":[\"qOnjG\"", queryReportRow2.Query);
 
             var queryAccessReportFile = reports.Single(file => file.EndsWith("public-api-query-access.parquet"));
 
@@ -196,7 +196,7 @@ public abstract class PublicApiQueriesProcessorTests
         [Fact]
         public async Task MultipleSourceFilesForSameQuery_ProduceSingleQueryRowAndMultipleQueryAccessRows()
         {
-            var pathResolver = new TestAnalyticsPathResolver();
+            using var pathResolver = new TestAnalyticsPathResolver();
 
             SetupQueryRequest(pathResolver, "Query2Request1.json");
             SetupQueryRequest(pathResolver, "Query2Request2.json");
@@ -286,7 +286,7 @@ public abstract class PublicApiQueriesProcessorTests
         [Fact]
         public async Task SameQueryStructureButDifferentDataSetVersion_ProducesTwoDistinctReportRows()
         {
-            var pathResolver = new TestAnalyticsPathResolver();
+            using var pathResolver = new TestAnalyticsPathResolver();
 
             SetupQueryRequest(pathResolver, "Query1Request.json");
             SetupQueryRequest(pathResolver, "Query1RequestMinorVersionUpdate.json");
@@ -374,17 +374,18 @@ public abstract class PublicApiQueriesProcessorTests
             var queryReportRows = (await duckDbConnection
                     .SqlBuilder($"SELECT * FROM read_parquet('{queryReportFile:raw}')")
                     .QueryAsync<QueryReportLine>())
+                .OrderBy(row => row.DataSetTitle)
                 .ToList();
             return queryReportRows;
         }
     }
 
     private PublicApiQueriesProcessor BuildService(
-        TestAnalyticsPathResolver? pathResolver = null)
+        TestAnalyticsPathResolver pathResolver)
     {
         return new PublicApiQueriesProcessor(
             duckDbConnection: new DuckDbConnection(),
-            pathResolver: pathResolver ?? new TestAnalyticsPathResolver(),
+            pathResolver: pathResolver,
             Mock.Of<ILogger<PublicApiQueriesProcessor>>());
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicZipDownloadsProcessorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicZipDownloadsProcessorTests.cs
@@ -1,0 +1,203 @@
+using System.Reflection;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using InterpolatedSql.Dapper;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests.Services;
+
+public abstract class PublicZipDownloadsProcessorTests
+{
+    private readonly string _resourcesPath = Path.Combine(
+        Assembly.GetExecutingAssembly().GetDirectoryPath(),
+        "Resources",
+        "PublicZipDownloads");
+
+    public class ProcessTests : PublicZipDownloadsProcessorTests
+    {
+        [Fact]
+        public async Task NoSourceFolder_NoReportProduced()
+        {
+            var pathResolver = new TestAnalyticsPathResolver();
+
+            var service = BuildService(
+                pathResolver: pathResolver);
+            await service.Process();
+
+            Assert.False(Directory.Exists(pathResolver.PublicZipDownloadsProcessingDirectoryPath()));
+            Assert.False(Directory.Exists(pathResolver.PublicZipDownloadsReportsDirectoryPath()));
+        }
+
+        [Fact]
+        public async Task NoRequestFilesToConsume_NoReportProduced()
+        {
+            var pathResolver = new TestAnalyticsPathResolver();
+
+            Directory.CreateDirectory(pathResolver.PublicZipDownloadsDirectoryPath());
+
+            var service = BuildService(
+                pathResolver: pathResolver);
+            await service.Process();
+
+            // Check that as there were no files to process, no working directories were
+            // created as a result.
+            Assert.False(Directory.Exists(pathResolver.PublicZipDownloadsProcessingDirectoryPath()));
+            Assert.False(Directory.Exists(pathResolver.PublicZipDownloadsReportsDirectoryPath()));
+        }
+
+        [Fact]
+        public async Task SingleRequestFileNoSubjectId_ProducesOneReportRow()
+        {
+            var pathResolver = new TestAnalyticsPathResolver();
+            SetupZipDownloadRequest(pathResolver, "ZipDownloadRequestFile_NoSubjectId.json");
+
+            var service = BuildService(
+                pathResolver: pathResolver);
+            await service.Process();
+
+            Assert.False(Directory.Exists(pathResolver.PublicZipDownloadsProcessingDirectoryPath()));
+            Assert.True(Directory.Exists(pathResolver.PublicZipDownloadsReportsDirectoryPath()));
+
+            var reports = Directory.GetFiles(pathResolver.PublicZipDownloadsReportsDirectoryPath());
+            var zipDownloadsReport = Assert.Single(reports);
+
+            Assert.EndsWith("public-zip-downloads.parquet", zipDownloadsReport);
+
+            var duckDbConnection = new DuckDbConnection();
+            duckDbConnection.Open();
+
+            var zipDownloadReportRows = await ReadZipDownloadReport(duckDbConnection, zipDownloadsReport);
+
+            // Check that the single recorded zip download has resulted in a
+            // single line in the report and the values match the
+            // values from the original JSON file and the calculated fields
+            // match the expected values also.
+            var zipDownloadReportRow = Assert.Single(zipDownloadReportRows);
+
+            Assert.Equal("2e1ff1faca8870e00a9ec1fab7e58409", zipDownloadReportRow.ZipDownloadHash);
+            Assert.Equal("publication name", zipDownloadReportRow.PublicationName);
+            Assert.Equal(Guid.Parse("319750f6-4c33-476c-9e6d-3da7a403201d"), zipDownloadReportRow.ReleaseVersionId);
+            Assert.Equal("release name", zipDownloadReportRow.ReleaseName);
+            Assert.Equal("release label", zipDownloadReportRow.ReleaseLabel);
+            Assert.Null(zipDownloadReportRow.SubjectId);
+            Assert.Null(zipDownloadReportRow.DataSetName);
+            Assert.Equal(1, zipDownloadReportRow.Downloads);
+        }
+
+        [Fact]
+        public async Task TwoDifferentSourceQueries_ProduceTwoDistinctReportRows()
+        {
+            var pathResolver = new TestAnalyticsPathResolver();
+
+            SetupZipDownloadRequest(pathResolver, "ZipDownloadRequestFile_NoSubjectId.json");
+            SetupZipDownloadRequest(pathResolver, "ZipDownloadRequestFile_WithSubjectId.json");
+
+            var service = BuildService(
+                pathResolver: pathResolver);
+            await service.Process();
+
+            var reports = Directory.GetFiles(pathResolver.PublicZipDownloadsReportsDirectoryPath());
+            var zipDownloadsReport = Assert.Single(reports);
+
+            Assert.EndsWith("public-zip-downloads.parquet", zipDownloadsReport);
+
+            var duckDbConnection = new DuckDbConnection();
+            duckDbConnection.Open();
+
+            var zipDownloadReportRows = await ReadZipDownloadReport(duckDbConnection, zipDownloadsReport);
+
+            Assert.Equal(2, zipDownloadReportRows.Count);
+
+            Assert.Equal("2e1ff1faca8870e00a9ec1fab7e58409", zipDownloadReportRows[0].ZipDownloadHash);
+            Assert.Equal("publication name", zipDownloadReportRows[0].PublicationName);
+            Assert.Equal(Guid.Parse("319750f6-4c33-476c-9e6d-3da7a403201d"), zipDownloadReportRows[0].ReleaseVersionId);
+            Assert.Equal("release name", zipDownloadReportRows[0].ReleaseName);
+            Assert.Equal("release label", zipDownloadReportRows[0].ReleaseLabel);
+            Assert.Null(zipDownloadReportRows[0].SubjectId);
+            Assert.Null(zipDownloadReportRows[0].DataSetName);
+            Assert.Equal(1, zipDownloadReportRows[0].Downloads);
+
+            Assert.Equal("670871b1327feb682dd3516374f35928", zipDownloadReportRows[1].ZipDownloadHash);
+            Assert.Equal("publication name 2", zipDownloadReportRows[1].PublicationName);
+            Assert.Equal(Guid.Parse("72a6856c-8d7b-4ad9-b533-2066d171d146"), zipDownloadReportRows[1].ReleaseVersionId);
+            Assert.Equal("release name 2", zipDownloadReportRows[1].ReleaseName);
+            Assert.Equal("release label 2", zipDownloadReportRows[1].ReleaseLabel);
+            Assert.Equal(Guid.Parse("66c5eb5f-a85b-4586-bae8-dc3504d3042f"), zipDownloadReportRows[1].SubjectId);
+            Assert.Equal("data set name 2", zipDownloadReportRows[1].DataSetName);
+            Assert.Equal(1, zipDownloadReportRows[1].Downloads);
+        }
+
+        [Fact]
+        public async Task MultipleRequestFilesForSameZipFile_ProduceSingleReportRow()
+        {
+            var pathResolver = new TestAnalyticsPathResolver();
+
+            SetupZipDownloadRequest(pathResolver, "ZipDownloadRequestFile_WithSubjectId.json");
+            SetupZipDownloadRequest(pathResolver, "ZipDownloadRequestFile_WithSubjectId_Copy.json");
+
+            var service = BuildService(
+                pathResolver: pathResolver);
+            await service.Process();
+
+            var reports = Directory.GetFiles(pathResolver.PublicZipDownloadsReportsDirectoryPath());
+            var zipDownloadsReport = Assert.Single(reports);
+
+            Assert.EndsWith("public-zip-downloads.parquet", zipDownloadsReport);
+
+            var duckDbConnection = new DuckDbConnection();
+            duckDbConnection.Open();
+
+            var zipDownloadReportRows = await ReadZipDownloadReport(duckDbConnection, zipDownloadsReport);
+
+            var zipDownloadReportRow = Assert.Single(zipDownloadReportRows);
+
+            Assert.Equal("670871b1327feb682dd3516374f35928", zipDownloadReportRow.ZipDownloadHash);
+            Assert.Equal("publication name 2", zipDownloadReportRow.PublicationName);
+            Assert.Equal(Guid.Parse("72a6856c-8d7b-4ad9-b533-2066d171d146"), zipDownloadReportRow.ReleaseVersionId);
+            Assert.Equal("release name 2", zipDownloadReportRow.ReleaseName);
+            Assert.Equal("release label 2", zipDownloadReportRow.ReleaseLabel);
+            Assert.Equal(Guid.Parse("66c5eb5f-a85b-4586-bae8-dc3504d3042f"), zipDownloadReportRow.SubjectId);
+            Assert.Equal("data set name 2", zipDownloadReportRow.DataSetName);
+            Assert.Equal(2, zipDownloadReportRow.Downloads);
+        }
+
+        private static async Task<List<ZipDownloadReportLine>> ReadZipDownloadReport(DuckDbConnection duckDbConnection, string reportFile)
+        {
+            return (await duckDbConnection
+                    .SqlBuilder($"SELECT * FROM read_parquet('{reportFile:raw}')")
+                    .QueryAsync<ZipDownloadReportLine>())
+                .ToList();
+        }
+    }
+
+    private PublicZipDownloadsProcessor BuildService(
+        TestAnalyticsPathResolver? pathResolver = null)
+    {
+        return new PublicZipDownloadsProcessor(
+            duckDbConnection: new DuckDbConnection(),
+            pathResolver: pathResolver ?? new TestAnalyticsPathResolver(),
+            Mock.Of<ILogger<PublicZipDownloadsProcessor>>());
+    }
+
+    private void SetupZipDownloadRequest(TestAnalyticsPathResolver pathResolver, string filename)
+    {
+        Directory.CreateDirectory(pathResolver.PublicZipDownloadsDirectoryPath());
+
+        var sourceFilePath = Path.Combine(_resourcesPath, filename);
+        File.Copy(sourceFilePath, Path.Combine(pathResolver.PublicZipDownloadsDirectoryPath(), filename));
+    }
+
+    // ReSharper disable once ClassNeverInstantiated.Local
+    private record ZipDownloadReportLine(
+        string ZipDownloadHash,
+        string PublicationName,
+        Guid ReleaseVersionId,
+        string ReleaseName,
+        string ReleaseLabel,
+        Guid? SubjectId,
+        string? DataSetName,
+        int Downloads);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
@@ -23,20 +23,39 @@ public class TestAnalyticsPathResolver : IAnalyticsPathResolver, IDisposable
         return _basePath;
     }
 
+    // PublicApiQueries
     public string PublicApiQueriesDirectoryPath()
     {
-        return Path.Combine(_basePath, "public-api");
+        return Path.Combine(_basePath, "public-api", "queries");
     }
 
     public string PublicApiQueriesProcessingDirectoryPath() {
-        return Path.Combine(_basePath, "public-api", "processing");
+        return Path.Combine(_basePath, "public-api", "queries", "processing");
     }
 
     public string PublicApiQueriesFailuresDirectoryPath() {
-        return Path.Combine(_basePath, "public-api", "failures");
+        return Path.Combine(_basePath, "public-api", "queries", "failures");
     }
 
     public string PublicApiQueriesReportsDirectoryPath() {
-        return Path.Combine(_basePath, "reports", "public-api", "reports");
+        return Path.Combine(_basePath, "reports", "public-api", "queries");
+    }
+
+    // PublicZipDownloads
+    public string PublicZipDownloadsDirectoryPath()
+    {
+        return Path.Combine(_basePath, "public", "zip-downloads");
+    }
+
+    public string PublicZipDownloadsProcessingDirectoryPath() {
+        return Path.Combine(_basePath, "public", "zip-downloads", "processing");
+    }
+
+    public string PublicZipDownloadsFailuresDirectoryPath() {
+        return Path.Combine(_basePath, "public", "zip-downloads", "failures");
+    }
+
+    public string PublicZipDownloadsReportsDirectoryPath() {
+        return Path.Combine(_basePath, "reports", "public", "zip-downloads");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
@@ -40,9 +40,10 @@ public static class ProcessorHostBuilder
                     .AddTransient<IAnalyticsPathResolver, AnalyticsPathResolver>()
                     .AddTransient<DuckDbConnection>(_ => new DuckDbConnection());
 
-                // Services to be called by ConsumeAnalyticsRequestFilesFunction
+                // To be used by ConsumeAnalyticsRequestFilesFunction
                 services
-                    .AddTransient<IRequestFileProcessor, PublicApiQueriesProcessor>();
+                    .AddTransient<IRequestFileProcessor, PublicApiQueriesProcessor>()
+                    .AddTransient<IRequestFileProcessor, PublicZipDownloadsProcessor>();
             });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
@@ -21,7 +21,16 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
             );
         }
         
-        _basePath = GetBasePath(options.Value.BasePath, environment);
+        var originalPath = options.Value.BasePath;
+        if (environment.IsDevelopment())
+        {
+            _basePath = Path.Combine(PathUtils.ProjectRootPath, PathUtils.OsPath(originalPath));
+        }
+        else
+        {
+            _basePath = originalPath;
+        }
+
     }
 
     public string BasePath()
@@ -29,6 +38,12 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
         return _basePath;
     }
 
+    private string ReportsDirectoryPath()
+    {
+        return Path.Combine(_basePath, "reports");
+    }
+
+    // PublicApiQueries
     public string PublicApiQueriesDirectoryPath()
     {
         return Path.Combine(_basePath, "public-api", "queries");
@@ -48,19 +63,25 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
     {
         return Path.Combine(ReportsDirectoryPath(), "public-api", "queries");
     }
-    
-    private string ReportsDirectoryPath()
+
+    // PublicZipDownloads
+    public string PublicZipDownloadsDirectoryPath()
     {
-        return Path.Combine(_basePath, "reports");
+        return Path.Combine(_basePath, "public", "zip-downloads");
     }
 
-    private string GetBasePath(string originalPath, IHostEnvironment environment)
+    public string PublicZipDownloadsProcessingDirectoryPath()
     {
-        if (!environment.IsDevelopment())
-        {
-            return originalPath;
-        }
-        
-        return Path.Combine(PathUtils.ProjectRootPath, PathUtils.OsPath(originalPath));
+        return Path.Combine(PublicZipDownloadsDirectoryPath(), "processing");
+    }
+
+    public string PublicZipDownloadsFailuresDirectoryPath()
+    {
+        return Path.Combine(PublicZipDownloadsDirectoryPath(), "failures");
+    }
+
+    public string PublicZipDownloadsReportsDirectoryPath()
+    {
+        return Path.Combine(ReportsDirectoryPath(), "public", "zip-downloads");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
@@ -4,6 +4,7 @@ public interface IAnalyticsPathResolver
 {
     string BasePath();
 
+    // PublicApiQueries
     string PublicApiQueriesDirectoryPath();
 
     string PublicApiQueriesProcessingDirectoryPath();
@@ -11,4 +12,13 @@ public interface IAnalyticsPathResolver
     string PublicApiQueriesFailuresDirectoryPath();
 
     string PublicApiQueriesReportsDirectoryPath();
+
+    // PublicZipDownloads
+    string PublicZipDownloadsDirectoryPath();
+
+    string PublicZipDownloadsProcessingDirectoryPath();
+
+    string PublicZipDownloadsFailuresDirectoryPath();
+
+    string PublicZipDownloadsReportsDirectoryPath();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicZipDownloadsProcessor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicZipDownloadsProcessor.cs
@@ -61,7 +61,7 @@ public class PublicZipDownloadsProcessor(
                 releaseName VARCHAR,
                 releaseLabel VARCHAR,
                 subjectId UUID,
-                dataSetName VARCHAR
+                dataSetTitle VARCHAR
             );
         ");
 
@@ -89,7 +89,7 @@ public class PublicZipDownloadsProcessor(
                                 releaseName: VARCHAR,
                                 releaseLabel: VARCHAR,
                                 subjectId: UUID,
-                                dataSetName: VARCHAR
+                                dataSetTitle: VARCHAR
                             }}
                         )
                      )
@@ -111,7 +111,7 @@ public class PublicZipDownloadsProcessor(
                 FIRST(releaseName) AS releaseName,
                 FIRST(releaseLabel) AS releaseLabel,
                 FIRST(subjectId) AS subjectId,
-                FIRST(dataSetName) AS dataSetName,
+                FIRST(dataSetTitle) AS dataSetTitle,
                 CAST(COUNT(zipDownloadHash) AS INT) AS downloads
             FROM zipDownloads
             GROUP BY zipDownloadHash

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicZipDownloadsProcessor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicZipDownloadsProcessor.cs
@@ -1,0 +1,151 @@
+using DuckDB.NET.Data;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
+
+public class PublicZipDownloadsProcessor(
+    DuckDbConnection duckDbConnection,
+    IAnalyticsPathResolver pathResolver,
+    ILogger<PublicZipDownloadsProcessor> logger) : IRequestFileProcessor
+{
+    public Task Process()
+    {
+        logger.LogInformation("{PublicZipDownloadsProcessor} triggered", nameof(PublicZipDownloadsProcessor));
+
+        var sourceDirectory = pathResolver.PublicZipDownloadsDirectoryPath();
+
+        if (!Directory.Exists(sourceDirectory))
+        {
+            logger.LogInformation("No public zip downloads to process");
+            return Task.CompletedTask;
+        }
+
+        var filesToProcess = Directory
+            .GetFiles(sourceDirectory)
+            .Select(Path.GetFileName)
+            .OfType<string>()
+            .ToList();
+
+        if (filesToProcess.Count == 0)
+        {
+            logger.LogInformation("No public zip downloads to process");
+            return Task.CompletedTask;
+        }
+
+        logger.LogInformation("Found {Count} zip downloads to process", filesToProcess.Count);
+
+        var processingDirectory = pathResolver.PublicZipDownloadsProcessingDirectoryPath();
+        var reportsDirectory = pathResolver.PublicZipDownloadsReportsDirectoryPath();
+
+        Directory.CreateDirectory(processingDirectory);
+        Directory.CreateDirectory(reportsDirectory);
+
+        Parallel.ForEach(filesToProcess, file =>
+        {
+            var originalPath = Path.Combine(sourceDirectory, file);
+            var newPath = Path.Combine(processingDirectory, file);
+            File.Move(originalPath, newPath);
+        });
+
+        duckDbConnection.Open();
+
+        duckDbConnection.ExecuteNonQuery("install json; load json");
+
+        duckDbConnection.ExecuteNonQuery(@"
+            CREATE TABLE zipDownloads (
+                zipDownloadHash VARCHAR,
+                publicationName VARCHAR,
+                releaseVersionId UUID,
+                releaseName VARCHAR,
+                releaseLabel VARCHAR,
+                subjectId UUID,
+                dataSetName VARCHAR
+            );
+        ");
+
+        // We fetch the files again in case there are files leftover in the processing dir from a previous function run
+        var filesReadyForProcessing = Directory
+            .GetFiles(processingDirectory)
+            .Select(Path.GetFileName)
+            .OfType<string>()
+            .ToList();
+
+        foreach (var filename in filesReadyForProcessing)
+        {
+            try
+            {
+                duckDbConnection.ExecuteNonQuery($@"
+                    INSERT INTO zipDownloads BY NAME (
+                        SELECT
+                            MD5(CONCAT(subjectId, releaseVersionId)) AS zipDownloadHash,
+                            *
+                        FROM read_json('{processingDirectory}/{filename}', 
+                            format='unstructured',
+                            columns = {{
+                                publicationName: VARCHAR,
+                                releaseVersionId: UUID,
+                                releaseName: VARCHAR,
+                                releaseLabel: VARCHAR,
+                                subjectId: UUID,
+                                dataSetName: VARCHAR
+                            }}
+                        )
+                     )
+                ");
+            }
+            catch (DuckDBException e)
+            {
+                logger.LogError(e, "Failed to process analytics request file {Filename}", filename);
+                MoveBadFileToFailuresDirectory(filename);
+            }
+        }
+
+        duckDbConnection.ExecuteNonQuery(@"
+            CREATE TABLE zipDownloadsReport AS 
+            SELECT 
+                zipDownloadHash,
+                FIRST(publicationName) AS publicationName,
+                FIRST(releaseVersionId) AS releaseVersionId,
+                FIRST(releaseName) AS releaseName,
+                FIRST(releaseLabel) AS releaseLabel,
+                FIRST(subjectId) AS subjectId,
+                FIRST(dataSetName) AS dataSetName,
+                CAST(COUNT(zipDownloadHash) AS INT) AS downloads
+            FROM zipDownloads
+            GROUP BY zipDownloadHash
+            ORDER BY zipDownloadHash");
+
+        var reportFilenamePrefix = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
+
+        var zipDownloadReportFilename = Path.Combine(
+            reportsDirectory,
+            $"{reportFilenamePrefix}_public-zip-downloads.parquet");
+
+        duckDbConnection.ExecuteNonQuery($@"
+            COPY (SELECT * FROM zipDownloadsReport)
+            TO '{zipDownloadReportFilename}' (FORMAT 'parquet', CODEC 'zstd')");
+
+        Directory.Delete(processingDirectory, recursive: true);
+
+        return Task.CompletedTask;
+    }
+
+    private void MoveBadFileToFailuresDirectory(string filename)
+    {
+        try
+        {
+            var failuresDirectoryPath = pathResolver.PublicZipDownloadsFailuresDirectoryPath();
+            Directory.CreateDirectory(failuresDirectoryPath);
+
+            var fileSourcePath = Path.Combine(pathResolver.PublicZipDownloadsProcessingDirectoryPath(), filename);
+            var fileDestPath = Path.Combine(failuresDirectoryPath, filename);
+            File.Move(fileSourcePath, fileDestPath);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to move bad file to failures directory {Filename}", filename);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
@@ -8,6 +8,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
@@ -144,7 +145,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
                     }
                 });
         }
-        
+
         public static void VerifyAllMocks(ITuple mocks)
         {
             Mock[] values = mocks
@@ -153,7 +154,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
                 .Select(f => f.GetValue(mocks))
                 .Cast<Mock>()
                 .ToArray();
-            
+
             VerifyAllMocks(values);
         }
 
@@ -163,13 +164,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
             return PopulateMockConfiguration(keysAndValues, configuration);
         }
 
-        public static Mock<IConfigurationSection> CreateMockConfigurationSection(params Tuple<string, string>[] keysAndValues)
+        public static Mock<IConfigurationSection> CreateMockConfigurationSection(
+            params Tuple<string, string>[] keysAndValues)
         {
             var configuration = new Mock<IConfigurationSection>(MockBehavior.Strict);
             return PopulateMockConfiguration(keysAndValues, configuration);
         }
 
-        private static Mock<TConfiguration> PopulateMockConfiguration<TConfiguration>(Tuple<string, string>[] keysAndValues, Mock<TConfiguration> configuration)
+        private static Mock<TConfiguration> PopulateMockConfiguration<TConfiguration>(
+            Tuple<string, string>[] keysAndValues, Mock<TConfiguration> configuration)
             where TConfiguration : class, IConfiguration
         {
             foreach (var keyValue in keysAndValues)
@@ -188,6 +191,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
             }
 
             return configuration;
+        }
+
+        public static void LoggerSetup<T>(Mock<ILogger<T>> logger, LogLevel logLevel, string logMessage)
+        {
+            logger.Setup(mock =>
+                mock.Log(
+                    It.Is<LogLevel>(ll => ll == logLevel),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Equals(logMessage)),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
@@ -193,7 +193,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
             return configuration;
         }
 
-        public static void LoggerSetup<T>(Mock<ILogger<T>> logger, LogLevel logLevel, string logMessage)
+        public static void ExpectLogMessage<T>(Mock<ILogger<T>> logger, LogLevel logLevel, string logMessage)
         {
             logger.Setup(mock =>
                 mock.Log(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerTests.cs
@@ -238,7 +238,7 @@ public abstract class ReleaseFileControllerTests(TestApplicationFactory testApp)
         : ReleaseFileControllerTests(testApp)
     {
         [Fact]
-        public async Task Success()
+        public async Task ZipWithSpecificFile_Success()
         {
             Publication publication = DataFixture.DefaultPublication()
                 .WithReleases(DataFixture.DefaultRelease(publishedVersions: 1)
@@ -251,8 +251,7 @@ public abstract class ReleaseFileControllerTests(TestApplicationFactory testApp)
                 context.Publications.Add(publication);
             });
 
-            var fileId1 = Guid.NewGuid();
-            var fileId2 = Guid.NewGuid();
+            var fileId = Guid.NewGuid();
 
             var releaseFileService = new Mock<IReleaseFileService>(Strict);
 
@@ -262,7 +261,7 @@ public abstract class ReleaseFileControllerTests(TestApplicationFactory testApp)
                         releaseVersion.Id,
                         It.IsAny<Stream>(),
                         It.Is<IEnumerable<Guid>>(
-                            ids => ids.SequenceEqual(ListOf(fileId1, fileId2))),
+                            ids => ids.SequenceEqual(ListOf(fileId))),
                         It.IsAny<CancellationToken>()
                     )
                 )
@@ -274,7 +273,7 @@ public abstract class ReleaseFileControllerTests(TestApplicationFactory testApp)
                 .CreateClient();
 
             var response = await client
-                .GetAsync($"/api/releases/{releaseVersion.Id}/files?fileIds={fileId1},{fileId2}");
+                .GetAsync($"/api/releases/{releaseVersion.Id}/files?fileIds={fileId}");
 
             MockUtils.VerifyAllMocks(releaseFileService);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
@@ -27,8 +27,4 @@
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model.Tests\GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj" />
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Model.Tests\GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.csproj" />
     </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Services\" />
-    </ItemGroup>
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
@@ -27,4 +27,8 @@
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model.Tests\GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj" />
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Model.Tests\GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.csproj" />
     </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Services\" />
+    </ItemGroup>
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
@@ -61,7 +61,7 @@ public class DataSetFilesController : ControllerBase
             .HandleFailuresOrOk();
     }
 
-    [HttpGet("data-set-files/{dataSetFileId:guid}/download")]
+    [HttpGet("data-set-files/{dataSetFileId:guid}/download")] // TODO EES-5979 analytics
     public async Task<ActionResult> DownloadDataSetFile(
         Guid dataSetFileId)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseFileController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseFileController.cs
@@ -66,7 +66,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         {
             if (fileIds is not null && fileIds.Count > 1)
             {
-                throw new ArgumentException("We don't expect multiple specific files to be requested.");
+                ModelState.AddModelError(
+                    "fileIds",
+                    "Providing multiple fileIds is deprecated.");
+                return BadRequest(ModelState);
             }
 
             return await persistenceHelper.CheckEntityExists<ReleaseVersion>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseFileController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseFileController.cs
@@ -57,8 +57,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         [Produces(MediaTypeNames.Application.Octet)]
         public async Task<ActionResult> StreamFilesToZip(
             Guid releaseVersionId,
+            // TODO EES-6034
+            // The previous data catalogue page allowed users to selected multiple specific files to include in the
+            // zip file, hence why this endpoint takes an array of fileIds, but this is no longer the case. Via the
+            // public frontend, users only download all the releaseVersion's data (by not providing fileIds) or provide
+            // a single fileId for a specific data set.
             [FromQuery] IList<Guid>? fileIds = null)
         {
+            if (fileIds is not null && fileIds.Count > 1)
+            {
+                throw new ArgumentException("We don't expect multiple specific files to be requested.");
+            }
+
             return await persistenceHelper.CheckEntityExists<ReleaseVersion>(
                     releaseVersionId,
                     q => q.Include(rv => rv.Release)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/appsettings.Development.json
@@ -17,5 +17,9 @@
     "Overrides": {
       "DurationInSeconds": 2
     }
+  },
+  "Analytics": {
+    "Enabled": false,
+    "BasePath": "data/analytics"
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.csproj
@@ -28,4 +28,8 @@
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.ViewModels\GovUk.Education.ExploreEducationStatistics.Content.ViewModels.csproj"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="StrategiesTests\__snapshots__\" />
+  </ItemGroup>
+
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServicePermissionTests.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
@@ -90,14 +91,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             IPersistenceHelper<ContentDbContext>? persistenceHelper = null,
             IPublicBlobStorageService? publicBlobStorageService = null,
             IDataGuidanceFileWriter? dataGuidanceFileWriter = null,
-            IUserService? userService = null)
+            IUserService? userService = null,
+            IAnalyticsManager? analyticsManager = null,
+            ILogger<ReleaseFileService>? logger = null)
         {
             return new(
                 contentDbContext ?? Mock.Of<ContentDbContext>(),
                 persistenceHelper ?? DefaultPersistenceHelperMock().Object,
                 publicBlobStorageService ?? Mock.Of<IPublicBlobStorageService>(),
                 dataGuidanceFileWriter ?? Mock.Of<IDataGuidanceFileWriter>(),
-                userService ?? Mock.Of<IUserService>()
+                userService ?? Mock.Of<IUserService>(),
+                analyticsManager ?? Mock.Of<IAnalyticsManager>(),
+                logger ?? Mock.Of<ILogger<ReleaseFileService>>()
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
@@ -19,6 +19,8 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
@@ -246,6 +248,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     (stream, _, _) => { stream.WriteText("Test data guidance blob"); }
                 );
 
+            // This should not happen during normal usage, as the public frontend doesn't allow users to request
+            // multiple files. At the time of writing, the service only officially allows users to download all data
+            // sets for a release (if fileIds is null) or a specific data set. But this endpoint takes an array of
+            // files as this is what the old Data catalogue page allowed.
+            var logger = new Mock<ILogger<ReleaseFileService>>(MockBehavior.Strict);
+            var expectedWarning =
+                "We only record analytics for zip downloads for an entire release or one specific data set. So this means someone manually attempted to download a zip with more than one specific file?";
+            MockUtils.LoggerSetup(logger, LogLevel.Warning, expectedWarning);
+
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var path = GenerateZipFilePath();
@@ -254,7 +265,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 var service = SetupReleaseFileService(
                     contentDbContext: contentDbContext,
                     publicBlobStorageService: publicBlobStorageService.Object,
-                    dataGuidanceFileWriter: dataGuidanceFileWriter.Object);
+                    dataGuidanceFileWriter: dataGuidanceFileWriter.Object,
+                    logger: logger.Object);
 
                 var fileIds = releaseFiles.Select(file => file.FileId).ToList();
 
@@ -285,13 +297,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task ZipFilesToStream_DataGuidanceForMultipleDataFiles()
+        public async Task ZipFilesToStream_DataGuidanceForSingleDataFile()
         {
             ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
                 .WithRelease(_dataFixture.DefaultRelease()
                     .WithPublication(_dataFixture.DefaultPublication()));
 
-            var releaseFile1 = new ReleaseFile
+            var releaseFile = new ReleaseFile
             {
                 ReleaseVersion = releaseVersion,
                 File = new Model.File
@@ -301,37 +313,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     Type = FileType.Data
                 }
             };
-            var releaseFile2 = new ReleaseFile
-            {
-                ReleaseVersion = releaseVersion,
-                File = new Model.File
-                {
-                    RootPath = Guid.NewGuid(),
-                    Filename = "data-2.csv",
-                    Type = FileType.Data
-                }
-            };
-            var releaseFiles = ListOf(releaseFile1, releaseFile2);
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 contentDbContext.ReleaseVersions.Add(releaseVersion);
-                contentDbContext.ReleaseFiles.AddRange(releaseFiles);
+                contentDbContext.ReleaseFiles.AddRange(releaseFile);
                 await contentDbContext.SaveChangesAsync();
             }
 
             var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
 
             publicBlobStorageService
-                .SetupCheckBlobExists(PublicReleaseFiles, releaseFile1.PublicPath(), true);
+                .SetupCheckBlobExists(PublicReleaseFiles, releaseFile.PublicPath(), true);
             publicBlobStorageService
-                .SetupCheckBlobExists(PublicReleaseFiles, releaseFile2.PublicPath(), true);
-            publicBlobStorageService
-                .SetupDownloadToStream(PublicReleaseFiles, releaseFile1.PublicPath(), "Test data 1 blob");
-            publicBlobStorageService
-                .SetupDownloadToStream(PublicReleaseFiles, releaseFile2.PublicPath(), "Test data 2 blob");
+                .SetupDownloadToStream(PublicReleaseFiles, releaseFile.PublicPath(), "Test data 1 blob");
 
             var dataGuidanceFileWriter = new Mock<IDataGuidanceFileWriter>(MockBehavior.Strict);
 
@@ -340,12 +337,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     s => s.WriteToStream(
                         It.IsAny<Stream>(),
                         It.Is<ReleaseVersion>(rv => rv.Id == releaseVersion.Id),
-                        ListOf(releaseFile1.FileId, releaseFile2.FileId))
+                        ListOf(releaseFile.FileId))
                 )
                 .Returns<Stream, ReleaseVersion, IEnumerable<Guid>?>((stream, _, _) => Task.FromResult(stream))
                 .Callback<Stream, ReleaseVersion, IEnumerable<Guid>?>(
                     (stream, _, _) => { stream.WriteText("Test data guidance blob"); }
                 );
+
+            var captureRequest = new CaptureZipDownloadRequest
+            (
+                PublicationName: releaseVersion.Release.Publication.Title,
+                ReleaseVersionId: releaseVersion.Id,
+                ReleaseName: releaseVersion.Release.Title,
+                ReleaseLabel: releaseVersion.Release.Label,
+                SubjectId: releaseFile.File.SubjectId,
+                DataSetName: releaseFile.Name
+            );
+            var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+            analyticsManager.Setup(m => m.Add(
+                    It.Is<CaptureZipDownloadRequest>(r =>
+                        r.IsDeepEqualTo(captureRequest, null)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
@@ -355,15 +368,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 var service = SetupReleaseFileService(
                     contentDbContext: contentDbContext,
                     publicBlobStorageService: publicBlobStorageService.Object,
-                    dataGuidanceFileWriter: dataGuidanceFileWriter.Object);
+                    dataGuidanceFileWriter: dataGuidanceFileWriter.Object,
+                    analyticsManager: analyticsManager.Object);
 
-                var fileIds = releaseFiles.Select(file => file.FileId).ToList();
+                var fileId = releaseFile.FileId;
 
                 var result = await service.ZipFilesToStream(
                     releaseVersionId: releaseVersion.Id,
                     outputStream: stream,
-                    fileIds: fileIds
-                );
+                    fileIds: [fileId]);
 
                 MockUtils.VerifyAllMocks(publicBlobStorageService, dataGuidanceFileWriter);
 
@@ -372,115 +385,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 using var zip = ZipFile.OpenRead(path);
 
                 // Entries are sorted alphabetically
-                Assert.Equal(3, zip.Entries.Count);
+                Assert.Equal(2, zip.Entries.Count);
                 Assert.Equal("data/data-1.csv", zip.Entries[0].FullName);
                 Assert.Equal("Test data 1 blob", zip.Entries[0].Open().ReadToEnd());
 
-                Assert.Equal("data/data-2.csv", zip.Entries[1].FullName);
-                Assert.Equal("Test data 2 blob", zip.Entries[1].Open().ReadToEnd());
-
                 // Data guidance is generated if there is at least one data file
-                Assert.Equal("data-guidance/data-guidance.txt", zip.Entries[2].FullName);
-                Assert.Equal("Test data guidance blob", zip.Entries[2].Open().ReadToEnd());
-            }
-        }
-
-        [Fact]
-        public async Task ZipFilesToStream_OrderedAlphabetically()
-        {
-            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion()
-                .WithRelease(_dataFixture.DefaultRelease()
-                    .WithPublication(_dataFixture.DefaultPublication()));
-
-            var releaseFile1 = new ReleaseFile
-            {
-                ReleaseVersion = releaseVersion,
-                File = new Model.File
-                {
-                    RootPath = Guid.NewGuid(),
-                    Filename = "test-2.pdf",
-                    Type = Ancillary,
-                }
-            };
-            var releaseFile2 = new ReleaseFile
-            {
-                ReleaseVersion = releaseVersion,
-                File = new Model.File
-                {
-                    RootPath = Guid.NewGuid(),
-                    Filename = "test-3.pdf",
-                    Type = Ancillary
-                }
-            };
-            var releaseFile3 = new ReleaseFile
-            {
-                ReleaseVersion = releaseVersion,
-                File = new Model.File
-                {
-                    RootPath = Guid.NewGuid(),
-                    Filename = "test-1.pdf",
-                    Type = Ancillary
-                }
-            };
-            var releaseFiles = ListOf(releaseFile1, releaseFile2, releaseFile3);
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            {
-                contentDbContext.ReleaseVersions.Add(releaseVersion);
-                contentDbContext.ReleaseFiles.AddRange(releaseFiles);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            var path = GenerateZipFilePath();
-            var stream = File.OpenWrite(path);
-
-            var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
-
-            publicBlobStorageService
-                .SetupCheckBlobExists(PublicReleaseFiles, releaseFile1.PublicPath(), true);
-            publicBlobStorageService
-                .SetupCheckBlobExists(PublicReleaseFiles, releaseFile2.PublicPath(), true);
-            publicBlobStorageService
-                .SetupCheckBlobExists(PublicReleaseFiles, releaseFile3.PublicPath(), true);
-            publicBlobStorageService
-                .SetupDownloadToStream(PublicReleaseFiles, releaseFile1.PublicPath(), "Test 2 blob");
-            publicBlobStorageService
-                .SetupDownloadToStream(PublicReleaseFiles, releaseFile2.PublicPath(), "Test 3 blob");
-            publicBlobStorageService
-                .SetupDownloadToStream(PublicReleaseFiles, releaseFile3.PublicPath(), "Test 1 blob");
-
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            {
-                var service = SetupReleaseFileService(
-                    contentDbContext: contentDbContext,
-                    publicBlobStorageService: publicBlobStorageService.Object);
-
-                var fileIds = releaseFiles.Select(file => file.FileId).ToList();
-
-                var result = await service.ZipFilesToStream(
-                    releaseVersionId: releaseVersion.Id,
-                    outputStream: stream,
-                    fileIds: fileIds
-                );
-
-                MockUtils.VerifyAllMocks(publicBlobStorageService);
-
-                result.AssertRight();
-
-                using var zip = ZipFile.OpenRead(path);
-
-                // Entries are sorted alphabetically
-                Assert.Equal(3, zip.Entries.Count);
-                Assert.Equal("supporting-files/test-1.pdf", zip.Entries[0].FullName);
-                Assert.Equal("Test 1 blob", zip.Entries[0].Open().ReadToEnd());
-
-                Assert.Equal("supporting-files/test-2.pdf", zip.Entries[1].FullName);
-                Assert.Equal("Test 2 blob", zip.Entries[1].Open().ReadToEnd());
-
-                Assert.Equal("supporting-files/test-3.pdf", zip.Entries[2].FullName);
-                Assert.Equal("Test 3 blob", zip.Entries[2].Open().ReadToEnd());
+                Assert.Equal("data-guidance/data-guidance.txt", zip.Entries[1].FullName);
+                Assert.Equal("Test data guidance blob", zip.Entries[1].Open().ReadToEnd());
             }
         }
 
@@ -548,11 +459,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
 
+            var captureRequest = new CaptureZipDownloadRequest
+            (
+                PublicationName: releaseVersion.Release.Publication.Title,
+                ReleaseVersionId: releaseVersion.Id,
+                ReleaseName: releaseVersion.Release.Title,
+                ReleaseLabel: releaseVersion.Release.Label
+            );
+            var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+            analyticsManager.Setup(m => m.Add(
+                    It.Is<CaptureZipDownloadRequest>(r =>
+                        r.IsDeepEqualTo(captureRequest, null)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = SetupReleaseFileService(
                     contentDbContext: contentDbContext,
-                    publicBlobStorageService: publicBlobStorageService.Object);
+                    publicBlobStorageService: publicBlobStorageService.Object,
+                    analyticsManager: analyticsManager.Object);
 
                 var fileIds = releaseFiles.Select(file => file.FileId).ToList();
 
@@ -579,7 +505,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 .WithRelease(_dataFixture.DefaultRelease()
                     .WithPublication(_dataFixture.DefaultPublication()));
 
-            var releaseFile1 = new ReleaseFile
+            var releaseFile = new ReleaseFile
             {
                 ReleaseVersion = releaseVersion,
                 File = new Model.File
@@ -589,25 +515,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     Type = FileType.Data,
                 }
             };
-            var releaseFile2 = new ReleaseFile
-            {
-                ReleaseVersion = releaseVersion,
-                File = new Model.File
-                {
-                    RootPath = Guid.NewGuid(),
-                    Filename = "ancillary.pdf",
-                    Type = Ancillary
-                }
-            };
-
-            var releaseFiles = ListOf(releaseFile1, releaseFile2);
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 contentDbContext.ReleaseVersions.Add(releaseVersion);
-                contentDbContext.ReleaseFiles.AddRange(releaseFiles);
+                contentDbContext.ReleaseFiles.AddRange(releaseFile);
                 await contentDbContext.SaveChangesAsync();
             }
 
@@ -616,22 +530,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
 
-            // Files do not exist in blob storage
-            publicBlobStorageService.SetupCheckBlobExists(PublicReleaseFiles, releaseFile1.PublicPath(), false);
-            publicBlobStorageService.SetupCheckBlobExists(PublicReleaseFiles, releaseFile2.PublicPath(), false);
+            // File does not exist in blob storage
+            publicBlobStorageService.SetupCheckBlobExists(PublicReleaseFiles, releaseFile.PublicPath(), false);
+
+            var request = new CaptureZipDownloadRequest
+            (
+                PublicationName: releaseVersion.Release.Publication.Title,
+                ReleaseVersionId: releaseVersion.Id,
+                ReleaseName: releaseVersion.Release.Title,
+                ReleaseLabel: releaseVersion.Release.Label
+            );
+            var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+            analyticsManager.Setup(m => m.Add(
+                    It.Is<CaptureZipDownloadRequest>(r =>
+                        r.IsDeepEqualTo(request, null)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = SetupReleaseFileService(
                     contentDbContext: contentDbContext,
-                    publicBlobStorageService: publicBlobStorageService.Object);
-
-                var fileIds = releaseFiles.Select(file => file.FileId).ToList();
+                    publicBlobStorageService: publicBlobStorageService.Object,
+                    analyticsManager: analyticsManager.Object);
 
                 var result = await service.ZipFilesToStream(
                     releaseVersionId: releaseVersion.Id,
                     outputStream: stream,
-                    fileIds: fileIds
+                    fileIds: [releaseFile.FileId]
                 );
 
                 MockUtils.VerifyAllMocks(publicBlobStorageService);
@@ -689,11 +615,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
 
+            var request = new CaptureZipDownloadRequest
+            (
+                PublicationName: releaseVersion.Release.Publication.Title,
+                ReleaseVersionId: releaseVersion.Id,
+                ReleaseName: releaseVersion.Release.Title,
+                ReleaseLabel: releaseVersion.Release.Label
+            );
+            var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+            analyticsManager.Setup(m => m.Add(
+                    It.Is<CaptureZipDownloadRequest>(r =>
+                        r.IsDeepEqualTo(request, null)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = SetupReleaseFileService(
                     contentDbContext: contentDbContext,
-                    publicBlobStorageService: publicBlobStorageService.Object);
+                    publicBlobStorageService: publicBlobStorageService.Object,
+                    analyticsManager: analyticsManager.Object);
 
                 var fileIds = releaseFiles.Select(file => file.FileId).ToList();
 
@@ -733,11 +674,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             var publicBlobStorageService = new Mock<IPublicBlobStorageService>(MockBehavior.Strict);
 
+            var request = new CaptureZipDownloadRequest
+            (
+                PublicationName: releaseVersion.Release.Publication.Title,
+                ReleaseVersionId: releaseVersion.Id,
+                ReleaseName: releaseVersion.Release.Title,
+                ReleaseLabel: releaseVersion.Release.Label
+            );
+            var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+            analyticsManager.Setup(m => m.Add(
+                    It.Is<CaptureZipDownloadRequest>(r =>
+                        r.IsDeepEqualTo(request, null)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = SetupReleaseFileService(
                     contentDbContext: contentDbContext,
-                    publicBlobStorageService: publicBlobStorageService.Object);
+                    publicBlobStorageService: publicBlobStorageService.Object,
+                    analyticsManager: analyticsManager.Object);
 
                 var fileIds = ListOf(Guid.NewGuid(), Guid.NewGuid());
                 var result = await service.ZipFilesToStream(releaseVersion.Id, stream, fileIds);
@@ -812,11 +768,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     cancellationToken: tokenSource.Token)
                 .Callback(() => tokenSource.Cancel());
 
+            // This should not happen during normal usage, as the public frontend doesn't allow users to request
+            // multiple files. At the time of writing, the service only officially allows users to download all data
+            // sets for a release (if fileIds is null) or a specific data set. But this endpoint takes an array of
+            // files as this is what the old Data catalogue page allowed.
+            var logger = new Mock<ILogger<ReleaseFileService>>(MockBehavior.Strict);
+            var expectedWarning =
+                "We only record analytics for zip downloads for an entire release or one specific data set. So this means someone manually attempted to download a zip with more than one specific file?";
+            MockUtils.LoggerSetup(logger, LogLevel.Warning, expectedWarning);
+
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = SetupReleaseFileService(
                     contentDbContext: contentDbContext,
-                    publicBlobStorageService: publicBlobStorageService.Object);
+                    publicBlobStorageService: publicBlobStorageService.Object,
+                    logger: logger.Object);
 
                 var fileIds = releaseFiles.Select(file => file.FileId).ToList();
 
@@ -925,6 +891,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     (stream, _, _) => { stream.WriteText("Test data guidance blob"); }
                 );
 
+            var request = new CaptureZipDownloadRequest
+            (
+                PublicationName: releaseVersion.Release.Publication.Title,
+                ReleaseVersionId: releaseVersion.Id,
+                ReleaseName: releaseVersion.Release.Title,
+                ReleaseLabel: releaseVersion.Release.Label
+            );
+            var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+            analyticsManager.Setup(m => m.Add(
+                    It.Is<CaptureZipDownloadRequest>(r =>
+                        r.IsDeepEqualTo(request, null)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var path = GenerateZipFilePath();
@@ -933,7 +913,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 var service = SetupReleaseFileService(
                     contentDbContext: contentDbContext,
                     publicBlobStorageService: publicBlobStorageService.Object,
-                    dataGuidanceFileWriter: dataGuidanceFileWriter.Object);
+                    dataGuidanceFileWriter: dataGuidanceFileWriter.Object,
+                    analyticsManager: analyticsManager.Object);
 
                 var result = await service.ZipFilesToStream(
                     releaseVersionId: releaseVersion.Id,
@@ -996,6 +977,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             publicBlobStorageService
                 .SetupDownloadToStream(PublicReleaseFiles, allFilesZipPath, "Test cached all files zip");
 
+            var request = new CaptureZipDownloadRequest
+            (
+                PublicationName: releaseVersion.Release.Publication.Title,
+                ReleaseVersionId: releaseVersion.Id,
+                ReleaseName: releaseVersion.Release.Title,
+                ReleaseLabel: releaseVersion.Release.Label
+            );
+            var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+            analyticsManager.Setup(m => m.Add(
+                    It.Is<CaptureZipDownloadRequest>(r =>
+                        r.IsDeepEqualTo(request, null)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var path = GenerateZipFilePath();
@@ -1003,7 +998,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
                 var service = SetupReleaseFileService(
                     contentDbContext: contentDbContext,
-                    publicBlobStorageService: publicBlobStorageService.Object);
+                    publicBlobStorageService: publicBlobStorageService.Object,
+                    analyticsManager: analyticsManager.Object);
 
                 var result = await service.ZipFilesToStream(
                     releaseVersionId: releaseVersion.Id,
@@ -1086,6 +1082,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 )
                 .Returns(Task.CompletedTask);
 
+            var request = new CaptureZipDownloadRequest
+            (
+                PublicationName: releaseVersion.Release.Publication.Title,
+                ReleaseVersionId: releaseVersion.Id,
+                ReleaseName: releaseVersion.Release.Title,
+                ReleaseLabel: releaseVersion.Release.Label
+            );
+
+            var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
+            analyticsManager.Setup(m => m.Add(
+                    It.Is<CaptureZipDownloadRequest>(r =>
+                        r.IsDeepEqualTo(request, null)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var path = GenerateZipFilePath();
@@ -1093,7 +1104,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
                 var service = SetupReleaseFileService(
                     contentDbContext: contentDbContext,
-                    publicBlobStorageService: publicBlobStorageService.Object);
+                    publicBlobStorageService: publicBlobStorageService.Object,
+                    analyticsManager: analyticsManager.Object);
 
                 var result = await service.ZipFilesToStream(
                     releaseVersionId: releaseVersion.Id,
@@ -1126,14 +1138,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             IPersistenceHelper<ContentDbContext>? contentPersistenceHelper = null,
             IPublicBlobStorageService? publicBlobStorageService = null,
             IDataGuidanceFileWriter? dataGuidanceFileWriter = null,
-            IUserService? userService = null)
+            IUserService? userService = null,
+            IAnalyticsManager? analyticsManager = null,
+            ILogger<ReleaseFileService>? logger = null)
         {
             return new(
                 contentDbContext,
                 contentPersistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
                 publicBlobStorageService ?? Mock.Of<IPublicBlobStorageService>(MockBehavior.Strict),
                 dataGuidanceFileWriter ?? Mock.Of<IDataGuidanceFileWriter>(MockBehavior.Strict),
-                userService ?? MockUtils.AlwaysTrueUserService().Object
+                userService ?? MockUtils.AlwaysTrueUserService().Object,
+                analyticsManager ?? Mock.Of<IAnalyticsManager>(),
+                logger ?? Mock.Of<ILogger<ReleaseFileService>>(MockBehavior.Strict)
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseFileServiceTests.cs
@@ -255,7 +255,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var logger = new Mock<ILogger<ReleaseFileService>>(MockBehavior.Strict);
             var expectedWarning =
                 "We only record analytics for zip downloads for an entire release or one specific data set. So this means someone manually attempted to download a zip with more than one specific file?";
-            MockUtils.LoggerSetup(logger, LogLevel.Warning, expectedWarning);
+            MockUtils.ExpectLogMessage(logger, LogLevel.Warning, expectedWarning);
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
@@ -351,12 +351,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 ReleaseName: releaseVersion.Release.Title,
                 ReleaseLabel: releaseVersion.Release.Label,
                 SubjectId: releaseFile.File.SubjectId,
-                DataSetName: releaseFile.Name
+                DataSetTitle: releaseFile.Name
             );
             var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
             analyticsManager.Setup(m => m.Add(
-                    It.Is<CaptureZipDownloadRequest>(r =>
-                        r.IsDeepEqualTo(captureRequest, null)),
+                    ItIs.DeepEqualTo(captureRequest),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -468,8 +467,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             );
             var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
             analyticsManager.Setup(m => m.Add(
-                    It.Is<CaptureZipDownloadRequest>(r =>
-                        r.IsDeepEqualTo(captureRequest, null)),
+                    ItIs.DeepEqualTo(captureRequest),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -542,8 +540,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             );
             var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
             analyticsManager.Setup(m => m.Add(
-                    It.Is<CaptureZipDownloadRequest>(r =>
-                        r.IsDeepEqualTo(request, null)),
+                    ItIs.DeepEqualTo(request),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -624,8 +621,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             );
             var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
             analyticsManager.Setup(m => m.Add(
-                    It.Is<CaptureZipDownloadRequest>(r =>
-                        r.IsDeepEqualTo(request, null)),
+                    ItIs.DeepEqualTo(request),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -683,8 +679,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             );
             var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
             analyticsManager.Setup(m => m.Add(
-                    It.Is<CaptureZipDownloadRequest>(r =>
-                        r.IsDeepEqualTo(request, null)),
+                    ItIs.DeepEqualTo(request),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -775,7 +770,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             var logger = new Mock<ILogger<ReleaseFileService>>(MockBehavior.Strict);
             var expectedWarning =
                 "We only record analytics for zip downloads for an entire release or one specific data set. So this means someone manually attempted to download a zip with more than one specific file?";
-            MockUtils.LoggerSetup(logger, LogLevel.Warning, expectedWarning);
+            MockUtils.ExpectLogMessage(logger, LogLevel.Warning, expectedWarning);
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
@@ -900,8 +895,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             );
             var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
             analyticsManager.Setup(m => m.Add(
-                    It.Is<CaptureZipDownloadRequest>(r =>
-                        r.IsDeepEqualTo(request, null)),
+                    ItIs.DeepEqualTo(request),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -986,8 +980,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             );
             var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
             analyticsManager.Setup(m => m.Add(
-                    It.Is<CaptureZipDownloadRequest>(r =>
-                        r.IsDeepEqualTo(request, null)),
+                    ItIs.DeepEqualTo(request),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -1092,8 +1085,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
 
             var analyticsManager = new Mock<IAnalyticsManager>(MockBehavior.Strict);
             analyticsManager.Setup(m => m.Add(
-                    It.Is<CaptureZipDownloadRequest>(r =>
-                        r.IsDeepEqualTo(request, null)),
+                    ItIs.DeepEqualTo(request),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Services/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Services/TestAnalyticsPathResolver.cs
@@ -1,6 +1,8 @@
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using System;
+using System.IO;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 
-namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Services;
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Services;
 
 public class TestAnalyticsPathResolver : IAnalyticsPathResolver, IDisposable
 {
@@ -18,8 +20,8 @@ public class TestAnalyticsPathResolver : IAnalyticsPathResolver, IDisposable
         "Analytics",
         Guid.NewGuid().ToString());
 
-    public string PublicApiQueriesDirectoryPath()
+    public string PublicZipDownloadsDirectoryPath()
     {
-        return Path.Combine(_basePath, "PublicApiQueries");
+        return Path.Combine(_basePath, "PublicZipDownloads");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/AnalyticsWritePublicZipDownloadStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/AnalyticsWritePublicZipDownloadStrategyTests.cs
@@ -15,31 +15,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Stra
 
 public class AnalyticsWritePublicZipDownloadStrategyTests
 {
-    public class CanHandleTests : AnalyticsWritePublicZipDownloadStrategyTests
-    {
-        [Fact]
-        public void CanHandle_CaptureZipDownloadRequest_True()
-        {
-            var strategy = BuildStrategy();
-            var result = strategy.CanHandle(new CaptureZipDownloadRequest(
-                "publication name",
-                Guid.NewGuid(),
-                "release name",
-                "release label"));
-            Assert.True(result);
-        }
-
-        private record CaptureSomethingElseRequest : BaseCaptureRequest;
-
-        [Fact]
-        public void CanHandle_OtherCaptureRequest_False()
-        {
-            var strategy = BuildStrategy();
-            var result = strategy.CanHandle(new CaptureSomethingElseRequest());
-            Assert.False(result);
-        }
-    }
-
     public class ReportTests : AnalyticsWritePublicZipDownloadStrategyTests
     {
         private const string SnapshotPrefix =
@@ -48,7 +23,7 @@ public class AnalyticsWritePublicZipDownloadStrategyTests
         [Fact]
         public async Task ProduceTwoRequestFiles_Success()
         {
-            var pathResolver = new TestAnalyticsPathResolver();
+            using var pathResolver = new TestAnalyticsPathResolver();
             var strategy = BuildStrategy(
                 pathResolver: pathResolver);
 
@@ -67,7 +42,7 @@ public class AnalyticsWritePublicZipDownloadStrategyTests
                     "release name 2",
                     "release label 2",
                     SubjectId: Guid.Parse("39132b60-d4a0-4b62-befe-ba10cea4b30e"),
-                    DataSetName: "data set name 2"),
+                    DataSetTitle: "data set title 2"),
                 default);
 
             var files = Directory.GetFiles(pathResolver.PublicZipDownloadsDirectoryPath())
@@ -96,11 +71,11 @@ public class AnalyticsWritePublicZipDownloadStrategyTests
     }
 
     private AnalyticsWritePublicZipDownloadStrategy BuildStrategy(
-        IAnalyticsPathResolver? pathResolver = null,
+        IAnalyticsPathResolver pathResolver,
         ILogger<AnalyticsWritePublicZipDownloadStrategy>? logger = null)
     {
         return new AnalyticsWritePublicZipDownloadStrategy(
-            pathResolver ?? new TestAnalyticsPathResolver(),
+            pathResolver,
             logger ?? Mock.Of<ILogger<AnalyticsWritePublicZipDownloadStrategy>>());
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/AnalyticsWritePublicZipDownloadStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/AnalyticsWritePublicZipDownloadStrategyTests.cs
@@ -1,39 +1,99 @@
 using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Snapshooter.Xunit;
 using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.StrategiesTests;
 
 public class AnalyticsWritePublicZipDownloadStrategyTests
 {
-    [Fact]
-    public void CanHandle_True()
+    public class CanHandleTests : AnalyticsWritePublicZipDownloadStrategyTests
     {
-        var strategy = BuildStrategy();
-        var result = strategy.CanHandle(new CaptureZipDownloadRequest(
-            "publication name",
-            Guid.NewGuid(),
-            "release name",
-            "release label"));
-        Assert.True(result);
+        [Fact]
+        public void CanHandle_CaptureZipDownloadRequest_True()
+        {
+            var strategy = BuildStrategy();
+            var result = strategy.CanHandle(new CaptureZipDownloadRequest(
+                "publication name",
+                Guid.NewGuid(),
+                "release name",
+                "release label"));
+            Assert.True(result);
+        }
+
+        private record CaptureSomethingElseRequest : BaseCaptureRequest;
+
+        [Fact]
+        public void CanHandle_OtherCaptureRequest_False()
+        {
+            var strategy = BuildStrategy();
+            var result = strategy.CanHandle(new CaptureSomethingElseRequest());
+            Assert.False(result);
+        }
     }
 
-    private record CaptureSomethingElseRequest : BaseCaptureRequest;
-
-    [Fact]
-    public void CanHandle_OtherCaptureRequest_False()
+    public class ReportTests : AnalyticsWritePublicZipDownloadStrategyTests
     {
-        var strategy = BuildStrategy();
-        var result = strategy.CanHandle(new CaptureSomethingElseRequest());
-        Assert.False(result);
-    }
+        private const string SnapshotPrefix =
+            $"{nameof(AnalyticsWritePublicZipDownloadStrategyTests)}.{nameof(ReportTests)}";
 
-    // @MarkFix more tests here
+        [Fact]
+        public async Task ProduceTwoRequestFiles_Success()
+        {
+            var pathResolver = new TestAnalyticsPathResolver();
+            var strategy = BuildStrategy(
+                pathResolver: pathResolver);
+
+            var releaseVersionId1 = Guid.Parse("5d3c0aec-c147-48ce-ae26-ef765ffa4a5b");
+            await strategy.Report(new CaptureZipDownloadRequest(
+                    "publication name 1",
+                    releaseVersionId1,
+                    "release name 1",
+                    "release label 1"),
+                default);
+
+            var releaseVersionId2 = Guid.Parse("254d53e4-1194-4285-82bd-d8a3b7c0853d");
+            await strategy.Report(new CaptureZipDownloadRequest(
+                    "publication name 2",
+                    releaseVersionId2,
+                    "release name 2",
+                    "release label 2",
+                    SubjectId: Guid.Parse("39132b60-d4a0-4b62-befe-ba10cea4b30e"),
+                    DataSetName: "data set name 2"),
+                default);
+
+            var files = Directory.GetFiles(pathResolver.PublicZipDownloadsDirectoryPath())
+                .ToList();
+
+            Assert.Equal(2, files.Count);
+
+            var requestFile1 = Assert.Single(
+                files
+                    .Where(file => file.Contains(releaseVersionId1.ToString()))
+                    .ToList());
+            var requestFile1Contents = await File.ReadAllTextAsync(requestFile1);
+            Snapshot.Match(
+                currentResult: requestFile1Contents,
+                snapshotName: $"{SnapshotPrefix}.{nameof(ProduceTwoRequestFiles_Success)}.NoSubjectId.snap");
+
+            var requestFile2 = Assert.Single(
+                files
+                    .Where(file => file.Contains(releaseVersionId2.ToString()))
+                    .ToList());
+            var requestFile2Contents = await File.ReadAllTextAsync(requestFile2);
+            Snapshot.Match(
+                currentResult: requestFile2Contents,
+                snapshotName: $"{SnapshotPrefix}.{nameof(ProduceTwoRequestFiles_Success)}.WithSubjectId.snap");
+        }
+    }
 
     private AnalyticsWritePublicZipDownloadStrategy BuildStrategy(
         IAnalyticsPathResolver? pathResolver = null,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/AnalyticsWritePublicZipDownloadStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/AnalyticsWritePublicZipDownloadStrategyTests.cs
@@ -1,0 +1,46 @@
+using System;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.StrategiesTests;
+
+public class AnalyticsWritePublicZipDownloadStrategyTests
+{
+    [Fact]
+    public void CanHandle_True()
+    {
+        var strategy = BuildStrategy();
+        var result = strategy.CanHandle(new CaptureZipDownloadRequest(
+            "publication name",
+            Guid.NewGuid(),
+            "release name",
+            "release label"));
+        Assert.True(result);
+    }
+
+    private record CaptureSomethingElseRequest : BaseCaptureRequest;
+
+    [Fact]
+    public void CanHandle_OtherCaptureRequest_False()
+    {
+        var strategy = BuildStrategy();
+        var result = strategy.CanHandle(new CaptureSomethingElseRequest());
+        Assert.False(result);
+    }
+
+    // @MarkFix more tests here
+
+    private AnalyticsWritePublicZipDownloadStrategy BuildStrategy(
+        IAnalyticsPathResolver? pathResolver = null,
+        ILogger<AnalyticsWritePublicZipDownloadStrategy>? logger = null)
+    {
+        return new AnalyticsWritePublicZipDownloadStrategy(
+            pathResolver ?? new TestAnalyticsPathResolver(),
+            logger ?? Mock.Of<ILogger<AnalyticsWritePublicZipDownloadStrategy>>());
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/__snapshots__/AnalyticsWritePublicZipDownloadStrategyTests.ReportTests.ProduceTwoRequestFiles_Success.NoSubjectId.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/__snapshots__/AnalyticsWritePublicZipDownloadStrategyTests.ReportTests.ProduceTwoRequestFiles_Success.NoSubjectId.snap
@@ -1,0 +1,6 @@
+﻿{
+  "publicationName": "publication name 1",
+  "releaseLabel": "release label 1",
+  "releaseName": "release name 1",
+  "releaseVersionId": "5d3c0aec-c147-48ce-ae26-ef765ffa4a5b"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/__snapshots__/AnalyticsWritePublicZipDownloadStrategyTests.ReportTests.ProduceTwoRequestFiles_Success.WithSubjectId.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/__snapshots__/AnalyticsWritePublicZipDownloadStrategyTests.ReportTests.ProduceTwoRequestFiles_Success.WithSubjectId.snap
@@ -1,5 +1,5 @@
 ﻿{
-  "dataSetName": "data set name 2",
+  "dataSetTitle": "data set title 2",
   "publicationName": "publication name 2",
   "releaseLabel": "release label 2",
   "releaseName": "release name 2",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/__snapshots__/AnalyticsWritePublicZipDownloadStrategyTests.ReportTests.ProduceTwoRequestFiles_Success.WithSubjectId.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/__snapshots__/AnalyticsWritePublicZipDownloadStrategyTests.ReportTests.ProduceTwoRequestFiles_Success.WithSubjectId.snap
@@ -1,0 +1,8 @@
+﻿{
+  "dataSetName": "data set name 2",
+  "publicationName": "publication name 2",
+  "releaseLabel": "release label 2",
+  "releaseName": "release name 2",
+  "releaseVersionId": "254d53e4-1194-4285-82bd-d8a3b7c0853d",
+  "subjectId": "39132b60-d4a0-4b62-befe-ba10cea4b30e"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsConsumer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsConsumer.cs
@@ -1,21 +1,30 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
 
 public class AnalyticsConsumer(
     IAnalyticsManager analyticsManager,
-    IAnalyticsWriter analyticsWriter) : BackgroundService
+    IAnalyticsWriter analyticsWriter,
+    ILogger<AnalyticsConsumer> logger) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         while (!stoppingToken.IsCancellationRequested)
         {
-            var request = await analyticsManager.Read(stoppingToken);
-
-            await analyticsWriter.Report(request, stoppingToken);
+            try
+            {
+                var request = await analyticsManager.Read(stoppingToken);
+                await analyticsWriter.Report(request, stoppingToken);
+            }
+            catch (Exception e)
+            {
+                logger.LogWarning(e, "Failed to read/report request recorded for analytics");
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsConsumer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsConsumer.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using Microsoft.Extensions.Hosting;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
+
+public class AnalyticsConsumer(
+    IAnalyticsManager analyticsManager,
+    IAnalyticsWriter analyticsWriter) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var request = await analyticsManager.Read(stoppingToken);
+
+            await analyticsWriter.Report(request, stoppingToken);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsManager.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsManager.cs
@@ -8,16 +8,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
 
 public class AnalyticsManager : IAnalyticsManager
 {
-    private readonly Channel<BaseCaptureRequest> _channel =
-        Channel.CreateUnbounded<BaseCaptureRequest>();
+    private readonly Channel<AnalyticsCaptureRequestBase> _channel =
+        Channel.CreateUnbounded<AnalyticsCaptureRequestBase>();
 
-    public async Task Add(BaseCaptureRequest request, CancellationToken cancellationToken)
+    public async Task Add(AnalyticsCaptureRequestBase request, CancellationToken cancellationToken)
     {
         await _channel.Writer.WriteAsync(request, cancellationToken);
     }
 
-    public ValueTask<BaseCaptureRequest> Read(CancellationToken cancellationToken)
+    public ValueTask<AnalyticsCaptureRequestBase> Read(CancellationToken cancellationToken)
     {
         return _channel.Reader.ReadAsync(cancellationToken);
+    }
+}
+
+public class NoOpAnalyticsManager : IAnalyticsManager
+{
+    public Task Add(AnalyticsCaptureRequestBase request, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public async ValueTask<AnalyticsCaptureRequestBase> Read(CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.Infinite, cancellationToken);
+        return default!;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsManager.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsManager.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
+
+public class AnalyticsManager : IAnalyticsManager
+{
+    private readonly Channel<BaseCaptureRequest> _channel =
+        Channel.CreateUnbounded<BaseCaptureRequest>();
+
+    public async Task Add(BaseCaptureRequest request, CancellationToken cancellationToken)
+    {
+        await _channel.Writer.WriteAsync(request, cancellationToken);
+    }
+
+    public ValueTask<BaseCaptureRequest> Read(CancellationToken cancellationToken)
+    {
+        return _channel.Reader.ReadAsync(cancellationToken);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsOptions.cs
@@ -1,0 +1,10 @@
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
+
+public class AnalyticsOptions
+{
+    public const string Section = "Analytics";
+
+    public bool Enabled { get; init; } = false;
+
+    public string BasePath { get; init; } = string.Empty;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsPathResolver.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
+
+public class AnalyticsPathResolver : IAnalyticsPathResolver
+{
+    private readonly string _basePath;
+
+    public AnalyticsPathResolver(IOptions<AnalyticsOptions> options, IWebHostEnvironment environment)
+    {
+
+        if (options.Value.BasePath.IsNullOrWhitespace())
+        {
+            throw new ArgumentException(
+                message: $"'{nameof(AnalyticsOptions.BasePath)}' must not be blank",
+                paramName: nameof(options)
+            );
+        }
+
+        var originalPath = options.Value.BasePath;
+        if (environment.IsDevelopment())
+        {
+            _basePath = Path.Combine(PathUtils.ProjectRootPath, PathUtils.OsPath(originalPath));
+        }
+        else
+        {
+            _basePath = originalPath;
+        }
+    }
+
+    public string PublicZipDownloadsDirectoryPath()
+    {
+        return Path.Combine(_basePath, "public", "zip-downloads");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsWriter.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies.Interfaces;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
+
+public class AnalyticsWriter(
+    IEnumerable<IAnalyticsWriteStrategy> writeStrategies) : IAnalyticsWriter
+{
+    public async Task Report(BaseCaptureRequest request, CancellationToken cancellationToken)
+    {
+        var strategy = writeStrategies
+            .Single(s => s.CanHandle(request));
+
+        await strategy.Report(request, cancellationToken);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsWriter.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
@@ -9,12 +9,15 @@ using GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies.Int
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
 
 public class AnalyticsWriter(
-    IEnumerable<IAnalyticsWriteStrategy> writeStrategies) : IAnalyticsWriter
+    IDictionary<Type, IAnalyticsWriteStrategy> strategyByRequestType) : IAnalyticsWriter
 {
-    public async Task Report(BaseCaptureRequest request, CancellationToken cancellationToken)
+    public async Task Report(AnalyticsCaptureRequestBase request, CancellationToken cancellationToken)
     {
-        var strategy = writeStrategies
-            .Single(s => s.CanHandle(request));
+        var success = strategyByRequestType.TryGetValue(request.GetType(), out var strategy);
+        if (!success)
+        {
+            throw new Exception($"No write strategy for request type {request.GetType()}");
+        }
 
         await strategy.Report(request, cancellationToken);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsManager.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsManager.cs
@@ -6,7 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces
 
 public interface IAnalyticsManager
 {
-    Task Add(BaseCaptureRequest request, CancellationToken cancellationToken);
+    Task Add(AnalyticsCaptureRequestBase request, CancellationToken cancellationToken);
 
-    ValueTask<BaseCaptureRequest> Read(CancellationToken cancellationToken);
+    ValueTask<AnalyticsCaptureRequestBase> Read(CancellationToken cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsManager.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsManager.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+
+public interface IAnalyticsManager
+{
+    Task Add(BaseCaptureRequest request, CancellationToken cancellationToken);
+
+    ValueTask<BaseCaptureRequest> Read(CancellationToken cancellationToken);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsPathResolver.cs
@@ -1,0 +1,6 @@
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+
+public interface IAnalyticsPathResolver
+{
+    string PublicZipDownloadsDirectoryPath();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsWriter.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+
+public interface IAnalyticsWriter
+{
+    Task Report(BaseCaptureRequest request, CancellationToken cancellationToken);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsWriter.cs
@@ -6,5 +6,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces
 
 public interface IAnalyticsWriter
 {
-    Task Report(BaseCaptureRequest request, CancellationToken cancellationToken);
+    Task Report(AnalyticsCaptureRequestBase request, CancellationToken cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/LocalAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/LocalAnalyticsPathResolver.cs
@@ -1,17 +1,18 @@
 using System;
 using System.IO;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
 
-public class AnalyticsPathResolver : IAnalyticsPathResolver
+public class LocalAnalyticsPathResolver : IAnalyticsPathResolver
 {
     private readonly string _basePath;
 
-    public AnalyticsPathResolver(IOptions<AnalyticsOptions> options, IWebHostEnvironment environment)
+    public LocalAnalyticsPathResolver(IOptions<AnalyticsOptions> options, IWebHostEnvironment environment)
     {
 
         if (options.Value.BasePath.IsNullOrWhitespace())
@@ -22,7 +23,8 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
             );
         }
 
-        _basePath = options.Value.BasePath;
+        var originalPath = options.Value.BasePath;
+        _basePath = Path.Combine(PathUtils.ProjectRootPath, PathUtils.OsPath(originalPath));
     }
 
     public string PublicZipDownloadsDirectoryPath()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -18,9 +18,11 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using File = System.IO.File;
 
@@ -31,7 +33,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
         IPersistenceHelper<ContentDbContext> persistenceHelper,
         IPublicBlobStorageService publicBlobStorageService,
         IDataGuidanceFileWriter dataGuidanceFileWriter,
-        IUserService userService)
+        IUserService userService,
+        IAnalyticsManager analyticsManager,
+        ILogger<ReleaseFileService> logger)
         : IReleaseFileService
     {
         /// How long the all files zip should be
@@ -131,19 +135,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                 .OnSuccessVoid(
                     async releaseVersion =>
                     {
-                        if (fileIds is null
-                            && await TryStreamCachedAllFilesZip(releaseVersion, outputStream, cancellationToken))
-                        {
-                            return;
-                        }
+                        List<ReleaseFile>? releaseFiles = null;
 
                         if (fileIds is null)
                         {
-                            await ZipAllFilesToStream(releaseVersion, outputStream, cancellationToken);
+                            var successfullyStreamCachedAllFilesZip =
+                                await TryStreamCachedAllFilesZip(releaseVersion, outputStream, cancellationToken);
+
+                            if (!successfullyStreamCachedAllFilesZip)
+                            {
+                                await ZipAllFilesToStream(releaseVersion, outputStream, cancellationToken);
+                            }
                         }
                         else
                         {
-                            var releaseFiles = (await QueryReleaseFiles(releaseVersionId)
+                            releaseFiles = (await QueryReleaseFiles(releaseVersionId)
                                     .Where(rf => fileIds.Contains(rf.FileId))
                                     .ToListAsync(cancellationToken: cancellationToken))
                                 .OrderBy(rf => rf.File.ZipFileEntryName())
@@ -151,6 +157,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
 
                             await DoZipFilesToStream(releaseFiles, releaseVersion, outputStream, cancellationToken);
                         }
+
+                        await RecordZipDownloadAnalytics(releaseVersion, releaseFiles, cancellationToken);
                     }
                 );
         }
@@ -285,6 +293,37 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                 .Include(f => f.File)
                 .Where(releaseFile => releaseFile.ReleaseVersionId == releaseVersionId
                                       && AllowedFileTypes.Contains(releaseFile.File.Type));
+        }
+
+        private async Task RecordZipDownloadAnalytics(
+            ReleaseVersion releaseVersion,
+            List<ReleaseFile>? releaseFiles,
+            CancellationToken cancellationToken)
+        {
+            if (releaseFiles is not null && releaseFiles.Count > 1)
+            {
+                logger.LogWarning("We only record analytics for zip downloads for an entire release or one specific data set. So this means someone manually attempted to download a zip with more than one specific file?");
+                return;
+            }
+
+            Guid? subjectId = null;
+            string? dataSetName = null;
+
+            if (releaseFiles is not null && releaseFiles.Count == 1)
+            {
+                subjectId = releaseFiles[0].File.SubjectId;
+                dataSetName = releaseFiles[0].Name;
+            }
+
+            await analyticsManager.Add(
+                new CaptureZipDownloadRequest(
+                    releaseVersion.Release.Publication.Title,
+                    releaseVersion.Id,
+                    releaseVersion.Release.Title,
+                    releaseVersion.Release.Label,
+                    subjectId,
+                    dataSetName),
+                cancellationToken);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/CaptureRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/CaptureRequests.cs
@@ -3,12 +3,15 @@ using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
 
-public abstract record BaseCaptureRequest;
+public abstract record AnalyticsCaptureRequestBase;
 
+/// <summary>
+/// To capture data relating to a zip download request for analytics.
+/// </summary>
 public record CaptureZipDownloadRequest(
     string PublicationName,
     Guid ReleaseVersionId,
     string ReleaseName,
     string? ReleaseLabel,
     Guid? SubjectId = null,
-    string? DataSetName = null) : BaseCaptureRequest;
+    string? DataSetTitle = null) : AnalyticsCaptureRequestBase;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/CaptureRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/CaptureRequests.cs
@@ -1,0 +1,14 @@
+#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+
+public abstract record BaseCaptureRequest;
+
+public record CaptureZipDownloadRequest(
+    string PublicationName,
+    Guid ReleaseVersionId,
+    string ReleaseName,
+    string? ReleaseLabel,
+    Guid? SubjectId = null,
+    string? DataSetName = null) : BaseCaptureRequest;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWritePublicZipDownloadStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWritePublicZipDownloadStrategy.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Utils;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies;
+
+public class AnalyticsWritePublicZipDownloadStrategy(
+    IAnalyticsPathResolver analyticsPathResolver,
+    ILogger<AnalyticsWritePublicZipDownloadStrategy> logger
+    ) : IAnalyticsWriteStrategy
+{
+    public bool CanHandle(BaseCaptureRequest request)
+    {
+        return request is CaptureZipDownloadRequest;
+    }
+
+    public async Task Report(BaseCaptureRequest request, CancellationToken cancellationToken)
+    {
+        var zipDownloadRequest = request as CaptureZipDownloadRequest
+                                 ?? throw new ArgumentException($"request isn't a {nameof(CaptureZipDownloadRequest)}");
+
+        logger.LogInformation(
+            "Capturing {RequestTypeName} for releaseVersion {ReleaseVersionId}{WithSubject}",
+            zipDownloadRequest.GetType().ToString(),
+            zipDownloadRequest.ReleaseVersionId,
+            zipDownloadRequest.SubjectId == null
+                ? ""
+                : " for subject " + zipDownloadRequest.SubjectId);
+
+        var serialisedRequest = JsonSerializationUtils.Serialize(
+            obj: zipDownloadRequest,
+            formatting: Formatting.Indented,
+            orderedProperties: true,
+            camelCase: true);
+
+        var directory = analyticsPathResolver.PublicZipDownloadsDirectoryPath();
+
+        var filename =
+            $"{DateTime.UtcNow:yyyyMMdd-HHmmss}_{zipDownloadRequest.ReleaseVersionId}_{RandomUtils.RandomString()}.json";
+
+        await AnalyticsUtils.WriteToFileShare(
+            request.GetType().ToString(),
+            directory,
+            filename,
+            serialisedRequest,
+            logger);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWriteStrategyBase.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWriteStrategyBase.cs
@@ -1,18 +1,20 @@
+#nullable enable
 using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Utils;
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies;
 
-public static class AnalyticsUtils
+public abstract class AnalyticsWriteStrategyBase(
+    ILogger<AnalyticsWriteStrategyBase> logger
+    )
 {
-    public static async Task WriteToFileShare(
+    protected async Task WriteToFileShare(
         string requestTypeName,
         string directory,
         string filename,
-        string serialisedRequest,
-        ILogger logger)
+        string serialisedRequest)
     {
         try
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/Interfaces/IAnalyticsWriteStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/Interfaces/IAnalyticsWriteStrategy.cs
@@ -6,7 +6,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies
 
 public interface IAnalyticsWriteStrategy
 {
-    bool CanHandle(BaseCaptureRequest request);
-
-    Task Report(BaseCaptureRequest request, CancellationToken cancellationToken);
+    Task Report(AnalyticsCaptureRequestBase request, CancellationToken cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/Interfaces/IAnalyticsWriteStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/Interfaces/IAnalyticsWriteStrategy.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies.Interfaces;
+
+public interface IAnalyticsWriteStrategy
+{
+    bool CanHandle(BaseCaptureRequest request);
+
+    Task Report(BaseCaptureRequest request, CancellationToken cancellationToken);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Utils/AnalyticsUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Utils/AnalyticsUtils.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Utils;
+
+public static class AnalyticsUtils
+{
+    public static async Task WriteToFileShare(
+        string requestTypeName,
+        string directory,
+        string filename,
+        string serialisedRequest,
+        ILogger logger)
+    {
+        try
+        {
+            Directory.CreateDirectory(directory);
+
+            var filePath = Path.Combine(directory, filename);
+
+            await File.WriteAllTextAsync(
+                filePath,
+                contents: serialisedRequest);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(
+                e,
+                "Error whilst writing {RequestTypeName} to disk",
+                requestTypeName);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/PermalinkController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/PermalinkController.cs
@@ -36,7 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
                     contentType: ContentTypes.Csv,
                     filename: $"permalink-{permalinkId}.csv");
 
-                return await _permalinkService.DownloadCsvToStream(
+                return await _permalinkService.DownloadCsvToStream( // TODO EES-5976 analytics
                         permalinkId: permalinkId,
                         stream: Response.BodyWriter.AsStream(),
                         cancellationToken: cancellationToken

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/QueryAnalyticsWriterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/QueryAnalyticsWriterTests.cs
@@ -15,7 +15,7 @@ public abstract class QueryAnalyticsWriterTests
         [Fact]
         public async Task Success()
         {
-            var pathResolver = new TestAnalyticsPathResolver();
+            using var pathResolver = new TestAnalyticsPathResolver();
             var service = BuildService(pathResolver);
 
             await service.ReportDataSetVersionQuery(new CaptureDataSetVersionQueryRequest(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -281,7 +281,7 @@ public class DataSetsController(
     )]
     [SwaggerResponse(403, type: typeof(ProblemDetailsViewModel), contentTypes: MediaTypeNames.Application.Json)]
     [SwaggerResponse(404, type: typeof(ProblemDetailsViewModel), contentTypes: MediaTypeNames.Application.Json)]
-    public async Task<ActionResult> DownloadDataSetCsv(
+    public async Task<ActionResult> DownloadDataSetCsv( // TODO EES-6007 analytics
         [SwaggerParameter("The ID of the data set.")] Guid dataSetId,
         [SwaggerParameter("""
                           The data set version e.g. 1.0, 1.1, 2.0, etc.

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/LocalAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/LocalAnalyticsPathResolver.cs
@@ -1,15 +1,16 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
-public class AnalyticsPathResolver : IAnalyticsPathResolver
+public class LocalAnalyticsPathResolver : IAnalyticsPathResolver
 {
     private readonly string _basePath;
 
-    public AnalyticsPathResolver(IOptions<AnalyticsOptions> options, IWebHostEnvironment environment)
+    public LocalAnalyticsPathResolver(IOptions<AnalyticsOptions> options, IWebHostEnvironment environment)
     {
         if (options.Value.BasePath.IsNullOrWhitespace())
         {
@@ -19,7 +20,8 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
             );
         }
         
-        _basePath = options.Value.BasePath;
+        var originalPath = options.Value.BasePath;
+        _basePath = Path.Combine(PathUtils.ProjectRootPath, PathUtils.OsPath(originalPath));
     }
 
     private string BasePath() => _basePath;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/QueryAnalyticsManager.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/QueryAnalyticsManager.cs
@@ -18,3 +18,17 @@ public class QueryAnalyticsManager : IQueryAnalyticsManager
         return _channel.Reader.ReadAsync(cancellationToken);
     }
 }
+
+public class NoOpQueryAnalyticsManager : IQueryAnalyticsManager
+{
+    public Task AddQuery(CaptureDataSetVersionQueryRequest request, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public async ValueTask<CaptureDataSetVersionQueryRequest> ReadQuery(CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.Infinite, cancellationToken);
+        return default!;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/QueryAnalyticsWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/QueryAnalyticsWriter.cs
@@ -32,7 +32,8 @@ public class QueryAnalyticsWriter(
         {
             Directory.CreateDirectory(directory);
 
-            var filename = $"{DateTime.UtcNow:yyyyMMdd-HHmmss}_{request.DataSetVersionId}_{RandomUtils.RandomString()}.json";
+            var filename =
+                $"{DateTime.UtcNow:yyyyMMdd-HHmmss}_{request.DataSetVersionId}_{RandomUtils.RandomString()}.json";
 
             await File.WriteAllTextAsync(
                 Path.Combine(directory, filename),

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -33,9 +33,6 @@ using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using AnalyticsOptions = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options.AnalyticsOptions;
-using AnalyticsPathResolver = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.AnalyticsPathResolver;
-using IAnalyticsPathResolver = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.IAnalyticsPathResolver;
 using RequestTimeoutOptions = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options.RequestTimeoutOptions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api;
@@ -258,8 +255,16 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         {
             services.AddSingleton<IQueryAnalyticsManager, QueryAnalyticsManager>();
             services.AddHostedService<QueryAnalyticsConsumer>();
-            services.AddSingleton<IAnalyticsPathResolver, AnalyticsPathResolver>();
             services.AddSingleton<IQueryAnalyticsWriter, QueryAnalyticsWriter>();
+
+            if (hostEnvironment.IsDevelopment())
+            {
+                services.AddSingleton<IAnalyticsPathResolver, LocalAnalyticsPathResolver>();
+            }
+            else
+            {
+                services.AddSingleton<IAnalyticsPathResolver, AnalyticsPathResolver>();
+            }
         }
         else
         {
@@ -373,19 +378,5 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         var migrations = serviceScope.ServiceProvider.GetServices<ICustomMigration>();
 
         migrations.ForEach(migration => migration.Apply());
-    }
-
-    private class NoOpQueryAnalyticsManager : IQueryAnalyticsManager
-    {
-        public Task AddQuery(CaptureDataSetVersionQueryRequest request, CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
-        }
-
-        public async ValueTask<CaptureDataSetVersionQueryRequest> ReadQuery(CancellationToken cancellationToken)
-        {
-            await Task.Delay(Timeout.Infinite, cancellationToken);
-            return default!;
-        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -263,7 +263,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         }
         else
         {
-            services.AddSingleton<IQueryAnalyticsManager, NoopQueryAnalyticsManager>();
+            services.AddSingleton<IQueryAnalyticsManager, NoOpQueryAnalyticsManager>();
         }
     }
 
@@ -375,7 +375,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         migrations.ForEach(migration => migration.Apply());
     }
 
-    private class NoopQueryAnalyticsManager : IQueryAnalyticsManager
+    private class NoOpQueryAnalyticsManager : IQueryAnalyticsManager
     {
         public Task AddQuery(CaptureDataSetVersionQueryRequest request, CancellationToken cancellationToken)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Extensions/MockTaskOrchestrationEntityFeatureExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Tests/Extensions/MockTaskOrchestrationEntityFeatureExtensions.cs
@@ -13,10 +13,10 @@ internal static class MockTaskOrchestrationEntityFeatureExtensions
     {
         return mock.Setup(entityFeature => entityFeature.LockEntitiesAsync(
                 new EntityInstanceId(nameof(ActivityLock), name)))
-            .ReturnsAsync(new NoopAsyncDisposable());
+            .ReturnsAsync(new NoOpAsyncDisposable());
     }
 
-    private sealed class NoopAsyncDisposable : IAsyncDisposable
+    private sealed class NoOpAsyncDisposable : IAsyncDisposable
     {
         ValueTask IAsyncDisposable.DisposeAsync() => ValueTask.CompletedTask;
     }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadTable.tsx
@@ -74,6 +74,7 @@ const DownloadTable = ({
           <Form
             id="downloadTableForm"
             onSubmit={async ({ fileFormat }) => {
+              // TODO EES-5852 analytics for table tool/permalink csv/ods downloads
               await onSubmit?.(fileFormat);
 
               if (fileFormat === 'csv') {


### PR DESCRIPTION
This PR adds analytics for zip downloads.It essentially copies the pattern established by EES-5242 when we started recording analytics for Public API queries, with a couple of tweaks.

As part of this work we explored whether the the EES-5242 approach is suitable for both this and for future analytics work where things that might be requested more frequently like release page views) and gave it the OK. If a performance problem arises we could at the very worst turn analytics off and would be relatively straightforward to change approach. 

When testing this work I did see that the Azure Function would take several minutes to process a couple thousands request files, so I do think that could become a problem in the future if we have a flood of requests in a short space of time and the Azure Function times out before they're all processed and/or another execution of the function overlaps the previous. But there are ways to mitigate these issues.

The high-level overview is that every time a user downloads a zip file from either a release page or a data set page, a file is created to record data associated with that zip download. (A request without a `SubjectId` is to download all data sets for a release version. A request with a `SubjectId` is only for that specific data set.) These files are then consumed by the analytics Azure function that processes all analytics request files once an hour and generates parquet file reports. These will be used by the DfE for their own purposes. The end users of the parquet files are statisticians and are used to working with data in this way.

Locally, the files and reports will be created in the `explore-education-statistics/data/analytics` directory - this can be edited in the Content API's `appsettings.Development.json`. On environments, the files will be written to a file share in the analytics Azure Storage instance. This fileshare is mounted with a file path `\\mounts\\analytics` - file paths must be provided in this "/mounts/{name}" format for app services. In unit tests, files are written to "ExploreEducationStatistics" in your OS's temp directory.

The writing of the original files to record the zip download are written using a `Channel`. We defer the creation of request files to a background task to avoid it interfering with the performance of more important tasks. `AnalyticsManager` creates the `Channel`. `AnalyticsWriter` writes request data into the channel, and then `AnalyticsConsumer` reads from the channel as a background task and creates the actual files (which will later be processed by the Azure Function and turned into a parquet file report).

The Channel is set up differently to `QueryAnalyticsManager`, where we have one channel for all recorded requests, rather than a separate channel for each type of recorded request. `QueryAnalyticsManager` will be aligned with the Content DB approach in EES-6066. 

The Azure Function is hooked up to an Azure Storage instance (`eessaanlyt`) and that is where the parquet files are saved.


### Other changes/notes
- `ReleaseFileService#ZipFilesToStream` allows users to specific an array of files that they want included in a zip. The public frontend used to allow users to specify a number of data set to be included in the zip, but this is no longer the case: users either download a zip with all data sets related to a release version or a sole data set. I've created EES-6034 to update `ZipFilesToStream` to take a single optional FileId as an argument.

- I've added Dispose methods to various analytic test classes to ensure temporary files get cleared up after running the unit tests.
- When INSERTing into the DuckDb tables, I've changed the format to `unstructured`. This was to prevent an issue where DuckDb wanted JSON in request files to be in an array. The DuckDB docs are here: https://duckdb.org/docs/stable/data/json/format_settings.html I believe the `PublicApiQueriesProcessor` INSERT format, which was set to `auto` would have been using `unstructured`, but for some reason the same didn't happen with the `PublicZipDownloadsProcessor` INSERT, so I needed to set `unstructured` explicitly.
- Renamed `ConsumePublicApiQueriesProcessorTests` to `PublicApiQueriesProcessorTests`.
- Removed an unnecessary `IF NOT EXISTS` from a DuckDb queries - the tables are created fresh each Azure Function run so no need for it.
- I've updated `Analytics.Consumer`'s `TestAnalyticsPathResolver`'s directories to match the structure from the real `AnalyticsPathResolver`.
