### PR TITLE
EES-5872 Add noindex header to /csv endpoints

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
@@ -64,6 +64,8 @@ public class DataSetFilesController : ControllerBase
     public async Task<ActionResult> DownloadDataSetFile(
         Guid dataSetFileId)
     {
+        HttpContext.Response.Headers["X-Robots-Tag"] = "noindex";
+
         return await _dataSetFileService
             .DownloadDataSetFile(dataSetFileId);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Controllers/DataSetsController.cs
@@ -297,6 +297,7 @@ public class DataSetsController(
             )
             .OnSuccess(fileStreamResult =>
             {
+                HttpContext.Response.Headers["X-Robots-Tag"] = "noindex";
                 HttpContext.Response.Headers.ContentEncoding = ContentEncodings.Gzip;
 
                 return fileStreamResult;


### PR DESCRIPTION
This PR adds X-Robots-Tag="noindex" no index header to the two "/csv" endpoints we have - one is used with API data sets and the other for non-API data sets.

One of the backend endpoints actually ends "/download", in the backend, but that is invisible to the user. The frontend redirects to that endpoint from "/csv", so as far as the user is concerned it is still a "/csv" endpoint.

The requirements suggested we eventually remove these noindex headers after 6 months and instead use robots.txt to disallow indexing of these uris. But I'm not sure this will work well - I believe it would need to be `Disallow: /csv$`, which is fairly broad.