### PR TITLE
EES-6152 Alter Search storage account Network option

### DIFF
--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -64,7 +64,7 @@ module searchServiceModule '../components/searchService.bicep' = {
   params: {
     name: searchServiceName
     location: location
-    ipRules: [] // TODO EES-5940 - Should be searchServiceIpRules
+    ipRules: searchServiceIpRules
     publicNetworkAccess: 'Enabled'
     sku: 'basic'
     systemAssignedIdentity: true

--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -77,7 +77,7 @@ module searchStorageAccountModule '../../public-api/components/storageAccount.bi
   params: {
     location: location
     storageAccountName: '${replace(resourcePrefix, '-', '')}${abbreviations.storageStorageAccounts}search'
-    publicNetworkAccessEnabled: false
+    publicNetworkAccessEnabled: true
     firewallRules: storageIpRules
     sku: 'Standard_LRS'
     kind: 'StorageV2'

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -151,7 +151,7 @@ module searchServiceModule 'application/searchService.bicep' = {
     indexName: 'index-1'
     resourceNames: resourceNames
     resourcePrefix: resourcePrefix
-    searchServiceIpRules: maintenanceIpRanges
+    searchServiceIpRules: []
     storageIpRules: maintenanceIpRanges
     deployAlerts: deployAlerts
     deploySearchConfig: deploySearchConfig


### PR DESCRIPTION
This PR sets `publicNetworkAccessEnabled` to true on the Search storage account. This is the equivalent to Network option 'Enabled from selected virtual networks and IP addresses') in the UI when firewallRules is set.

This prevents us needing to manually change the option to ‘Enabled from selected virtual networks and IP addresses’ to allow access from the maintenance range of IP addresses with every deploy.

### Other changes

- Tidy up TODO in searchService.bicep. Search service remains publicly accessible.