### PR TITLE
EES-6105 Raise an event in Admin when publications are archived

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserMockBuilder.cs
@@ -14,12 +14,27 @@ public class AdminEventRaiserMockBuilder
 {
     private readonly Mock<IAdminEventRaiser> _mock = new(MockBehavior.Strict);
     private readonly List<InvokeArguments> _invocations = new();
-    private static readonly Expression<Func<IAdminEventRaiser, Task>> OnReleaseSlugChanged =  
+
+    private static readonly Expression<Func<IAdminEventRaiser, Task>> OnReleaseSlugChanged =
         m => m.OnReleaseSlugChanged(
-            It.IsAny<Guid>(), 
-            It.IsAny<string>(), 
-            It.IsAny<Guid>(), 
+            It.IsAny<Guid>(),
+            It.IsAny<string>(),
+            It.IsAny<Guid>(),
             It.IsAny<string>());
+
+    private static readonly Expression<Func<IAdminEventRaiser, Task>> OnPublicationArchived =
+        m => m.OnPublicationArchived(
+            It.IsAny<Guid>(),
+            It.IsAny<string>(),
+            It.IsAny<Guid>());
+
+    private static readonly Expression<Func<IAdminEventRaiser, Task>> OnPublicationChanged =
+        m => m.OnPublicationChanged(It.IsAny<Publication>());
+
+    private static readonly Expression<Func<IAdminEventRaiser, Task>> OnPublicationLatestPublishedReleaseReordered =
+        m => m.OnPublicationLatestPublishedReleaseReordered(
+            It.IsAny<Publication>(),
+            It.IsAny<Guid>());
 
     public IAdminEventRaiser Build() => _mock.Object;
 
@@ -28,78 +43,103 @@ public class AdminEventRaiserMockBuilder
         _mock
             .Setup(m => m.OnThemeUpdated(It.IsAny<Theme>()))
             .Returns(Task.CompletedTask);
-        
+
         _mock
             .Setup(OnReleaseSlugChanged)
             .Returns(Task.CompletedTask);
-        
+
         _mock
-            .Setup(m => m.OnPublicationChanged(It.IsAny<Publication>()))
+            .Setup(OnPublicationArchived)
             .Returns(Task.CompletedTask);
-        
+
+        _mock
+            .Setup(OnPublicationChanged)
+            .Returns(Task.CompletedTask);
+
         _mock
             .Setup(m => m.OnPublicationLatestPublishedReleaseReordered(
                 It.IsAny<Publication>(),
                 It.IsAny<Guid>()))
-            .Callback((Publication publication, Guid oldLatestPublishedReleaseVersionId) => 
+            .Callback((Publication publication, Guid oldLatestPublishedReleaseVersionId) =>
                 _invocations
                     .Add(new InvokeArguments(publication, oldLatestPublishedReleaseVersionId)))
             .Returns(Task.CompletedTask);
     }
 
     private record InvokeArguments(Publication Publication, Guid OldLatestPublishedReleaseVersionId);
-    
+
     public class Asserter(AdminEventRaiserMockBuilder mockBuilder)
     {
-        public void ThatOnThemeUpdatedRaised(Func<Theme, bool>? predicate = null) => 
-            mockBuilder._mock.Verify(m => m.OnThemeUpdated(It.Is<Theme>(t => predicate == null || predicate(t))), Times.Once);
+        public void ThatOnThemeUpdatedRaised(Func<Theme, bool>? predicate = null) =>
+            mockBuilder._mock.Verify(m => m.OnThemeUpdated(It.Is<Theme>(t => predicate == null || predicate(t))),
+                Times.Once);
 
         public void OnReleaseSlugChangedWasRaised(
             Guid? expectedReleaseId = null,
             string? expectedNewReleaseSlug = null,
             Guid? expectedPublicationId = null,
-            string? expectedPublicationSlug = null) => 
+            string? expectedPublicationSlug = null) =>
             mockBuilder._mock.Verify(m => m.OnReleaseSlugChanged(
-                It.Is<Guid>(releaseId => expectedReleaseId == null || releaseId == expectedReleaseId), 
-                It.Is<string>(newReleaseSlug => expectedNewReleaseSlug == null || newReleaseSlug == expectedNewReleaseSlug), 
-                It.Is<Guid>(publicationId => expectedPublicationId == null || publicationId == expectedPublicationId), 
-                It.Is<string>(publicationSlug => expectedPublicationSlug == null || publicationSlug == expectedPublicationSlug)),
+                    It.Is<Guid>(releaseId => expectedReleaseId == null || releaseId == expectedReleaseId),
+                    It.Is<string>(newReleaseSlug =>
+                        expectedNewReleaseSlug == null || newReleaseSlug == expectedNewReleaseSlug),
+                    It.Is<Guid>(
+                        publicationId => expectedPublicationId == null || publicationId == expectedPublicationId),
+                    It.Is<string>(publicationSlug =>
+                        expectedPublicationSlug == null || publicationSlug == expectedPublicationSlug)),
                 Times.Once);
 
-        public void OnReleaseSlugChangedWasNotRaised() => 
+        public void OnReleaseSlugChangedWasNotRaised() =>
             mockBuilder._mock.Verify(OnReleaseSlugChanged, Times.Never);
 
+        public void OnPublicationArchivedWasRaised(
+            Guid? publicationId = null,
+            string? publicationSlug = null,
+            Guid? supersededByPublicationId = null) =>
+            mockBuilder._mock.Verify(m => m.OnPublicationArchived(
+                    It.Is<Guid>(actual => publicationId == null || actual == publicationId),
+                    It.Is<string>(actual => publicationSlug == null || actual == publicationSlug),
+                    It.Is<Guid>(actual => supersededByPublicationId == null || actual == supersededByPublicationId)),
+                Times.Once);
+
+        private void OnPublicationArchivedWasNotRaised() =>
+            mockBuilder._mock.Verify(OnPublicationArchived, Times.Never);
+
         public void OnPublicationChangedWasRaised(Publication? publication = null) =>
-            mockBuilder._mock.Verify(m => m.OnPublicationChanged(It.Is<Publication>(p => 
-                publication == null 
-                || new PublicationChangedEvent(p) == new PublicationChangedEvent(publication))), Times.Once);
+            mockBuilder._mock.Verify(m => m.OnPublicationChanged(It.Is<Publication>(p =>
+                    publication == null || new PublicationChangedEvent(p) == new PublicationChangedEvent(publication))),
+                Times.Once);
+
+        private void OnPublicationChangedWasNotRaised() =>
+            mockBuilder._mock.Verify(OnPublicationChanged, Times.Never);
 
         public void OnPublicationLatestPublishedReleaseReorderedWasRaised(
             Publication publication,
             Guid previousReleaseVersionId)
         {
             var expectedEvent = new PublicationLatestPublishedReleaseReorderedEvent(
-                publication, 
+                publication,
                 previousReleaseVersionId);
 
             Xunit.Assert.Single(
-                mockBuilder._invocations, 
+                mockBuilder._invocations,
                 inv =>
                     new PublicationLatestPublishedReleaseReorderedEvent(
                         inv.Publication,
                         inv.OldLatestPublishedReleaseVersionId)
                     == expectedEvent);
         }
-            
 
-        public void OnPublicationChangedWasNotRaised()
+        private void OnPublicationLatestPublishedReleaseReorderedWasNotRaised() =>
+            mockBuilder._mock.Verify(OnPublicationLatestPublishedReleaseReordered, Times.Never);
+
+        public void AssertOnPublicationChangedEventsNotRaised()
         {
-            mockBuilder._mock.Verify(m => m.OnPublicationChanged(It.IsAny<Publication>()), Times.Never);
-            mockBuilder._mock.Verify(m => m.OnPublicationLatestPublishedReleaseReordered(
-                It.IsAny<Publication>(),
-                It.IsAny<Guid>()), 
-                Times.Never);
+            OnPublicationArchivedWasNotRaised();
+            OnPublicationChangedWasNotRaised();
+            OnPublicationLatestPublishedReleaseReorderedWasNotRaised();
         }
     }
+
     public Asserter Assert => new(this);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserMockBuilder.cs
@@ -78,15 +78,12 @@ public class AdminEventRaiserMockBuilder
             Guid? expectedReleaseId = null,
             string? expectedNewReleaseSlug = null,
             Guid? expectedPublicationId = null,
-            string? expectedPublicationSlug = null) =>
+            string? expectedPublicationSlug = null) => 
             mockBuilder._mock.Verify(m => m.OnReleaseSlugChanged(
-                    It.Is<Guid>(releaseId => expectedReleaseId == null || releaseId == expectedReleaseId),
-                    It.Is<string>(newReleaseSlug =>
-                        expectedNewReleaseSlug == null || newReleaseSlug == expectedNewReleaseSlug),
-                    It.Is<Guid>(
-                        publicationId => expectedPublicationId == null || publicationId == expectedPublicationId),
-                    It.Is<string>(publicationSlug =>
-                        expectedPublicationSlug == null || publicationSlug == expectedPublicationSlug)),
+                    It.Is<Guid>(releaseId => expectedReleaseId == null || releaseId == expectedReleaseId), 
+                    It.Is<string>(newReleaseSlug => expectedNewReleaseSlug == null || newReleaseSlug == expectedNewReleaseSlug), 
+                    It.Is<Guid>(publicationId => expectedPublicationId == null || publicationId == expectedPublicationId), 
+                    It.Is<string>(publicationSlug => expectedPublicationSlug == null || publicationSlug == expectedPublicationSlug)),
                 Times.Once);
 
         public void OnReleaseSlugChangedWasNotRaised() =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/PublicationCacheServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/PublicationCacheServiceMockBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
@@ -15,8 +16,18 @@ public class PublicationCacheServiceMockBuilder
     {
         _mock
             .Setup(m => m.UpdatePublication(It.IsAny<string>()))
-            .ReturnsAsync((string slug) => (Either<ActionResult, PublicationCacheViewModel>)new PublicationCacheViewModel { Slug = slug });
+            .ReturnsAsync((string slug) =>
+                (Either<ActionResult, PublicationCacheViewModel>)new PublicationCacheViewModel { Slug = slug });
+
+        _mock
+            .Setup(m => m.UpdatePublicationTree())
+            .ReturnsAsync([]);
+
+        _mock
+            .Setup(m => m.RemovePublication(It.IsAny<string>()))
+            .ReturnsAsync(Unit.Instance);
     }
+
     public IPublicationCacheService Build() => _mock.Object;
 
     public PublicationCacheServiceMockBuilder WhereInvalidatingPublicationThrows(string? publicationSlug = null)
@@ -27,7 +38,7 @@ public class PublicationCacheServiceMockBuilder
             .Throws((string slug) => new Exception("This is a mock exception: UpdatePublication: " + slug));
         return this;
     }
-    
+
     public PublicationCacheServiceMockBuilder WhereInvalidatingPublicationFails(string? publicationSlug = null)
     {
         _mock
@@ -38,18 +49,37 @@ public class PublicationCacheServiceMockBuilder
     }
 
     public Asserter Assert => new(_mock);
+
     public class Asserter(Mock<IPublicationCacheService> mock)
     {
-        public void CacheInvalidatedForPublicationSlug(string publicationSlug) => 
+        public void CacheInvalidatedForPublicationAndReleases(string publicationSlug) =>
+            mock
+                .Verify(
+                    m => m.RemovePublication(It.Is<string>(actual => actual == publicationSlug)),
+                    Times.Once);
+
+        public void CacheNotInvalidatedForPublicationAndReleases(string publicationSlug) =>
+            mock
+                .Verify(
+                    m => m.RemovePublication(It.Is<string>(actual => actual == publicationSlug)),
+                    Times.Never);
+
+        public void CacheInvalidatedForPublicationEntry(string publicationSlug) =>
             mock
                 .Verify(
                     m => m.UpdatePublication(It.Is<string>(actual => actual == publicationSlug)),
                     Times.Once);
-        
-        public void CacheNotInvalidatedForPublicationSlug(string publicationSlug) => 
+
+        public void CacheNotInvalidatedForPublicationEntry(string publicationSlug) =>
             mock
                 .Verify(
                     m => m.UpdatePublication(It.Is<string>(actual => actual == publicationSlug)),
                     Times.Never);
+
+        public void CacheInvalidatedForPublicationTree() =>
+            mock.Verify(m => m.UpdatePublicationTree(), Times.Once);
+
+        public void CacheNotInvalidatedForPublicationTree() =>
+            mock.Verify(m => m.UpdatePublicationTree(), Times.Never);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Events;
@@ -33,7 +34,7 @@ public class AdminEventRaiserTests
         var expectedEvent = new ThemeChangedEvent(theme);
         _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
     }
-    
+
     [Fact]
     public async Task WhenOnReleaseSlugChanged_ThenEventPublished()
     {
@@ -42,7 +43,7 @@ public class AdminEventRaiserTests
         var newReleaseSlug = "new-release-slug";
         var publicationId = Guid.NewGuid();
         var publicationSlug = "publication-slug";
-        
+
         var sut = GetSut();
 
         // ACT
@@ -60,7 +61,31 @@ public class AdminEventRaiserTests
             publicationSlug);
         _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
     }
-    
+
+    [Fact]
+    public async Task WhenOnPublicationArchived_ThenEventPublished()
+    {
+        // ARRANGE
+        var publicationId = Guid.NewGuid();
+        const string publicationSlug = "publication-slug";
+        var supersededByPublicationId = Guid.NewGuid();
+
+        var sut = GetSut();
+
+        // ACT
+        await sut.OnPublicationArchived(
+            publicationId,
+            publicationSlug,
+            supersededByPublicationId);
+
+        // ASSERT
+        var expectedEvent = new PublicationArchivedEvent(
+            publicationId,
+            publicationSlug,
+            supersededByPublicationId);
+        _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
+    }
+
     [Fact]
     public async Task WhenOnPublicationChanged_ThenEventPublished()
     {
@@ -72,7 +97,7 @@ public class AdminEventRaiserTests
             Summary = "This is the publication summary",
             Slug = "publication-slug"
         };
-        
+
         var sut = GetSut();
 
         // ACT
@@ -82,7 +107,7 @@ public class AdminEventRaiserTests
         var expectedEvent = new PublicationChangedEvent(publication);
         _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
     }
-    
+
     [Fact]
     public async Task WhenOnPublicationLatestPublishedReleaseReordered_ThenEventPublished()
     {
@@ -96,23 +121,24 @@ public class AdminEventRaiserTests
             LatestPublishedReleaseVersionId = Guid.NewGuid()
         };
         var previousLatestPublishedReleaseVersionId = Guid.NewGuid();
-        
+
         var sut = GetSut();
 
         // ACT
         await sut.OnPublicationLatestPublishedReleaseReordered(
-            publication, 
+            publication,
             previousLatestPublishedReleaseVersionId);
 
         // ASSERT
         var expectedEvent = new PublicationLatestPublishedReleaseReorderedEvent(
-            publication, 
+            publication,
             previousLatestPublishedReleaseVersionId);
         _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
     }
-    
+
     [Fact]
-    public async Task GivenPublicationLatestPublishedReleaseVersionIdIsNull_WhenOnPublicationLatestPublishedReleaseReordered_ThenNoEventPublished()
+    public async Task
+        GivenPublicationLatestPublishedReleaseVersionIdIsNull_WhenOnPublicationLatestPublishedReleaseReordered_ThenNoEventPublished()
     {
         // ARRANGE
         var publication = new Publication
@@ -124,12 +150,12 @@ public class AdminEventRaiserTests
             LatestPublishedReleaseVersionId = null
         };
         var previousLatestPublishedReleaseVersionId = Guid.NewGuid();
-        
+
         var sut = GetSut();
 
         // ACT
         await sut.OnPublicationLatestPublishedReleaseReordered(
-            publication, 
+            publication,
             previousLatestPublishedReleaseVersionId);
 
         // ASSERT

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -949,52 +949,31 @@ public class PublicationServiceTests
     [Fact]
     public async Task UpdatePublication_NotPublished()
     {
-        var theme = new Theme
-        {
-            Title = "New theme",
-        };
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithTheme(_dataFixture.DefaultTheme());
 
-        var publication = new Publication
-        {
-            Title = "Old title",
-            Summary = "Old summary",
-            Slug = "old-slug",
-            Theme = new Theme
-            {
-                Title = "Old theme"
-            },
-            Contact = new Contact
-            {
-                ContactName = "Old name",
-                ContactTelNo = "0987654321",
-                TeamName = "Old team",
-                TeamEmail = "old.smith@test.com",
-            },
-            SupersededById = Guid.NewGuid(),
-        };
+        Theme otherTheme = _dataFixture.DefaultTheme();
 
         var contextId = Guid.NewGuid().ToString();
-
         await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            context.Add(theme);
-            context.Add(publication);
-
+            context.Publications.Add(publication);
+            context.Themes.Add(otherTheme);
             await context.SaveChangesAsync();
         }
 
-        var newSupersededById = Guid.NewGuid();
+        var methodologyService = new Mock<IMethodologyService>(Strict);
+        methodologyService
+            .Setup(s => s.PublicationTitleOrSlugChanged(
+                publication.Id,
+                publication.Slug,
+                "New title",
+                "new-title"))
+            .Returns(Task.CompletedTask);
+
         await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            var methodologyService = new Mock<IMethodologyService>(Strict);
-            methodologyService
-                .Setup(s => s.PublicationTitleOrSlugChanged(
-                    publication.Id,
-                    publication.Slug,
-                    "New title",
-                    "new-title"))
-                .Returns(Task.CompletedTask);
-
             var publicationService = BuildPublicationService(context,
                 methodologyService: methodologyService.Object);
 
@@ -1004,9 +983,10 @@ public class PublicationServiceTests
                 new PublicationSaveRequest
                 {
                     Title = "New title",
+                    Slug = "new-title",
                     Summary = "New summary",
-                    ThemeId = theme.Id,
-                    SupersededById = newSupersededById,
+                    ThemeId = otherTheme.Id,
+                    SupersededById = null
                 }
             );
 
@@ -1017,10 +997,10 @@ public class PublicationServiceTests
             Assert.Equal("New title", viewModel.Title);
             Assert.Equal("New summary", viewModel.Summary);
 
-            Assert.Equal(theme.Id, viewModel.Theme.Id);
-            Assert.Equal(theme.Title, viewModel.Theme.Title);
+            Assert.Equal(otherTheme.Id, viewModel.Theme.Id);
+            Assert.Equal(otherTheme.Title, viewModel.Theme.Title);
 
-            Assert.Equal(newSupersededById, viewModel.SupersededById);
+            Assert.Null(viewModel.SupersededById);
         }
 
         await using (var context = InMemoryApplicationDbContext(contextId))
@@ -1028,117 +1008,74 @@ public class PublicationServiceTests
             var updatedPublication = await context.Publications
                 .Include(p => p.Contact)
                 .Include(p => p.Theme)
-                .SingleAsync(p => p.Title == "New title");
+                .SingleAsync(p => p.Id == publication.Id);
 
             Assert.False(updatedPublication.Live);
             updatedPublication.Updated.AssertUtcNow();
             Assert.Equal("new-title", updatedPublication.Slug);
             Assert.Equal("New title", updatedPublication.Title);
-            Assert.Equal(newSupersededById, updatedPublication.SupersededById);
+            Assert.Null(updatedPublication.SupersededById);
 
-            Assert.Equal("Old name", updatedPublication.Contact.ContactName);
-            Assert.Equal("0987654321", updatedPublication.Contact.ContactTelNo);
-            Assert.Equal("Old team", updatedPublication.Contact.TeamName);
-            Assert.Equal("old.smith@test.com", updatedPublication.Contact.TeamEmail);
+            Assert.Equal(publication.Contact.ContactName, updatedPublication.Contact.ContactName);
+            Assert.Equal(publication.Contact.ContactTelNo, updatedPublication.Contact.ContactTelNo);
+            Assert.Equal(publication.Contact.TeamName, updatedPublication.Contact.TeamName);
+            Assert.Equal(publication.Contact.TeamEmail, updatedPublication.Contact.TeamEmail);
 
-            Assert.Equal(theme.Id, updatedPublication.ThemeId);
-            Assert.Equal("New theme", updatedPublication.Theme.Title);
+            Assert.Equal(otherTheme.Id, updatedPublication.ThemeId);
+            Assert.Equal(otherTheme.Title, updatedPublication.Theme.Title);
 
             var publicationRedirects = await context.PublicationRedirects.ToListAsync();
             Assert.Empty(publicationRedirects);
         }
-        
-        AssertOnPublicationChangedEventNotRaised();
+
+        _publicationCacheServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationTree();
+        _publicationCacheServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationEntry("new-title");
+        _publicationCacheServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationAndReleases(publication.Slug);
+        AssertOnPublicationChangedEventsNotRaised();
     }
 
     [Fact]
     public async Task UpdatePublication_AlreadyPublished()
     {
-        var theme = new Theme
-        {
-            Title = "New theme",
-        };
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1, draftVersion: false)])
+            .WithTheme(_dataFixture.DefaultTheme());
 
-        var supersedingPublicationToRemove = new Publication
-        {
-            Slug = "superseding-to-remove-slug",
-        };
-
-        var publication = new Publication
-        {
-            Slug = "old-title",
-            Title = "Old title",
-            Summary = "Old summary",
-            Theme = new Theme
-            {
-                Title = "Old theme"
-            },
-            Contact = new Contact
-            {
-                ContactName = "Old name",
-                ContactTelNo = "0987654321",
-                TeamName = "Old team",
-                TeamEmail = "old.smith@test.com",
-            },
-            LatestPublishedReleaseVersion = new ReleaseVersion(),
-            SupersededBy = supersedingPublicationToRemove,
-        };
-
-        var supersededPublication = new Publication
-        {
-            Slug = "superseded-slug",
-            SupersededBy = publication,
-        };
+        Theme otherTheme = _dataFixture.DefaultTheme();
 
         var contextId = Guid.NewGuid().ToString();
         await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            context.AddRange(theme, publication, supersedingPublicationToRemove, supersededPublication);
+            context.Publications.Add(publication);
+            context.Themes.Add(otherTheme);
             await context.SaveChangesAsync();
         }
 
-        var newSupersededById = Guid.NewGuid();
+        var methodologyService = new Mock<IMethodologyService>(Strict);
+        methodologyService
+            .Setup(s => s.PublicationTitleOrSlugChanged(
+                publication.Id,
+                publication.Slug,
+                "New title",
+                "new-title"))
+            .Returns(Task.CompletedTask);
+
+        var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
+        methodologyCacheService.Setup(mock => mock.UpdateSummariesTree())
+            .ReturnsAsync(new Either<ActionResult, List<AllMethodologiesThemeViewModel>>([]));
+
+        var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
+        redirectsCacheService.Setup(mock => mock.UpdateRedirects())
+            .ReturnsAsync(new RedirectsViewModel(
+                PublicationRedirects: [],
+                MethodologyRedirects: [],
+                ReleaseRedirectsByPublicationSlug: []));
 
         await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            var methodologyService = new Mock<IMethodologyService>(Strict);
-            var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
-            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-            var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
-
-            methodologyService
-                .Setup(s => s.PublicationTitleOrSlugChanged(
-                    publication.Id,
-                    publication.Slug,
-                    "New title",
-                    "new-title"))
-                .Returns(Task.CompletedTask);
-
-            methodologyCacheService.Setup(mock => mock.UpdateSummariesTree())
-                .ReturnsAsync(new Either<ActionResult, List<AllMethodologiesThemeViewModel>>(
-                    new List<AllMethodologiesThemeViewModel>()));
-
-            publicationCacheService.Setup(mock => mock.UpdatePublication("new-title"))
-                .ReturnsAsync(new PublicationCacheViewModel());
-
-            publicationCacheService.Setup(mock => mock.UpdatePublication(supersededPublication.Slug))
-                .ReturnsAsync(new PublicationCacheViewModel());
-
-            publicationCacheService.Setup(mock => mock.UpdatePublicationTree())
-                .ReturnsAsync(new List<PublicationTreeThemeViewModel>());
-
-            publicationCacheService.Setup(mock => mock.RemovePublication("old-title"))
-                .ReturnsAsync(Unit.Instance);
-
-            redirectsCacheService.Setup(mock => mock.UpdateRedirects())
-                .ReturnsAsync(new RedirectsViewModel(
-                    PublicationRedirects: [],
-                    MethodologyRedirects: [],
-                    ReleaseRedirectsByPublicationSlug: []));
-
             var publicationService = BuildPublicationService(context,
                 methodologyService: methodologyService.Object,
-                publicationCacheService: publicationCacheService.Object,
                 methodologyCacheService: methodologyCacheService.Object,
                 redirectsCacheService: redirectsCacheService.Object);
 
@@ -1147,25 +1084,27 @@ public class PublicationServiceTests
                 new PublicationSaveRequest
                 {
                     Title = "New title",
+                    Slug = "new-title",
                     Summary = "New summary",
-                    ThemeId = theme.Id,
-                    SupersededById = newSupersededById,
+                    ThemeId = otherTheme.Id,
+                    SupersededById = null
                 }
             );
 
-            VerifyAllMocks(methodologyService,
+            VerifyAllMocks(
+                methodologyService,
                 methodologyCacheService,
-                publicationCacheService);
+                redirectsCacheService);
 
             var viewModel = result.AssertRight();
 
             Assert.Equal("New title", viewModel.Title);
             Assert.Equal("New summary", viewModel.Summary);
 
-            Assert.Equal(theme.Id, viewModel.Theme.Id);
-            Assert.Equal(theme.Title, viewModel.Theme.Title);
+            Assert.Equal(otherTheme.Id, viewModel.Theme.Id);
+            Assert.Equal(otherTheme.Title, viewModel.Theme.Title);
 
-            Assert.Equal(newSupersededById, viewModel.SupersededById);
+            Assert.Null(viewModel.SupersededById);
         }
 
         await using (var context = InMemoryApplicationDbContext(contextId))
@@ -1173,33 +1112,169 @@ public class PublicationServiceTests
             var updatedPublication = await context.Publications
                 .Include(p => p.Contact)
                 .Include(p => p.Theme)
-                .SingleAsync(p => p.Title == "New title");
+                .SingleAsync(p => p.Id == publication.Id);
 
             Assert.True(updatedPublication.Live);
             updatedPublication.Updated.AssertUtcNow();
-            Assert.Equal("New title", updatedPublication.Title);
             Assert.Equal("new-title", updatedPublication.Slug);
-            Assert.Equal("New summary", updatedPublication.Summary);
+            Assert.Equal("New title", updatedPublication.Title);
+            Assert.Null(updatedPublication.SupersededById);
 
-            Assert.Equal("Old name", updatedPublication.Contact.ContactName);
-            Assert.Equal("0987654321", updatedPublication.Contact.ContactTelNo);
-            Assert.Equal("Old team", updatedPublication.Contact.TeamName);
-            Assert.Equal("old.smith@test.com", updatedPublication.Contact.TeamEmail);
+            Assert.Equal(publication.Contact.ContactName, updatedPublication.Contact.ContactName);
+            Assert.Equal(publication.Contact.ContactTelNo, updatedPublication.Contact.ContactTelNo);
+            Assert.Equal(publication.Contact.TeamName, updatedPublication.Contact.TeamName);
+            Assert.Equal(publication.Contact.TeamEmail, updatedPublication.Contact.TeamEmail);
 
-            Assert.Equal(theme.Id, updatedPublication.ThemeId);
-            Assert.Equal("New theme", updatedPublication.Theme.Title);
-
-            Assert.Equal(newSupersededById, updatedPublication.SupersededById);
+            Assert.Equal(otherTheme.Id, updatedPublication.ThemeId);
+            Assert.Equal(otherTheme.Title, updatedPublication.Theme.Title);
 
             var publicationRedirects = await context.PublicationRedirects
                 .ToListAsync();
 
             var publicationRedirect = Assert.Single(publicationRedirects);
 
-            Assert.Equal("old-title", publicationRedirect.Slug);
+            Assert.Equal(publication.Slug, publicationRedirect.Slug);
             Assert.Equal(publication.Id, publicationRedirect.PublicationId);
 
             AssertOnPublicationChangedEventRaised(updatedPublication);
+        }
+
+        _publicationCacheServiceMockBuilder.Assert.CacheInvalidatedForPublicationTree();
+        _publicationCacheServiceMockBuilder.Assert.CacheInvalidatedForPublicationEntry("new-title");
+        _publicationCacheServiceMockBuilder.Assert.CacheInvalidatedForPublicationAndReleases(publication.Slug);
+    }
+
+    [Theory]
+    [MemberData(nameof(PublicationServiceTestsTheoryData.PublicationArchivedEventTestData),
+        MemberType = typeof(PublicationServiceTestsTheoryData))]
+    public async Task UpdatePublication_RaisesEventsDependentOnLiveAndArchivedStatus(
+        Func<Publication> initialPublicationGenerator,
+        Func<Publication?> initialPublicationSupersededByGenerator,
+        Func<Publication?> updatedPublicationSupersededByGenerator,
+        bool expectPublicationArchivedEventRaised)
+    {
+        // Generate the initial publication being updated (live or not live)
+        var publication = initialPublicationGenerator();
+
+        // Generate the initial publication's `SupersededBy` publication (null, live, or not live)
+        publication.SupersededBy = initialPublicationSupersededByGenerator();
+
+        // Generate the new `SupersededBy` publication being set in the update (null, live, or not live)
+        var newSupersededBy = updatedPublicationSupersededByGenerator();
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Publications.Add(publication);
+            if (newSupersededBy != null)
+            {
+                context.Publications.Add(newSupersededBy);
+            }
+
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var publicationService = BuildPublicationService(context,
+                methodologyCacheService: new Mock<IMethodologyCacheService>(Default).Object,
+                redirectsCacheService: new Mock<IRedirectsCacheService>(Default).Object);
+
+            await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
+                {
+                    Title = publication.Title,
+                    Slug = publication.Slug,
+                    Summary = publication.Summary,
+                    ThemeId = publication.ThemeId,
+                    SupersededById = newSupersededBy?.Id
+                }
+            );
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var updatedPublication = await context.Publications
+                .SingleAsync(p => p.Id == publication.Id);
+
+            if (expectPublicationArchivedEventRaised)
+            {
+                AssertOnPublicationArchivedEventRaised(updatedPublication);
+            }
+            else
+            {
+                AssertOnPublicationChangedEventsNotRaised();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task UpdatePublication_CacheInvalidatedForSupersededPublications()
+    {
+        Theme theme = _dataFixture.DefaultTheme();
+
+        Publication publication = _dataFixture
+            .DefaultPublication()
+            .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 1, draftVersion: false)])
+            .WithTheme(theme);
+
+        // These publications are superseded by the publication being updated
+        var (supersededPublication1, supersededPublication2) = _dataFixture
+            .DefaultPublication()
+            .WithSupersededBy(publication)
+            .WithTheme(theme)
+            .GenerateTuple2();
+
+        // This is another publication not superseded by the publication being updated
+        Publication notSupersededPublication = _dataFixture
+            .DefaultPublication();
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            context.Themes.Add(theme);
+            context.Publications.AddRange(publication,
+                supersededPublication1,
+                supersededPublication2,
+                notSupersededPublication);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var publicationService = BuildPublicationService(context,
+                methodologyCacheService: new Mock<IMethodologyCacheService>(Default).Object,
+                redirectsCacheService: new Mock<IRedirectsCacheService>(Default).Object);
+
+            await publicationService.UpdatePublication(
+                publication.Id,
+                new PublicationSaveRequest
+                {
+                    Title = publication.Title,
+                    Slug = publication.Slug,
+                    Summary = publication.Summary,
+                    ThemeId = publication.ThemeId,
+                    SupersededById = null
+                }
+            );
+        }
+
+        await using (var context = InMemoryApplicationDbContext(contextId))
+        {
+            var updatedPublication = await context.Publications
+                .SingleAsync(p => p.Id == publication.Id);
+
+            // Ensure the cache was only invalidated for the updated and superseded publications
+            Publication[] expectedInvalidatedPublications =
+                [updatedPublication, supersededPublication1, supersededPublication2];
+            foreach (var expected in expectedInvalidatedPublications)
+            {
+                _publicationCacheServiceMockBuilder.Assert.CacheInvalidatedForPublicationEntry(expected.Slug);
+            }
+
+            _publicationCacheServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationEntry(
+                notSupersededPublication.Slug);
         }
     }
 
@@ -1397,8 +1472,8 @@ public class PublicationServiceTests
             Assert.Equal("New summary", viewModel.Summary);
             Assert.Equal(publication.SupersededById, viewModel.SupersededById);
         }
-        
-        AssertOnPublicationChangedEventNotRaised();
+
+        AssertOnPublicationChangedEventsNotRaised();
     }
 
     [Fact]
@@ -1530,8 +1605,8 @@ public class PublicationServiceTests
 
             result.AssertBadRequest(ThemeDoesNotExist);
         }
-        
-        AssertOnPublicationChangedEventNotRaised();
+
+        AssertOnPublicationChangedEventsNotRaised();
     }
 
     [Fact]
@@ -3116,8 +3191,8 @@ public class PublicationServiceTests
             Assert.Equal(release2022.Versions[1].Id, actualPublication.LatestPublishedReleaseVersionId);
         }
         
-        // The latest release is unchanged so no event should have been raised
-        AssertOnPublicationChangedEventNotRaised();
+        // The latest release is unchanged so no events should have been raised
+        AssertOnPublicationChangedEventsNotRaised();
     }
 
     [Fact]
@@ -3378,8 +3453,8 @@ public class PublicationServiceTests
 
             Assert.Empty(actualPublication.ReleaseSeries);
         }
-        
-        AssertOnPublicationChangedEventNotRaised();
+
+        AssertOnPublicationChangedEventsNotRaised();
     }
 
     [Fact]
@@ -3538,7 +3613,7 @@ public class PublicationServiceTests
             publicationRepository ?? new PublicationRepository(context),
             releaseVersionRepository ?? new ReleaseVersionRepository(context),
             methodologyService ?? Mock.Of<IMethodologyService>(Strict),
-            publicationCacheService ?? Mock.Of<IPublicationCacheService>(Strict),
+            publicationCacheService ?? _publicationCacheServiceMockBuilder.Build(),
             releaseCacheService ?? Mock.Of<IReleaseCacheService>(Strict),
             methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
             redirectsCacheService ?? Mock.Of<IRedirectsCacheService>(Strict),
@@ -3546,8 +3621,15 @@ public class PublicationServiceTests
     }
 
     private readonly AdminEventRaiserMockBuilder _adminEventRaiserMockBuilder = new();
+    private readonly PublicationCacheServiceMockBuilder _publicationCacheServiceMockBuilder = new();
 
-    private void AssertOnPublicationChangedEventRaised(Publication? publication = null) =>
+    private void AssertOnPublicationArchivedEventRaised(Publication publication) =>
+        _adminEventRaiserMockBuilder.Assert.OnPublicationArchivedWasRaised(
+            publication.Id,
+            publication.Slug,
+            publication.SupersededById);
+
+    private void AssertOnPublicationChangedEventRaised(Publication publication) =>
         _adminEventRaiserMockBuilder.Assert.OnPublicationChangedWasRaised(publication);
     
     private void AssertOnPublicationLatestPublishedReleaseReorderedWasRaised(
@@ -3556,7 +3638,9 @@ public class PublicationServiceTests
         _adminEventRaiserMockBuilder.Assert.OnPublicationLatestPublishedReleaseReorderedWasRaised(
             publication,
             previousReleaseVersionId);
-    
-    private void AssertOnPublicationChangedEventNotRaised() =>
-        _adminEventRaiserMockBuilder.Assert.OnPublicationChangedWasNotRaised();
+
+    private void AssertOnPublicationChangedEventsNotRaised()
+    {
+        _adminEventRaiserMockBuilder.Assert.AssertOnPublicationChangedEventsNotRaised();
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -1189,19 +1189,16 @@ public class PublicationServiceTests
             );
         }
 
-        await using (var context = InMemoryApplicationDbContext(contextId))
+        if (expectPublicationArchivedEventRaised)
         {
+            await using var context = InMemoryApplicationDbContext(contextId);
             var updatedPublication = await context.Publications
                 .SingleAsync(p => p.Id == publication.Id);
-
-            if (expectPublicationArchivedEventRaised)
-            {
-                AssertOnPublicationArchivedEventRaised(updatedPublication);
-            }
-            else
-            {
-                AssertOnPublicationChangedEventsNotRaised();
-            }
+            AssertOnPublicationArchivedEventRaised(updatedPublication);
+        }
+        else
+        {
+            AssertOnPublicationChangedEventsNotRaised();
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTestsTheoryData.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTestsTheoryData.cs
@@ -10,13 +10,11 @@ internal class PublicationServiceTestsTheoryData
 {
     private static readonly DataFixture DataFixture = new();
 
-    private static readonly Func<Publication?> NullPublication = () => null;
-
-    private static readonly Func<Publication> NotLivePublication = () => DataFixture
+    private static Publication NotLivePublication() => DataFixture
         .DefaultPublication()
-        .WithTheme(DataFixture.DefaultTheme());
+        .WithTheme(DataFixture.DefaultTheme().Generate());
 
-    private static readonly Func<Publication> LivePublication = () => DataFixture
+    private static Publication LivePublication() => DataFixture
         .DefaultPublication()
         .WithReleases([DataFixture.DefaultRelease(publishedVersions: 1, draftVersion: false)])
         .WithTheme(DataFixture.DefaultTheme());
@@ -32,16 +30,16 @@ internal class PublicationServiceTestsTheoryData
     /// <description>description</description>
     /// </listheader>
     /// <item>
-    /// <term>initialPublicationGenerator</term>
-    /// <description>A generator for the initial publication (live or not live).</description>
+    /// <term>publication</term>
+    /// <description>The initial publication (live or not live).</description>
     /// </item>
     /// <item>
-    /// <term>initialPublicationSupersededByGenerator</term>
-    /// <description>A generator for the initial `SupersededBy` publication (null, live, or not live).</description>
+    /// <term>initialPublicationSupersededBy</term>
+    /// <description>The initial `SupersededBy` publication (null, live, or not live).</description>
     /// </item>
     /// <item>
-    /// <term>updatedPublicationSupersededByGenerator</term>
-    /// <description>A generator for the new `SupersededBy` publication (null, live, or not live).</description>
+    /// <term>updatedPublicationSupersededBy</term>
+    /// <description>The updated `SupersededBy` publication (null, live, or not live).</description>
     /// </item>
     /// <item>
     /// <term>expectPublicationArchivedEventRaised</term>
@@ -49,30 +47,30 @@ internal class PublicationServiceTestsTheoryData
     /// </item>
     /// </list>
     /// </remarks>
-    public static readonly TheoryData<Func<Publication>, Func<Publication?>, Func<Publication?>, bool>
+    public static readonly TheoryData<Publication, Publication?, Publication?, bool>
         PublicationArchivedEventTestData =
             new()
             {
                 // When the publication is live expect events to be raised dependent on states
                 // of the initial and updated `SupersededBy` publications
-                { LivePublication, NullPublication, NullPublication, false },
-                { LivePublication, NullPublication, NotLivePublication, false },
-                { LivePublication, NullPublication, LivePublication, true }, // Transition to archived
-                { LivePublication, NotLivePublication, NullPublication, false },
-                { LivePublication, NotLivePublication, NotLivePublication, false },
-                { LivePublication, NotLivePublication, LivePublication, true }, // Transition to archived
-                { LivePublication, LivePublication, NullPublication, false },
-                { LivePublication, LivePublication, NotLivePublication, false },
-                { LivePublication, LivePublication, LivePublication, false },
+                { LivePublication(), null, null, false },
+                { LivePublication(), null, NotLivePublication(), false },
+                { LivePublication(), null, LivePublication(), true }, // Transition to archived
+                { LivePublication(), NotLivePublication(), null, false },
+                { LivePublication(), NotLivePublication(), NotLivePublication(), false },
+                { LivePublication(), NotLivePublication(), LivePublication(), true }, // Transition to archived
+                { LivePublication(), LivePublication(), null, false },
+                { LivePublication(), LivePublication(), NotLivePublication(), false },
+                { LivePublication(), LivePublication(), LivePublication(), false },
                 // When the publication is not live expect no events to be raised
-                { NotLivePublication, NullPublication, NullPublication, false },
-                { NotLivePublication, NullPublication, NotLivePublication, false },
-                { NotLivePublication, NullPublication, LivePublication, false },
-                { NotLivePublication, NotLivePublication, NullPublication, false },
-                { NotLivePublication, NotLivePublication, NotLivePublication, false },
-                { NotLivePublication, NotLivePublication, LivePublication, false },
-                { NotLivePublication, LivePublication, NullPublication, false },
-                { NotLivePublication, LivePublication, NotLivePublication, false },
-                { NotLivePublication, LivePublication, LivePublication, false }
+                { NotLivePublication(), null, null, false },
+                { NotLivePublication(), null, NotLivePublication(), false },
+                { NotLivePublication(), null, LivePublication(), false },
+                { NotLivePublication(), NotLivePublication(), null, false },
+                { NotLivePublication(), NotLivePublication(), NotLivePublication(), false },
+                { NotLivePublication(), NotLivePublication(), LivePublication(), false },
+                { NotLivePublication(), LivePublication(), null, false },
+                { NotLivePublication(), LivePublication(), NotLivePublication(), false },
+                { NotLivePublication(), LivePublication(), LivePublication(), false }
             };
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTestsTheoryData.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTestsTheoryData.cs
@@ -1,0 +1,78 @@
+﻿#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+internal class PublicationServiceTestsTheoryData
+{
+    private static readonly DataFixture DataFixture = new();
+
+    private static readonly Func<Publication?> NullPublication = () => null;
+
+    private static readonly Func<Publication> NotLivePublication = () => DataFixture
+        .DefaultPublication()
+        .WithTheme(DataFixture.DefaultTheme());
+
+    private static readonly Func<Publication> LivePublication = () => DataFixture
+        .DefaultPublication()
+        .WithReleases([DataFixture.DefaultRelease(publishedVersions: 1, draftVersion: false)])
+        .WithTheme(DataFixture.DefaultTheme());
+
+    /// <summary>
+    /// Test data to verify if expected events are raised during a publication update based on the publication's live
+    /// state and the states of the initial and updated `SupersededBy` publications.
+    /// </summary>
+    /// <remarks>
+    /// <list type="table">
+    /// <listheader>
+    /// <term>parameter</term>
+    /// <description>description</description>
+    /// </listheader>
+    /// <item>
+    /// <term>initialPublicationGenerator</term>
+    /// <description>A generator for the initial publication (live or not live).</description>
+    /// </item>
+    /// <item>
+    /// <term>initialPublicationSupersededByGenerator</term>
+    /// <description>A generator for the initial `SupersededBy` publication (null, live, or not live).</description>
+    /// </item>
+    /// <item>
+    /// <term>updatedPublicationSupersededByGenerator</term>
+    /// <description>A generator for the new `SupersededBy` publication (null, live, or not live).</description>
+    /// </item>
+    /// <item>
+    /// <term>expectPublicationArchivedEventRaised</term>
+    /// <description>A boolean indicating whether a publication archived event is expected to be raised.</description>
+    /// </item>
+    /// </list>
+    /// </remarks>
+    public static readonly TheoryData<Func<Publication>, Func<Publication?>, Func<Publication?>, bool>
+        PublicationArchivedEventTestData =
+            new()
+            {
+                // When the publication is live expect events to be raised dependent on states
+                // of the initial and updated `SupersededBy` publications
+                { LivePublication, NullPublication, NullPublication, false },
+                { LivePublication, NullPublication, NotLivePublication, false },
+                { LivePublication, NullPublication, LivePublication, true }, // Transition to archived
+                { LivePublication, NotLivePublication, NullPublication, false },
+                { LivePublication, NotLivePublication, NotLivePublication, false },
+                { LivePublication, NotLivePublication, LivePublication, true }, // Transition to archived
+                { LivePublication, LivePublication, NullPublication, false },
+                { LivePublication, LivePublication, NotLivePublication, false },
+                { LivePublication, LivePublication, LivePublication, false },
+                // When the publication is not live expect no events to be raised
+                { NotLivePublication, NullPublication, NullPublication, false },
+                { NotLivePublication, NullPublication, NotLivePublication, false },
+                { NotLivePublication, NullPublication, LivePublication, false },
+                { NotLivePublication, NotLivePublication, NullPublication, false },
+                { NotLivePublication, NotLivePublication, NotLivePublication, false },
+                { NotLivePublication, NotLivePublication, LivePublication, false },
+                { NotLivePublication, LivePublication, NullPublication, false },
+                { NotLivePublication, LivePublication, NotLivePublication, false },
+                { NotLivePublication, LivePublication, LivePublication, false }
+            };
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -182,7 +182,7 @@ public class ThemeServiceTests
 
             Assert.All(
                 expectedPublicationSlugs,
-                publicationCacheService.Assert.CacheInvalidatedForPublicationSlug);
+                publicationCacheService.Assert.CacheInvalidatedForPublicationEntry);
         }
     }
 
@@ -983,12 +983,12 @@ public class ThemeServiceTests
             var expectedInvalidatedPublications = publications.Where(p => p.ThemeId == themeId).ToArray();
             foreach (var expected in expectedInvalidatedPublications)
             {
-                publicationCacheService.Assert.CacheInvalidatedForPublicationSlug(expected.Slug);
+                publicationCacheService.Assert.CacheInvalidatedForPublicationEntry(expected.Slug);
             }
             var expectedNotInvalidatedPublications = publications.Except(expectedInvalidatedPublications);
             foreach (var notExpected in expectedNotInvalidatedPublications)
             {
-                publicationCacheService.Assert.CacheNotInvalidatedForPublicationSlug(notExpected.Slug);
+                publicationCacheService.Assert.CacheNotInvalidatedForPublicationEntry(notExpected.Slug);
             }
         }
         
@@ -1027,9 +1027,9 @@ public class ThemeServiceTests
             }
 
             // ASSERT
-            publicationCacheService.Assert.CacheInvalidatedForPublicationSlug("publication-slug-1");
-            publicationCacheService.Assert.CacheInvalidatedForPublicationSlug("publication-slug-2");
-            publicationCacheService.Assert.CacheInvalidatedForPublicationSlug("publication-slug-3");
+            publicationCacheService.Assert.CacheInvalidatedForPublicationEntry("publication-slug-1");
+            publicationCacheService.Assert.CacheInvalidatedForPublicationEntry("publication-slug-2");
+            publicationCacheService.Assert.CacheInvalidatedForPublicationEntry("publication-slug-3");
         }
         
         [Fact]
@@ -1067,9 +1067,9 @@ public class ThemeServiceTests
             }
 
             // ASSERT
-            publicationCacheService.Assert.CacheInvalidatedForPublicationSlug("publication-slug-1");
-            publicationCacheService.Assert.CacheInvalidatedForPublicationSlug("publication-slug-2");
-            publicationCacheService.Assert.CacheInvalidatedForPublicationSlug("publication-slug-3");
+            publicationCacheService.Assert.CacheInvalidatedForPublicationEntry("publication-slug-1");
+            publicationCacheService.Assert.CacheInvalidatedForPublicationEntry("publication-slug-2");
+            publicationCacheService.Assert.CacheInvalidatedForPublicationEntry("publication-slug-3");
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Utils/PublicationArchiveStatusTransitionResolverTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Utils/PublicationArchiveStatusTransitionResolverTests.cs
@@ -1,0 +1,51 @@
+﻿#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Admin.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Utils.PublicationArchiveStatusTransitionResolver.
+    PublicationArchiveStatusTransition;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Utils;
+
+public abstract class PublicationArchiveStatusTransitionResolverTests
+{
+    public class GetTransitionTests : PublicationArchiveStatusTransitionResolverTests
+    {
+        private static readonly Publication LivePublication = CreatePublication(live: true);
+        private static readonly Publication NotLivePublication = CreatePublication(live: false);
+
+        private static Publication CreatePublication(bool live)
+        {
+            return new Publication { LatestPublishedReleaseVersionId = live ? Guid.NewGuid() : null };
+        }
+
+        public static readonly TheoryData<Publication?, Publication?,
+                PublicationArchiveStatusTransitionResolver.PublicationArchiveStatusTransition>
+            GetTransitionTestCases = new()
+            {
+                { null, null, NotArchivedToNotArchived },
+                { null, NotLivePublication, NotArchivedToNotArchived },
+                { null, LivePublication, NotArchivedToArchived },
+                { NotLivePublication, null, NotArchivedToNotArchived },
+                { NotLivePublication, NotLivePublication, NotArchivedToNotArchived },
+                { NotLivePublication, LivePublication, NotArchivedToArchived },
+                { LivePublication, null, ArchivedToNotArchived },
+                { LivePublication, NotLivePublication, ArchivedToNotArchived },
+                { LivePublication, LivePublication, ArchivedToArchived }
+            };
+
+        [Theory]
+        [MemberData(nameof(GetTransitionTestCases))]
+        public void GetTransition_ReturnsExpectedTransition(
+            Publication? beforeSupersededBy,
+            Publication? afterSupersededBy,
+            PublicationArchiveStatusTransitionResolver.PublicationArchiveStatusTransition expected)
+        {
+            var result = PublicationArchiveStatusTransitionResolver.GetTransition(
+                beforeSupersededBy,
+                afterSupersededBy);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationArchivedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationArchivedEvent.cs
@@ -1,0 +1,48 @@
+﻿#nullable enable
+using System;
+using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Events;
+
+public record PublicationArchivedEvent : IEvent
+{
+    public PublicationArchivedEvent(
+        Guid publicationId,
+        string publicationSlug,
+        Guid supersededByPublicationId)
+    {
+        Subject = publicationId.ToString();
+        Payload = new EventPayload
+        {
+            PublicationSlug = publicationSlug,
+            SupersededByPublicationId = supersededByPublicationId
+        };
+    }
+
+    // Changes to this event should also increment the version accordingly.
+    private const string DataVersion = "1.0";
+    private const string EventType = "publication-archived";
+
+    // Which Topic endpoint to use from the appsettings
+    public static string EventTopicOptionsKey => "PublicationChangedEvent";
+
+    /// <summary>
+    /// The PublicationId is the subject
+    /// </summary>
+    public string Subject { get; }
+
+    /// <summary>
+    /// The event payload
+    /// </summary>
+    public EventPayload Payload { get; }
+
+    public record EventPayload
+    {
+        public required string PublicationSlug { get; init; }
+
+        public required Guid SupersededByPublicationId { get; init; }
+    }
+
+    public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiser.cs
@@ -16,22 +16,46 @@ public class AdminEventRaiser(IEventRaiser eventRaiser) : IAdminEventRaiser
     /// <summary>
     /// On Theme Updated
     /// </summary>
-    public async Task OnThemeUpdated(Theme theme) => 
+    /// <param name="theme">The theme that has been updated.</param>
+    public async Task OnThemeUpdated(Theme theme) =>
         await eventRaiser.RaiseEvent(new ThemeChangedEvent(theme));
 
     /// <summary>
     /// On Release Slug changed
     /// </summary>
+    /// <param name="releaseId">The unique identifier of the release.</param>
+    /// <param name="newReleaseSlug">The new slug for the release.</param>
+    /// <param name="publicationId">The unique identifier of the associated publication.</param>
+    /// <param name="publicationSlug">The slug of the associated publication.</param>
     public async Task OnReleaseSlugChanged(
         Guid releaseId,
         string newReleaseSlug,
         Guid publicationId,
         string publicationSlug) =>
-        await eventRaiser.RaiseEvent(new ReleaseSlugChangedEvent(releaseId, newReleaseSlug, publicationId, publicationSlug));
+        await eventRaiser.RaiseEvent(new ReleaseSlugChangedEvent(releaseId,
+            newReleaseSlug,
+            publicationId,
+            publicationSlug));
+
+    /// <summary>
+    /// Publishes an event when a publication is archived.
+    /// </summary>
+    /// <param name="publicationId">The unique identifier of the publication that has been archived.</param>
+    /// <param name="publicationSlug">The slug of the publication that has been archived.</param>
+    /// <param name="supersededByPublicationId">The unique identifier of the publication that has superseded the archived publication.</param>
+    public async Task OnPublicationArchived(
+        Guid publicationId,
+        string publicationSlug,
+        Guid supersededByPublicationId) =>
+        await eventRaiser.RaiseEvent(new PublicationArchivedEvent(
+            publicationId,
+            publicationSlug,
+            supersededByPublicationId));
 
     /// <summary>
     /// On Publication Changed
     /// </summary>
+    /// <param name="publication">The publication that has been changed.</param>
     public async Task OnPublicationChanged(Publication publication) =>
         await eventRaiser.RaiseEvent(new PublicationChangedEvent(publication));
 
@@ -40,6 +64,10 @@ public class AdminEventRaiser(IEventRaiser eventRaiser) : IAdminEventRaiser
     /// It is assumed that the publication LatestPublishedReleaseVersionId has a value assigned to it.
     /// If it is null, then no event will be raised.
     /// </summary>
+    /// <param name="publication">The publication whose latest published release has been reordered.</param>
+    /// <param name="previousLatestPublishedReleaseVersionId">
+    /// The unique identifier of the previous latest published release version.
+    /// </param>
     public async Task OnPublicationLatestPublishedReleaseReordered(
         Publication publication,
         Guid previousLatestPublishedReleaseVersionId)
@@ -56,4 +84,3 @@ public class AdminEventRaiser(IEventRaiser eventRaiser) : IAdminEventRaiser
                 previousLatestPublishedReleaseVersionId));
     }
 }
-

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiser.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -7,7 +8,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 public interface IAdminEventRaiser
 {
     Task OnThemeUpdated(Theme theme);
-    Task OnReleaseSlugChanged(Guid releaseId, string newReleaseSlug, Guid publicationId, string publicationSlug);
+
+    Task OnReleaseSlugChanged(
+        Guid releaseId,
+        string newReleaseSlug,
+        Guid publicationId,
+        string publicationSlug);
+
+    Task OnPublicationArchived(
+        Guid publicationId,
+        string publicationSlug,
+        Guid supersededByPublicationId);
+
     Task OnPublicationChanged(Publication publication);
-    Task OnPublicationLatestPublishedReleaseReordered(Publication publication, Guid previousLatestPublishedReleaseVersionId);
+
+    Task OnPublicationLatestPublishedReleaseReordered(
+        Publication publication,
+        Guid previousLatestPublishedReleaseVersionId);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -3,7 +3,6 @@ using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
-using GovUk.Education.ExploreEducationStatistics.Admin.Services.Util;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -29,6 +28,8 @@ using IReleaseVersionRepository = GovUk.Education.ExploreEducationStatistics.Con
 using PublicationViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.PublicationViewModel;
 using ReleaseVersionSummaryViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ReleaseVersionSummaryViewModel;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Util;
+using GovUk.Education.ExploreEducationStatistics.Admin.Utils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
@@ -166,13 +167,14 @@ public class PublicationService(
             })
             .OnSuccess(async publication =>
             {
-                var originalTitle = publication.Title;
-                var originalSlug = publication.Slug;
-                var originalSummary = publication.Summary;
+                var previousTitle = publication.Title;
+                var previousSlug = publication.Slug;
+                var previousSummary = publication.Summary;
+                var previousSupersededById = publication.SupersededById;
 
-                var titleChanged = originalTitle != updatedPublication.Title;
-                var slugChanged = originalSlug != updatedPublication.Slug;
-                var summaryChanged = originalSummary != updatedPublication.Summary;
+                var titleChanged = previousTitle != updatedPublication.Title;
+                var slugChanged = previousSlug != updatedPublication.Slug;
+                var summaryChanged = previousSummary != updatedPublication.Summary;
 
                 if (slugChanged)
                 {
@@ -188,11 +190,11 @@ public class PublicationService(
 
                     if (publication.Live
                         && context.PublicationRedirects.All(pr =>
-                            !(pr.PublicationId == publicationId && pr.Slug == originalSlug))) // don't create duplicate redirect
+                            !(pr.PublicationId == publicationId && pr.Slug == previousSlug))) // don't create duplicate redirect
                     {
                         var publicationRedirect = new PublicationRedirect
                         {
-                            Slug = originalSlug,
+                            Slug = previousSlug,
                             Publication = publication,
                             PublicationId = publication.Id,
                         };
@@ -222,7 +224,7 @@ public class PublicationService(
                 if (titleChanged || slugChanged)
                 {
                     await methodologyService.PublicationTitleOrSlugChanged(publicationId,
-                        originalSlug,
+                        previousSlug,
                         publication.Title,
                         publication.Slug);
                 }
@@ -235,10 +237,11 @@ public class PublicationService(
 
                     if (slugChanged)
                     {
-                        await publicationCacheService.RemovePublication(originalSlug);
+                        await publicationCacheService.RemovePublication(previousSlug);
                         await redirectsCacheService.UpdateRedirects();
                     }
 
+                    await RaiseEventIfSupersededByChanged(publication, previousSupersededById);
                     await UpdateCachedSupersededPublications(publication);
                 }
 
@@ -246,9 +249,40 @@ public class PublicationService(
                 {
                     await adminEventRaiser.OnPublicationChanged(publication);
                 }
-                
+
                 return await GetPublication(publication.Id);
             });
+    }
+
+    private async Task RaiseEventIfSupersededByChanged(Publication publication, Guid? previousSupersededById)
+    {
+        if (previousSupersededById != publication.SupersededById)
+        {
+            var previousSupersedingPublication = await GetSupersedingPublication(previousSupersededById);
+            var newSupersedingPublication = await GetSupersedingPublication(publication.SupersededById);
+
+            var transition = PublicationArchiveStatusTransitionResolver.GetTransition(
+                previousSupersedingPublication,
+                newSupersedingPublication);
+
+            if (transition == PublicationArchiveStatusTransitionResolver.PublicationArchiveStatusTransition
+                    .NotArchivedToArchived)
+            {
+                await adminEventRaiser.OnPublicationArchived(
+                    publication.Id,
+                    publication.Slug,
+                    supersededByPublicationId: publication.SupersededById!.Value);
+            }
+        }
+    }
+
+    private async Task<Publication?> GetSupersedingPublication(Guid? supersededByPublicationId)
+    {
+        return supersededByPublicationId != null
+            ? await context.Publications
+                .Where(p => p.Id == supersededByPublicationId)
+                .SingleAsync(p => p.Id == supersededByPublicationId)
+            : null;
     }
 
     private async Task UpdateCachedSupersededPublications(Publication publication)
@@ -624,7 +658,7 @@ public class PublicationService(
             // Strictly, we should also check whether the owned methodology inherits the publication slug - we don't
             // need to validate the new slug against methodologies if it isn't changing the methodology slug - but
             // this check is expensive and an unlikely edge case, so doesn't seem worth it.
-            )
+           )
         {
             var methodologySlugValidation = await methodologyService
                 .ValidateMethodologySlug(newSlug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Utils/PublicationArchiveStatusTransitionResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Utils/PublicationArchiveStatusTransitionResolver.cs
@@ -1,0 +1,40 @@
+﻿#nullable enable
+
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Utils;
+
+public class PublicationArchiveStatusTransitionResolver
+{
+    /// <summary>
+    /// Represents the possible transitions of a publication's archive status.
+    /// </summary>
+    public enum PublicationArchiveStatusTransition
+    {
+        NotArchivedToNotArchived,
+        NotArchivedToArchived,
+        ArchivedToNotArchived,
+        ArchivedToArchived
+    }
+
+    /// <summary>
+    /// Determines the archive status transition of a publication based on its superseding publication
+    /// before and after an update.
+    /// </summary>
+    /// <param name="before">The publication that superseded the current one before the update, or null if none.</param>
+    /// <param name="after">The publication that superseded the current one after the update, or null if none.</param>
+    /// <returns>
+    /// A <see cref="PublicationArchiveStatusTransition"/> value representing the transition of the publication's archive status.
+    /// </returns>
+    internal static PublicationArchiveStatusTransition GetTransition(Publication? before, Publication? after) =>
+        (IsSupersededByLivePublication(before), IsSupersededByLivePublication(after)) switch
+        {
+            (false, false) => PublicationArchiveStatusTransition.NotArchivedToNotArchived,
+            (false, true) => PublicationArchiveStatusTransition.NotArchivedToArchived,
+            (true, false) => PublicationArchiveStatusTransition.ArchivedToNotArchived,
+            (true, true) => PublicationArchiveStatusTransition.ArchivedToArchived
+        };
+
+    private static bool IsSupersededByLivePublication(Publication? publication) =>
+        publication?.Live ?? false;
+}


### PR DESCRIPTION
The Admin service allows updating publications including setting and un-setting a  'superseded by' publication for a publication. A publication is considered to be archived if it has a superseding publication which is live, i.e. the superseding publication has one or more published releases.

This PR changes the Admin service to raise an Event Grid event when publications are archived. The event is only raised if a publication was not previously archived, but now is.

To know whether to raise the event or not, we work out the transition of the publication's archived status and only raise it if the status is changing from not archived to archived.

The Search Function App is subscribed to these events and will manage searchable documents accordingly. This change was made to the Search Function App in https://github.com/dfe-analytical-services/explore-education-statistics/pull/5834 and https://github.com/dfe-analytical-services/explore-education-statistics/pull/5808.

### Other changes

- Change the unit tests `PublicationServiceTests.UpdatePublication_NotPublished` and `PublicationServiceTests.UpdatePublication_AlreadyPublished` to use `PublicationCacheServiceMockBuilder`.
- Change the unit tests `PublicationServiceTests.UpdatePublication_NotPublished` and `PublicationServiceTests.UpdatePublication_AlreadyPublished` to not test the effect of setting a 'superseded by' publication on the publications cache and move this to a new test `PublicationServiceTests.UpdatePublication_PublicationSupersedesPublications_CacheInvalidatedForSupersededPublications`.