### PR TITLE
EES-6064 Rename the Publisher app settings used to control the schedule of Cron triggered functions to match the function names

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -26,10 +26,10 @@
     "slackAlertsChannel": {
       "value": "C067Z1K68UD"
     },
-    "publishReleasesCronSchedule": {
+    "stageScheduledReleasesFunctionCronSchedule": {
       "value": "0 0 * * * *"
     },
-    "publishReleaseContentCronSchedule": {
+    "publishScheduledReleasesFunctionCronSchedule": {
       "value": "0 30 * * * *"
     },
     "preReleaseMinutesBeforeStart": {

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -29,10 +29,10 @@
     "slackAlertsChannel": {
       "value": "C0681S50SP5"
     },
-    "publishReleasesCronSchedule": {
+    "stageScheduledReleasesFunctionCronSchedule": {
       "value": "0 5 0 * * *"
     },
-    "publishReleaseContentCronSchedule": {
+    "publishScheduledReleasesFunctionCronSchedule": {
       "value": "0 30 9 * * *"
     },
     "useSubnets": {

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -32,10 +32,10 @@
     "publicAppBasicAuth": {
       "value": "false"
     },
-    "publishReleasesCronSchedule": {
+    "stageScheduledReleasesFunctionCronSchedule": {
       "value": "0 5 0 * * *"
     },
-    "publishReleaseContentCronSchedule": {
+    "publishScheduledReleasesFunctionCronSchedule": {
       "value": "0 30 9 * * *"
     },
     "useSubnets": {

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -26,10 +26,10 @@
     "slackAlertsChannel": {
       "value": "C0681S23291"
     },
-    "publishReleasesCronSchedule": {
+    "stageScheduledReleasesFunctionCronSchedule": {
       "value": "0 0 * * * *"
     },
-    "publishReleaseContentCronSchedule": {
+    "publishScheduledReleasesFunctionCronSchedule": {
       "value": "0 30 * * * *"
     },
     "useSubnets": {

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -481,18 +481,18 @@
       "type": "bool",
       "defaultValue": true
     },
-    "publishReleasesCronSchedule": {
+    "stageScheduledReleasesFunctionCronSchedule": {
       "type": "string",
       "defaultValue": "0 5 0 * * *",
       "metadata": {
-        "description": "Cron string that is used to control the schedule of the StageScheduledReleases Function in the Publisher App"
+        "description": "Cron string that is used to control the schedule of the StageScheduledReleases function in the Publisher Function App"
       }
     },
-    "publishReleaseContentCronSchedule": {
+    "publishScheduledReleasesFunctionCronSchedule": {
       "type": "string",
       "defaultValue": "0 30 9 * * *",
       "metadata": {
-        "description": "Cron string that is used to control the schedule of the PublishScheduledReleases Function in the Publisher App"
+        "description": "Cron string that is used to control the schedule of the PublishScheduledReleases function in the Publisher Function App"
       }
     },
     "preReleaseMinutesBeforeStart": {
@@ -1846,8 +1846,8 @@
         "PublicStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-public')).secretUriWithVersion, ')')]",
         "PublisherStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher'), '2018-02-14').secretUriWithVersion, ')')]",
         "PreReleaseAccess__AccessWindow__MinutesBeforeReleaseTimeStart": "[parameters('preReleaseMinutesBeforeStart')]",
-        "ReleaseApproval__PublishReleasesCronSchedule": "[parameters('publishReleasesCronSchedule')]",
-        "ReleaseApproval__PublishReleaseContentCronSchedule": "[parameters('publishReleaseContentCronSchedule')]",
+        "ReleaseApproval__StageScheduledReleasesFunctionCronSchedule": "[parameters('stageScheduledReleasesFunctionCronSchedule')]",
+        "ReleaseApproval__PublishScheduledReleasesFunctionCronSchedule": "[parameters('publishScheduledReleasesFunctionCronSchedule')]",
         "TableBuilder__MaxTableCellsAllowed": "[parameters('tableBuilderMaxTableCellsAllowed')]",
         "PublicApp__Url": "[variables('publicAppUrl')]",
         "PublicDataDbExists": "[parameters('publicDataDbExists')]",
@@ -3374,8 +3374,8 @@
         "FUNCTIONS_EXTENSION_VERSION": "~4",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('microsoft.insights/components/', variables('publisherAppInsights')), '2020-02-02').InstrumentationKey]",
-        "App__PublishReleasesCronSchedule": "[parameters('publishReleasesCronSchedule')]",
-        "App__PublishReleaseContentCronSchedule": "[parameters('publishReleaseContentCronSchedule')]",
+        "App__StageScheduledReleasesFunctionCronSchedule": "[parameters('stageScheduledReleasesFunctionCronSchedule')]",
+        "App__PublishScheduledReleasesFunctionCronSchedule": "[parameters('publishScheduledReleasesFunctionCronSchedule')]",
         "App__PrivateStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-core')).secretUriWithVersion, ')')]",
         "App__NotifierStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-notifications')).secretUriWithVersion, ')')]",
         "App__PublicStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-public')).secretUriWithVersion, ')')]",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseApprovalServiceTests.cs
@@ -276,8 +276,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             // Set up the cron schedules for publishing
             var options = new ReleaseApprovalOptions
             {
-                PublishReleasesCronSchedule = "0 0 0 * * *", // Next occurrence 2023-01-01T00:00:00Z
-                PublishReleaseContentCronSchedule = "0 30 9 * * *" // Next occurrence 2023-01-01T09:30:00Z
+                StageScheduledReleasesFunctionCronSchedule = "0 0 0 * * *", // Next occurrence 2023-01-01T00:00:00Z
+                PublishScheduledReleasesFunctionCronSchedule = "0 30 9 * * *" // Next occurrence 2023-01-01T09:30:00Z
             };
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -335,8 +335,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             // Set up the cron schedules for publishing
             var options = new ReleaseApprovalOptions
             {
-                PublishReleasesCronSchedule = "0 0 0 * * *", // Next occurrence 2023-06-06T23:00:00Z
-                PublishReleaseContentCronSchedule = "0 30 9 * * *" // Next occurrence 2023-06-07T08:30:00Z
+                StageScheduledReleasesFunctionCronSchedule = "0 0 0 * * *", // Next occurrence 2023-06-06T23:00:00Z
+                PublishScheduledReleasesFunctionCronSchedule = "0 30 9 * * *" // Next occurrence 2023-06-07T08:30:00Z
             };
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -391,8 +391,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             // Set up the cron schedules for publishing
             var options = new ReleaseApprovalOptions
             {
-                PublishReleasesCronSchedule = "0 0 0 * * *", // Next occurrence 2023-01-02T00:00:00Z
-                PublishReleaseContentCronSchedule = "0 30 9 * * *" // Next occurrence 2023-01-01T09:30:00Z
+                StageScheduledReleasesFunctionCronSchedule = "0 0 0 * * *", // Next occurrence 2023-01-02T00:00:00Z
+                PublishScheduledReleasesFunctionCronSchedule = "0 30 9 * * *" // Next occurrence 2023-01-01T09:30:00Z
             };
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -450,8 +450,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             // Set up the cron schedules for publishing
             var options = new ReleaseApprovalOptions
             {
-                PublishReleasesCronSchedule = "0 0 0 * * *", // Next occurrence 2023-06-07T23:00:00Z
-                PublishReleaseContentCronSchedule = "0 30 9 * * *" // Next occurrence 2023-06-07T08:30:00Z
+                StageScheduledReleasesFunctionCronSchedule = "0 0 0 * * *", // Next occurrence 2023-06-07T23:00:00Z
+                PublishScheduledReleasesFunctionCronSchedule = "0 30 9 * * *" // Next occurrence 2023-06-07T08:30:00Z
             };
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -506,8 +506,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             // Set up the cron schedules for publishing
             var options = new ReleaseApprovalOptions
             {
-                PublishReleasesCronSchedule = "0 0 0 * * 1-5", // Only occurs on weekdays Monday - Friday
-                PublishReleaseContentCronSchedule = "0 30 9 * * 1-5" // Only occurs on weekdays Monday - Friday
+                StageScheduledReleasesFunctionCronSchedule = "0 0 0 * * 1-5", // Only occurs on weekdays Monday - Friday
+                PublishScheduledReleasesFunctionCronSchedule = "0 30 9 * * 1-5" // Only occurs on weekdays Monday - Friday
             };
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -564,8 +564,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             // will have an occurrence on the day, but not the second
             var options = new ReleaseApprovalOptions
             {
-                PublishReleasesCronSchedule = "0 30 * * * *", // Occurs hourly at minute 30
-                PublishReleaseContentCronSchedule = "0 15 * * * *" // Occurs hourly at minute 15
+                StageScheduledReleasesFunctionCronSchedule = "0 30 * * * *", // Occurs hourly at minute 30
+                PublishScheduledReleasesFunctionCronSchedule = "0 15 * * * *" // Occurs hourly at minute 15
             };
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -1986,8 +1986,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             return new ReleaseApprovalOptions
             {
-                PublishReleasesCronSchedule = "0 0 0 * * *",
-                PublishReleaseContentCronSchedule = "0 30 9 * * *"
+                StageScheduledReleasesFunctionCronSchedule = "0 0 0 * * *",
+                PublishScheduledReleasesFunctionCronSchedule = "0 30 9 * * *"
             }.ToOptionsWrapper();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/appsettings.IntegrationTest.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/appsettings.IntegrationTest.json
@@ -35,8 +35,8 @@
     }
   },
   "ReleaseApproval": {
-    "PublishReleasesCronSchedule": "0 0-58/2 * * * *",
-    "PublishReleaseContentCronSchedule": "0 1-59/2 * * * *"
+    "StageScheduledReleasesFunctionCronSchedule": "0 0-58/2 * * * *",
+    "PublishScheduledReleasesFunctionCronSchedule": "0 1-59/2 * * * *"
   },
   "PublicApp": {
     "Url": "http://localhost:3000"

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Options/ReleaseApprovalOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Options/ReleaseApprovalOptions.cs
@@ -5,7 +5,7 @@ public record ReleaseApprovalOptions
 {
     public const string Section = "ReleaseApproval";
 
-    public string PublishReleasesCronSchedule { get; init; } = string.Empty;
-    
-    public string PublishReleaseContentCronSchedule { get; init; } = string.Empty;
+    public string StageScheduledReleasesFunctionCronSchedule { get; init; } = string.Empty;
+
+    public string PublishScheduledReleasesFunctionCronSchedule { get; init; } = string.Empty;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseApprovalService.cs
@@ -338,7 +338,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             // Publishing won't occur unless there's an occurrence of (1) between the publishing range
             var nextOccurrenceUtc = GetNextOccurrenceForCronExpression(
-                cronExpression: _options.PublishReleasesCronSchedule,
+                cronExpression: _options.StageScheduledReleasesFunctionCronSchedule,
                 fromUtc: fromUtc,
                 toUtc: toUtc,
                 timeZone: ukTimeZone);
@@ -347,7 +347,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             {
                 // Publishing won't occur unless there's an occurrence of (2) after (1) but before the end of the range
                 return GetNextOccurrenceForCronExpression(
-                    cronExpression: _options.PublishReleaseContentCronSchedule,
+                    cronExpression: _options.PublishScheduledReleasesFunctionCronSchedule,
                     fromUtc: nextOccurrenceUtc.Value,
                     toUtc: toUtc,
                     timeZone: ukTimeZone).HasValue;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -39,8 +39,8 @@
     }
   },
   "ReleaseApproval": {
-    "PublishReleasesCronSchedule": "0 0-58/2 * * * *",
-    "PublishReleaseContentCronSchedule": "0 1-59/2 * * * *"
+    "StageScheduledReleasesFunctionCronSchedule": "0 0-58/2 * * * *",
+    "PublishScheduledReleasesFunctionCronSchedule": "0 1-59/2 * * * *"
   },
   "PublicApp": {
     "Url": "http://localhost:3000"

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingServiceTests.cs
@@ -411,8 +411,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 PublicStorageConnectionString = PublicStorageConnectionString,
                 NotifierStorageConnectionString = string.Empty,
                 PublisherStorageConnectionString = string.Empty,
-                PublishReleaseContentCronSchedule = string.Empty,
-                PublishReleasesCronSchedule = string.Empty
+                PublishScheduledReleasesFunctionCronSchedule = string.Empty,
+                StageScheduledReleasesFunctionCronSchedule = string.Empty
             }.ToOptionsWrapper();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishScheduledReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishScheduledReleasesFunction.cs
@@ -31,7 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         /// <returns></returns>
         [Function(nameof(PublishScheduledReleases))]
         public async Task PublishScheduledReleases(
-            [TimerTrigger("%App:PublishReleaseContentCronSchedule%")] TimerInfo timer,
+            [TimerTrigger("%App:PublishScheduledReleasesFunctionCronSchedule%")] TimerInfo timer,
             FunctionContext context)
         {
             logger.LogInformation("{FunctionName} triggered", context.FunctionDefinition.Name);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/StageReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/StageReleaseContentFunction.cs
@@ -47,11 +47,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             try
             {
                 var nextScheduledPublishingTime = CronExpressionUtil.GetNextOccurrence(
-                    cronExpression: _appOptions.PublishReleaseContentCronSchedule,
+                    cronExpression: _appOptions.PublishScheduledReleasesFunctionCronSchedule,
                     from: now,
                     timeZone
                 ) ?? throw new CronNoFutureOccurrenceException(
-                    cronExpression: _appOptions.PublishReleaseContentCronSchedule,
+                    cronExpression: _appOptions.PublishScheduledReleasesFunctionCronSchedule,
                     from: now,
                     timeZone);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/StageScheduledReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/StageScheduledReleasesFunction.cs
@@ -36,7 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         /// <param name="context"></param>
         [Function(nameof(StageScheduledReleases))]
         public async Task StageScheduledReleases(
-            [TimerTrigger("%App:PublishReleasesCronSchedule%")] TimerInfo timer,
+            [TimerTrigger("%App:StageScheduledReleasesFunctionCronSchedule%")] TimerInfo timer,
             FunctionContext context)
         {
             logger.LogInformation("{FunctionName} triggered", context.FunctionDefinition.Name);
@@ -46,11 +46,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 
             // Get the next scheduled publishing time using the cron expression of the PublishScheduledReleases function
             var nextScheduledPublishingTime = CronExpressionUtil.GetNextOccurrence(
-                cronExpression: _appOptions.PublishReleaseContentCronSchedule,
+                cronExpression: _appOptions.PublishScheduledReleasesFunctionCronSchedule,
                 from: now,
                 timeZone
             ) ?? throw new CronNoFutureOccurrenceException(
-                cronExpression: _appOptions.PublishReleaseContentCronSchedule,
+                cronExpression: _appOptions.PublishScheduledReleasesFunctionCronSchedule,
                 from: now,
                 timeZone);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Options/AppOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Options/AppOptions.cs
@@ -12,7 +12,7 @@ public class AppOptions
 
     public required string PublisherStorageConnectionString { get; init; }
 
-    public required string PublishReleaseContentCronSchedule { get; init; }
+    public required string PublishScheduledReleasesFunctionCronSchedule { get; init; }
 
-    public required string PublishReleasesCronSchedule { get; init; }
+    public required string StageScheduledReleasesFunctionCronSchedule { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/local.settings.json
@@ -4,8 +4,8 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://data-storage",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "WEBSITE_TIME_ZONE": "Europe/London",
-    "App:PublishReleasesCronSchedule": "0 0-58/2 * * * *",
-    "App:PublishReleaseContentCronSchedule": "0 1-59/2 * * * *"
+    "App:StageScheduledReleasesFunctionCronSchedule": "0 0-58/2 * * * *",
+    "App:PublishScheduledReleasesFunctionCronSchedule": "0 1-59/2 * * * *"
   },
   "ConnectionStrings": {
     "ContentDb": "Server=db;Database=content;User=publisher;Password=Your_Password123;TrustServerCertificate=True;",


### PR DESCRIPTION
This PR renames the Publisher app settings used to control the schedule of Cron triggered functions to match the function names.
The functions have been renamed in the past but the app settings and the definitions of those settings in the infrastructure have not caught up, and this is causing confusion.

- `PublishReleasesCronSchedule` is renamed to `StageScheduledReleasesFunctionCronSchedule`.
- `PublishReleaseContentCronSchedule` is renamed to `PublishScheduledReleasesFunctionCronSchedule`.

