### PR TITLE
Event properties are non-optional therefore mark as required

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationChangedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationChangedEvent.cs
@@ -39,9 +39,9 @@ public record PublicationChangedEvent : IEvent
     
     public record EventPayload
     {
-        public string Title { get; init; }
-        public string Summary { get; init; }
-        public string Slug { get; init; }
+        public required string Title { get; init; }
+        public required string Summary { get; init; }
+        public required string Slug { get; init; }
     }
 
     public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseSlugChangedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseSlugChangedEvent.cs
@@ -39,9 +39,9 @@ public record ReleaseSlugChangedEvent : IEvent
     
     public record EventPayload
     {
-        public string NewReleaseSlug { get; init; }
-        public string PublicationId { get; init; }
-        public string PublicationSlug { get; init; }
+        public required string NewReleaseSlug { get; init; }
+        public required string PublicationId { get; init; }
+        public required string PublicationSlug { get; init; }
     }
 
     public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ThemeChangedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ThemeChangedEvent.cs
@@ -39,9 +39,9 @@ public record ThemeChangedEvent : IEvent
     
     public record EventPayload
     {
-        public string Title { get; init; }
-        public string Summary { get; init; }
-        public string Slug { get; init; }
+        public required string Title { get; init; }
+        public required string Summary { get; init; }
+        public required string Slug { get; init; }
     }
 
     public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);


### PR DESCRIPTION
The new event payloads all have non-optional properties. These needed to be marked as `required`.