### PR TITLE
Add explicit cast to aid compiler

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Events/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/Extensions/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ public static class ServiceCollectionExtensions
             .AddTransient<IEventGridClientFactory, EventGridClientFactory>()
             .AddTransient<IEventRaiser, EventRaiser>()
             .AddTransient<IConfiguredEventGridClientFactory, ConfiguredEventGridClientFactory>()
-            .AddTransient(typeof(Func<ILogger<SafeEventGridClient>>), sp => sp.GetRequiredService<ILogger<SafeEventGridClient>>)
+            .AddTransient(typeof(Func<ILogger<SafeEventGridClient>>), sp => (Func<ILogger<SafeEventGridClient>>)sp.GetRequiredService<ILogger<SafeEventGridClient>>)
             .Configure<EventGridOptions>(configuration.GetSection(EventGridOptions.Section))
     ;
 }


### PR DESCRIPTION
Whilst the cast is not strictly necessary, it helps to inform the compiler (and the reader!) that this is a factory method. The compiler suggests that we've provided the method name and it looks like we might have meant to invoke it - which is a fair assumption.
