### PR TITLE
Troubleshooting Logging

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/LoggerConfigurationExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/LoggerConfigurationExtensions.cs
@@ -1,11 +1,7 @@
-﻿using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.Configuration;
 using Serilog;
 using Serilog.Events;
 using Serilog.Exceptions;
-using Serilog.Formatting.Compact;
-using Serilog.Formatting.Display;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
 
@@ -31,8 +27,7 @@ public static class LoggerConfigurationExtensions
         IConfiguration configuration) =>
         logger
             .AddEnrichers()
-            .ReadFrom.Configuration(configuration)
-        ;
+            .ReadFrom.Configuration(configuration);
 
     private static LoggerConfiguration AddEnrichers(this LoggerConfiguration loggerConfiguration) =>
         // To simply the config, specify the common enrichers here.

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/LoggerConfigurationExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/LoggerConfigurationExtensions.cs
@@ -5,6 +5,7 @@ using Serilog;
 using Serilog.Events;
 using Serilog.Exceptions;
 using Serilog.Formatting.Compact;
+using Serilog.Formatting.Display;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
 
@@ -27,14 +28,11 @@ public static class LoggerConfigurationExtensions
 
     public static LoggerConfiguration ConfigureSerilogLogger(
         this LoggerConfiguration logger,
-        IServiceProvider services,
         IConfiguration configuration) =>
         logger
-            .ConfigureBootstrapLogger()
-            // .ReadFrom.Configuration(configuration)
-            .WriteTo.ApplicationInsights(
-                services.GetRequiredService<TelemetryConfiguration>(),
-                TelemetryConverter.Traces);
+            .AddEnrichers()
+            .ReadFrom.Configuration(configuration)
+        ;
 
     private static LoggerConfiguration AddEnrichers(this LoggerConfiguration loggerConfiguration) =>
         // To simply the config, specify the common enrichers here.

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
@@ -50,6 +50,9 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="appsettings.Production.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="appsettings.Development.json">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
@@ -12,7 +12,9 @@
     "IndexerName": "-- insert indexer name here --"
   },
   "Serilog": {
-    "Using":  [ "Serilog.Sinks.Console" ],
+    "Using": [
+      "Serilog.Sinks.Console"
+    ],
     "MinimumLevel": {
       "Default": "Verbose",
       "Override": {
@@ -21,6 +23,10 @@
         "System": "Warning"
       }
     },
-    "WriteTo": [{ "Name": "Console"}]
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ]
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
@@ -16,16 +16,11 @@
     "MinimumLevel": {
       "Default": "Verbose",
       "Override": {
-        "Microsoft": "Warning"
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "System": "Warning"
       }
     },
-    "WriteTo": [
-      { 
-        "Name": "Console",
-        "Args": {
-          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
-        }
-      }
-    ]
+    "WriteTo": [{ "Name": "Console"}]
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Production.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Production.json
@@ -1,0 +1,20 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Verbose",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      }
+    ]
+  }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.json
@@ -1,10 +1,2 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Verbose",
-      "Override": {
-        "Microsoft": "Warning"
-      }
-    }
-  }
 }


### PR DESCRIPTION
- Removed hardcoded Application Insights sink. 
- Add appsettings.Production.json to format the logs when deployed differently to when running locally. Note: having the prod Serilog config in appsettings.json meant it was also read in when running locally.
- Prevent default logger from logging to console, duplicating Serilog logs.
