### PR TITLE
Disable console logging in Azure

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ServiceCollectionExtensions.cs
@@ -44,16 +44,14 @@ public static class ServiceCollectionExtensions
                 // Instead, let Serilog handle that.
                 lb.SetMinimumLevel(LogLevel.None);
 
-                // Resolve the telemetry configuration that was registered by SetupAppInsights
+                // Resolve the telemetry configuration that was registered by SetupAppInsights.
+                // Note: It's a bit naughty resolving it here and potentially might not be ready.
                 var telemetryConfiguration = serviceCollection.BuildServiceProvider().GetRequiredService<TelemetryConfiguration>();
 
                 // Setup Serilog to log to the Console and to App Insights
                 lb.AddSerilog(
                     new LoggerConfiguration()
                         .ReadFrom.Configuration(configuration)
-                        .Enrich.WithExceptionDetails()
-                        .Enrich.FromLogContext()
-                        .WriteTo.Console()
                         .WriteTo.ApplicationInsights(telemetryConfiguration, TelemetryConverter.Traces)
                         .CreateLogger(),
                     dispose: true

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
@@ -10,5 +10,23 @@
     "SearchServiceEndpoint": "-- insert search service endpoint here e.g. https://xxxxx.search.windows.net/ --",
     "SearchServiceAccessKey" : "-- insert search service access key here --",
     "IndexerName": "-- insert indexer name here --"
+  },
+  "Serilog": {
+    "Using":  [ "Serilog.Sinks.Console" ],
+    "MinimumLevel": {
+      "Default": "Verbose",
+      "Override": {
+        "Microsoft": "Warning"
+      }
+    },
+    "WriteTo": [
+      { 
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      }
+    ],
+    "Enrich": [ "FromLogContext", "WithExceptionDetails", "WithThreadId" ]
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.json
@@ -5,6 +5,7 @@
       "Override": {
         "Microsoft": "Warning"
       }
-    }
+    },
+    "Enrich": [ "FromLogContext", "WithExceptionDetails", "WithThreadId" ]
   }
 }


### PR DESCRIPTION
Remove the hardcoded console logger and instead declare it in the appsettings. This allows us to enable it when running locally but disable it when reployed to Azure. Also, enriched the logs with ThreadId which is useful to untangle logs when multiple things are occurring simultaneously.
