### PR TITLE
Update `Microsoft.Search/searchservices` API version

### DIFF
--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -101,7 +101,7 @@ resource searchableDocumentsContainer 'Microsoft.Storage/storageAccounts/blobSer
   name: searchableDocumentsContainerName
 }
 
-resource searchService 'Microsoft.Search/searchServices@2024-06-01-preview' existing = {
+resource searchService 'Microsoft.Search/searchServices@2025-02-01-preview' existing = {
   name: searchServiceName
 }
 

--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -11,9 +11,6 @@ param functionAppFirewallRules FirewallRule[]
 @description('The id of the Log Analytics workspace which logs and metrics will be sent to.')
 param logAnalyticsWorkspaceId string
 
-@description('Specifies the base URL of the Search Service endpoint for interacting with the data plane REST API. For example: https://[search-service-name].search.windows.net')
-param searchServiceEndpoint string
-
 @description('Specifies the Search Service indexer name.')
 param searchServiceIndexerName string
 
@@ -123,8 +120,7 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
       }
       {
         name: 'AzureSearch__SearchServiceEndpoint'
-        // Should be able to replace this with searchService.properties.endpoint in future using API version 2025-02-01-preview or later
-        value: searchServiceEndpoint
+        value: searchService.properties.endpoint
       }
       {
         name: 'AzureSearch__IndexerName'

--- a/infrastructure/templates/search/components/searchService.bicep
+++ b/infrastructure/templates/search/components/searchService.bicep
@@ -100,6 +100,6 @@ resource searchService 'Microsoft.Search/searchServices@2025-02-01-preview' = {
   tags: tagValues
 }
 
-output searchServiceEndpoint string = 'https://${searchService.name}.search.windows.net'
+output searchServiceEndpoint string = searchService.properties.endpoint
 output searchServiceIdentityPrincipalId string = systemAssignedIdentity ? searchService.identity.principalId : ''
 output searchServiceName string = searchService.name

--- a/infrastructure/templates/search/components/searchService.bicep
+++ b/infrastructure/templates/search/components/searchService.bicep
@@ -70,7 +70,7 @@ resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@
   name: userAssignedIdentityName
 }
 
-resource searchService 'Microsoft.Search/searchServices@2024-06-01-preview' = {
+resource searchService 'Microsoft.Search/searchServices@2025-02-01-preview' = {
   name: name
   location: location
   sku: {

--- a/infrastructure/templates/search/components/searchServiceConfig.bicep
+++ b/infrastructure/templates/search/components/searchServiceConfig.bicep
@@ -41,7 +41,7 @@ param indexerScheduleInterval string = ''
 @description('Specifies the location for all resources.')
 param location string
 
-resource searchService 'Microsoft.Search/searchServices@2022-09-01' existing = {
+resource searchService 'Microsoft.Search/searchServices@2025-02-01-preview' existing = {
   name: searchServiceName
 }
 

--- a/infrastructure/templates/search/components/searchServiceRoleAssignment.bicep
+++ b/infrastructure/templates/search/components/searchServiceRoleAssignment.bicep
@@ -19,7 +19,7 @@ var rolesToRoleIds = {
   'Search Service Contributor': '7ca78c08-252a-4471-8644-bb5ff32d4ba0'
 }
 
-resource searchService 'Microsoft.Search/searchServices@2024-06-01-preview' existing = {
+resource searchService 'Microsoft.Search/searchServices@2025-02-01-preview' existing = {
   name: searchServiceName
 }
 

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -119,7 +119,6 @@ module searchDocsFunctionModule 'application/searchDocsFunction.bicep' = {
       maintenanceFirewallRules
     )
     logAnalyticsWorkspaceId: monitoringModule.outputs.logAnalyticsWorkspaceId
-    searchServiceEndpoint: searchServiceModule.outputs.searchServiceEndpoint
     searchServiceIndexerName: searchServiceModule.outputs.searchServiceIndexerName
     searchServiceName: searchServiceModule.outputs.searchServiceName
     searchStorageAccountName: searchServiceModule.outputs.searchStorageAccountName


### PR DESCRIPTION
This PR updates the API version for for Microsoft.Search/searchservices from `2024-06-01-preview` to `2025-02-01-preview` allowing us to use new property `endpoint` in `searchService.bicep` and `searchDocsFunction.bicep`.

API version `2025-05-01` is latest but there is a change to `UserAssignedManagedIdentities` type in this version which we will need to update for. Being relatively new it does not have Bicep type definitions generated yet and deploying using `2025-05-01` results in warnings:

```
Warning BCP081: Resource type "Microsoft.Search/searchServices@2025-05-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed.
```