### PR TITLE
EES-6047 Ensure canonical links are on all pages

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 
 export interface PageMetaProps {
   includeDefaultMetaTitle?: boolean;
+  canonicalPathOverride?: string;
   title?: string;
   description?: string;
   imgUrl?: string;
@@ -12,10 +14,20 @@ const defaultPageTitle = 'Explore education statistics - GOV.UK';
 
 const PageMeta = ({
   includeDefaultMetaTitle = true,
+  canonicalPathOverride,
   title = defaultPageTitle,
   description = 'Find, download and explore official Department for Education (DfE) statistics and data in England.',
   imgUrl,
 }: PageMetaProps) => {
+  // Generate canonical link
+  const router = useRouter();
+  const { asPath } = router; // Full path including query params
+  const url = new URL(asPath, process.env.PUBLIC_URL);
+  const pageParam = url.searchParams.get('page');
+  url.hash = '';
+  url.search = pageParam ? `page=${pageParam}` : '';
+  const canonicalLink = url.toString();
+
   return (
     <Head>
       {/* <!-- Primary Meta Tags --> */}
@@ -30,6 +42,16 @@ const PageMeta = ({
       <meta
         name="google-site-verification"
         content="jWf4Mg_pzTOgXDWccGcv9stMsdyptYwHeVpODHdesoY"
+      />
+
+      <link
+        rel="canonical"
+        href={
+          canonicalPathOverride
+            ? `${process.env.PUBLIC_URL}${canonicalPathOverride}`
+            : canonicalLink
+        }
+        key="canonical"
       />
 
       {process.env.APP_ENV !== 'Production' && (

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
@@ -49,7 +49,6 @@ import { logEvent } from '@frontend/services/googleAnalyticsService';
 import compact from 'lodash/compact';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
 import {
@@ -290,13 +289,6 @@ const DataCataloguePage: NextPage<Props> = ({ showTypeFilter }) => {
       includeDefaultMetaTitle={pageTitle === defaultPageTitle}
       metaTitle={pageTitle}
     >
-      <Head>
-        <link
-          rel="canonical"
-          href={`${process.env.PUBLIC_URL}data-catalogue`}
-          key="canonical"
-        />
-      </Head>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <p className="govuk-body-l">


### PR DESCRIPTION
- Remove hardcoded `data-catalogue` canonical link.
- Ensure canonical links are on all pages
- Ensure canonical links respect paginated pages, but ignore other query params.

The canonical path is generated automatically from the next router path, with all query params except for `page` stripped out.

I've left in the potential to override the canonical link as a prop on page meta, in case this functionality is useful or needed in future.