### PR TITLE
EES-6085 - refactoring analytics components to use common workflows

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicApiDataSetCallsProcessorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicApiDataSetCallsProcessorTests.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Workflow;
-using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests.Services.Workflow.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using InterpolatedSql.Dapper;
@@ -25,23 +24,20 @@ public abstract class PublicApiDataSetCallsProcessorTests
         public async Task ProcessorUsesWorkflow()
         {
             using var pathResolver = new TestAnalyticsPathResolver();
-            SetupRequestFile(pathResolver, "WithCoreDataSetDetails.json");
 
-            var workflowActorBuilder = new WorkflowActorMockBuilder<PublicApiDataSetCallsProcessor>();
+            var workflow = new Mock<IProcessRequestFilesWorkflow>(MockBehavior.Strict);
+
+            workflow
+                .Setup(s => s.Process(It.IsAny<IWorkflowActor>()))
+                .Returns(Task.CompletedTask);
             
-            var workflowActor = workflowActorBuilder 
-                .WhereDuckDbInitialisedWithErrors()
-                .Build();
-
             var service = BuildService(
                 pathResolver: pathResolver,
-                workflowActor: workflowActor);
+                workflow: workflow.Object);
             
-            await Assert.ThrowsAsync<ArgumentException>(service.Process);
+            await service.Process();
 
-            workflowActorBuilder
-                .Assert
-                .InitialiseDuckDbCalled();
+            workflow.Verify(s => s.Process(It.IsAny<IWorkflowActor>()), Times.Once);
         }
 
         [Fact]
@@ -244,12 +240,12 @@ public abstract class PublicApiDataSetCallsProcessorTests
 
     private PublicApiDataSetCallsProcessor BuildService(
         TestAnalyticsPathResolver pathResolver,
-        IWorkflowActor<PublicApiDataSetCallsProcessor>? workflowActor = null)
+        IProcessRequestFilesWorkflow? workflow = null)
     {
         return new PublicApiDataSetCallsProcessor(
             pathResolver: pathResolver,
-            logger: Mock.Of<ILogger<PublicApiDataSetCallsProcessor>>(),
-            workflowActor: workflowActor);
+            workflow: workflow ?? new ProcessRequestFilesWorkflow(
+                logger: Mock.Of<ILogger<ProcessRequestFilesWorkflow>>()));
     }
 
     private void SetupRequestFile(TestAnalyticsPathResolver pathResolver, string filename)

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicApiDataSetVersionCallsProcessorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/PublicApiDataSetVersionCallsProcessorTests.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Workflow;
-using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests.Services.Workflow.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using InterpolatedSql.Dapper;
@@ -25,23 +24,20 @@ public abstract class PublicApiDataSetVersionCallsProcessorTests
         public async Task ProcessorUsesWorkflow()
         {
             using var pathResolver = new TestAnalyticsPathResolver();
-            SetupRequestFile(pathResolver, "WithCoreDataSetVersionDetails.json");
 
-            var workflowActorBuilder = new WorkflowActorMockBuilder<PublicApiDataSetVersionCallsProcessor>();
+            var workflow = new Mock<IProcessRequestFilesWorkflow>(MockBehavior.Strict);
+
+            workflow
+                .Setup(s => s.Process(It.IsAny<IWorkflowActor>()))
+                .Returns(Task.CompletedTask);
             
-            var workflowActor = workflowActorBuilder 
-                .WhereDuckDbInitialisedWithErrors()
-                .Build();
-
             var service = BuildService(
                 pathResolver: pathResolver,
-                workflowActor: workflowActor);
+                workflow: workflow.Object);
             
-            await Assert.ThrowsAsync<ArgumentException>(service.Process);
+            await service.Process();
 
-            workflowActorBuilder
-                .Assert
-                .InitialiseDuckDbCalled();
+            workflow.Verify(s => s.Process(It.IsAny<IWorkflowActor>()), Times.Once);
         }
 
         [Fact]
@@ -251,15 +247,15 @@ public abstract class PublicApiDataSetVersionCallsProcessorTests
             Assert.Null(queryReportRow.PreviewTokenDataSetVersionId);
         }
     }
-
+    
     private PublicApiDataSetVersionCallsProcessor BuildService(
         TestAnalyticsPathResolver pathResolver,
-        IWorkflowActor<PublicApiDataSetVersionCallsProcessor>? workflowActor = null)
+        IProcessRequestFilesWorkflow? workflow = null)
     {
         return new PublicApiDataSetVersionCallsProcessor(
             pathResolver: pathResolver,
-            logger: Mock.Of<ILogger<PublicApiDataSetVersionCallsProcessor>>(),
-            workflowActor: workflowActor);
+            workflow: workflow ?? new ProcessRequestFilesWorkflow(
+                logger: Mock.Of<ILogger<ProcessRequestFilesWorkflow>>()));
     }
 
     private void SetupRequestFile(TestAnalyticsPathResolver pathResolver, string filename)

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/Workflow/MockBuilders/WorkflowActorMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests/Services/Workflow/MockBuilders/WorkflowActorMockBuilder.cs
@@ -1,5 +1,4 @@
 using System.Data;
-using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Workflow;
 using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -7,22 +6,29 @@ using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Tests.Services.Workflow.MockBuilders;
 
-public class WorkflowActorMockBuilder<TRequestFileProcessor>
-    where TRequestFileProcessor : IRequestFileProcessor
+public class WorkflowActorMockBuilder
 {
-    private readonly Mock<IWorkflowActor<TRequestFileProcessor>> _mock = new(MockBehavior.Strict);
+    private readonly Mock<IWorkflowActor> _mock = new(MockBehavior.Strict);
 
     public WorkflowActorMockBuilder()
     {
         Assert = new Asserter(_mock);
     }
     
-    public IWorkflowActor<TRequestFileProcessor> Build()
+    public IWorkflowActor Build()
     {
+        _mock
+            .Setup(s => s.GetSourceDirectory())
+            .Returns("source");
+            
+        _mock
+            .Setup(s => s.GetReportsDirectory())
+            .Returns("reports");
+
         return _mock.Object;
     }
 
-    public WorkflowActorMockBuilder<TRequestFileProcessor> WhereDuckDbInitialisedSuccessfully()
+    public WorkflowActorMockBuilder WhereDuckDbInitialisedSuccessfully()
     {
         _mock
             .Setup(m => m.InitialiseDuckDb(ItIsOpenDuckDbConnection()))
@@ -30,7 +36,7 @@ public class WorkflowActorMockBuilder<TRequestFileProcessor>
         return this;
     }
     
-    public WorkflowActorMockBuilder<TRequestFileProcessor> WhereDuckDbInitialisedWithErrors()
+    public WorkflowActorMockBuilder WhereDuckDbInitialisedWithErrors()
     {
         _mock
             .Setup(m => m.InitialiseDuckDb(ItIsOpenDuckDbConnection()))
@@ -38,7 +44,7 @@ public class WorkflowActorMockBuilder<TRequestFileProcessor>
         return this;
     }
 
-    public WorkflowActorMockBuilder<TRequestFileProcessor> WhereSourceFilesAreProcessedSuccessfully(
+    public WorkflowActorMockBuilder WhereSourceFilesAreProcessedSuccessfully(
         string processingFolder,
         IEnumerable<string> sourceFiles)
     {
@@ -53,7 +59,7 @@ public class WorkflowActorMockBuilder<TRequestFileProcessor>
         return this;
     }
 
-    public WorkflowActorMockBuilder<TRequestFileProcessor> WhereSourceFilesAreProcessedWithErrors(
+    public WorkflowActorMockBuilder WhereSourceFilesAreProcessedWithErrors(
         string processingFolder,
         IEnumerable<string> sourceFiles)
     {
@@ -68,7 +74,7 @@ public class WorkflowActorMockBuilder<TRequestFileProcessor>
         return this;
     }
     
-    public WorkflowActorMockBuilder<TRequestFileProcessor> WhereReportsAreGeneratedSuccessfully(
+    public WorkflowActorMockBuilder WhereReportsAreGeneratedSuccessfully(
         string reportsFolder,
         string reportsFilenamePrefix)
     {
@@ -80,7 +86,7 @@ public class WorkflowActorMockBuilder<TRequestFileProcessor>
         return this;
     }
     
-    public WorkflowActorMockBuilder<TRequestFileProcessor> WhereReportsAreGeneratedWithErrors(
+    public WorkflowActorMockBuilder WhereReportsAreGeneratedWithErrors(
         string reportsFolder,
         string reportsFilenamePrefix)
     {
@@ -94,7 +100,7 @@ public class WorkflowActorMockBuilder<TRequestFileProcessor>
 
     public Asserter Assert { get; }
 
-    public class Asserter(Mock<IWorkflowActor<TRequestFileProcessor>> mock)
+    public class Asserter(Mock<IWorkflowActor> mock)
     {
         public Asserter InitialiseDuckDbCalled()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
@@ -1,6 +1,7 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Options;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Workflow;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -43,7 +44,8 @@ public static class ProcessorHostBuilder
                     .AddTransient<IRequestFileProcessor, PublicApiDataSetCallsProcessor>()
                     .AddTransient<IRequestFileProcessor, PublicApiDataSetVersionCallsProcessor>()
                     .AddTransient<IRequestFileProcessor, PublicApiQueriesProcessor>()
-                    .AddTransient<IRequestFileProcessor, PublicZipDownloadsProcessor>();
+                    .AddTransient<IRequestFileProcessor, PublicZipDownloadsProcessor>()
+                    .AddTransient<IProcessRequestFilesWorkflow, ProcessRequestFilesWorkflow>();
             });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicApiDataSetCallsProcessor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicApiDataSetCallsProcessor.cs
@@ -1,31 +1,33 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Workflow;
 using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
-using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
 
 public class PublicApiDataSetCallsProcessor(
     IAnalyticsPathResolver pathResolver,
-    ILogger<PublicApiDataSetCallsProcessor> logger,
-    IWorkflowActor<PublicApiDataSetCallsProcessor>? workflowActor = null) : IRequestFileProcessor
+    IProcessRequestFilesWorkflow workflow) : IRequestFileProcessor
 {
-    private readonly IWorkflowActor<PublicApiDataSetCallsProcessor> _workflowActor 
-        = workflowActor ?? new WorkflowActor();
-    
     public Task Process()
     {
-        var workflow = new ProcessRequestFilesWorkflow<PublicApiDataSetCallsProcessor>(
+        return workflow.Process(new WorkflowActor(
             sourceDirectory: pathResolver.PublicApiDataSetCallsDirectoryPath(),
-            reportsDirectory: pathResolver.PublicApiDataSetCallsReportsDirectoryPath(),
-            actor: _workflowActor,
-            logger: logger);
-
-        return workflow.Process();
+            reportsDirectory: pathResolver.PublicApiDataSetCallsReportsDirectoryPath()));
     }
 
-    private class WorkflowActor : IWorkflowActor<PublicApiDataSetCallsProcessor>
+    private class WorkflowActor(string sourceDirectory, string reportsDirectory) 
+        : IWorkflowActor
     {
+        public string GetSourceDirectory()
+        {
+            return sourceDirectory;
+        }
+
+        public string GetReportsDirectory()
+        {
+            return reportsDirectory;
+        }
+
         public async Task InitialiseDuckDb(DuckDbConnection connection)
         {
             await connection.ExecuteNonQueryAsync(@"

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicApiDataSetVersionCallsProcessor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicApiDataSetVersionCallsProcessor.cs
@@ -1,32 +1,33 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Workflow;
 using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
-using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
 
 public class PublicApiDataSetVersionCallsProcessor(
     IAnalyticsPathResolver pathResolver,
-    ILogger<PublicApiDataSetVersionCallsProcessor> logger,
-    IWorkflowActor<PublicApiDataSetVersionCallsProcessor>? workflowActor = null) : IRequestFileProcessor
+    IProcessRequestFilesWorkflow workflow) : IRequestFileProcessor
 {
-    private readonly IWorkflowActor<PublicApiDataSetVersionCallsProcessor> _workflowActor 
-        = workflowActor ?? new WorkflowActor();
-    
     public Task Process()
     {
-        var workflow = new ProcessRequestFilesWorkflow<PublicApiDataSetVersionCallsProcessor>(
+        return workflow.Process(new WorkflowActor(
             sourceDirectory: pathResolver.PublicApiDataSetVersionCallsDirectoryPath(),
-            reportsDirectory: pathResolver.PublicApiDataSetVersionCallsReportsDirectoryPath(),
-            actor: _workflowActor,
-            logger: logger);
-
-        return workflow.Process();
+            reportsDirectory: pathResolver.PublicApiDataSetVersionCallsReportsDirectoryPath()));
     }
 
-    private class WorkflowActor : IWorkflowActor<PublicApiDataSetVersionCallsProcessor>
+    private class WorkflowActor(string sourceDirectory, string reportsDirectory) 
+        : IWorkflowActor
     {
+        public string GetSourceDirectory()
+        {
+            return sourceDirectory;
+        }
+
+        public string GetReportsDirectory()
+        {
+            return reportsDirectory;
+        }
+        
         public async Task InitialiseDuckDb(DuckDbConnection connection)
         {
             await connection.ExecuteNonQueryAsync(@"

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicApiQueriesProcessor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicApiQueriesProcessor.cs
@@ -1,32 +1,33 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Workflow;
 using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
-using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
 
 public class PublicApiQueriesProcessor(
     IAnalyticsPathResolver pathResolver,
-    ILogger<PublicApiQueriesProcessor> logger,
-    IWorkflowActor<PublicApiQueriesProcessor>? workflowActor = null) : IRequestFileProcessor
+    IProcessRequestFilesWorkflow workflow) : IRequestFileProcessor
 {
-    private readonly IWorkflowActor<PublicApiQueriesProcessor> _workflowActor 
-        = workflowActor ?? new WorkflowActor();
-    
     public Task Process()
     {
-        var workflow = new ProcessRequestFilesWorkflow<PublicApiQueriesProcessor>(
+        return workflow.Process(new WorkflowActor(
             sourceDirectory: pathResolver.PublicApiQueriesDirectoryPath(),
-            reportsDirectory: pathResolver.PublicApiQueriesReportsDirectoryPath(),
-            actor: _workflowActor,
-            logger: logger);
-
-        return workflow.Process();
+            reportsDirectory: pathResolver.PublicApiQueriesReportsDirectoryPath()));
     }
 
-    private class WorkflowActor : IWorkflowActor<PublicApiQueriesProcessor>
+    private class WorkflowActor(string sourceDirectory, string reportsDirectory) 
+        : IWorkflowActor
     {
+        public string GetSourceDirectory()
+        {
+            return sourceDirectory;
+        }
+
+        public string GetReportsDirectory()
+        {
+            return reportsDirectory;
+        }
+        
         public async Task InitialiseDuckDb(DuckDbConnection connection)
         {
             await connection.ExecuteNonQueryAsync(@"

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicZipDownloadsProcessor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/PublicZipDownloadsProcessor.cs
@@ -1,32 +1,33 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Workflow;
 using GovUk.Education.ExploreEducationStatistics.Common.DuckDb.DuckDb;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
-using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services;
 
 public class PublicZipDownloadsProcessor(
     IAnalyticsPathResolver pathResolver,
-    ILogger<PublicZipDownloadsProcessor> logger,
-    IWorkflowActor<PublicZipDownloadsProcessor>? workflowActor = null) : IRequestFileProcessor
+    IProcessRequestFilesWorkflow workflow) : IRequestFileProcessor
 {
-    private readonly IWorkflowActor<PublicZipDownloadsProcessor> _workflowActor 
-        = workflowActor ?? new WorkflowActor();
-    
-    public Task Process() {
-    
-        var workflow = new ProcessRequestFilesWorkflow<PublicZipDownloadsProcessor>(
+    public Task Process()
+    {
+        return workflow.Process(new WorkflowActor(
             sourceDirectory: pathResolver.PublicZipDownloadsDirectoryPath(),
-            reportsDirectory: pathResolver.PublicZipDownloadsReportsDirectoryPath(),
-            actor: _workflowActor,
-            logger: logger);
-
-        return workflow.Process();
+            reportsDirectory: pathResolver.PublicZipDownloadsReportsDirectoryPath()));
     }
 
-    private class WorkflowActor : IWorkflowActor<PublicZipDownloadsProcessor>
+    private class WorkflowActor(string sourceDirectory, string reportsDirectory) 
+        : IWorkflowActor
     {
+        public string GetSourceDirectory()
+        {
+            return sourceDirectory;
+        }
+
+        public string GetReportsDirectory()
+        {
+            return reportsDirectory;
+        }
+        
         public async Task InitialiseDuckDb(DuckDbConnection connection)
         {
             await connection.ExecuteNonQueryAsync(@"

--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Workflow/ProcessRequestFilesWorkflow.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/Workflow/ProcessRequestFilesWorkflow.cs
@@ -5,6 +5,11 @@ using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services.Workflow;
 
+public interface IProcessRequestFilesWorkflow
+{
+    Task Process(IWorkflowActor actor);
+}
+
 /// <summary>
 /// This class represents a common workflow that a number of IRequestFileProcessor
 /// implementations use in order to generate their Parquet report files.
@@ -22,15 +27,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services
 /// implementation-specific steps along the way. 
 /// 
 /// </summary>
-/// <param name="sourceDirectory">
-///     Folder in which to find the source files to read in this workflow.
-/// </param>
-/// <param name="reportsDirectory">
-///     Folder in which to generate the Parquet report files in this workflow.
-/// </param>
-/// <param name="actor">
-///     The <see cref="IWorkflowActor{TRequestFileProcessor}" /> implementation being guided through the workflow.
-/// </param>
 /// <param name="logger">
 ///     Logger from the associated Processor.
 /// </param>
@@ -41,25 +37,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Analytics.Consumer.Services
 /// <param name="dateTimeProvider">
 ///     Optional <see cref="DateTimeProvider"/>. If not provided, defaults to providing the current time.  
 /// </param>
-public class ProcessRequestFilesWorkflow<TRequestFileProcessor>(
-    string sourceDirectory,
-    string reportsDirectory,
-    IWorkflowActor<TRequestFileProcessor> actor, 
-    ILogger<IRequestFileProcessor> logger,
+public class ProcessRequestFilesWorkflow(
+    ILogger<ProcessRequestFilesWorkflow> logger,
     IFileAccessor? fileAccessor = null,
     DateTimeProvider? dateTimeProvider = null)
-    where TRequestFileProcessor : IRequestFileProcessor
+    : IProcessRequestFilesWorkflow
 {
-    private readonly string _processingDirectory = Path.Combine(sourceDirectory, "processing");
-    private readonly string _failuresDirectory = Path.Combine(sourceDirectory, "failures");
     private readonly IFileAccessor _fileAccessor = fileAccessor ?? new FilesystemFileAccessor();
     private readonly DateTimeProvider _dateTimeProvider = dateTimeProvider ?? new DateTimeProvider();
 
-    public async Task Process()
+    public async Task Process(IWorkflowActor actor)
     {
-        var processorName = typeof(TRequestFileProcessor).Name;
+        var processorName = actor.GetType().FullName;
         
         logger.LogInformation("{Processor} triggered", processorName);
+
+        var sourceDirectory = actor.GetSourceDirectory();
+        var reportsDirectory = actor.GetReportsDirectory();
+        var processingDirectory = Path.Combine(sourceDirectory, "processing");
+        var failuresDirectory = Path.Combine(sourceDirectory, "failures");
         
         if (!_fileAccessor.DirectoryExists(sourceDirectory))
         {
@@ -83,12 +79,12 @@ public class ProcessRequestFilesWorkflow<TRequestFileProcessor>(
 
         await actor.InitialiseDuckDb(duckDbConnection);
 
-        _fileAccessor.CreateDirectory(_processingDirectory);
+        _fileAccessor.CreateDirectory(processingDirectory);
 
         Parallel.ForEach(filesToProcess, file =>
         {
             var originalPath = Path.Combine(sourceDirectory, file);
-            var newPath = Path.Combine(_processingDirectory, file);
+            var newPath = Path.Combine(processingDirectory, file);
             _fileAccessor.Move(originalPath, newPath);
         });
 
@@ -99,7 +95,7 @@ public class ProcessRequestFilesWorkflow<TRequestFileProcessor>(
             try
             {
                 await actor.ProcessSourceFile(
-                    sourceFilePath: Path.Combine(_processingDirectory, filename),
+                    sourceFilePath: Path.Combine(processingDirectory, filename),
                     connection: duckDbConnection);
 
                 someFilesProcessedSuccessfully = true;
@@ -107,11 +103,14 @@ public class ProcessRequestFilesWorkflow<TRequestFileProcessor>(
             catch (Exception e)
             {
                 logger.LogError(e, "Failed to process request file {Filename}", filename);
-                MoveBadFileToFailuresDirectory(filename);
+                MoveBadFileToFailuresDirectory(
+                    filename: filename,
+                    processingDirectory: processingDirectory,
+                    failuresDirectory: failuresDirectory);
             }
         }
 
-        _fileAccessor.DeleteDirectory(_processingDirectory);
+        _fileAccessor.DeleteDirectory(processingDirectory);
 
         // If no files were successfully processed, there is no need to generate
         // reports, so exit early.
@@ -131,14 +130,17 @@ public class ProcessRequestFilesWorkflow<TRequestFileProcessor>(
             connection: duckDbConnection);
     }
 
-    private void MoveBadFileToFailuresDirectory(string filename)
+    private void MoveBadFileToFailuresDirectory(
+        string filename,
+        string processingDirectory,
+        string failuresDirectory)
     {
         try
         {
-            _fileAccessor.CreateDirectory(_failuresDirectory);
+            _fileAccessor.CreateDirectory(failuresDirectory);
 
-            var fileSourcePath = Path.Combine(_processingDirectory, filename);
-            var fileDestPath = Path.Combine(_failuresDirectory, filename);
+            var fileSourcePath = Path.Combine(processingDirectory, filename);
+            var fileDestPath = Path.Combine(failuresDirectory, filename);
             _fileAccessor.Move(fileSourcePath, fileDestPath);
         }
         catch (Exception e)
@@ -207,16 +209,19 @@ internal class FilesystemFileAccessor : IFileAccessor
 
 /// <summary>
 /// This class represents an actor who is guided through the workflow
-/// as implemented in <see cref="ProcessRequestFilesWorkflow{TRequestFileProcessor}"/>.
+/// as implemented in <see cref="ProcessRequestFilesWorkflow"/>.
 ///
 /// This class is responsible for implementing steps that
 /// are carried out during the workflow that are specific to individual
 /// use cases e.g. collecting data about and generating Parquet report
 /// files for Public API queries.
 /// </summary>
-public interface IWorkflowActor<TRequestFileProcessor>
-    where TRequestFileProcessor : IRequestFileProcessor
+public interface IWorkflowActor
 {
+    string GetSourceDirectory();
+    
+    string GetReportsDirectory();
+
     /// <summary>
     /// Create any initial tables and state needed for collecting information
     /// from source files.

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Analytics/AnalyticsTestUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Analytics/AnalyticsTestUtils.cs
@@ -1,0 +1,105 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Analytics;
+
+public static class AnalyticsTheoryData
+{
+    public record PreviewTokenSummary(
+        string Label,
+        DateTimeOffset Created,
+        DateTimeOffset Expiry);
+
+    public static readonly TheoryData<PreviewTokenSummary>
+        PreviewTokens =
+        [
+            null,
+            new(Label: "Preview token",
+                Created: DateTimeOffset.UtcNow.AddDays(-1),
+                Expiry: DateTimeOffset.UtcNow.AddDays(1))
+        ];
+
+    public static readonly TheoryData<(PreviewTokenSummary?, string?)>
+        PreviewTokensAndRequestedDataSetVersions =
+        [
+            (null, null),
+            (new PreviewTokenSummary(Label: "Preview token",
+                Created: DateTimeOffset.UtcNow.AddDays(-1),
+                Expiry: DateTimeOffset.UtcNow.AddDays(1)), "1.0.*")
+        ];
+}
+
+public static class AnalyticsTestAssertions
+{
+    public static async Task AssertDataSetVersionAnalyticsCallCaptured(
+        DataSet dataSet,
+        DataSetVersion dataSetVersion,
+        DataSetVersionCallType expectedType,
+        string expectedAnalyticsPath,
+        object? expectedParameters,
+        string? expectedRequestedDataSetVersion,
+        AnalyticsTheoryData.PreviewTokenSummary? expectedPreviewToken)
+    {
+        // Add a slight delay as the writing of the analytics capture is non-blocking
+        // and could occur slightly after the Controller response is returned to the user.
+        Thread.Sleep(2000);
+
+        // Expect the successful call to have been recorded for analytics.
+        Assert.True(Directory.Exists(expectedAnalyticsPath));
+        var analyticsFiles = Directory.GetFiles(expectedAnalyticsPath);
+        var analyticFile = Assert.Single(analyticsFiles);
+        var contents = await File.ReadAllTextAsync(analyticFile);
+
+        var capturedCall = JsonConvert.DeserializeObject<CaptureDataSetVersionCallRequest>(contents);
+
+        Assert.NotNull(capturedCall);
+        Assert.Equal(expectedType, capturedCall.Type);
+        Assert.Equal(dataSet.Id, capturedCall.DataSetId);
+        Assert.Equal(dataSet.Title, capturedCall.DataSetTitle);
+        Assert.Equal(dataSetVersion.Id, capturedCall.DataSetVersionId);
+        Assert.Equal(dataSetVersion.SemVersion().ToString(), capturedCall.DataSetVersion);
+        Assert.Equal(expectedRequestedDataSetVersion, capturedCall.RequestedDataSetVersion);
+        capturedCall.StartTime.AssertUtcNow(withinMillis: 5000);
+
+        if (expectedParameters == null)
+        {
+            Assert.Null(capturedCall.Parameters);
+        }
+        else
+        {
+            // Expect any additional parameters to have been recorded. 
+            Assert.NotNull(capturedCall.Parameters);
+            var parameters = JsonConvert.DeserializeObject(
+                capturedCall.Parameters.ToString()!, expectedParameters.GetType());
+            Assert.NotNull(parameters);
+            parameters.AssertDeepEqualTo(expectedParameters);
+        }
+        
+        if (expectedPreviewToken == null)
+        {
+            Assert.Null(capturedCall.PreviewToken);
+        }
+        else
+        {
+            Assert.NotNull(capturedCall.PreviewToken);
+            Assert.Equal(expectedPreviewToken.Label, capturedCall.PreviewToken.Label);
+            Assert.Equal(dataSetVersion.Id, capturedCall.PreviewToken.DataSetVersionId);
+            Assert.Equal(expectedPreviewToken.Created.TruncateMicroseconds(),
+                capturedCall.PreviewToken.Created);
+            Assert.Equal(expectedPreviewToken.Expiry.TruncateMicroseconds(), capturedCall.PreviewToken.Expiry);
+        }
+    }
+
+    public static void AssertAnalyticsCallNotCaptured(string expectedAnalyticsPath)
+    {
+        // Add a slight delay as the writing of the analytics capture is non-blocking
+        // and could occur slightly after the Controller response is returned to the user.
+        Thread.Sleep(2000);
+
+        // Expect that nothing was recorded for analytics.
+        Assert.False(Directory.Exists(expectedAnalyticsPath));
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetVersionsControllerTests.cs
@@ -15,7 +15,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Moq;
@@ -854,8 +853,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
             var response = await GetDataSetVersion(
                 dataSetId: dataSet.Id,
                 dataSetVersion: dataSetVersion.PublicVersion,
-                additionalHeaders: new Dictionary<string, string> { { RequestHeaderNames.RequestSource, "EES" } } 
-            );
+                requestSource: "EES");
 
             response.AssertOk<DataSetVersionViewModel>(useSystemJson: true);
 
@@ -867,13 +865,13 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
             Guid dataSetId,
             string dataSetVersion,
             Guid? previewTokenId = null,
-            Dictionary<string, string>? additionalHeaders = null,
+            string? requestSource = null,
             IContentApiClient? contentApiClient = null)
         {
             var client = BuildApp(contentApiClient)
                 .CreateClient()
                 .WithPreviewTokenHeader(previewTokenId)
-                .WithAdditionalHeaders(additionalHeaders);
+                .WithRequestSourceHeader(requestSource);
 
             var uri = new Uri($"{BaseUrl}/{dataSetId}/versions/{dataSetVersion}", UriKind.Relative);
 
@@ -2053,7 +2051,7 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
                 var response = await GetDataSetVersionChanges(
                     dataSetId: dataSet.Id,
                     dataSetVersion: dataSetVersion.PublicVersion,
-                    additionalHeaders: new Dictionary<string, string> { { RequestHeaderNames.RequestSource, "EES" } });
+                    requestSource: "EES");
 
                 response.AssertOk<DataSetVersionChangesViewModel>(useSystemJson: true);
 
@@ -2068,13 +2066,13 @@ public abstract class DataSetVersionsControllerTests(TestApplicationFactory test
             IContentApiClient? contentApiClient = null,
             Guid? previewTokenId = null,
             ClaimsPrincipal? user = null,
-            Dictionary<string, string>? additionalHeaders = null)
+            string? requestSource = null)
         {
             var client = BuildApp(contentApiClient)
                 .WithUser(user)
                 .CreateClient()
                 .WithPreviewTokenHeader(previewTokenId)
-                .WithAdditionalHeaders(additionalHeaders);
+                .WithRequestSourceHeader(requestSource);
 
             var uri = new Uri($"{BaseUrl}/{dataSetId}/versions/{dataSetVersion}/changes", UriKind.Relative);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerGetQueryTests.cs
@@ -20,7 +20,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
@@ -2987,7 +2986,7 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
                 debug: true,
                 page: 2,
                 pageSize: 3,
-                additionalHeaders: new Dictionary<string, string> { { RequestHeaderNames.RequestSource, "EES" } });
+                requestSource: "EES");
 
             var viewModel = response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
 
@@ -3101,7 +3100,7 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
         IDictionary<string, StringValues>? queryParameters = null,
         Guid? previewTokenId = null,
         WebApplicationFactory<Startup>? app = null,
-        Dictionary<string, string>? additionalHeaders = null)
+        string? requestSource = null)
     {
         var query = new Dictionary<string, StringValues>
         {
@@ -3141,7 +3140,7 @@ public abstract class DataSetsControllerGetQueryTests(TestApplicationFactory tes
         var client = (app ?? BuildApp())
             .CreateClient()
             .WithPreviewTokenHeader(previewTokenId)
-            .WithAdditionalHeaders(additionalHeaders);
+            .WithRequestSourceHeader(requestSource);
 
         var uri = QueryHelpers.AddQueryString($"{BaseUrl}/{dataSetId}/query", query);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Controllers/DataSetsControllerPostQueryTests.cs
@@ -22,7 +22,6 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
@@ -4002,7 +4001,7 @@ public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory te
             var response = await QueryDataSet(
                 dataSetId: dataSetVersion.DataSetId,
                 request: request,
-                additionalHeaders: new Dictionary<string, string> { { RequestHeaderNames.RequestSource, "EES" } });
+                requestSource: "EES");
             
             response.AssertOk<DataSetQueryPaginatedResultsViewModel>(useSystemJson: true);
             
@@ -4145,7 +4144,7 @@ public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory te
         string? dataSetVersion = null,
         Guid? previewTokenId = null,
         WebApplicationFactory<Startup>? app = null,
-        Dictionary<string, string>? additionalHeaders = null)
+        string? requestSource = null)
     {
         var query = new Dictionary<string, StringValues>();
 
@@ -4157,7 +4156,7 @@ public abstract class DataSetsControllerPostQueryTests(TestApplicationFactory te
         var client = (app ?? BuildApp())
             .CreateClient()
             .WithPreviewTokenHeader(previewTokenId)
-            .WithAdditionalHeaders(additionalHeaders);
+            .WithRequestSourceHeader(requestSource);
 
         var uri = QueryHelpers.AddQueryString($"{BaseUrl}/{dataSetId}/query", query);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Extensions/HttpClientExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Extensions/HttpClientExtensions.cs
@@ -9,11 +9,26 @@ public static class HttpClientExtensions
         this HttpClient client,
         Guid? previewToken)
     {
-        if (previewToken != null)
+        return client.WithOptionalHeader(RequestHeaderNames.PreviewToken, previewToken?.ToString());
+    }
+    
+    public static HttpClient WithRequestSourceHeader(
+        this HttpClient client,
+        string? requestSource)
+    {
+        return client.WithOptionalHeader(RequestHeaderNames.RequestSource, requestSource);
+    }
+    
+    private static HttpClient WithOptionalHeader(
+        this HttpClient client,
+        string headerName,
+        string? headerValue)
+    {
+        if (headerValue != null)
         {
             client.WithAdditionalHeaders(new Dictionary<string, string>
             {
-                { RequestHeaderNames.PreviewToken, previewToken.Value.ToString() }
+                { headerName, headerValue }
             });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/TestAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Services/TestAnalyticsPathResolver.cs
@@ -1,30 +1,25 @@
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Services;
 
-public class TestAnalyticsPathResolver : IAnalyticsPathResolver, IDisposable
+public class TestAnalyticsPathResolver : AnalyticsPathResolverBase, IDisposable
 {
-    public void Dispose()
-    {
-        if (Directory.Exists(_basePath))
-        {
-            Directory.Delete(_basePath, recursive: true);
-        }
-    }
-
     private readonly string _basePath = Path.Combine(
         Path.GetTempPath(),
         "ExploreEducationStatistics",
         "Analytics",
         Guid.NewGuid().ToString());
 
-    public string PublicApiQueriesDirectoryPath()
+    protected override string GetBasePath()
     {
-        return Path.Combine(_basePath, "queries");
+        return _basePath;
     }
-
-    public string PublicApiDataSetVersionCallsDirectoryPath()
+    
+    public void Dispose()
     {
-        return Path.Combine(_basePath, "data-set-versions");
+        if (Directory.Exists(_basePath))
+        {
+            Directory.Delete(_basePath, recursive: true);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetLevelCallsStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetLevelCallsStrategyTests.cs
@@ -1,0 +1,94 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Snapshooter.Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Strategies;
+
+public abstract class AnalyticsWriteDataSetCallsStrategyTests
+{
+    public class ReportTests : AnalyticsWriteDataSetCallsStrategyTests
+    {
+        private const string SnapshotPrefix = $"{nameof(AnalyticsWriteDataSetCallsStrategyTests)}.{nameof(ReportTests)}";
+        
+        [Fact]
+        public async Task CallWrittenSuccessfully_WithCoreDataSetDetails()
+        {
+            using var pathResolver = new TestAnalyticsPathResolver();
+            
+            var strategy = BuildStrategy(
+                pathResolver: pathResolver,
+                dateTimeProvider: new DateTimeProvider(DateTime.Parse("2025-03-16T12:01:02Z")));
+            
+            await strategy.Report(new CaptureDataSetCallRequest(
+                DataSetId: new Guid("01d29401-7274-a871-a8db-d4bc4e98c324"),
+                DataSetTitle: "Data Set 1",
+                StartTime: DateTime.Parse("2025-02-28T03:07:44.850Z"),
+                PreviewToken: null,
+                Type: DataSetCallType.GetSummary), default);
+            
+            var files = Directory
+                .GetFiles(pathResolver.PublicApiDataSetCallsDirectoryPath());
+            
+            var filePath = Assert.Single(files);
+
+            var filename = filePath
+                .Split($"{pathResolver.PublicApiDataSetCallsDirectoryPath()}{Path.DirectorySeparatorChar}")[1];
+            Assert.StartsWith("20250316-120102_", filename);
+
+            Snapshot.Match(
+                currentResult: await File.ReadAllTextAsync(filePath),
+                snapshotName: $"{SnapshotPrefix}.{nameof(CallWrittenSuccessfully_WithCoreDataSetDetails)}");
+        }
+        
+        [Fact]
+        public async Task CallWrittenSuccessfully_WithPreviewToken()
+        {
+            using var pathResolver = new TestAnalyticsPathResolver();
+            
+            var strategy = BuildStrategy(
+                pathResolver: pathResolver,
+                dateTimeProvider: new DateTimeProvider(DateTime.Parse("2025-03-16T12:01:02Z")));
+            
+            await strategy.Report(new CaptureDataSetCallRequest(
+                DataSetId: new Guid("01d29401-7274-a871-a8db-d4bc4e98c324"),
+                DataSetTitle: "Data Set 1",
+                StartTime: DateTime.Parse("2025-02-26T03:07:44.850Z"),
+                PreviewToken: new PreviewTokenRequest(
+                    Label: "Preview token content",
+                    DataSetVersionId: new Guid("01d29401-7974-1276-a06b-b28a6a5385c6"),
+                    Created: DateTime.Parse("2025-02-23T11:02:44.850Z"),
+                    Expiry: DateTime.Parse("2025-02-24T11:02:44.850Z")),
+                Type: DataSetCallType.GetSummary), default);
+            
+            var files = Directory
+                .GetFiles(pathResolver.PublicApiDataSetCallsDirectoryPath());
+            
+            var filePath = Assert.Single(files);
+
+            var filename = filePath
+                .Split($"{pathResolver.PublicApiDataSetCallsDirectoryPath()}{Path.DirectorySeparatorChar}")[1];
+            Assert.StartsWith("20250316-120102_", filename);
+            Assert.StartsWith("20250316-120102_", filename);
+
+            Snapshot.Match(
+                currentResult: await File.ReadAllTextAsync(filePath),
+                snapshotName: $"{SnapshotPrefix}.{nameof(CallWrittenSuccessfully_WithPreviewToken)}");
+        }
+        
+        private static AnalyticsWriteDataSetCallsStrategy BuildStrategy(
+            IAnalyticsPathResolver pathResolver,
+            DateTimeProvider? dateTimeProvider = null)
+        {
+            return new AnalyticsWriteDataSetCallsStrategy(
+                pathResolver,
+                dateTimeProvider ?? new DateTimeProvider(),
+                Mock.Of<ILogger<AnalyticsWriteDataSetCallsStrategy>>());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetLevelCallsStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetLevelCallsStrategyTests.cs
@@ -87,8 +87,9 @@ public abstract class AnalyticsWriteDataSetCallsStrategyTests
         {
             return new AnalyticsWriteDataSetCallsStrategy(
                 pathResolver,
-                dateTimeProvider ?? new DateTimeProvider(),
-                Mock.Of<ILogger<AnalyticsWriteDataSetCallsStrategy>>());
+                new CommonAnalyticsWriteStrategyWorkflow<CaptureDataSetCallRequest>(
+                    dateTimeProvider: dateTimeProvider ?? new DateTimeProvider(),
+                    Mock.Of<ILogger<CommonAnalyticsWriteStrategyWorkflow<CaptureDataSetCallRequest>>>()));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetLevelCallsStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetLevelCallsStrategyTests.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies.Workflow;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Services;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetVersionLevelCallsStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetVersionLevelCallsStrategyTests.cs
@@ -126,8 +126,9 @@ public abstract class AnalyticsWriteDataSetVersionCallsStrategyTests
         {
             return new AnalyticsWriteDataSetVersionCallsStrategy(
                 pathResolver,
-                dateTimeProvider ?? new DateTimeProvider(),
-                Mock.Of<ILogger<AnalyticsWriteDataSetVersionCallsStrategy>>());
+                new CommonAnalyticsWriteStrategyWorkflow<CaptureDataSetVersionCallRequest>(
+                    dateTimeProvider: dateTimeProvider ?? new DateTimeProvider(),
+                    Mock.Of<ILogger<CommonAnalyticsWriteStrategyWorkflow<CaptureDataSetVersionCallRequest>>>()));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetVersionLevelCallsStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWriteDataSetVersionLevelCallsStrategyTests.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies.Workflow;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Services;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWritePublicApiQueryStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWritePublicApiQueryStrategyTests.cs
@@ -2,6 +2,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies.Workflow;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.Services;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWritePublicApiQueryStrategyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/AnalyticsWritePublicApiQueryStrategyTests.cs
@@ -89,8 +89,9 @@ public abstract class AnalyticsWritePublicApiQueryStrategyTests
         {
             return new AnalyticsWritePublicApiQueryStrategy(
                 pathResolver,
-                dateTimeProvider ?? new DateTimeProvider(),
-                Mock.Of<ILogger<AnalyticsWritePublicApiQueryStrategy>>());
+                new CommonAnalyticsWriteStrategyWorkflow<CaptureDataSetVersionQueryRequest>(
+                    dateTimeProvider: dateTimeProvider ?? new DateTimeProvider(),
+                    Mock.Of<ILogger<CommonAnalyticsWriteStrategyWorkflow<CaptureDataSetVersionQueryRequest>>>()));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithCoreDataSetDetails.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithCoreDataSetDetails.snap
@@ -1,0 +1,6 @@
+﻿{
+  "dataSetId": "01d29401-7274-a871-a8db-d4bc4e98c324",
+  "dataSetTitle": "Data Set 1",
+  "startTime": "2025-02-28T03:07:44.850Z",
+  "type": "GetSummary"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithPreviewToken.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/Strategies/__snapshots__/AnalyticsWriteDataSetCallsStrategyTests.ReportTests.CallWrittenSuccessfully_WithPreviewToken.snap
@@ -1,0 +1,12 @@
+﻿{
+  "dataSetId": "01d29401-7274-a871-a8db-d4bc4e98c324",
+  "dataSetTitle": "Data Set 1",
+  "previewToken": {
+    "created": "2025-02-23T11:02:44.850Z",
+    "dataSetVersionId": "01d29401-7974-1276-a06b-b28a6a5385c6",
+    "expiry": "2025-02-24T11:02:44.850Z",
+    "label": "Preview token content"
+  },
+  "startTime": "2025-02-26T03:07:44.850Z",
+  "type": "GetSummary"
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Extensions;
 
@@ -41,6 +42,9 @@ public static class AnalyticsServiceCollectionExtensions
         services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWriteDataSetCallsStrategy>();
         services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWriteDataSetVersionCallsStrategy>();
         services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicApiQueryStrategy>();
+        services.AddTransient(
+            typeof(ICommonAnalyticsWriteStrategyWorkflow<>),
+            typeof(CommonAnalyticsWriteStrategyWorkflow<>));
         return services;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
@@ -38,9 +38,9 @@ public static class AnalyticsServiceCollectionExtensions
             services.AddSingleton<IAnalyticsPathResolver, AnalyticsPathResolver>();
         }
 
-        services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicApiQueryStrategy>();
+        services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWriteDataSetCallsStrategy>();
         services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWriteDataSetVersionCallsStrategy>();
-
+        services.AddTransient<IAnalyticsWriteStrategy, AnalyticsWritePublicApiQueryStrategy>();
         return services;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Extensions/AnalyticsServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies.Workflow;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Extensions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/AnalyticsCaptureRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Requests/AnalyticsCaptureRequests.cs
@@ -5,6 +5,15 @@ using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 
+public record CaptureDataSetCallRequest(
+    Guid DataSetId,
+    string DataSetTitle,
+    PreviewTokenRequest? PreviewToken,
+    DateTimeOffset StartTime,
+    [property:JsonConverter(typeof(StringEnumConverter))]
+    DataSetCallType Type
+) : IAnalyticsCaptureRequestBase;
+
 public record CaptureDataSetVersionQueryRequest(
     Guid DataSetId,
     Guid DataSetVersionId,
@@ -30,6 +39,12 @@ public record CaptureDataSetVersionCallRequest(
     DataSetVersionCallType Type,
     object? Parameters = null
 ) : IAnalyticsCaptureRequestBase;
+
+public enum DataSetCallType
+{
+    GetSummary,
+    GetVersions
+}
 
 public enum DataSetVersionCallType
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsPathResolver.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
-public class AnalyticsPathResolver : IAnalyticsPathResolver
+public class AnalyticsPathResolver : AnalyticsPathResolverBase
 {
     private readonly string _basePath;
 
@@ -18,19 +18,12 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
                 paramName: nameof(options)
             );
         }
-        
+
         _basePath = options.Value.BasePath;
     }
 
-    private string BasePath() => _basePath;
-
-    public string PublicApiQueriesDirectoryPath()
+    protected override string GetBasePath()
     {
-        return Path.Combine(BasePath(), "public-api", "queries");
-    }
-    
-    public string PublicApiDataSetVersionCallsDirectoryPath()
-    {
-        return Path.Combine(BasePath(), "public-api", "data-set-versions");
+        return _basePath;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsPathResolverBase.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/AnalyticsPathResolverBase.cs
@@ -1,0 +1,26 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
+
+public abstract class AnalyticsPathResolverBase : IAnalyticsPathResolver
+{
+    protected abstract string GetBasePath();
+    
+    public string PublicApiQueriesDirectoryPath()
+    {
+        return Path.Combine(GetBasePath(), "public-api", "queries");
+    }
+    
+    public string PublicApiDataSetCallsDirectoryPath()
+    {
+        return Path.Combine(GetBasePath(), "public-api", "data-sets");
+    }
+    
+    public string PublicApiDataSetVersionCallsDirectoryPath()
+    {
+        return Path.Combine(GetBasePath(), "public-api", "data-set-versions");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -110,6 +110,11 @@ internal class DataSetService(
                 version: dataSetVersion,
                 cancellationToken: cancellationToken)
             .OnSuccessDo(userService.CheckCanViewDataSetVersion)
+            .OnSuccessDo(dsv => analyticsService.CaptureDataSetVersionCall(
+                dataSetVersionId: dsv.Id,
+                type: DataSetVersionCallType.GetSummary,
+                requestedDataSetVersion: dataSetVersion,
+                cancellationToken: cancellationToken))
             .OnSuccess(MapDataSetVersion);
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/DataSetService.cs
@@ -29,11 +29,16 @@ internal class DataSetService(
         Guid dataSetId,
         CancellationToken cancellationToken = default)
     {
-        return await publicDataDbContext.DataSets
+        return await publicDataDbContext
+            .DataSets
             .AsNoTracking()
             .Include(ds => ds.LatestLiveVersion)
             .SingleOrNotFoundAsync(ds => ds.Id == dataSetId, cancellationToken: cancellationToken)
             .OnSuccessDo(userService.CheckCanViewDataSet)
+            .OnSuccessDo(ds => analyticsService.CaptureDataSetCall(
+                dataSetId: ds.Id,
+                type: DataSetCallType.GetSummary,
+                cancellationToken: cancellationToken))
             .OnSuccess(MapDataSet);
     }
 
@@ -103,7 +108,8 @@ internal class DataSetService(
         string dataSetVersion,
         CancellationToken cancellationToken = default)
     {
-        return await publicDataDbContext.DataSetVersions
+        return await publicDataDbContext
+            .DataSetVersions
             .AsNoTracking()
             .FindByVersion(
                 dataSetId: dataSetId,
@@ -124,7 +130,8 @@ internal class DataSetService(
         int pageSize,
         CancellationToken cancellationToken = default)
     {
-        return await publicDataDbContext.DataSets
+        return await publicDataDbContext
+            .DataSets
             .AsNoTracking()
             .SingleOrNotFoundAsync(ds => ds.Id == dataSetId, cancellationToken: cancellationToken)
             .OnSuccessDo(userService.CheckCanViewDataSet)
@@ -164,7 +171,8 @@ internal class DataSetService(
         int pageSize,
         CancellationToken cancellationToken = default)
     {
-        var queryable = publicDataDbContext.DataSetVersions
+        var queryable = publicDataDbContext
+            .DataSetVersions
             .AsNoTracking()
             .Where(ds => ds.DataSetId == dataSet.Id)
             .WherePublicStatus();

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IAnalyticsPathResolver.cs
@@ -4,5 +4,7 @@ public interface IAnalyticsPathResolver
 {
     string PublicApiQueriesDirectoryPath();
     
+    string PublicApiDataSetCallsDirectoryPath();
+    
     string PublicApiDataSetVersionCallsDirectoryPath();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IAnalyticsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/Interfaces/IAnalyticsService.cs
@@ -6,6 +6,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.In
 
 public interface IAnalyticsService
 {
+    Task CaptureDataSetCall(
+        Guid dataSetId,
+        DataSetCallType type,
+        CancellationToken cancellationToken = default);
+    
     Task CaptureDataSetVersionCall(
         Guid dataSetVersionId,
         DataSetVersionCallType type,

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/LocalAnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/LocalAnalyticsPathResolver.cs
@@ -1,12 +1,11 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Options;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces;
 using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services;
 
-public class LocalAnalyticsPathResolver : IAnalyticsPathResolver
+public class LocalAnalyticsPathResolver : AnalyticsPathResolverBase
 {
     private readonly string _basePath;
 
@@ -24,15 +23,8 @@ public class LocalAnalyticsPathResolver : IAnalyticsPathResolver
         _basePath = Path.Combine(PathUtils.ProjectRootPath, PathUtils.OsPath(originalPath));
     }
 
-    private string BasePath() => _basePath;
-
-    public string PublicApiQueriesDirectoryPath()
+    protected override string GetBasePath()
     {
-        return Path.Combine(BasePath(), "public-api", "queries");
-    }
-    
-    public string PublicApiDataSetVersionCallsDirectoryPath()
-    {
-        return Path.Combine(BasePath(), "public-api", "data-set-versions");
+        return _basePath;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetCallsStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetCallsStrategy.cs
@@ -1,5 +1,6 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies.Workflow;
 using IAnalyticsPathResolver = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.IAnalyticsPathResolver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetCallsStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetCallsStrategy.cs
@@ -1,56 +1,30 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
-using Newtonsoft.Json;
 using IAnalyticsPathResolver = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.IAnalyticsPathResolver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
 
 public class AnalyticsWriteDataSetCallsStrategy(
     IAnalyticsPathResolver analyticsPathResolver,
-    DateTimeProvider dateTimeProvider,
-    ILogger<AnalyticsWriteDataSetCallsStrategy> logger
+    ICommonAnalyticsWriteStrategyWorkflow<CaptureDataSetCallRequest> workflow
     ) : IAnalyticsWriteStrategy
 {
+    private readonly IWorkflowActor<CaptureDataSetCallRequest> _workflowActor =
+        new WorkflowActor(analyticsPath: analyticsPathResolver.PublicApiDataSetCallsDirectoryPath());
+        
     public Type RequestType => typeof(CaptureDataSetCallRequest);
 
     public async Task Report(IAnalyticsCaptureRequestBase request, CancellationToken cancellationToken)
     {
-        if (request is not CaptureDataSetCallRequest callRequest)
+        await workflow.Report(_workflowActor, request, cancellationToken);
+    }
+
+    private class WorkflowActor(string analyticsPath)
+        : WorkflowActorBase<CaptureDataSetCallRequest>(analyticsPath)
+    {
+        public override string GetFilenamePart(CaptureDataSetCallRequest request)
         {
-            throw new ArgumentException($"request isn't a {nameof(CaptureDataSetCallRequest)}");
-        }
-        
-        logger.LogInformation(
-            "Capturing DataSet-level call of type {Type} for analytics - for data set {DataSetTitle}",
-            callRequest.Type,
-            callRequest.DataSetTitle);
-
-        var directory = analyticsPathResolver.PublicApiDataSetCallsDirectoryPath();
-        var filename =
-            $"{dateTimeProvider.UtcNow:yyyyMMdd-HHmmss}_{callRequest.DataSetId}_{RandomUtils.RandomString()}.json";
-
-        try
-        {
-            Directory.CreateDirectory(directory);
-
-            var filePath = Path.Combine(directory, filename);
-
-            var serialisedRequest = JsonSerializationUtils.Serialize(
-                obj: callRequest,
-                formatting: Formatting.Indented,
-                orderedProperties: true,
-                camelCase: true);
-
-            await File.WriteAllTextAsync(filePath, contents: serialisedRequest, cancellationToken: cancellationToken);
-        }
-        catch (Exception e)
-        {
-            logger.LogError(
-                e,
-                "Error whilst writing {RequestTypeName} to disk",
-                callRequest.GetType().ToString());
+            return request.DataSetId.ToString();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetCallsStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetCallsStrategy.cs
@@ -7,29 +7,29 @@ using IAnalyticsPathResolver = GovUk.Education.ExploreEducationStatistics.Public
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
 
-public class AnalyticsWriteDataSetVersionCallsStrategy(
+public class AnalyticsWriteDataSetCallsStrategy(
     IAnalyticsPathResolver analyticsPathResolver,
     DateTimeProvider dateTimeProvider,
-    ILogger<AnalyticsWriteDataSetVersionCallsStrategy> logger
+    ILogger<AnalyticsWriteDataSetCallsStrategy> logger
     ) : IAnalyticsWriteStrategy
 {
-    public Type RequestType => typeof(CaptureDataSetVersionCallRequest);
+    public Type RequestType => typeof(CaptureDataSetCallRequest);
 
     public async Task Report(IAnalyticsCaptureRequestBase request, CancellationToken cancellationToken)
     {
-        if (request is not CaptureDataSetVersionCallRequest callRequest)
+        if (request is not CaptureDataSetCallRequest callRequest)
         {
-            throw new ArgumentException($"request isn't a {nameof(CaptureDataSetVersionCallRequest)}");
+            throw new ArgumentException($"request isn't a {nameof(CaptureDataSetCallRequest)}");
         }
         
         logger.LogInformation(
-            "Capturing DataSetVersion-level call of type {Type} for analytics - for data set {DataSetTitle}",
+            "Capturing DataSet-level call of type {Type} for analytics - for data set {DataSetTitle}",
             callRequest.Type,
             callRequest.DataSetTitle);
 
-        var directory = analyticsPathResolver.PublicApiDataSetVersionCallsDirectoryPath();
+        var directory = analyticsPathResolver.PublicApiDataSetCallsDirectoryPath();
         var filename =
-            $"{dateTimeProvider.UtcNow:yyyyMMdd-HHmmss}_{callRequest.DataSetVersionId}_{RandomUtils.RandomString()}.json";
+            $"{dateTimeProvider.UtcNow:yyyyMMdd-HHmmss}_{callRequest.DataSetId}_{RandomUtils.RandomString()}.json";
 
         try
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetVersionCallsStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWriteDataSetVersionCallsStrategy.cs
@@ -1,5 +1,6 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies.Workflow;
 using IAnalyticsPathResolver = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.IAnalyticsPathResolver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWritePublicApiQueryStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWritePublicApiQueryStrategy.cs
@@ -1,57 +1,37 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
-using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Utils;
-using Newtonsoft.Json;
 using IAnalyticsPathResolver = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.IAnalyticsPathResolver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
 
 public class AnalyticsWritePublicApiQueryStrategy(
     IAnalyticsPathResolver analyticsPathResolver,
-    DateTimeProvider dateTimeProvider,
-    ILogger<AnalyticsWritePublicApiQueryStrategy> logger
+    ICommonAnalyticsWriteStrategyWorkflow<CaptureDataSetVersionQueryRequest> workflow
     ) : IAnalyticsWriteStrategy
 {
+    private readonly IWorkflowActor<CaptureDataSetVersionQueryRequest> _workflowActor =
+        new WorkflowActor(analyticsPath: analyticsPathResolver.PublicApiQueriesDirectoryPath());
+        
     public Type RequestType => typeof(CaptureDataSetVersionQueryRequest);
 
     public async Task Report(IAnalyticsCaptureRequestBase request, CancellationToken cancellationToken)
     {
-        if (request is not CaptureDataSetVersionQueryRequest queryRequest)
+        await workflow.Report(_workflowActor, request, cancellationToken);
+    }
+
+    private class WorkflowActor(string analyticsPath) 
+        : WorkflowActorBase<CaptureDataSetVersionQueryRequest>(analyticsPath)
+    {
+        public override string GetFilenamePart(CaptureDataSetVersionQueryRequest request)
         {
-            throw new ArgumentException($"request isn't a {nameof(CaptureDataSetVersionQueryRequest)}");
+            return request.DataSetVersionId.ToString();
         }
 
-        logger.LogInformation(
-            "Capturing query for analytics for data set {DataSetTitle}",
-            queryRequest.DataSetTitle);
-
-        var requestToSerialise = queryRequest with { Query = DataSetQueryNormalisationUtil.NormaliseQuery(queryRequest.Query) };
-        var directory = analyticsPathResolver.PublicApiQueriesDirectoryPath();
-        var filename =
-            $"{dateTimeProvider.UtcNow:yyyyMMdd-HHmmss}_{queryRequest.DataSetVersionId}_{RandomUtils.RandomString()}.json";
-
-        try
+        public override CaptureDataSetVersionQueryRequest PrepareForSerialisation(
+            CaptureDataSetVersionQueryRequest originalRequest)
         {
-            Directory.CreateDirectory(directory);
-
-            var filePath = Path.Combine(directory, filename);
-
-            var serialisedRequest = JsonSerializationUtils.Serialize(
-                obj: requestToSerialise,
-                formatting: Formatting.Indented,
-                orderedProperties: true,
-                camelCase: true);
-
-            await File.WriteAllTextAsync(filePath, contents: serialisedRequest, cancellationToken: cancellationToken);
-        }
-        catch (Exception e)
-        {
-            logger.LogError(
-                e,
-                "Error whilst writing {RequestTypeName} to disk",
-                request!.GetType().ToString());
+            return originalRequest with { Query = DataSetQueryNormalisationUtil.NormaliseQuery(originalRequest.Query) };
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWritePublicApiQueryStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/AnalyticsWritePublicApiQueryStrategy.cs
@@ -1,6 +1,7 @@
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Utils;
+using GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies.Workflow;
 using IAnalyticsPathResolver = GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Services.Interfaces.IAnalyticsPathResolver;
 
 namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/CommonAnalyticsWriteStrategyWorkflow.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/CommonAnalyticsWriteStrategyWorkflow.cs
@@ -1,0 +1,93 @@
+using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
+
+public interface ICommonAnalyticsWriteStrategyWorkflow<TAnalyticsRequest>
+    where TAnalyticsRequest : IAnalyticsCaptureRequestBase
+{
+    Task Report(
+        IWorkflowActor<TAnalyticsRequest> workflowActor,
+        IAnalyticsCaptureRequestBase request,
+        CancellationToken cancellationToken);
+}
+
+public class CommonAnalyticsWriteStrategyWorkflow<TAnalyticsRequest>(
+    DateTimeProvider dateTimeProvider,
+    ILogger<CommonAnalyticsWriteStrategyWorkflow<TAnalyticsRequest>> logger)
+    : ICommonAnalyticsWriteStrategyWorkflow<TAnalyticsRequest>
+    where TAnalyticsRequest : IAnalyticsCaptureRequestBase
+{
+    public async Task Report(
+        IWorkflowActor<TAnalyticsRequest> workflowActor,
+        IAnalyticsCaptureRequestBase request,
+        CancellationToken cancellationToken)
+    {
+        if (typeof(TAnalyticsRequest) != request.GetType())
+        {
+            throw new ArgumentException($"Request isn't of type {typeof(TAnalyticsRequest)}");
+        }
+
+        var analyticsRequest = (TAnalyticsRequest)request;
+
+        logger.LogDebug("Capturing request of type {RequestType} for analytics", typeof(TAnalyticsRequest));
+
+        var filename =
+            $"{dateTimeProvider.UtcNow:yyyyMMdd-HHmmss}_" +
+            $"{workflowActor.GetFilenamePart(analyticsRequest)}_" +
+            $"{RandomUtils.RandomString()}.json";
+
+        try
+        {
+            Directory.CreateDirectory(workflowActor.GetAnalyticsPath());
+
+            var filePath = Path.Combine(workflowActor.GetAnalyticsPath(), filename);
+
+            var requestToSerialise = workflowActor.PrepareForSerialisation(analyticsRequest);
+
+            var serialisedRequest = JsonSerializationUtils.Serialize(
+                obj: requestToSerialise,
+                formatting: Formatting.Indented,
+                orderedProperties: true,
+                camelCase: true);
+
+            await File.WriteAllTextAsync(
+                path: filePath,
+                contents: serialisedRequest,
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Error whilst writing {RequestType} to disk", typeof(TAnalyticsRequest));
+        }
+    }
+}
+
+public interface IWorkflowActor<TAnalyticsRequest> 
+    where TAnalyticsRequest : IAnalyticsCaptureRequestBase
+{
+    string GetAnalyticsPath();
+    
+    string GetFilenamePart(TAnalyticsRequest request);
+    
+    TAnalyticsRequest PrepareForSerialisation(TAnalyticsRequest originalRequest);
+}
+
+public abstract class WorkflowActorBase<TAnalyticsRequest>(string analyticsPath) 
+    : IWorkflowActor<TAnalyticsRequest> 
+    where TAnalyticsRequest : IAnalyticsCaptureRequestBase
+{
+    public string GetAnalyticsPath()
+    {
+        return analyticsPath;
+    }
+
+    public virtual TAnalyticsRequest PrepareForSerialisation(TAnalyticsRequest originalRequest)
+    {
+        return originalRequest;
+    }
+
+    public abstract string GetFilenamePart(TAnalyticsRequest request);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/Workflow/CommonAnalyticsWriteStrategyWorkflow.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Strategies/Workflow/CommonAnalyticsWriteStrategyWorkflow.cs
@@ -3,7 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Newtonsoft.Json;
 
-namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies;
+namespace GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Strategies.Workflow;
 
 public interface ICommonAnalyticsWriteStrategyWorkflow<TAnalyticsRequest>
     where TAnalyticsRequest : IAnalyticsCaptureRequestBase


### PR DESCRIPTION
This PR:
- updates the various analytics writer strategies in the Public API project to use a common workflow.
- refactors the common request processor workflow and its various processors in the Analytics project to adopt the same pattern of having the workflow be an injectable property rather than having each implementation create its own.