### PR TITLE
EES-6070 Remove Searchable Document Function

### DIFF
--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -58,6 +58,7 @@ param storageQueueNames SearchStorageQueueNames = {
   releaseSlugChanged: 'release-slug-changed-queue'
   releaseVersionPublished: 'release-version-published-queue'
   removePublicationSearchableDocuments: 'remove-publication-searchable-documents-queue'
+  removeSearchableDocument: 'remove-searchable-document-queue'
   searchableDocumentCreated: 'search-document-created-queue'
   themeUpdated: 'theme-updated-queue'
 }
@@ -161,6 +162,10 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
       {
         name: 'RemovePublicationSearchableDocumentsQueueName'
         value: storageQueueNames.removePublicationSearchableDocuments
+      }
+      {
+        name: 'RemoveSearchableDocumentQueueName'
+        value: storageQueueNames.removeSearchableDocument
       }
       {
         name: 'SearchableDocumentCreatedQueueName'

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -37,6 +37,8 @@ type SearchStorageQueueNames = {
   releaseVersionPublished: string
   @description('Queue name for removing searchable documents associated with a publication.')
   removePublicationSearchableDocuments: string
+  @description('Queue name for removing a single searchable document.')
+  removeSearchableDocument: string
   @description('Queue name for when a searchable document is created.')
   searchableDocumentCreated: string
   @description('Queue name for when a theme is updated.')

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/SearchableDocumentRemoverMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/SearchableDocumentRemoverMockBuilder.cs
@@ -6,7 +6,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 public class SearchableDocumentRemoverMockBuilder
 {
     private readonly Mock<ISearchableDocumentRemover> _mock = new(MockBehavior.Strict);
-    private RemovePublicationSearchableDocumentsResponse? _response;
+    private RemovePublicationSearchableDocumentsResponse? _removePublicationSearchableDocumentsResponse;
+    private RemoveSearchableDocumentResponse? _removeSearchableDocumentResponse;
 
     public SearchableDocumentRemoverMockBuilder()
     {
@@ -16,7 +17,13 @@ public class SearchableDocumentRemoverMockBuilder
             .Setup(m => m.RemovePublicationSearchableDocuments(
                 It.IsAny<RemovePublicationSearchableDocumentsRequest>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(_response ?? new RemovePublicationSearchableDocumentsResponse(new Dictionary<Guid, bool>()));
+            .ReturnsAsync(_removePublicationSearchableDocumentsResponse ?? new RemovePublicationSearchableDocumentsResponse(new Dictionary<Guid, bool>()));
+        
+        _mock
+            .Setup(m => m.RemoveSearchableDocument(
+                It.IsAny<RemoveSearchableDocumentRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_removeSearchableDocumentResponse ?? new RemoveSearchableDocumentResponse(Success: true));
     }
 
     public ISearchableDocumentRemover Build()
@@ -26,7 +33,13 @@ public class SearchableDocumentRemoverMockBuilder
 
     public SearchableDocumentRemoverMockBuilder WhereResponseIs(RemovePublicationSearchableDocumentsResponse response)
     {
-        _response = response;
+        _removePublicationSearchableDocumentsResponse = response;
+        return this;
+    }
+
+    public SearchableDocumentRemoverMockBuilder WhereResponseIs(RemoveSearchableDocumentResponse response)
+    {
+        _removeSearchableDocumentResponse = response;
         return this;
     }
 
@@ -51,6 +64,26 @@ public class SearchableDocumentRemoverMockBuilder
                     It.IsAny<RemovePublicationSearchableDocumentsRequest>(),
                     It.IsAny<CancellationToken>()),
                 Times.Never);
+        }
+
+        public void RemoveSearchableDocumentCalledFor(Guid releaseId)
+        {
+            mock
+                .Verify(m => m.RemoveSearchableDocument(
+                        It.Is<RemoveSearchableDocumentRequest>(
+                            req =>
+                                req.ReleaseId == releaseId),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+        }
+
+        public void RemoveSearchableDocumentNotCalled()
+        {
+            mock
+                .Verify(m => m.RemoveSearchableDocument(
+                        It.IsAny<RemoveSearchableDocumentRequest>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Never);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemoveSearchableDocument/RemoveSearchableDocumentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemoveSearchableDocument/RemoveSearchableDocumentTests.cs
@@ -1,0 +1,41 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.RemoveSearchableDocument;
+
+public class RemoveSearchableDocumentTests
+{
+    private readonly SearchableDocumentRemoverMockBuilder _searchableDocumentRemoverMockBuilder = new();
+    private RemoveSearchableDocumentFunction GetSut() => new(
+        new NullLogger<RemoveSearchableDocumentFunction>(),
+        _searchableDocumentRemoverMockBuilder.Build());
+
+    [Fact]
+    public void CanInstantiateSut() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task WhenMessageContainsReleaseId_ThenDocumentRemoverCalled()
+    {
+        var command = new RemoveSearchableDocumentDto { ReleaseId = Guid.NewGuid() };
+
+        await GetSut().RemoveSearchableDocument(command, new FunctionContextMockBuilder().Build());
+
+        _searchableDocumentRemoverMockBuilder.Assert
+            .RemoveSearchableDocumentCalledFor(command.ReleaseId.Value);
+    }
+
+    public static TheoryData<Guid?> MissingGuids = [Guid.Empty, null];
+
+    [Theory]
+    [MemberData(nameof(MissingGuids))]
+    public async Task WhenMessageDoesNotContainReleaseId_ThenDocumentRemoverNotCalled(Guid? missingReleaseId)
+    {
+        var command = new RemoveSearchableDocumentDto { ReleaseId = missingReleaseId };
+
+        await GetSut().RemoveSearchableDocument(command, new FunctionContextMockBuilder().Build());
+
+        _searchableDocumentRemoverMockBuilder.Assert.RemoveSearchableDocumentNotCalled();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RemoveSearchableDocument/Dto/RemoveSearchableDocumentDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RemoveSearchableDocument/Dto/RemoveSearchableDocumentDto.cs
@@ -1,0 +1,6 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument.Dto;
+
+public record RemoveSearchableDocumentDto
+{
+    public Guid? ReleaseId { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RemoveSearchableDocument/RemoveSearchableDocumentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RemoveSearchableDocument/RemoveSearchableDocumentFunction.cs
@@ -1,0 +1,30 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument;
+
+public class RemoveSearchableDocumentFunction(
+    ILogger<RemoveSearchableDocumentFunction> logger,
+    ISearchableDocumentRemover searchableDocumentRemover)
+{
+    [Function(nameof(RemoveSearchableDocument))]
+    public async Task RemoveSearchableDocument(
+        [QueueTrigger("%RemoveSearchableDocumentQueueName%")] RemoveSearchableDocumentDto message,
+        FunctionContext context)
+    {
+        var releaseId = message.ReleaseId;
+        if (releaseId is null || releaseId == Guid.Empty)
+        {
+            return;
+        }
+
+        var response = await searchableDocumentRemover.RemoveSearchableDocument(
+            new RemoveSearchableDocumentRequest { ReleaseId = releaseId.Value },
+            context.CancellationToken);
+
+        logger.LogInformation(
+            "Removed searchable document \"{ReleaseId}\". Response: {@response}", releaseId, response);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/ISearchableDocumentRemover.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/ISearchableDocumentRemover.cs
@@ -5,4 +5,8 @@ public interface ISearchableDocumentRemover
     Task<RemovePublicationSearchableDocumentsResponse> RemovePublicationSearchableDocuments(
         RemovePublicationSearchableDocumentsRequest request,
         CancellationToken cancellationToken = default);
+    
+    Task<RemoveSearchableDocumentResponse> RemoveSearchableDocument(
+        RemoveSearchableDocumentRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/RemoveSearchableDocumentRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/RemoveSearchableDocumentRequest.cs
@@ -1,0 +1,6 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+
+public record RemoveSearchableDocumentRequest
+{
+    public required Guid ReleaseId { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/RemoveSearchableDocumentResponse.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/RemoveSearchableDocumentResponse.cs
@@ -1,0 +1,3 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+
+public record RemoveSearchableDocumentResponse(bool Success);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/SearchableDocumentCreator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/SearchableDocumentCreator.cs
@@ -1,6 +1,6 @@
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
 using Microsoft.Extensions.Options;
 using Blob = GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage.Blob;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/SearchableDocumentRemover.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/SearchableDocumentRemover.cs
@@ -25,14 +25,24 @@ internal class SearchableDocumentRemover(
 
         foreach (var releaseInfo in releaseInfos)
         {
-            var blobName = releaseInfo.ReleaseId.ToString();
-            results[releaseInfo.ReleaseId] =
-                await azureBlobStorageClient.DeleteBlobIfExists(
-                    appOptions.Value.SearchableDocumentsContainerName,
-                    blobName,
-                    cancellationToken);
+            var result = await RemoveSearchableDocument(new RemoveSearchableDocumentRequest{ ReleaseId = releaseInfo.ReleaseId }, cancellationToken);
+            results[releaseInfo.ReleaseId] = result.Success;
         }
 
         return new RemovePublicationSearchableDocumentsResponse(results);
+    }
+
+    public async Task<RemoveSearchableDocumentResponse> RemoveSearchableDocument(
+        RemoveSearchableDocumentRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var blobName = request.ReleaseId.ToString();
+
+        var success = await azureBlobStorageClient.DeleteBlobIfExists(
+            appOptions.Value.SearchableDocumentsContainerName,
+            blobName,
+            cancellationToken);
+
+        return new RemoveSearchableDocumentResponse(success);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/local.settings.json
@@ -11,6 +11,7 @@
     "ReleaseSlugChangedQueueName": "release-slug-changed-queue",
     "ReleaseVersionPublishedQueueName": "release-version-published-queue",
     "RemovePublicationSearchableDocumentsQueueName": "remove-publication-searchable-documents-queue",
+    "RemoveSearchableDocumentQueueName": "remove-searchable-document-queue",
     "SearchableDocumentCreatedQueueName": "search-document-created-queue",
     "ThemeUpdatedQueueName": "theme-updated-queue"
   },


### PR DESCRIPTION
We introduced a new Azure function that removes specified searchable documents in preparation for removing searchable documents when there has been a reorder.
