### PR TITLE
EES-6071: Add previous release id to release version published event

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
@@ -15,6 +15,7 @@ public record ReleaseVersionPublishedEvent : IEvent
             PublicationId = publishedReleaseVersion.PublicationId,
             PublicationSlug = publishedReleaseVersion.PublicationSlug,
             PublicationLatestPublishedReleaseVersionId = publishedReleaseVersion.PublicationLatestPublishedReleaseVersionId,
+            PreviousLatestReleaseId = publishedReleaseVersion.PreviousLatestReleaseId,
         };
     }
 
@@ -40,6 +41,7 @@ public record ReleaseVersionPublishedEvent : IEvent
         public required Guid PublicationId { get; init; }
         public required string PublicationSlug { get; init; }
         public required Guid PublicationLatestPublishedReleaseVersionId { get; init; }    
+        public Guid? PreviousLatestReleaseId { get; init; }
     }
     public EventPayload Payload { get; }
     
@@ -52,6 +54,12 @@ public record ReleaseVersionPublishedEvent : IEvent
         public string ReleaseSlug { get; init; } = string.Empty;
         public Guid PublicationId { get; init; }
         public string PublicationSlug { get; init; } = string.Empty;
+        
+        /// <summary>
+        /// The release version that has been published may not be the latest.
+        /// This property contains the latest published release version id.
+        /// </summary>
         public Guid PublicationLatestPublishedReleaseVersionId { get; init; }
+        public Guid? PreviousLatestReleaseId { get; init; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ContentDbContextMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ContentDbContextMockBuilder.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Models;
 using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Services;
@@ -19,18 +20,43 @@ public class ContentDbContextMockBuilder
 
     public ContentDbContextMockBuilder With(ReleaseVersion releaseVersion)
     {
-        _inMemoryContentDbContext.ReleaseVersions.Add(releaseVersion);
+        if (_inMemoryContentDbContext.ReleaseVersions.Any(rv => rv.Id == releaseVersion.Id))
+        {
+            _inMemoryContentDbContext.ReleaseVersions.Update(releaseVersion);
+        }
+        else
+        {
+            _inMemoryContentDbContext.ReleaseVersions.Add(releaseVersion);
+        }
         _inMemoryContentDbContext.SaveChanges();
         return this;
     }
 
     public ContentDbContextMockBuilder With(Publication publication)
     {
-        _inMemoryContentDbContext.Publications.Add(publication);
+        if (_inMemoryContentDbContext.Publications.Any(p => p.Id == publication.Id))
+        {
+            _inMemoryContentDbContext.Publications.Update(publication);
+        }
+        else
+        {
+            _inMemoryContentDbContext.Publications.Add(publication);
+        }
         _inMemoryContentDbContext.SaveChanges();
         return this;
     }
 
+    public ContentDbContextMockBuilder WherePublication(Guid publicationId, Action<Publication> modifier)
+    {
+        var publication = _inMemoryContentDbContext.Publications.SingleOrDefault(p => p.Id == publicationId);
+        if (publication == null)
+            Xunit.Assert.Fail($"No publication was found with id {publicationId}");
+        
+        modifier(publication);
+        _inMemoryContentDbContext.SaveChanges();
+        return this;
+    }
+    
     public class Asserter(ContentDbContext contentDbContext)
     {
         public void PublicationsLatestPublishedReleaseVersionIdIs(Guid publicationId, Guid expectedLatestPublishedReleaseVersionId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -135,10 +135,12 @@ public class PublishingCompletionService(
         ReleaseVersionPublishedEvent.PublishedReleaseVersionInfo info)
     {
         var publication = await contentDbContext.Publications
+            .Include(p => p.LatestPublishedReleaseVersion)
             .SingleAsync(p => p.Id == info.PublicationId);
 
         var latestPublishedReleaseVersion = await releaseService.GetLatestPublishedReleaseVersion(info.PublicationId);
 
+        var previousLatestReleaseId = publication.LatestPublishedReleaseVersion?.ReleaseId;
         publication.LatestPublishedReleaseVersionId = latestPublishedReleaseVersion.Id;
 
         await contentDbContext.SaveChangesAsync();
@@ -146,7 +148,8 @@ public class PublishingCompletionService(
         return info with
         {
             PublicationLatestPublishedReleaseVersionId = latestPublishedReleaseVersion.Id,
-            PublicationSlug = publication.Slug
+            PublicationSlug = publication.Slug,
+            PreviousLatestReleaseId = previousLatestReleaseId,
         };
     }
 }


### PR DESCRIPTION
By including the previous release id, if the latest release has changed then we can use this information to delete the previous latest searchable document.
