### PR TITLE
Fixing UI test failure in manage_users_page.robot

### DIFF
--- a/tests/robot-tests/tests/admin/bau/manage_users_page.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_users_page.robot
@@ -81,10 +81,9 @@ Check the initial manage user page
 
     user checks select contains option    name:releaseId    ${PUBLICATION_NAME} - ${RELEASE_NAME}
     user checks select contains option    name:releaseId    ${PUBLICATION_2_NAME} - ${RELEASE_2_NAME}
-    user checks select contains x options    name:releaseRole    5
+    user checks select contains x options    name:releaseRole    4
     user checks select contains option    name:releaseRole    Approver
     user checks select contains option    name:releaseRole    Contributor
-    user checks select contains option    name:releaseRole    Lead
     user checks select contains option    name:releaseRole    PrereleaseViewer
     user checks select contains option    name:releaseRole    Viewer
 


### PR DESCRIPTION
This PR fixes recent UI tests failure in `Admin` - Lead role was deleted , updated tests accordingly.
![image](https://github.com/user-attachments/assets/cfa0525c-f839-4a22-9d09-4be4698c18aa)

