### PR TITLE
EES-6070 Remove previous "latest" release version's searachable document

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationArchived/OnPublicationArchivedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationArchived/OnPublicationArchivedFunctionTests.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Func
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemovePublicationSearchableDocuments.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDataHelpers;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.OnPublicationArchived;
@@ -29,8 +30,7 @@ public class OnPublicationArchivedFunctionTests
     }
 
     [Theory]
-    [InlineData(null)]
-    [InlineData("")]
+    [MemberData(nameof(TheoryDatas.Blank.Strings), MemberType = typeof(TheoryDatas.Blank))]
     public async Task GivenEvent_WhenPayloadDoesNotContainSlug_ThenNothingIsReturned(string? blankSlug)
     {
         var payload = new PublicationArchivedEventDto { PublicationSlug = blankSlug };

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationChanged/OnReleaseSlugChangedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationChanged/OnReleaseSlugChangedFunctionTests.cs
@@ -2,6 +2,7 @@
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationChanged.Dtos;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDataHelpers;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.OnPublicationChanged;
@@ -38,8 +39,7 @@ public class OnPublicationChangedFunctionTests
     }
     
     [Theory]
-    [InlineData((string?)null)]
-    [InlineData("")]
+    [MemberData(nameof(TheoryDatas.Blank.Strings), MemberType = typeof(TheoryDatas.Blank))]
     public async Task GivenEvent_WhenPayloadDoesNotContainSlug_ThenNothingIsReturned(string? blankSlug)
     {
         // ARRANGE

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationRestored/OnPublicationRestoredFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationRestored/OnPublicationRestoredFunctionTests.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Func
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RefreshSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDataHelpers;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.OnPublicationRestored;
@@ -29,8 +30,7 @@ public class OnPublicationRestoredFunctionTests
     }
 
     [Theory]
-    [InlineData(null)]
-    [InlineData("")]
+    [MemberData(nameof(TheoryDatas.Blank.Strings), MemberType = typeof(TheoryDatas.Blank))]
     public async Task GivenEvent_WhenPayloadDoesNotContainSlug_ThenNothingIsReturned(string? blankSlug)
     {
         var payload = new PublicationRestoredEventDto { PublicationSlug = blankSlug };

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseSlugChanged/OnReleaseSlugChangedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseSlugChanged/OnReleaseSlugChangedFunctionTests.cs
@@ -2,6 +2,7 @@
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseSlugChanged.Dtos;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDataHelpers;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.OnReleaseSlugChanged;
@@ -38,8 +39,7 @@ public class OnReleaseSlugChangedFunctionTests
     }
     
     [Theory]
-    [InlineData((string?)null)]
-    [InlineData("")]
+    [MemberData(nameof(TheoryDatas.Blank.Strings), MemberType = typeof(TheoryDatas.Blank))]
     public async Task GivenEvent_WhenPayloadDoesNotContainPublicationSlug_ThenNothingIsReturned(string? blankPublicationSlug)
     {
         // ARRANGE

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseVersionPublished/OnReleaseVersionPublishedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseVersionPublished/OnReleaseVersionPublishedFunctionTests.cs
@@ -2,6 +2,7 @@
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnReleaseVersionPublished.Dtos;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDataHelpers;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.OnReleaseVersionPublished;
@@ -38,8 +39,7 @@ public class OnReleaseVersionPublishedFunctionTests
     }
     
     [Theory]
-    [InlineData((string?)null)]
-    [InlineData("")]
+    [MemberData(nameof(TheoryDatas.Blank.Strings), MemberType = typeof(TheoryDatas.Blank))]
     public async Task GivenEvent_WhenPayloadDoesNotContainPublicationSlug_ThenNothingIsReturned(string? blankPublicationSlug)
     {
         // ARRANGE

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RefreshSearchableDocument/RefreshSearchableDocumentFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RefreshSearchableDocument/RefreshSearchableDocumentFunctionTests.cs
@@ -2,6 +2,7 @@
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RefreshSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDataHelpers;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.RefreshSearchableDocument;
 
@@ -33,8 +34,7 @@ public class RefreshSearchableDocumentFunctionTests
     }
     
     [Theory]
-    [InlineData("")]
-    [InlineData(null)]
+    [MemberData(nameof(TheoryDatas.Blank.Strings), MemberType = typeof(TheoryDatas.Blank))]
     public async Task WhenMessageHasNoPublicationSlug_ThenDocumentCreatorNotCalled(string? blankPublicationSlug)
     {
         // ARRANGE

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsTests.cs
@@ -3,6 +3,7 @@
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.
     RemovePublicationSearchableDocuments.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDataHelpers;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.
@@ -31,8 +32,7 @@ public class RemovePublicationSearchableDocumentsTests
     }
 
     [Theory]
-    [InlineData(null)]
-    [InlineData("")]
+    [MemberData(nameof(TheoryDatas.Blank.Strings), MemberType = typeof(TheoryDatas.Blank))]
     public async Task WhenMessageDoesNotContainSlug_ThenDocumentRemoverNotCalled(string? publicationSlug)
     {
         var command = new RemovePublicationSearchableDocumentsDto { PublicationSlug = publicationSlug };

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemoveSearchableDocument/RemoveSearchableDocumentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemoveSearchableDocument/RemoveSearchableDocumentTests.cs
@@ -1,6 +1,7 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDatas;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.RemoveSearchableDocument;
@@ -26,10 +27,9 @@ public class RemoveSearchableDocumentTests
             .RemoveSearchableDocumentCalledFor(command.ReleaseId.Value);
     }
 
-    public static TheoryData<Guid?> MissingGuids = [Guid.Empty, null];
 
     [Theory]
-    [MemberData(nameof(MissingGuids))]
+    [MemberData(nameof(Empty.GuidValues), MemberType = typeof(Empty))]
     public async Task WhenMessageDoesNotContainReleaseId_ThenDocumentRemoverNotCalled(Guid? missingReleaseId)
     {
         var command = new RemoveSearchableDocumentDto { ReleaseId = missingReleaseId };

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemoveSearchableDocument/RemoveSearchableDocumentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemoveSearchableDocument/RemoveSearchableDocumentTests.cs
@@ -1,7 +1,7 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDatas;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDataHelpers;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.RemoveSearchableDocument;
@@ -29,7 +29,7 @@ public class RemoveSearchableDocumentTests
 
 
     [Theory]
-    [MemberData(nameof(Empty.GuidValues), MemberType = typeof(Empty))]
+    [MemberData(nameof(TheoryDatas.Blank.Guids), MemberType = typeof(TheoryDatas.Blank))]
     public async Task WhenMessageDoesNotContainReleaseId_ThenDocumentRemoverNotCalled(Guid? missingReleaseId)
     {
         var command = new RemoveSearchableDocumentDto { ReleaseId = missingReleaseId };

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/TheoryDataHelpers/BlankValues.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/TheoryDataHelpers/BlankValues.cs
@@ -1,0 +1,10 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDataHelpers;
+
+public static class TheoryDatas
+{
+    public static class Blank
+    {
+        public static TheoryData<string?> Strings => [null, string.Empty];
+        public static TheoryData<Guid?> Guids => [null, Guid.Empty];
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/TheoryDatas/Empty.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/TheoryDatas/Empty.cs
@@ -1,7 +1,0 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDatas;
-
-public class Empty
-{
-    public static TheoryData<string?> StringValues => [null, string.Empty];
-    public static TheoryData<Guid?> GuidValues => [null, Guid.Empty];
-}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/TheoryDatas/Empty.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/TheoryDatas/Empty.cs
@@ -1,0 +1,7 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDatas;
+
+public class Empty
+{
+    public static TheoryData<string?> StringValues => [null, string.Empty];
+    public static TheoryData<Guid?> GuidValues => [null, Guid.Empty];
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/GuidExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/GuidExtensions.cs
@@ -1,0 +1,8 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
+
+public static class GuidExtensions
+{
+    public static bool HasNonEmptyValue([NotNullWhen(true)]this Guid? guid) => !(guid is null || guid == Guid.Empty);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationLatestPublishedReleaseReordered/OnPublicationLatestPublishedReleaseReorderedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationLatestPublishedReleaseReordered/OnPublicationLatestPublishedReleaseReorderedFunction.cs
@@ -1,6 +1,8 @@
 using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationLatestPublishedReleaseReordered.Dtos;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RefreshSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using Microsoft.Azure.Functions.Worker;
 
@@ -9,17 +11,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 public class OnPublicationLatestPublishedReleaseReorderedFunction(IEventGridEventHandler eventGridEventHandler)
 {
     [Function(nameof(OnPublicationLatestPublishedReleaseReordered))]
-    [QueueOutput("%RefreshSearchableDocumentQueueName%")]
-    public async Task<RefreshSearchableDocumentMessageDto[]> OnPublicationLatestPublishedReleaseReordered(
+    public async Task<OnPublicationLatestPublishedReleaseReorderedOutput> OnPublicationLatestPublishedReleaseReordered(
         [QueueTrigger("%PublicationLatestPublishedReleaseReorderedQueueName%")]
         EventGridEvent eventDto,
         FunctionContext context) =>
-        await eventGridEventHandler.Handle<PublicationLatestPublishedReleaseReorderedEventDto, RefreshSearchableDocumentMessageDto[]>(
+        await eventGridEventHandler.Handle<PublicationLatestPublishedReleaseReorderedEventDto, OnPublicationLatestPublishedReleaseReorderedOutput>(
             context, 
             eventDto,
-            (payload, ct) => 
-                Task.FromResult<RefreshSearchableDocumentMessageDto[]>(
-                    string.IsNullOrEmpty(payload.Slug)
-                        ? []
-                        : [ new RefreshSearchableDocumentMessageDto { PublicationSlug = payload.Slug } ]));
+            (payload, ct) =>
+            {
+                if (string.IsNullOrEmpty(payload.Slug))
+                {
+                    return Task.FromResult(OnPublicationLatestPublishedReleaseReorderedOutput.Empty);
+                }
+
+                // Create searchable document for the release version that has become the latest version
+                RefreshSearchableDocumentMessageDto[] newSearchableDocuments = [new() { PublicationSlug = payload.Slug }];
+
+                // Remove the previous "latest" release version's searchable document 
+                RemoveSearchableDocumentDto[] removeSearchableDocuments =
+                    payload.PreviousReleaseVersionId.HasNonEmptyValue()
+                        ? [ new RemoveSearchableDocumentDto{ ReleaseId = payload.PreviousReleaseVersionId.Value} ]
+                        : [];
+                
+                return Task.FromResult(new OnPublicationLatestPublishedReleaseReorderedOutput
+                {
+                    RefreshSearchableDocuments = newSearchableDocuments,
+                    RemoveSearchableDocuments = removeSearchableDocuments
+                });
+            });
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationLatestPublishedReleaseReordered/OnPublicationLatestPublishedReleaseReorderedOutput.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationLatestPublishedReleaseReordered/OnPublicationLatestPublishedReleaseReorderedOutput.cs
@@ -1,0 +1,16 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RefreshSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument.Dto;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationLatestPublishedReleaseReordered;
+
+public class OnPublicationLatestPublishedReleaseReorderedOutput
+{
+    [QueueOutput("%RefreshSearchableDocumentQueueName%")]
+    public RefreshSearchableDocumentMessageDto[] RefreshSearchableDocuments { get; init; } = [];
+
+    [QueueOutput("%RemoveSearchableDocumentQueueName%")]
+    public RemoveSearchableDocumentDto[] RemoveSearchableDocuments { get; init; } = [];
+    
+    public static OnPublicationLatestPublishedReleaseReorderedOutput Empty => new();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationLatestPublishedReleaseReordered/OnPublicationLatestPublishedReleaseReorderedOutput.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/OnPublicationLatestPublishedReleaseReordered/OnPublicationLatestPublishedReleaseReorderedOutput.cs
@@ -4,7 +4,7 @@ using Microsoft.Azure.Functions.Worker;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.OnPublicationLatestPublishedReleaseReordered;
 
-public class OnPublicationLatestPublishedReleaseReorderedOutput
+public record OnPublicationLatestPublishedReleaseReorderedOutput
 {
     [QueueOutput("%RefreshSearchableDocumentQueueName%")]
     public RefreshSearchableDocumentMessageDto[] RefreshSearchableDocuments { get; init; } = [];

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RemoveSearchableDocument/RemoveSearchableDocumentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/RemoveSearchableDocument/RemoveSearchableDocumentFunction.cs
@@ -1,4 +1,5 @@
-﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument.Dto;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.RemoveSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
@@ -15,7 +16,7 @@ public class RemoveSearchableDocumentFunction(
         FunctionContext context)
     {
         var releaseId = message.ReleaseId;
-        if (releaseId is null || releaseId == Guid.Empty)
+        if (!releaseId.HasNonEmptyValue())
         {
             return;
         }


### PR DESCRIPTION
Only the latest release of a publication is searchable.
Releases can be reordered so that a new release version becomes the "latest".
When this occurs, a new searchable document was being created for the new "latest" release version.
However, the previous "latest" searchable document was not being removed.
This PR looks to address that.