### PR TITLE
Ees 6071 Add logging to health check strategies

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/HeathCheckStrategyBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Builders/HeathCheckStrategyBuilder.cs
@@ -12,8 +12,12 @@ public class HealthCheckStrategyMockBuilder
     public IHealthCheckStrategy Build()
     {
         _mock
+            .Setup(m => m.Description)
+            .Returns(() => "Mock Health Check Strategy");
+        
+        _mock
             .Setup(m => m.Run(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new HealthCheckResult(_healthCheckIsSuccessful, _healthCheckMessage));
+            .ReturnsAsync(new HealthCheckResult(_mock.Object, _healthCheckIsSuccessful, _healthCheckMessage));
         
         return _mock.Object;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/HealthChecks/HealthCheckFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/HealthChecks/HealthCheckFunctionTests.cs
@@ -4,12 +4,14 @@ using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Func
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks.Strategies;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.HealthChecks;
 
 public class HealthCheckFunctionTests
 {
-    private HealthCheckFunction GetSut(IEnumerable<IHealthCheckStrategy> strategies) => new(strategies);
+    private HealthCheckFunction GetSut(IEnumerable<IHealthCheckStrategy> strategies) => 
+        new(strategies, new NullLogger<HealthCheckFunction>());
 
     [Fact]
     public void Can_instantiate_sut() => Assert.NotNull(GetSut([]));
@@ -86,11 +88,11 @@ public class HealthCheckFunctionTests
         Assert.NotNull(result);
         var okResult = Assert.IsType<ObjectResult>(result);
         var healthCheckResult = Assert.IsType<HealthCheckResponse>(okResult.Value);
-        var expectedResults = new[]
+        var expectedResults = new HealthCheckResultViewModel[]
         {
-            new HealthCheckResult(true, "Result one"),
-            new HealthCheckResult(false, "Result two"),
-            new HealthCheckResult(true, "Result three")
+            new HealthCheckResult(strategies[0], true, "Result one"),
+            new HealthCheckResult(strategies[1], false, "Result two"),
+            new HealthCheckResult(strategies[2], true, "Result three")
         };
         Assert.Equal(expectedResults, healthCheckResult.Results);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/HealthChecks/Strategies/ContentApiHealthCheckStrategyIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/HealthChecks/Strategies/ContentApiHealthCheckStrategyIntegrationTests.cs
@@ -1,6 +1,7 @@
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks.Strategies;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit.Abstractions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.HealthChecks.Strategies;
@@ -16,21 +17,19 @@ public class ContentApiHealthCheckStrategyIntegrationTests(ITestOutputHelper out
         var sut = new ContentApiHealthCheckStrategy(
             Microsoft.Extensions.Options.Options.Create(
                 new ContentApiOptions()),
-                () => new ContentApiClient(
-                    new HttpClient
-                    {
-                        BaseAddress = new Uri(ContentApiUrl)
-                    }));
-        
+                new NullLogger<ContentApiHealthCheckStrategy>(),
+            () => new ContentApiClient(
+                new HttpClient { BaseAddress = new Uri(ContentApiUrl) }));
+
         // ACT
         var healthCheckResult = await sut.Run(CancellationToken.None);
-        
+
         // ASSERT
         Print(healthCheckResult);
         Assert.NotNull(healthCheckResult);
         Assert.True(healthCheckResult.IsHealthy);
         Assert.Null(healthCheckResult.Message);
     }
-    
+
     private void Print(object obj) => output.WriteLine(obj.ToString());
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks.Strategies;
@@ -22,7 +22,7 @@ public static class ServiceCollectionExtensions
             .AddTransient<IHealthCheckStrategy, ContentApiHealthCheckStrategy>()
             .AddTransient<IHealthCheckStrategy, AzureBlobStorageHealthCheckStrategy>()
             .AddTransient<IHealthCheckStrategy, AzureSearchHealthCheckStrategy>()
-            // Factories to allow Healthcheck to evaluate config before attempting to instantiate clients
+            // Factories to allow Health check to evaluate config before attempting to instantiate clients
             .AddTransient<Func<IContentApiClient>>(sp => sp.GetRequiredService<IContentApiClient>)
             .AddTransient<Func<IAzureBlobStorageClient>>(sp => sp.GetRequiredService<IAzureBlobStorageClient>)
             .AddTransient<Func<ISearchIndexerClient>>(sp => sp.GetRequiredService<ISearchIndexerClient>);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/FullReset/FullResetFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/FullReset/FullResetFunction.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Serv
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.ResetSearchableDocuments;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker;
+#pragma warning disable IDE0060 // Suppress Remove unused parameter HttpRequest
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.FullReset;
 
@@ -14,7 +15,7 @@ public class FullResetFunction(
     [QueueOutput("%RefreshSearchableDocumentQueueName%")]
     public async Task<RefreshSearchableDocumentMessageDto[]> FullSearchableDocumentsReset(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = nameof(FullSearchableDocumentsReset))]
-        HttpRequest _,
+        HttpRequest ignored, // The binding name _ is invalid
         FunctionContext context) =>
         await commandHandler.Handle(
             ResetSearchableDocument,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/ReindexSearchableDocuments/ReindexSearchableDocumentsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/CommandHandlers/ReindexSearchableDocuments/ReindexSearchableDocumentsFunction.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Func
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
+#pragma warning disable IDE0060 // Suppress Remove unused parameter SearchableDocumentCreatedMessageDto
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.ReindexSearchableDocuments;
 
@@ -14,7 +15,7 @@ public class ReindexSearchableDocumentsFunction(
     [Function(nameof(ReindexSearchableDocuments))]
     public async Task ReindexSearchableDocuments(
         [QueueTrigger("%SearchableDocumentCreatedQueueName%")]
-        SearchableDocumentCreatedMessageDto _,
+        SearchableDocumentCreatedMessageDto ignored, //  The binding name _ is invalid 
         FunctionContext context) =>
         await commandHandler.Handle(
             searchIndexerClient.RunIndexer, 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Dtos/HealthCheckResponse.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Dtos/HealthCheckResponse.cs
@@ -5,5 +5,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 public record HealthCheckResponse
 {
     public bool IsHealthy => Results.All(r => r.IsHealthy);
-    public required HealthCheckResult[] Results { get; init; }
+    public required HealthCheckResultViewModel[] Results { get; init; }
 }
+
+/// <summary>
+/// The result of checking the health of a part of the system
+/// </summary>
+/// <param name="Description">The description of the strategy running the health check</param>
+/// <param name="StrategyTypeName">The full type name of the strategy.</param>
+/// <param name="IsHealthy">Did the check pass?</param>
+/// <param name="Message">A helpful description of what did or did not pass, with any useful error messages to help diagnose any issues.</param>
+public record HealthCheckResultViewModel(string Description, string StrategyTypeName, bool IsHealthy, string Message)
+{
+    private HealthCheckResultViewModel(HealthCheckResult healthCheckResult)
+        : this(
+            healthCheckResult.Strategy.Description,
+            healthCheckResult.Strategy.GetType()?.Name ?? string.Empty,
+            healthCheckResult.IsHealthy, 
+            healthCheckResult.Message) { }
+    
+    public static implicit operator HealthCheckResultViewModel(HealthCheckResult healthCheckResult) => new(healthCheckResult); 
+};

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/HealthCheckFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/HealthCheckFunction.cs
@@ -44,7 +44,7 @@ public class HealthCheckFunction(IEnumerable<IHealthCheckStrategy> strategies, I
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Error occurred whilst trying to run healthcheck: {Message} {StrategyType}", e.Message, strategy.GetType().Name);
+                logger.LogError(e, "Error occurred whilst trying to run health check: {StrategyType}", strategy.GetType());
                 return new HealthCheckResult(strategy, false, $"Exception: {e.Message}");
             }
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/HealthCheckFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/HealthCheckFunction.cs
@@ -3,10 +3,11 @@ using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Func
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks;
 
-public class HealthCheckFunction(IEnumerable<IHealthCheckStrategy> strategies)
+public class HealthCheckFunction(IEnumerable<IHealthCheckStrategy> strategies, ILogger<HealthCheckFunction> logger)
 {
     [Function(nameof(HealthCheck))]
     [Produces("application/json")]
@@ -19,7 +20,8 @@ public class HealthCheckFunction(IEnumerable<IHealthCheckStrategy> strategies)
         // Execute strategies sequentially so as not to interleave the logs.
         var results = await strategies
             .ToAsyncEnumerable()
-            .SelectAwait(async strategy => await strategy.Run(cancellationToken))
+            .SelectAwait(async strategy => await Run(strategy))
+            .Select(result => (HealthCheckResultViewModel) result)
             .ToArrayAsync(cancellationToken: cancellationToken);
         
         var healthCheckResponse = new HealthCheckResponse
@@ -33,5 +35,18 @@ public class HealthCheckFunction(IEnumerable<IHealthCheckStrategy> strategies)
             {
                 StatusCode = StatusCodes.Status500InternalServerError
             };
+
+        async Task<HealthCheckResult> Run(IHealthCheckStrategy strategy)
+        {
+            try
+            {
+                return await strategy.Run(cancellationToken);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error occurred whilst trying to run healthcheck: {Message} {StrategyType}", e.Message, strategy.GetType().Name);
+                return new HealthCheckResult(strategy, false, $"Exception: {e.Message}");
+            }
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureBlobStorageHealthCheckStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureBlobStorageHealthCheckStrategy.cs
@@ -1,33 +1,41 @@
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureBlobStorage;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks.Strategies;
 
 internal class AzureBlobStorageHealthCheckStrategy(
     Func<IAzureBlobStorageClient> azureBlobStorageClientFactory,
+    ILogger<AzureBlobStorageHealthCheckStrategy> logger,
     IOptions<AppOptions> appOptions) : IHealthCheckStrategy
 {
     public async Task<HealthCheckResult> Run(CancellationToken cancellationToken)
     {
+        logger.LogInformation("Running Azure blob storage health check");
+        
         if (!appOptions.Value.IsValid(out var errorMessage))
         {
+            logger.LogWarning("Azure blob storage health check failed: Provider options are not valid. {@Options}", appOptions.Value);
             return new HealthCheckResult(false,  errorMessage);
         }
         
         var containerName = appOptions.Value.SearchableDocumentsContainerName;
         if (string.IsNullOrWhiteSpace(containerName))
         {
+            logger.LogWarning("Azure blob storage health check failed: Container name is not specified in configuration.");
             return new HealthCheckResult(false,
                 $"Azure blob storage container name is not specified in {AppOptions.Section}.{nameof(AppOptions.SearchableDocumentsContainerName)}");
         }
 
         try
         {
+            logger.LogInformation("Attempting to connect to Azure blob storage container '{ContainerName}'...", containerName);
             var  azureBlobStorageClient = azureBlobStorageClientFactory();
             var containerExists = await azureBlobStorageClient.ContainerExists(containerName, cancellationToken);
             if (!containerExists)
             {
+                logger.LogWarning("Azure blob storage container '{ContainerName}' is not found.", containerName);
                 return new HealthCheckResult(false,
                     $"Azure blob storage container '{containerName}' is not found");
             }
@@ -35,9 +43,11 @@ internal class AzureBlobStorageHealthCheckStrategy(
         }
         catch (Exception e)
         {
+            logger.LogError(e, "Error occurred whilst trying to check for Azure blob storage container '{ContainerName}': {Message}", containerName, e.Message);
             return new HealthCheckResult(false, $"Error occurred whilst trying to check for Azure blob storage container '{containerName}': {e.Message}");
         }
-        
+
+        logger.LogInformation("Healthcheck was successful: Azure blob storage container '{ContainerName}' is found.", containerName);
         return new HealthCheckResult(true, "Connection to Azure blob storage container:OK");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureBlobStorageHealthCheckStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureBlobStorageHealthCheckStrategy.cs
@@ -55,7 +55,7 @@ internal class AzureBlobStorageHealthCheckStrategy(
                 $"Error occurred whilst trying to check for Azure blob storage container '{containerName}': {e.Message}");
         }
 
-        logger.LogInformation("Healthcheck was successful: Azure blob storage container '{ContainerName}' is found.", containerName);
+        logger.LogInformation("Health check was successful: Azure blob storage container '{ContainerName}' is found.", containerName);
         return new HealthCheckResult(
             this,
             true, 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureSearchHealthCheckStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureSearchHealthCheckStrategy.cs
@@ -10,13 +10,14 @@ internal class AzureSearchHealthCheckStrategy(
     ILogger<AzureBlobStorageHealthCheckStrategy> logger,
     IOptions<AzureSearchOptions> azureSearchOptions) : IHealthCheckStrategy
 {
+    public string Description => "Azure Search Indexer check";
     public async Task<HealthCheckResult> Run(CancellationToken cancellationToken)
     {
         logger.LogInformation("Running Azure Search health check");
         if (!azureSearchOptions.Value.IsValid(out var errorMessage))
         {
             logger.LogWarning("Azure Search health check failed: Provider options are not valid. {@Options}", azureSearchOptions.Value);
-            return new HealthCheckResult(false, errorMessage);
+            return new HealthCheckResult(this, false, errorMessage);
         }
 
         try
@@ -26,16 +27,16 @@ internal class AzureSearchHealthCheckStrategy(
             if (!await client.IndexerExists(cancellationToken))
             {
                 logger.LogWarning("Azure Search Indexer is not found.");
-                return new HealthCheckResult(false, $"Azure Search Indexer is not found");
+                return new HealthCheckResult(this, false, $"Azure Search Indexer is not found");
             }
         }
         catch (Exception e)
         {
             logger.LogWarning(e, "Could not connect to Azure Search Indexer: {Message}", e.Message);
-            return new HealthCheckResult(false, $"Error occurred whilst trying to run healthcheck for Azure Search Indexer: {e.Message}");
+            return new HealthCheckResult(this, false, $"Error occurred whilst trying to run healthcheck for Azure Search Indexer: {e.Message}");
         }
 
         logger.LogInformation("Healthcheck was successful: Azure Search Indexer is found.");
-        return new HealthCheckResult(true, "Connection to Azure Search Indexer:OK");
+        return new HealthCheckResult(this, true, "Connection to Azure Search Indexer:OK");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureSearchHealthCheckStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureSearchHealthCheckStrategy.cs
@@ -33,10 +33,10 @@ internal class AzureSearchHealthCheckStrategy(
         catch (Exception e)
         {
             logger.LogWarning(e, "Could not connect to Azure Search Indexer: {Message}", e.Message);
-            return new HealthCheckResult(this, false, $"Error occurred whilst trying to run healthcheck for Azure Search Indexer: {e.Message}");
+            return new HealthCheckResult(this, false, $"Error occurred whilst trying to run health check for Azure Search Indexer: {e.Message}");
         }
 
-        logger.LogInformation("Healthcheck was successful: Azure Search Indexer is found.");
+        logger.LogInformation("Health check was successful: Azure Search Indexer is found.");
         return new HealthCheckResult(this, true, "Connection to Azure Search Indexer:OK");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureSearchHealthCheckStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureSearchHealthCheckStrategy.cs
@@ -1,33 +1,41 @@
 ﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.AzureSearch;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks.Strategies;
 
 internal class AzureSearchHealthCheckStrategy(
-    Func<ISearchIndexerClient> searchIndexClientFactory,
+    Func<ISearchIndexerClient> searchIndexerClientFactory,
+    ILogger<AzureBlobStorageHealthCheckStrategy> logger,
     IOptions<AzureSearchOptions> azureSearchOptions) : IHealthCheckStrategy
 {
     public async Task<HealthCheckResult> Run(CancellationToken cancellationToken)
     {
+        logger.LogInformation("Running Azure Search health check");
         if (!azureSearchOptions.Value.IsValid(out var errorMessage))
         {
+            logger.LogWarning("Azure Search health check failed: Provider options are not valid. {@Options}", azureSearchOptions.Value);
             return new HealthCheckResult(false, errorMessage);
         }
 
         try
         {
-            var client = searchIndexClientFactory();
+            logger.LogInformation("Attempting to connect to Azure Search Indexer. {@Options}...", azureSearchOptions.Value);
+            var client = searchIndexerClientFactory();
             if (!await client.IndexerExists(cancellationToken))
             {
+                logger.LogWarning("Azure Search Indexer is not found.");
                 return new HealthCheckResult(false, $"Azure Search Indexer is not found");
             }
         }
         catch (Exception e)
         {
+            logger.LogWarning(e, "Could not connect to Azure Search Indexer: {Message}", e.Message);
             return new HealthCheckResult(false, $"Error occurred whilst trying to run healthcheck for Azure Search Indexer: {e.Message}");
         }
 
+        logger.LogInformation("Healthcheck was successful: Azure Search Indexer is found.");
         return new HealthCheckResult(true, "Connection to Azure Search Indexer:OK");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/ContentApiHealthCheckStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/ContentApiHealthCheckStrategy.cs
@@ -10,6 +10,7 @@ internal class ContentApiHealthCheckStrategy(
     ILogger<ContentApiHealthCheckStrategy> logger,
     Func<IContentApiClient> contentApiClientFactory) : IHealthCheckStrategy
 {
+    public string Description => "Content API check";
     public async Task<HealthCheckResult> Run(CancellationToken cancellationToken)
     {
         logger.LogInformation("Running Content API health check");
@@ -17,7 +18,7 @@ internal class ContentApiHealthCheckStrategy(
         if (!options.Value.IsValid(out var errorMessage))
         {
             logger.LogWarning("Content API health check failed: Provider options are not valid. {@Options}", options.Value);
-            return new HealthCheckResult(false,  errorMessage);
+            return new HealthCheckResult(this, false,  errorMessage);
         }
         
         logger.LogInformation("Making Ping call to Content API...");
@@ -31,6 +32,7 @@ internal class ContentApiHealthCheckStrategy(
         logger.LogInformation("Result:{ResultMessage}", resultMessage);
         
         return new(
+            this,
             pingResult.WasSuccesssful, 
             resultMessage);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/ContentApiHealthCheckStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/ContentApiHealthCheckStrategy.cs
@@ -1,26 +1,37 @@
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Clients.ContentApi;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Options;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks.Strategies;
 
 internal class ContentApiHealthCheckStrategy(
     IOptions<ContentApiOptions> options,
+    ILogger<ContentApiHealthCheckStrategy> logger,
     Func<IContentApiClient> contentApiClientFactory) : IHealthCheckStrategy
 {
     public async Task<HealthCheckResult> Run(CancellationToken cancellationToken)
     {
+        logger.LogInformation("Running Content API health check");
+        
         if (!options.Value.IsValid(out var errorMessage))
         {
+            logger.LogWarning("Content API health check failed: Provider options are not valid. {@Options}", options.Value);
             return new HealthCheckResult(false,  errorMessage);
         }
+        
+        logger.LogInformation("Making Ping call to Content API...");
         var contentApiClient = contentApiClientFactory();
         var pingResult = await contentApiClient.Ping(cancellationToken);
+
+        var resultMessage = pingResult.WasSuccesssful
+            ? "Connection to Content API:OK"
+            : pingResult.ErrorMessage ?? "Connection to Content API:Failed";
+        
+        logger.LogInformation("Result:{ResultMessage}", resultMessage);
         
         return new(
             pingResult.WasSuccesssful, 
-            pingResult.WasSuccesssful
-                ? "Connection to Content API:OK"
-                : pingResult.ErrorMessage ?? "Connection to Content API:Failed");
+            resultMessage);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/HeathCheckResult.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/HeathCheckResult.cs
@@ -3,6 +3,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 /// <summary>
 /// The result of checking the health of a part of the system
 /// </summary>
+/// <param name="Strategy">The strategy running the health check</param>
 /// <param name="IsHealthy">Did the check pass?</param>
 /// <param name="Message">A helpful description of what did or did not pass, with any useful error messages to help diagnose any issues.</param>
-public record HealthCheckResult(bool IsHealthy, string Message);
+public record HealthCheckResult(IHealthCheckStrategy Strategy, bool IsHealthy, string Message);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/IHeathCheckStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/IHeathCheckStrategy.cs
@@ -2,5 +2,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.
 
 public interface IHealthCheckStrategy
 {
+    string Description { get; }
     Task<HealthCheckResult> Run(CancellationToken cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
     
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Added logging into the healthcheck strategies. A helpful way to induce some logging from the function app to test whether logs are being received in Application Insights.