### PR TITLE
Fix linter warnings in Search pipeline

### DIFF
--- a/infrastructure/templates/common/components/event-grid/eventGridMessaging.bicep
+++ b/infrastructure/templates/common/components/event-grid/eventGridMessaging.bicep
@@ -1,4 +1,3 @@
-import { abbreviations } from '../../abbreviations.bicep'
 import { buildFullyQualifiedTopicName } from '../../functions.bicep'
 import { IpRange } from '../../types.bicep'
 

--- a/infrastructure/templates/public-api/components/fileShare.bicep
+++ b/infrastructure/templates/public-api/components/fileShare.bicep
@@ -1,5 +1,4 @@
-import { responseTimeConfig } from 'alerts/dynamicAlertConfig.bicep'
-import { staticAverageLessThanHundred, staticMaxGreaterThanZero, staticAverageGreaterThanZero, capacity } from 'alerts/staticAlertConfig.bicep'
+import { staticAverageLessThanHundred, staticAverageGreaterThanZero } from 'alerts/staticAlertConfig.bicep'
 import { AllValuesForDimension } from 'alerts/types.bicep'
 import { percentage, gbsToBytes } from '../functions.bicep'
 
@@ -10,7 +9,7 @@ param fileShareQuotaGbs int = 6
 param fileShareName string
 
 @description('Type of the file share access tier')
-@allowed(['Cool','Hot','Premium','TransactionOptimized'])
+@allowed(['Cool', 'Hot', 'Premium', 'TransactionOptimized'])
 param fileShareAccessTier string = 'Hot'
 
 @description('Name of the Storage Account')
@@ -37,7 +36,7 @@ resource fileService 'Microsoft.Storage/storageAccounts/fileServices@2023-05-01'
 }
 
 resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-05-01' = {
-  name:  fileShareName
+  name: fileShareName
   parent: fileService
   properties: {
     accessTier: fileShareAccessTier

--- a/infrastructure/templates/public-api/components/storageAccount.bicep
+++ b/infrastructure/templates/public-api/components/storageAccount.bicep
@@ -1,4 +1,3 @@
-import { responseTimeConfig } from 'alerts/dynamicAlertConfig.bicep'
 import { staticAverageLessThanHundred, staticAverageGreaterThanZero } from 'alerts/staticAlertConfig.bicep'
 import { IpRange, StorageAccountPrivateEndpoints } from '../types.bicep'
 

--- a/infrastructure/templates/search/application/eventMessaging.bicep
+++ b/infrastructure/templates/search/application/eventMessaging.bicep
@@ -3,7 +3,6 @@ Sets up event messaging infrastructure using Azure Event Grid and ensures that b
 Publisher Function App have the necessary permissions to send events to the Event Grid topics.
 '''
 
-import { abbreviations } from '../../common/abbreviations.bicep'
 import { builtInRoleDefinitionIds } from '../../common/builtInRoles.bicep'
 import { eventTopics } from '../../common/eventTopics.bicep'
 import { buildFullyQualifiedTopicName } from '../../common/functions.bicep'


### PR DESCRIPTION
This PR fixes the following Bicep linter rule warnings seen in the Search Infrastructure and Deploy pipeline.

```
eventGridMessaging.bicep(1,10) : Warning no-unused-imports: Import "abbreviations" is declared but never used. [https://aka.ms/bicep/linter/no-unused-imports]
eventMessaging.bicep(6,10) : Warning no-unused-imports: Import "abbreviations" is declared but never used. [https://aka.ms/bicep/linter/no-unused-imports]
fileShare.bicep(1,10) : Warning no-unused-imports: Import "responseTimeConfig" is declared but never used. [https://aka.ms/bicep/linter/no-unused-imports]
fileShare.bicep(2,40) : Warning no-unused-imports: Import "staticMaxGreaterThanZero" is declared but never used. [https://aka.ms/bicep/linter/no-unused-imports]
fileShare.bicep(2,96) : Warning no-unused-imports: Import "capacity" is declared but never used. [https://aka.ms/bicep/linter/no-unused-imports]
storageAccount.bicep(1,10) : Warning no-unused-imports: Import "responseTimeConfig" is declared but never used. [https://aka.ms/bicep/linter/no-unused-imports]
```