### PR TITLE
New simple Healthcheck call

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/HealthChecks/HealthCheckFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/HealthChecks/HealthCheckFunctionTests.cs
@@ -29,7 +29,7 @@ public class HealthCheckFunctionTests
         var sut = GetSut(strategies);
         
         // ACT
-        var result = await sut.HealthCheck(null!, CancellationToken.None);
+        var result = await sut.FullHealthCheck(null!, CancellationToken.None);
         
         // ASSERT
         Assert.NotNull(result);
@@ -59,7 +59,7 @@ public class HealthCheckFunctionTests
         var sut = GetSut(strategies);
         
         // ACT
-        var result = await sut.HealthCheck(null!, CancellationToken.None);
+        var result = await sut.FullHealthCheck(null!, CancellationToken.None);
         
         // ASSERT
         Assert.NotNull(result);
@@ -82,7 +82,7 @@ public class HealthCheckFunctionTests
         var sut = GetSut(strategies);
         
         // ACT
-        var result = await sut.HealthCheck(null!, CancellationToken.None);
+        var result = await sut.FullHealthCheck(null!, CancellationToken.None);
         
         // ASSERT
         Assert.NotNull(result);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/HealthCheckFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/HealthCheckFunction.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
+#pragma warning disable IDE0060 // Suppress removing unused parameter - must have a valid binding name for Azure function
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.HealthChecks;
 
@@ -11,9 +12,15 @@ public class HealthCheckFunction(IEnumerable<IHealthCheckStrategy> strategies, I
 {
     [Function(nameof(HealthCheck))]
     [Produces("application/json")]
-    public async Task<IActionResult> HealthCheck(
+    public Task<IActionResult> HealthCheck(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get")]
+        HttpRequest httpRequest) =>
+        Task.FromResult<IActionResult>(new OkResult());
+
+    [Function(nameof(FullHealthCheck))]
+    [Produces("application/json")]
+    public async Task<IActionResult> FullHealthCheck(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get")] 
-        #pragma warning disable IDE0060 // Suppress removing unused parameter - must have a valid binding name for Azure function
         HttpRequest httpRequest,
         CancellationToken cancellationToken)
     {


### PR DESCRIPTION
Move the current healthcheck to a new `Full health check` so that we can still test config and security with it. And reduce the default heathcheck `Are you alive` to a simple returning of OK result.
