### PR TITLE
EES-6123 Fix themeTitle field name which was missed during rename

### DIFF
--- a/infrastructure/templates/search/application/indexes/index-1.json
+++ b/infrastructure/templates/search/application/indexes/index-1.json
@@ -334,7 +334,7 @@
           ],
           "prioritizedKeywordsFields": [
             {
-              "fieldName": "theme"
+              "fieldName": "themeTitle"
             }
           ]
         }


### PR DESCRIPTION
This PR fixes the `themeTitle` field name in the Azure AI Search configuration which should have been renamed from `theme` to `themeTitle` by https://github.com/dfe-analytical-services/explore-education-statistics/pull/5856.