### PR TITLE
EES-5979 Record analytics when public user downloads single csv

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicCsvDownloads/CsvDownloadRequestFile1.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicCsvDownloads/CsvDownloadRequestFile1.json
@@ -1,0 +1,8 @@
+{
+  "dataSetTitle": "data set title 1",
+  "publicationName": "publication name 1",
+  "releaseLabel": "release label 1",
+  "releaseName": "release name 1",
+  "releaseVersionId": "72a6856c-8d7b-4ad9-b533-2066d171d146",
+  "subjectId": "66c5eb5f-a85b-4586-bae8-dc3504d3042f"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicCsvDownloads/CsvDownloadRequestFile1_Copy.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicCsvDownloads/CsvDownloadRequestFile1_Copy.json
@@ -1,0 +1,8 @@
+{
+  "dataSetTitle": "data set title 1",
+  "publicationName": "publication name 1",
+  "releaseLabel": "release label 1",
+  "releaseName": "release name 1",
+  "releaseVersionId": "72a6856c-8d7b-4ad9-b533-2066d171d146",
+  "subjectId": "66c5eb5f-a85b-4586-bae8-dc3504d3042f"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicCsvDownloads/CsvDownloadRequestFile2.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Resources/PublicCsvDownloads/CsvDownloadRequestFile2.json
@@ -1,0 +1,7 @@
+{
+  "dataSetTitle": "data set title 2",
+  "publicationName": "publication name 2",
+  "releaseName": "release name 2",
+  "releaseVersionId": "0a159ab6-bf58-41cc-a399-026b454d41f2",
+  "subjectId": "76613f62-38d1-4886-be27-6301d7896fa0"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicCsvDownloadsProcessorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicCsvDownloadsProcessorTests.cs
@@ -1,0 +1,196 @@
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Workflow;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests.Services.Workflow.MockBuilders;
+using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using InterpolatedSql.Dapper;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests.Services;
+
+public abstract class PublicCsvDownloadsProcessorTests
+{
+    private readonly string _resourcesPath = Path.Combine(
+        Assembly.GetExecutingAssembly().GetDirectoryPath(),
+        "Resources",
+        "PublicCsvDownloads");
+
+    public class ProcessTests : PublicCsvDownloadsProcessorTests
+    {
+        [Fact]
+        public async Task ProcessorUsesWorkflow()
+        {
+            using var pathResolver = new TestAnalyticsPathResolver();
+            SetupRequestFile(pathResolver, "CsvDownloadRequestFile1.json");
+
+            var workflowActorBuilder = new WorkflowActorMockBuilder<PublicCsvDownloadsProcessor>();
+            
+            var workflowActor = workflowActorBuilder 
+                .WhereDuckDbInitialisedWithErrors()
+                .Build();
+
+            var service = BuildService(
+                pathResolver: pathResolver,
+                workflowActor: workflowActor);
+            
+            await Assert.ThrowsAsync<ArgumentException>(service.Process);
+
+            workflowActorBuilder
+                .Assert
+                .InitialiseDuckDbCalled();
+        }
+
+        [Fact]
+        public async Task TwoDifferentSourceQueries_ProduceTwoDistinctReportRows()
+        {
+            using var pathResolver = new TestAnalyticsPathResolver();
+
+            SetupRequestFile(pathResolver, "CsvDownloadRequestFile1.json");
+            SetupRequestFile(pathResolver, "CsvDownloadRequestFile2.json");
+
+            var service = BuildService(
+                pathResolver: pathResolver);
+            await service.Process();
+
+            Assert.False(Directory.Exists(ProcessingDirectoryPath(pathResolver)));
+            Assert.True(Directory.Exists(pathResolver.PublicCsvDownloadsReportsDirectoryPath()));
+
+            var reports = Directory.GetFiles(pathResolver.PublicCsvDownloadsReportsDirectoryPath());
+            var csvDownloadsReport = Assert.Single(reports);
+
+            Assert.EndsWith("public-csv-downloads.parquet", csvDownloadsReport);
+
+            var duckDbConnection = new DuckDbConnection();
+            duckDbConnection.Open();
+
+            var csvDownloadReportRows = await ReadReport(duckDbConnection, csvDownloadsReport);
+
+            Assert.Equal(2, csvDownloadReportRows.Count);
+
+            await AssertReportRow(
+                csvDownloadReportRows[0],
+                "CsvDownloadRequestFile1.json",
+                1);
+
+            await AssertReportRow(
+                csvDownloadReportRows[1],
+                "CsvDownloadRequestFile2.json",
+                1);
+        }
+
+        [Fact]
+        public async Task MultipleRequestFilesForSameCsvFile_ProduceSingleReportRow()
+        {
+            using var pathResolver = new TestAnalyticsPathResolver();
+
+            SetupRequestFile(pathResolver, "CsvDownloadRequestFile1.json");
+            SetupRequestFile(pathResolver, "CsvDownloadRequestFile1_Copy.json");
+
+            var service = BuildService(
+                pathResolver: pathResolver);
+            await service.Process();
+
+            var reports = Directory.GetFiles(pathResolver.PublicCsvDownloadsReportsDirectoryPath());
+            var csvDownloadsReport = Assert.Single(reports);
+
+            Assert.EndsWith("public-csv-downloads.parquet", csvDownloadsReport);
+
+            var duckDbConnection = new DuckDbConnection();
+            duckDbConnection.Open();
+
+            var csvDownloadReportRows = await ReadReport(duckDbConnection, csvDownloadsReport);
+
+            var csvDownloadReportRow = Assert.Single(csvDownloadReportRows);
+
+            await AssertReportRow(
+                csvDownloadReportRow,
+                "CsvDownloadRequestFile1.json",
+                2);
+        }
+
+        private static async Task<List<CsvDownloadReportLine>> ReadReport(DuckDbConnection duckDbConnection, string reportFile)
+        {
+            return (await duckDbConnection
+                    .SqlBuilder($"SELECT * FROM read_parquet('{reportFile:raw}')")
+                    .QueryAsync<CsvDownloadReportLine>())
+                .OrderBy(row => row.DataSetTitle)
+                .ToList();
+        }
+    }
+
+    private static PublicCsvDownloadsProcessor BuildService(
+        TestAnalyticsPathResolver pathResolver,
+        IWorkflowActor<PublicCsvDownloadsProcessor>? workflowActor = null)
+    {
+        return new PublicCsvDownloadsProcessor(
+            pathResolver: pathResolver,
+            Mock.Of<ILogger<PublicCsvDownloadsProcessor>>(),
+            workflowActor: workflowActor);
+    }
+
+    private void SetupRequestFile(TestAnalyticsPathResolver pathResolver, string filename)
+    {
+        Directory.CreateDirectory(pathResolver.PublicCsvDownloadsDirectoryPath());
+
+        var sourceFilePath = Path.Combine(_resourcesPath, filename);
+        File.Copy(sourceFilePath, Path.Combine(pathResolver.PublicCsvDownloadsDirectoryPath(), filename));
+    }
+
+    private async Task AssertReportRow(
+        CsvDownloadReportLine row,
+        string jsonFileName,
+        int numRequests)
+    {
+        var jsonText = await File.ReadAllTextAsync(Path.Combine(_resourcesPath, jsonFileName));
+
+        var request = JsonConvert.DeserializeObject<CaptureCsvDownloadRequest>(jsonText);
+        Assert.NotNull(request);
+
+        Assert.Equal(request.PublicationName, row.PublicationName);
+        Assert.Equal(request.ReleaseVersionId, row.ReleaseVersionId);
+        Assert.Equal(request.ReleaseName, row.ReleaseName);
+        Assert.Equal(request.ReleaseLabel, row.ReleaseLabel);
+        Assert.Equal(request.SubjectId, row.SubjectId);
+        Assert.Equal(request.DataSetTitle, row.DataSetTitle);
+
+        // Generate expected CsvDownloadHash
+        var strToHash = $"{request.SubjectId.ToString().ToLower()}{request.ReleaseVersionId.ToString().ToLower()}";
+        var bytesToHash = Encoding.UTF8.GetBytes(strToHash);
+        var hash = MD5.Create().ComputeHash(bytesToHash);
+        var hashSb = new StringBuilder();
+        hash.ForEach(b => hashSb.Append(b.ToString("x2")));
+
+        Assert.Equal(hashSb.ToString(), row.CsvDownloadHash);
+        Assert.Equal(numRequests, row.Downloads);
+    }
+    
+    private static string ProcessingDirectoryPath(TestAnalyticsPathResolver pathResolver)
+    {
+        return Path.Combine(pathResolver.PublicCsvDownloadsDirectoryPath(), "processing");
+    }
+
+    public record CaptureCsvDownloadRequest(
+        string PublicationName,
+        Guid ReleaseVersionId,
+        string ReleaseName,
+        string? ReleaseLabel,
+        Guid SubjectId,
+        string DataSetTitle);
+
+    // ReSharper disable once ClassNeverInstantiated.Local
+    private record CsvDownloadReportLine(
+        string CsvDownloadHash,
+        string PublicationName,
+        Guid ReleaseVersionId,
+        string ReleaseName,
+        string? ReleaseLabel,
+        Guid SubjectId,
+        string DataSetTitle,
+        int Downloads);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
@@ -63,13 +63,13 @@ public class TestAnalyticsPathResolver : IAnalyticsPathResolver, IDisposable
         return Path.Combine(_basePath, "reports", "public", "zip-downloads");
     }
 
-    // PublicDataSetFileDownloads
-    public string PublicDataSetFileDownloadsDirectoryPath()
+    // PublicCsvDownloads
+    public string PublicCsvDownloadsDirectoryPath()
     {
         return Path.Combine(_basePath, "public", "csv-downloads");
     }
 
-    public string PublicDataSetFileDownloadsReportsDirectoryPath()
+    public string PublicCsvDownloadsReportsDirectoryPath()
     {
         return Path.Combine(_basePath, "reports", "public", "csv-downloads");
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/TestAnalyticsPathResolver.cs
@@ -62,4 +62,15 @@ public class TestAnalyticsPathResolver : IAnalyticsPathResolver, IDisposable
     public string PublicZipDownloadsReportsDirectoryPath() {
         return Path.Combine(_basePath, "reports", "public", "zip-downloads");
     }
+
+    // PublicDataSetFileDownloads
+    public string PublicDataSetFileDownloadsDirectoryPath()
+    {
+        return Path.Combine(_basePath, "public", "csv-downloads");
+    }
+
+    public string PublicDataSetFileDownloadsReportsDirectoryPath()
+    {
+        return Path.Combine(_basePath, "reports", "public", "csv-downloads");
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
@@ -44,8 +44,8 @@ public static class ProcessorHostBuilder
                     .AddTransient<IRequestFileProcessor, PublicApiDataSetVersionCallsProcessor>()
                     .AddTransient<IRequestFileProcessor, PublicApiQueriesProcessor>()
                     .AddTransient<IRequestFileProcessor, PublicZipDownloadsProcessor>()
-                    .AddTransient<IRequestFileProcessor, PublicDataSetFileDownloadsProcessor>();
-                    // @MarkFix write PublicDataSetFileDownloadProcessor tests
+                    .AddTransient<IRequestFileProcessor, PublicCsvDownloadsProcessor>();
+                    // @MarkFix write PublicCsvDownloadProcessor tests
             });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
@@ -44,6 +44,8 @@ public static class ProcessorHostBuilder
                     .AddTransient<IRequestFileProcessor, PublicApiDataSetVersionCallsProcessor>()
                     .AddTransient<IRequestFileProcessor, PublicApiQueriesProcessor>()
                     .AddTransient<IRequestFileProcessor, PublicZipDownloadsProcessor>();
+                    // @MarkFix add PublicDataSetFileDownloadsProcessor
+                    // @MarkFix and then write PublicDataSetFileDownloadProcessor tests
             });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
@@ -43,9 +43,9 @@ public static class ProcessorHostBuilder
                     .AddTransient<IRequestFileProcessor, PublicApiDataSetCallsProcessor>()
                     .AddTransient<IRequestFileProcessor, PublicApiDataSetVersionCallsProcessor>()
                     .AddTransient<IRequestFileProcessor, PublicApiQueriesProcessor>()
-                    .AddTransient<IRequestFileProcessor, PublicZipDownloadsProcessor>();
-                    // @MarkFix add PublicDataSetFileDownloadsProcessor
-                    // @MarkFix and then write PublicDataSetFileDownloadProcessor tests
+                    .AddTransient<IRequestFileProcessor, PublicZipDownloadsProcessor>()
+                    .AddTransient<IRequestFileProcessor, PublicDataSetFileDownloadsProcessor>();
+                    // @MarkFix write PublicDataSetFileDownloadProcessor tests
             });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
@@ -45,7 +45,6 @@ public static class ProcessorHostBuilder
                     .AddTransient<IRequestFileProcessor, PublicApiQueriesProcessor>()
                     .AddTransient<IRequestFileProcessor, PublicZipDownloadsProcessor>()
                     .AddTransient<IRequestFileProcessor, PublicCsvDownloadsProcessor>();
-                    // @MarkFix write PublicCsvDownloadProcessor tests
             });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
@@ -88,12 +88,12 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
     }
 
     // PublicDataSetFileDownloads
-    public string PublicDataSetFileDownloadsDirectoryPath()
+    public string PublicCsvDownloadsDirectoryPath()
     {
         return Path.Combine(_basePath, "public", "csv-downloads");
     }
 
-    public string PublicDataSetFileDownloadsReportsDirectoryPath()
+    public string PublicCsvDownloadsReportsDirectoryPath()
     {
         return Path.Combine(ReportsDirectoryPath(), "public", "csv-downloads");
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
@@ -86,4 +86,15 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
     {
         return Path.Combine(ReportsDirectoryPath(), "public", "zip-downloads");
     }
+
+    // PublicDataSetFileDownloads
+    public string PublicDataSetFileDownloadsDirectoryPath()
+    {
+        return Path.Combine(_basePath, "public", "csv-downloads");
+    }
+
+    public string PublicDataSetFileDownloadsReportsDirectoryPath()
+    {
+        return Path.Combine(ReportsDirectoryPath(), "public", "csv-downloads");
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
@@ -24,9 +24,8 @@ public interface IAnalyticsPathResolver
 
     string PublicZipDownloadsReportsDirectoryPath();
 
-    // PublicDataSetFileDownloads
+    // PublicCsvDownloads
+    string PublicCsvDownloadsDirectoryPath();
 
-    string PublicDataSetFileDownloadsDirectoryPath();
-
-    string PublicDataSetFileDownloadsReportsDirectoryPath();
+    string PublicCsvDownloadsReportsDirectoryPath();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Interfaces/IAnalyticsPathResolver.cs
@@ -23,4 +23,10 @@ public interface IAnalyticsPathResolver
     string PublicZipDownloadsDirectoryPath();
 
     string PublicZipDownloadsReportsDirectoryPath();
+
+    // PublicDataSetFileDownloads
+
+    string PublicDataSetFileDownloadsDirectoryPath();
+
+    string PublicDataSetFileDownloadsReportsDirectoryPath();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicDataSetFileDownloadsProcessor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicDataSetFileDownloadsProcessor.cs
@@ -1,0 +1,92 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Workflow;
+using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
+
+public class PublicDataSetFileDownloadsProcessor(
+    IAnalyticsPathResolver pathResolver,
+    ILogger<PublicDataSetFileDownloadsProcessor> logger,
+    IWorkflowActor<PublicDataSetFileDownloadsProcessor>? workflowActor = null) : IRequestFileProcessor
+{
+    private readonly IWorkflowActor<PublicDataSetFileDownloadsProcessor> _workflowActor
+        = workflowActor ?? new WorkflowActor();
+
+    public Task Process() {
+    
+        var workflow = new ProcessRequestFilesWorkflow<PublicDataSetFileDownloadsProcessor>(
+            sourceDirectory: pathResolver.PublicDataSetFileDownloadsDirectoryPath(),
+            reportsDirectory: pathResolver.PublicDataSetFileDownloadsReportsDirectoryPath(),
+            actor: _workflowActor,
+            logger: logger);
+
+        return workflow.Process();
+    }
+
+    private class WorkflowActor : IWorkflowActor<PublicDataSetFileDownloadsProcessor>
+    {
+        public async Task InitialiseDuckDb(DuckDbConnection connection)
+        {
+            await connection.ExecuteNonQueryAsync(@"
+                CREATE TABLE dataSetFileDownloads (
+                    dataSetFileDownloadHash VARCHAR,
+                    publicationName VARCHAR,
+                    releaseVersionId UUID,
+                    releaseName VARCHAR,
+                    releaseLabel VARCHAR,
+                    subjectId UUID,
+                    dataSetTitle VARCHAR
+                )
+            ");
+        }
+
+        public async Task ProcessSourceFile(string sourceFilePath, DuckDbConnection connection)
+        {
+            await connection.ExecuteNonQueryAsync($@"
+                INSERT INTO dataSetFileDownloads BY NAME (
+                    SELECT
+                        MD5(CONCAT(subjectId, releaseVersionId)) AS dataSetFileDownloadHash,
+                        *
+                    FROM read_json('{sourceFilePath}', 
+                        format='unstructured',
+                        columns = {{
+                            publicationName: VARCHAR,
+                            releaseVersionId: UUID,
+                            releaseName: VARCHAR,
+                            releaseLabel: VARCHAR,
+                            subjectId: UUID,
+                            dataSetTitle: VARCHAR
+                        }}
+                    )
+                 )
+            ");
+        }
+
+        public async Task CreateParquetReports(string reportsFolderPathAndFilenamePrefix, DuckDbConnection connection)
+        {
+            await connection.ExecuteNonQueryAsync(@"
+                CREATE TABLE dataSetFileDownloadsReport AS 
+                SELECT 
+                    dataSetFileDownloadHash,
+                    FIRST(publicationName) AS publicationName,
+                    FIRST(releaseVersionId) AS releaseVersionId,
+                    FIRST(releaseName) AS releaseName,
+                    FIRST(releaseLabel) AS releaseLabel,
+                    FIRST(subjectId) AS subjectId,
+                    FIRST(dataSetTitle) AS dataSetTitle,
+                    CAST(COUNT(dataSetFileDownloadHash) AS INT) AS downloads
+                FROM dataSetFileDownloads
+                GROUP BY dataSetFileDownloadHash
+                ORDER BY dataSetFileDownloadHash
+            ");
+        
+            var reportFilePath = 
+                $"{reportsFolderPathAndFilenamePrefix}_public-csv-downloads.parquet";
+
+            await connection.ExecuteNonQueryAsync($@"
+                COPY (SELECT * FROM dataSetFileDownloadsReport)
+                TO '{reportFilePath}' (FORMAT 'parquet', CODEC 'zstd')");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerAnalyticsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerAnalyticsTests.cs
@@ -1,0 +1,141 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Services;
+using Snapshooter.Xunit;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers;
+
+public abstract class DataSetFilesControllerAnalyticsTests : IntegrationTestFixture
+{
+    private readonly DataFixture _fixture = new();
+
+    private DataSetFilesControllerAnalyticsTests(TestApplicationFactory testApp) : base(testApp)
+    {
+    }
+
+    public class DownloadDataSetFileAnalyticsTests(TestApplicationFactory testApp)
+        : DataSetFilesControllerAnalyticsTests(testApp)
+    {
+        public override async Task InitializeAsync() => await StartAzurite();
+
+        [Fact]
+        public async Task DownloadDataSetFile_RecordAnalytics()
+        {
+            Publication publication = _fixture.DefaultPublication()
+                .WithReleases(_ => [_fixture.DefaultRelease(publishedVersions: 1)])
+                .WithTheme(_fixture.DefaultTheme());
+
+            ReleaseFile releaseFile = _fixture.DefaultReleaseFile()
+                .WithReleaseVersion(publication.Releases[0].Versions[0])
+                .WithFile(_fixture.DefaultFile(FileType.Data));
+
+            var testApp = BuildApp(
+                enableAzurite: true,
+                enableAnalytics: true);
+            var publicBlobStorageService = testApp.Services.GetRequiredService<IPublicBlobStorageService>();
+            var analyticsPathResolver = testApp.Services.GetRequiredService<IAnalyticsPathResolver>();
+
+            var formFile = CreateDataCsvFormFile("test file contents 2");
+
+            await publicBlobStorageService.UploadFile(
+                containerName: BlobContainers.PublicReleaseFiles,
+                releaseFile.PublicPath(),
+                formFile);
+
+            await TestApp.AddTestData<ContentDbContext>(context =>
+            {
+                context.ReleaseFiles.Add(releaseFile);
+            });
+
+            var client = testApp.CreateClient();
+
+            var response = await client.GetAsync($"/api/data-set-files/{releaseFile.File.DataSetFileId}/download");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var analyticsRequestFiles = Directory.GetFiles(
+                    analyticsPathResolver.PublicCsvDownloadsDirectoryPath())
+                .ToList();
+
+            var requestFile = Assert.Single(analyticsRequestFiles);
+            var requestFileContents = await System.IO.File.ReadAllTextAsync(requestFile);
+            Snapshot.Match(
+                currentResult: requestFileContents,
+                snapshotName: $"{nameof(DownloadDataSetFileAnalyticsTests)}.{nameof(DownloadDataSetFile_RecordAnalytics)}.snap");
+        }
+    }
+
+    private WebApplicationFactory<Startup> BuildApp(
+        ContentDbContext? contentDbContext = null,
+        StatisticsDbContext? statisticsDbContext = null,
+        bool enableAzurite = false,
+        bool enableAnalytics = false)
+    {
+        return WithAzurite(
+                enabled: enableAzurite,
+                withAnalytics: enableAnalytics)
+            .ConfigureServices(services =>
+            {
+                services.ReplaceService(MemoryCacheService);
+
+                if (contentDbContext is not null)
+                {
+                    services.ReplaceService(contentDbContext);
+                }
+
+                if (statisticsDbContext is not null)
+                {
+                    services.ReplaceService(statisticsDbContext);
+                }
+
+                if (enableAnalytics)
+                {
+                    services.ReplaceService<IAnalyticsPathResolver>(sp =>
+                        new TestAnalyticsPathResolver());
+                }
+            });
+    }
+
+    private static IFormFile CreateDataCsvFormFile(string content)
+    {
+        var memoryStream = new MemoryStream();
+        var writer = new StreamWriter(memoryStream);
+        writer.Write(content);
+        writer.Flush();
+        memoryStream.Position = 0;
+
+        var headerDictionary = new HeaderDictionary
+        {
+            ["ContentType"] = "text/csv"
+        };
+
+        return new FormFile(
+            memoryStream,
+            0,
+            memoryStream.Length,
+            "id_from_form",
+            "dataCsv.csv")
+        {
+            Headers = headerDictionary,
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerAnalyticsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerAnalyticsTests.cs
@@ -20,7 +20,6 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Services;
 using Microsoft.AspNetCore.Hosting;
 using Snapshooter.Xunit;
 using Xunit;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -33,6 +33,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
 using Xunit;
 using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
 using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;
@@ -2515,7 +2516,10 @@ public abstract class DataSetFilesControllerTests : IntegrationTestFixture
         StatisticsDbContext? statisticsDbContext = null,
         bool enableAzurite = false)
     {
-        return WithAzurite(enabled: enableAzurite)
+        List<Action<IWebHostBuilder>> configFuncs = enableAzurite
+            ? [WithAzurite()]
+            : [];
+        return BuildWebApplicationFactory(configFuncs)
             .ConfigureServices(services =>
             {
                 services.ReplaceService(MemoryCacheService);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/RedirectsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/RedirectsControllerTests.cs
@@ -12,6 +12,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -415,6 +416,9 @@ public abstract class RedirectsControllerTests(TestApplicationFactory testApp) :
 
     private WebApplicationFactory<Startup> BuildApp(bool enableAzurite = false)
     {
-        return WithAzurite(enabled: enableAzurite);
+        List<Action<IWebHostBuilder>> configFuncs = enableAzurite
+            ? [WithAzurite()]
+            : [];
+        return BuildWebApplicationFactory(configFuncs);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/__snapshots__/DownloadDataSetFileAnalyticsTests.DownloadDataSetFile_RecordAnalytics.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/__snapshots__/DownloadDataSetFileAnalyticsTests.DownloadDataSetFile_RecordAnalytics.snap
@@ -1,0 +1,7 @@
+﻿{
+  "dataSetTitle": "ReleaseFile 0 :: Name",
+  "publicationName": "Publication 0 :: Title",
+  "releaseName": "Academic year 2000/01",
+  "releaseVersionId": "0cac6aa8-5450-3146-a7c1-59624fcab65b",
+  "subjectId": "3dd306f7-2e54-a0d6-4616-5bc96fef5da6"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Fixtures/IntegrationTestFixture.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Fixtures/IntegrationTestFixture.cs
@@ -13,6 +13,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Services;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -60,27 +61,41 @@ public abstract class IntegrationTestFixture(TestApplicationFactory testApp) :
         await _azuriteContainer.DisposeAsync();
     }
 
-    public WebApplicationFactory<Startup> WithAzurite(
-        bool enabled = true,
-        bool withAnalytics = false)
+    public WebApplicationFactory<Startup> BuildWebApplicationFactory(
+        List<Action<IWebHostBuilder>> webHostBuilderConfigFuncs)
     {
-        if (!enabled)
+        return TestApp.WithWebHostBuilder(builder =>
         {
-            return TestApp;
-        }
+            foreach (var configFunc in webHostBuilderConfigFuncs)
+            {
+                configFunc(builder);
+            }
+        });
+    }
 
-        if (withAnalytics)
+    public Action<IWebHostBuilder> WithAnalytics()
+    {
+        TestApp.AddAppSettings("appsettings.IntegrationTest.AnalyticsEnabled.json");
+
+        return builder =>
         {
-            TestApp.AddAppSettings("appsettings.IntegrationTest.AnalyticsEnabled.json");
-        }
+            builder.ConfigureServices(services =>
+            {
+                services.ReplaceService<IAnalyticsPathResolver>(sp =>
+                    new TestAnalyticsPathResolver(), optional: true);
+            });
+        };
+    }
 
+    public Action<IWebHostBuilder> WithAzurite()
+    {
         if (_azuriteContainer.State != TestcontainersStates.Running)
         {
             throw new InvalidOperationException(
                 $"Azurite container must be started via '{nameof(StartAzurite)}' method first");
         }
 
-        return TestApp.WithWebHostBuilder(builder =>
+        return builder =>
         {
             builder
                 .ConfigureAppConfiguration((_, config) =>
@@ -98,13 +113,7 @@ public abstract class IntegrationTestFixture(TestApplicationFactory testApp) :
                             sp.GetRequiredService<ILogger<IBlobStorageService>>()
                         )
                     );
-
-                    if (withAnalytics)
-                    {
-                        services.ReplaceService<IAnalyticsPathResolver>(sp =>
-                            new TestAnalyticsPathResolver());
-                    }
                 });
-        });
+        };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Fixtures/TestApplicationFactory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Fixtures/TestApplicationFactory.cs
@@ -1,11 +1,16 @@
 #nullable enable
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Moq;
 
@@ -13,16 +18,37 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Fixtures;
 
 public sealed class TestApplicationFactory : TestApplicationFactory<Startup>
 {
+    private readonly HashSet<string> _additionalAppsettingsFiles = new();
+
     public async Task ClearAllTestData()
     {
         await EnsureDatabaseDeleted<ContentDbContext>();
         await EnsureDatabaseDeleted<StatisticsDbContext>();
     }
 
+    public TestApplicationFactory AddAppSettings(string filename)
+    {
+        _additionalAppsettingsFiles.Add(filename);
+        return this;
+    }
+
     protected override IHostBuilder CreateHostBuilder()
     {
         return base
             .CreateHostBuilder()
+            .ConfigureAppConfiguration((_, builder) =>
+            {
+                var configuration = new ConfigurationBuilder();
+
+                _additionalAppsettingsFiles.ForEach(settingsFile =>
+                {
+                    configuration.AddJsonFile(
+                        Path.Combine(Assembly.GetExecutingAssembly().GetDirectoryPath(),
+                            settingsFile), optional: false);
+                });
+
+                builder.AddConfiguration(configuration.Build());
+            })
             .ConfigureServices(services =>
             {
                 services

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Fixtures/TestApplicationFactory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Fixtures/TestApplicationFactory.cs
@@ -55,7 +55,7 @@ public sealed class TestApplicationFactory : TestApplicationFactory<Startup>
                     .UseInMemoryDbContext<ContentDbContext>()
                     .UseInMemoryDbContext<StatisticsDbContext>()
                     .ReplaceService(new Mock<IPublicBlobStorageService>())
-                    .ReplaceService(new Mock<IAnalyticsPathResolver>());
+                    .ReplaceService(new Mock<IAnalyticsPathResolver>(), optional: true);
             });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
@@ -25,6 +25,18 @@
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Api\GovUk.Education.ExploreEducationStatistics.Content.Api.csproj" />
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common.Tests\GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj" />
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model.Tests\GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj" />
+        <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Services.Tests\GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.csproj" />
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Model.Tests\GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.csproj" />
     </ItemGroup>
+
+    <ItemGroup>
+      <Content Include="appsettings.IntegrationTest.AnalyticsEnabled.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Controllers\__snapshots__\" />
+    </ItemGroup>
+
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/appsettings.IntegrationTest.AnalyticsEnabled.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/appsettings.IntegrationTest.AnalyticsEnabled.json
@@ -1,0 +1,6 @@
+{
+  "Analytics": {
+    "Enabled": true,
+    "BasePath": "data/analytics"
+  }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
@@ -60,14 +60,15 @@ public class DataSetFilesController : ControllerBase
             .HandleFailuresOrOk();
     }
 
-    [HttpGet("data-set-files/{dataSetFileId:guid}/download")] // TODO EES-5979 analytics
+    [HttpGet("data-set-files/{dataSetFileId:guid}/download")]
     public async Task<ActionResult> DownloadDataSetFile(
-        Guid dataSetFileId)
+        Guid dataSetFileId,
+        CancellationToken cancellationToken)
     {
         HttpContext.Response.Headers["X-Robots-Tag"] = "noindex";
 
         return await _dataSetFileService
-            .DownloadDataSetFile(dataSetFileId);
+            .DownloadDataSetFile(dataSetFileId, cancellationToken);
     }
 
     [HttpGet("data-set-files/sitemap-items")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ public static class AnalyticsServiceCollectionExtensions
         }
 
         services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicZipDownloadStrategy>();
-        services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicDataSetFileDownloadStrategy>();
+        services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicCsvDownloadStrategy>();
 
         return services;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ public static class AnalyticsServiceCollectionExtensions
         }
 
         services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicZipDownloadStrategy>();
+        services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicDataSetFileDownloadStrategy>();
 
         return services;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
@@ -20,7 +20,7 @@ public static class AnalyticsServiceCollectionExtensions
             .GetSection(AnalyticsOptions.Section)
             .Get<AnalyticsOptions>();
 
-        if (analyticsOptions is { Enabled: false })
+        if (analyticsOptions is null or { Enabled: false })
         {
             services.AddSingleton<IAnalyticsManager, NoOpAnalyticsManager>();
             return services;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Services/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Services/TestAnalyticsPathResolver.cs
@@ -24,4 +24,9 @@ public class TestAnalyticsPathResolver : IAnalyticsPathResolver, IDisposable
     {
         return Path.Combine(_basePath, "PublicZipDownloads");
     }
+
+    public string PublicDataSetFileDownloadsDirectoryPath()
+    {
+        return Path.Combine(_basePath, "PublicDataSetFileDownloads");
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Services/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Services/TestAnalyticsPathResolver.cs
@@ -25,8 +25,8 @@ public class TestAnalyticsPathResolver : IAnalyticsPathResolver, IDisposable
         return Path.Combine(_basePath, "PublicZipDownloads");
     }
 
-    public string PublicDataSetFileDownloadsDirectoryPath()
+    public string PublicCsvDownloadsDirectoryPath()
     {
-        return Path.Combine(_basePath, "PublicDataSetFileDownloads");
+        return Path.Combine(_basePath, "PublicCsvDownloads");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/AnalyticsWritePublicCsvDownloadStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/AnalyticsWritePublicCsvDownloadStrategyTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Snapshooter.Xunit;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.StrategiesTests;
+
+public class AnalyticsWritePublicCsvDownloadStrategyTests
+{
+    public class ReportTests : AnalyticsWritePublicCsvDownloadStrategyTests
+    {
+        private const string SnapshotPrefix =
+            $"{nameof(AnalyticsWritePublicCsvDownloadStrategyTests)}.{nameof(ReportTests)}";
+
+        [Fact]
+        public async Task ProduceTwoRequestFiles_Success()
+        {
+            using var pathResolver = new TestAnalyticsPathResolver();
+            var strategy = BuildStrategy(
+                pathResolver: pathResolver);
+
+            var releaseVersionId1 = Guid.Parse("5d3c0aec-c147-48ce-ae26-ef765ffa4a5b");
+            var subjectId1 = Guid.Parse("714b997f-3d7c-4c02-843b-55abf944cb4f");
+            await strategy.Report(new CaptureCsvDownloadRequest(
+                    "publication name 1",
+                    releaseVersionId1,
+                    "release name 1",
+                    "release label 1",
+                    subjectId1,
+                    "data set title 1"),
+                default);
+
+            var releaseVersionId2 = Guid.Parse("254d53e4-1194-4285-82bd-d8a3b7c0853d");
+            var subjectId2 = Guid.Parse("19b4993d-3d32-4e64-9573-d9baac320857");
+            await strategy.Report(new CaptureCsvDownloadRequest(
+                    "publication name 2",
+                    releaseVersionId2,
+                    "release name 2",
+                    "release label 2",
+                    subjectId2,
+                    DataSetTitle: "data set title 2"),
+                default);
+
+            var files = Directory.GetFiles(pathResolver.PublicCsvDownloadsDirectoryPath())
+                .ToList();
+
+            Assert.Equal(2, files.Count);
+
+            var requestFile1 = Assert.Single(
+                files
+                    .Where(file => file.Contains(releaseVersionId1.ToString()))
+                    .ToList());
+            var requestFile1Contents = await File.ReadAllTextAsync(requestFile1);
+            Snapshot.Match(
+                currentResult: requestFile1Contents,
+                snapshotName: $"{SnapshotPrefix}.{nameof(ProduceTwoRequestFiles_Success)}.SubjectId1.snap");
+
+            var requestFile2 = Assert.Single(
+                files
+                    .Where(file => file.Contains(releaseVersionId2.ToString()))
+                    .ToList());
+            var requestFile2Contents = await File.ReadAllTextAsync(requestFile2);
+            Snapshot.Match(
+                currentResult: requestFile2Contents,
+                snapshotName: $"{SnapshotPrefix}.{nameof(ProduceTwoRequestFiles_Success)}.SubjectId2.snap");
+        }
+    }
+
+    private AnalyticsWritePublicCsvDownloadStrategy BuildStrategy(
+        IAnalyticsPathResolver pathResolver,
+        DateTimeProvider? dateTimeProvider = null,
+        ILogger<AnalyticsWritePublicCsvDownloadStrategy>? logger = null)
+    {
+        return new AnalyticsWritePublicCsvDownloadStrategy(
+            pathResolver,
+            dateTimeProvider ?? new DateTimeProvider(),
+            logger ?? Mock.Of<ILogger<AnalyticsWritePublicCsvDownloadStrategy>>());
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/__snapshots__/AnalyticsWritePublicCsvDownloadStrategyTests.ReportTests.ProduceTwoRequestFiles_Success.SubjectId1.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/__snapshots__/AnalyticsWritePublicCsvDownloadStrategyTests.ReportTests.ProduceTwoRequestFiles_Success.SubjectId1.snap
@@ -1,0 +1,8 @@
+﻿{
+  "dataSetTitle": "data set title 1",
+  "publicationName": "publication name 1",
+  "releaseLabel": "release label 1",
+  "releaseName": "release name 1",
+  "releaseVersionId": "5d3c0aec-c147-48ce-ae26-ef765ffa4a5b",
+  "subjectId": "714b997f-3d7c-4c02-843b-55abf944cb4f"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/__snapshots__/AnalyticsWritePublicCsvDownloadStrategyTests.ReportTests.ProduceTwoRequestFiles_Success.SubjectId2.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/StrategiesTests/__snapshots__/AnalyticsWritePublicCsvDownloadStrategyTests.ReportTests.ProduceTwoRequestFiles_Success.SubjectId2.snap
@@ -1,0 +1,8 @@
+﻿{
+  "dataSetTitle": "data set title 2",
+  "publicationName": "publication name 2",
+  "releaseLabel": "release label 2",
+  "releaseName": "release name 2",
+  "releaseVersionId": "254d53e4-1194-4285-82bd-d8a3b7c0853d",
+  "subjectId": "19b4993d-3d32-4e64-9573-d9baac320857"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsPathResolver.cs
@@ -29,4 +29,9 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
     {
         return Path.Combine(_basePath, "public", "zip-downloads");
     }
+
+    public string PublicDataSetFileDownloadsDirectoryPath()
+    {
+        return Path.Combine(_basePath, "public", "data-set-file-downloads");
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsPathResolver.cs
@@ -30,8 +30,8 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
         return Path.Combine(_basePath, "public", "zip-downloads");
     }
 
-    public string PublicDataSetFileDownloadsDirectoryPath()
+    public string PublicCsvDownloadsDirectoryPath()
     {
-        return Path.Combine(_basePath, "public", "data-set-file-downloads");
+        return Path.Combine(_basePath, "public", "csv-downloads");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -442,7 +442,7 @@ public class DataSetFileService(
             return;
         }
 
-        await analyticsManager.Add(new CaptureDataSetFileDownloadRequest(
+        await analyticsManager.Add(new CaptureCsvDownloadRequest(
             releaseFile.ReleaseVersion.Release.Publication.Title,
             releaseFile.ReleaseVersionId,
             releaseFile.ReleaseVersion.Release.Title,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -435,6 +435,7 @@ public class DataSetFileService(
         ReleaseFile releaseFile, CancellationToken cancellationToken)
     {
         var subjectId = releaseFile.File.SubjectId;
+
         if (!subjectId.HasValue)
         {
             logger.LogWarning("ReleaseFile does not have a SubjectId set. ReleaseId: {ReleaseVersionId} FileId: {FileId}",
@@ -442,14 +443,24 @@ public class DataSetFileService(
             return;
         }
 
-        await analyticsManager.Add(new CaptureCsvDownloadRequest(
-            releaseFile.ReleaseVersion.Release.Publication.Title,
-            releaseFile.ReleaseVersionId,
-            releaseFile.ReleaseVersion.Release.Title,
-            releaseFile.ReleaseVersion.Release.Label,
-            subjectId.Value,
-            releaseFile.Name ?? "No data set title"
-        ), cancellationToken);
+        try
+        {
+            await analyticsManager.Add(new CaptureCsvDownloadRequest(
+                releaseFile.ReleaseVersion.Release.Publication.Title,
+                releaseFile.ReleaseVersionId,
+                releaseFile.ReleaseVersion.Release.Title,
+                releaseFile.ReleaseVersion.Release.Label,
+                subjectId.Value,
+                releaseFile.Name ?? "No data set title"
+            ), cancellationToken);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(
+                exception: e,
+                message: "Error whilst capturing csv download analytics for subject {SubjectId}",
+                subjectId);
+        }
     }
 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -290,7 +290,7 @@ public class DataSetFileService(
             return new NotFoundResult();
         }
 
-        await RecordDownloadDataSetFileAnalytics(releaseFile, cancellationToken);
+        await RecordCsvDownloadAnalytics(releaseFile, cancellationToken);
 
         var stream = await publicBlobStorageService.StreamBlob(
             containerName: BlobContainers.PublicReleaseFiles,
@@ -431,7 +431,7 @@ public class DataSetFileService(
         };
     }
 
-    private async Task RecordDownloadDataSetFileAnalytics(
+    private async Task RecordCsvDownloadAnalytics(
         ReleaseFile releaseFile, CancellationToken cancellationToken)
     {
         var subjectId = releaseFile.File.SubjectId;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -446,6 +446,7 @@ public class DataSetFileService(
             releaseFile.ReleaseVersion.Release.Publication.Title,
             releaseFile.ReleaseVersionId,
             releaseFile.ReleaseVersion.Release.Title,
+            releaseFile.ReleaseVersion.Release.Label,
             subjectId.Value,
             releaseFile.Name ?? "No data set title"
         ), cancellationToken);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -26,7 +26,10 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.SortDirection;
 using static GovUk.Education.ExploreEducationStatistics.Content.Requests.DataSetsListRequestSortBy;
 using ReleaseVersion = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseVersion;
@@ -37,7 +40,9 @@ public class DataSetFileService(
     ContentDbContext contentDbContext,
     IReleaseVersionRepository releaseVersionRepository,
     IPublicBlobStorageService publicBlobStorageService,
-    IFootnoteRepository footnoteRepository)
+    IFootnoteRepository footnoteRepository,
+    IAnalyticsManager analyticsManager,
+    ILogger<DataSetFileService> logger)
     : IDataSetFileService
 {
     public async Task<Either<ActionResult, PaginatedListViewModel<DataSetFileSummaryViewModel>>> ListDataSetFiles(
@@ -265,27 +270,32 @@ public class DataSetFileService(
     }
 
     public async Task<ActionResult> DownloadDataSetFile(
-        Guid dataSetFileId)
+        Guid dataSetFileId,
+        CancellationToken cancellationToken)
     {
         var releaseFile = await contentDbContext.ReleaseFiles
             .Include(rf => rf.File)
+            .Include(rf => rf.ReleaseVersion.Release.Publication)
             .Where(rf =>
                 rf.File.DataSetFileId == dataSetFileId
                 && rf.ReleaseVersion.Published.HasValue
                 && DateTime.UtcNow >= rf.ReleaseVersion.Published.Value)
             .OrderByDescending(rf => rf.ReleaseVersion.Version)
-            .FirstOrDefaultAsync();
+            .FirstOrDefaultAsync(cancellationToken);
 
         if (releaseFile == null
             || !await releaseVersionRepository.IsLatestPublishedReleaseVersion(
-                releaseFile.ReleaseVersionId))
+                releaseFile.ReleaseVersionId, cancellationToken))
         {
             return new NotFoundResult();
         }
 
+        await RecordDownloadDataSetFileAnalytics(releaseFile, cancellationToken);
+
         var stream = await publicBlobStorageService.StreamBlob(
             containerName: BlobContainers.PublicReleaseFiles,
-            path: releaseFile.PublicPath());
+            path: releaseFile.PublicPath(),
+            cancellationToken: cancellationToken);
 
         return new FileStreamResult(stream, "text/csv")
         {
@@ -419,6 +429,26 @@ public class DataSetFileService(
             Id = releaseFile.PublicApiDataSetId.Value,
             Version = releaseFile.PublicApiDataSetVersionString!,
         };
+    }
+
+    private async Task RecordDownloadDataSetFileAnalytics(
+        ReleaseFile releaseFile, CancellationToken cancellationToken)
+    {
+        var subjectId = releaseFile.File.SubjectId;
+        if (!subjectId.HasValue)
+        {
+            logger.LogWarning("ReleaseFile does not have a SubjectId set. ReleaseId: {ReleaseVersionId} FileId: {FileId}",
+                releaseFile.ReleaseVersionId, releaseFile.FileId);
+            return;
+        }
+
+        await analyticsManager.Add(new CaptureDataSetFileDownloadRequest(
+            releaseFile.ReleaseVersion.Release.Publication.Title,
+            releaseFile.ReleaseVersionId,
+            releaseFile.ReleaseVersion.Release.Title,
+            subjectId.Value,
+            releaseFile.Name ?? "No data set title"
+        ), cancellationToken);
     }
 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsPathResolver.cs
@@ -4,4 +4,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces
 public interface IAnalyticsPathResolver
 {
     string PublicZipDownloadsDirectoryPath();
+
+    string PublicDataSetFileDownloadsDirectoryPath();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IAnalyticsPathResolver.cs
@@ -5,5 +5,5 @@ public interface IAnalyticsPathResolver
 {
     string PublicZipDownloadsDirectoryPath();
 
-    string PublicDataSetFileDownloadsDirectoryPath();
+    string PublicCsvDownloadsDirectoryPath();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
@@ -30,7 +30,9 @@ public interface IDataSetFileService
 
     Task<Either<ActionResult, DataSetFileViewModel>> GetDataSetFile(Guid dataSetFileId);
 
-    Task<ActionResult> DownloadDataSetFile(Guid dataSetFileId);
+    Task<ActionResult> DownloadDataSetFile(
+        Guid dataSetFileId,
+        CancellationToken cancellationToken);
 
     Task<Either<ActionResult, List<DataSetSitemapItemViewModel>>> ListSitemapItems(
         CancellationToken cancellationToken = default);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/LocalAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/LocalAnalyticsPathResolver.cs
@@ -32,8 +32,8 @@ public class LocalAnalyticsPathResolver : IAnalyticsPathResolver
         return Path.Combine(_basePath, "public", "zip-downloads");
     }
 
-    public string PublicDataSetFileDownloadsDirectoryPath()
+    public string PublicCsvDownloadsDirectoryPath()
     {
-        return Path.Combine(_basePath, "public", "data-set-file-downloads");
+        return Path.Combine(_basePath, "public", "csv-downloads");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/LocalAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/LocalAnalyticsPathResolver.cs
@@ -31,4 +31,9 @@ public class LocalAnalyticsPathResolver : IAnalyticsPathResolver
     {
         return Path.Combine(_basePath, "public", "zip-downloads");
     }
+
+    public string PublicDataSetFileDownloadsDirectoryPath()
+    {
+        return Path.Combine(_basePath, "public", "data-set-file-downloads");
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -319,18 +319,40 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                 dataSetName = releaseFiles[0].Name;
             }
 
-            await analyticsManager.Add(
-                new CaptureZipDownloadRequest
+            try
+            {
+                await analyticsManager.Add(
+                    new CaptureZipDownloadRequest
+                    {
+                        PublicationName = releaseVersion.Release.Publication.Title,
+                        ReleaseVersionId = releaseVersion.Id,
+                        ReleaseName = releaseVersion.Release.Title,
+                        ReleaseLabel = releaseVersion.Release.Label,
+                        FromPage = fromPage,
+                        SubjectId = subjectId,
+                        DataSetTitle = dataSetName,
+                    },
+                    cancellationToken);
+            }
+            catch (Exception e)
+            {
+                if (subjectId == null)
                 {
-                    PublicationName = releaseVersion.Release.Publication.Title,
-                    ReleaseVersionId = releaseVersion.Id,
-                    ReleaseName = releaseVersion.Release.Title,
-                    ReleaseLabel = releaseVersion.Release.Label,
-                    FromPage = fromPage,
-                    SubjectId = subjectId,
-                    DataSetTitle = dataSetName,
-                },
-                cancellationToken);
+                    logger.LogError(
+                        exception: e,
+                        message: "Error whilst capturing zip download analytics for releaseVersion {ReleaseVersion}",
+                        releaseVersion.Id);
+                }
+                else
+                {
+                    logger.LogError(
+                        exception: e,
+                        message: "Error whilst capturing zip download analytics for releaseVersion {ReleaseVersionId} and subject {SubjectId}",
+                        releaseVersion.Id,
+                        subjectId);
+
+                }
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/AnalyticsCaptureRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/AnalyticsCaptureRequests.cs
@@ -28,7 +28,7 @@ public record CaptureZipDownloadRequest : IAnalyticsCaptureRequestBase
     public string? DataSetTitle = null;
 };
 
-public record CaptureDataSetFileDownloadRequest(
+public record CaptureCsvDownloadRequest(
     string PublicationName,
     Guid ReleaseVersionId,
     string ReleaseName,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/AnalyticsCaptureRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/AnalyticsCaptureRequests.cs
@@ -32,5 +32,6 @@ public record CaptureDataSetFileDownloadRequest(
     string PublicationName,
     Guid ReleaseVersionId,
     string ReleaseName,
+    string? ReleaseLabel,
     Guid SubjectId,
     string DataSetTitle) : IAnalyticsCaptureRequestBase;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/AnalyticsCaptureRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/AnalyticsCaptureRequests.cs
@@ -28,3 +28,9 @@ public record CaptureZipDownloadRequest : IAnalyticsCaptureRequestBase
     public string? DataSetTitle = null;
 };
 
+public record CaptureDataSetFileDownloadRequest(
+    string PublicationName,
+    Guid ReleaseVersionId,
+    string ReleaseName,
+    Guid SubjectId,
+    string DataSetTitle) : IAnalyticsCaptureRequestBase;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWritePublicCsvDownloadStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWritePublicCsvDownloadStrategy.cs
@@ -13,30 +13,30 @@ using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies;
 
-public class AnalyticsWritePublicDataSetFileDownloadStrategy( // @MarkFix write tests
+public class AnalyticsWritePublicCsvDownloadStrategy( // @MarkFix write tests
     IAnalyticsPathResolver analyticsPathResolver,
     DateTimeProvider dateTimeProvider,
-    ILogger<AnalyticsWritePublicDataSetFileDownloadStrategy> logger
+    ILogger<AnalyticsWritePublicCsvDownloadStrategy> logger
     ) : IAnalyticsWriteStrategy
 {
-    public Type RequestType => typeof(CaptureDataSetFileDownloadRequest);
+    public Type RequestType => typeof(CaptureCsvDownloadRequest);
 
     public async Task Report(IAnalyticsCaptureRequestBase request, CancellationToken cancellationToken)
     {
-        if (request is not CaptureDataSetFileDownloadRequest dataSetFileDownloadRequest)
+        if (request is not CaptureCsvDownloadRequest csvDownloadRequest)
         {
-            throw new ArgumentException($"request isn't a {nameof(CaptureDataSetFileDownloadRequest)}");
+            throw new ArgumentException($"request isn't a {nameof(CaptureCsvDownloadRequest)}");
         }
 
         logger.LogInformation(
             "Capturing {RequestTypeName} for releaseVersion {ReleaseVersionId} and subjectId {SubjectId}",
-            dataSetFileDownloadRequest.GetType().ToString(),
-            dataSetFileDownloadRequest.ReleaseVersionId,
-            dataSetFileDownloadRequest.SubjectId);
+            csvDownloadRequest.GetType().ToString(),
+            csvDownloadRequest.ReleaseVersionId,
+            csvDownloadRequest.SubjectId);
 
-        var directory = analyticsPathResolver.PublicDataSetFileDownloadsDirectoryPath();
+        var directory = analyticsPathResolver.PublicCsvDownloadsDirectoryPath();
         var filename =
-            $"{dateTimeProvider.UtcNow:yyyyMMdd-HHmmss}_{dataSetFileDownloadRequest.ReleaseVersionId}_{dataSetFileDownloadRequest.SubjectId}_{RandomUtils.RandomString()}.json";
+            $"{dateTimeProvider.UtcNow:yyyyMMdd-HHmmss}_{csvDownloadRequest.ReleaseVersionId}_{csvDownloadRequest.SubjectId}_{RandomUtils.RandomString()}.json";
 
         try
         {
@@ -45,7 +45,7 @@ public class AnalyticsWritePublicDataSetFileDownloadStrategy( // @MarkFix write 
             var filePath = Path.Combine(directory, filename);
 
             var serialisedRequest = JsonSerializationUtils.Serialize(
-                obj: dataSetFileDownloadRequest,
+                obj: csvDownloadRequest,
                 formatting: Formatting.Indented,
                 orderedProperties: true,
                 camelCase: true);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWritePublicCsvDownloadStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWritePublicCsvDownloadStrategy.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies;
 
-public class AnalyticsWritePublicCsvDownloadStrategy( // @MarkFix write tests
+public class AnalyticsWritePublicCsvDownloadStrategy(
     IAnalyticsPathResolver analyticsPathResolver,
     DateTimeProvider dateTimeProvider,
     ILogger<AnalyticsWritePublicCsvDownloadStrategy> logger

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWritePublicDataSetFileDownloadStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWritePublicDataSetFileDownloadStrategy.cs
@@ -1,0 +1,64 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Strategies;
+
+public class AnalyticsWritePublicDataSetFileDownloadStrategy( // @MarkFix write tests
+    IAnalyticsPathResolver analyticsPathResolver,
+    DateTimeProvider dateTimeProvider,
+    ILogger<AnalyticsWritePublicDataSetFileDownloadStrategy> logger
+    ) : IAnalyticsWriteStrategy
+{
+    public Type RequestType => typeof(CaptureDataSetFileDownloadRequest);
+
+    public async Task Report(IAnalyticsCaptureRequestBase request, CancellationToken cancellationToken)
+    {
+        if (request is not CaptureDataSetFileDownloadRequest dataSetFileDownloadRequest)
+        {
+            throw new ArgumentException($"request isn't a {nameof(CaptureDataSetFileDownloadRequest)}");
+        }
+
+        logger.LogInformation(
+            "Capturing {RequestTypeName} for releaseVersion {ReleaseVersionId} and subjectId {SubjectId}",
+            dataSetFileDownloadRequest.GetType().ToString(),
+            dataSetFileDownloadRequest.ReleaseVersionId,
+            dataSetFileDownloadRequest.SubjectId);
+
+        var directory = analyticsPathResolver.PublicDataSetFileDownloadsDirectoryPath();
+        var filename =
+            $"{dateTimeProvider.UtcNow:yyyyMMdd-HHmmss}_{dataSetFileDownloadRequest.ReleaseVersionId}_{dataSetFileDownloadRequest.SubjectId}_{RandomUtils.RandomString()}.json";
+
+        try
+        {
+            Directory.CreateDirectory(directory);
+
+            var filePath = Path.Combine(directory, filename);
+
+            var serialisedRequest = JsonSerializationUtils.Serialize(
+                obj: dataSetFileDownloadRequest,
+                formatting: Formatting.Indented,
+                orderedProperties: true,
+                camelCase: true);
+
+            await File.WriteAllTextAsync(
+                filePath, contents: serialisedRequest, cancellationToken: cancellationToken);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(
+                e,
+                "Error whilst writing {RequestTypeName} to disk",
+                request!.GetType().ToString());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ public static class AnalyticsServiceCollectionExtensions
 
         services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicApiQueryStrategy>();
         services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWriteDataSetVersionCallsStrategy>();
+        services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWrite();
 
         return services;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
@@ -40,7 +40,6 @@ public static class AnalyticsServiceCollectionExtensions
 
         services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicApiQueryStrategy>();
         services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWriteDataSetVersionCallsStrategy>();
-        services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWrite();
 
         return services;
     }


### PR DESCRIPTION
This PR adds analytics for when a user downloads a single csv (via the /csv endpoint). There are actually two different ways for public users to download a single CSV: through the Content API or through the Public API> This PR only for the Content API - recording analytics for the Public API will be implemented separately.

### Other changes

I've refactored `WithAzurite` a little to keep setting up the analytics setup uncoupled from the Azurite setup.