### PR TITLE
EES-5977 Fix Content API

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1593,6 +1593,7 @@
       "properties": {
         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('microsoft.insights/components/', variables('contentAppInsights')), '2020-02-02').InstrumentationKey]",
         "WEBSITE_NODE_DEFAULT_VERSION": "20.16.0",
+        "WEBSITE_CONTENTOVERVNET": "1",
         "WEBSITE_RUN_FROM_PACKAGE": "1",
         "PublicStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-public'), '2018-02-14').secretUriWithVersion, ')')]",
         "enableSwagger": "[parameters('enableSwagger')]",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -200,7 +200,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
                     services.AddSingleton<IAnalyticsPathResolver, AnalyticsPathResolver>();
                 }
 
-                services.AddSingleton<IAnalyticsWriteStrategy, AnalyticsWritePublicZipDownloadStrategy>();
+                services.AddSingleton<AnalyticsWritePublicZipDownloadStrategy>();
 
                 services.AddSingleton<IDictionary<Type, IAnalyticsWriteStrategy>>(provider =>
                     new Dictionary<Type, IAnalyticsWriteStrategy>


### PR DESCRIPTION
This PR fixes two things:

- The Content API's Startup.cs
- Sets WEBSITE_CONTENTOVERVNET to 1 for the Content App service. We needed to set this as otherwise the the Content API couldn't mount the analytics file share. (Solved by Dunc who also had the same error a while back related to the publisher.)