### PR TITLE
EES-6178 Remove `deployAlerts` parameter from Search infrastructure pipeline

### DIFF
--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -30,9 +30,6 @@ param searchableDocumentsContainerName string
 @description('The IP address ranges that can access the Search Docs Function App storage accounts.')
 param storageFirewallRules IpRange[]
 
-@description('Whether to create/update Azure Monitor alerts during this deploy.')
-param deployAlerts bool
-
 @description('Specifies common resource naming variables.')
 param resourceNames ResourceNames
 
@@ -199,20 +196,18 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
       storageAccounts: searchDocsFunctionPrivateEndpointSubnet.id
     }
     outboundSubnetId: outboundVnetSubnet.id
-    alerts: deployAlerts
-      ? {
-          cpuPercentage: true
-          functionAppHealth: true
-          httpErrors: true
-          memoryPercentage: true
-          storageAccountAvailability: true
-          storageLatency: false
-          fileServiceAvailability: true
-          fileServiceLatency: false
-          fileServiceCapacity: true
-          alertsGroupName: resourceNames.existingResources.alertsGroup
-        }
-      : null
+    alerts: {
+      cpuPercentage: true
+      functionAppHealth: true
+      httpErrors: true
+      memoryPercentage: true
+      storageAccountAvailability: true
+      storageLatency: false
+      fileServiceAvailability: true
+      fileServiceLatency: false
+      fileServiceCapacity: true
+      alertsGroupName: resourceNames.existingResources.alertsGroup
+    }
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -2,9 +2,6 @@ import { abbreviations } from '../../common/abbreviations.bicep'
 import { IpRange } from '../../common/types.bicep'
 import { ResourceNames } from '../types.bicep'
 
-@description('Whether to create/update Azure Monitor alerts during this deploy.')
-param deployAlerts bool
-
 @description('Whether to deploy the Search service configuration to create/update the data source, index and indexer.')
 param deploySearchConfig bool
 
@@ -82,11 +79,11 @@ module searchStorageAccountModule '../../public-api/components/storageAccount.bi
     sku: 'Standard_LRS'
     kind: 'StorageV2'
     keyVaultName: keyVault.name
-    alerts: deployAlerts ? {
+    alerts: {
       availability: true
       latency: true
       alertsGroupName: resourceNames.existingResources.alertsGroup
-    } : null
+    }
     privateEndpointSubnetIds: {
       blob: searchStoragePrivateEndpointSubnet.id
     }

--- a/infrastructure/templates/search/ci/azure-pipelines.yml
+++ b/infrastructure/templates/search/ci/azure-pipelines.yml
@@ -12,13 +12,6 @@ trigger:
 pr: none
 
 parameters:
-  - name: deployAlerts
-    displayName: Do the Azure Monitor alerts need creating/updating?
-    type: string
-    values:
-      - Yes
-      - No
-    default: No
   - name: deploySearchConfig
     displayName: Does the Azure Search configuration need creating/updating?
     type: string
@@ -60,8 +53,6 @@ variables:
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   - name: vmImageName
     value: ubuntu-latest
-  - name: deployAlerts
-    value: ${{ iif(eq(parameters.deployAlerts, 'Yes'), true, false) }}
   - name: deploySearchConfig
     value: ${{ iif(eq(parameters.deploySearchConfig, 'Yes'), true, false) }}
 

--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -31,7 +31,6 @@ jobs:
                 action: validate
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
-                deployAlerts: false
                 deploySearchConfig: false
                 githubSourceRef: $(Build.SourceBranch)
                 searchDocsFunctionAppExists: false
@@ -49,7 +48,6 @@ jobs:
                 action: create
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
-                deployAlerts: $(deployAlerts)
                 deploySearchConfig: $(deploySearchConfig)
                 githubSourceRef: $(Build.SourceBranch)
                 searchDocsFunctionAppExists: $(searchDocsFunctionAppExists)

--- a/infrastructure/templates/search/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/search/ci/tasks/deploy-bicep.yml
@@ -11,8 +11,6 @@ parameters:
     type: string
   - name: parameterFile
     type: string
-  - name: deployAlerts
-    type: string
   - name: deploySearchConfig
     type: string
   - name: githubSourceRef
@@ -45,7 +43,6 @@ steps:
               subscription='$(subscription)' \
               resourceTags='$(resourceTags)' \
               maintenanceIpRanges='$(maintenanceFirewallRules)' \
-              deployAlerts=${{ parameters.deployAlerts }} \
               deploySearchConfig=${{ parameters.deploySearchConfig }} \
               githubSourceRef=${{ parameters.githubSourceRef }} \
               searchDocsFunctionAppExists=${{ parameters.searchDocsFunctionAppExists }}

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -23,9 +23,6 @@ param resourceTags {
 @description('Tagging : Date Provisioned. Used for tagging resources created by this infrastructure pipeline.')
 param dateProvisioned string = utcNow('u')
 
-@description('Whether to create/update Azure Monitor alerts during this deploy.')
-param deployAlerts bool = false
-
 @description('Whether to deploy the Search service configuration to create/update the data source, index and indexer.')
 param deploySearchConfig bool = false
 
@@ -127,7 +124,6 @@ module searchDocsFunctionModule 'application/searchDocsFunction.bicep' = {
     storageFirewallRules: maintenanceIpRanges
     applicationInsightsConnectionString: monitoringModule.outputs.applicationInsightsConnectionString
     tagValues: tagValues
-    deployAlerts: deployAlerts
   }
 }
 
@@ -153,7 +149,6 @@ module searchServiceModule 'application/searchService.bicep' = {
     resourcePrefix: resourcePrefix
     searchServiceIpRules: []
     storageIpRules: maintenanceIpRanges
-    deployAlerts: deployAlerts
     deploySearchConfig: deploySearchConfig
     tagValues: tagValues
   }


### PR DESCRIPTION
This PR removes the `deployAlerts` parameter from the Search infrastructure pipeline ensuring that alert rules are always included.

The parameter defaulted to false and alert rules were never created up until now. They have now been created and I can't see a reason why we wouldn't want to continue including them in every deploy from now on.