### PR TITLE
EES-6107 Raise event when publishing causes publications to be archived

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -3424,8 +3424,10 @@
         "App__PublicStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-public')).secretUriWithVersion, ')')]",
         "App__PublisherStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher')).secretUriWithVersion, ')')]",
         "DataFiles__BasePath": "[variables('publicDataFileShareMountPathWindows')]",
-        "EventGrid__EventTopics__0__Key": "ReleaseVersionChangedEvent",
-        "EventGrid__EventTopics__0__TopicEndpoint": "[if(parameters('eventGridTopicsExist'), reference(resourceId('Microsoft.EventGrid/topics', variables('eventGridTopicNameReleaseVersionChanged')), '2025-02-15').endpoint, '')]",
+        "EventGrid__EventTopics__0__Key": "PublicationChangedEvent",
+        "EventGrid__EventTopics__0__TopicEndpoint": "[if(parameters('eventGridTopicsExist'), reference(resourceId('Microsoft.EventGrid/topics', variables('eventGridTopicNamePublicationChanged')), '2025-02-15').endpoint, '')]",
+        "EventGrid__EventTopics__1__Key": "ReleaseVersionChangedEvent",
+        "EventGrid__EventTopics__1__TopicEndpoint": "[if(parameters('eventGridTopicsExist'), reference(resourceId('Microsoft.EventGrid/topics', variables('eventGridTopicNameReleaseVersionChanged')), '2025-02-15').endpoint, '')]",
         "PublicDataDbExists": "[parameters('publicDataDbExists')]"
       }
     },

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/PublisherEventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/PublisherEventRaiserMockBuilder.cs
@@ -17,16 +17,16 @@ public class PublisherEventRaiserMockBuilder
     public PublisherEventRaiserMockBuilder()
     {
         _mock
-            .Setup(m => m.RaiseReleaseVersionPublishedEvents(
+            .Setup(m => m.OnReleaseVersionsPublished(
                 It.IsAny<IReadOnlyList<PublishedPublicationInfo>>()))
             .Returns(Task.CompletedTask);
     }
 
     public class Asserter(Mock<IPublisherEventRaiser> mock)
     {
-        public void EventWasRaised(Func<PublishedPublicationInfo, bool> expected)
+        public void ReleaseVersionPublishedEventWasRaised(Func<PublishedPublicationInfo, bool> expected)
         {
-            mock.Verify(m => m.RaiseReleaseVersionPublishedEvents(
+            mock.Verify(m => m.OnReleaseVersionsPublished(
                 It.Is<IReadOnlyList<PublishedPublicationInfo>>(
                     actual => actual.Any(expected))));
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/PublisherEventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/PublisherEventRaiserMockBuilder.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Moq;
@@ -17,6 +18,13 @@ public class PublisherEventRaiserMockBuilder
     public PublisherEventRaiserMockBuilder()
     {
         _mock
+            .Setup(m => m.OnPublicationArchived(
+                It.IsAny<Guid>(),
+                It.IsAny<string>(),
+                It.IsAny<Guid>()))
+            .Returns(Task.CompletedTask);
+
+        _mock
             .Setup(m => m.OnReleaseVersionsPublished(
                 It.IsAny<IReadOnlyList<PublishedPublicationInfo>>()))
             .Returns(Task.CompletedTask);
@@ -24,6 +32,24 @@ public class PublisherEventRaiserMockBuilder
 
     public class Asserter(Mock<IPublisherEventRaiser> mock)
     {
+        public void PublicationArchivedEventWasRaised(Publication publication)
+        {
+            mock.Verify(m => m.OnPublicationArchived(
+                    publication.Id,
+                    publication.Slug,
+                    publication.SupersededById!.Value),
+                Times.Once());
+        }
+
+        public void PublicationArchivedEventWasNotRaised()
+        {
+            mock.Verify(m => m.OnPublicationArchived(
+                    It.IsAny<Guid>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Guid>()),
+                Times.Never());
+        }
+
         public void ReleaseVersionPublishedEventWasRaised(Func<PublishedPublicationInfo, bool> expected)
         {
             mock.Verify(m => m.OnReleaseVersionsPublished(

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserTests.cs
@@ -59,7 +59,7 @@ public class PublisherEventRaiserTests
             };
 
             // ACT
-            await sut.RaiseReleaseVersionPublishedEvents([info]);
+            await sut.OnReleaseVersionsPublished([info]);
 
             // ASSERT
             var expectedEvent = new ReleaseVersionPublishedEvent(
@@ -140,7 +140,7 @@ public class PublisherEventRaiserTests
             };
 
             // ACT
-            await sut.RaiseReleaseVersionPublishedEvents(infos);
+            await sut.OnReleaseVersionsPublished(infos);
 
             // ASSERT
             var expectedEvents = infos.SelectMany(info =>
@@ -229,7 +229,7 @@ public class PublisherEventRaiserTests
             };
 
             // ACT
-            await sut.RaiseReleaseVersionPublishedEvents([info]);
+            await sut.OnReleaseVersionsPublished([info]);
 
             // ASSERT
             // Check unit test output for logs

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserTests.cs
@@ -31,6 +31,33 @@ public class PublisherEventRaiserTests
         public void Can_instantiate_sut() => Assert.NotNull(GetSut());
     }
 
+    public class OnPublicationArchivedTests : PublisherEventRaiserTests
+    {
+        [Fact]
+        public async Task WhenOnPublicationArchived_ThenEventRaised()
+        {
+            // ARRANGE
+            var publicationId = Guid.NewGuid();
+            const string publicationSlug = "publication-slug";
+            var supersededByPublicationId = Guid.NewGuid();
+
+            var sut = GetSut();
+
+            // ACT
+            await sut.OnPublicationArchived(
+                publicationId,
+                publicationSlug,
+                supersededByPublicationId);
+
+            // ASSERT
+            var expectedEvent = new PublicationArchivedEvent(
+                publicationId,
+                publicationSlug,
+                supersededByPublicationId);
+            _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
+        }
+    }
+
     public class RaiseReleaseVersionPublishedPublisherEvents : PublisherEventRaiserTests
     {
         [Fact]
@@ -171,15 +198,15 @@ public class PublisherEventRaiserTests
                 .ConfigureTestAppConfiguration()
                 .ConfigureServices()
                 .Build();
-            
+
             // ACT
             var eventRaiser = host.Services.GetRequiredService<IPublisherEventRaiser>();
-            
+
             // ASSERT
             Assert.NotNull(eventRaiser);
         }
     }
-    
+
     public class IntegrationTests(ITestOutputHelper output) : PublisherEventRaiserTests
     {
         // Define a topic and access key to run this integration test

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
@@ -626,7 +626,7 @@ public class PublishingCompletionServiceTests
                         ]
                     };
   
-                    _publisherEventRaiser.Assert.EventWasRaised(evt => evt == expectedInfo);
+                    _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(evt => evt == expectedInfo);
                 }
 
                 [Fact]
@@ -669,7 +669,7 @@ public class PublishingCompletionServiceTests
                             }
                         ]
                     };
-                    _publisherEventRaiser.Assert.EventWasRaised(evt => evt == expectedInfo); 
+                    _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(evt => evt == expectedInfo); 
                 }
 
                 [Fact]
@@ -714,7 +714,7 @@ public class PublishingCompletionServiceTests
                         ]
                     };
 
-                    _publisherEventRaiser.Assert.EventWasRaised(evt => evt == expectedInfo);
+                    _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(evt => evt == expectedInfo);
                 }
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
@@ -44,7 +44,7 @@ public class PublishingCompletionServiceTests
         [Fact]
         public void Can_instantiate_Sut() => Assert.NotNull(GetSut());
     }
-    
+
     public class ContainerRegistrationTests : PublishingCompletionServiceTests
     {
         [Fact]
@@ -54,7 +54,7 @@ public class PublishingCompletionServiceTests
                 .ConfigureTestAppConfiguration()
                 .ConfigureServices()
                 .Build();
-            
+
             ActivatorUtilities.CreateInstance<PublishingCompletionService>(host.Services);
         }
     }
@@ -76,10 +76,10 @@ public class PublishingCompletionServiceTests
                 var releasePublishingStatus2 = new ReleasePublishingStatusBuilder(releasePublishingKey2)
                     .WhereFilesStatusIs(ReleasePublishingStatusFilesStage.NotStarted)
                     .Build();
-                
+
                 var notReadyKeys = new List<ReleasePublishingKey>()
                 {
-                    releasePublishingKey1, 
+                    releasePublishingKey1,
                     releasePublishingKey2
                 };
 
@@ -141,10 +141,10 @@ public class PublishingCompletionServiceTests
                     .Build();
 
                 // Assign the release versions a status id
-                ReleasePublishingKey[] readyKeys = 
+                ReleasePublishingKey[] readyKeys =
                 [
-                    new(_releaseVersion1.Id, ReleaseStatusId:Guid.NewGuid()), 
-                    new(_releaseVersion2.Id, ReleaseStatusId:Guid.NewGuid()), 
+                    new(_releaseVersion1.Id, ReleaseStatusId: Guid.NewGuid()),
+                    new(_releaseVersion2.Id, ReleaseStatusId: Guid.NewGuid()),
                 ];
 
                 // Set the Status Service to report on whether a release version is ready to be published or not ie Complete 
@@ -156,7 +156,7 @@ public class PublishingCompletionServiceTests
                             .WhereContentStatusIs(ReleasePublishingStatusContentStage.Complete)
                             .Build());
                 }
-                
+
                 // Add Release Versions and their Publications to the mock Database
                 _contentDbContext.With(_releaseVersion1);
                 _contentDbContext.With(_releaseVersion2);
@@ -183,10 +183,10 @@ public class PublishingCompletionServiceTests
                     // Create some other keys that we'll set to "not complete"
                     ReleasePublishingKey[] notReadyKeys =
                     [
-                        new(Guid.NewGuid(), Guid.NewGuid()), 
+                        new(Guid.NewGuid(), Guid.NewGuid()),
                         new(Guid.NewGuid(), Guid.NewGuid()),
                     ];
-                
+
                     foreach (var notReadyKey in notReadyKeys)
                     {
                         _releasePublishingStatusService.WhereGetReturns(
@@ -212,13 +212,14 @@ public class PublishingCompletionServiceTests
                             readyKey,
                             ReleasePublishingStatusPublishingStage.Started);
                     }
+
                     // Update Publishing Stage Was Not Called
                     foreach (var notReadyKey in notReadyKeys)
                     {
                         _releasePublishingStatusService.Assert.UpdatePublishingStageWasNotCalled(notReadyKey);
                     }
                 }
-                
+
                 [Fact]
                 public async Task PublishingStatusSetToComplete()
                 {
@@ -226,10 +227,10 @@ public class PublishingCompletionServiceTests
                     // Create some other keys that we'll set to "not complete"
                     ReleasePublishingKey[] notReadyKeys =
                     [
-                        new(Guid.NewGuid(), Guid.NewGuid()), 
+                        new(Guid.NewGuid(), Guid.NewGuid()),
                         new(Guid.NewGuid(), Guid.NewGuid()),
                     ];
-                
+
                     foreach (var notReadyKey in notReadyKeys)
                     {
                         _releasePublishingStatusService.WhereGetReturns(
@@ -255,6 +256,7 @@ public class PublishingCompletionServiceTests
                             readyKey,
                             ReleasePublishingStatusPublishingStage.Complete);
                     }
+
                     // Not ready Keys were not set to anything
                     foreach (var notReadyKey in notReadyKeys)
                     {
@@ -262,7 +264,7 @@ public class PublishingCompletionServiceTests
                     }
                 }
             }
-            
+
             public class CompletePublishingTests : ReadyTests
             {
                 [Fact]
@@ -271,7 +273,7 @@ public class PublishingCompletionServiceTests
                     // ARRANGE
                     var readyKeys = SetupHappyPath();
                     var sut = GetSut();
-                    
+
                     // ACT
                     await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
 
@@ -290,20 +292,26 @@ public class PublishingCompletionServiceTests
                     var releaseVersion = _releaseService.Get(releaseVersionId);
                     _methodologyService.WhereGetLatestVersionByReleaseReturnsNoMethodologies(releaseVersion);
                 }
-                
+
                 private void SetupMethodologies(Guid releaseVersionId, MethodologyVersion methodologyToPublish)
                 {
                     var releaseVersion = _releaseService.Get(releaseVersionId);
                     _methodologyService.WhereGetLatestVersionByReleaseReturns(releaseVersion, methodologyToPublish);
                     _methodologyService.WhereIsBeingPublishedAlongsideRelease(methodologyToPublish, releaseVersion);
                 }
-                
-                private void SetupMethodologies(Guid releaseVersionId, MethodologyVersion methodologyToPublish, MethodologyVersion methodologyNotToPublish)
+
+                private void SetupMethodologies(
+                    Guid releaseVersionId,
+                    MethodologyVersion methodologyToPublish,
+                    MethodologyVersion methodologyNotToPublish)
                 {
                     var releaseVersion = _releaseService.Get(releaseVersionId);
-                    _methodologyService.WhereGetLatestVersionByReleaseReturns(releaseVersion, methodologyToPublish, methodologyNotToPublish);
+                    _methodologyService.WhereGetLatestVersionByReleaseReturns(releaseVersion,
+                        methodologyToPublish,
+                        methodologyNotToPublish);
                     _methodologyService.WhereIsBeingPublishedAlongsideRelease(methodologyToPublish, releaseVersion);
-                    _methodologyService.WhereIsNotBeingPublishedAlongsideRelease(methodologyNotToPublish, releaseVersion);
+                    _methodologyService.WhereIsNotBeingPublishedAlongsideRelease(methodologyNotToPublish,
+                        releaseVersion);
                 }
 
                 [Fact]
@@ -315,23 +323,23 @@ public class PublishingCompletionServiceTests
                     {
                         SetupNoMethodologies(key.ReleaseVersionId);
                     }
-                    
+
                     var sut = GetSut();
-                    
+
                     // ACT
                     await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
 
                     // ASSERT
                     _methodologyService.Assert.NoMethodologiesPublished();
                 }
-                
+
                 [Fact]
                 public async Task WhenHasMethodology_ThenMethodologyPublished()
                 {
                     // ARRANGE
                     var readyKeys = SetupHappyPath();
                     var methodologies = new MethodologyVersion[readyKeys.Count];
-                    
+
                     for (var i = 0; i < readyKeys.Count; i++)
                     {
                         var key = readyKeys[i];
@@ -340,7 +348,7 @@ public class PublishingCompletionServiceTests
                     }
 
                     var sut = GetSut();
-                    
+
                     // ACT
                     await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
 
@@ -350,7 +358,7 @@ public class PublishingCompletionServiceTests
                         _methodologyService.Assert.MethodologyPublished(methodology);
                     }
                 }
-                
+
                 [Fact]
                 public async Task WhenHasSomeMethodologiesToPublish_ThenOnlyMethodologiesToBePublishedArePublished()
                 {
@@ -358,17 +366,19 @@ public class PublishingCompletionServiceTests
                     var readyKeys = SetupHappyPath();
                     var methodologiesToPublish = new MethodologyVersion[readyKeys.Count];
                     var methodologiesNotToPublish = new MethodologyVersion[readyKeys.Count];
-                    
+
                     for (var i = 0; i < readyKeys.Count; i++)
                     {
                         var key = readyKeys[i];
                         methodologiesToPublish[i] = new MethodologyVersion();
                         methodologiesNotToPublish[i] = new MethodologyVersion();
-                        SetupMethodologies(key.ReleaseVersionId, methodologiesToPublish[i], methodologiesNotToPublish[i]);
+                        SetupMethodologies(key.ReleaseVersionId,
+                            methodologiesToPublish[i],
+                            methodologiesNotToPublish[i]);
                     }
 
                     var sut = GetSut();
-                    
+
                     // ACT
                     await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
 
@@ -377,6 +387,7 @@ public class PublishingCompletionServiceTests
                     {
                         _methodologyService.Assert.MethodologyPublished(methodology);
                     }
+
                     foreach (var methodology in methodologiesNotToPublish)
                     {
                         _methodologyService.Assert.MethodologyNotPublished(methodology);
@@ -392,7 +403,7 @@ public class PublishingCompletionServiceTests
                     // ARRANGE
                     var readyKeys = SetupHappyPath();
                     var sut = GetSut();
-                    
+
                     // ACT
                     await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
 
@@ -400,7 +411,7 @@ public class PublishingCompletionServiceTests
                     _contentDbContext.Assert.PublicationsLatestPublishedReleaseVersionIdIs(PublicationId1, _releaseVersion1.Id);
                     _contentDbContext.Assert.PublicationsLatestPublishedReleaseVersionIdIs(PublicationId2, _releaseVersion2.Id);
                 }
-                
+
                 [Fact]
                 public async Task WhenPublishedReleaseVersionIsNotLatestVersion_ThenPublicationLatestReleaseVersionSetToLatestReleaseVersion()
                 {
@@ -413,10 +424,12 @@ public class PublishingCompletionServiceTests
                         .Build();
 
                     // Set that release version "1 version 2" is the latest for the Publication
-                    _releaseService.WherePublicationLatestPublishedReleaseVersionIs(releaseVersion1V2.Release.PublicationId, releaseVersion1V2);
-                    
+                    _releaseService.WherePublicationLatestPublishedReleaseVersionIs(
+                        releaseVersion1V2.Release.PublicationId,
+                        releaseVersion1V2);
+
                     var sut = GetSut();
-                    
+
                     // ACT
                     await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
 
@@ -513,7 +526,7 @@ public class PublishingCompletionServiceTests
                     // ASSERT
                     _contentService.Assert.DeletePreviousVersionsDownloadFilesCalled(_releaseVersion1.Id, _releaseVersion2.Id);
                 }
-                
+
                 [Fact]
                 public async Task PreviousVersionsContentDeleted()
                 {
@@ -527,7 +540,7 @@ public class PublishingCompletionServiceTests
                     // ASSERT
                     _contentService.Assert.DeletePreviousVersionsContentCalled(_releaseVersion1.Id, _releaseVersion2.Id);
                 }
-                
+
                 [Fact]
                 public async Task CachedTaxonomyBlobsUpdated()
                 {
@@ -559,7 +572,7 @@ public class PublishingCompletionServiceTests
                     _notificationsService.Assert.NotifySubscribersIfApplicableCalled(_releaseVersion1.Id, _releaseVersion2.Id);
                 }
             }
-            
+
             public class RedirectsCacheServiceTests : ReadyTests
             {
                 [Fact]
@@ -593,7 +606,7 @@ public class PublishingCompletionServiceTests
                     _dataSetPublishingService.Assert.DataSetsWerePublished(_releaseVersion1.Id, _releaseVersion2.Id);
                 }
             }
-            
+
             public class EventRaiserTests : ReadyTests
             {
                 [Fact]
@@ -625,7 +638,7 @@ public class PublishingCompletionServiceTests
                             }
                         ]
                     };
-  
+
                     _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(evt => evt == expectedInfo);
                 }
 
@@ -669,7 +682,7 @@ public class PublishingCompletionServiceTests
                             }
                         ]
                     };
-                    _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(evt => evt == expectedInfo); 
+                    _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(evt => evt == expectedInfo);
                 }
 
                 [Fact]
@@ -690,7 +703,7 @@ public class PublishingCompletionServiceTests
                     _releaseService.WherePublicationLatestPublishedReleaseVersionIs(PublicationId1, releaseVersion1V2);
 
                     var sut = GetSut();
-                    
+
                     // ACT
                     await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
@@ -449,7 +449,7 @@ public class PublishingCompletionServiceTests
                     // ARRANGE
                     var readyKeys = SetupHappyPath();
 
-                    // Set publication 1 to have published releases prior to the current publishing run
+                    // Set publication 1 to have a published release prior to the current publishing run
                     WherePreviousPublicationLatestPublishedReleaseVersionIs(
                         publicationId: PublicationId1,
                         releaseVersion: new ReleaseVersionBuilder()
@@ -641,7 +641,10 @@ public class PublishingCompletionServiceTests
                             .WithReleaseSlug("release-slug-previous"))
                         .Build();
 
+                    // Set publication 1 to have a published release prior to the current publishing run
                     WherePreviousPublicationLatestPublishedReleaseVersionIs(publicationId: PublicationId1, releaseVersion: previousReleaseVersion);
+
+                    // Set release version 1 to be the latest published release version after publishing
                     _releaseService.WherePublicationLatestPublishedReleaseVersionIs(PublicationId1, _releaseVersion1);
 
                     // ACT
@@ -680,10 +683,12 @@ public class PublishingCompletionServiceTests
                         .ForRelease(_releaseVersion1.Release)
                         .Build();
 
-                    // Set that release version 1V2 is the latest, not release version 1
+                    // Set publication 1 to have published release version 1V2 prior to the current publishing run
+                    WherePreviousPublicationLatestPublishedReleaseVersionIs(publicationId: PublicationId1, releaseVersion: releaseVersion1V2);
+
+                    // Set release version 1V2 to be the latest after publishing, not release version 1
                     _releaseService.WherePublicationLatestPublishedReleaseVersionIs(PublicationId1, releaseVersion1V2);
-                    WherePreviousPublicationLatestPublishedReleaseVersionIs(PublicationId1, releaseVersion1V2);
-                    
+
                     var sut = GetSut();
                     
                     // ACT

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublisherEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublisherEventRaiser.cs
@@ -5,5 +5,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
 public interface IPublisherEventRaiser
 {
-    Task RaiseReleaseVersionPublishedEvents(IReadOnlyList<PublishedPublicationInfo> publishedReleaseVersionEventInfos);
+    Task OnReleaseVersionsPublished(IReadOnlyList<PublishedPublicationInfo> publishedPublications);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublisherEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublisherEventRaiser.cs
@@ -1,9 +1,15 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 
 public interface IPublisherEventRaiser
 {
+    Task OnPublicationArchived(
+        Guid publicationId,
+        string publicationSlug,
+        Guid supersededByPublicationId);
+
     Task OnReleaseVersionsPublished(IReadOnlyList<PublishedPublicationInfo> publishedPublications);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
@@ -13,10 +13,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 public class PublisherEventRaiser(IEventRaiser eventRaiser) : IPublisherEventRaiser
 {
     /// <summary>
-    /// On Release Version Published
+    /// Publishes events for release versions that have been published.
     /// </summary>
-    /// <param name="publishedPublications">information about the one or more publications that have been published</param>
-    public async Task RaiseReleaseVersionPublishedEvents(
+    /// <param name="publishedPublications">A list of publications, each containing information about the publication
+    /// and its associated release versions that have been published.
+    /// </param>
+    public async Task OnReleaseVersionsPublished(
         IReadOnlyList<PublishedPublicationInfo> publishedPublications)
     {
         var events = publishedPublications.SelectMany(publication =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,6 +13,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 /// </summary>
 public class PublisherEventRaiser(IEventRaiser eventRaiser) : IPublisherEventRaiser
 {
+    /// <summary>
+    /// Publishes an event when a publication is archived.
+    /// </summary>
+    /// <param name="publicationId">The unique identifier of the publication that has been archived.</param>
+    /// <param name="publicationSlug">The slug of the publication that has been archived.</param>
+    /// <param name="supersededByPublicationId">The unique identifier of the publication that has superseded the archived publication.</param>
+    public async Task OnPublicationArchived(
+        Guid publicationId,
+        string publicationSlug,
+        Guid supersededByPublicationId) =>
+        await eventRaiser.RaiseEvent(new PublicationArchivedEvent(
+            publicationId,
+            publicationSlug,
+            supersededByPublicationId));
+
     /// <summary>
     /// Publishes events for release versions that have been published.
     /// </summary>

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -93,7 +93,7 @@ public class PublishingCompletionService(
 
         await dataSetPublishingService.PublishDataSets(releaseVersionIdsToUpdate);
 
-        await publisherEventRaiser.RaiseReleaseVersionPublishedEvents(publishedPublicationInfos);
+        await publisherEventRaiser.OnReleaseVersionsPublished(publishedPublicationInfos);
 
         await prePublishingStagesComplete
             .ToAsyncEnumerable()

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -178,6 +178,12 @@ public class PublishingCompletionService(
         {
             // Invalidate the cache of the publication to reflect its new archived status
             await publicationCacheService.UpdatePublication(archivedPublication.Slug);
+
+            // Raise an event to indicate the publication has been archived
+            await publisherEventRaiser.OnPublicationArchived(
+                archivedPublication.Id,
+                archivedPublication.Slug,
+                archivedPublication.SupersededById!.Value);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/appsettings.example.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/appsettings.example.json
@@ -4,8 +4,13 @@
     "EventTopics":
     [
       {
+        "Key":"PublicationChangedEvent",
+        "TopicEndpoint":"",
+        "TopicAccessKey":""
+      },
+      {
         "Key":"ReleaseVersionChangedEvent",
-        "TopicEndpoint":"https://release-version-changes-topic.uksouth-1.eventgrid.azure.net/api/events",
+        "TopicEndpoint":"",
         "TopicAccessKey":""
       }
     ]


### PR DESCRIPTION
This PR raises an event when publishing causes publications to be archived.

### Other changes

- Add more comments explaining setting latest published release versions in `PublishingCompletionServiceTests`.
- Rename `IPublisherEventRaiser.RaiseReleaseVersionPublishedEvents` to `OnReleaseVersionsPublished`.
- Remove sample topic endpoint URL from `appsettings.example.json`.
- Reformat `PublishingCompletionServiceTests`.