### PR TITLE
EES-6132 Fix frontend build failure

### DIFF
--- a/src/explore-education-statistics-frontend/.env
+++ b/src/explore-education-statistics-frontend/.env
@@ -1,3 +1,5 @@
+# Note: To override any of these settings, create a `.env.local` file.
+# The `.env.local` file is gitignored.
 CONTENT_API_BASE_URL=http://localhost:5010/api
 DATA_API_BASE_URL=http://localhost:5000/api
 PUBLIC_API_BASE_URL=http://localhost:5050
@@ -7,6 +9,6 @@ GA_TRACKING_ID=
 PUBLIC_URL=http://localhost:3000/
 PROD_PUBLIC_URL=https://explore-education-statistics.service.gov.uk
 APP_ENV=Local
-AZURE_SEARCH_QUERY_KEY=
+AZURE_SEARCH_QUERY_KEY=azure-search-query-key
 AZURE_SEARCH_ENDPOINT=
 AZURE_SEARCH_INDEX=


### PR DESCRIPTION
This PR fixes the build failure that is occurring in #5864 by assigning the `AZURE_SEARCH_QUERY_KEY` env parameter key a non-empty value.

When developing locally the values of the Azure AI Search parameters can be overridden by creating a `.env.local` file which is gitignored.