### PR TITLE
🐛 EES-6121 Partially revert changes made to `DeleteBlobIfExists`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureBlobStorage/AzureBlobStorageClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/AzureBlobStorage/AzureBlobStorageClient.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using Azure.Storage.Blobs;
-using Azure.Storage.Blobs.Models;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Exceptions;
 using Microsoft.Extensions.Logging;
 
@@ -19,9 +18,10 @@ public class AzureBlobStorageClient(
         CancellationToken cancellationToken = default)
     {
         var blobContainerClient = BlobServiceClient.GetBlobContainerClient(containerName);
+        var blobClient = blobContainerClient.GetBlobClient(blobName);
         try
         {
-            return await blobContainerClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+            return await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
This PR partially reverts changes made to `DeleteBlobIfExists` made in https://github.com/dfe-analytical-services/explore-education-statistics/pull/5863.

That change ignored the blob name and deleted the container. Whenever a searchable document should have been deleted, this was resulting in the `searchable-documents` container being deleted.