### PR TITLE
EES-6091 - added capturing of Public API "Get Changes" calls to analytics

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient.cs
@@ -12,6 +12,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Publi
 using GovUk.Education.ExploreEducationStatistics.Admin.Options;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Hosting;
@@ -47,6 +48,10 @@ public class PublicDataApiClient(
     {
         await AddBearerToken(cancellationToken);
 
+        // Add an HTTP header to signal to the Public API that this call originates from the
+        // EES service.
+        httpClient.DefaultRequestHeaders.Add(RequestHeaderNames.RequestSource, "EES Admin");
+            
         var response = await requestFunction();
 
         if (!response.IsSuccessStatusCode)

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
@@ -6,7 +6,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Fixture;
@@ -3126,8 +3125,9 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
             query.AddRange(queryParameters);
         }
 
-        var client = (app ?? BuildApp()).CreateClient();
-        client.AddPreviewTokenHeader(previewTokenId);
+        var client = (app ?? BuildApp())
+            .CreateClient()
+            .WithPreviewTokenHeader(previewTokenId);
 
         var uri = QueryHelpers.AddQueryString($"{BaseUrl}/{dataSetId}/query", query);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
@@ -4098,8 +4098,9 @@ public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory te
             query["dataSetVersion"] = dataSetVersion;
         }
 
-        var client = (app ?? BuildApp()).CreateClient();
-        client.AddPreviewTokenHeader(previewTokenId);
+        var client = (app ?? BuildApp())
+            .CreateClient()
+            .WithPreviewTokenHeader(previewTokenId);
 
         var uri = QueryHelpers.AddQueryString($"{BaseUrl}/{dataSetId}/query", query);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Extensions/HttpClientExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Extensions/HttpClientExtensions.cs
@@ -1,16 +1,32 @@
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Constants;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Extensions;
 
 public static class HttpClientExtensions
 {
-    public static void AddPreviewTokenHeader(
+    public static HttpClient WithPreviewTokenHeader(
         this HttpClient client,
-        Guid? previewToken = null)
+        Guid? previewToken)
     {
         if (previewToken != null)
         {
-            client.DefaultRequestHeaders.Add(RequestHeaderNames.PreviewToken, previewToken.ToString());
+            client.WithAdditionalHeaders(new Dictionary<string, string>
+            {
+                { RequestHeaderNames.PreviewToken, previewToken.Value.ToString() }
+            });
         }
+
+        return client;
+    }
+
+    public static HttpClient WithAdditionalHeaders(
+        this HttpClient client,
+        Dictionary<string, string>? additionalHeaders)
+    {
+        additionalHeaders?.ForEach(header =>
+            client.DefaultRequestHeaders.Add(header.Key, header.Value));
+
+        return client;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Fixture/IntegrationTestFixture.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Fixture/IntegrationTestFixture.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Fixture;
@@ -7,7 +8,7 @@ public abstract class IntegrationTestFixture(TestApplicationFactory testApp) : I
     protected readonly DataFixture DataFixture = new();
 
     protected readonly TestApplicationFactory TestApp = testApp;
-
+    
     public async Task InitializeAsync()
     {
         await TestApp.Initialize();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Fixture/TestApplicationFactory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Fixture/TestApplicationFactory.cs
@@ -84,25 +84,16 @@ public class TestApplicationFactory : TestApplicationFactory<Startup>
                     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                     .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(JwtBearerDefaults.AuthenticationScheme, null);
 
+                services.AddSingleton<TestAuthHandlerUserProvider>();
+                
                 services
                     .ReplaceService<IAnalyticsPathResolver>(new TestAnalyticsPathResolver(), optional: true);
             });
     }
-    
-    /// <summary>
-    /// This method adds an authenticated User in the form of a ClaimsPrincipal to the HttpContext.
-    /// </summary>
-    /// <param name="user"></param>
-    /// <returns></returns>
-    public WebApplicationFactory<Startup> SetUser(ClaimsPrincipal? user)
+
+    internal class TestAuthHandlerUserProvider
     {
-        return this.ConfigureServices(services =>
-        {
-            if (user != null)
-            {
-                services.AddScoped(_ => user);
-            }
-        });
+        public ClaimsPrincipal? User { get; set; }
     }
     
     /// <summary>
@@ -113,19 +104,32 @@ public class TestApplicationFactory : TestApplicationFactory<Startup>
         IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger,
         UrlEncoder encoder,
-        ClaimsPrincipal? claimsPrincipal = null)
+        TestAuthHandlerUserProvider userProvider)
         : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
     {
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
-            if (claimsPrincipal == null)
+            var user = userProvider.User;
+
+            if (user == null)
             {
                 return Task.FromResult(AuthenticateResult.NoResult());
             }
 
-            var ticket = new AuthenticationTicket(claimsPrincipal, JwtBearerDefaults.AuthenticationScheme);
+            var ticket = new AuthenticationTicket(user, JwtBearerDefaults.AuthenticationScheme);
             var result = AuthenticateResult.Success(ticket);
             return Task.FromResult(result);
         }
+    }
+}
+
+public static class TestWebApplicationFactoryExtensions
+{
+    public static WebApplicationFactory<Startup> WithUser(this WebApplicationFactory<Startup> factory,
+        ClaimsPrincipal? user)
+    {
+        var authHandler = factory.Services.GetRequiredService<TestApplicationFactory.TestAuthHandlerUserProvider>();
+        authHandler.User = user;
+        return factory;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandlerTests.cs
@@ -1,11 +1,11 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Constants;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.TheoryData;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetAuthorizationHandlerTests.cs
@@ -1,6 +1,5 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Constants;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Security;
@@ -8,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.TheoryDat
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Security/AuthorizationHandlers/ViewDataSetVersionAuthorizationHandlerTests.cs
@@ -2,7 +2,6 @@ using System.Security.Claims;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Constants;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Security;
@@ -11,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.TheoryDat
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Constants/RequestHeaderNames.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Constants/RequestHeaderNames.cs
@@ -1,9 +1,0 @@
-namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Constants;
-
-public static class RequestHeaderNames
-{
-    /// <summary>
-    /// Sets preview tokens for accessing unpublished data.
-    /// </summary>
-    public const string PreviewToken = "preview-token";
-}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Security/AuthorizationHandlers/QueryDataSetVersionAuthorizationHandler.cs
@@ -1,5 +1,4 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Constants;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using Microsoft.AspNetCore.Authorization;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsService.cs
@@ -1,8 +1,10 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
@@ -11,7 +13,9 @@ public class AnalyticsService(
     IAnalyticsManager analyticsManager,
     IPreviewTokenService previewTokenService,
     PublicDataDbContext publicDataDbContext,
-    DateTimeProvider dateTimeProvider) : IAnalyticsService
+    DateTimeProvider dateTimeProvider,
+    IHttpContextAccessor httpContextAccessor,
+    ILogger<AnalyticsService> logger) : IAnalyticsService
 {
     public async Task CaptureDataSetVersionCall(
         Guid dataSetVersionId,
@@ -20,23 +24,47 @@ public class AnalyticsService(
         object? parameters = null,
         CancellationToken cancellationToken = default)
     {
-        var dataSetVersion = await publicDataDbContext
-            .DataSetVersions
-            .Include(dsv => dsv.DataSet)
-            .SingleAsync(dsv => dsv.Id == dataSetVersionId, cancellationToken);
+        try
+        {
+            // Filter out any non-public calls from analytics.
+            if (!IncludeAnalyticsCall())
+            {
+                logger.LogDebug(
+                    message: """
+                             Ignoring capturing analytics for "{Type}" call for DataSetVersion {Id}
+                             for privileged user's call.
+                             """,
+                    type,
+                    dataSetVersionId);
+                return;
+            }
 
-        var request = new CaptureDataSetVersionCallRequest(
-            DataSetId: dataSetVersion.DataSetId,
-            DataSetVersionId: dataSetVersion.Id,
-            DataSetVersion: dataSetVersion.SemVersion().ToString(),
-            DataSetTitle: dataSetVersion.DataSet.Title,
-            Parameters: parameters,
-            PreviewToken: await GetPreviewTokenRequest(),
-            RequestedDataSetVersion: requestedDataSetVersion,
-            StartTime: dateTimeProvider.UtcNow,
-            Type: type);
-        
-        await analyticsManager.Add(request, cancellationToken);
+            var dataSetVersion = await publicDataDbContext
+                .DataSetVersions
+                .Include(dsv => dsv.DataSet)
+                .SingleAsync(dsv => dsv.Id == dataSetVersionId, cancellationToken);
+
+            var request = new CaptureDataSetVersionCallRequest(
+                DataSetId: dataSetVersion.DataSetId,
+                DataSetVersionId: dataSetVersion.Id,
+                DataSetVersion: dataSetVersion.SemVersion().ToString(),
+                DataSetTitle: dataSetVersion.DataSet.Title,
+                Parameters: parameters,
+                PreviewToken: await GetPreviewTokenRequest(),
+                RequestedDataSetVersion: requestedDataSetVersion,
+                StartTime: dateTimeProvider.UtcNow,
+                Type: type);
+
+            await analyticsManager.Add(request, cancellationToken);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(
+                exception: e,
+                message: """Error whilst capturing analytics for "{Type}" call for DataSetVersion {Id}""",
+                type,
+                dataSetVersionId);
+        }
     }
 
     private async Task<PreviewTokenRequest?> GetPreviewTokenRequest()
@@ -53,5 +81,25 @@ public class AnalyticsService(
             DataSetVersionId: previewToken.DataSetVersionId,
             Created: previewToken.Created,
             Expiry: previewToken.Expiry);
+    }
+
+    private bool IncludeAnalyticsCall()
+    {
+        return !httpContextAccessor
+            .HttpContext
+            .TryGetRequestHeader(RequestHeaderNames.RequestSource, out _);
+    }
+}
+
+public class NoOpAnalyticsService : IAnalyticsService
+{
+    public Task CaptureDataSetVersionCall(
+        Guid dataSetVersionId,
+        DataSetVersionCallType type,
+        string? requestedDataSetVersion,
+        object? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/PreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/PreviewTokenService.cs
@@ -1,8 +1,8 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Constants;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Security/AuthorizationHandlerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Security/AuthorizationHandlerService.cs
@@ -1,32 +1,28 @@
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Constants;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Security;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
-using Microsoft.Extensions.Primitives;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Security;
 
 public class AuthorizationHandlerService(
     IHttpContextAccessor httpContextAccessor,
     IWebHostEnvironment environment,
-    IPreviewTokenService previewTokenService)
-    : IAuthorizationHandlerService
+    IPreviewTokenService previewTokenService) : IAuthorizationHandlerService
 {
     public bool CanAccessUnpublishedData()
     {
         // Simulate authentication in non-Azure environments.
         if (!environment.IsProduction() &&
             httpContextAccessor.HttpContext?.Request.Headers.UserAgent.Contains(
-                Common.Security.SecurityConstants.AdminUserAgent) == true)
+                SecurityConstants.AdminUserAgent) == true)
         {
             return true;
         }
         
         var user = httpContextAccessor.HttpContext?.User;
 
-        if (user is not null && user.IsInRole(SecurityConstants.AdminAccessAppRole))
+        if (user is not null && user.IsInRole(Api.Security.SecurityConstants.AdminAccessAppRole))
         {
             return true;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Utils/Requests/RequestHeaderNames.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Utils/Requests/RequestHeaderNames.cs
@@ -1,0 +1,14 @@
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
+
+public static class RequestHeaderNames
+{
+    /// <summary>
+    /// Sets preview tokens for accessing unpublished data.
+    /// </summary>
+    public const string PreviewToken = "preview-token";
+
+    /// <summary>
+    /// Identifies calls as having originated from the EES service itself.
+    /// </summary>
+    public const string RequestSource = "ees-request-source";
+}

--- a/src/explore-education-statistics-common/src/services/api/index.ts
+++ b/src/explore-education-statistics-common/src/services/api/index.ts
@@ -2,7 +2,14 @@ import {
   networkActivityRequestInterceptor,
   networkActivityResponseInterceptor,
 } from '@common/contexts/NetworkActivityContext';
-import Client from './Client';
+import Client, { RequestInterceptor } from './Client';
+
+const eesRequestSourceInterceptor: RequestInterceptor = {
+  onRequest: config => {
+    config.headers.set('ees-request-source', 'EES');
+    return config;
+  },
+};
 
 export const contentApi = new Client({
   baseURL: process.env.CONTENT_API_BASE_URL,
@@ -18,6 +25,9 @@ export const dataApi = new Client({
 
 export const publicApi = new Client({
   baseURL: `${process.env.PUBLIC_API_BASE_URL}/v1`,
-  requestInterceptors: [networkActivityRequestInterceptor],
+  requestInterceptors: [
+    eesRequestSourceInterceptor,
+    networkActivityRequestInterceptor,
+  ],
   responseInterceptors: [networkActivityResponseInterceptor],
 });


### PR DESCRIPTION
This PR:
- adds the capturing of Public API "Get Changes" calls to analytics.
- refactors AnalyticsService to deal with its own exceptions rather than client code, allowing for cleaner calls from dependent services.

In addition to the above, this PR also adds filtering out of Public API calls from Analytics that originated from the EES service itself.  For example, Admin calls the Public API to generate the changelog when creating a new version of a data set, the Public Site's "API data set" pages call the API to list data set versions etc.  These calls all now pass a special header indicating that they originated from components of the EES service itself, and therefore they are filtered out in AnalyticsService.

There is also an incidental change in TestApplicationFactory to make the adding of users to the calls a little less hacky, and nicer to write with a `WithUser` method.  It doesn't have to be part of this PR, as I didn't end up using it as I'd originally planned to, but it does no harm to stay in if the reviewer is happy to leave it.