### PR TITLE
EES-6052 fix updated footnotes in datablocks in admin release content

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -20,6 +20,7 @@ export interface DataBlockTabsProps {
     | ((props: { dataBlock: DataBlock }) => ReactNode)
     | ReactNode;
   dataBlock: DataBlock;
+  dataBlockStaleTime?: number;
   firstTabs?: ReactNode;
   lastTabs?: ReactNode;
   getInfographic?: GetInfographic;
@@ -31,6 +32,7 @@ export interface DataBlockTabsProps {
 const DataBlockTabs = ({
   additionalTabContent,
   dataBlock,
+  dataBlockStaleTime,
   firstTabs,
   lastTabs,
   getInfographic,
@@ -47,6 +49,7 @@ const DataBlockTabs = ({
     isGeoJsonInitialLoading,
   } = useDataBlock({
     dataBlock,
+    dataBlockStaleTime,
     releaseVersionId,
     getInfographic,
   });

--- a/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useDataBlock.ts
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useDataBlock.ts
@@ -11,14 +11,16 @@ import { useCallback, useMemo, useState } from 'react';
 
 interface Options {
   dataBlock: Pick<DataBlock, 'id' | 'charts' | 'query' | 'dataBlockParentId'>;
-  releaseVersionId: string;
+  dataBlockStaleTime?: number;
   getInfographic?: GetInfographic;
+  releaseVersionId: string;
 }
 
 export default function useDataBlock({
   dataBlock,
-  releaseVersionId,
+  dataBlockStaleTime,
   getInfographic,
+  releaseVersionId,
 }: Options) {
   const getChartFile = useGetReleaseFile(releaseVersionId);
   const queryClient = useQueryClient();
@@ -39,7 +41,7 @@ export default function useDataBlock({
       releaseVersionId,
       dataBlock.dataBlockParentId,
     ),
-    staleTime: Infinity,
+    staleTime: dataBlockStaleTime,
   });
 
   const {

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationReleaseHeadlinesSection.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationReleaseHeadlinesSection.tsx
@@ -84,6 +84,7 @@ const PublicationReleaseHeadlinesSection = ({
       releaseVersionId={releaseVersionId}
       getInfographic={getReleaseFile}
       dataBlock={keyStatisticsSecondarySection.content[0]}
+      dataBlockStaleTime={Infinity}
       firstTabs={summaryTab}
     />
   );

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
@@ -47,6 +47,7 @@ const PublicationSectionBlocks = ({
             <Gate condition={!!visible} key={block.id}>
               <DataBlockTabs
                 dataBlock={block}
+                dataBlockStaleTime={Infinity}
                 releaseVersionId={releaseVersion.id}
                 getInfographic={getReleaseFile}
                 onToggle={section => {

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -317,9 +317,6 @@ Navigate to release content page
 Check updated footnote is displayed in release content page
     [Documentation]    EES-3136
 
-    # EES-6052 - remove page reload below once the bug in EES-6052 is fixed.
-    user reloads page
-
     user clicks button    Test data block section
     ${section}=    user gets accordion section content element    Test data block section
     ...    //*[@data-testid="editableAccordionSection"]


### PR DESCRIPTION
Fixes a bug in the admin where if you updated a footnote included in a data block embedded in a release, then went back to the release content tab, the footnote would not be updated unless you refreshed the page. This was caused by the `staleTime` being set to `Infinity` which prevented the data block from being refetched. I've changed it so the `staleTime` is only set for data blocks in the public frontend.