### PR TITLE
EES-6064 Partially revert time zone change made by #5831

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -587,9 +587,9 @@
     },
     "publisherFunctionAppTimeZone": {
       "type": "string",
-      "defaultValue": "Europe/London",
+      "defaultValue": "GMT Standard Time",
       "metadata": {
-        "description": "The time zone of the Publisher Function App. This time zone is used for evaluating Cron expressions of the functions running with Cron triggers and altering it will change the time of execution of these functions."
+        "description": "The time zone of the Publisher Function App. This time zone is used for evaluating Cron expressions of the functions running with Cron triggers and altering it will change the time of execution of these functions. The name of this time zone depends on the operating system and plan on which the function app runs."
       }
     },
     "branch": {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/local.settings.json
@@ -3,7 +3,7 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://data-storage",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "WEBSITE_TIME_ZONE": "Europe/London",
+    "WEBSITE_TIME_ZONE": "GMT Standard Time",
     "App:StageScheduledReleasesFunctionCronSchedule": "0 0-58/2 * * * *",
     "App:PublishScheduledReleasesFunctionCronSchedule": "0 1-59/2 * * * *"
   },


### PR DESCRIPTION
This PR partially reverts the changes made in https://github.com/dfe-analytical-services/explore-education-statistics/pull/5831 commit d404c28.

The `WEBSITE_TIME_ZONE` value needs to be a Windows time zone Id when running on Windows operating system as per the documentation for [WEBSITE_TIME_ZONE](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#website_time_zone).

The ability to use Windows time zone id's and IANA/TZ time zone id's interchangeably is possible since .NET6 , for example, `TimeZoneInfo.FindSystemTimeZoneById("Europe/London")` will now return the same time zone as `TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time")` on Windows, but this benefit doesn't apply to the function app environment setting here.