### PR TITLE
Fix implicit SemVersion string conversions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
@@ -18,6 +18,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Fixtures;
 using Microsoft.EntityFrameworkCore;
 using Moq;
+using Semver;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
@@ -319,7 +320,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     ],
                     Published = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
                     PublicApiDataSetId = Guid.NewGuid(),
-                    PublicApiDataSetVersion = "1.0.0",
+                    PublicApiDataSetVersion = SemVersion.Parse("1.0.0", SemVersionStyles.Any),
                 },
                 new()
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTests.cs
@@ -1395,7 +1395,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 ReleaseVersion = releaseVersion,
                 Name = "Test subject 1",
                 PublicApiDataSetId = Guid.NewGuid(),
-                PublicApiDataSetVersion = "1.0.1",
+                PublicApiDataSetVersion = SemVersion.Parse("1.0.1", SemVersionStyles.Any),
                 File = new File
                 {
                     Filename = "test-data-1.csv",


### PR DESCRIPTION
Implicit string conversions to SemVersions are deprecated. Replaced with explicit parse calls.