### PR TITLE
EES-6169 Search infrastructure changes for Application Insights and Log Analytics

### DIFF
--- a/infrastructure/templates/common/components/functionApp.bicep
+++ b/infrastructure/templates/common/components/functionApp.bicep
@@ -47,6 +47,12 @@ param appSettings {
 @description('The Application Insights connection string that is associated with this resource.')
 param applicationInsightsConnectionString string
 
+@description('Enable diagnostic setting to send logs and metrics to Log Analytics.')
+param diagnosticSettingEnabled bool = false
+
+@description('The id of the Log Analytics workspace to which logs and metrics will be sent.')
+param logAnalyticsWorkspaceId string?
+
 @description('Specifies whether to grant the Function App role-based access to storage account queue data.')
 param deployQueueRoleAssignment bool = false
 
@@ -402,6 +408,15 @@ module expectedHttpStatusCodeAlerts '../../public-api/components/alerts/dynamicM
     }
   }
 ]
+
+module diagnosticSetting 'monitoring/functionAppDiagnosticSetting.bicep' = if (diagnosticSettingEnabled) {
+  name: '${functionAppName}DiagnosticSettingModuleDeploy'
+  params: {
+    functionAppName: functionApp.name
+    diagnosticSettingName: 'Send all logs and metrics to Log Analytics'
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
+  }
+}
 
 output name string = functionApp.name
 output url string = 'https://${functionApp.name}.azurewebsites.net'

--- a/infrastructure/templates/common/components/monitoring/functionAppDiagnosticSetting.bicep
+++ b/infrastructure/templates/common/components/monitoring/functionAppDiagnosticSetting.bicep
@@ -1,0 +1,55 @@
+@description('The name of the Function App to which the diagnostic setting will be applied.')
+param functionAppName string
+
+@description('The name of the diagnostic setting e.g. Send all logs and metrics to Log Analytics.')
+param diagnosticSettingName string
+
+@description('The id of the Log Analytics workspace to send logs and/or metrics to or null if Log Analytics is not a destination.')
+param logAnalyticsWorkspaceId string?
+
+@description('The categories of logs to enable.')
+@allowed([
+  'FunctionAppLogs'
+  'AppServiceAuthenticationLogs'
+])
+param logCategoriesToEnable array = [
+  'FunctionAppLogs'
+  'AppServiceAuthenticationLogs'
+]
+
+@description('The categories of metrics to enable.')
+@allowed([
+  'AllMetrics'
+])
+param metricCategoriesToEnable array = [
+  'AllMetrics'
+]
+
+var logSettings = [
+  for category in logCategoriesToEnable: {
+    category: category
+    enabled: true
+  }
+]
+
+var metricSettings = [
+  for metric in metricCategoriesToEnable: {
+    category: metric
+    enabled: true
+  }
+]
+
+resource functionApp 'Microsoft.Web/sites@2024-04-01' existing = {
+  name: functionAppName
+}
+
+resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: diagnosticSettingName
+  scope: functionApp
+  properties: {
+    logAnalyticsDestinationType: null
+    logs: logSettings
+    metrics: metricSettings
+    workspaceId: logAnalyticsWorkspaceId
+  }
+}

--- a/infrastructure/templates/public-api/components/appInsights.bicep
+++ b/infrastructure/templates/public-api/components/appInsights.bicep
@@ -6,6 +6,9 @@ param location string
 @description('Specifies the Application Insights name')
 param appInsightsName string
 
+@description('Resource Id of the log analytics workspace which the data will be ingested to.')
+param logAnalyticsWorkspaceId string?
+
 @description('Whether to create or update Azure Monitor alerts during this deploy')
 param alerts {
   exceptionCount: bool
@@ -27,6 +30,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
     Application_Type: kind
     publicNetworkAccessForIngestion: 'Enabled'
     publicNetworkAccessForQuery: 'Enabled'
+    WorkspaceResourceId: logAnalyticsWorkspaceId
   }
   tags: tagValues
 }

--- a/infrastructure/templates/search/application/monitoring.bicep
+++ b/infrastructure/templates/search/application/monitoring.bicep
@@ -13,11 +13,17 @@ param location string
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
+// Shared log analytics workspace. Currently the Public API deployment is responsible for creating this.
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-02-01' existing = {
+  name: resourceNames.existingResources.logAnalyticsWorkspace
+}
+
 module applicationInsightsModule '../../public-api/components/appInsights.bicep' = {
   name: 'applicationInsightsModuleDeploy'
   params: {
     location: location
     appInsightsName: '${resourcePrefix}-${abbreviations.insightsComponents}-search'
+    logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     alerts: {
       exceptionCount: true
       exceptionServerCount: true
@@ -30,3 +36,5 @@ module applicationInsightsModule '../../public-api/components/appInsights.bicep'
 
 output applicationInsightsConnectionString string = applicationInsightsModule.outputs.applicationInsightsConnectionString
 output applicationInsightsName string = applicationInsightsModule.outputs.applicationInsightsName
+output logAnalyticsWorkspaceId string = logAnalyticsWorkspace.id
+output logAnalyticsWorkspaceName string = logAnalyticsWorkspace.name

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -8,6 +8,9 @@ param contentApiUrl string
 @description('The IP address ranges that can access the Search Docs Function App endpoints.')
 param functionAppFirewallRules FirewallRule[]
 
+@description('The id of the Log Analytics workspace which logs and metrics will be sent to.')
+param logAnalyticsWorkspaceId string
+
 @description('Specifies the base URL of the Search Service endpoint for interacting with the data plane REST API. For example: https://[search-service-name].search.windows.net')
 param searchServiceEndpoint string
 
@@ -188,6 +191,8 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
     functionAppRuntime: 'dotnet-isolated'
     functionAppRuntimeVersion: '8.0'
     deployQueueRoleAssignment: true
+    diagnosticSettingEnabled: true
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
     storageAccountName: '${replace(resourcePrefix, '-', '')}${abbreviations.storageStorageAccounts}searchdocsfn'
     storageAccountPublicNetworkAccessEnabled: false
     publicNetworkAccessEnabled: true

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -118,6 +118,7 @@ module searchDocsFunctionModule 'application/searchDocsFunction.bicep' = {
       ],
       maintenanceFirewallRules
     )
+    logAnalyticsWorkspaceId: monitoringModule.outputs.logAnalyticsWorkspaceId
     searchServiceEndpoint: searchServiceModule.outputs.searchServiceEndpoint
     searchServiceIndexerName: searchServiceModule.outputs.searchServiceIndexerName
     searchServiceName: searchServiceModule.outputs.searchServiceName

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -60,6 +60,7 @@ var resourcePrefix = '${subscription}-ees'
 var resourceNames = {
   existingResources: {
     adminApp: '${subscription}-as-ees-admin'
+    logAnalyticsWorkspace: '${resourcePrefix}-${abbreviations.operationalInsightsWorkspaces}'
     publisherFunction: '${subscription}-fa-ees-publisher'
     keyVault: '${subscription}-kv-ees-01'
     vNet: '${subscription}-vnet-ees'
@@ -72,9 +73,8 @@ var resourceNames = {
   }
 }
 
-// Create a shared Application Insights resource for Search resources to use.
-module applicationInsightsModule 'application/searchApplicationInsights.bicep' = {
-  name: 'searchApplicationInsightsModule'
+module monitoringModule 'application/monitoring.bicep' = {
+  name: 'monitoringModule'
   params: {
     location: location
     resourcePrefix: resourcePrefix
@@ -125,7 +125,7 @@ module searchDocsFunctionModule 'application/searchDocsFunction.bicep' = {
     searchStorageAccountConnectionStringSecretName: searchServiceModule.outputs.searchStorageAccountConnectionStringSecretName
     searchableDocumentsContainerName: searchServiceModule.outputs.searchableDocumentsContainerName
     storageFirewallRules: maintenanceIpRanges
-    applicationInsightsConnectionString: applicationInsightsModule.outputs.applicationInsightsConnectionString
+    applicationInsightsConnectionString: monitoringModule.outputs.applicationInsightsConnectionString
     tagValues: tagValues
     deployAlerts: deployAlerts
   }

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -2,6 +2,7 @@
 type ResourceNames = {
   existingResources: {
     adminApp: string
+    logAnalyticsWorkspace: string
     publisherFunction: string
     keyVault: string
     vNet: string


### PR DESCRIPTION
This PR makes the following infrastructure changes:

### Associate the Search Application Insights with common Log Analytics workspace

When deploying  the Search Application Insights resource, we see the deployment automatically attempting to create a managed Log Analytics workspace with the name format `ai_<APPINSIGHTS RESOURCE NAME>_<APPINSIGHTS RESOURCE ID>_manage`.

In order to prevent it from attempting to create an additional workspace and make it to use our existing shared workspace for the Resource Group we now associate it using the `WorkspaceResourceId` parameter . Currently the Public API deployment is responsible for creating the shared Resource Group workspace. See the changes in module `monitoring.bicep` which has been renamed from `searchApplicationInsights.bicep`.

###  Add support to common Function App component template for a Log Analytics Diagnostic Setting

This adds a new parameter to the common Function App template which can enable sending logs and resource metrics to a Log Analytics workspace. It is disabled by default so that it does not affect deployments of Analytics/Screener/Public API until we want to enable it for those applications.

See new component `functionAppDiagnosticSetting.bicep` and the changes to `functionApp.bicep`.

### Enable the Diagnostic Setting to send logs and metrics to Log Analytics for the Search Function App.

This changes the Search Function App application module to enable the new Log Analytics Diagnostic Setting.

See the changes to `searchDocsFunction.bicep`. It now requires a Log Analytics Workspace resource id as a parameter which is the shared Log Analytics Workspace for the Resource Group.