### PR TITLE
EES-6166 Set the `eventGridTopicsExist` param to true in the Test environment

### DIFF
--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -94,9 +94,6 @@
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
-    },
-    "eventGridTopicsExist": {
-      "value": false
     }
   }
 }


### PR DESCRIPTION
This PR sets the `eventGridTopicsExist` parameter in the infrastructure ARM template to `true` in the Test environment causing the topic endpoint app settings to be applied for the Admin and Publisher services.

The parameter has a default value of `true`.