### PR TITLE
EES-6060-fix UI tests failing on Pre-prod

### DIFF
--- a/tests/robot-tests/tests/general_public/prod_only/old_fast_track.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/old_fast_track.robot
@@ -15,7 +15,7 @@ Navigate to Absence publication
     user checks page contains    This is not the latest data
 
 Open Overall absence accordion
-    user opens accordion section    About these statistics      id:content-1
+    user opens accordion section    About these statistics    id:content-1
     user scrolls to accordion section    About these statistics    id:content-1
 
 Follow Explore data link
@@ -25,7 +25,8 @@ Follow Explore data link
 Navigate to the Table Tool
     user waits until h1 is visible    Create your own tables    %{WAIT_SMALL}
     user clicks radio    View all featured tables
-    user clicks link containing text    Adult education and training participation and achievement by ethnicity group, 2014/15 to 2019/20
+    user clicks link containing text
+    ...    Adult education and training participation and achievement by ethnicity group, 2014/15 to 2019/20
 
 Visit featured table and generate a permalink
     user waits until page contains    This data is not from the latest release
@@ -42,15 +43,13 @@ Open shareable link and check outdated warning
 Validate that View latest data link takes user to the latest release page
     user goes back
     user waits until page contains    This data is not from the latest release
-    user clicks link containing text    View latest data: Academic year 2024/25
+    user clicks element    css:[data-testid="View latest data link"]
     user waits until h1 is visible    Further education and skills
-    user checks page contains   Academic year 2024/25
     user checks page contains    This is the latest data
 
  Validate that Publication link in Related information takes user to the latest release page
     user goes back
-    user waits until page contains link    Further education and skills, Academic year 2024/25
-    user clicks link containing text    Further education and skills, Academic year 2024/25
+    user waits until page finishes loading
+    user clicks link containing text    Further education and skills
     user waits until h1 is visible    Further education and skills
-    user checks page contains   Academic year 2024/25
     user checks page contains    This is the latest data


### PR DESCRIPTION
Fixing UI tests failures on Pre prod in `general_public` suite.
Chose different key words that do not rely on release name or x-path -So that the tests pass on both Pre prod and Prod even if the latest release name gets changed over time.

![image](https://github.com/user-attachments/assets/34842230-a46b-43e8-a335-e0e08f8cc96f)
