### PR TITLE
Ees 6071 Delete old searchable doc when release changes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseVersionPublished/OnReleaseVersionPublishedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseVersionPublished/OnReleaseVersionPublishedFunctionTests.cs
@@ -1,6 +1,6 @@
-﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnReleaseVersionPublished;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemoveSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnReleaseVersionPublished;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnReleaseVersionPublished.Dtos;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDataHelpers;
@@ -19,11 +19,8 @@ public class OnReleaseVersionPublishedFunctionTests
     public async Task GivenEvent_WhenPayloadContainsPublicationSlug_ThenRefreshSearchableDocumentMessageDtoReturned()
     {
         // ARRANGE
-        var payload = new ReleaseVersionPublishedEventDto
-        {
-            PublicationSlug = "this-is-a-publication-slug",
-        };
-
+        var payload = NewReleaseVersionPublishedEvents.NewlyPublishedIsLatest;
+        
         var eventGridEvent = new EventGridEventBuilder()
             .WithPayload(payload)
             .Build();
@@ -34,21 +31,19 @@ public class OnReleaseVersionPublishedFunctionTests
         var response = await sut.OnReleaseVersionPublished(eventGridEvent, new FunctionContextMockBuilder().Build());
         
         // ASSERT
-        var actual = Assert.Single(response);
+        Assert.NotNull(response);
+        var actual = Assert.Single(response.RefreshSearchableDocumentMessages);
         Assert.NotNull(actual);
         Assert.Equal(payload.PublicationSlug, actual.PublicationSlug);
     }
     
     [Theory]
     [MemberData(nameof(TheoryDatas.Blank.Strings), MemberType = typeof(TheoryDatas.Blank))]
-    public async Task GivenEvent_WhenPayloadDoesNotContainPublicationSlug_ThenNothingIsReturned(string? blankPublicationSlug)
+    public async Task GivenEvent_WhenPayloadDoesNotContainPublicationSlug_ThenEmptyIsReturned(string? blankPublicationSlug)
     {
         // ARRANGE
-        var payload = new ReleaseVersionPublishedEventDto
-        {
-            PublicationSlug = blankPublicationSlug,
-        };
-
+        var payload = NewReleaseVersionPublishedEvents.NoPublicationSlug();
+        
         var eventGridEvent = new EventGridEventBuilder()
             .WithPayload(payload)
             .Build();
@@ -59,8 +54,111 @@ public class OnReleaseVersionPublishedFunctionTests
         var response = await sut.OnReleaseVersionPublished(eventGridEvent, new FunctionContextMockBuilder().Build());
         
         // ASSERT
-        Assert.Empty(response);
+        Assert.Equal(OnReleaseVersionPublishedOutput.Empty, response);
     }
 
+    [Fact]
+    public async Task GivenEvent_WhenPublishedReleaseVersionIsNotTheLatest_ThenEmptyIsReturned()
+    {
+        // ARRANGE
+        var payload = NewReleaseVersionPublishedEvents.NewlyPublishedIsNotLatest;
+        
+        var eventGridEvent = new EventGridEventBuilder()
+            .WithPayload(payload)
+            .Build();
 
+        var sut = GetSut();
+        
+        // ACT
+        var response = await sut.OnReleaseVersionPublished(eventGridEvent, new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        Assert.Equal(OnReleaseVersionPublishedOutput.Empty, response);
+    }
+    
+    // New release, then ensure old searchable doc is removed
+    [Fact]
+    public async Task GivenEvent_WhenPublishedReleaseVersionIsADifferentRelease_ThenPreviousReleaseSearchableDocumentIsRemoved()
+    {
+        // ARRANGE
+        var payload = NewReleaseVersionPublishedEvents.NewlyPublishedIsLatestButDifferentRelease;
+        
+        var eventGridEvent = new EventGridEventBuilder()
+            .WithPayload(payload)
+            .Build();
+
+        var sut = GetSut();
+        
+        // ACT
+        var response = await sut.OnReleaseVersionPublished(eventGridEvent, new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        Assert.Equal([new RemoveSearchableDocumentDto{ ReleaseId = payload.PreviousLatestReleaseId }], response.RemoveSearchableDocuments);
+    }
+    
+    // Different release version for the same release, then no document is removed - it will be overwritten
+    [Fact]
+    public async Task GivenEvent_WhenPublishedReleaseVersionIsSameRelease_ThenNoSearchableDocumentIsRemoved()
+    {
+        // ARRANGE
+        var payload = NewReleaseVersionPublishedEvents.NewlyPublishedIsForSameRelease;
+        
+        var eventGridEvent = new EventGridEventBuilder()
+            .WithPayload(payload)
+            .Build();
+
+        var sut = GetSut();
+        
+        // ACT
+        var response = await sut.OnReleaseVersionPublished(eventGridEvent, new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        Assert.Empty(response.RemoveSearchableDocuments);
+    }
+
+    private static class NewReleaseVersionPublishedEvents
+    {
+        private static ReleaseVersionPublishedEventDto Base
+        {
+            get
+            {
+                // By default, create an event where
+                // - the newly published release version is the latest
+                // - the newly published release version is for the same release as the previous latest release
+                var newlyPublishedLatestReleaseVersionId = Guid.NewGuid();
+                var newlyPublishedLatestReleaseId = Guid.NewGuid();
+                return new()
+                {
+                    ReleaseVersionId = newlyPublishedLatestReleaseVersionId,
+                    ReleaseId = newlyPublishedLatestReleaseId,
+                    ReleaseSlug = "this-is-a-release-slug",
+                    PublicationId = Guid.NewGuid(),
+                    PublicationSlug = "this-is-a-publication-slug",
+                    PublicationLatestPublishedReleaseVersionId = newlyPublishedLatestReleaseVersionId,
+                    PreviousLatestReleaseId = newlyPublishedLatestReleaseId
+                };
+            }
+        }
+
+        public static ReleaseVersionPublishedEventDto NoPublicationSlug() => 
+            Base with
+            {
+                PublicationSlug = null
+            };
+        public static ReleaseVersionPublishedEventDto NewlyPublishedIsNotLatest => 
+            Base with
+            {
+                PublicationLatestPublishedReleaseVersionId = Guid.NewGuid()
+            };
+
+        public static ReleaseVersionPublishedEventDto NewlyPublishedIsLatest => Base;
+
+        public static ReleaseVersionPublishedEventDto NewlyPublishedIsLatestButDifferentRelease => 
+            Base with
+            {
+                PreviousLatestReleaseId = Guid.NewGuid()
+            };
+
+        public static ReleaseVersionPublishedEventDto NewlyPublishedIsForSameRelease => Base;
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/Dtos/ReleaseVersionPublishedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/Dtos/ReleaseVersionPublishedEventDto.cs
@@ -2,9 +2,48 @@
 
 public record ReleaseVersionPublishedEventDto
 {
+    /// <summary>
+    /// Newly published release version id
+    /// </summary>
+    public Guid ReleaseVersionId { get; init; }
+    
+    /// <summary>
+    /// The Release Id for the newly published release version
+    /// </summary>
     public Guid? ReleaseId {get;init;}
+    
+    /// <summary>
+    /// The release slug for the newly published release version
+    /// </summary>
     public string? ReleaseSlug { get; init; }
+    
+    /// <summary>
+    /// The publication id for the newly published release version
+    /// </summary>
     public Guid? PublicationId { get; init; }
+    
+    /// <summary>
+    /// The publication slug for the newly published release version
+    /// </summary>
     public string? PublicationSlug { get; init; }
-    public Guid? PublicationLatestPublishedReleaseVersionId { get; init; }   
+    
+    /// <summary>
+    /// The Release Version Id of the current "latest release version".
+    /// </summary>
+    public Guid? PublicationLatestPublishedReleaseVersionId { get; init; }
+    
+    /// <summary>
+    /// The Release Id of the previous "latest release version"
+    /// </summary>
+    public Guid? PreviousLatestReleaseId { get; init; }
+    
+    /// <summary>
+    /// Is this newly published release version the new latest version?
+    /// </summary>
+    public bool NewlyPublishedReleaseVersionIsLatest => PublicationLatestPublishedReleaseVersionId == ReleaseVersionId;
+    
+    /// <summary>
+    /// Has a different release become the new latest?
+    /// </summary>
+    public bool NewlyPublishedReleaseVersionIsForDifferentRelease => PreviousLatestReleaseId != ReleaseId;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/OnReleaseVersionPublishedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/OnReleaseVersionPublishedFunction.cs
@@ -1,5 +1,6 @@
 using Azure.Messaging.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemoveSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnReleaseVersionPublished.Dtos;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
@@ -10,22 +11,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 public class OnReleaseVersionPublishedFunction(IEventGridEventHandler eventGridEventHandler)
 {
     [Function(nameof(OnReleaseVersionPublished))]
-    [QueueOutput("%RefreshSearchableDocumentQueueName%")]
-    public async Task<RefreshSearchableDocumentMessageDto[]> OnReleaseVersionPublished(
+    public async Task<OnReleaseVersionPublishedOutput> OnReleaseVersionPublished(
         [QueueTrigger("%ReleaseVersionPublishedQueueName%")]
         EventGridEvent eventDto,
         FunctionContext context) =>
-        await eventGridEventHandler.Handle<ReleaseVersionPublishedEventDto, RefreshSearchableDocumentMessageDto[]>(
+        await eventGridEventHandler.Handle<ReleaseVersionPublishedEventDto, OnReleaseVersionPublishedOutput>(
             context,
             eventDto,
             (payload, _) =>
                 Task.FromResult(
-                    // TODO: Detect whether this is the latest published release version.
-                    // If not, we don't need to refresh the Searchable Document (which is only for the latest release version) so return empty.
-                    string.IsNullOrEmpty(payload.PublicationSlug)
-                        ? []
-                        : new[]
+                    string.IsNullOrEmpty(payload.PublicationSlug) || !payload.NewlyPublishedReleaseVersionIsLatest
+                        ? OnReleaseVersionPublishedOutput.Empty
+                        : new OnReleaseVersionPublishedOutput
                         {
-                            new RefreshSearchableDocumentMessageDto { PublicationSlug = payload.PublicationSlug }
+                            RefreshSearchableDocumentMessages = 
+                                [ new RefreshSearchableDocumentMessageDto { PublicationSlug = payload.PublicationSlug } ],
+                            RemoveSearchableDocuments = payload.NewlyPublishedReleaseVersionIsForDifferentRelease
+                                ? [ new RemoveSearchableDocumentDto { ReleaseId = payload.PreviousLatestReleaseId } ]
+                                : []
                         }));
+}
+
+public record OnReleaseVersionPublishedOutput
+{
+    [QueueOutput("%RefreshSearchableDocumentQueueName%")]
+    public RefreshSearchableDocumentMessageDto[] RefreshSearchableDocumentMessages { get; init; } = [];
+    
+    [QueueOutput("%RemoveSearchableDocumentQueueName%")]
+    public RemoveSearchableDocumentDto[] RemoveSearchableDocuments { get; init; } = [];
+    
+    public static OnReleaseVersionPublishedOutput Empty => new();
 }


### PR DESCRIPTION
The OnReleaseVersionPublished function now handles the scenario
where a newly published release version is for a different release
than the previous latest release.

In this case, the function removes the searchable document
for the previous latest release.

It also identifies the case when the newly published release version is
not the Publication's latest, in which case we can ignore the event.
