### PR TITLE
Log the telemetry configuration 

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/HostBuilderExtension.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
+using Serilog;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
 
@@ -71,4 +72,17 @@ public static class HostBuilderExtension
                         })
         )
         .Build();
+
+    public static IHostBuilder InitialiseSerilog(this IHostBuilder hostBuilder)
+    {
+        // Setup Serilog
+        // https://github.com/serilog/serilog-aspnetcore
+        Log.Logger = new LoggerConfiguration()
+            // Because we can't access appsettings before creating the HostBuilder we'll use a bootstrap logger
+            // without configuration specific initialization first and replace it after the HostBuilder was created.
+            // See https://github.com/serilog/serilog-aspnetcore#two-stage-initialization
+            .ConfigureBootstrapLogger()
+            .CreateBootstrapLogger();
+        return hostBuilder;
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/LoggerConfigurationExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/LoggerConfigurationExtensions.cs
@@ -28,11 +28,20 @@ public static class LoggerConfigurationExtensions
     public static LoggerConfiguration ConfigureSerilogLogger(
         this LoggerConfiguration logger,
         IServiceProvider services,
-        IConfiguration configuration) =>
-        logger
+        IConfiguration configuration)
+    {
+        var telemetryConfiguration = services.GetRequiredService<TelemetryConfiguration>();
+        Log.Logger.Information("Telemetry Configuration: {@TelemetryConfiguration}", telemetryConfiguration);
+        Log.Logger.Information("Telemetry Configuration ConnectionString: {TelemetryConfigurationConnectionString}", telemetryConfiguration.ConnectionString);
+        Log.Logger.Information("Telemetry Configuration InstrumentationKey: {InstrumentationKey}", telemetryConfiguration.InstrumentationKey);
+        
+        return logger
             .ConfigureBootstrapLogger()
             // .ReadFrom.Configuration(configuration)
-            .WriteTo.ApplicationInsights(services.GetRequiredService<TelemetryConfiguration>(), TelemetryConverter.Traces);
+            .WriteTo.ApplicationInsights(
+                telemetryConfiguration,
+                TelemetryConverter.Traces);
+    }
 
     private static LoggerConfiguration AddEnrichers(this LoggerConfiguration loggerConfiguration) =>
         // To simply the config, specify the common enrichers here.

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Program.cs
@@ -2,5 +2,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Exte
 using Microsoft.Extensions.Hosting;
 
 await new HostBuilder()
+            .InitialiseSerilog()
             .BuildHost()
             .RunAsync();


### PR DESCRIPTION
Restore the bootstrapper logger to enable me to log the telemetry configuration during start up.
