### PR TITLE
EES-6064 Change Publisher function app time zone setting

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -585,9 +585,12 @@
         "description": "Maximum number of table cells that a table builder query could potentially render for a request to be valid"
       }
     },
-    "timeZone": {
+    "publisherFunctionAppTimeZone": {
       "type": "string",
-      "defaultValue": "GMT Standard Time"
+      "defaultValue": "Europe/London",
+      "metadata": {
+        "description": "The time zone of the Publisher Function App. This time zone is used for evaluating Cron expressions of the functions running with Cron triggers and altering it will change the time of execution of these functions."
+      }
     },
     "branch": {
       "type": "string",
@@ -3366,7 +3369,7 @@
         "AzureWebJobs.StageScheduledReleaseVersionsImmediately.Disabled": "[not(parameters('immediatePublicationOfScheduledReleaseVersionsEnabled'))]",
         "AzureWebJobs.PublishStagedReleaseVersionContentImmediately.Disabled": "[not(parameters('immediatePublicationOfScheduledReleaseVersionsEnabled'))]",
         "WEBSITE_CONTENTOVERVNET": "1",
-        "WEBSITE_TIME_ZONE": "[parameters('timeZone')]",
+        "WEBSITE_TIME_ZONE": "[parameters('publisherFunctionAppTimeZone')]",
         "WEBSITE_RUN_FROM_PACKAGE": "1",
         "FUNCTIONS_EXTENSION_VERSION": "~4",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/local.settings.json
@@ -3,7 +3,7 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://data-storage",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "WEBSITE_TIME_ZONE": "GMT Standard Time",
+    "WEBSITE_TIME_ZONE": "Europe/London",
     "App:PublishReleasesCronSchedule": "0 0-58/2 * * * *",
     "App:PublishReleaseContentCronSchedule": "0 1-59/2 * * * *"
   },


### PR DESCRIPTION
* Rename parameter `timeZone` to `publisherFunctionAppTimeZone` in template.json as it wasn't clear that it only applies to the Publisher Function App.

* Add a description to the parameter to explain its impact on Cron triggered functions.

* Change the time zone from Windows time zone ID `GMT Standard Time` to IANA time zone `Europe/London`. The naming of `GMT Standard Time` doesn't reflect its daylight saving behaviour clearly and could cause confusion.

 It should be possible to use `Europe/London` across different operating systems now starting with .NET6.

The [docs for Azure Function App settings ](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#website_time_zone) still suggest needing to use `GMT Standard Time` for Windows but I think this is an oversight. NET6 should have removed this limitation. See [Time Zone Conversion APIs](https://devblogs.microsoft.com/dotnet/date-time-and-time-zone-enhancements-in-net-6/#time-zone-conversion-apis).