### PR TITLE
EES-6084 and EES-6086 - corrected reports base path for parquet file …

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/Services/AnalyticsPathResolver.cs
@@ -62,7 +62,7 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
 
     public string PublicApiDataSetCallsReportsDirectoryPath()
     {
-        return Path.Combine(PublicApiDataSetCallsDirectoryPath(), "public-api", "data-sets");
+        return Path.Combine(ReportsDirectoryPath(), "public-api", "data-sets");
     }
 
     // PublicApiDataSetVersions
@@ -73,7 +73,7 @@ public class AnalyticsPathResolver : IAnalyticsPathResolver
 
     public string PublicApiDataSetVersionCallsReportsDirectoryPath()
     {
-        return Path.Combine(PublicApiDataSetVersionCallsDirectoryPath(), "public-api", "data-set-versions");
+        return Path.Combine(ReportsDirectoryPath(), "public-api", "data-set-versions");
     }
 
     // PublicZipDownloads


### PR DESCRIPTION
This PR:
- corrects a bug whereby the Parquet report location for DataSet and DataSetVersion-level Public API calls was incorrectly set. 