### PR TITLE
Simple fixes.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityUtils.cs
@@ -1,13 +1,13 @@
+#nullable enable
 using System.Security.Claims;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Security;
+
+public class SecurityUtils
 {
-    public class SecurityUtils
+    public static bool HasClaim(ClaimsPrincipal user, SecurityClaimTypes claimType, string? claimValue = null)
     {
-        public static bool HasClaim(ClaimsPrincipal user, SecurityClaimTypes claimType, string? claimValue = null)
-        {
-            return user.HasClaim(
-                c => c.Type == claimType.ToString() && (claimValue == null || c.Value == claimValue));
-        }
+        return user.HasClaim(
+            c => c.Type == claimType.ToString() && (claimValue == null || c.Value == claimValue));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
@@ -357,7 +357,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         private static ContentBlock CreateContentBlockForType(ContentBlockType type)
         {
             var classType = GetContentBlockClassTypeFromEnumValue(type);
-            var newContentBlock = (ContentBlock) Activator.CreateInstance(classType);
+            var newContentBlock = (ContentBlock) (Activator.CreateInstance(classType) 
+                                                  ?? throw new ArgumentException($"Could not create content block for {type} with class type {classType}"));
             newContentBlock.Id = Guid.NewGuid();
             newContentBlock.Created = DateTime.UtcNow;
             return newContentBlock;


### PR DESCRIPTION
- SecurityUtils is using nullable notation but nullable was not enabled. Fixed.
- If a content block could not be created then throw immediately instead of waiting for a null ref
