### PR TITLE
EES-6107 Refactor `PublishingCompletionService` to improve handling when publications are archived

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -27,6 +27,7 @@
         <PackageReference Include="CsvHelper" Version="31.0.4" />
         <PackageReference Include="FluentValidation" Version="11.11.0" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+        <PackageReference Include="Generator.Equals" Version="3.2.0" />
         <PackageReference Include="InterpolatedSql" Version="2.3.0" />
         <PackageReference Include="Medo.Uuid7" Version="1.9.1" />
         <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Events.Tests/EventGrid/Builders/EventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events.Tests/EventGrid/Builders/EventRaiserMockBuilder.cs
@@ -14,9 +14,9 @@ public class EventRaiserMockBuilder
             where TEventBuilder : IEvent
             => Xunit.Assert.True(parent._mock.EventWasRaised(expectedEvent));
 
-        public void EventsRaised<TEventBuilder>(IEnumerable<TEventBuilder> expectedEvents) 
+        public void EventsRaised<TEventBuilder>(IEnumerable<TEventBuilder> expectedEvents)
             where TEventBuilder : IEvent
-            => Xunit.Assert.All(expectedEvents, e => Xunit.Assert.True( parent._mock.EventWasRaised(e)));
+            => Xunit.Assert.All(expectedEvents, e => Xunit.Assert.True(parent._mock.EventWasRaised(e)));
 
         public void NoEventRaised() 
             => Xunit.Assert.False(parent._mock.EventWasRaised());

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
@@ -5,17 +5,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Events;
 
 public record ReleaseVersionPublishedEvent : IEvent
 {
-    public ReleaseVersionPublishedEvent(PublishedReleaseVersionInfo publishedReleaseVersion)
+    public ReleaseVersionPublishedEvent(ReleaseVersionPublishedEventInfo releaseVersionPublishedEvent)
     {
-        Subject = publishedReleaseVersion.ReleaseVersionId.ToString();
-        Payload = new()
+        Subject = releaseVersionPublishedEvent.ReleaseVersionId.ToString();
+        Payload = new EventPayload
         {
-            ReleaseId = publishedReleaseVersion.ReleaseId,
-            ReleaseSlug = publishedReleaseVersion.ReleaseSlug,
-            PublicationId = publishedReleaseVersion.PublicationId,
-            PublicationSlug = publishedReleaseVersion.PublicationSlug,
-            PublicationLatestPublishedReleaseVersionId = publishedReleaseVersion.PublicationLatestPublishedReleaseVersionId,
-            PreviousLatestReleaseId = publishedReleaseVersion.PreviousLatestReleaseId,
+            ReleaseId = releaseVersionPublishedEvent.ReleaseId,
+            ReleaseSlug = releaseVersionPublishedEvent.ReleaseSlug,
+            PublicationId = releaseVersionPublishedEvent.PublicationId,
+            PublicationSlug = releaseVersionPublishedEvent.PublicationSlug,
+            PublicationLatestPublishedReleaseVersionId = releaseVersionPublishedEvent.PublicationLatestPublishedReleaseVersionId,
+            PreviousLatestReleaseId = releaseVersionPublishedEvent.PreviousLatestReleaseId,
         };
     }
 
@@ -47,7 +47,7 @@ public record ReleaseVersionPublishedEvent : IEvent
     
     public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);
 
-    public record PublishedReleaseVersionInfo
+    public record ReleaseVersionPublishedEventInfo
     {
         /// <summary>
         /// Newly published release version id

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Models/PublicationBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Models/PublicationBuilder.cs
@@ -5,7 +5,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Mo
 
 public class PublicationBuilder(Guid publicationId, string publicationSlug)
 {
-    private Guid? _latestPublishedReleaseVersionId;
     private Guid? _supersededByPublicationId;
 
     public Publication Build()
@@ -14,16 +13,9 @@ public class PublicationBuilder(Guid publicationId, string publicationSlug)
         {
             Id = publicationId,
             Slug = publicationSlug,
-            LatestPublishedReleaseVersionId = _latestPublishedReleaseVersionId,
-            SupersededById = _supersededByPublicationId,
+            SupersededById = _supersededByPublicationId
         };
         return publication;
-    }
-
-    public PublicationBuilder WithLatestPublishedReleaseVersionId(Guid? latestPublishedReleaseVersionId)
-    {
-        _latestPublishedReleaseVersionId = latestPublishedReleaseVersionId;
-        return this;
     }
 
     public PublicationBuilder SupersededBy(Guid supersededByPublicationId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Models/PublicationBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Models/PublicationBuilder.cs
@@ -5,6 +5,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Mo
 
 public class PublicationBuilder(Guid publicationId, string publicationSlug)
 {
+    private Guid? _latestPublishedReleaseVersionId;
     private Guid? _supersededByPublicationId;
 
     public Publication Build()
@@ -13,9 +14,16 @@ public class PublicationBuilder(Guid publicationId, string publicationSlug)
         {
             Id = publicationId,
             Slug = publicationSlug,
-            SupersededById = _supersededByPublicationId
+            LatestPublishedReleaseVersionId = _latestPublishedReleaseVersionId,
+            SupersededById = _supersededByPublicationId,
         };
         return publication;
+    }
+
+    public PublicationBuilder WithLatestPublishedReleaseVersionId(Guid? latestPublishedReleaseVersionId)
+    {
+        _latestPublishedReleaseVersionId = latestPublishedReleaseVersionId;
+        return this;
     }
 
     public PublicationBuilder SupersededBy(Guid supersededByPublicationId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/PublicationCacheServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/PublicationCacheServiceMockBuilder.cs
@@ -26,5 +26,10 @@ public class PublicationCacheServiceMockBuilder
         {
             mock.Verify(m => m.UpdatePublication(publicationSlug), Times.Once);
         }
+
+        public void PublicationNotUpdated(string publicationSlug)
+        {
+            mock.Verify(m => m.UpdatePublication(publicationSlug), Times.Never);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/PublisherEventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/PublisherEventRaiserMockBuilder.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Events;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Moq;
 
@@ -13,19 +13,21 @@ public class PublisherEventRaiserMockBuilder
     private readonly Mock<IPublisherEventRaiser> _mock = new(MockBehavior.Strict);
     public IPublisherEventRaiser Build() => _mock.Object;
     public Asserter Assert => new(_mock);
+
     public PublisherEventRaiserMockBuilder()
     {
         _mock
-            .Setup(m => m.RaiseReleaseVersionPublishedEvents(It.IsAny<IList<ReleaseVersionPublishedEvent.PublishedReleaseVersionInfo>>()))
+            .Setup(m => m.RaiseReleaseVersionPublishedEvents(
+                It.IsAny<IReadOnlyList<PublishedPublicationInfo>>()))
             .Returns(Task.CompletedTask);
     }
 
     public class Asserter(Mock<IPublisherEventRaiser> mock)
     {
-        public void EventWasRaised(Func<ReleaseVersionPublishedEvent.PublishedReleaseVersionInfo, bool> expected)
+        public void EventWasRaised(Func<PublishedPublicationInfo, bool> expected)
         {
             mock.Verify(m => m.RaiseReleaseVersionPublishedEvents(
-                It.Is<IList<ReleaseVersionPublishedEvent.PublishedReleaseVersionInfo>>(
+                It.Is<IReadOnlyList<PublishedPublicationInfo>>(
                     actual => actual.Any(expected))));
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublisherEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublisherEventRaiser.cs
@@ -1,11 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Events;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 
 public interface IPublisherEventRaiser
 {
-    Task RaiseReleaseVersionPublishedEvents(
-        IEnumerable<ReleaseVersionPublishedEvent.PublishedReleaseVersionInfo> publishedReleaseVersionInfos);
+    Task RaiseReleaseVersionPublishedEvents(IReadOnlyList<PublishedPublicationInfo> publishedReleaseVersionEventInfos);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedPublicationInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedPublicationInfo.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
+using Generator.Equals;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 
-public record PublishedPublicationInfo
+[Equatable]
+public partial record PublishedPublicationInfo
 {
     public required Guid PublicationId { get; init; }
 
@@ -35,6 +36,7 @@ public record PublishedPublicationInfo
     /// <summary>
     /// The list of information about published release versions for a publication.
     /// </summary>
+    [UnorderedEquality]
     public required IReadOnlyList<PublishedReleaseVersionInfo> PublishedReleaseVersions { get; init; }
 
     /// <summary>
@@ -42,35 +44,4 @@ public record PublishedPublicationInfo
     /// </summary>
     ///
     public bool WasAlreadyPublished => PreviousLatestPublishedReleaseVersionId != null;
-
-    public virtual bool Equals(PublishedPublicationInfo? other)
-    {
-        if (other is null)
-        {
-            return false;
-        }
-
-        if (ReferenceEquals(this, other))
-        {
-            return true;
-        }
-
-        return PublicationId.Equals(other.PublicationId) &&
-               PublicationSlug == other.PublicationSlug &&
-               LatestPublishedReleaseId.Equals(other.LatestPublishedReleaseId) &&
-               LatestPublishedReleaseVersionId.Equals(other.LatestPublishedReleaseVersionId) &&
-               Nullable.Equals(PreviousLatestPublishedReleaseId, other.PreviousLatestPublishedReleaseId) &&
-               Nullable.Equals(PreviousLatestPublishedReleaseVersionId,
-                   other.PreviousLatestPublishedReleaseVersionId) &&
-               PublishedReleaseVersions.SequenceEqual(other.PublishedReleaseVersions);
-    }
-
-    public override int GetHashCode() => HashCode.Combine(
-        PublicationId,
-        PublicationSlug,
-        LatestPublishedReleaseId,
-        LatestPublishedReleaseVersionId,
-        PreviousLatestPublishedReleaseId,
-        PreviousLatestPublishedReleaseVersionId,
-        PublishedReleaseVersions);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedPublicationInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedPublicationInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services;
@@ -35,7 +35,7 @@ public record PublishedPublicationInfo
     /// <summary>
     /// The list of information about published release versions for a publication.
     /// </summary>
-    public required IImmutableList<PublishedReleaseVersionInfo> PublishedReleaseVersions { get; init; }
+    public required IReadOnlyList<PublishedReleaseVersionInfo> PublishedReleaseVersions { get; init; }
 
     /// <summary>
     /// Indicates whether the publication was already published before the publishing run.

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedPublicationInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedPublicationInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 
@@ -34,11 +35,42 @@ public record PublishedPublicationInfo
     /// <summary>
     /// The list of information about published release versions for a publication.
     /// </summary>
-    public required List<PublishedReleaseVersionInfo> PublishedReleaseVersions { get; init; }
+    public required IImmutableList<PublishedReleaseVersionInfo> PublishedReleaseVersions { get; init; }
 
     /// <summary>
     /// Indicates whether the publication was already published before the publishing run.
     /// </summary>
     ///
     public bool WasAlreadyPublished => PreviousLatestPublishedReleaseVersionId != null;
+
+    public virtual bool Equals(PublishedPublicationInfo? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return PublicationId.Equals(other.PublicationId) &&
+               PublicationSlug == other.PublicationSlug &&
+               LatestPublishedReleaseId.Equals(other.LatestPublishedReleaseId) &&
+               LatestPublishedReleaseVersionId.Equals(other.LatestPublishedReleaseVersionId) &&
+               Nullable.Equals(PreviousLatestPublishedReleaseId, other.PreviousLatestPublishedReleaseId) &&
+               Nullable.Equals(PreviousLatestPublishedReleaseVersionId,
+                   other.PreviousLatestPublishedReleaseVersionId) &&
+               PublishedReleaseVersions.SequenceEqual(other.PublishedReleaseVersions);
+    }
+
+    public override int GetHashCode() => HashCode.Combine(
+        PublicationId,
+        PublicationSlug,
+        LatestPublishedReleaseId,
+        LatestPublishedReleaseVersionId,
+        PreviousLatestPublishedReleaseId,
+        PreviousLatestPublishedReleaseVersionId,
+        PublishedReleaseVersions);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedPublicationInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedPublicationInfo.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+
+public record PublishedPublicationInfo
+{
+    public required Guid PublicationId { get; init; }
+
+    public required string PublicationSlug { get; init; }
+
+    /// <summary>
+    /// The unique identifier of the latest published release for a publication, after the publishing run.
+    /// </summary>
+    public required Guid LatestPublishedReleaseId { get; init; }
+
+    /// <summary>
+    /// The unique identifier of the latest published release version for a publication, after the publishing run.
+    /// </summary>
+    public required Guid LatestPublishedReleaseVersionId { get; init; }
+
+    /// <summary>
+    /// The unique identifier of the previous latest published release for a publication, before the publishing run.
+    /// This value is nullable, indicating that the publication may not have had a previously published release.
+    /// </summary>
+    public required Guid? PreviousLatestPublishedReleaseId { get; init; }
+
+    /// <summary>
+    /// The unique identifier of the previous latest published release version for a publication, before the publishing run.
+    /// This value is nullable, indicating that the publication may not have had a previously published release.
+    /// </summary>
+    public required Guid? PreviousLatestPublishedReleaseVersionId { get; init; }
+
+    /// <summary>
+    /// The list of information about published release versions for a publication.
+    /// </summary>
+    public required List<PublishedReleaseVersionInfo> PublishedReleaseVersions { get; init; }
+
+    /// <summary>
+    /// Indicates whether the publication was already published before the publishing run.
+    /// </summary>
+    ///
+    public bool WasAlreadyPublished => PreviousLatestPublishedReleaseVersionId != null;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedReleaseVersionInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedReleaseVersionInfo.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+
+public record PublishedReleaseVersionInfo
+{
+    public required Guid ReleaseVersionId { get; init; }
+
+    public required Guid ReleaseId { get; init; }
+
+    public required string ReleaseSlug { get; init; } = string.Empty;
+
+    public required Guid PublicationId { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedReleaseVersionInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedReleaseVersionInfo.cs
@@ -8,7 +8,7 @@ public record PublishedReleaseVersionInfo
 
     public required Guid ReleaseId { get; init; }
 
-    public required string ReleaseSlug { get; init; } = string.Empty;
+    public required string ReleaseSlug { get; init; }
 
     public required Guid PublicationId { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
@@ -15,9 +15,25 @@ public class PublisherEventRaiser(IEventRaiser eventRaiser) : IPublisherEventRai
     /// <summary>
     /// On Release Version Published
     /// </summary>
-    /// <param name="publishedReleaseVersionInfos">information about the one or more release versions that have been published</param>
+    /// <param name="publishedPublications">information about the one or more publications that have been published</param>
     public async Task RaiseReleaseVersionPublishedEvents(
-        IEnumerable<ReleaseVersionPublishedEvent.PublishedReleaseVersionInfo> publishedReleaseVersionInfos) =>
-        await eventRaiser.RaiseEvents(
-            publishedReleaseVersionInfos.Select(info => new ReleaseVersionPublishedEvent(info)));
+        IReadOnlyList<PublishedPublicationInfo> publishedPublications)
+    {
+        var events = publishedPublications.SelectMany(publication =>
+            publication.PublishedReleaseVersions.Select(releaseVersion =>
+                new ReleaseVersionPublishedEvent(
+                    new ReleaseVersionPublishedEvent.ReleaseVersionPublishedEventInfo
+                    {
+                        ReleaseId = releaseVersion.ReleaseId,
+                        ReleaseSlug = releaseVersion.ReleaseSlug,
+                        ReleaseVersionId = releaseVersion.ReleaseVersionId,
+                        PublicationId = publication.PublicationId,
+                        PublicationSlug = publication.PublicationSlug,
+                        PreviousLatestReleaseId = publication.PreviousLatestPublishedReleaseId,
+                        PublicationLatestPublishedReleaseVersionId = publication.LatestPublishedReleaseVersionId
+                    })))
+            .ToList();
+
+        await eventRaiser.RaiseEvents(events);
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
-using GovUk.Education.ExploreEducationStatistics.Events;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -76,38 +75,10 @@ public class PublishingCompletionService(
                 }
             });
 
-        var publishedReleaseVersionInfos = await contentDbContext
-            .ReleaseVersions
-            .Where(rv => releaseVersionIdsToUpdate.Contains(rv.Id))
-            .Select(rv => new ReleaseVersionPublishedEvent.PublishedReleaseVersionInfo
-            {
-                ReleaseVersionId = rv.Id, 
-                ReleaseId = rv.ReleaseId,
-                ReleaseSlug = rv.Release.Slug,
-                PublicationId = rv.Release.PublicationId
-            })
-            .Distinct()
-            .ToListAsync();
+        var publishedReleaseVersionInfos = await BuildPublishedReleaseVersionInfos(releaseVersionIdsToUpdate);
+        var publishedPublicationInfos = await PublishPublications(publishedReleaseVersionInfos);
 
-        publishedReleaseVersionInfos = await publishedReleaseVersionInfos
-            .ToAsyncEnumerable()
-            .SelectAwait(UpdateLatestPublishedReleaseVersionForPublication)
-            .ToListAsync();
-
-        var directlyRelatedPublicationIds = publishedReleaseVersionInfos.Select(info => info.PublicationId).Distinct().ToList();
-        
-        // Update the cached publication and any cached superseded publications.
-        // If this is the first live release of the publication, the superseding is now enforced
-        var publicationSlugsToUpdate = await contentDbContext
-            .Publications
-            .Where(p => directlyRelatedPublicationIds.Contains(p.Id) ||
-                        (p.SupersededById != null && directlyRelatedPublicationIds.Contains(p.SupersededById.Value)))
-            .Select(p => p.Slug)
-            .ToListAsync();
-
-        await publicationSlugsToUpdate
-            .ToAsyncEnumerable()
-            .ForEachAwaitAsync(publicationCacheService.UpdatePublication);
+        await HandleArchivedPublications(publishedPublicationInfos);
 
         await contentService.DeletePreviousVersionsDownloadFiles(releaseVersionIdsToUpdate);
         await contentService.DeletePreviousVersionsContent(releaseVersionIdsToUpdate);
@@ -122,8 +93,8 @@ public class PublishingCompletionService(
 
         await dataSetPublishingService.PublishDataSets(releaseVersionIdsToUpdate);
 
-        await publisherEventRaiser.RaiseReleaseVersionPublishedEvents(publishedReleaseVersionInfos);
-        
+        await publisherEventRaiser.RaiseReleaseVersionPublishedEvents(publishedPublicationInfos);
+
         await prePublishingStagesComplete
             .ToAsyncEnumerable()
             .ForEachAwaitAsync(async status =>
@@ -131,25 +102,82 @@ public class PublishingCompletionService(
                     .UpdatePublishingStage(status.AsTableRowKey(), ReleasePublishingStatusPublishingStage.Complete));
     }
 
-    private async ValueTask<ReleaseVersionPublishedEvent.PublishedReleaseVersionInfo> UpdateLatestPublishedReleaseVersionForPublication(
-        ReleaseVersionPublishedEvent.PublishedReleaseVersionInfo info)
+    private async ValueTask<List<PublishedReleaseVersionInfo>>
+        BuildPublishedReleaseVersionInfos(IReadOnlyList<Guid> releaseVersionIds)
+    {
+        return await contentDbContext
+            .ReleaseVersions
+            .Where(rv => releaseVersionIds.Contains(rv.Id))
+            .Select(rv => new PublishedReleaseVersionInfo
+            {
+                ReleaseVersionId = rv.Id,
+                ReleaseId = rv.ReleaseId,
+                ReleaseSlug = rv.Release.Slug,
+                PublicationId = rv.Release.PublicationId
+            })
+            .ToListAsync();
+    }
+
+    private async ValueTask<List<PublishedPublicationInfo>> PublishPublications(
+        IReadOnlyList<PublishedReleaseVersionInfo> releaseVersions)
+    {
+        return await releaseVersions
+            .GroupBy(info => info.PublicationId)
+            .ToAsyncEnumerable()
+            .SelectAwait(group => PublishPublication(
+                publicationId: group.Key,
+                publishedReleaseVersions: group.ToList()))
+            .ToListAsync();
+    }
+
+    private async ValueTask<PublishedPublicationInfo> PublishPublication(
+        Guid publicationId,
+        List<PublishedReleaseVersionInfo> publishedReleaseVersions)
     {
         var publication = await contentDbContext.Publications
             .Include(p => p.LatestPublishedReleaseVersion)
-            .SingleAsync(p => p.Id == info.PublicationId);
+            .SingleAsync(p => p.Id == publicationId);
 
-        var latestPublishedReleaseVersion = await releaseService.GetLatestPublishedReleaseVersion(info.PublicationId);
+        var previousLatestPublishedReleaseVersion = publication.LatestPublishedReleaseVersion;
 
-        var previousLatestReleaseId = publication.LatestPublishedReleaseVersion?.ReleaseId;
+        // Update the latest published releaseVersion for the publication
+        var latestPublishedReleaseVersion = await releaseService.GetLatestPublishedReleaseVersion(publicationId);
         publication.LatestPublishedReleaseVersionId = latestPublishedReleaseVersion.Id;
-
         await contentDbContext.SaveChangesAsync();
-        
-        return info with
+
+        // Invalidate the cache for the publication
+        await publicationCacheService.UpdatePublication(publication.Slug);
+
+        return new PublishedPublicationInfo
         {
-            PublicationLatestPublishedReleaseVersionId = latestPublishedReleaseVersion.Id,
+            PublicationId = publication.Id,
             PublicationSlug = publication.Slug,
-            PreviousLatestReleaseId = previousLatestReleaseId,
+            LatestPublishedReleaseId = latestPublishedReleaseVersion.ReleaseId,
+            LatestPublishedReleaseVersionId = latestPublishedReleaseVersion.Id,
+            PreviousLatestPublishedReleaseId = previousLatestPublishedReleaseVersion?.ReleaseId,
+            PreviousLatestPublishedReleaseVersionId = previousLatestPublishedReleaseVersion?.Id,
+            PublishedReleaseVersions = publishedReleaseVersions
         };
+    }
+
+    private async Task HandleArchivedPublications(IReadOnlyList<PublishedPublicationInfo> publications)
+    {
+        // Archived publications are those replaced by another publication with at least one published release.
+        // Filter publications from this run, excluding those already published.
+        var publicationIds = publications
+            .Where(p => !p.WasAlreadyPublished)
+            .Select(p => p.PublicationId)
+            .ToList();
+
+        // Find publications that should now be archived because they have been replaced by these publications
+        var archivedPublications = await contentDbContext.Publications
+            .Where(p => p.SupersededById != null && publicationIds.Contains(p.SupersededById.Value))
+            .ToListAsync();
+
+        foreach (var archivedPublication in archivedPublications)
+        {
+            // Invalidate the cache of the publication to reflect its new archived status
+            await publicationCacheService.UpdatePublication(archivedPublication.Slug);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -126,13 +127,13 @@ public class PublishingCompletionService(
             .ToAsyncEnumerable()
             .SelectAwait(group => PublishPublication(
                 publicationId: group.Key,
-                publishedReleaseVersions: group.ToList()))
+                publishedReleaseVersions: group.ToImmutableList()))
             .ToListAsync();
     }
 
     private async ValueTask<PublishedPublicationInfo> PublishPublication(
         Guid publicationId,
-        List<PublishedReleaseVersionInfo> publishedReleaseVersions)
+        IImmutableList<PublishedReleaseVersionInfo> publishedReleaseVersions)
     {
         var publication = await contentDbContext.Publications
             .Include(p => p.LatestPublishedReleaseVersion)


### PR DESCRIPTION
This PR refactors the Publisher's `PublishingCompletionService.CompletePublishingIfAllPriorStagesComplete` method to improve handling when publications are archived.

It adds a new `HandleArchivedPublications` method which is called with a list of publications that have been affected by publishing (i.e. they are related to releases just published).

Within `HandleArchivedPublications`, it only performs actions for publications which it finds are newly archived. These are publications which are replaced by any of the publications affected by publishing that were not already published (i.e. they had no published releases prior to publishing). If the publications they are replaced by were already published, their archive status is not changing, and no action is necessary.

Currently the only action performed is cache clearance, but in https://github.com/dfe-analytical-services/explore-education-statistics/pull/5868 this will be updated to also include raising a `PublicationArchivedEvent` event.

This change is being made to support adding the event and also because prior to it, this transition in archive status was not being determined, so cache clearance was happening for publications regardless.

### Other changes

- Rename Events `ReleaseVersionPublishedEvent.PublishedReleaseVersionInfo` to `ReleaseVersionPublishedEventInfo` and reinstate Publisher's own `PublishedReleaseVersionInfo` which now only has properties related directly to the published release version. A separate `PublishedPublicationInfo` is added to Publisher which holds useful info about publications affected by publishing, built after publications are updated.