### PR TITLE
EES-6106 Raise an event in Admin when archived publications are restored

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserMockBuilder.cs
@@ -109,7 +109,7 @@ public class AdminEventRaiserMockBuilder
                     It.Is<Guid>(actual => supersededByPublicationId == null || actual == supersededByPublicationId)),
                 Times.Once);
 
-        private void OnPublicationArchivedWasNotRaised() =>
+        public void OnPublicationArchivedWasNotRaised() =>
             mockBuilder._mock.Verify(OnPublicationArchived, Times.Never);
 
         public void OnPublicationChangedWasRaised(Publication? publication = null) =>
@@ -151,10 +151,10 @@ public class AdminEventRaiserMockBuilder
                         previousSupersededByPublicationId == null || actual == previousSupersededByPublicationId)),
                 Times.Once);
 
-        private void OnPublicationRestoredWasNotRaised() =>
+        public void OnPublicationRestoredWasNotRaised() =>
             mockBuilder._mock.Verify(OnPublicationRestored, Times.Never);
 
-        public void AssertOnPublicationChangedEventsNotRaised()
+        public void OnPublicationChangedEventsNotRaised()
         {
             OnPublicationArchivedWasNotRaised();
             OnPublicationChangedWasNotRaised();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserTests.cs
@@ -137,6 +137,30 @@ public class AdminEventRaiserTests
     }
 
     [Fact]
+    public async Task WhenOnPublicationRestored_ThenEventPublished()
+    {
+        // ARRANGE
+        var publicationId = Guid.NewGuid();
+        const string publicationSlug = "publication-slug";
+        var previousSupersededByPublicationId = Guid.NewGuid();
+
+        var sut = GetSut();
+
+        // ACT
+        await sut.OnPublicationRestored(
+            publicationId: publicationId,
+            publicationSlug,
+            previousSupersededByPublicationId: previousSupersededByPublicationId);
+
+        // ASSERT
+        var expectedEvent = new PublicationRestoredEvent(
+            publicationId,
+            publicationSlug,
+            previousSupersededByPublicationId);
+        _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
+    }
+
+    [Fact]
     public async Task
         GivenPublicationLatestPublishedReleaseVersionIdIsNull_WhenOnPublicationLatestPublishedReleaseReordered_ThenNoEventPublished()
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -1199,13 +1199,23 @@ public class PublicationServiceTests
             {
                 AssertOnPublicationArchivedEventRaised(updatedPublication);
             }
-            else if (expectedPublicationRestoredEventRaised)
+            else
+            {
+                AssertOnPublicationArchivedEventNotRaised();
+            }
+
+            if (expectedPublicationRestoredEventRaised)
             {
                 AssertOnPublicationRestoredEventRaised(
                     updatedPublication,
                     previousSupersededByPublicationId: publication.SupersededById!.Value);
             }
             else
+            {
+                AssertOnPublicationRestoredEventNotRaised();
+            }
+
+            if (!expectPublicationArchivedEventRaised && !expectedPublicationRestoredEventRaised)
             {
                 AssertOnPublicationChangedEventsNotRaised();
             }
@@ -3632,9 +3642,12 @@ public class PublicationServiceTests
             publication.Slug,
             publication.SupersededById);
 
+    private void AssertOnPublicationArchivedEventNotRaised() =>
+        _adminEventRaiserMockBuilder.Assert.OnPublicationArchivedWasNotRaised();
+
     private void AssertOnPublicationChangedEventRaised(Publication publication) =>
         _adminEventRaiserMockBuilder.Assert.OnPublicationChangedWasRaised(publication);
-    
+
     private void AssertOnPublicationLatestPublishedReleaseReorderedWasRaised(
         Publication publication,
         Guid previousReleaseVersionId) =>
@@ -3650,8 +3663,11 @@ public class PublicationServiceTests
             publication.Slug,
             previousSupersededByPublicationId);
 
+    private void AssertOnPublicationRestoredEventNotRaised() =>
+        _adminEventRaiserMockBuilder.Assert.OnPublicationRestoredWasNotRaised();
+
     private void AssertOnPublicationChangedEventsNotRaised()
     {
-        _adminEventRaiserMockBuilder.Assert.AssertOnPublicationChangedEventsNotRaised();
+        _adminEventRaiserMockBuilder.Assert.OnPublicationChangedEventsNotRaised();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTestsTheoryData.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTestsTheoryData.cs
@@ -45,32 +45,38 @@ internal class PublicationServiceTestsTheoryData
     /// <term>expectPublicationArchivedEventRaised</term>
     /// <description>A boolean indicating whether a publication archived event is expected to be raised.</description>
     /// </item>
+    /// <item>
+    /// <term>expectedPublicationRestoredEventRaised</term>
+    /// <description>A boolean indicating whether a publication restored event is expected to be raised.</description>
+    /// </item>
     /// </list>
     /// </remarks>
-    public static readonly TheoryData<Publication, Publication?, Publication?, bool>
+    public static readonly TheoryData<Publication, Publication?, Publication?, bool, bool>
         PublicationArchivedEventTestData =
             new()
             {
+                // @formatter:off
                 // When the publication is live expect events to be raised dependent on states
                 // of the initial and updated `SupersededBy` publications
-                { LivePublication(), null, null, false },
-                { LivePublication(), null, NotLivePublication(), false },
-                { LivePublication(), null, LivePublication(), true }, // Transition to archived
-                { LivePublication(), NotLivePublication(), null, false },
-                { LivePublication(), NotLivePublication(), NotLivePublication(), false },
-                { LivePublication(), NotLivePublication(), LivePublication(), true }, // Transition to archived
-                { LivePublication(), LivePublication(), null, false },
-                { LivePublication(), LivePublication(), NotLivePublication(), false },
-                { LivePublication(), LivePublication(), LivePublication(), false },
+                { LivePublication(), null, null, false, false },
+                { LivePublication(), null, NotLivePublication(), false, false },
+                { LivePublication(), null, LivePublication(), true, false }, // Transition to archived
+                { LivePublication(), NotLivePublication(), null, false, false },
+                { LivePublication(), NotLivePublication(), NotLivePublication(), false, false },
+                { LivePublication(), NotLivePublication(), LivePublication(), true, false }, // Transition to archived
+                { LivePublication(), LivePublication(), null, false, true }, // Transition to not archived
+                { LivePublication(), LivePublication(), NotLivePublication(), false, true }, // Transition to not archived
+                { LivePublication(), LivePublication(), LivePublication(), false, false },
                 // When the publication is not live expect no events to be raised
-                { NotLivePublication(), null, null, false },
-                { NotLivePublication(), null, NotLivePublication(), false },
-                { NotLivePublication(), null, LivePublication(), false },
-                { NotLivePublication(), NotLivePublication(), null, false },
-                { NotLivePublication(), NotLivePublication(), NotLivePublication(), false },
-                { NotLivePublication(), NotLivePublication(), LivePublication(), false },
-                { NotLivePublication(), LivePublication(), null, false },
-                { NotLivePublication(), LivePublication(), NotLivePublication(), false },
-                { NotLivePublication(), LivePublication(), LivePublication(), false }
+                { NotLivePublication(), null, null, false, false },
+                { NotLivePublication(), null, NotLivePublication(), false, false },
+                { NotLivePublication(), null, LivePublication(), false, false },
+                { NotLivePublication(), NotLivePublication(), null, false, false },
+                { NotLivePublication(), NotLivePublication(), NotLivePublication(), false, false },
+                { NotLivePublication(), NotLivePublication(), LivePublication(), false, false },
+                { NotLivePublication(), LivePublication(), null, false, false },
+                { NotLivePublication(), LivePublication(), NotLivePublication(), false, false },
+                { NotLivePublication(), LivePublication(), LivePublication(), false, false }
+                // @formatter:on
             };
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationRestoredEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Events/PublicationRestoredEvent.cs
@@ -1,0 +1,48 @@
+﻿#nullable enable
+using System;
+using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.EventGrid;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Events;
+
+public record PublicationRestoredEvent : IEvent
+{
+    public PublicationRestoredEvent(
+        Guid publicationId,
+        string publicationSlug,
+        Guid previousSupersededByPublicationId)
+    {
+        Subject = publicationId.ToString();
+        Payload = new EventPayload
+        {
+            PublicationSlug = publicationSlug,
+            PreviousSupersededByPublicationId = previousSupersededByPublicationId
+        };
+    }
+
+    // Changes to this event should also increment the version accordingly.
+    private const string DataVersion = "1.0";
+    private const string EventType = "publication-restored";
+
+    // Which Topic endpoint to use from the appsettings
+    public static string EventTopicOptionsKey => "PublicationChangedEvent";
+
+    /// <summary>
+    /// The PublicationId is the subject
+    /// </summary>
+    public string Subject { get; }
+
+    /// <summary>
+    /// The event payload
+    /// </summary>
+    public EventPayload Payload { get; }
+
+    public record EventPayload
+    {
+        public required string PublicationSlug { get; init; }
+
+        public required Guid PreviousSupersededByPublicationId { get; init; }
+    }
+
+    public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiser.cs
@@ -83,4 +83,19 @@ public class AdminEventRaiser(IEventRaiser eventRaiser) : IAdminEventRaiser
                 publication,
                 previousLatestPublishedReleaseVersionId));
     }
+
+    /// <summary>
+    /// Publishes an event when an archived publication is restored.
+    /// </summary>
+    /// <param name="publicationId">The unique identifier of the archived publication that has been restored.</param>
+    /// <param name="publicationSlug">The slug of the archived publication that has been restored.</param>
+    /// <param name="previousSupersededByPublicationId">The unique identifier of the publication that superseded the archived publication before it was restored.</param>
+    public async Task OnPublicationRestored(
+        Guid publicationId,
+        string publicationSlug,
+        Guid previousSupersededByPublicationId) =>
+        await eventRaiser.RaiseEvent(new PublicationRestoredEvent(
+            publicationId,
+            publicationSlug,
+            previousSupersededByPublicationId));
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiser.cs
@@ -25,4 +25,9 @@ public interface IAdminEventRaiser
     Task OnPublicationLatestPublishedReleaseReordered(
         Publication publication,
         Guid previousLatestPublishedReleaseVersionId);
+
+    Task OnPublicationRestored(
+        Guid publicationId,
+        string publicationSlug,
+        Guid previousSupersededByPublicationId);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -276,6 +276,14 @@ public class PublicationService(
                 publication.Slug,
                 supersededByPublicationId: publication.SupersededById!.Value);
         }
+        else if (transition == PublicationArchiveStatusTransitionResolver.PublicationArchiveStatusTransition
+                     .ArchivedToNotArchived)
+        {
+            await adminEventRaiser.OnPublicationRestored(
+                publication.Id,
+                publication.Slug,
+                previousSupersededByPublicationId: previousSupersededById!.Value);
+        }
     }
 
     private async Task<Publication?> GetSupersedingPublication(Guid? supersededByPublicationId)


### PR DESCRIPTION
This PR is a follow up to https://github.com/dfe-analytical-services/explore-education-statistics/pull/5848 and raises an event in Admin when archived publications are restored.

The Admin service allows updating publications including setting and un-setting a 'superseded by' publication for a publication. A publication is considered to be archived if it has a superseding publication which is live, i.e. the superseding publication has one or more published releases.

This PR changes the Admin service to raise an Event Grid event when archived publications are restored. The event is only raised if a publication was previously archived but now isn't.

To know whether to raise the event or not, we work out the transition of the publication's archived status and only raise it if the status is changing from archived to not archived.

The Search Function App is subscribed to these events and will manage searchable documents accordingly. This change was made to the Search Function App in https://github.com/dfe-analytical-services/explore-education-statistics/pull/5846.