### PR TITLE
Ees 6107 changes to release version published event

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseVersionPublished/OnReleaseVersionPublishedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseVersionPublished/OnReleaseVersionPublishedFunctionTests.cs
@@ -74,7 +74,7 @@ public class OnReleaseVersionPublishedFunctionTests
         // If the newly published release version is for a different release then the new searchable
         // document will be created using its new ReleaseId.
         // Therefore, the existing, previously latest searchable document needs to be removed.
-        Assert.Equal([new RemoveSearchableDocumentDto{ ReleaseId = payload.PreviousLatestReleaseId }], response.RemoveSearchableDocuments);
+        Assert.Equal([new RemoveSearchableDocumentDto{ ReleaseId = payload.PreviousLatestPublishedReleaseId }], response.RemoveSearchableDocuments);
     }
     
     [Fact]
@@ -118,8 +118,8 @@ public class OnReleaseVersionPublishedFunctionTests
                     ReleaseSlug = "this-is-a-release-slug",
                     PublicationId = Guid.NewGuid(),
                     PublicationSlug = "this-is-a-publication-slug",
-                    PublicationLatestPublishedReleaseVersionId = newlyPublishedLatestReleaseVersionId,
-                    PreviousLatestReleaseId = newlyPublishedLatestReleaseId
+                    LatestPublishedReleaseVersionId = newlyPublishedLatestReleaseVersionId,
+                    PreviousLatestPublishedReleaseId = newlyPublishedLatestReleaseId
                 };
             }
         }
@@ -134,14 +134,14 @@ public class OnReleaseVersionPublishedFunctionTests
             Base with
             {
                 // Latest release version id is something other than the release version just published
-                PublicationLatestPublishedReleaseVersionId = Guid.NewGuid()
+                LatestPublishedReleaseVersionId = Guid.NewGuid()
             };
 
         public static ReleaseVersionPublishedEventDto NewlyPublishedIsForNewLatestRelease => 
             Base with
             {
                 // The previous release id is a different release
-                PreviousLatestReleaseId = Guid.NewGuid()
+                PreviousLatestPublishedReleaseId = Guid.NewGuid()
             };
 
         public static ReleaseVersionPublishedEventDto NewlyPublishedIsForSameRelease => Base;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/Dtos/ReleaseVersionPublishedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/Dtos/ReleaseVersionPublishedEventDto.cs
@@ -6,42 +6,50 @@ public record ReleaseVersionPublishedEventDto
     /// Newly published release version id
     /// </summary>
     public Guid ReleaseVersionId { get; init; }
-    
+
     /// <summary>
     /// The Release Id for the newly published release version
     /// </summary>
-    public Guid? ReleaseId {get;init;}
-    
+    public Guid? ReleaseId { get; init; }
+
     /// <summary>
     /// The release slug for the newly published release version
     /// </summary>
     public string? ReleaseSlug { get; init; }
-    
+
     /// <summary>
     /// The publication id for the newly published release version
     /// </summary>
     public Guid? PublicationId { get; init; }
-    
+
     /// <summary>
     /// The publication slug for the newly published release version
     /// </summary>
     public string? PublicationSlug { get; init; }
-    
+
+    /// <summary>
+    /// </summary>
+    public Guid? LatestPublishedReleaseId { get; init; }
+
     /// <summary>
     /// The Release Version Id of the current "latest release version".
     /// </summary>
     public Guid? LatestPublishedReleaseVersionId { get; init; }
-    
+
     /// <summary>
     /// The Release Id of the previous "latest release version"
     /// </summary>
     public Guid? PreviousLatestPublishedReleaseId { get; init; }
-    
+
+    /// <summary>
+    /// </summary>
+    public Guid? PreviousLatestPublishedReleaseVersionId { get; init; }
+
     /// <summary>
     /// Is this newly published release version the new latest version?
     /// </summary>
     public bool NewlyPublishedReleaseVersionIsLatest => LatestPublishedReleaseVersionId == ReleaseVersionId;
-    
+
     /// <summary>
     /// Has a different release become the new latest?
     /// </summary>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/Dtos/ReleaseVersionPublishedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/Dtos/ReleaseVersionPublishedEventDto.cs
@@ -30,20 +30,20 @@ public record ReleaseVersionPublishedEventDto
     /// <summary>
     /// The Release Version Id of the current "latest release version".
     /// </summary>
-    public Guid? PublicationLatestPublishedReleaseVersionId { get; init; }
+    public Guid? LatestPublishedReleaseVersionId { get; init; }
     
     /// <summary>
     /// The Release Id of the previous "latest release version"
     /// </summary>
-    public Guid? PreviousLatestReleaseId { get; init; }
+    public Guid? PreviousLatestPublishedReleaseId { get; init; }
     
     /// <summary>
     /// Is this newly published release version the new latest version?
     /// </summary>
-    public bool NewlyPublishedReleaseVersionIsLatest => PublicationLatestPublishedReleaseVersionId == ReleaseVersionId;
+    public bool NewlyPublishedReleaseVersionIsLatest => LatestPublishedReleaseVersionId == ReleaseVersionId;
     
     /// <summary>
     /// Has a different release become the new latest?
     /// </summary>
-    public bool NewlyPublishedReleaseVersionIsForDifferentRelease => PreviousLatestReleaseId != ReleaseId;
+    public bool NewlyPublishedReleaseVersionIsForDifferentRelease => PreviousLatestPublishedReleaseId != ReleaseId;
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/OnReleaseVersionPublishedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/OnReleaseVersionPublishedFunction.cs
@@ -2,7 +2,6 @@ using Azure.Messaging.EventGrid;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RefreshSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemoveSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnReleaseVersionPublished.Dtos;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using Microsoft.Azure.Functions.Worker;
 
@@ -27,7 +26,7 @@ public class OnReleaseVersionPublishedFunction(IEventGridEventHandler eventGridE
                             RefreshSearchableDocumentMessages = 
                                 [ new RefreshSearchableDocumentMessageDto { PublicationSlug = payload.PublicationSlug } ],
                             RemoveSearchableDocuments = payload.NewlyPublishedReleaseVersionIsForDifferentRelease
-                                ? [ new RemoveSearchableDocumentDto { ReleaseId = payload.PreviousLatestReleaseId } ]
+                                ? [ new RemoveSearchableDocumentDto { ReleaseId = payload.PreviousLatestPublishedReleaseId } ]
                                 : []
                         }));
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
@@ -14,8 +14,8 @@ public record ReleaseVersionPublishedEvent : IEvent
             ReleaseSlug = releaseVersionPublishedEvent.ReleaseSlug,
             PublicationId = releaseVersionPublishedEvent.PublicationId,
             PublicationSlug = releaseVersionPublishedEvent.PublicationSlug,
-            PublicationLatestPublishedReleaseVersionId = releaseVersionPublishedEvent.PublicationLatestPublishedReleaseVersionId,
-            PreviousLatestReleaseId = releaseVersionPublishedEvent.PreviousLatestReleaseId,
+            LatestPublishedReleaseVersionId = releaseVersionPublishedEvent.LatestPublishedReleaseVersionId,
+            PreviousLatestPublishedReleaseId = releaseVersionPublishedEvent.PreviousLatestPublishedReleaseId,
         };
     }
 
@@ -36,12 +36,12 @@ public record ReleaseVersionPublishedEvent : IEvent
     /// </summary>
     public record EventPayload
     {
-        public required Guid ReleaseId {get;init;}
+        public required Guid ReleaseId { get; init; }
         public required string ReleaseSlug { get; init; }
         public required Guid PublicationId { get; init; }
         public required string PublicationSlug { get; init; }
-        public required Guid PublicationLatestPublishedReleaseVersionId { get; init; }    
-        public Guid? PreviousLatestReleaseId { get; init; }
+        public required Guid LatestPublishedReleaseVersionId { get; init; }
+        public Guid? PreviousLatestPublishedReleaseId { get; init; }
     }
     public EventPayload Payload { get; }
     
@@ -52,37 +52,37 @@ public record ReleaseVersionPublishedEvent : IEvent
         /// <summary>
         /// Newly published release version id
         /// </summary>
-        public Guid ReleaseVersionId { get; init; }
-    
+        public required Guid ReleaseVersionId { get; init; }
+
         /// <summary>
         /// The Release Id for the newly published release version
         /// </summary>
-        public Guid ReleaseId {get;init;}
-        
+        public required Guid ReleaseId { get; init; }
+
         /// <summary>
         /// The release slug for the newly published release version
         /// </summary>
-        public string ReleaseSlug { get; init; } = string.Empty;
-        
+        public required string ReleaseSlug { get; init; }
+
         /// <summary>
         /// The publication id for the newly published release version
         /// </summary>
-        public Guid PublicationId { get; init; }
-        
+        public required Guid PublicationId { get; init; }
+
         /// <summary>
         /// The publication slug for the newly published release version
         /// </summary>
-        public string PublicationSlug { get; init; } = string.Empty;
-        
+        public required string PublicationSlug { get; init; }
+
         /// <summary>
         /// The release version that has been published may not be the latest.
         /// This property contains the latest published release version id.
         /// </summary>
-        public Guid PublicationLatestPublishedReleaseVersionId { get; init; }
-        
+        public required Guid LatestPublishedReleaseVersionId { get; init; }
+
         /// <summary>
         /// The Release Id of the previous "latest release version"
         /// </summary>
-        public Guid? PreviousLatestReleaseId { get; init; }
+        public required Guid? PreviousLatestPublishedReleaseId { get; init; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
@@ -5,17 +5,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Events;
 
 public record ReleaseVersionPublishedEvent : IEvent
 {
-    public ReleaseVersionPublishedEvent(ReleaseVersionPublishedEventInfo releaseVersionPublishedEvent)
+    public ReleaseVersionPublishedEvent(ReleaseVersionPublishedEventInfo eventInfo)
     {
-        Subject = releaseVersionPublishedEvent.ReleaseVersionId.ToString();
+        Subject = eventInfo.ReleaseVersionId.ToString();
         Payload = new EventPayload
         {
-            ReleaseId = releaseVersionPublishedEvent.ReleaseId,
-            ReleaseSlug = releaseVersionPublishedEvent.ReleaseSlug,
-            PublicationId = releaseVersionPublishedEvent.PublicationId,
-            PublicationSlug = releaseVersionPublishedEvent.PublicationSlug,
-            LatestPublishedReleaseVersionId = releaseVersionPublishedEvent.LatestPublishedReleaseVersionId,
-            PreviousLatestPublishedReleaseId = releaseVersionPublishedEvent.PreviousLatestPublishedReleaseId,
+            ReleaseId = eventInfo.ReleaseId,
+            ReleaseSlug = eventInfo.ReleaseSlug,
+            PublicationId = eventInfo.PublicationId,
+            PublicationSlug = eventInfo.PublicationSlug,
+            LatestPublishedReleaseId = eventInfo.LatestPublishedReleaseId,
+            LatestPublishedReleaseVersionId = eventInfo.LatestPublishedReleaseVersionId,
+            PreviousLatestPublishedReleaseId = eventInfo.PreviousLatestPublishedReleaseId,
+            PreviousLatestPublishedReleaseVersionId = eventInfo.PreviousLatestPublishedReleaseVersionId
         };
     }
 
@@ -40,8 +42,10 @@ public record ReleaseVersionPublishedEvent : IEvent
         public required string ReleaseSlug { get; init; }
         public required Guid PublicationId { get; init; }
         public required string PublicationSlug { get; init; }
+        public required Guid LatestPublishedReleaseId { get; init; }
         public required Guid LatestPublishedReleaseVersionId { get; init; }
         public Guid? PreviousLatestPublishedReleaseId { get; init; }
+        public Guid? PreviousLatestPublishedReleaseVersionId { get; init; }
     }
     public EventPayload Payload { get; }
     
@@ -75,6 +79,10 @@ public record ReleaseVersionPublishedEvent : IEvent
         public required string PublicationSlug { get; init; }
 
         /// <summary>
+        /// </summary>
+        public required Guid LatestPublishedReleaseId { get; init; }
+
+        /// <summary>
         /// The release version that has been published may not be the latest.
         /// This property contains the latest published release version id.
         /// </summary>
@@ -84,5 +92,9 @@ public record ReleaseVersionPublishedEvent : IEvent
         /// The Release Id of the previous "latest release version"
         /// </summary>
         public required Guid? PreviousLatestPublishedReleaseId { get; init; }
+
+        /// <summary>
+        /// </summary>
+        public required Guid? PreviousLatestPublishedReleaseVersionId { get; init; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserTests.cs
@@ -98,6 +98,8 @@ public class PublisherEventRaiserTests
                     ReleaseSlug = info.PublishedReleaseVersions[0].ReleaseSlug,
                     ReleaseVersionId = info.PublishedReleaseVersions[0].ReleaseVersionId,
                     PreviousLatestPublishedReleaseId = info.PreviousLatestPublishedReleaseId,
+                    PreviousLatestPublishedReleaseVersionId = info.PreviousLatestPublishedReleaseVersionId,
+                    LatestPublishedReleaseId = info.LatestPublishedReleaseId,
                     LatestPublishedReleaseVersionId = info.LatestPublishedReleaseVersionId
                 });
             _eventRaiserMockBuilder.Assert.EventsRaised([expectedEvent]);
@@ -181,6 +183,8 @@ public class PublisherEventRaiserTests
                             ReleaseSlug = version.ReleaseSlug,
                             ReleaseVersionId = version.ReleaseVersionId,
                             PreviousLatestPublishedReleaseId = info.PreviousLatestPublishedReleaseId,
+                            PreviousLatestPublishedReleaseVersionId = info.PreviousLatestPublishedReleaseVersionId,
+                            LatestPublishedReleaseId = info.LatestPublishedReleaseId,
                             LatestPublishedReleaseVersionId = info.LatestPublishedReleaseVersionId
                         }))).ToList();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserTests.cs
@@ -97,8 +97,8 @@ public class PublisherEventRaiserTests
                     ReleaseId = info.PublishedReleaseVersions[0].ReleaseId,
                     ReleaseSlug = info.PublishedReleaseVersions[0].ReleaseSlug,
                     ReleaseVersionId = info.PublishedReleaseVersions[0].ReleaseVersionId,
-                    PreviousLatestReleaseId = info.PreviousLatestPublishedReleaseId,
-                    PublicationLatestPublishedReleaseVersionId = info.LatestPublishedReleaseVersionId
+                    PreviousLatestPublishedReleaseId = info.PreviousLatestPublishedReleaseId,
+                    LatestPublishedReleaseVersionId = info.LatestPublishedReleaseVersionId
                 });
             _eventRaiserMockBuilder.Assert.EventsRaised([expectedEvent]);
         }
@@ -180,8 +180,8 @@ public class PublisherEventRaiserTests
                             ReleaseId = version.ReleaseId,
                             ReleaseSlug = version.ReleaseSlug,
                             ReleaseVersionId = version.ReleaseVersionId,
-                            PreviousLatestReleaseId = info.PreviousLatestPublishedReleaseId,
-                            PublicationLatestPublishedReleaseVersionId = info.LatestPublishedReleaseVersionId
+                            PreviousLatestPublishedReleaseId = info.PreviousLatestPublishedReleaseId,
+                            LatestPublishedReleaseVersionId = info.LatestPublishedReleaseVersionId
                         }))).ToList();
 
             _eventRaiserMockBuilder.Assert.EventsRaised(expectedEvents);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
@@ -48,6 +48,8 @@ public class PublisherEventRaiser(IEventRaiser eventRaiser) : IPublisherEventRai
                         PublicationId = publication.PublicationId,
                         PublicationSlug = publication.PublicationSlug,
                         PreviousLatestPublishedReleaseId = publication.PreviousLatestPublishedReleaseId,
+                        PreviousLatestPublishedReleaseVersionId = publication.PreviousLatestPublishedReleaseVersionId,
+                        LatestPublishedReleaseId = publication.LatestPublishedReleaseId,
                         LatestPublishedReleaseVersionId = publication.LatestPublishedReleaseVersionId
                     })))
             .ToList();

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
@@ -47,8 +47,8 @@ public class PublisherEventRaiser(IEventRaiser eventRaiser) : IPublisherEventRai
                         ReleaseVersionId = releaseVersion.ReleaseVersionId,
                         PublicationId = publication.PublicationId,
                         PublicationSlug = publication.PublicationSlug,
-                        PreviousLatestReleaseId = publication.PreviousLatestPublishedReleaseId,
-                        PublicationLatestPublishedReleaseVersionId = publication.LatestPublishedReleaseVersionId
+                        PreviousLatestPublishedReleaseId = publication.PreviousLatestPublishedReleaseId,
+                        LatestPublishedReleaseVersionId = publication.LatestPublishedReleaseVersionId
                     })))
             .ToList();
 


### PR DESCRIPTION
Following on from https://github.com/dfe-analytical-services/explore-education-statistics/pull/5867 this PR makes changes to `ReleaseVersionPublishedEvent`, `ReleaseVersionPublishedEventInfo`, and `ReleaseVersionPublishedEventDto` to tidy up some of the properties related to the published release version's publication's previous and latest published release.

### Consistency

To make the naming of properties consistent with each other:

- Rename `PublicationLatestPublishedReleaseVersionId` to `LatestPublishedReleaseVersionId`
- Rename `PreviousLatestReleaseId` to `PreviousLatestPublishedReleaseId`

### Add useful values to the Event

To provide a full compliment of both 'latest' and 'previous', 'release id' and 'release version id' properties:

- Add `LatestPublishedReleaseId`
- Add `PreviousLatestPublishedReleaseVersionId`

### Result

`ReleaseVersionPublishedEvent`, `ReleaseVersionPublishedEventInfo`, and `ReleaseVersionPublishedEventDto` now have the following latest/previous properties consistently:

```
LatestPublishedReleaseId
LatestPublishedReleaseVersionId
PreviousLatestPublishedReleaseId
PreviousLatestPublishedReleaseVersionId
```