### PR TITLE
EES-5708: Consolidate remaining data set upload methods to use a shared approach

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetFileBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetFileBuilder.cs
@@ -48,7 +48,7 @@ public class DataSetFileBuilder
             };
     }
 
-    public async Task<List<ZipDataSetFileViewModel>> BuildViewModelsFromZip(bool withReplacement = false)
+    public async Task<List<DataSetUploadResultViewModel>> BuildViewModelsFromZip(bool withReplacement = false)
     {
         _fileName ??= "bulk-data-zip-valid.zip";
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetFileStorageTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetFileStorageTests.cs
@@ -357,7 +357,7 @@ public class DataSetFileStorageTests
             await contentDbContext.SaveChangesAsync();
         }
 
-        var dataSet = new ZipDataSetFileViewModel
+        var dataSet = new DataSetUploadResultViewModel
         {
             Title = dataSetName,
             DataFileId = Guid.NewGuid(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServicePermissionTests.cs
@@ -218,7 +218,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         var service = SetupReleaseDataFileService(userService: userService.Object);
                         return service.SaveDataSetsFromTemporaryBlobStorage(
                             releaseVersionId: _releaseVersion.Id,
-                            dataSetFiles: new Mock<List<ZipDataSetFileViewModel>>().Object,
+                            dataSetFiles: new Mock<List<DataSetUploadResultViewModel>>().Object,
                             cancellationToken: default);
                     }
                 );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTests.cs
@@ -1799,7 +1799,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(Strict);
             var dataSetFileStorage = new Mock<IDataSetFileStorage>(Strict);
 
-            var dataSetFile = new ZipDataSetFileViewModel
+            var dataSetFile = new DataSetUploadResultViewModel
             {
                 Title = dataSetName,
                 DataFileId = dataFile.Id,
@@ -1820,7 +1820,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             dataSetFileStorage
                 .Setup(mock => mock.MoveDataSetsToPermanentStorage(
                     It.IsAny<Guid>(),
-                    It.IsAny<List<ZipDataSetFileViewModel>>(),
+                    It.IsAny<List<DataSetUploadResultViewModel>>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(releaseFiles));
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseVersionsController.cs
@@ -98,7 +98,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [HttpPost("releaseVersions/data")]
         [DisableRequestSizeLimit]
         [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
-        public async Task<ActionResult<DataFileInfo>> UploadDataSet(
+        public async Task<ActionResult<List<DataSetUploadResultViewModel>>> UploadDataSet(
             [FromForm] UploadDataSetRequest request,
             CancellationToken cancellationToken)
         {
@@ -113,10 +113,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
+        // TODO (EES-6176): Remove once manual replacement process has been consolidated to use UploadDataSet
+        [HttpPost("releaseVersions/replacement-data")]
+        [DisableRequestSizeLimit]
+        [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
+        public async Task<ActionResult<DataFileInfo>> UploadDataSetForReplacement(
+            [FromForm] UploadDataSetRequest request,
+            CancellationToken cancellationToken)
+        {
+            return await _releaseDataFileService
+                .UploadForReplacement(
+                    request.ReleaseVersionId,
+                    request.DataFile,
+                    request.MetaFile,
+                    request.Title,
+                    request.ReplacingFileId,
+                    cancellationToken)
+                .HandleFailuresOrOk();
+        }
+
         [HttpPost("releaseVersions/zip-data")]
         [DisableRequestSizeLimit]
         [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
-        public async Task<ActionResult<DataFileInfo>> UploadDataSetAsZip(
+        public async Task<ActionResult<List<DataSetUploadResultViewModel>>> UploadDataSetAsZip(
             [FromForm] UploadDataSetAsZipRequest request,
             CancellationToken cancellationToken)
         {
@@ -130,10 +149,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
+        // TODO (EES-6176): Remove once manual replacement process has been consolidated to use UploadDataSetAsZip
+        [HttpPost("releaseVersions/replacement-zip-data")]
+        [DisableRequestSizeLimit]
+        [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
+        public async Task<ActionResult<DataFileInfo>> UploadDataSetAsZipForReplacement(
+            [FromForm] UploadDataSetAsZipRequest request,
+            CancellationToken cancellationToken)
+        {
+            return await _releaseDataFileService
+                .UploadFromZipForReplacement(
+                    request.ReleaseVersionId,
+                    request.ZipFile,
+                    request.Title,
+                    request.ReplacingFileId,
+                    cancellationToken)
+                .HandleFailuresOrOk();
+        }
+
         [HttpPost("releaseVersions/upload-bulk-zip-data")]
         [DisableRequestSizeLimit]
         [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
-        public async Task<ActionResult<List<ZipDataSetFileViewModel>>> UploadDataSetAsBulkZip(
+        public async Task<ActionResult<List<DataSetUploadResultViewModel>>> UploadDataSetAsBulkZip(
             [FromForm] UploadDataSetAsBulkZipRequest request,
             CancellationToken cancellationToken)
         {
@@ -142,11 +179,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
-        // We intend to change this route, to make these endpoints more consistent, as per EES-5895
-        [HttpPost("release/{releaseVersionId:guid}/import-bulk-zip-data")]
+        [HttpPost("releases/{releaseVersionId:guid}/import-data-sets")]
         public async Task<ActionResult<List<DataFileInfo>>> ImportBulkZipDataSetsFromTempStorage(
             Guid releaseVersionId,
-            List<ZipDataSetFileViewModel> dataSetFiles,
+            List<DataSetUploadResultViewModel> dataSetFiles,
             CancellationToken cancellationToken)
         {
             return await _releaseDataFileService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetFileStorage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetFileStorage.cs
@@ -47,6 +47,12 @@ public class DataSetFileStorage(
         if (dataSet.ReplacingFile is not null)
         {
             replacedReleaseDataFile = await GetReplacedReleaseFile(releaseVersionId, dataSet.ReplacingFile.Id);
+
+            if (replacedReleaseDataFile is not null)
+            {
+                replacedReleaseDataFile.File.ReplacedById = dataSet.ReplacingFile.Id;
+                await contentDbContext.SaveChangesAsync(cancellationToken);
+            }
         }
 
         var releaseDataFileOrder = await GetNextDataFileOrder(releaseVersionId, replacedReleaseDataFile?.File.Id);
@@ -157,18 +163,18 @@ public class DataSetFileStorage(
         await dataSet.MetaFile.FileStream.DisposeAsync();
     }
 
-    public async Task<List<ZipDataSetFileViewModel>> UploadDataSetsToTemporaryStorage(
+    public async Task<List<DataSetUploadResultViewModel>> UploadDataSetsToTemporaryStorage(
         Guid releaseVersionId,
         List<DataSet> dataSets,
         CancellationToken cancellationToken)
     {
-        var viewModels = new List<ZipDataSetFileViewModel>();
+        var viewModels = new List<DataSetUploadResultViewModel>();
 
         foreach (var dataSet in dataSets)
         {
             var uploadResult = await UploadDataSetToTemporaryStorage(releaseVersionId, dataSet, cancellationToken);
 
-            viewModels.Add(new ZipDataSetFileViewModel
+            viewModels.Add(new DataSetUploadResultViewModel
             {
                 Title = dataSet.Title,
                 DataFileId = uploadResult.DataFileId,
@@ -224,7 +230,7 @@ public class DataSetFileStorage(
 
     public async Task<List<ReleaseFile>> MoveDataSetsToPermanentStorage(
         Guid releaseVersionId,
-        List<ZipDataSetFileViewModel> dataSets,
+        List<DataSetUploadResultViewModel> dataSets,
         CancellationToken cancellationToken)
     {
         var releaseFiles = new List<ReleaseFile>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetValidator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetValidator.cs
@@ -72,8 +72,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     return errors;
                 }
 
-                // TODO (EES-5708): The `performAutoReplacement` condition can be removed once upload methods are aligned
-                // Auto-replacement is currently only available for bulk zip uploads (EES-5708)
+                // TODO (EES-5708/6176): The `performAutoReplacement` condition can be removed once upload methods are aligned
+                // Auto-replacement is currently only available for bulk zip uploads, and replacements triggered via the UI
                 if (performAutoReplacement || featureFlags.Value.EnableReplacementOfPublicApiDataSets)
                 {
                     await GetReplacingFileIfExists(dataSet.ReleaseVersionId, dataSet.Title)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/IDataSetFileStorage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/IDataSetFileStorage.cs
@@ -36,7 +36,7 @@ public interface IDataSetFileStorage
     /// The data sets are uploaded to temporary storage in the first instance. Once the upload has been manually confirmed, the files are then moved to permanent storage.
     /// </remarks>
     /// <returns>A summary of each data set.</returns>
-    Task<List<ZipDataSetFileViewModel>> UploadDataSetsToTemporaryStorage(
+    Task<List<DataSetUploadResultViewModel>> UploadDataSetsToTemporaryStorage(
         Guid releaseVersionId,
         List<DataSet> dataSets,
         CancellationToken cancellationToken);
@@ -55,6 +55,6 @@ public interface IDataSetFileStorage
     /// <returns>A collection of the entities which represent the data set files.</returns>
     Task<List<ReleaseFile>> MoveDataSetsToPermanentStorage(
         Guid releaseVersionId,
-        List<ZipDataSetFileViewModel> dataSets,
+        List<DataSetUploadResultViewModel> dataSets,
         CancellationToken cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseDataFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseDataFileService.cs
@@ -33,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             Guid releaseVersionId,
             List<Guid> fileIds);
 
-        Task<Either<ActionResult, DataFileInfo>> Upload(
+        Task<Either<ActionResult, List<DataSetUploadResultViewModel>>> Upload(
             Guid releaseVersionId,
             IFormFile dataFormFile,
             IFormFile metaFormFile,
@@ -41,21 +41,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             Guid? replacingFileId,
             CancellationToken cancellationToken);
 
-        Task<Either<ActionResult, DataFileInfo>> UploadFromZip(
+        Task<Either<ActionResult, DataFileInfo>> UploadForReplacement(
+            Guid releaseVersionId,
+            IFormFile dataFormFile,
+            IFormFile metaFormFile,
+            string dataSetTitle,
+            Guid? replacingFileId,
+            CancellationToken cancellationToken);
+
+        Task<Either<ActionResult, List<DataSetUploadResultViewModel>>> UploadFromZip(
             Guid releaseVersionId,
             IFormFile zipFormFile,
             string dataSetTitle,
             Guid? replacingFileId,
             CancellationToken cancellationToken);
 
-        Task<Either<ActionResult, List<ZipDataSetFileViewModel>>> UploadFromBulkZip(
+        Task<Either<ActionResult, DataFileInfo>> UploadFromZipForReplacement(
+            Guid releaseVersionId,
+            IFormFile zipFormFile,
+            string dataSetTitle,
+            Guid? replacingFileId,
+            CancellationToken cancellationToken);
+
+        Task<Either<ActionResult, List<DataSetUploadResultViewModel>>> UploadFromBulkZip(
             Guid releaseVersionId,
             IFormFile zipFormFile,
             CancellationToken cancellationToken);
 
         Task<Either<ActionResult, List<DataFileInfo>>> SaveDataSetsFromTemporaryBlobStorage(
             Guid releaseVersionId,
-            List<ZipDataSetFileViewModel> dataSetFiles,
+            List<DataSetUploadResultViewModel> dataSetFiles,
             CancellationToken cancellationToken);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataSetUploadResultViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataSetUploadResultViewModel.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
-public record ZipDataSetFileViewModel
+public record DataSetUploadResultViewModel
 {
     public string Title { get; set; } = string.Empty;
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacePage.tsx
@@ -97,18 +97,25 @@ const ReleaseDataFileReplacePage = ({
     let file: DataFile;
 
     if (values.uploadType === 'csv') {
-      file = await releaseDataFileService.uploadDataFiles(releaseVersionId, {
-        title: values.title ?? dataFile!.title,
-        replacingFileId: currentFile.id,
-        dataFile: values.dataFile as File,
-        metadataFile: values.metadataFile as File,
-      });
+      file = await releaseDataFileService.uploadDataSetFilePairForReplacement(
+        releaseVersionId,
+        {
+          title: values.title ?? dataFile!.title,
+          replacingFileId: currentFile.id,
+          dataFile: values.dataFile as File,
+          metadataFile: values.metadataFile as File,
+        },
+      );
     } else {
-      file = await releaseDataFileService.uploadZipDataFile(releaseVersionId, {
-        title: values.title ?? dataFile!.title,
-        replacingFileId: currentFile.id,
-        zipFile: values.zipFile as File,
-      });
+      file =
+        await releaseDataFileService.uploadZippedDataSetFilePairForReplacement(
+          releaseVersionId,
+          {
+            title: values.title ?? dataFile!.title,
+            replacingFileId: currentFile.id,
+            zipFile: values.zipFile as File,
+          },
+        );
     }
 
     setDataFile({

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataSetUploadModalConfirm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataSetUploadModalConfirm.tsx
@@ -1,16 +1,16 @@
 import ModalConfirm from '@common/components/ModalConfirm';
 import WarningMessage from '@common/components/WarningMessage';
-import { ArchiveDataSetFile } from 'src/services/releaseDataFileService';
+import { DataSetUploadResult } from 'src/services/releaseDataFileService';
 import React from 'react';
 
 interface Props {
-  bulkUploadPlan: ArchiveDataSetFile[];
-  onConfirm: (bulkUploadPlan: ArchiveDataSetFile[]) => void;
+  uploadResults: DataSetUploadResult[];
+  onConfirm: (uploadResult: DataSetUploadResult[]) => void;
   onCancel: () => void;
 }
 
-export default function BulkZipUploadModalConfirm({
-  bulkUploadPlan,
+export default function DataSetUploadModalConfirm({
+  uploadResults,
   onConfirm,
   onCancel,
 }: Props) {
@@ -18,7 +18,7 @@ export default function BulkZipUploadModalConfirm({
     <ModalConfirm
       title="Upload summary"
       open
-      onConfirm={() => onConfirm(bulkUploadPlan)}
+      onConfirm={() => onConfirm(uploadResults)}
       onExit={onCancel}
       onCancel={onCancel}
     >
@@ -31,12 +31,12 @@ export default function BulkZipUploadModalConfirm({
           </tr>
         </thead>
         <tbody>
-          {bulkUploadPlan.map(archiveDataSet => (
-            <tr key={archiveDataSet.title}>
-              <td>{archiveDataSet.title}</td>
-              <td>{archiveDataSet.dataFileName}</td>
+          {uploadResults.map(uploadResult => (
+            <tr key={uploadResult.title}>
+              <td>{uploadResult.title}</td>
+              <td>{uploadResult.dataFileName}</td>
               <td>
-                {archiveDataSet.replacingFileId && (
+                {uploadResult.replacingFileId && (
                   <WarningMessage className="govuk-!-margin-0 govuk-!-padding-0">
                     Upload will initiate a file replacement
                   </WarningMessage>

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -33,8 +33,10 @@ Upload a ZIP file file
     user waits until page contains element    id:dataFileUploadForm-zipFile
     user chooses file    id:dataFileUploadForm-zipFile    ${FILES_DIR}upload-zip-test.zip
     user clicks button    Upload data files
-
-    user waits until h2 is visible    Uploaded data files
+    user waits until modal is visible    Upload summary
+    user waits until modal table cell contains    1    1    Absence in PRUs
+    user clicks button    Confirm
+    user waits until modal is not visible    Upload summary
     user waits until page contains data uploads table
 
     # To ensure "Data file size" and "Number of rows" will be filled

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -574,7 +574,11 @@ user uploads subject
     user chooses file    id:dataFileUploadForm-dataFile    ${FOLDER}${SUBJECT_FILE}
     user chooses file    id:dataFileUploadForm-metadataFile    ${FOLDER}${META_FILE}
     user clicks button    Upload data files
-    user waits until h2 is visible    Uploaded data files    %{WAIT_LONG}
+    user waits until modal is visible    Upload summary
+    user waits until modal table cell contains    1    1    ${SUBJECT_NAME}
+    user waits until modal table cell contains    1    2    ${SUBJECT_FILE}
+    user clicks button    Confirm
+    user waits until modal is not visible    Upload summary
     user waits until page contains element    testid:Data files table
 
     IF    "${IMPORT_STATUS}" != "Importing"

--- a/tests/robot-tests/tests/libs/tables-common.robot
+++ b/tests/robot-tests/tests/libs/tables-common.robot
@@ -33,6 +33,12 @@ user waits until table cell contains
     ...    xpath:.//tbody/tr[${row}]/td[${column}][contains(., "${expected}")]
     ...    timeout=${wait}
 
+user waits until modal table cell contains
+    [Arguments]    ${row}    ${column}    ${expected}    ${parent}=css:div[role='dialog']    ${wait}=%{WAIT_SMALL}
+    user waits until parent contains element    ${parent}
+    ...    xpath:.//table/tbody/tr[${row}]/td[${column}][contains(., "${expected}")]
+    ...    timeout=${wait}
+
 user checks table cell does not contain
     [Arguments]    ${row}    ${column}    ${expected}    ${parent}=css:table
     user waits until parent does not contain element    ${parent}


### PR DESCRIPTION
This work applies a staged approach to data set uploads for the remaining upload methods (CSV file pair, and zipped CSV file pair), to match the process created for bulk zip uploads in preparation for the screener integration.

The process is; the files are uploaded to the server, validated, then uploaded into a temp container with a result returned to the user. When the screener is integrated, the result will be included in this response. When validation succeeds, the user can then manually trigger the import - this process used to be performed automatically as part of the upload.

### Notes
- I renamed the bulk zip-specific view model to `DataSetUploadResultViewModel` to represent consolidation. The name might stay the same when the screener is integrated, but the structure will change to include the screener result data
- I’ve left the original FE service methods in because they are still used by the replacement page. This area will be consolidated to use the same functions as part of [EES-6176](https://dfedigital.atlassian.net/browse/EES-6176)
- The two upload methods changed here will only ever return a single `DataSetUploadResultViewModel`, but these are returning a `List` for the time being for simplicity and consistency with the bulk upload method. Along with keeping these changes small, this will also avoid unnecessary work, as the response structure will be changed as part of the screener integration
- _New_ duplicate data sets can be uploaded into temp storage before the import is triggered, as the duplication validation only applies to _imported_ data sets. The validation acts against records stored in the database, which don't exist until the import has been confirmed by the user. This is because a file is given a unique path when it is uploaded, consisting of a newly-generated GUID - uploading the same file again will give it a new unique path as the process has no knowledge of previous upload paths. The only issues here are:
  - users may waste their time uploading data sets multiple times if they cancel the upload results modal
  - more storage use in the temporary container, however files are automatically removed after 24h of inactivity (see [EES-5709](https://dfedigital.atlassian.net/browse/EES-5709))
  - Another point to consider is the removal of duplicate data set validation on uploads, and allow auto replacement for all upload methods (i.e. matching bulk upload). This may also lead to the question of whether a separate screen for manual replacements is still needed, see [EES-6176](https://dfedigital.atlassian.net/browse/EES-6176).