### PR TITLE
Find unknown methodology

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
@@ -29,7 +29,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         public async Task<MethodologyVersion> Get(Guid methodologyVersionId)
         {
-            return await _context.MethodologyVersions.FindAsync(methodologyVersionId);
+            return await _context.MethodologyVersions.FindAsync(methodologyVersionId)
+                ?? throw new KeyNotFoundException($"MethodologyVersion not found with Id {methodologyVersionId}");
         }
 
         public async Task<List<MethodologyVersion>> GetLatestVersionByRelease(ReleaseVersion releaseVersion)


### PR DESCRIPTION
If controller requests a methodology using an unknown key then the Methodology service is returning null - despite the interface being non-nullable. The controller does not check this value and passes it into a method that will encounter an null ref exception almost immediately. Instead, if the methodology isn't found, raise a more appropriate exception with a useful message at that point.
