### PR TITLE
Remove static DataFixture

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Security/SignInControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Security/SignInControllerTests.cs
@@ -504,22 +504,9 @@ public class SignInControllerTests(TestApplicationFactory testApp) : Integration
         }
     }
 
-    private static List<IdentityRole> GetGlobalRoles()
-    {
-        return new List<IdentityRole>
-        {
-            new()
-            {
-                Id = "role-1",
-                Name = "Role 1",
-                NormalizedName = "ROLE 1"
-            },
-            new()
-            {
-                Id = "role-2",
-                Name = "Role 2",
-                NormalizedName = "ROLE 2"
-            }
-        };
-    }
+    private static List<IdentityRole> GetGlobalRoles() =>
+    [
+        new() { Id = "role-1", Name = "Role 1", NormalizedName = "ROLE 1" },
+        new() { Id = "role-2", Name = "Role 2", NormalizedName = "ROLE 2" }
+    ];
 }


### PR DESCRIPTION
Remove DataFixture in derived test class which was hiding the parent property.
We do not want a static data fixture being shared between tests, do we? This can easily lead to unexpected behaviour. It also breaks the seeded random of each test object since now objects are created an an indeterminate order.
