### PR TITLE
EES-6174 Add robot test for azure search find stats page

### DIFF
--- a/tests/robot-tests/tests/general_public/statistics_page_azure_search.robot
+++ b/tests/robot-tests/tests/general_public/statistics_page_azure_search.robot
@@ -1,6 +1,5 @@
 *** Settings ***
 Resource            ../libs/public-common.robot
-Resource            ../seed_data/seed_data_theme_1_constants.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser

--- a/tests/robot-tests/tests/general_public/statistics_page_azure_search.robot
+++ b/tests/robot-tests/tests/general_public/statistics_page_azure_search.robot
@@ -32,17 +32,17 @@ Validate sort controls exist
 
 Validate publications list exists and all publications are shown
     user checks page contains element    testid:publicationsList
-    user checks page contains element    xpath://p[contains(text(),"showing all publications")]
+    user checks page contains    showing all publications
 
 Search publications
     user clicks element    id:searchForm-search
     user presses keys    pupil absence
     user clicks button    Search
     user checks page contains button    pupil absence
-    user checks page does not contain element    css:[class="govuk-warning-text"]
-    user checks page does not contain element    xpath://p[contains(text(),"showing all publications")]
+    user checks page does not contain    Cannot load publications
+    user checks page does not contain    showing all publications
 
 Validate search is reset by clearing search term
     user clicks button    pupil absence
     user waits until page does not contain button    pupil absence
-    user checks page contains element    xpath://p[contains(text(),"showing all publications")]
+    user checks page contains    showing all publications

--- a/tests/robot-tests/tests/general_public/statistics_page_azure_search.robot
+++ b/tests/robot-tests/tests/general_public/statistics_page_azure_search.robot
@@ -1,0 +1,47 @@
+*** Settings ***
+Resource            ../libs/public-common.robot
+Resource            ../seed_data/seed_data_theme_1_constants.robot
+Resource            ../seed_data/seed_data_theme_2_constants.robot
+
+Suite Setup         user opens the browser
+Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
+
+Force Tags          Dev    PreProd    Prod
+
+
+*** Test Cases ***
+Navigate to Find Statistics page with azure search enabled
+    environment variable should be set    PUBLIC_URL
+    user navigates to    %{PUBLIC_URL}/find-statistics?azsearch=true
+    user waits until h1 is visible    Find statistics and data
+
+Validate Related information section and links does not exist
+    user checks page does not contain element    css:[aria-labelledby="related-information"]
+
+Validate themes filters exist
+    user checks select contains option    id:filters-form-theme    All themes
+    user checks selected option label    id:filters-form-theme    All themes
+
+Validate release type filters exist
+    user checks select contains option    id:filters-form-release-type    All release types
+    user checks selected option label    id:filters-form-release-type    All release types
+
+Validate sort controls exist
+    user checks select contains option    id:filters-form-sortBy    Newest
+    user checks select contains option    id:filters-form-sortBy    Oldest
+    user checks select contains option    id:filters-form-sortBy    A to Z
+
+Validate publications list exists
+    user checks page contains element    testid:publicationsList
+
+Searching
+    user clicks element    id:searchForm-search
+    user presses keys    pupil absence
+    user clicks button    Search
+    user checks page contains button    pupil absence
+    user checks page does not contain element    css:[class="govuk-warning-text"]
+
+Removing search
+    user clicks button    pupil absence
+    user waits until page does not contain button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}

--- a/tests/robot-tests/tests/general_public/statistics_page_azure_search.robot
+++ b/tests/robot-tests/tests/general_public/statistics_page_azure_search.robot
@@ -1,13 +1,12 @@
 *** Settings ***
 Resource            ../libs/public-common.robot
 Resource            ../seed_data/seed_data_theme_1_constants.robot
-Resource            ../seed_data/seed_data_theme_2_constants.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
-Force Tags          Dev    PreProd    Prod
+Force Tags          GeneralPublic    Dev    PreProd    Prod
 
 
 *** Test Cases ***
@@ -32,16 +31,19 @@ Validate sort controls exist
     user checks select contains option    id:filters-form-sortBy    Oldest
     user checks select contains option    id:filters-form-sortBy    A to Z
 
-Validate publications list exists
+Validate publications list exists and all publications are shown
     user checks page contains element    testid:publicationsList
+    user checks page contains element    xpath://p[contains(text(),"showing all publications")]
 
-Searching
+Search publications
     user clicks element    id:searchForm-search
     user presses keys    pupil absence
     user clicks button    Search
     user checks page contains button    pupil absence
     user checks page does not contain element    css:[class="govuk-warning-text"]
+    user checks page does not contain element    xpath://p[contains(text(),"showing all publications")]
 
-Removing search
+Validate search is reset by clearing search term
     user clicks button    pupil absence
-    user waits until page does not contain button    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
+    user waits until page does not contain button    pupil absence
+    user checks page contains element    xpath://p[contains(text(),"showing all publications")]


### PR DESCRIPTION
This PR adds a robot test for the find stats page when azure search is enabled (behind the feature flag).
It doesn't run locally, only on dev, preprod and prod environments as the azure search should already be configured for those environments. 

When this feature work goes live, we can replace the existing `statistics_page.robot` tests with this. 

We are intentionally not checking for search result _content_ as we can't guarantee what will be returned by azure search. 