### PR TITLE
Fix CodeQL build issue

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.407",
+    "version": "8.0.114",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
The SDK version numbers are weird. By choosing the highest patched SDK version number, we've prevented "latestMajor" from using the newer release of the SDK. Please see https://github.com/dotnet/core/blob/main/release-notes/8.0/README.md

To see an example of CodeQL breaking.
Note: it is requesting SDK 8.0.407 (as per our global.json) but it only has the *newer* 8.0.115. But since 115<407, latestMajor isn't allowing it.
https://github.com/dfe-analytical-services/explore-education-statistics/actions/runs/15279975095/job/42976871798
