### PR TITLE
EES-6083 - added the capture of "Get metadata" Public API data set ve…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerTests.cs
@@ -29,6 +29,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Contr
 public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : IntegrationTestFixtureWithCommonTestDataSetup(testApp)
 {
     private const string BaseUrl = "v1/data-sets";
+    
+    public record PreviewTokenSummary(
+        string Label,
+        DateTimeOffset Created,
+        DateTimeOffset Expiry);
+
+    public static readonly TheoryData<(PreviewTokenSummary?, string?)>
+        PreviewTokensAndRequestedDataSetVersions =
+        [
+            (null, null),
+            (new PreviewTokenSummary(Label: "Preview token",
+                Created: DateTimeOffset.UtcNow.AddDays(-1),
+                Expiry: DateTimeOffset.UtcNow.AddDays(1)), "1.0.*")
+        ];
 
     public abstract class GetDataSetTests(TestApplicationFactory testApp) : DataSetsControllerTests(testApp)
     {
@@ -1369,6 +1383,144 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                 response.AssertForbidden();
             }
         }
+        
+        public class AnalyticsEnabledTests : GetDataSetMetaTests, IDisposable
+        {
+            public AnalyticsEnabledTests(TestApplicationFactory testApp) : base(testApp)
+            {
+                testApp.AddAppSettings("appsettings.AnalyticsEnabled.json");
+            }
+
+            public void Dispose()
+            {
+                var queriesDirectory = GetAnalyticsPathResolver().PublicApiDataSetVersionCallsDirectoryPath();
+                if (Directory.Exists(queriesDirectory))
+                {
+                    Directory.Delete(queriesDirectory, recursive: true);
+                }
+            }
+            
+            public static readonly TheoryData<(PreviewTokenSummary?, string?, DataSetMetaType[]?)>
+                PreviewTokensRequestedDataSetVersionsAndTypes =
+                [
+                    (null, null, null),
+                    (
+                        new PreviewTokenSummary(Label: "Preview token",
+                            Created: DateTimeOffset.UtcNow.AddDays(-1),
+                            Expiry: DateTimeOffset.UtcNow.AddDays(1)),
+                        "1.0.*",
+                        [DataSetMetaType.Filters, DataSetMetaType.Locations])
+                ];
+
+            [Theory]
+            [MemberData(nameof(PreviewTokensRequestedDataSetVersionsAndTypes))]
+            public async Task AnalyticsRequestCaptured(
+                (PreviewTokenSummary?, string?, DataSetMetaType[]? types) previewTokenRequestedDataSetVersionAndParameters)
+            {
+                var (expectedPreviewToken, requestedDataSetVersion, types)
+                    = previewTokenRequestedDataSetVersionAndParameters;
+                
+                DataSet dataSet = DataFixture
+                    .DefaultDataSet()
+                    .WithStatusPublished();
+
+                await TestApp.AddTestData<PublicDataDbContext>(context => context.DataSets.Add(dataSet));
+
+                DataSetVersion dataSetVersion = DataFixture
+                    .DefaultDataSetVersion(filters: 1, indicators: 1, locations: 1, timePeriods: 3)
+                    .WithStatusPublished()
+                    .WithDataSetId(dataSet.Id)
+                    .WithPreviewTokens(expectedPreviewToken != null
+                        ? DataFixture
+                            .DefaultPreviewToken()
+                            .WithLabel(expectedPreviewToken.Label)
+                            .WithCreated(expectedPreviewToken.Created)
+                            .WithExpiry(expectedPreviewToken.Expiry)
+                            .Generate(1) 
+                        : [])
+                    .WithFilterMetas(() =>
+                    [
+                        DataFixture
+                            .DefaultFilterMeta()
+                            .WithLabel("filter 1")
+                    ])
+                    .FinishWith(dsv => dataSet.LatestLiveVersion = dsv);
+
+                await TestApp.AddTestData<PublicDataDbContext>(context =>
+                {
+                    context.DataSetVersions.Add(dataSetVersion);
+                    context.DataSets.Update(dataSet);
+                });
+
+                var persistedPreviewToken = dataSetVersion
+                    .PreviewTokens
+                    .SingleOrDefault();
+                
+                var response = await GetDataSetMeta(
+                    dataSetId: dataSet.Id,
+                    dataSetVersion: requestedDataSetVersion,
+                    types: types?
+                        .Select(type => type.ToString())
+                        .ToArray(),
+                    previewTokenId: persistedPreviewToken?.Id);
+
+                var content = response.AssertOk<DataSetMetaViewModel>(useSystemJson: true);
+                Assert.NotNull(content);
+                Assert.Equal("filter 1", content.Filters.Single().Label);
+
+                // Add a slight delay as the writing of the analytics capture is non-blocking
+                // and could occur slightly after the Controller response is returned to the user.
+                Thread.Sleep(2000);
+
+                var analyticsPath = GetAnalyticsPathResolver().PublicApiDataSetVersionCallsDirectoryPath();
+
+                // Expect the successful call to have been recorded for analytics.
+                Assert.True(Directory.Exists(analyticsPath));
+                var analyticsFiles = Directory.GetFiles(analyticsPath);
+                var analyticFile = Assert.Single(analyticsFiles);
+                var contents = await File.ReadAllTextAsync(analyticFile);
+
+                var capturedCall = JsonConvert.DeserializeObject<CaptureDataSetVersionCallRequest>(contents);
+
+                Assert.NotNull(capturedCall);
+                Assert.Equal(DataSetVersionCallType.GetMetadata, capturedCall.Type);
+                Assert.Equal(dataSet.Id, capturedCall.DataSetId);
+                Assert.Equal(dataSet.Title, capturedCall.DataSetTitle);
+                Assert.Equal(dataSetVersion.Id, capturedCall.DataSetVersionId);
+                Assert.Equal(dataSetVersion.SemVersion().ToString(), capturedCall.DataSetVersion);
+                Assert.Equal(requestedDataSetVersion, capturedCall.RequestedDataSetVersion);
+
+                if (types == null)
+                {
+                    Assert.Null(capturedCall.Parameters);
+                }
+                else
+                {
+                    // Expect the requested metadata types to have been recorded as the call's parameters. 
+                    Assert.NotNull(capturedCall.Parameters);
+                    var parameters = JsonConvert.DeserializeObject<GetMetadataAnalyticsParameters>(
+                        capturedCall.Parameters.ToString()!);
+                    Assert.NotNull(parameters);
+                    Assert.Equal([DataSetMetaType.Filters, DataSetMetaType.Locations], parameters.Types);
+                }
+                
+                capturedCall.StartTime.AssertUtcNow(withinMillis: 5000);
+
+                if (expectedPreviewToken == null)
+                {
+                    Assert.Null(capturedCall.PreviewToken);
+                }
+                else
+                {
+                    Assert.NotNull(persistedPreviewToken);
+                    Assert.NotNull(capturedCall.PreviewToken);
+                    Assert.Equal(expectedPreviewToken.Label, capturedCall.PreviewToken.Label);
+                    Assert.Equal(dataSetVersion.Id, capturedCall.PreviewToken.DataSetVersionId);
+                    Assert.Equal(expectedPreviewToken.Created.TruncateMicroseconds(), capturedCall.PreviewToken.Created);
+                    Assert.Equal(expectedPreviewToken.Expiry.TruncateMicroseconds(), capturedCall.PreviewToken.Expiry);
+                }
+            }
+        }
 
         private async Task<HttpResponseMessage> GetDataSetMeta(
             Guid dataSetId,
@@ -1922,20 +2074,6 @@ public abstract class DataSetsControllerTests(TestApplicationFactory testApp) : 
                     Directory.Delete(queriesDirectory, recursive: true);
                 }
             }
-
-            public record PreviewTokenSummary(
-                string Label,
-                DateTimeOffset Created,
-                DateTimeOffset Expiry);
-
-            public static readonly TheoryData<(PreviewTokenSummary?, string?)>
-                PreviewTokensAndRequestedDataSetVersions =
-                [
-                    (null, null),
-                    (new PreviewTokenSummary(Label: "Preview token",
-                        Created: DateTimeOffset.UtcNow.AddDays(-1),
-                        Expiry: DateTimeOffset.UtcNow.AddDays(1)), "1.0.*")
-                ];
 
             [Theory]
             [MemberData(nameof(PreviewTokensAndRequestedDataSetVersions))]

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetVersionLevelCallsStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetVersionLevelCallsStrategyTests.cs
@@ -1,5 +1,5 @@
-using System.Text.RegularExpressions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
@@ -101,12 +101,12 @@ public abstract class AnalyticsWriteDataSetVersionCallsStrategyTests
                 DataSetVersion: "1.2.0",
                 DataSetTitle: "Data Set 1",
                 StartTime: DateTime.Parse("2025-02-24T03:07:44.850Z"),
-                Parameters: new Parameters(
+                Parameters: new GetMetadataAnalyticsParameters(
                     Types: [
-                        "Filters",
-                        "Indicators",
-                        "Locations",
-                        "TimePeriods"
+                        DataSetMetaType.Filters,
+                        DataSetMetaType.Indicators,
+                        DataSetMetaType.Locations,
+                        DataSetMetaType.TimePeriods
                     ]),
                 PreviewToken: null,
                 RequestedDataSetVersion: null,
@@ -129,7 +129,5 @@ public abstract class AnalyticsWriteDataSetVersionCallsStrategyTests
                 dateTimeProvider ?? new DateTimeProvider(),
                 Mock.Of<ILogger<AnalyticsWriteDataSetVersionCallsStrategy>>());
         }
-
-        private record Parameters(string[] Types);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/AnalyticsCaptureRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/AnalyticsCaptureRequests.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
@@ -35,6 +36,10 @@ public enum DataSetVersionCallType
     DownloadCsv,
     GetChanges
 }
+
+public record GetMetadataAnalyticsParameters(
+    [property:JsonProperty(ItemConverterType=typeof(StringEnumConverter))]
+    IEnumerable<DataSetMetaType> Types);
 
 public record PreviewTokenRequest(
     string Label,


### PR DESCRIPTION
This PR:
- adds the capturing of "Get metadata" Public API requests for analytics.

This PR builds atop of https://github.com/dfe-analytical-services/explore-education-statistics/pull/5883 to add the next DataSetVersion-level Public API request to analytics.

This PR also tackles the serialisation of parameters for the "Get metadata" endpoint.