### PR TITLE
EES-6046 Fix build error seen in CodeQL Github action build

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj
@@ -7,11 +7,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.30.0" />
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.24.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.4" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />


### PR DESCRIPTION
This PR fixes the build error seen during the CodeQL autobuild action:

'Could not copy the file obj\GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp\release\extensions.json' because it was not found.'

It was reproducible locally with `dotnet clean` followed by `dotnet publish` on the Search solution file.

```
$ dotnet publish GovUk.Education.ExploreEducationStatistics.Search.sln
  Determining projects to restore...
  Restored C:\Users\BenOutram\dev\ees\src\GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp\GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.csproj (in 333 ms).
  Restored C:\Users\BenOutram\dev\ees\src\GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests\GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.csproj (in 333
  ms).
  Determining projects to restore...
C:\Program Files\dotnet\sdk\8.0.410\Microsoft.Common.CurrentVersion.targets(5321,5): error MSB3030: Could not copy the file "C:\Users\BenOutram\dev\ees\src\artifacts\obj\GovUk.Education.ExploreEducationStatist
ics.Content.Search.FunctionApp\release\extensions.json" because it was not found. [C:\Users\BenOutram\dev\ees\src\GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp\GovUk.Education.ExploreEd
ucationStatistics.Content.Search.FunctionApp.csproj]
```

This bug is mentioned by https://github.com/Azure/azure-functions-dotnet-worker/issues/2305 and https://github.com/Azure/azure-functions-dotnet-worker/issues/2601.