### PR TITLE
EES-6103 Subscribe Search Function App to publication archived events

### DIFF
--- a/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
@@ -18,6 +18,11 @@ var eventGridCustomTopicSubscriptions = [
     topicName: eventTopics.publicationChanged
     subscriptions: [
       {
+        name: 'publication-archived'
+        includedEventTypes: ['publication-archived']
+        queueName: storageQueueNames.publicationArchived
+      }
+      {
         name: 'publication-changed'
         includedEventTypes: ['publication-changed']
         queueName: storageQueueNames.publicationChanged

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationArchived/OnPublicationArchivedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationArchived/OnPublicationArchivedFunctionTests.cs
@@ -32,7 +32,7 @@ public class OnPublicationArchivedFunctionTests
     [InlineData("")]
     public async Task GivenEvent_WhenPayloadDoesNotContainSlug_ThenNothingIsReturned(string? blankSlug)
     {
-        var payload = new PublicationArchivedEventDto { Slug = blankSlug };
+        var payload = new PublicationArchivedEventDto { PublicationSlug = blankSlug };
         var eventGridEvent = new EventGridEventBuilder().WithPayload(payload).Build();
 
         var response = await GetSut().OnPublicationArchived(eventGridEvent, new FunctionContextMockBuilder().Build());

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationArchived/OnPublicationArchivedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationArchived/OnPublicationArchivedFunctionTests.cs
@@ -1,6 +1,5 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationArchived;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationArchived.Dtos;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationChanged.Dtos;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -16,15 +15,15 @@ public class OnPublicationArchivedFunctionTests
     public void CanInstantiateSut() => Assert.NotNull(GetSut());
 
     [Fact]
-    public async Task GivenEvent_WhenPayloadContainsSlug_ReturnsExpectedDto()
+    public async Task GivenEvent_WhenPayloadContainsPublicationSlug_ReturnsExpectedDto()
     {
-        var payload = new PublicationChangedEventDto { Slug = "publication-slug" };
+        var payload = new PublicationArchivedEventDto { PublicationSlug = "publication-slug" };
         var eventGridEvent = new EventGridEventBuilder().WithPayload(payload).Build();
 
         var response = await GetSut().OnPublicationArchived(eventGridEvent, new FunctionContextMockBuilder().Build());
 
         var actual = Assert.Single(response);
-        Assert.Equal(payload.Slug, actual.PublicationSlug);
+        Assert.Equal(payload.PublicationSlug, actual.PublicationSlug);
     }
 
     [Theory]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationArchived/Dtos/PublicationArchivedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationArchived/Dtos/PublicationArchivedEventDto.cs
@@ -2,5 +2,7 @@
 
 public class PublicationArchivedEventDto
 {
-    public string? Slug { get; init; }
+    public Guid? SupersededByPublicationId { get; init; }
+
+    public string? PublicationSlug { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationArchived/OnPublicationArchivedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationArchived/OnPublicationArchivedFunction.cs
@@ -18,7 +18,7 @@ public class OnPublicationArchivedFunction(IEventGridEventHandler eventGridEvent
             eventDto,
             (payload, _) =>
                 Task.FromResult<RemovePublicationSearchableDocumentsDto[]>(
-                    string.IsNullOrEmpty(payload.Slug)
+                    string.IsNullOrEmpty(payload.PublicationSlug)
                         ? []
-                        : [new RemovePublicationSearchableDocumentsDto { PublicationSlug = payload.Slug }]));
+                        : [new RemovePublicationSearchableDocumentsDto { PublicationSlug = payload.PublicationSlug }]));
 }


### PR DESCRIPTION
This PR adds in the configuration to subscribe the Search Function App to publication archived events. This was missed from https://github.com/dfe-analytical-services/explore-education-statistics/pull/5808 which added the function and the storage queue but did not subscribe the function via the queue.

### Other changes

- Rename `Slug` to `PublicationSlug` in `PublicationArchivedEventDto` for clarity. Add `PreviousSupersededByPublicationId` and `NewSupersededByPublicationId` as extra information which will be in the event payload.
- Correct unit test `GivenEvent_WhenPayloadContainsSlug_ReturnsExpectedDto` to use `PublicationArchivedEventDto` instead of `PublicationChangedEventDto`.