### PR TITLE
EES-6147 - hotfix to give Public Site access to Key Vault certificates

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1247,6 +1247,10 @@
       ]
     },
     "templateBaseUrl": "[concat('https://raw.githubusercontent.com/dfe-analytical-services/explore-education-statistics/', parameters('branch'), '/infrastructure/templates/')]",
+    "keyVaultCertificateUserRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'db79e9a7-68ee-4b58-9aeb-b90e7c24fcba')]",
+    "keyVaultCertificateUserPrincipalRefs": [
+      "[concat('Microsoft.Web/sites/', variables('publicAppName'))]"
+    ],
     "keyVaultSecretsUserRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
     "keyVaultSecretsUserPrincipalRefs": [
       "[concat('Microsoft.Web/sites/', variables('adminAppName'))]",
@@ -3999,6 +4003,21 @@
           }
         }
       ]
+    },
+    {
+      "copy": {
+        "name": "keyVaultCertificateUsersCopy",
+        "count": "[length(variables('keyVaultCertificateUserPrincipalRefs'))]"
+      },
+      "type": "Microsoft.KeyVault/vaults/providers/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[concat(variables('keyVaultName'), '/Microsoft.Authorization/', guid(resourceId('Microsoft.KeyVault/vaults',  variables('keyVaultName')), variables('keyVaultCertificateUserRoleDefinitionId'), variables('keyVaultCertificateUserPrincipalRefs')[copyIndex()]))]",
+      "properties": {
+        "roleDefinitionId": "[variables('keyVaultCertificateUserRoleDefinitionId')]",
+        "principalId": "[reference(variables('keyVaultCertificateUserPrincipalRefs')[copyIndex()], '2022-09-01', 'Full').identity.principalId]",
+        "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+        "principalType": "ServicePrincipal"
+      }
     },
     {
       "copy": {


### PR DESCRIPTION
This PR:
- grants the Public Site App Service's Managed Identity the "Key Vault Certificate User" role within its environment's Key Vault.

This is the prerequisite step in order for us to be able to connect an auto-renewing GlobalSign certificate from Production's Key Vault with the Production Public Site.

For those interested, the "magic GUID" in this PR comes from https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/security#key-vault-certificate-user.