### PR TITLE
EES-6130 Change azure search input to type="search"

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormTextInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormTextInput.tsx
@@ -7,6 +7,7 @@ export interface FormTextInputProps extends FormBaseInputProps {
   defaultValue?: string;
   pattern?: string;
   value?: string;
+  type?: 'text' | 'search';
 }
 
 export default function FormTextInput({

--- a/src/explore-education-statistics-common/src/styles/_form.scss
+++ b/src/explore-education-statistics-common/src/styles/_form.scss
@@ -7,12 +7,6 @@
   cursor: not-allowed;
 }
 
-// Hide the clear button on search inputs as they
-// are not keyboard accessible, see EES-5210.
-[type='search']::-webkit-search-cancel-button {
-  appearance: none;
-}
-
 // EES-5308 - increase the radio border width on hover to make
 // the hover style more noticeable.
 // This has been suggested as a change to the design system,

--- a/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
@@ -39,6 +39,7 @@ export default function SearchForm({
           label={label}
           labelSize="m"
           name="search"
+          type="search"
         />
       </Form>
     </FormProvider>


### PR DESCRIPTION
This reinstates the browser default search input behaviour, including showing a cross button to clear the input as per the updated designs.

N.b this undoes some previous work to explicitly *hide* this button after a DAC audit. But having discussed the issue on slack, we are going to follow the example of the main gov.uk search and include the native browser search input.