### PR TITLE
EES-6057 Add test CI build jobs to see if we're effected by CDN Domai…

### DIFF
--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -46,6 +46,52 @@ pr:
       - renovate.json
 
 jobs:
+  - job:
+    pool:
+      name: ees-ubuntu2204-large
+    steps:
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          try {
+            Invoke-WebRequest -Method HEAD `
+                              -Uri https://download.agent.dev.azure.com/agent/4.252.0/vsts-agent-win-x64-4.252.0.zip `
+                              -TimeoutSec 5 `
+                              -UseBasicParsing `
+                              | Set-Variable response
+            if ($response.StatusCode -lt 400) {
+              Write-Host "Agent CDN is accessible. Status code: $($response.StatusCode)"
+            } else {
+              throw
+            }
+          } catch {
+            Write-Host "##vso[task.logissue type=warning]Can't access download.agent.dev.azure.com. Please make sure the access is not blocked by a firewall."
+            Write-Error "Agent CDN is inaccessible. Please make sure the access is not blocked by a firewall"
+            $response | Format-List
+          }
+        displayName: 'Test download.agent.dev.azure.com access for ees-ubuntu2024-large'
+  - job:
+    pool:
+      name: ees-ubuntu2204-xlarge
+    steps:
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          try {
+            Invoke-WebRequest -Method HEAD `
+                              -Uri https://download.agent.dev.azure.com/agent/4.252.0/vsts-agent-win-x64-4.252.0.zip `
+                              -TimeoutSec 5 `
+                              -UseBasicParsing `
+                              | Set-Variable response
+            if ($response.StatusCode -lt 400) {
+              Write-Host "Agent CDN is accessible. Status code: $($response.StatusCode)"
+            } else {
+              throw
+            }
+          } catch {
+            Write-Host "##vso[task.logissue type=warning]Can't access download.agent.dev.azure.com. Please make sure the access is not blocked by a firewall."
+            Write-Error "Agent CDN is inaccessible. Please make sure the access is not blocked by a firewall"
+            $response | Format-List
+          }
+        displayName: 'Test download.agent.dev.azure.com access for ees-ubuntu2024-xlarge'
   - job: BackendVerify
     pool: ees-ubuntu2204-large
     workspace:


### PR DESCRIPTION
…n URL change

This PR adds some test jobs to ensure that our existing Agent Pools on DevOps will work after the Azure's CDN Domain URL change.

Details can be found here: https://devblogs.microsoft.com/devops/cdn-domain-url-change-for-agents-in-pipelines/

I will be removing this later after we've established whether we have an issue or not. 