### PR TITLE
EES-6129 - added the capture of the "Download CSV" Public API endpoint

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicApi/DataSetVersionCalls/WithPreviewTokenAndRequestedDataSetVersion.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicApi/DataSetVersionCalls/WithPreviewTokenAndRequestedDataSetVersion.json
@@ -4,12 +4,12 @@
   "dataSetVersion": "1.2.0",
   "dataSetVersionId": "01d29401-7974-1276-a06b-b28a6a5385c6",
   "previewToken": {
-    "label": "Preview token content",
-    "dataSetVersionId": "01d29401-7974-1276-a06b-b28a6a5385c6",
     "created": "2025-02-23T11:02:44.850Z",
-    "expiry": "2025-02-24T11:02:44.850Z"
+    "dataSetVersionId": "01d29401-7974-1276-a06b-b28a6a5385c6",
+    "expiry": "2025-02-24T11:02:44.850Z",
+    "label": "Preview token content"
   },
   "requestedDataSetVersion": "1.*",
-  "startTime": "2025-02-28T03:07:44.850Z",
-  "type": "GetDataSetVersionSummary"
+  "startTime": "2025-02-26T03:07:44.850Z",
+  "type": "DownloadCsv"
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicApiDataSetVersionCallsProcessorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicApiDataSetVersionCallsProcessorTests.cs
@@ -72,17 +72,18 @@ public abstract class PublicApiDataSetVersionCallsProcessorTests
 
             AssertReportRowOk(
                 queryReportRow,
-                expectedType: "GetDataSetVersionMetadata",
+                expectedType: "GetSummary",
                 expectPreviewToken: false,
-                expectedStartTime: DateTime.Parse("2025-02-24T02:07:44.850Z"),
+                expectedStartTime: DateTime.Parse("2025-02-28T03:07:44.850Z"),
+                expectedRequestedDataSetVersion: null,
                 expectedParameters: null);
         }
         
         [Fact]
-        public async Task WithPreviewTokens_CapturedInReport()
+        public async Task WithPreviewTokenAndRequestedDataSetVersion_CapturedInReport()
         {
             using var pathResolver = new TestAnalyticsPathResolver();
-            SetupRequestFile(pathResolver, "WithPreviewTokens.json");
+            SetupRequestFile(pathResolver, "WithPreviewTokenAndRequestedDataSetVersion.json");
 
             var service = BuildService(pathResolver: pathResolver);
             await service.Process();
@@ -106,9 +107,10 @@ public abstract class PublicApiDataSetVersionCallsProcessorTests
 
             AssertReportRowOk(
                 queryReportRow,
-                expectedType: "GetDataSetVersionSummary",
+                expectedType: "DownloadCsv",
                 expectPreviewToken: true,
-                expectedStartTime: DateTime.Parse("2025-02-28T03:07:44.850Z"),
+                expectedStartTime: DateTime.Parse("2025-02-26T03:07:44.850Z"),
+                expectedRequestedDataSetVersion: "1.*",
                 expectedParameters: null);
         }
         
@@ -140,9 +142,10 @@ public abstract class PublicApiDataSetVersionCallsProcessorTests
 
             AssertReportRowOk(
                 queryReportRow,
-                expectedType: "GetDataSetVersionMetadata",
+                expectedType: "GetMetadata",
                 expectPreviewToken: false,
                 expectedStartTime: DateTime.Parse("2025-02-24T03:07:44.850Z"),
+                expectedRequestedDataSetVersion: null,
                 expectedParameters: """{"types":["Filters","Indicators","Locations","TimePeriods"]}""");
         }
         
@@ -152,7 +155,7 @@ public abstract class PublicApiDataSetVersionCallsProcessorTests
             using var pathResolver = new TestAnalyticsPathResolver();
             SetupRequestFile(pathResolver, "WithCoreDataSetVersionDetails.json");
             SetupRequestFile(pathResolver, "WithParameters.json");
-            SetupRequestFile(pathResolver, "WithPreviewTokens.json");
+            SetupRequestFile(pathResolver, "WithPreviewTokenAndRequestedDataSetVersion.json");
 
             var service = BuildService(pathResolver: pathResolver);
             await service.Process();
@@ -175,23 +178,26 @@ public abstract class PublicApiDataSetVersionCallsProcessorTests
             
             AssertReportRowOk(
                 reportRows[0],
-                expectedType: "GetDataSetVersionMetadata",
-                expectPreviewToken: false,
-                expectedStartTime: DateTime.Parse("2025-02-24T02:07:44.850Z"),
-                expectedParameters: null);
-            
-            AssertReportRowOk(
-                reportRows[1],
-                expectedType: "GetDataSetVersionMetadata",
+                expectedType: "GetMetadata",
                 expectPreviewToken: false,
                 expectedStartTime: DateTime.Parse("2025-02-24T03:07:44.850Z"),
+                expectedRequestedDataSetVersion: null,
                 expectedParameters: """{"types":["Filters","Indicators","Locations","TimePeriods"]}""");
             
             AssertReportRowOk(
-                reportRows[2],
-                expectedType: "GetDataSetVersionSummary",
+                reportRows[1],
+                expectedType: "DownloadCsv",
                 expectPreviewToken: true,
+                expectedStartTime: DateTime.Parse("2025-02-26T03:07:44.850Z"),
+                expectedRequestedDataSetVersion: "1.*",
+                expectedParameters: null);
+            
+            AssertReportRowOk(
+                reportRows[2],
+                expectedType: "GetSummary",
+                expectPreviewToken: false,
                 expectedStartTime: DateTime.Parse("2025-02-28T03:07:44.850Z"),
+                expectedRequestedDataSetVersion: null,
                 expectedParameters: null);
         }
 
@@ -210,13 +216,14 @@ public abstract class PublicApiDataSetVersionCallsProcessorTests
         string expectedType,
         DateTime expectedStartTime,
         bool expectPreviewToken,
+        string? expectedRequestedDataSetVersion,
         string? expectedParameters)
     {
         Assert.Equal(expectedType, queryReportRow.Type);
         Assert.Equal(Guid.Parse("01d29401-7274-a871-a8db-d4bc4e98c324"), queryReportRow.DataSetId);
         Assert.Equal(Guid.Parse("01d29401-7974-1276-a06b-b28a6a5385c6"), queryReportRow.DataSetVersionId);
         Assert.Equal("1.2.0", queryReportRow.DataSetVersion);
-        Assert.Equal("1.*", queryReportRow.RequestedDataSetVersion);
+        Assert.Equal(expectedRequestedDataSetVersion, queryReportRow.RequestedDataSetVersion);
         Assert.Equal("Data Set 1", queryReportRow.DataSetTitle);
         Assert.Equal(expectedStartTime, queryReportRow.StartTime);
 
@@ -276,7 +283,7 @@ public abstract class PublicApiDataSetVersionCallsProcessorTests
         public string DataSetVersion { get; init; } = string.Empty;
         public Guid DataSetVersionId { get; init; }
         public string? Parameters { get; init; }
-        public string RequestedDataSetVersion { get; init; } = string.Empty;
+        public string? RequestedDataSetVersion { get; init; }
         public string? PreviewTokenLabel { get; init; }
         public Guid? PreviewTokenDataSetVersionId { get; init; }
         public DateTime? PreviewTokenCreated { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicApiDataSetCallsProcessor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicApiDataSetCallsProcessor.cs
@@ -1,7 +1,6 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Workflow;
 using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeOffsetExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeOffsetExtensions.cs
@@ -5,6 +5,50 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 public static class DateTimeOffsetExtensions
 {
     /// <summary>
+    /// Strip the microsecond and nanosecond components from a DateTimeOffset. Helpful for testing in scenarios where
+    /// precision can change throughout a DateTimeOffset's lifecycle.
+    ///
+    /// An example would be when comparing DateTimeOffsets when one has been retrieved from JSON, where the
+    /// precision is less than that of C# itself.
+    /// 
+    /// </summary>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    public static DateTimeOffset TruncateMicroseconds(this DateTimeOffset offset)
+    {
+        return new DateTimeOffset(
+            offset.Year, 
+            offset.Month, 
+            offset.Day, 
+            offset.Hour, 
+            offset.Minute, 
+            offset.Second,
+            offset.Millisecond, 
+            0, 
+            TimeSpan.Zero);
+    }
+    
+    /// <summary>
+    /// Strip the microsecond and nanosecond components from a DateTimeOffset. Helpful for testing in scenarios where
+    /// precision can change throughout a DateTimeOffset's lifecycle.
+    ///
+    /// An example would be when comparing DateTimeOffsets when one has been retrieved from JSON, where the
+    /// precision is less than that of C# itself.
+    /// 
+    /// </summary>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    public static DateTimeOffset TruncateMicroseconds(this DateTimeOffset? offset)
+    {
+        if (offset == null)
+        {
+            throw new ArgumentException("offset cannot be null when truncating microseconds");
+        }
+        
+        return TruncateMicroseconds(offset.Value);
+    }
+    
+    /// <summary>
     /// Strip the nanosecond component from a DateTimeOffset. Helpful for testing in scenarios where precision can
     /// change throughout a DateTimeOffset's lifecycle.
     ///
@@ -44,6 +88,7 @@ public static class DateTimeOffsetExtensions
         {
             throw new ArgumentException("offset cannot be null when truncating nanoseconds");
         }
-        return TruncateNanoseconds((DateTimeOffset)offset);
+        
+        return TruncateNanoseconds(offset.Value);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Net.Mime;
-using System.Text.Json;
 using CsvHelper;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -23,6 +22,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Controllers;
 
@@ -1998,8 +1998,7 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                 var analyticFile = Assert.Single(analyticsFiles);
                 var contents = await File.ReadAllTextAsync(analyticFile);
 
-                var capturedCall = JsonSerializer.Deserialize<CaptureDataSetVersionCallRequest>(contents,
-                    new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                var capturedCall = JsonConvert.DeserializeObject<CaptureDataSetVersionCallRequest>(contents);
 
                 Assert.NotNull(capturedCall);
                 Assert.Equal(DataSetVersionCallType.DownloadCsv, capturedCall.Type);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -29,6 +29,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Contr
 public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : IntegrationTestFixtureWithCommonTestDataSetup(testApp)
 {
     private const string BaseUrl = "v1/data-sets";
+    
+    public record PreviewTokenSummary(
+        string Label,
+        DateTimeOffset Created,
+        DateTimeOffset Expiry);
+
+    public static readonly TheoryData<(PreviewTokenSummary?, string?)>
+        PreviewTokensAndRequestedDataSetVersions =
+        [
+            (null, null),
+            (new PreviewTokenSummary(Label: "Preview token",
+                Created: DateTimeOffset.UtcNow.AddDays(-1),
+                Expiry: DateTimeOffset.UtcNow.AddDays(1)), "1.0.*")
+        ];
 
     public abstract class GetDataSetTests(TestApplicationFactory testApp) : DataSetsControllerTests(testApp)
     {
@@ -1369,6 +1383,144 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                 response.AssertForbidden();
             }
         }
+        
+        public class AnalyticsEnabledTests : GetDataSetMetaTests, IDisposable
+        {
+            public AnalyticsEnabledTests(TestApplicationFactory testApp) : base(testApp)
+            {
+                testApp.AddAppSettings("appsettings.AnalyticsEnabled.json");
+            }
+
+            public void Dispose()
+            {
+                var queriesDirectory = GetAnalyticsPathResolver().PublicApiDataSetVersionCallsDirectoryPath();
+                if (Directory.Exists(queriesDirectory))
+                {
+                    Directory.Delete(queriesDirectory, recursive: true);
+                }
+            }
+            
+            public static readonly TheoryData<(PreviewTokenSummary?, string?, DataSetMetaType[]?)>
+                PreviewTokensRequestedDataSetVersionsAndTypes =
+                [
+                    (null, null, null),
+                    (
+                        new PreviewTokenSummary(Label: "Preview token",
+                            Created: DateTimeOffset.UtcNow.AddDays(-1),
+                            Expiry: DateTimeOffset.UtcNow.AddDays(1)),
+                        "1.0.*",
+                        [DataSetMetaType.Filters, DataSetMetaType.Locations])
+                ];
+
+            [Theory]
+            [MemberData(nameof(PreviewTokensRequestedDataSetVersionsAndTypes))]
+            public async Task AnalyticsRequestCaptured(
+                (PreviewTokenSummary?, string?, DataSetMetaType[]? types) previewTokenRequestedDataSetVersionAndParameters)
+            {
+                var (expectedPreviewToken, requestedDataSetVersion, types)
+                    = previewTokenRequestedDataSetVersionAndParameters;
+                
+                DataSet dataSet = DataFixture
+                    .DefaultDataSet()
+                    .WithStatusPublished();
+
+                await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+                DataSetVersion dataSetVersion = DataFixture
+                    .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 3)
+                    .WithStatusPublished()
+                    .WithDataSetId(dataSet.Id)
+                    .WithPreviewTokens(expectedPreviewToken != null
+                        ? DataFixture
+                            .DefaultPreviewToken()
+                            .WithLabel(expectedPreviewToken.Label)
+                            .WithCreated(expectedPreviewToken.Created)
+                            .WithExpiry(expectedPreviewToken.Expiry)
+                            .Generate(1) 
+                        : [])
+                    .WithFilterMetas(() =>
+                    [
+                        DataFixture
+                            .DefaultFilterMeta()
+                            .WithLabel("filter 1")
+                    ])
+                    .FinishWith(dsv => dataSet.LatestLiveVersion = dsv);
+
+                await TestApp.AddTestData<PublicDataDbContext>(context =>
+                {
+                    context.DataSetVersions.Add(dataSetVersion);
+                    context.DataSets.Update(dataSet);
+                });
+
+                var persistedPreviewToken = dataSetVersion
+                    .PreviewTokens
+                    .SingleOrDefault();
+                
+                var response = await GetDataSetMeta(
+                    dataSetId: dataSet.Id,
+                    dataSetVersion: requestedDataSetVersion,
+                    types: types?
+                        .Select(type => type.ToString())
+                        .ToArray(),
+                    previewTokenId: persistedPreviewToken?.Id);
+
+                var content = response.AssertOk<DataSetMetaViewModel>(useSystemJson: true);
+                Assert.NotNull(content);
+                Assert.Equal("filter 1", content.Filters.Single().Label);
+
+                // Add a slight delay as the writing of the analytics capture is non-blocking
+                // and could occur slightly after the Controller response is returned to the user.
+                Thread.Sleep(2000);
+
+                var analyticsPath = GetAnalyticsPathResolver().PublicApiDataSetVersionCallsDirectoryPath();
+
+                // Expect the successful call to have been recorded for analytics.
+                Assert.True(Directory.Exists(analyticsPath));
+                var analyticsFiles = Directory.GetFiles(analyticsPath);
+                var analyticFile = Assert.Single(analyticsFiles);
+                var contents = await File.ReadAllTextAsync(analyticFile);
+
+                var capturedCall = JsonConvert.DeserializeObject<CaptureDataSetVersionCallRequest>(contents);
+
+                Assert.NotNull(capturedCall);
+                Assert.Equal(DataSetVersionCallType.GetMetadata, capturedCall.Type);
+                Assert.Equal(dataSet.Id, capturedCall.DataSetId);
+                Assert.Equal(dataSet.Title, capturedCall.DataSetTitle);
+                Assert.Equal(dataSetVersion.Id, capturedCall.DataSetVersionId);
+                Assert.Equal(dataSetVersion.SemVersion().ToString(), capturedCall.DataSetVersion);
+                Assert.Equal(requestedDataSetVersion, capturedCall.RequestedDataSetVersion);
+
+                if (types == null)
+                {
+                    Assert.Null(capturedCall.Parameters);
+                }
+                else
+                {
+                    // Expect the requested metadata types to have been recorded as the call's parameters. 
+                    Assert.NotNull(capturedCall.Parameters);
+                    var parameters = JsonConvert.DeserializeObject<GetMetadataAnalyticsParameters>(
+                        capturedCall.Parameters.ToString()!);
+                    Assert.NotNull(parameters);
+                    Assert.Equal([DataSetMetaType.Filters, DataSetMetaType.Locations], parameters.Types);
+                }
+                
+                capturedCall.StartTime.AssertUtcNow(withinMillis: 5000);
+
+                if (expectedPreviewToken == null)
+                {
+                    Assert.Null(capturedCall.PreviewToken);
+                }
+                else
+                {
+                    Assert.NotNull(persistedPreviewToken);
+                    Assert.NotNull(capturedCall.PreviewToken);
+                    Assert.Equal(expectedPreviewToken.Label, capturedCall.PreviewToken.Label);
+                    Assert.Equal(dataSetVersion.Id, capturedCall.PreviewToken.DataSetVersionId);
+                    Assert.Equal(expectedPreviewToken.Created.TruncateMicroseconds(), capturedCall.PreviewToken.Created);
+                    Assert.Equal(expectedPreviewToken.Expiry.TruncateMicroseconds(), capturedCall.PreviewToken.Expiry);
+                }
+            }
+        }
 
         private async Task<HttpResponseMessage> GetDataSetMeta(
             Guid dataSetId,
@@ -1922,20 +2074,6 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                     Directory.Delete(queriesDirectory, recursive: true);
                 }
             }
-
-            public record PreviewTokenSummary(
-                string Label,
-                DateTimeOffset Created,
-                DateTimeOffset Expiry);
-
-            public static readonly TheoryData<(PreviewTokenSummary?, string?)>
-                PreviewTokensAndRequestedDataSetVersions =
-                [
-                    (null, null),
-                    (new PreviewTokenSummary(Label: "Preview token",
-                        Created: DateTimeOffset.UtcNow.AddDays(-1),
-                        Expiry: DateTimeOffset.UtcNow.AddDays(1)), "1.0.*")
-                ];
 
             [Theory]
             [MemberData(nameof(PreviewTokensAndRequestedDataSetVersions))]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Net.Mime;
+using System.Text.Json;
 using CsvHelper;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -7,6 +8,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Fixture;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.TheoryData;
@@ -1904,9 +1907,129 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
             }
         }
 
+        public class AnalyticsEnabledTests : DownloadDataSetCsvTests, IDisposable
+        {
+            public AnalyticsEnabledTests(TestApplicationFactory testApp) : base(testApp)
+            {
+                testApp.AddAppSettings("appsettings.AnalyticsEnabled.json");
+            }
+
+            public void Dispose()
+            {
+                var queriesDirectory = GetAnalyticsPathResolver().PublicApiDataSetVersionCallsDirectoryPath();
+                if (Directory.Exists(queriesDirectory))
+                {
+                    Directory.Delete(queriesDirectory, recursive: true);
+                }
+            }
+
+            public record PreviewTokenSummary(
+                string Label,
+                DateTimeOffset Created,
+                DateTimeOffset Expiry);
+
+            public static readonly TheoryData<(PreviewTokenSummary?, string?)>
+                PreviewTokensAndRequestedDataSetVersions =
+                [
+                    (null, null),
+                    (new PreviewTokenSummary(Label: "Preview token",
+                        Created: DateTimeOffset.UtcNow.AddDays(-1),
+                        Expiry: DateTimeOffset.UtcNow.AddDays(1)), "1.0.*")
+                ];
+
+            [Theory]
+            [MemberData(nameof(PreviewTokensAndRequestedDataSetVersions))]
+            public async Task AnalyticsRequestCaptured(
+                (PreviewTokenSummary?, string?) previewTokenAndRequestedDataSetVersion)
+            {
+                var (expectedPreviewToken, requestedDataSetVersion) = previewTokenAndRequestedDataSetVersion;
+                
+                DataSet dataSet = DataFixture
+                    .DefaultDataSet()
+                    .WithStatusPublished();
+
+                await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+                DataSetVersion dataSetVersion = DataFixture
+                    .DefaultDataSetVersion()
+                    .WithStatus(DataSetVersionStatus.Published)
+                    .WithDataSet(dataSet)
+                    .WithPreviewTokens(expectedPreviewToken != null
+                        ? DataFixture
+                            .DefaultPreviewToken()
+                            .WithLabel(expectedPreviewToken.Label)
+                            .WithCreated(expectedPreviewToken.Created)
+                            .WithExpiry(expectedPreviewToken.Expiry)
+                            .Generate(1) 
+                        : [])
+                    .FinishWith(dsv => dataSet.LatestLiveVersion = dsv);
+
+                await TestApp.AddTestData<PublicDataDbContext>(context =>
+                {
+                    context.DataSetVersions.Add(dataSetVersion);
+                    context.DataSets.Update(dataSet);
+                });
+
+                await CreateGZippedTestCsv(dataSetVersion, CsvData);
+
+                var persistedPreviewToken = dataSetVersion
+                    .PreviewTokens
+                    .SingleOrDefault();
+                
+                var response = await DownloadDataSet(
+                    dataSetId: dataSet.Id,
+                    dataSetVersion: requestedDataSetVersion,
+                    previewTokenId: persistedPreviewToken?.Id);
+                
+                response.AssertOk();
+                
+                var results = await DecompressGZippedCsv(response);
+                Assert.Equal(CsvData, results);
+
+                // Add a slight delay as the writing of the analytics capture is non-blocking
+                // and could occur slightly after the Controller response is returned to the user.
+                Thread.Sleep(2000);
+
+                var analyticsPath = GetAnalyticsPathResolver().PublicApiDataSetVersionCallsDirectoryPath();
+
+                // Expect the successful call to have been recorded for analytics.
+                Assert.True(Directory.Exists(analyticsPath));
+                var analyticsFiles = Directory.GetFiles(analyticsPath);
+                var analyticFile = Assert.Single(analyticsFiles);
+                var contents = await File.ReadAllTextAsync(analyticFile);
+
+                var capturedCall = JsonSerializer.Deserialize<CaptureDataSetVersionCallRequest>(contents,
+                    new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+                Assert.NotNull(capturedCall);
+                Assert.Equal(DataSetVersionCallType.DownloadCsv, capturedCall.Type);
+                Assert.Equal(dataSet.Id, capturedCall.DataSetId);
+                Assert.Equal(dataSet.Title, capturedCall.DataSetTitle);
+                Assert.Equal(dataSetVersion.Id, capturedCall.DataSetVersionId);
+                Assert.Equal(dataSetVersion.SemVersion().ToString(), capturedCall.DataSetVersion);
+                Assert.Equal(requestedDataSetVersion, capturedCall.RequestedDataSetVersion);
+                Assert.Null(capturedCall.Parameters);
+                capturedCall.StartTime.AssertUtcNow(withinMillis: 5000);
+
+                if (expectedPreviewToken == null)
+                {
+                    Assert.Null(capturedCall.PreviewToken);
+                }
+                else
+                {
+                    Assert.NotNull(persistedPreviewToken);
+                    Assert.NotNull(capturedCall.PreviewToken);
+                    Assert.Equal(expectedPreviewToken.Label, capturedCall.PreviewToken.Label);
+                    Assert.Equal(dataSetVersion.Id, capturedCall.PreviewToken.DataSetVersionId);
+                    Assert.Equal(expectedPreviewToken.Created.TruncateMicroseconds(), capturedCall.PreviewToken.Created);
+                    Assert.Equal(expectedPreviewToken.Expiry.TruncateMicroseconds(), capturedCall.PreviewToken.Expiry);
+                }
+            }
+        }
+
         private async Task CreateGZippedTestCsv(DataSetVersion dataSetVersion, IReadOnlyList<TestClass> csvData)
         {
-            var dataSetVersionPathResolver = TestApp.Services.GetRequiredService<IDataSetVersionPathResolver>();
+            var dataSetVersionPathResolver = BuildApp().Services.GetRequiredService<IDataSetVersionPathResolver>();
 
             await using var memStream = new MemoryStream();
             await using var streamWriter = new StreamWriter(memStream);
@@ -1962,6 +2085,11 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
             public string FirstColumn { get; init; } = null!;
             public string SecondColumn { get; init; } = null!;
         }
+    }
+
+    private IAnalyticsPathResolver GetAnalyticsPathResolver()
+    {
+        return BuildApp().Services.GetRequiredService<IAnalyticsPathResolver>();
     }
 
     private WebApplicationFactory<Startup> BuildApp()

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Fixture/TestApplicationFactory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Fixture/TestApplicationFactory.cs
@@ -4,6 +4,8 @@ using System.Text.Encodings.Web;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -81,6 +83,9 @@ public class TestApplicationFactory : TestApplicationFactory<Startup>
                 services
                     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                     .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(JwtBearerDefaults.AuthenticationScheme, null);
+
+                services
+                    .ReplaceService<IAnalyticsPathResolver>(new TestAnalyticsPathResolver(), optional: true);
             });
     }
     

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandlerTests.cs
@@ -191,10 +191,11 @@ public class QueryDataSetVersionAuthorizationHandlerTests
         var requestFeature = new HttpRequestFeature { Headers = new HeaderDictionary(requestHeaders?.ToDictionary()) };
         httpContext.Features.Set<IHttpRequestFeature>(requestFeature);
 
-        var previewTokenService = new PreviewTokenService(publicDataDbContext);
+        var previewTokenService = new PreviewTokenService(
+            publicDataDbContext: publicDataDbContext,
+            httpContextAccessor: new HttpContextAccessor { HttpContext = httpContext });
 
         return new QueryDataSetVersionAuthorizationHandler(
-            new HttpContextAccessor { HttpContext = httpContext },
             previewTokenService);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandlerTests.cs
@@ -251,7 +251,9 @@ public class ViewDataSetAuthorizationHandlerTests
         requestHeaders?.ForEach(header => 
             headers.Append(header.Key, header.Value));
 
-        var previewTokenService = new PreviewTokenService(dbContext);
+        var previewTokenService = new PreviewTokenService(
+            publicDataDbContext: dbContext,
+            httpContextAccessor: httpContextAccessor);
 
         var authorizationHandlerService = new AuthorizationHandlerService(
             httpContextAccessor: httpContextAccessor,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandlerTests.cs
@@ -321,7 +321,9 @@ public class ViewDataSetVersionAuthorizationHandlerTests
             .SetupGet(s => s.EnvironmentName)
             .Returns(environmentName ?? Environments.Production);
 
-        var previewTokenService = new PreviewTokenService(dbContext);
+        var previewTokenService = new PreviewTokenService(
+            publicDataDbContext: dbContext,
+            httpContextAccessor: httpContextAccessor);
 
         var authorizationHandlerService = new AuthorizationHandlerService(
             httpContextAccessor: httpContextAccessor,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/TestAnalyticsPathResolver.cs
@@ -20,6 +20,11 @@ public class TestAnalyticsPathResolver : IAnalyticsPathResolver, IDisposable
 
     public string PublicApiQueriesDirectoryPath()
     {
-        return Path.Combine(_basePath, "PublicApiQueries");
+        return Path.Combine(_basePath, "queries");
+    }
+
+    public string PublicApiDataSetVersionCallsDirectoryPath()
+    {
+        return Path.Combine(_basePath, "data-set-versions");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetVersionLevelCallsStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetVersionLevelCallsStrategyTests.cs
@@ -1,5 +1,5 @@
-using System.Text.RegularExpressions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
@@ -101,12 +101,12 @@ public abstract class AnalyticsWriteDataSetVersionCallsStrategyTests
                 DataSetVersion: "1.2.0",
                 DataSetTitle: "Data Set 1",
                 StartTime: DateTime.Parse("2025-02-24T03:07:44.850Z"),
-                Parameters: new Parameters(
+                Parameters: new GetMetadataAnalyticsParameters(
                     Types: [
-                        "Filters",
-                        "Indicators",
-                        "Locations",
-                        "TimePeriods"
+                        DataSetMetaType.Filters,
+                        DataSetMetaType.Indicators,
+                        DataSetMetaType.Locations,
+                        DataSetMetaType.TimePeriods
                     ]),
                 PreviewToken: null,
                 RequestedDataSetVersion: null,
@@ -129,7 +129,5 @@ public abstract class AnalyticsWriteDataSetVersionCallsStrategyTests
                 dateTimeProvider ?? new DateTimeProvider(),
                 Mock.Of<ILogger<AnalyticsWriteDataSetVersionCallsStrategy>>());
         }
-
-        private record Parameters(string[] Types);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetVersionLevelCallsStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetVersionLevelCallsStrategyTests.cs
@@ -1,0 +1,135 @@
+using System.Text.RegularExpressions;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Snapshooter.Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Strategies;
+
+public abstract class AnalyticsWriteDataSetVersionCallsStrategyTests
+{
+    public class ReportTests : AnalyticsWriteDataSetVersionCallsStrategyTests
+    {
+        private const string SnapshotPrefix = $"{nameof(AnalyticsWriteDataSetVersionCallsStrategyTests)}.{nameof(ReportTests)}";
+        
+        [Fact]
+        public async Task CallWrittenSuccessfully_WithCoreDataSetVersionDetails()
+        {
+            using var pathResolver = new TestAnalyticsPathResolver();
+            
+            var strategy = BuildStrategy(
+                pathResolver: pathResolver,
+                dateTimeProvider: new DateTimeProvider(DateTime.Parse("2025-03-16T12:01:02Z")));
+            
+            await strategy.Report(new CaptureDataSetVersionCallRequest(
+                DataSetId: new Guid("01d29401-7274-a871-a8db-d4bc4e98c324"),
+                DataSetVersionId: new Guid("01d29401-7974-1276-a06b-b28a6a5385c6"),
+                DataSetVersion: "1.2.0",
+                DataSetTitle: "Data Set 1",
+                StartTime: DateTime.Parse("2025-02-28T03:07:44.850Z"),
+                Parameters: null,
+                PreviewToken: null,
+                RequestedDataSetVersion: null,
+                Type: DataSetVersionCallType.GetSummary), default);
+            
+            var files = Directory
+                .GetFiles(pathResolver.PublicApiDataSetVersionCallsDirectoryPath());
+            
+            var filePath = Assert.Single(files);
+
+            var filename = filePath
+                .Split($"{pathResolver.PublicApiDataSetVersionCallsDirectoryPath()}{Path.DirectorySeparatorChar}")[1];
+            Assert.StartsWith("20250316-120102_", filename);
+
+            Snapshot.Match(
+                currentResult: await File.ReadAllTextAsync(filePath),
+                snapshotName: $"{SnapshotPrefix}.{nameof(CallWrittenSuccessfully_WithCoreDataSetVersionDetails)}");
+        }
+        
+        [Fact]
+        public async Task CallWrittenSuccessfully_WithPreviewTokenAndRequestedDataSetVersion()
+        {
+            using var pathResolver = new TestAnalyticsPathResolver();
+            
+            var strategy = BuildStrategy(
+                pathResolver: pathResolver,
+                dateTimeProvider: new DateTimeProvider(DateTime.Parse("2025-03-16T12:01:02Z")));
+            
+            await strategy.Report(new CaptureDataSetVersionCallRequest(
+                DataSetId: new Guid("01d29401-7274-a871-a8db-d4bc4e98c324"),
+                DataSetVersionId: new Guid("01d29401-7974-1276-a06b-b28a6a5385c6"),
+                DataSetVersion: "1.2.0",
+                DataSetTitle: "Data Set 1",
+                StartTime: DateTime.Parse("2025-02-26T03:07:44.850Z"),
+                Parameters: null,
+                PreviewToken: new PreviewTokenRequest(
+                    Label: "Preview token content",
+                    DataSetVersionId: new Guid("01d29401-7974-1276-a06b-b28a6a5385c6"),
+                    Created: DateTime.Parse("2025-02-23T11:02:44.850Z"),
+                    Expiry: DateTime.Parse("2025-02-24T11:02:44.850Z")),
+                RequestedDataSetVersion: "1.*",
+                Type: DataSetVersionCallType.DownloadCsv), default);
+            
+            var files = Directory
+                .GetFiles(pathResolver.PublicApiDataSetVersionCallsDirectoryPath());
+            
+            var filePath = Assert.Single(files);
+
+            var filename = filePath
+                .Split($"{pathResolver.PublicApiDataSetVersionCallsDirectoryPath()}{Path.DirectorySeparatorChar}")[1];
+            Assert.StartsWith("20250316-120102_", filename);
+
+            Snapshot.Match(
+                currentResult: await File.ReadAllTextAsync(filePath),
+                snapshotName: $"{SnapshotPrefix}.{nameof(CallWrittenSuccessfully_WithPreviewTokenAndRequestedDataSetVersion)}");
+        }
+        
+        [Fact]
+        public async Task CallWrittenSuccessfully_WithParameters()
+        {
+            using var pathResolver = new TestAnalyticsPathResolver();
+            
+            var strategy = BuildStrategy(pathResolver);
+
+            await strategy.Report(new CaptureDataSetVersionCallRequest(
+                DataSetId: new Guid("01d29401-7274-a871-a8db-d4bc4e98c324"),
+                DataSetVersionId: new Guid("01d29401-7974-1276-a06b-b28a6a5385c6"),
+                DataSetVersion: "1.2.0",
+                DataSetTitle: "Data Set 1",
+                StartTime: DateTime.Parse("2025-02-24T03:07:44.850Z"),
+                Parameters: new Parameters(
+                    Types: [
+                        "Filters",
+                        "Indicators",
+                        "Locations",
+                        "TimePeriods"
+                    ]),
+                PreviewToken: null,
+                RequestedDataSetVersion: null,
+                Type: DataSetVersionCallType.GetMetadata), default);
+
+            var filePath = Assert.Single(Directory
+                .GetFiles(pathResolver.PublicApiDataSetVersionCallsDirectoryPath()));
+            
+            Snapshot.Match(
+                currentResult: await File.ReadAllTextAsync(filePath),
+                snapshotName: $"{SnapshotPrefix}.{nameof(CallWrittenSuccessfully_WithParameters)}");
+        }
+
+        private static AnalyticsWriteDataSetVersionCallsStrategy BuildStrategy(
+            IAnalyticsPathResolver pathResolver,
+            DateTimeProvider? dateTimeProvider = null)
+        {
+            return new AnalyticsWriteDataSetVersionCallsStrategy(
+                pathResolver,
+                dateTimeProvider ?? new DateTimeProvider(),
+                Mock.Of<ILogger<AnalyticsWriteDataSetVersionCallsStrategy>>());
+        }
+
+        private record Parameters(string[] Types);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetVersionCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithCoreDataSetVersionDetails.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetVersionCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithCoreDataSetVersionDetails.snap
@@ -1,4 +1,4 @@
-{
+﻿{
   "dataSetId": "01d29401-7274-a871-a8db-d4bc4e98c324",
   "dataSetTitle": "Data Set 1",
   "dataSetVersion": "1.2.0",

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetVersionCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithParameters.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetVersionCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithParameters.snap
@@ -1,4 +1,4 @@
-{
+﻿{
   "dataSetId": "01d29401-7274-a871-a8db-d4bc4e98c324",
   "dataSetTitle": "Data Set 1",
   "dataSetVersion": "1.2.0",

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetVersionCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithPreviewTokenAndRequestedDataSetVersion.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetVersionCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithPreviewTokenAndRequestedDataSetVersion.snap
@@ -1,0 +1,15 @@
+﻿{
+  "dataSetId": "01d29401-7274-a871-a8db-d4bc4e98c324",
+  "dataSetTitle": "Data Set 1",
+  "dataSetVersion": "1.2.0",
+  "dataSetVersionId": "01d29401-7974-1276-a06b-b28a6a5385c6",
+  "previewToken": {
+    "created": "2025-02-23T11:02:44.850Z",
+    "dataSetVersionId": "01d29401-7974-1276-a06b-b28a6a5385c6",
+    "expiry": "2025-02-24T11:02:44.850Z",
+    "label": "Preview token content"
+  },
+  "requestedDataSetVersion": "1.*",
+  "startTime": "2025-02-26T03:07:44.850Z",
+  "type": "DownloadCsv"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -281,7 +281,7 @@ public class DataSetsController(
     )]
     [SwaggerResponse(403, type: typeof(ProblemDetailsViewModel), contentTypes: MediaTypeNames.Application.Json)]
     [SwaggerResponse(404, type: typeof(ProblemDetailsViewModel), contentTypes: MediaTypeNames.Application.Json)]
-    public async Task<ActionResult> DownloadDataSetCsv( // TODO EES-6007 analytics
+    public async Task<ActionResult> DownloadDataSetCsv(
         [SwaggerParameter("The ID of the data set.")] Guid dataSetId,
         [SwaggerParameter("""
                           The data set version e.g. 1.0, 1.1, 2.0, etc.

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
@@ -18,6 +18,8 @@ public static class AnalyticsServiceCollectionExtensions
             .GetSection(AnalyticsOptions.Section)
             .Get<AnalyticsOptions>();
 
+        services.AddTransient<IAnalyticsService, AnalyticsService>();
+
         if (analyticsOptions is { Enabled: false })
         {
             services.AddSingleton<IAnalyticsManager, NoOpAnalyticsManager>();
@@ -38,6 +40,7 @@ public static class AnalyticsServiceCollectionExtensions
         }
 
         services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicApiQueryStrategy>();
+        services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWriteDataSetVersionCallsStrategy>();
 
         return services;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/AnalyticsCaptureRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/AnalyticsCaptureRequests.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
@@ -21,6 +23,7 @@ public record CaptureDataSetVersionCallRequest(
     PreviewTokenRequest? PreviewToken,
     string? RequestedDataSetVersion,
     DateTimeOffset StartTime,
+    [property:JsonConverter(typeof(StringEnumConverter))]
     DataSetVersionCallType Type,
     object? Parameters = null
 ) : IAnalyticsCaptureRequestBase;
@@ -32,7 +35,6 @@ public enum DataSetVersionCallType
     DownloadCsv,
     GetChanges
 }
-
 
 public record PreviewTokenRequest(
     string Label,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/AnalyticsCaptureRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/AnalyticsCaptureRequests.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
@@ -35,6 +36,10 @@ public enum DataSetVersionCallType
     DownloadCsv,
     GetChanges
 }
+
+public record GetMetadataAnalyticsParameters(
+    [property:JsonProperty(ItemConverterType=typeof(StringEnumConverter))]
+    IEnumerable<DataSetMetaType> Types);
 
 public record PreviewTokenRequest(
     string Label,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/AnalyticsCaptureRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/AnalyticsCaptureRequests.cs
@@ -12,3 +12,30 @@ public record CaptureDataSetVersionQueryRequest(
     DateTime StartTime,
     DateTime EndTime,
     DataSetQueryRequest Query) : IAnalyticsCaptureRequestBase;
+
+public record CaptureDataSetVersionCallRequest(
+    Guid DataSetId,
+    Guid DataSetVersionId,
+    string DataSetVersion,
+    string DataSetTitle,
+    PreviewTokenRequest? PreviewToken,
+    string? RequestedDataSetVersion,
+    DateTimeOffset StartTime,
+    DataSetVersionCallType Type,
+    object? Parameters = null
+) : IAnalyticsCaptureRequestBase;
+
+public enum DataSetVersionCallType
+{
+    GetMetadata,
+    GetSummary,
+    DownloadCsv,
+    GetChanges
+}
+
+
+public record PreviewTokenRequest(
+    string Label,
+    Guid DataSetVersionId,
+    DateTimeOffset Created,
+    DateTimeOffset Expiry);

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandler.cs
@@ -9,7 +9,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.Au
 public class QueryDataSetVersionRequirement : IAuthorizationRequirement;
 
 public class QueryDataSetVersionAuthorizationHandler(
-    IHttpContextAccessor httpContextAccessor,
     IPreviewTokenService previewTokenService)
     : AuthorizationHandler<QueryDataSetVersionRequirement, DataSetVersion>
 {
@@ -32,9 +31,6 @@ public class QueryDataSetVersionAuthorizationHandler(
 
     private async Task<bool> RequestHasValidPreviewToken(DataSetVersion dataSetVersion)
     {
-        return httpContextAccessor.HttpContext.TryGetRequestHeader(
-                   RequestHeaderNames.PreviewToken,
-                   out var previewToken)
-               && await previewTokenService.ValidatePreviewTokenForDataSetVersion(previewToken.ToString(), dataSetVersion.Id);
+        return await previewTokenService.ValidatePreviewTokenForDataSetVersion(dataSetVersion.Id);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsPathResolver.cs
@@ -28,4 +28,9 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
     {
         return Path.Combine(BasePath(), "public-api", "queries");
     }
+    
+    public string PublicApiDataSetVersionCallsDirectoryPath()
+    {
+        return Path.Combine(BasePath(), "public-api", "data-set-versions");
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsService.cs
@@ -1,0 +1,60 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
+
+public class AnalyticsService(
+    IAnalyticsManager analyticsManager,
+    IPreviewTokenService previewTokenService,
+    PublicDataDbContext publicDataDbContext,
+    DateTimeProvider dateTimeProvider) : IAnalyticsService
+{
+    public async Task CaptureDataSetVersionCall(
+        Guid dataSetVersionId,
+        DataSetVersionCallType type,
+        string? requestedDataSetVersion,
+        object? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        var dataSetVersion = await publicDataDbContext
+            .DataSetVersions
+            .Include(dsv => dsv.DataSet)
+            .SingleOrDefaultAsync(dsv => dsv.Id == dataSetVersionId, cancellationToken);
+
+        if (dataSetVersion == null)
+        {
+            return;
+        }
+
+        var request = new CaptureDataSetVersionCallRequest(
+            DataSetId: dataSetVersion.DataSetId,
+            DataSetVersionId: dataSetVersion.Id,
+            DataSetVersion: dataSetVersion.SemVersion().ToString(),
+            DataSetTitle: dataSetVersion.DataSet.Title,
+            PreviewToken: await GetPreviewTokenRequest(),
+            RequestedDataSetVersion: requestedDataSetVersion,
+            StartTime: dateTimeProvider.UtcNow,
+            Type: type);
+        
+        await analyticsManager.Add(request, cancellationToken);
+    }
+
+    private async Task<PreviewTokenRequest?> GetPreviewTokenRequest()
+    {
+        var previewToken = await previewTokenService.GetPreviewTokenFromRequest();
+
+        if (previewToken == null)
+        {
+            return null;
+        }
+
+        return new PreviewTokenRequest(
+            Label: previewToken.Label,
+            DataSetVersionId: previewToken.DataSetVersionId,
+            Created: previewToken.Created,
+            Expiry: previewToken.Expiry);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsService.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
@@ -22,18 +23,14 @@ public class AnalyticsService(
         var dataSetVersion = await publicDataDbContext
             .DataSetVersions
             .Include(dsv => dsv.DataSet)
-            .SingleOrDefaultAsync(dsv => dsv.Id == dataSetVersionId, cancellationToken);
-
-        if (dataSetVersion == null)
-        {
-            return;
-        }
+            .SingleAsync(dsv => dsv.Id == dataSetVersionId, cancellationToken);
 
         var request = new CaptureDataSetVersionCallRequest(
             DataSetId: dataSetVersion.DataSetId,
             DataSetVersionId: dataSetVersion.Id,
             DataSetVersion: dataSetVersion.SemVersion().ToString(),
             DataSetTitle: dataSetVersion.DataSet.Title,
+            Parameters: parameters,
             PreviewToken: await GetPreviewTokenRequest(),
             RequestedDataSetVersion: requestedDataSetVersion,
             StartTime: dateTimeProvider.UtcNow,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IAnalyticsPathResolver.cs
@@ -3,4 +3,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.In
 public interface IAnalyticsPathResolver
 {
     string PublicApiQueriesDirectoryPath();
+    
+    string PublicApiDataSetVersionCallsDirectoryPath();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IAnalyticsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IAnalyticsService.cs
@@ -1,0 +1,13 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+
+public interface IAnalyticsService
+{
+    Task CaptureDataSetVersionCall(
+        Guid dataSetVersionId,
+        DataSetVersionCallType type,
+        string? requestedDataSetVersion,
+        object? parameters = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IPreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IPreviewTokenService.cs
@@ -1,14 +1,16 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 
 public interface IPreviewTokenService
 {
+    Task<PreviewToken?> GetPreviewTokenFromRequest();
+    
     Task<bool> ValidatePreviewTokenForDataSet(
-        string previewToken,
         Guid dataSetId,
         CancellationToken cancellationToken = default);
     
     Task<bool> ValidatePreviewTokenForDataSetVersion(
-        string previewToken,
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/LocalAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/LocalAnalyticsPathResolver.cs
@@ -30,4 +30,9 @@ public class LocalAnalyticsPathResolver : IAnalyticsPathResolver
     {
         return Path.Combine(BasePath(), "public-api", "queries");
     }
+    
+    public string PublicApiDataSetVersionCallsDirectoryPath()
+    {
+        return Path.Combine(BasePath(), "public-api", "data-set-versions");
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/PreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/PreviewTokenService.cs
@@ -1,3 +1,5 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Constants;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
@@ -5,18 +7,35 @@ using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
-public class PreviewTokenService(PublicDataDbContext publicDataDbContext) : IPreviewTokenService
+public class PreviewTokenService(
+    PublicDataDbContext publicDataDbContext,
+    IHttpContextAccessor httpContextAccessor) : IPreviewTokenService
 {
+    public async Task<PreviewToken?> GetPreviewTokenFromRequest()
+    {
+        var tokenId = GetPreviewTokenIdFromRequest();
+
+        if (tokenId == null)
+        {
+            return null;
+        }
+
+        return await publicDataDbContext
+            .PreviewTokens
+            .SingleOrDefaultAsync(pt => pt.Id == tokenId);
+    }
+
     public async Task<bool> ValidatePreviewTokenForDataSet(
-        string previewToken,
         Guid dataSetId,
         CancellationToken cancellationToken = default)
     {
-        if (!Guid.TryParse(previewToken, out var previewTokenId))
+        var previewTokenId = GetPreviewTokenIdFromRequest();
+
+        if (previewTokenId is null)
         {
             return false;
         }
-
+            
         var dataSet = await publicDataDbContext
             .DataSets
             .AsNoTracking()
@@ -34,23 +53,24 @@ public class PreviewTokenService(PublicDataDbContext publicDataDbContext) : IPre
 
         return await HasActivePreviewToken(
             dataSetVersionId: dataSet.LatestDraftVersionId.Value,
-            previewTokenId: previewTokenId,
+            previewTokenId: previewTokenId.Value,
             cancellationToken: cancellationToken);
     }
     
     public async Task<bool> ValidatePreviewTokenForDataSetVersion(
-        string previewToken,
         Guid dataSetVersionId,
         CancellationToken cancellationToken = default)
     {
-        if (!Guid.TryParse(previewToken, out var previewTokenId))
+        var previewTokenId = GetPreviewTokenIdFromRequest();
+
+        if (previewTokenId is null)
         {
             return false;
         }
 
         return await HasActivePreviewToken(
             dataSetVersionId: dataSetVersionId,
-            previewTokenId: previewTokenId,
+            previewTokenId: previewTokenId.Value,
             cancellationToken: cancellationToken);
     }
 
@@ -59,11 +79,31 @@ public class PreviewTokenService(PublicDataDbContext publicDataDbContext) : IPre
         Guid previewTokenId,
         CancellationToken cancellationToken)
     {
-        return await publicDataDbContext.PreviewTokens
+        return await publicDataDbContext
+            .PreviewTokens
             .Where(pt => pt.Id == previewTokenId)
             .Where(pt => pt.DataSetVersionId == dataSetVersionId)
             .Where(pt => pt.DataSetVersion.Status == DataSetVersionStatus.Draft)
             .Where(pt => pt.Expiry > DateTimeOffset.UtcNow)
             .AnyAsync(cancellationToken: cancellationToken);
+    }
+    
+    private Guid? GetPreviewTokenIdFromRequest()
+    {
+        if (!httpContextAccessor
+            .HttpContext
+            .TryGetRequestHeader(
+                RequestHeaderNames.PreviewToken,
+                out var previewTokenString))
+        {
+            return null;
+        }
+        
+        if (!Guid.TryParse(previewTokenString, out var previewTokenId))
+        {
+            return null;
+        }
+
+        return previewTokenId;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Security/AuthorizationHandlerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Security/AuthorizationHandlerService.cs
@@ -36,24 +36,13 @@ public class AuthorizationHandlerService(
     
     public async Task<bool> RequestHasValidPreviewToken(DataSet dataSet)
     {
-        return TryGetPreviewToken(out var previewToken) && 
-               await previewTokenService.ValidatePreviewTokenForDataSet(
-                   previewToken: previewToken.ToString(),
-                   dataSetId: dataSet.Id);
+        return await previewTokenService
+            .ValidatePreviewTokenForDataSet(dataSetId: dataSet.Id);
     }
 
     public async Task<bool> RequestHasValidPreviewToken(DataSetVersion dataSetVersion)
     {
-        return TryGetPreviewToken(out var previewToken) && 
-               await previewTokenService.ValidatePreviewTokenForDataSetVersion(
-                   previewToken: previewToken.ToString(),
-                   dataSetVersionId: dataSetVersion.Id);
-    }
-
-    private bool TryGetPreviewToken(out StringValues previewToken)
-    {
-        return httpContextAccessor.HttpContext.TryGetRequestHeader(
-            RequestHeaderNames.PreviewToken,
-            out previewToken);       
+        return await previewTokenService
+            .ValidatePreviewTokenForDataSetVersion(dataSetVersionId: dataSetVersion.Id);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Startup.cs
@@ -61,10 +61,6 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         .GetSection(AppInsightsOptions.Section)
         .Get<AppInsightsOptions>()!;
     
-    private readonly AnalyticsOptions _analyticsOptions = configuration
-        .GetRequiredSection(AnalyticsOptions.Section)
-        .Get<AnalyticsOptions>()!;
-
     // This method gets called by the runtime. Use this method to add services to the container.
     public void ConfigureServices(IServiceCollection services)
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetVersionCallsStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetVersionCallsStrategy.cs
@@ -1,0 +1,56 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies.Interfaces;
+using Newtonsoft.Json;
+using IAnalyticsPathResolver = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.IAnalyticsPathResolver;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
+
+public class AnalyticsWriteDataSetVersionCallsStrategy(
+    IAnalyticsPathResolver analyticsPathResolver,
+    DateTimeProvider dateTimeProvider,
+    ILogger<AnalyticsWriteDataSetVersionCallsStrategy> logger
+    ) : IAnalyticsWriteStrategy
+{
+    public Type RequestType => typeof(CaptureDataSetVersionCallRequest);
+
+    public async Task Report(IAnalyticsCaptureRequestBase request, CancellationToken cancellationToken)
+    {
+        if (request is not CaptureDataSetVersionCallRequest queryRequest)
+        {
+            throw new ArgumentException($"request isn't a {nameof(CaptureDataSetVersionQueryRequest)}");
+        }
+        
+        logger.LogInformation(
+            "Capturing query for analytics for data set {DataSetTitle}",
+            queryRequest.DataSetTitle);
+
+        var directory = analyticsPathResolver.PublicApiDataSetVersionCallsDirectoryPath();
+        var filename =
+            $"{dateTimeProvider.UtcNow:yyyyMMdd-HHmmss}_{queryRequest.DataSetVersionId}_{RandomUtils.RandomString()}.json";
+
+        try
+        {
+            Directory.CreateDirectory(directory);
+
+            var filePath = Path.Combine(directory, filename);
+
+            var serialisedRequest = JsonSerializationUtils.Serialize(
+                obj: queryRequest,
+                formatting: Formatting.Indented,
+                orderedProperties: true,
+                camelCase: true);
+
+            await File.WriteAllTextAsync(filePath, contents: serialisedRequest, cancellationToken: cancellationToken);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(
+                e,
+                "Error whilst writing {RequestTypeName} to disk",
+                queryRequest.GetType().ToString());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetVersionCallsStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetVersionCallsStrategy.cs
@@ -1,8 +1,7 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Utils;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies.Interfaces;
 using Newtonsoft.Json;
 using IAnalyticsPathResolver = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.IAnalyticsPathResolver;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/DataSetVersionGeneratorExtensions.cs
@@ -197,6 +197,11 @@ public static class DataSetVersionGeneratorExtensions
 
     public static Generator<DataSetVersion> WithPreviewTokens(
         this Generator<DataSetVersion> generator,
+        IEnumerable<PreviewToken> previewTokens)
+        => generator.WithPreviewTokens(() => previewTokens);
+
+    public static Generator<DataSetVersion> WithPreviewTokens(
+        this Generator<DataSetVersion> generator,
         Func<IEnumerable<PreviewToken>> previewTokens)
         => generator.ForInstance(s => s.SetPreviewTokens(previewTokens));
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/PreviewTokenGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/Fixtures/PreviewTokenGeneratorExtensions.cs
@@ -25,6 +25,11 @@ public static class PreviewTokenGeneratorExtensions
         Guid createdByUserId)
         => generator.ForInstance(s => s.SetCreatedByUserId(createdByUserId));
 
+    public static Generator<PreviewToken> WithCreated(
+        this Generator<PreviewToken> generator,
+        DateTimeOffset created)
+        => generator.ForInstance(s => s.SetCreated(created));
+
     public static Generator<PreviewToken> WithExpiry(
         this Generator<PreviewToken> generator,
         DateTimeOffset expiry)
@@ -61,6 +66,11 @@ public static class PreviewTokenGeneratorExtensions
         this InstanceSetters<PreviewToken> instanceSetter,
         Guid createdByUserId)
         => instanceSetter.Set(pt => pt.CreatedByUserId, createdByUserId);
+
+    public static InstanceSetters<PreviewToken> SetCreated(
+        this InstanceSetters<PreviewToken> instanceSetter,
+        DateTimeOffset created)
+        => instanceSetter.Set(pt => pt.Created, created);
 
     public static InstanceSetters<PreviewToken> SetExpiry(
         this InstanceSetters<PreviewToken> instanceSetter,


### PR DESCRIPTION
This PR:
- adds the capture of "Download CSV" endpoint calls to the Public API.

## Details being captured

This is the first of many "capture" tasks for DataSetVersion-level calls to the Public API.  In general they all contain a common set of information, notably:

* DataSetId - the Id of the overarching data set that owns the version being downloaded
* DataSetTitle - the title of the overarching data set that owns the version being downloaded
* DataSetVersionId - the Id of the actual version that is being downloaded
* DataSetVersion - the Semver of the actual version that is being downloaded
* PreviewToken - an optional preview token that is taken from the Preview Token HTTP header
* RequestedDataSetVersion - an optional HTTP parameter that allows specific or wildcarded data set versions to be targeted 
* StartTime - the datetime when the request was made

In addition to the common details above, some calls support additional parameters, captured in a generic "Parameters" field.

And finally, all DataSetVersion-level calls support a "Type" field which is used to identify the type of call being made.  In this PR, the call is "DownloadCsv".

## Refactoring in this PR

### PreviewTokenService

I needed easy access to the optional Preview Token that is provided in an HTTP header.  We already had a way to pull this string value (its Id) from the header and then pass the value to a `PreviewTokenService` for validation, but that didn't help me too much, other than potentially create some duplication.

Therefore, I moved the grabbing of the token id from the HTTP header *into* PreviewTokenService itself, plus added a method for getting the optional PreviewToken entity from the database if the HTTP header was present.  This way, our analytics code could get to the Preview Token much more easily.

### AnalyticsService

Because the capturing of the Download CSV endpoint was a bit more involved than the existing Public API Query-capturing code, I felt it best to move it into a separate `AnalyticsService` and keep `DataSetService` a little cleaner.

My plan is to then do the same thing for the existing Public API Query-capturing code, thus making `DataSetQueryService` a little cleaner too, but this would have bloated this PR.

After that is in place, I was also pondering creating a NoOpAnalyticsService within the Public API project, and have the selection of that no-op implementation dependent on the "AnalyticsEnabled" flag, rather than using a `NoOpAnalyticsManager`, but it's not a massive advantage unless we're actually planning to disable analytics anywhere to gain a performance edge.

## Updates to Analytics.Tests tests

Taking the JSON output from `AnalyticsWriteDataSetVersionLevelCallsStrategyTests.cs`, I transferred them to the equivalent Analytics.Consumer report creation test (PublicApiDataSetVersionCallsProcessorTests.cs) Resources folder and updated expectations there to match any small variations in behaviour. 
