### PR TITLE
Ees 6071 add logging to command handlers

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/TestableCommandHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/TestableCommandHandler.cs
@@ -2,27 +2,27 @@
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
 
-public class TestableCommandHandler :ICommandHandler
+public class TestableCommandHandler : ICommandHandler
 {
-    public Task<TResponse> Handle<TCommand, TResponse>(
-        Func<TCommand, CancellationToken, Task<TResponse>> commandHandler, 
-        TCommand commandMessage, 
+    public Task<TResponse?> Handle<TCommand, TResponse>(
+        Func<TCommand, CancellationToken, Task<TResponse>> commandHandler,
+        TCommand commandMessage,
         CancellationToken cancellationToken) =>
-        commandHandler(commandMessage, cancellationToken);
+        commandHandler(commandMessage, cancellationToken)!;
 
     public Task Handle<TCommand>(
-        Func<TCommand, CancellationToken, Task> commandHandler, 
-        TCommand commandMessage, 
+        Func<TCommand, CancellationToken, Task> commandHandler,
+        TCommand commandMessage,
         CancellationToken cancellationToken) =>
         commandHandler(commandMessage, cancellationToken);
 
-    public Task<TResponse> Handle<TResponse>(
-        Func<CancellationToken, Task<TResponse>> commandHandler, 
-        CancellationToken cancellationToken) => 
-        commandHandler(cancellationToken);
+    public Task<TResponse?> Handle<TResponse>(
+        Func<CancellationToken, Task<TResponse>> commandHandler,
+        CancellationToken cancellationToken) =>
+        commandHandler(cancellationToken)!;
 
     public Task Handle(
-        Func<CancellationToken, Task> commandHandler, 
+        Func<CancellationToken, Task> commandHandler,
         CancellationToken cancellationToken) =>
         commandHandler(cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/TestableCommandHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/TestableCommandHandler.cs
@@ -4,11 +4,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 
 public class TestableCommandHandler : ICommandHandler
 {
-    public Task<TResponse?> Handle<TCommand, TResponse>(
+    public Task<TResponse> Handle<TCommand, TResponse>(
         Func<TCommand, CancellationToken, Task<TResponse>> commandHandler,
         TCommand commandMessage,
         CancellationToken cancellationToken) =>
-        commandHandler(commandMessage, cancellationToken)!;
+        commandHandler(commandMessage, cancellationToken);
 
     public Task Handle<TCommand>(
         Func<TCommand, CancellationToken, Task> commandHandler,
@@ -16,10 +16,10 @@ public class TestableCommandHandler : ICommandHandler
         CancellationToken cancellationToken) =>
         commandHandler(commandMessage, cancellationToken);
 
-    public Task<TResponse?> Handle<TResponse>(
+    public Task<TResponse> Handle<TResponse>(
         Func<CancellationToken, Task<TResponse>> commandHandler,
         CancellationToken cancellationToken) =>
-        commandHandler(cancellationToken)!;
+        commandHandler(cancellationToken);
 
     public Task Handle(
         Func<CancellationToken, Task> commandHandler,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/TestableCommandHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/TestableCommandHandler.cs
@@ -1,0 +1,28 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+
+public class TestableCommandHandler :ICommandHandler
+{
+    public Task<TResponse> Handle<TCommand, TResponse>(
+        Func<TCommand, CancellationToken, Task<TResponse>> commandHandler, 
+        TCommand commandMessage, 
+        CancellationToken cancellationToken) =>
+        commandHandler(commandMessage, cancellationToken);
+
+    public Task Handle<TCommand>(
+        Func<TCommand, CancellationToken, Task> commandHandler, 
+        TCommand commandMessage, 
+        CancellationToken cancellationToken) =>
+        commandHandler(commandMessage, cancellationToken);
+
+    public Task<TResponse> Handle<TResponse>(
+        Func<CancellationToken, Task<TResponse>> commandHandler, 
+        CancellationToken cancellationToken) => 
+        commandHandler(cancellationToken);
+
+    public Task Handle(
+        Func<CancellationToken, Task> commandHandler, 
+        CancellationToken cancellationToken) =>
+        commandHandler(cancellationToken);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Clients/AzureBlobStorage/AzureBlobStorageIntegrationClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Clients/AzureBlobStorage/AzureBlobStorageIntegrationClient.cs
@@ -55,12 +55,12 @@ public class AzureBlobStorageIntegrationHelper
             var response = await blobClient.DeleteAsync(DeleteSnapshotsOption.IncludeSnapshots, cancellationToken: cancellationToken);
             if (response.IsError)
             {
-                throw new Exception($"Blob \"{blobName}\" could not be deleted from container \"{containerName}\". {response.ReasonPhrase}({response.Status})");
+                throw new Exception($"""Blob "{blobName}" could not be deleted from container "{containerName}". {response.ReasonPhrase}({response.Status})""");
             }
         }
         catch (Exception e)
         {
-            throw new Exception($"Blob \"{blobName}\" could not be deleted from container \"{containerName}\". {e.Message}");
+            throw new Exception($"""Blob "{blobName}" could not be deleted from container "{containerName}". {e.Message}""");
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/FullReset/FullResetFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/FullReset/FullResetFunctionTests.cs
@@ -1,5 +1,6 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Domain;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.FullReset;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
 using Microsoft.AspNetCore.Http;
 
@@ -9,7 +10,9 @@ public class FullResetFunctionTests
 {
     private readonly FullSearchableDocumentResetterMockBuilder _fullSearchableDocumentResetter = new();
     
-    private FullResetFunction GetSut() => new(_fullSearchableDocumentResetter.Build());
+    private FullResetFunction GetSut() => new(
+        _fullSearchableDocumentResetter.Build(), 
+        new TestableCommandHandler());
     
     [Fact]
     public void Can_instantiate_Sut() => Assert.NotNull(GetSut());

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RefreshSearchableDocument/RefreshSearchableDocumentFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RefreshSearchableDocument/RefreshSearchableDocumentFunctionTests.cs
@@ -11,7 +11,9 @@ public class RefreshSearchableDocumentFunctionTests
 {
     private readonly SearchableDocumentCreatorMockBuilder _searchableDocumentCreatorMockBuilder = new();
     
-    private RefreshSearchableDocumentFunction GetSut() => new(_searchableDocumentCreatorMockBuilder.Build());
+    private RefreshSearchableDocumentFunction GetSut() => new(
+        _searchableDocumentCreatorMockBuilder.Build(), 
+        new TestableCommandHandler());
     
     [Fact]
     public void Can_instantiate_SUT() => Assert.NotNull(GetSut());

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/ReindexSearchableDocuments/ReindexSearchableDocumentsFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/ReindexSearchableDocuments/ReindexSearchableDocumentsFunctionTests.cs
@@ -1,17 +1,22 @@
-﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.ReindexSearchableDocuments;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.
+    RefreshSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.
+    ReindexSearchableDocuments;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.ReindexSearchableDocuments;
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.
+    ReindexSearchableDocuments;
 
 public class ReindexSearchableDocumentsFunctionTests
 {
     private readonly SearchIndexClientMockBuilder _searchIndexClientMockBuilder = new();
-    
-    private ReindexSearchableDocumentsFunction GetSut() => new(new NullLogger<ReindexSearchableDocumentsFunction>(),
-                                                               _searchIndexClientMockBuilder.Build());
-    
+
+    private ReindexSearchableDocumentsFunction GetSut() => new(
+        new NullLogger<ReindexSearchableDocumentsFunction>(),
+        _searchIndexClientMockBuilder.Build(),
+        new TestableCommandHandler());
+
     [Fact]
     public void Can_instantiate_SUT() => Assert.NotNull(GetSut());
 
@@ -24,7 +29,7 @@ public class ReindexSearchableDocumentsFunctionTests
 
         // ACT
         await sut.ReindexSearchableDocuments(message, new FunctionContextMockBuilder().Build());
-        
+
         // ASSERT
         _searchIndexClientMockBuilder.Assert.IndexerRun();
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsTests.cs
@@ -13,7 +13,8 @@ public class RemovePublicationSearchableDocumentsTests
 
     private RemovePublicationSearchableDocumentsFunction GetSut() => new(
         new NullLogger<RemovePublicationSearchableDocumentsFunction>(),
-        _searchableDocumentRemoverMockBuilder.Build());
+        _searchableDocumentRemoverMockBuilder.Build(),
+        new TestableCommandHandler());
 
     [Fact]
     public void CanInstantiateSut() => Assert.NotNull(GetSut());

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemoveSearchableDocument/RemoveSearchableDocumentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/RemoveSearchableDocument/RemoveSearchableDocumentTests.cs
@@ -11,7 +11,8 @@ public class RemoveSearchableDocumentTests
     private readonly SearchableDocumentRemoverMockBuilder _searchableDocumentRemoverMockBuilder = new();
     private RemoveSearchableDocumentFunction GetSut() => new(
         new NullLogger<RemoveSearchableDocumentFunction>(),
-        _searchableDocumentRemoverMockBuilder.Build());
+        _searchableDocumentRemoverMockBuilder.Build(), 
+        new TestableCommandHandler());
 
     [Fact]
     public void CanInstantiateSut() => Assert.NotNull(GetSut());

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Exceptions/AzureBlobStorageException.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Exceptions/AzureBlobStorageException.cs
@@ -6,7 +6,7 @@ public class AzureBlobStorageException : Exception
     public string BlobName { get; }
 
     public AzureBlobStorageException(string containerName, string blobName, string errorReason) : base(
-        $"Error with Blob \"{blobName}\" in container \"{containerName}\": ${errorReason}")
+        $"""Error with Blob "{blobName}" in container "{containerName}": ${errorReason}""")
     {
         ContainerName = containerName;
         BlobName = blobName;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Exceptions/UnableToGetPublicationLatestReleaseSearchViewModelException.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Exceptions/UnableToGetPublicationLatestReleaseSearchViewModelException.cs
@@ -4,4 +4,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 /// The call to the ContentAPI to retrieve the searchable document form of the latest release failed
 /// </summary>
 public class UnableToGetPublicationLatestReleaseSearchViewModelException(string publicationSlug, string? errorMessage)
-    : Exception($"Unable to get latest release search view model for publication \"{publicationSlug}\". Error: \"{errorMessage}\"");
+    : Exception($"""
+                 Unable to get latest release search view model for publication "{publicationSlug}". Error: "{errorMessage}"
+                 """);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Exceptions/UnableToGetReleasesForPublicationException.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Exceptions/UnableToGetReleasesForPublicationException.cs
@@ -4,5 +4,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 /// Exception thrown when the call to the Content API to retrieve the releases for a publication fails.
 /// </summary>
 public class UnableToGetReleasesForPublicationException(string publicationSlug, string? errorMessage)
-    : Exception($"Unable to get releases for publication \"{publicationSlug}\". Error: \"{errorMessage}\"");
+    : Exception($"""
+                 Unable to get releases for publication "{publicationSlug}". Error: "{errorMessage}"
+                 """);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
@@ -62,6 +62,7 @@ public static class HostBuilderExtension
                     .AddTransient<IFullSearchableDocumentResetter, FullSearchableDocumentResetter>()
                     // Functions
                     .AddTransient<IEventGridEventHandler, EventGridEventHandler>()
+                    .AddTransient<ICommandHandler, CommandHandler>()
                     .AddHealthChecks()
                     // Clients
                     .AddTransient<ISearchIndexerClient, SearchIndexerClient>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
@@ -4,7 +4,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clie
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.CreateSearchableDocuments;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.RemoveSearchableDocument;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/FullReset/FullResetFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/FullReset/FullResetFunction.cs
@@ -18,7 +18,7 @@ public class FullResetFunction(
         FunctionContext context) =>
         await commandHandler.Handle(
             ResetSearchableDocument,
-            context.CancellationToken);
+            context.CancellationToken) ?? [];
 
     private async Task<RefreshSearchableDocumentMessageDto[]> ResetSearchableDocument(CancellationToken cancellationToken)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/FullReset/FullResetFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/FullReset/FullResetFunction.cs
@@ -1,29 +1,32 @@
-﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.
-    RefreshSearchableDocument.Dto;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.ResetSearchableDocuments;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.FullReset;
 
-public class FullResetFunction(IFullSearchableDocumentResetter fullSearchableDocumentResetter)
+public class FullResetFunction(
+    IFullSearchableDocumentResetter fullSearchableDocumentResetter,
+    ICommandHandler commandHandler)
 {
     [Function(nameof(FullSearchableDocumentsReset))]
     [QueueOutput("%RefreshSearchableDocumentQueueName%")]
     public async Task<RefreshSearchableDocumentMessageDto[]> FullSearchableDocumentsReset(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = nameof(FullSearchableDocumentsReset))]
         HttpRequest _,
-        FunctionContext context)
+        FunctionContext context) =>
+        await commandHandler.Handle(
+            ResetSearchableDocument,
+            context.CancellationToken);
+
+    private async Task<RefreshSearchableDocumentMessageDto[]> ResetSearchableDocument(CancellationToken cancellationToken)
     {
-        var response = await fullSearchableDocumentResetter.PerformReset(context.CancellationToken);
+        var response = await fullSearchableDocumentResetter.PerformReset(cancellationToken);
 
         return response.AllPublications
-                .Select(publication =>
-                            new RefreshSearchableDocumentMessageDto
-                            {
-                                PublicationSlug = publication.PublicationSlug
-                            })
-                .ToArray();
+            .Select(publication =>
+                    new RefreshSearchableDocumentMessageDto { PublicationSlug = publication.PublicationSlug })
+            .ToArray();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RefreshSearchableDocument/RefreshSearchableDocumentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RefreshSearchableDocument/RefreshSearchableDocumentFunction.cs
@@ -1,18 +1,29 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.CreateSearchableDocuments;
 using Microsoft.Azure.Functions.Worker;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument;
 
-public class RefreshSearchableDocumentFunction(ISearchableDocumentCreator searchableDocumentCreator)
+public class RefreshSearchableDocumentFunction(
+    ISearchableDocumentCreator searchableDocumentCreator,
+    ICommandHandler commandHandler)
 {
     [Function(nameof(RefreshSearchableDocument))]
     [QueueOutput("%SearchableDocumentCreatedQueueName%")]
     public async Task<SearchableDocumentCreatedMessageDto[]> RefreshSearchableDocument(
         [QueueTrigger("%RefreshSearchableDocumentQueueName%")]
         RefreshSearchableDocumentMessageDto message,
-        FunctionContext context)
+        FunctionContext context) =>
+        await commandHandler.Handle(
+            RefreshSearchableDocument,
+            message,
+            context.CancellationToken);
+
+    private async Task<SearchableDocumentCreatedMessageDto[]> RefreshSearchableDocument(
+        RefreshSearchableDocumentMessageDto message, 
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(message.PublicationSlug))
         {
@@ -28,7 +39,7 @@ public class RefreshSearchableDocumentFunction(ISearchableDocumentCreator search
         var response =
             await searchableDocumentCreator.CreatePublicationLatestReleaseSearchableDocument(
                 request,
-                context.CancellationToken);
+                cancellationToken);
 
         return
         [

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RefreshSearchableDocument/RefreshSearchableDocumentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RefreshSearchableDocument/RefreshSearchableDocumentFunction.cs
@@ -1,5 +1,4 @@
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.CreateSearchableDocuments;
 using Microsoft.Azure.Functions.Worker;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RefreshSearchableDocument/RefreshSearchableDocumentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RefreshSearchableDocument/RefreshSearchableDocumentFunction.cs
@@ -1,4 +1,4 @@
-﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.CreateSearchableDocuments;
@@ -19,7 +19,7 @@ public class RefreshSearchableDocumentFunction(
         await commandHandler.Handle(
             RefreshSearchableDocument,
             message,
-            context.CancellationToken);
+            context.CancellationToken) ?? [];
 
     private async Task<SearchableDocumentCreatedMessageDto[]> RefreshSearchableDocument(
         RefreshSearchableDocumentMessageDto message, 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/ReindexSearchableDocuments/ReindexSearchableDocumentsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/ReindexSearchableDocuments/ReindexSearchableDocumentsFunction.cs
@@ -1,5 +1,6 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -7,18 +8,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 
 public class ReindexSearchableDocumentsFunction(
     ILogger<ReindexSearchableDocumentsFunction> logger,
-    ISearchIndexerClient searchIndexerClient)
+    ISearchIndexerClient searchIndexerClient,
+    ICommandHandler commandHandler)
 {
     [Function(nameof(ReindexSearchableDocuments))]
     public async Task ReindexSearchableDocuments(
         [QueueTrigger("%SearchableDocumentCreatedQueueName%")]
-        SearchableDocumentCreatedMessageDto messageDto,
-        FunctionContext context)
-    {
-        logger.LogInformation("{FunctionName} triggered: {@Request}", context.FunctionDefinition.Name, messageDto);
-
-        await searchIndexerClient.RunIndexer(context.CancellationToken);
-        
-        logger.LogInformation("{FunctionName} completed.", context.FunctionDefinition.Name);
-    }
+        SearchableDocumentCreatedMessageDto _,
+        FunctionContext context) =>
+        await commandHandler.Handle(
+            searchIndexerClient.RunIndexer, 
+            context.CancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsFunction.cs
@@ -1,5 +1,6 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemovePublicationSearchableDocuments.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.RemoveSearchableDocument;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
@@ -9,12 +10,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 
 public class RemovePublicationSearchableDocumentsFunction(
     ILogger<RemovePublicationSearchableDocumentsFunction> logger,
-    ISearchableDocumentRemover searchableDocumentRemover)
+    ISearchableDocumentRemover searchableDocumentRemover,
+    ICommandHandler commandHandler)
 {
     [Function(nameof(RemovePublicationSearchableDocuments))]
     public async Task RemovePublicationSearchableDocuments(
         [QueueTrigger("%RemovePublicationSearchableDocumentsQueueName%")] RemovePublicationSearchableDocumentsDto message,
-        FunctionContext context)
+        FunctionContext context) =>
+        await commandHandler.Handle(RemovePublicationSearchableDocuments, message, context.CancellationToken);
+    
+    private async Task RemovePublicationSearchableDocuments(
+        RemovePublicationSearchableDocumentsDto message, 
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(message.PublicationSlug))
         {
@@ -23,9 +30,11 @@ public class RemovePublicationSearchableDocumentsFunction(
 
         var response = await searchableDocumentRemover.RemovePublicationSearchableDocuments(
             new RemovePublicationSearchableDocumentsRequest { PublicationSlug = message.PublicationSlug },
-            context.CancellationToken);
+            cancellationToken);
 
         logger.LogInformation(
-            "Removed searchable documents for publication \"{PublicationSlug}\". Response: {@response}", message.PublicationSlug, response);
+            "Removed searchable documents for publication \"{PublicationSlug}\". Response: {@response}", 
+            message.PublicationSlug, 
+            response);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsFunction.cs
@@ -1,5 +1,4 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemovePublicationSearchableDocuments.Dto;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.RemoveSearchableDocument;
 using Microsoft.Azure.Functions.Worker;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RemovePublicationSearchableDocuments/RemovePublicationSearchableDocumentsFunction.cs
@@ -32,7 +32,7 @@ public class RemovePublicationSearchableDocumentsFunction(
             cancellationToken);
 
         logger.LogInformation(
-            "Removed searchable documents for publication \"{PublicationSlug}\". Response: {@response}", 
+            """Removed searchable documents for publication "{PublicationSlug}". Response: {@response}""", 
             message.PublicationSlug, 
             response);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RemoveSearchableDocument/RemoveSearchableDocumentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/RemoveSearchableDocument/RemoveSearchableDocumentFunction.cs
@@ -31,6 +31,6 @@ public class RemoveSearchableDocumentFunction(
             cancellationToken);
 
         logger.LogInformation(
-            "Removed searchable document \"{ReleaseId}\". Response: {@response}", releaseId, response);
+            """Removed searchable document "{ReleaseId}". Response: {@response}""", releaseId, response);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationArchived/OnPublicationArchivedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationArchived/OnPublicationArchivedFunction.cs
@@ -1,7 +1,6 @@
 ﻿using Azure.Messaging.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemovePublicationSearchableDocuments.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationArchived.Dtos;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using Microsoft.Azure.Functions.Worker;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationChanged/OnPublicationChangedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationChanged/OnPublicationChangedFunction.cs
@@ -1,7 +1,6 @@
 ﻿using Azure.Messaging.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationChanged.Dtos;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using Microsoft.Azure.Functions.Worker;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationLatestPublishedReleaseReordered/OnPublicationLatestPublishedReleaseReorderedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationLatestPublishedReleaseReordered/OnPublicationLatestPublishedReleaseReorderedFunction.cs
@@ -3,7 +3,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Exte
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemoveSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationLatestPublishedReleaseReordered.Dtos;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using Microsoft.Azure.Functions.Worker;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationRestored/OnPublicationRestoredFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationRestored/OnPublicationRestoredFunction.cs
@@ -1,7 +1,6 @@
 ﻿using Azure.Messaging.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationRestored.Dtos;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using Microsoft.Azure.Functions.Worker;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseSlugChanged/OnReleaseSlugChangedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseSlugChanged/OnReleaseSlugChangedFunction.cs
@@ -1,7 +1,6 @@
 using Azure.Messaging.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnReleaseSlugChanged.Dtos;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using Microsoft.Azure.Functions.Worker;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/OnReleaseVersionPublishedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/OnReleaseVersionPublishedFunction.cs
@@ -2,7 +2,6 @@ using Azure.Messaging.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemoveSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnReleaseVersionPublished.Dtos;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using Microsoft.Azure.Functions.Worker;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnThemeUpdated/OnThemeUpdatedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnThemeUpdated/OnThemeUpdatedFunction.cs
@@ -2,7 +2,6 @@
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnThemeUpdated.Dtos;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/CommandHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/CommandHandler.cs
@@ -13,7 +13,7 @@ public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
         try
         {
             var response = await commandHandler(commandMessage, cancellationToken);
-            logger.LogDebug("Handled command: {@Command}  Response:{@Response}", commandMessage, response);
+            logger.LogDebug("Handled command: {@Command}. Response:{@Response}", commandMessage, response);
             return response;
         }
         catch (TaskCanceledException)
@@ -58,7 +58,7 @@ public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
         try
         {
             var response = await commandHandler(cancellationToken);
-            logger.LogDebug("Handled command: Response:{@Response}", response);
+            logger.LogDebug("Handled command. Response:{@Response}", response);
             return response;
         }
         catch (TaskCanceledException)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/CommandHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/CommandHandler.cs
@@ -16,6 +16,10 @@ public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
             logger.LogDebug("Handled command: {@Command}  Response:{@Response}", commandMessage, response);
             return response;
         }
+        catch (TaskCanceledException)
+        {
+            logger.LogWarning("Task was cancelled.");
+        }
         catch (Exception e)
         {
             logger.LogError(e, "Error handling command: {@Command}", commandMessage);
@@ -33,6 +37,10 @@ public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
         {
             await commandHandler(commandMessage, cancellationToken);
             logger.LogDebug("Handled command: {@Command}", commandMessage);
+        }
+        catch (TaskCanceledException)
+        {
+            logger.LogWarning("Task was cancelled.");
         }
         catch (Exception e)
         {
@@ -52,6 +60,10 @@ public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
             logger.LogDebug("Handled command: Response:{@Response}", response);
             return response;
         }
+        catch (TaskCanceledException)
+        {
+            logger.LogWarning("Task was cancelled.");
+        }
         catch (Exception e)
         {
             logger.LogError(e, "Error handling command.");
@@ -67,6 +79,10 @@ public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
         {
             await commandHandler(cancellationToken);
             logger.LogDebug("Handled command.");
+        }
+        catch (TaskCanceledException)
+        {
+            logger.LogWarning("Task was cancelled.");
         }
         catch (Exception e)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/CommandHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/CommandHandler.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
+
+public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
+{
+    public async Task<TResponse> Handle<TCommand, TResponse>(
+        Func<TCommand, CancellationToken, Task<TResponse>> commandHandler, 
+        TCommand commandMessage,
+        CancellationToken cancellationToken)
+    {
+        logger.LogDebug("Handling command: {@Command}", commandMessage);
+        try
+        {
+            var response = await commandHandler(commandMessage, cancellationToken);
+            logger.LogDebug("Handled command: {@Command}  Response:{@Response}", commandMessage, response);
+            return response;
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Error handling command: {@Command}", commandMessage);
+            throw;
+        }
+    }
+    
+    public async Task Handle<TCommand>(
+        Func<TCommand, CancellationToken, Task> commandHandler, 
+        TCommand commandMessage,
+        CancellationToken cancellationToken)
+    {
+        logger.LogDebug("Handling command: {@Command}", commandMessage);
+        try
+        {
+            await commandHandler(commandMessage, cancellationToken);
+            logger.LogDebug("Handled command: {@Command}", commandMessage);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Error handling command: {@Command}", commandMessage);
+            throw;
+        }
+    }
+
+    public async Task<TResponse> Handle<TResponse>(
+        Func<CancellationToken, Task<TResponse>> commandHandler,
+        CancellationToken cancellationToken)
+    {
+        logger.LogDebug("Handling command.");
+        try
+        {
+            var response = await commandHandler(cancellationToken);
+            logger.LogDebug("Handled command: Response:{@Response}", response);
+            return response;
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Error handling command.");
+            throw;
+        }
+    }
+    public async Task Handle(
+        Func<CancellationToken, Task> commandHandler,
+        CancellationToken cancellationToken)
+    {
+        logger.LogDebug("Handling command.");
+        try
+        {
+            await commandHandler(cancellationToken);
+            logger.LogDebug("Handled command.");
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Error handling command.");
+            throw;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/CommandHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/CommandHandler.cs
@@ -4,7 +4,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 
 public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
 {
-    public async Task<TResponse?> Handle<TCommand, TResponse>(
+    public async Task<TResponse> Handle<TCommand, TResponse>(
         Func<TCommand, CancellationToken, Task<TResponse>> commandHandler, 
         TCommand commandMessage,
         CancellationToken cancellationToken)
@@ -19,7 +19,7 @@ public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
         catch (TaskCanceledException)
         {
             logger.LogWarning("Task was cancelled.");
-            return default;
+            throw;
         }
         catch (Exception e)
         {
@@ -50,7 +50,7 @@ public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
         }
     }
 
-    public async Task<TResponse?> Handle<TResponse>(
+    public async Task<TResponse> Handle<TResponse>(
         Func<CancellationToken, Task<TResponse>> commandHandler,
         CancellationToken cancellationToken)
     {
@@ -64,7 +64,7 @@ public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
         catch (TaskCanceledException)
         {
             logger.LogWarning("Task was cancelled.");
-            return default;
+            throw;
         }
         catch (Exception e)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/CommandHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/CommandHandler.cs
@@ -4,7 +4,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 
 public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
 {
-    public async Task<TResponse> Handle<TCommand, TResponse>(
+    public async Task<TResponse?> Handle<TCommand, TResponse>(
         Func<TCommand, CancellationToken, Task<TResponse>> commandHandler, 
         TCommand commandMessage,
         CancellationToken cancellationToken)
@@ -19,6 +19,7 @@ public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
         catch (TaskCanceledException)
         {
             logger.LogWarning("Task was cancelled.");
+            return default;
         }
         catch (Exception e)
         {
@@ -49,7 +50,7 @@ public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
         }
     }
 
-    public async Task<TResponse> Handle<TResponse>(
+    public async Task<TResponse?> Handle<TResponse>(
         Func<CancellationToken, Task<TResponse>> commandHandler,
         CancellationToken cancellationToken)
     {
@@ -63,6 +64,7 @@ public class CommandHandler(ILogger<CommandHandler> logger) : ICommandHandler
         catch (TaskCanceledException)
         {
             logger.LogWarning("Task was cancelled.");
+            return default;
         }
         catch (Exception e)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/ICommandHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/ICommandHandler.cs
@@ -2,7 +2,7 @@
 
 public interface ICommandHandler
 {
-    Task<TResponse> Handle<TCommand, TResponse>(
+    Task<TResponse?> Handle<TCommand, TResponse>(
         Func<TCommand, CancellationToken, Task<TResponse>> commandHandler, 
         TCommand commandMessage,
         CancellationToken cancellationToken);
@@ -12,7 +12,7 @@ public interface ICommandHandler
         TCommand commandMessage,
         CancellationToken cancellationToken);
     
-    Task<TResponse> Handle<TResponse>(
+    Task<TResponse?> Handle<TResponse>(
         Func<CancellationToken, Task<TResponse>> commandHandler, 
         CancellationToken cancellationToken);
     

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/ICommandHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/ICommandHandler.cs
@@ -1,0 +1,22 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
+
+public interface ICommandHandler
+{
+    Task<TResponse> Handle<TCommand, TResponse>(
+        Func<TCommand, CancellationToken, Task<TResponse>> commandHandler, 
+        TCommand commandMessage,
+        CancellationToken cancellationToken);
+
+    Task Handle<TCommand>(
+        Func<TCommand, CancellationToken, Task> commandHandler, 
+        TCommand commandMessage,
+        CancellationToken cancellationToken);
+    
+    Task<TResponse> Handle<TResponse>(
+        Func<CancellationToken, Task<TResponse>> commandHandler, 
+        CancellationToken cancellationToken);
+    
+    Task Handle(
+        Func<CancellationToken, Task> commandHandler, 
+        CancellationToken cancellationToken);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/ICommandHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/ICommandHandler.cs
@@ -2,7 +2,7 @@
 
 public interface ICommandHandler
 {
-    Task<TResponse?> Handle<TCommand, TResponse>(
+    Task<TResponse> Handle<TCommand, TResponse>(
         Func<TCommand, CancellationToken, Task<TResponse>> commandHandler, 
         TCommand commandMessage,
         CancellationToken cancellationToken);
@@ -12,7 +12,7 @@ public interface ICommandHandler
         TCommand commandMessage,
         CancellationToken cancellationToken);
     
-    Task<TResponse?> Handle<TResponse>(
+    Task<TResponse> Handle<TResponse>(
         Func<CancellationToken, Task<TResponse>> commandHandler, 
         CancellationToken cancellationToken);
     


### PR DESCRIPTION
Our event handlers all pass through a common component that handles logging.
Added a similar component for handling all of the commands.
The primary driver for this was to add logging to all of our command handlers to aid troubleshooting in dev.