### PR TITLE
Event Raiser Mock

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Events.Tests/EventGrid/Builders/EventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events.Tests/EventGrid/Builders/EventRaiserMockBuilder.cs
@@ -28,7 +28,7 @@ public class EventRaiserMockBuilder
 
         private Task AddEvent<TEventBuilder>(TEventBuilder @event)
         {
-            _events.Add(@event);
+            _events.Add(@event ?? throw new ArgumentNullException(nameof(@event)));
             return Task.CompletedTask;
         }
         private Task AddEvents<TEventBuilder>(IEnumerable<TEventBuilder> @events)
@@ -38,7 +38,7 @@ public class EventRaiserMockBuilder
         }
 
         public bool EventWasRaised<TEventBuilder>(TEventBuilder expectedEvent) => 
-            _events.OfType<TEventBuilder>().Any(actual => actual.Equals(expectedEvent));
+            _events.OfType<TEventBuilder>().Any(actual => actual!.Equals(expectedEvent));
 
         public bool EventWasRaised() => _events.Any();
 


### PR DESCRIPTION
Prevent null event being added to the list of mock events, since a null event doesn't make sense. 
Then we can safely assume that none of the events stored in the list are null after that.
