### PR TITLE
EES-6108 Changes to the Azure Search index to support frontend development

### DIFF
--- a/infrastructure/templates/search/application/indexes/index-1.json
+++ b/infrastructure/templates/search/application/indexes/index-1.json
@@ -1,5 +1,7 @@
 {
   "name": "index-1",
+  "analyzers": [],
+  "charFilters": [],
   "defaultScoringProfile": "scoring-profile-1",
   "fields": [
     {
@@ -271,14 +273,6 @@
       "functions": []
     }
   ],
-  "suggesters": [],
-  "analyzers": [],
-  "tokenizers": [],
-  "tokenFilters": [],
-  "charFilters": [],
-  "similarity": {
-    "@odata.type": "#Microsoft.Azure.Search.BM25Similarity"
-  },
   "semantic": {
     "configurations": [
       {
@@ -303,5 +297,10 @@
         }
       }
     ]
-  }
+  },
+  "similarity": {
+    "@odata.type": "#Microsoft.Azure.Search.BM25Similarity"
+  },
+  "tokenFilters": [],
+  "tokenizers": []
 }

--- a/infrastructure/templates/search/application/indexes/index-1.json
+++ b/infrastructure/templates/search/application/indexes/index-1.json
@@ -2,6 +2,13 @@
   "name": "index-1",
   "analyzers": [],
   "charFilters": [],
+  "corsOptions": {
+    "allowedOrigins": [
+      "http://localhost:3000",
+      "https://localhost:3000"
+    ],
+    "maxAgeInSeconds": 300
+  },
   "defaultScoringProfile": "scoring-profile-1",
   "fields": [
     {
@@ -301,6 +308,16 @@
   "similarity": {
     "@odata.type": "#Microsoft.Azure.Search.BM25Similarity"
   },
+  "suggesters": [
+    {
+      "name": "suggester-1",
+      "searchMode": "analyzingInfixMatching",
+      "sourceFields": [
+        "title",
+        "summary"
+      ]
+    }
+  ],
   "tokenFilters": [],
   "tokenizers": []
 }


### PR DESCRIPTION
This PR makes a couple of changes to the Azure Search Index config to support the local frontend development of the new search feature.

- Add CORS config to allow CORS preflight requests from localhost.
- Add Suggester config to provide the autocomplete and suggestions.

Documentation for both can be found in [Create Index](https://learn.microsoft.com/en-us/rest/api/searchservice/create-index) and [Configure a suggester for autocomplete and suggestions in a query](https://learn.microsoft.com/en-us/azure/search/index-add-suggesters).


### Other changes

- Reorder the top level keys in the json into alphabetical order.