### PR TITLE
EES-6085 - capture Public API "data set summary" call

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
@@ -15,7 +15,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Moq;
@@ -854,8 +853,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
             var response = await GetDataSetVersion(
                 dataSetId: dataSet.Id,
                 dataSetVersion: dataSetVersion.PublicVersion,
-                additionalHeaders: new Dictionary<string, string> { { RequestHeaderNames.RequestSource, "EES" } } 
-            );
+                requestSource: "EES");
 
             response.AssertOk<DataSetVersionViewModel>(useSystemJson: true);
 
@@ -867,13 +865,13 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
             Guid dataSetId,
             string dataSetVersion,
             Guid? previewTokenId = null,
-            Dictionary<string, string>? additionalHeaders = null,
+            string? requestSource = null,
             IContentApiClient? contentApiClient = null)
         {
             var client = BuildApp(contentApiClient)
                 .CreateClient()
                 .WithPreviewTokenHeader(previewTokenId)
-                .WithAdditionalHeaders(additionalHeaders);
+                .WithRequestSourceHeader(requestSource);
 
             var uri = new Uri($"{BaseUrl}/{dataSetId}/versions/{dataSetVersion}", UriKind.Relative);
 
@@ -2053,7 +2051,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
                 var response = await GetDataSetVersionChanges(
                     dataSetId: dataSet.Id,
                     dataSetVersion: dataSetVersion.PublicVersion,
-                    additionalHeaders: new Dictionary<string, string> { { RequestHeaderNames.RequestSource, "EES" } });
+                    requestSource: "EES");
 
                 response.AssertOk<DataSetVersionChangesViewModel>(useSystemJson: true);
 
@@ -2068,13 +2066,13 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
             IContentApiClient? contentApiClient = null,
             Guid? previewTokenId = null,
             ClaimsPrincipal? user = null,
-            Dictionary<string, string>? additionalHeaders = null)
+            string? requestSource = null)
         {
             var client = BuildApp(contentApiClient)
                 .WithUser(user)
                 .CreateClient()
                 .WithPreviewTokenHeader(previewTokenId)
-                .WithAdditionalHeaders(additionalHeaders);
+                .WithRequestSourceHeader(requestSource);
 
             var uri = new Uri($"{BaseUrl}/{dataSetId}/versions/{dataSetVersion}/changes", UriKind.Relative);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
@@ -20,7 +20,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
@@ -2987,7 +2986,7 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
                 debug: true,
                 page: 2,
                 pageSize: 3,
-                additionalHeaders: new Dictionary<string, string> { { RequestHeaderNames.RequestSource, "EES" } });
+                requestSource: "EES");
 
             var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
 
@@ -3101,7 +3100,7 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
         IDictionary<string, StringValues>? queryParameters = null,
         Guid? previewTokenId = null,
         WebApplicationFactory<Startup>? app = null,
-        Dictionary<string, string>? additionalHeaders = null)
+        string? requestSource = null)
     {
         var query = new Dictionary<string, StringValues>
         {
@@ -3141,7 +3140,7 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
         var client = (app ?? BuildApp())
             .CreateClient()
             .WithPreviewTokenHeader(previewTokenId)
-            .WithAdditionalHeaders(additionalHeaders);
+            .WithRequestSourceHeader(requestSource);
 
         var uri = QueryHelpers.AddQueryString($"{BaseUrl}/{dataSetId}/query", query);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
@@ -22,7 +22,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
@@ -4002,7 +4001,7 @@ public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory te
             var response = await QueryDataSet(
                 dataSetId: dataSetVersion.DataSetId,
                 request: request,
-                additionalHeaders: new Dictionary<string, string> { { RequestHeaderNames.RequestSource, "EES" } });
+                requestSource: "EES");
             
             response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
             
@@ -4145,7 +4144,7 @@ public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory te
         string? dataSetVersion = null,
         Guid? previewTokenId = null,
         WebApplicationFactory<Startup>? app = null,
-        Dictionary<string, string>? additionalHeaders = null)
+        string? requestSource = null)
     {
         var query = new Dictionary<string, StringValues>();
 
@@ -4157,7 +4156,7 @@ public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory te
         var client = (app ?? BuildApp())
             .CreateClient()
             .WithPreviewTokenHeader(previewTokenId)
-            .WithAdditionalHeaders(additionalHeaders);
+            .WithRequestSourceHeader(requestSource);
 
         var uri = QueryHelpers.AddQueryString($"{BaseUrl}/{dataSetId}/query", query);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Extensions/HttpClientExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Extensions/HttpClientExtensions.cs
@@ -9,11 +9,26 @@ public static class HttpClientExtensions
         this HttpClient client,
         Guid? previewToken)
     {
-        if (previewToken != null)
+        return client.WithOptionalHeader(RequestHeaderNames.PreviewToken, previewToken?.ToString());
+    }
+    
+    public static HttpClient WithRequestSourceHeader(
+        this HttpClient client,
+        string? requestSource)
+    {
+        return client.WithOptionalHeader(RequestHeaderNames.RequestSource, requestSource);
+    }
+    
+    private static HttpClient WithOptionalHeader(
+        this HttpClient client,
+        string headerName,
+        string? headerValue)
+    {
+        if (headerValue != null)
         {
             client.WithAdditionalHeaders(new Dictionary<string, string>
             {
-                { RequestHeaderNames.PreviewToken, previewToken.Value.ToString() }
+                { headerName, headerValue }
             });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/TestAnalyticsPathResolver.cs
@@ -1,30 +1,25 @@
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Services;
 
-public class TestAnalyticsPathResolver : IAnalyticsPathResolver, IDisposable
+public class TestAnalyticsPathResolver : AnalyticsPathResolverBase, IDisposable
 {
-    public void Dispose()
-    {
-        if (Directory.Exists(_basePath))
-        {
-            Directory.Delete(_basePath, recursive: true);
-        }
-    }
-
     private readonly string _basePath = Path.Combine(
         Path.GetTempPath(),
         "ExploreEducationStatistics",
         "Analytics",
         Guid.NewGuid().ToString());
 
-    public string PublicApiQueriesDirectoryPath()
+    protected override string GetBasePath()
     {
-        return Path.Combine(_basePath, "queries");
+        return _basePath;
     }
-
-    public string PublicApiDataSetVersionCallsDirectoryPath()
+    
+    public void Dispose()
     {
-        return Path.Combine(_basePath, "data-set-versions");
+        if (Directory.Exists(_basePath))
+        {
+            Directory.Delete(_basePath, recursive: true);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetLevelCallsStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetLevelCallsStrategyTests.cs
@@ -1,0 +1,94 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Snapshooter.Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Strategies;
+
+public abstract class AnalyticsWriteDataSetCallsStrategyTests
+{
+    public class ReportTests : AnalyticsWriteDataSetCallsStrategyTests
+    {
+        private const string SnapshotPrefix = $"{nameof(AnalyticsWriteDataSetCallsStrategyTests)}.{nameof(ReportTests)}";
+        
+        [Fact]
+        public async Task CallWrittenSuccessfully_WithCoreDataSetDetails()
+        {
+            using var pathResolver = new TestAnalyticsPathResolver();
+            
+            var strategy = BuildStrategy(
+                pathResolver: pathResolver,
+                dateTimeProvider: new DateTimeProvider(DateTime.Parse("2025-03-16T12:01:02Z")));
+            
+            await strategy.Report(new CaptureDataSetCallRequest(
+                DataSetId: new Guid("01d29401-7274-a871-a8db-d4bc4e98c324"),
+                DataSetTitle: "Data Set 1",
+                StartTime: DateTime.Parse("2025-02-28T03:07:44.850Z"),
+                PreviewToken: null,
+                Type: DataSetCallType.GetSummary), default);
+            
+            var files = Directory
+                .GetFiles(pathResolver.PublicApiDataSetCallsDirectoryPath());
+            
+            var filePath = Assert.Single(files);
+
+            var filename = filePath
+                .Split($"{pathResolver.PublicApiDataSetCallsDirectoryPath()}{Path.DirectorySeparatorChar}")[1];
+            Assert.StartsWith("20250316-120102_", filename);
+
+            Snapshot.Match(
+                currentResult: await File.ReadAllTextAsync(filePath),
+                snapshotName: $"{SnapshotPrefix}.{nameof(CallWrittenSuccessfully_WithCoreDataSetDetails)}");
+        }
+        
+        [Fact]
+        public async Task CallWrittenSuccessfully_WithPreviewToken()
+        {
+            using var pathResolver = new TestAnalyticsPathResolver();
+            
+            var strategy = BuildStrategy(
+                pathResolver: pathResolver,
+                dateTimeProvider: new DateTimeProvider(DateTime.Parse("2025-03-16T12:01:02Z")));
+            
+            await strategy.Report(new CaptureDataSetCallRequest(
+                DataSetId: new Guid("01d29401-7274-a871-a8db-d4bc4e98c324"),
+                DataSetTitle: "Data Set 1",
+                StartTime: DateTime.Parse("2025-02-26T03:07:44.850Z"),
+                PreviewToken: new PreviewTokenRequest(
+                    Label: "Preview token content",
+                    DataSetVersionId: new Guid("01d29401-7974-1276-a06b-b28a6a5385c6"),
+                    Created: DateTime.Parse("2025-02-23T11:02:44.850Z"),
+                    Expiry: DateTime.Parse("2025-02-24T11:02:44.850Z")),
+                Type: DataSetCallType.GetSummary), default);
+            
+            var files = Directory
+                .GetFiles(pathResolver.PublicApiDataSetCallsDirectoryPath());
+            
+            var filePath = Assert.Single(files);
+
+            var filename = filePath
+                .Split($"{pathResolver.PublicApiDataSetCallsDirectoryPath()}{Path.DirectorySeparatorChar}")[1];
+            Assert.StartsWith("20250316-120102_", filename);
+            Assert.StartsWith("20250316-120102_", filename);
+
+            Snapshot.Match(
+                currentResult: await File.ReadAllTextAsync(filePath),
+                snapshotName: $"{SnapshotPrefix}.{nameof(CallWrittenSuccessfully_WithPreviewToken)}");
+        }
+        
+        private static AnalyticsWriteDataSetCallsStrategy BuildStrategy(
+            IAnalyticsPathResolver pathResolver,
+            DateTimeProvider? dateTimeProvider = null)
+        {
+            return new AnalyticsWriteDataSetCallsStrategy(
+                pathResolver,
+                dateTimeProvider ?? new DateTimeProvider(),
+                Mock.Of<ILogger<AnalyticsWriteDataSetCallsStrategy>>());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithCoreDataSetDetails.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithCoreDataSetDetails.snap
@@ -1,0 +1,6 @@
+﻿{
+  "dataSetId": "01d29401-7274-a871-a8db-d4bc4e98c324",
+  "dataSetTitle": "Data Set 1",
+  "startTime": "2025-02-28T03:07:44.850Z",
+  "type": "GetSummary"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithPreviewToken.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithPreviewToken.snap
@@ -1,0 +1,12 @@
+﻿{
+  "dataSetId": "01d29401-7274-a871-a8db-d4bc4e98c324",
+  "dataSetTitle": "Data Set 1",
+  "previewToken": {
+    "created": "2025-02-23T11:02:44.850Z",
+    "dataSetVersionId": "01d29401-7974-1276-a06b-b28a6a5385c6",
+    "expiry": "2025-02-24T11:02:44.850Z",
+    "label": "Preview token content"
+  },
+  "startTime": "2025-02-26T03:07:44.850Z",
+  "type": "GetSummary"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
@@ -38,9 +38,9 @@ public static class AnalyticsServiceCollectionExtensions
             services.AddSingleton<IAnalyticsPathResolver, AnalyticsPathResolver>();
         }
 
-        services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicApiQueryStrategy>();
+        services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWriteDataSetCallsStrategy>();
         services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWriteDataSetVersionCallsStrategy>();
-
+        services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicApiQueryStrategy>();
         return services;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/AnalyticsCaptureRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/AnalyticsCaptureRequests.cs
@@ -5,6 +5,15 @@ using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
+public record CaptureDataSetCallRequest(
+    Guid DataSetId,
+    string DataSetTitle,
+    PreviewTokenRequest? PreviewToken,
+    DateTimeOffset StartTime,
+    [property:JsonConverter(typeof(StringEnumConverter))]
+    DataSetCallType Type
+) : IAnalyticsCaptureRequestBase;
+
 public record CaptureDataSetVersionQueryRequest(
     Guid DataSetId,
     Guid DataSetVersionId,
@@ -30,6 +39,12 @@ public record CaptureDataSetVersionCallRequest(
     DataSetVersionCallType Type,
     object? Parameters = null
 ) : IAnalyticsCaptureRequestBase;
+
+public enum DataSetCallType
+{
+    GetSummary,
+    GetVersions
+}
 
 public enum DataSetVersionCallType
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsPathResolver.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
-public class AnalyticsPathResolver : IAnalyticsPathResolver
+public class AnalyticsPathResolver : AnalyticsPathResolverBase
 {
     private readonly string _basePath;
 
@@ -18,19 +18,12 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
                 paramName: nameof(options)
             );
         }
-        
+
         _basePath = options.Value.BasePath;
     }
 
-    private string BasePath() => _basePath;
-
-    public string PublicApiQueriesDirectoryPath()
+    protected override string GetBasePath()
     {
-        return Path.Combine(BasePath(), "public-api", "queries");
-    }
-    
-    public string PublicApiDataSetVersionCallsDirectoryPath()
-    {
-        return Path.Combine(BasePath(), "public-api", "data-set-versions");
+        return _basePath;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsPathResolverBase.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsPathResolverBase.cs
@@ -1,0 +1,26 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
+
+public abstract class AnalyticsPathResolverBase : IAnalyticsPathResolver
+{
+    protected abstract string GetBasePath();
+    
+    public string PublicApiQueriesDirectoryPath()
+    {
+        return Path.Combine(GetBasePath(), "public-api", "queries");
+    }
+    
+    public string PublicApiDataSetCallsDirectoryPath()
+    {
+        return Path.Combine(GetBasePath(), "public-api", "data-sets");
+    }
+    
+    public string PublicApiDataSetVersionCallsDirectoryPath()
+    {
+        return Path.Combine(GetBasePath(), "public-api", "data-set-versions");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -29,11 +29,16 @@ internal class DataSetService(
         Guid dataSetId,
         CancellationToken cancellationToken = default)
     {
-        return await publicDataDbContext.DataSets
+        return await publicDataDbContext
+            .DataSets
             .AsNoTracking()
             .Include(ds => ds.LatestLiveVersion)
             .SingleOrNotFoundAsync(ds => ds.Id == dataSetId, cancellationToken: cancellationToken)
             .OnSuccessDo(userService.CheckCanViewDataSet)
+            .OnSuccessDo(ds => analyticsService.CaptureDataSetCall(
+                dataSetId: ds.Id,
+                type: DataSetCallType.GetSummary,
+                cancellationToken: cancellationToken))
             .OnSuccess(MapDataSet);
     }
 
@@ -103,7 +108,8 @@ internal class DataSetService(
         string dataSetVersion,
         CancellationToken cancellationToken = default)
     {
-        return await publicDataDbContext.DataSetVersions
+        return await publicDataDbContext
+            .DataSetVersions
             .AsNoTracking()
             .FindByVersion(
                 dataSetId: dataSetId,
@@ -124,7 +130,8 @@ internal class DataSetService(
         int pageSize,
         CancellationToken cancellationToken = default)
     {
-        return await publicDataDbContext.DataSets
+        return await publicDataDbContext
+            .DataSets
             .AsNoTracking()
             .SingleOrNotFoundAsync(ds => ds.Id == dataSetId, cancellationToken: cancellationToken)
             .OnSuccessDo(userService.CheckCanViewDataSet)
@@ -164,7 +171,8 @@ internal class DataSetService(
         int pageSize,
         CancellationToken cancellationToken = default)
     {
-        var queryable = publicDataDbContext.DataSetVersions
+        var queryable = publicDataDbContext
+            .DataSetVersions
             .AsNoTracking()
             .Where(ds => ds.DataSetId == dataSet.Id)
             .WherePublicStatus();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IAnalyticsPathResolver.cs
@@ -4,5 +4,7 @@ public interface IAnalyticsPathResolver
 {
     string PublicApiQueriesDirectoryPath();
     
+    string PublicApiDataSetCallsDirectoryPath();
+    
     string PublicApiDataSetVersionCallsDirectoryPath();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IAnalyticsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IAnalyticsService.cs
@@ -6,6 +6,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.In
 
 public interface IAnalyticsService
 {
+    Task CaptureDataSetCall(
+        Guid dataSetId,
+        DataSetCallType type,
+        CancellationToken cancellationToken = default);
+    
     Task CaptureDataSetVersionCall(
         Guid dataSetVersionId,
         DataSetVersionCallType type,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/LocalAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/LocalAnalyticsPathResolver.cs
@@ -1,12 +1,11 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
-public class LocalAnalyticsPathResolver : IAnalyticsPathResolver
+public class LocalAnalyticsPathResolver : AnalyticsPathResolverBase
 {
     private readonly string _basePath;
 
@@ -24,15 +23,8 @@ public class LocalAnalyticsPathResolver : IAnalyticsPathResolver
         _basePath = Path.Combine(PathUtils.ProjectRootPath, PathUtils.OsPath(originalPath));
     }
 
-    private string BasePath() => _basePath;
-
-    public string PublicApiQueriesDirectoryPath()
+    protected override string GetBasePath()
     {
-        return Path.Combine(BasePath(), "public-api", "queries");
-    }
-    
-    public string PublicApiDataSetVersionCallsDirectoryPath()
-    {
-        return Path.Combine(BasePath(), "public-api", "data-set-versions");
+        return _basePath;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetCallsStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetCallsStrategy.cs
@@ -7,29 +7,29 @@ using IAnalyticsPathResolver = GovUk.Education.ExploreEducationStatistics.Public
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
 
-public class AnalyticsWriteDataSetVersionCallsStrategy(
+public class AnalyticsWriteDataSetCallsStrategy(
     IAnalyticsPathResolver analyticsPathResolver,
     DateTimeProvider dateTimeProvider,
-    ILogger<AnalyticsWriteDataSetVersionCallsStrategy> logger
+    ILogger<AnalyticsWriteDataSetCallsStrategy> logger
     ) : IAnalyticsWriteStrategy
 {
-    public Type RequestType => typeof(CaptureDataSetVersionCallRequest);
+    public Type RequestType => typeof(CaptureDataSetCallRequest);
 
     public async Task Report(IAnalyticsCaptureRequestBase request, CancellationToken cancellationToken)
     {
-        if (request is not CaptureDataSetVersionCallRequest callRequest)
+        if (request is not CaptureDataSetCallRequest callRequest)
         {
-            throw new ArgumentException($"request isn't a {nameof(CaptureDataSetVersionCallRequest)}");
+            throw new ArgumentException($"request isn't a {nameof(CaptureDataSetCallRequest)}");
         }
         
         logger.LogInformation(
-            "Capturing DataSetVersion-level call of type {Type} for analytics - for data set {DataSetTitle}",
+            "Capturing DataSet-level call of type {Type} for analytics - for data set {DataSetTitle}",
             callRequest.Type,
             callRequest.DataSetTitle);
 
-        var directory = analyticsPathResolver.PublicApiDataSetVersionCallsDirectoryPath();
+        var directory = analyticsPathResolver.PublicApiDataSetCallsDirectoryPath();
         var filename =
-            $"{dateTimeProvider.UtcNow:yyyyMMdd-HHmmss}_{callRequest.DataSetVersionId}_{RandomUtils.RandomString()}.json";
+            $"{dateTimeProvider.UtcNow:yyyyMMdd-HHmmss}_{callRequest.DataSetId}_{RandomUtils.RandomString()}.json";
 
         try
         {


### PR DESCRIPTION
This PR:
- adds the first of a set of DataSet-level API calls - this time simply "Get summary".
- restructures the Public API's AnalyticsPathResolver to use an AnalyticsPathResolverBase to reduce duplication.
- a few other minor changes to improve readability.