### PR TITLE
EES-5548 confirm replacements from data files page

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
@@ -255,9 +255,7 @@ describe('ReleaseDataFileReplacePage', () => {
       );
       expect(screen.getByTestId('Data file size')).toHaveTextContent('200 B');
       expect(screen.getByTestId('Number of rows')).toHaveTextContent('100');
-      expect(screen.getByTestId('Status')).toHaveTextContent(
-        'Replacement in progress',
-      );
+      expect(screen.getByTestId('Status')).toHaveTextContent('Complete');
       expect(screen.getByTestId('Uploaded by')).toHaveTextContent(
         'original@test.com',
       );
@@ -316,9 +314,7 @@ describe('ReleaseDataFileReplacePage', () => {
       );
       expect(screen.getByTestId('Data file size')).toHaveTextContent('200 B');
       expect(screen.getByTestId('Number of rows')).toHaveTextContent('100');
-      expect(screen.getByTestId('Status')).toHaveTextContent(
-        'Replacement in progress',
-      );
+      expect(screen.getByTestId('Status')).toHaveTextContent('Complete');
       expect(screen.getByTestId('Uploaded by')).toHaveTextContent(
         'original@test.com',
       );
@@ -326,8 +322,8 @@ describe('ReleaseDataFileReplacePage', () => {
         '20 September 2020 12:00',
       );
 
-      expect(screen.getByText('Pending data replacement')).toBeInTheDocument();
-      expect(screen.getByText('Replacement in progress')).toBeInTheDocument();
+      expect(screen.getByText('Complete')).toBeInTheDocument();
+      expect(screen.getByText('Complete')).toBeInTheDocument();
       expect(
         screen.getByText(
           'There was a problem loading the data replacement information.',
@@ -375,9 +371,6 @@ describe('ReleaseDataFileReplacePage', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Pending data replacement')).toBeInTheDocument();
-      expect(screen.getByText('Replacement in progress')).toBeInTheDocument();
-
       expect(screen.getByText('Data blocks: OK')).toBeInTheDocument();
       expect(screen.getByText('Footnotes: OK')).toBeInTheDocument();
 
@@ -430,8 +423,8 @@ describe('ReleaseDataFileReplacePage', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Pending data replacement')).toBeInTheDocument();
-      expect(screen.getByText('Replacement in progress')).toBeInTheDocument();
+      expect(screen.getByText('Complete')).toBeInTheDocument();
+      expect(screen.getByText('Complete')).toBeInTheDocument();
       expect(
         screen.getByText(/The replacement data file is still being processed/),
       );
@@ -480,8 +473,6 @@ describe('ReleaseDataFileReplacePage', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Pending data replacement')).toBeInTheDocument();
-      expect(screen.getByText('Replacement in progress')).toBeInTheDocument();
       expect(
         screen.getByText(
           'There was a problem loading the data replacement information.',

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTable.tsx
@@ -9,7 +9,7 @@ interface Props {
   publicationId: string;
   releaseVersionId: string;
   testId?: string;
-  onConfirmReplacement?: () => void;
+  onConfirmAction?: () => void;
 }
 
 export default function DataFilesReplacementTable({
@@ -18,7 +18,7 @@ export default function DataFilesReplacementTable({
   publicationId,
   releaseVersionId,
   testId,
-  onConfirmReplacement,
+  onConfirmAction,
 }: Props) {
   return (
     <table className={styles.table} data-testid={testId}>
@@ -40,7 +40,7 @@ export default function DataFilesReplacementTable({
             key={dataFile.title}
             publicationId={publicationId}
             releaseVersionId={releaseVersionId}
-            onConfirmReplacement={onConfirmReplacement}
+            onConfirmAction={onConfirmAction}
           />
         ))}
       </tbody>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTable.tsx
@@ -1,34 +1,24 @@
-import {
-  DataFile,
-  DataFileImportStatus,
-} from '@admin/services/releaseDataFileService';
+import { DataFile } from '@admin/services/releaseDataFileService';
 import styles from '@admin/pages/release/data/components/DataFilesTable.module.scss';
-import DataFilesTableRow from '@admin/pages/release/data/components/DataFilesTableRow';
+import DataFileReplacementTableRow from '@admin/pages/release/data/components/DataFilesReplacementTableRow';
 import React from 'react';
 
 interface Props {
-  canUpdateRelease?: boolean;
   caption: string;
   dataFiles: DataFile[];
   publicationId: string;
   releaseVersionId: string;
   testId?: string;
-  onDeleteFile: (deletedFileId: string) => void;
-  onStatusChange: (
-    dataFile: DataFile,
-    importStatus: DataFileImportStatus,
-  ) => Promise<void>;
+  onConfirmReplacement?: () => void;
 }
 
-export default function DataFilesTable({
-  canUpdateRelease,
+export default function DataFilesReplacementTable({
   caption,
   dataFiles,
   publicationId,
   releaseVersionId,
   testId,
-  onDeleteFile,
-  onStatusChange,
+  onConfirmReplacement,
 }: Props) {
   return (
     <table className={styles.table} data-testid={testId}>
@@ -38,21 +28,19 @@ export default function DataFilesTable({
         <tr>
           <th scope="col">Title</th>
           <th scope="col">Size</th>
-          <th scope="col">Status</th>
+          <th scope="col">Replacement status</th>
           <th scope="col">Actions</th>
         </tr>
       </thead>
 
       <tbody>
         {dataFiles.map(dataFile => (
-          <DataFilesTableRow
-            canUpdateRelease={canUpdateRelease}
+          <DataFileReplacementTableRow
             dataFile={dataFile}
             key={dataFile.title}
             publicationId={publicationId}
             releaseVersionId={releaseVersionId}
-            onConfirmDelete={onDeleteFile}
-            onStatusChange={onStatusChange}
+            onConfirmReplacement={onConfirmReplacement}
           />
         ))}
       </tbody>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
@@ -26,14 +26,14 @@ interface Props {
   dataFile: DataFile;
   publicationId: string;
   releaseVersionId: string;
-  onConfirmReplacement?: () => void;
+  onConfirmAction?: () => void;
 }
 
 export default function DataFilesReplacementTableRow({
   dataFile,
   publicationId,
   releaseVersionId,
-  onConfirmReplacement,
+  onConfirmAction,
 }: Props) {
   const [fetchPlan, toggleFetchPlan] = useToggle(false);
 
@@ -60,7 +60,7 @@ export default function DataFilesReplacementTableRow({
   }, [replacementDataFile?.status, toggleFetchPlan]);
 
   const handleStatusChange = (
-    file: DataFile,
+    _file: DataFile,
     importStatus: DataFileImportStatus,
   ) => {
     if (importStatus.status === 'COMPLETE') {
@@ -119,45 +119,41 @@ export default function DataFilesReplacementTableRow({
           >
             View details
           </Link>
-          {plan?.valid && (
-            <>
-              {plan.valid && (
-                <ButtonText
-                  onClick={async () => {
-                    await dataReplacementService.replaceData(
-                      releaseVersionId,
-                      dataFile.id,
-                      replacementDataFile.id,
-                    );
-
-                    onConfirmReplacement?.();
-                  }}
-                >
-                  Confirm replacement
-                </ButtonText>
-              )}
-              <ModalConfirm
-                title="Cancel data replacement"
-                triggerButton={
-                  <ButtonText variant="secondary">
-                    Cancel replacement
-                  </ButtonText>
-                }
-                onConfirm={async () => {
-                  await releaseDataFileService.deleteDataFiles(
+          <>
+            <ModalConfirm
+              title="Cancel data replacement"
+              triggerButton={
+                <ButtonText variant="secondary">Cancel replacement</ButtonText>
+              }
+              onConfirm={async () => {
+                await releaseDataFileService.deleteDataFiles(
+                  releaseVersionId,
+                  replacementDataFile.id,
+                );
+                onConfirmAction?.();
+              }}
+            >
+              <p>
+                Are you sure you want to cancel this data replacement? The
+                pending replacement data file will be deleted.
+              </p>
+            </ModalConfirm>
+            {plan?.valid && (
+              <ButtonText
+                onClick={async () => {
+                  await dataReplacementService.replaceData(
                     releaseVersionId,
+                    dataFile.id,
                     replacementDataFile.id,
                   );
-                  onConfirmReplacement?.();
+
+                  onConfirmAction?.();
                 }}
               >
-                <p>
-                  Are you sure you want to cancel this data replacement? The
-                  pending replacement data file will be deleted.
-                </p>
-              </ModalConfirm>
-            </>
-          )}
+                Confirm replacement
+              </ButtonText>
+            )}
+          </>
         </ButtonGroup>
       </td>
     </tr>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
@@ -1,0 +1,165 @@
+import Link from '@admin/components/Link';
+import ImporterStatus from '@admin/pages/release/data/components/ImporterStatus';
+import {
+  releaseDataFileReplaceRoute,
+  ReleaseDataFileReplaceRouteParams,
+} from '@admin/routes/releaseRoutes';
+import dataFileReplacementQueries from '@admin/queries/dataFileReplacementQueries';
+import releaseDataFileQueries from '@admin/queries/releaseDataFileQueries';
+import releaseDataFileService, {
+  DataFile,
+  DataFileImportStatus,
+} from '@admin/services/releaseDataFileService';
+import dataReplacementService from '@admin/services/dataReplacementService';
+import useToggle from '@common/hooks/useToggle';
+import ButtonGroup from '@common/components/ButtonGroup';
+import ButtonText from '@common/components/ButtonText';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import ModalConfirm from '@common/components/ModalConfirm';
+import Tag from '@common/components/Tag';
+import React, { useEffect } from 'react';
+import { generatePath } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import styles from './DataFilesTable.module.scss';
+
+interface Props {
+  dataFile: DataFile;
+  publicationId: string;
+  releaseVersionId: string;
+  onConfirmReplacement?: () => void;
+}
+
+export default function DataFilesReplacementTableRow({
+  dataFile,
+  publicationId,
+  releaseVersionId,
+  onConfirmReplacement,
+}: Props) {
+  const [fetchPlan, toggleFetchPlan] = useToggle(false);
+
+  const { data: replacementDataFile, isLoading } = useQuery(
+    releaseDataFileQueries.getDataFile(
+      releaseVersionId,
+      dataFile.replacedBy ?? '',
+    ),
+  );
+
+  const { data: plan } = useQuery({
+    ...dataFileReplacementQueries.getReplacementPlan(
+      releaseVersionId,
+      dataFile.id,
+      dataFile.replacedBy ?? '',
+    ),
+    enabled: fetchPlan,
+  });
+
+  useEffect(() => {
+    if (replacementDataFile?.status === 'COMPLETE') {
+      toggleFetchPlan.on();
+    }
+  }, [replacementDataFile?.status, toggleFetchPlan]);
+
+  const handleStatusChange = (
+    file: DataFile,
+    importStatus: DataFileImportStatus,
+  ) => {
+    if (importStatus.status === 'COMPLETE') {
+      toggleFetchPlan.on();
+    }
+  };
+
+  if (!replacementDataFile) {
+    return (
+      <tr>
+        <td>
+          <LoadingSpinner loading={isLoading} />
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <tr key={dataFile.title}>
+      <td data-testid="Title" className={styles.title}>
+        {dataFile.title}
+      </td>
+      <td data-testid="Size" className={styles.fileSize}>
+        {dataFile.fileSize.size.toLocaleString()} {dataFile.fileSize.unit}
+      </td>
+      <td data-testid="Status">
+        {plan ? (
+          <>
+            {plan?.valid ? (
+              <Tag colour="green">Ready</Tag>
+            ) : (
+              <Tag colour="red">Error</Tag>
+            )}
+          </>
+        ) : (
+          <ImporterStatus
+            className={styles.fileStatus}
+            dataFile={replacementDataFile}
+            hideErrors
+            releaseVersionId={releaseVersionId}
+            onStatusChange={handleStatusChange}
+          />
+        )}
+      </td>
+      <td data-testid="Actions">
+        <ButtonGroup className={styles.actions}>
+          <Link
+            to={generatePath<ReleaseDataFileReplaceRouteParams>(
+              releaseDataFileReplaceRoute.path,
+              {
+                publicationId,
+                releaseVersionId,
+                fileId: dataFile.id,
+              },
+            )}
+          >
+            View details
+          </Link>
+          {plan?.valid && (
+            <>
+              {plan.valid && (
+                <ButtonText
+                  onClick={async () => {
+                    await dataReplacementService.replaceData(
+                      releaseVersionId,
+                      dataFile.id,
+                      replacementDataFile.id,
+                    );
+
+                    onConfirmReplacement?.();
+                  }}
+                >
+                  Confirm replacement
+                </ButtonText>
+              )}
+              <ModalConfirm
+                title="Cancel data replacement"
+                triggerButton={
+                  <ButtonText variant="secondary">
+                    Cancel replacement
+                  </ButtonText>
+                }
+                onConfirm={async () => {
+                  await releaseDataFileService.deleteDataFiles(
+                    releaseVersionId,
+                    replacementDataFile.id,
+                  );
+                  onConfirmReplacement?.();
+                }}
+              >
+                <p>
+                  Are you sure you want to cancel this data replacement? The
+                  pending replacement data file will be deleted.
+                </p>
+              </ModalConfirm>
+            </>
+          )}
+        </ButtonGroup>
+      </td>
+    </tr>
+  );
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
@@ -136,16 +136,8 @@ const ImporterStatus = ({
   return (
     <div className={className}>
       <div className="dfe-flex dfe-align-items--center">
-        <Tag
-          colour={
-            dataFile.replacedBy
-              ? 'blue'
-              : getImportStatusColour(currentStatus.status)
-          }
-        >
-          {dataFile.replacedBy
-            ? 'Replacement in progress'
-            : getImportStatusLabel(currentStatus.status)}
+        <Tag colour={getImportStatusColour(currentStatus.status)}>
+          {getImportStatusLabel(currentStatus.status)}
         </Tag>
 
         {!hasTerminalStatus && (

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -279,7 +279,7 @@ export default function ReleaseDataUploadsSection({
                     publicationId={publicationId}
                     releaseVersionId={releaseVersionId}
                     testId="Data file replacements table"
-                    onConfirmReplacement={refetchDataFiles}
+                    onConfirmAction={refetchDataFiles}
                   />
                 )}
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -9,6 +9,9 @@ import releaseDataFileService, {
   DataFile,
   DataFileImportStatus,
 } from '@admin/services/releaseDataFileService';
+import DataSetUploadModalConfirm from '@admin/pages/release/data/components/DataSetUploadModalConfirm';
+import DataFilesTable from '@admin/pages/release/data/components/DataFilesTable';
+import DataFilesReplacementTable from '@admin/pages/release/data/components/DataFilesReplacementTable';
 import Button from '@common/components/Button';
 import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -16,8 +19,6 @@ import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import { useQuery } from '@tanstack/react-query';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import DataSetUploadModalConfirm from './DataSetUploadModalConfirm';
-import DataFilesTable from './DataFilesTable';
 
 interface Props {
   publicationId: string;
@@ -56,6 +57,12 @@ export default function ReleaseDataUploadsSection({
     () => allDataFiles.filter(dataFile => dataFile.replacedBy),
     [allDataFiles],
   );
+
+  // TODO - bulk confirmation of replacements
+  //  const validReplacedDataFiles = replacedDataFiles.filter(
+  //   file => file.status === 'COMPLETE',
+  // );
+  // const allowBulkConfirm = validReplacedDataFiles.length > 1;
 
   const dataFiles = useMemo(
     () => allDataFiles.filter(dataFile => !dataFile.replacedBy),
@@ -99,6 +106,7 @@ export default function ReleaseDataUploadsSection({
                 rows: totalRows,
                 status,
                 permissions,
+                replacedBy: file.replacedBy,
               },
         ),
       );
@@ -181,6 +189,9 @@ export default function ReleaseDataUploadsSection({
     [releaseVersionId, toggleReordering],
   );
 
+  // TODO - bulk confirmation of replacements
+  // const handleConfirmAllReplacements = () => {};
+
   return (
     <>
       <h2>Add data file to release</h2>
@@ -240,9 +251,17 @@ export default function ReleaseDataUploadsSection({
             <h2>Uploaded data files</h2>
 
             {!isReordering && allDataFiles.length > 1 && (
-              <Button onClick={toggleReordering.on} variant="secondary">
-                Reorder data files
-              </Button>
+              <div className="dfe-flex dfe-justify-content--space-between">
+                <Button onClick={toggleReordering.on} variant="secondary">
+                  Reorder data files
+                </Button>
+                {/* TODO - bulk confirmation of replacements */}
+                {/* {allowBulkConfirm && (
+                  <Button onClick={handleConfirmAllReplacements}>
+                    Confirm all valid replacements
+                  </Button>
+                )} */}
+              </div>
             )}
 
             {isReordering ? (
@@ -254,15 +273,13 @@ export default function ReleaseDataUploadsSection({
             ) : (
               <>
                 {replacedDataFiles.length > 0 && (
-                  <DataFilesTable
-                    canUpdateRelease={canUpdateRelease}
+                  <DataFilesReplacementTable
                     caption="Data file replacements"
                     dataFiles={replacedDataFiles}
                     publicationId={publicationId}
                     releaseVersionId={releaseVersionId}
                     testId="Data file replacements table"
-                    onDeleteFile={handleDeleteConfirm}
-                    onStatusChange={handleStatusChange}
+                    onConfirmReplacement={refetchDataFiles}
                   />
                 )}
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesReplacementTableRow.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesReplacementTableRow.test.tsx
@@ -128,8 +128,5 @@ describe('DataFilesReplacementTableRow', () => {
     expect(
       within(cells[3]).queryByRole('button', { name: 'Confirm replacement' }),
     ).not.toBeInTheDocument();
-    expect(
-      within(cells[3]).queryByRole('button', { name: 'Cancel replacement' }),
-    ).not.toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesReplacementTableRow.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesReplacementTableRow.test.tsx
@@ -1,0 +1,135 @@
+import _releaseDataFileService, {
+  DataFile,
+} from '@admin/services/releaseDataFileService';
+import _dataReplacementService, {
+  DataReplacementPlan,
+} from '@admin/services/dataReplacementService';
+import DataFilesReplacementTableRow from '@admin/pages/release/data/components/DataFilesReplacementTableRow';
+import render from '@common-test/render';
+import React from 'react';
+import { screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('@admin/services/releaseDataFileService');
+jest.mock('@admin/services/dataReplacementService');
+
+const releaseDataFileService = jest.mocked(_releaseDataFileService);
+const dataReplacementService = jest.mocked(_dataReplacementService);
+
+describe('DataFilesReplacementTableRow', () => {
+  const testDataFile: DataFile = {
+    fileName: '',
+    metaFileName: '',
+    metaFileId: '',
+    userName: '',
+    id: 'file-1',
+    replacedBy: 'file-1-replacement',
+    title: 'Test File',
+    status: 'COMPLETE',
+    fileSize: { size: 1000, unit: 'B' },
+    permissions: { canCancelImport: false },
+  };
+
+  const testReplacementDataFile: DataFile = {
+    fileName: '',
+    metaFileName: '',
+    metaFileId: '',
+    userName: '',
+    id: 'file-1-replacement',
+    title: 'Test File',
+    status: 'COMPLETE',
+    fileSize: { size: 1000, unit: 'B' },
+    permissions: { canCancelImport: false },
+  };
+
+  const testDataReplacementPlan: DataReplacementPlan = {
+    originalSubjectId: 'subject-1',
+    replacementSubjectId: 'subject-1',
+    dataBlocks: [],
+    footnotes: [],
+    apiDataSetVersionPlan: {
+      id: '',
+      dataSetId: '',
+      name: '',
+      version: '',
+      status: '',
+      valid: true,
+    },
+    valid: true,
+  };
+
+  test('renders with a valid replacement', async () => {
+    releaseDataFileService.getDataFile.mockResolvedValue(
+      testReplacementDataFile,
+    );
+
+    dataReplacementService.getReplacementPlan.mockResolvedValue(
+      testDataReplacementPlan,
+    );
+
+    render(
+      <MemoryRouter>
+        <DataFilesReplacementTableRow
+          dataFile={testDataFile}
+          publicationId="test-publication"
+          releaseVersionId="test-release-version"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Test File')).toBeInTheDocument();
+    expect(await screen.findByText('Ready')).toBeInTheDocument();
+
+    const cells = screen.getAllByRole('cell');
+    expect(cells[0]).toHaveTextContent('Test File');
+    expect(cells[1]).toHaveTextContent('1,000 B');
+    expect(cells[2]).toHaveTextContent('Ready');
+    expect(
+      within(cells[3]).getByRole('link', { name: 'View details' }),
+    ).toBeInTheDocument();
+    expect(
+      within(cells[3]).getByRole('button', { name: 'Confirm replacement' }),
+    ).toBeInTheDocument();
+    expect(
+      within(cells[3]).getByRole('button', { name: 'Cancel replacement' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders with a replacement error', async () => {
+    releaseDataFileService.getDataFile.mockResolvedValue(
+      testReplacementDataFile,
+    );
+
+    dataReplacementService.getReplacementPlan.mockResolvedValue({
+      ...testDataReplacementPlan,
+      valid: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <DataFilesReplacementTableRow
+          dataFile={testDataFile}
+          publicationId="test-publication"
+          releaseVersionId="test-release-version"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Test File')).toBeInTheDocument();
+    expect(await screen.findByText('Error')).toBeInTheDocument();
+
+    const cells = screen.getAllByRole('cell');
+    expect(cells[0]).toHaveTextContent('Test File');
+    expect(cells[1]).toHaveTextContent('1,000 B');
+    expect(cells[2]).toHaveTextContent('Error');
+    expect(
+      within(cells[3]).getByRole('link', { name: 'View details' }),
+    ).toBeInTheDocument();
+    expect(
+      within(cells[3]).queryByRole('button', { name: 'Confirm replacement' }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(cells[3]).queryByRole('button', { name: 'Cancel replacement' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesTableRow.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesTableRow.test.tsx
@@ -1,9 +1,11 @@
-﻿import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { FeatureFlags } from '@admin/config/featureFlags';
+﻿import { FeatureFlags } from '@admin/config/featureFlags';
 import { FeatureFlagProvider } from '@admin/contexts/FeatureFlagContext';
-import DataFilesTableRow from '../DataFilesTableRow';
+import DataFilesTableRow from '@admin/pages/release/data/components/DataFilesTableRow';
+import { DataFile } from '@admin/services/releaseDataFileService';
+import render from '@common-test/render';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { screen, waitFor } from '@testing-library/react';
 
 describe('DataFilesTableRow', () => {
   const baseProps = {
@@ -14,7 +16,7 @@ describe('DataFilesTableRow', () => {
     onStatusChange: jest.fn(),
   };
 
-  const mockDataFile = {
+  const mockDataFile: DataFile = {
     fileName: '',
     metaFileName: '',
     metaFileId: '',
@@ -36,29 +38,17 @@ describe('DataFilesTableRow', () => {
       const testFeatureFlag: FeatureFlags = {
         enableReplacementOfPublicApiDataSets: true,
       };
-      render(
+      const { user } = render(
         <FeatureFlagProvider initialFlags={testFeatureFlag}>
           <MemoryRouter>
-            <table>
-              <thead>
-                <tr>
-                  <th scope="col">Title</th>
-                  <th scope="col">Size</th>
-                  <th scope="col">Status</th>
-                  <th scope="col">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                <DataFilesTableRow {...baseProps} dataFile={dataFile} />
-              </tbody>
-            </table>
+            <DataFilesTableRow {...baseProps} dataFile={dataFile} />
           </MemoryRouter>
         </FeatureFlagProvider>,
       );
       const replaceLink = screen.getByText('Replace data');
       expect(replaceLink).toBeInTheDocument();
 
-      fireEvent.click(replaceLink);
+      await user.click(replaceLink);
 
       await waitFor(() => {
         expect(
@@ -72,29 +62,17 @@ describe('DataFilesTableRow', () => {
       const testFeatureFlag: FeatureFlags = {
         enableReplacementOfPublicApiDataSets: false,
       };
-      render(
+      const { user } = render(
         <FeatureFlagProvider initialFlags={testFeatureFlag}>
           <MemoryRouter>
-            <table>
-              <thead>
-                <tr>
-                  <th scope="col">Title</th>
-                  <th scope="col">Size</th>
-                  <th scope="col">Status</th>
-                  <th scope="col">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                <DataFilesTableRow {...baseProps} dataFile={dataFile} />
-              </tbody>
-            </table>
+            <DataFilesTableRow {...baseProps} dataFile={dataFile} />
           </MemoryRouter>
         </FeatureFlagProvider>,
       );
       const replaceLink = screen.getByText('Replace data');
       expect(replaceLink).toBeInTheDocument();
 
-      fireEvent.click(replaceLink);
+      await user.click(replaceLink);
 
       await waitFor(() => {
         expect(

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -6,6 +6,9 @@ import _releaseDataFileService, {
   UploadZipDataFileRequest,
   DataSetUploadResult,
 } from '@admin/services/releaseDataFileService';
+import _dataReplacementService, {
+  DataReplacementPlan,
+} from '@admin/services/dataReplacementService';
 import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
@@ -16,9 +19,11 @@ import render from '@common-test/render';
 
 jest.mock('@admin/services/releaseDataFileService');
 jest.mock('@admin/services/permissionService');
+jest.mock('@admin/services/dataReplacementService');
 
 const releaseDataFileService = jest.mocked(_releaseDataFileService);
 const permissionService = jest.mocked(_permissionService);
+const dataReplacementService = jest.mocked(_dataReplacementService);
 
 describe('ReleaseDataUploadsSection', () => {
   const testDataFiles: DataFile[] = [
@@ -110,6 +115,22 @@ describe('ReleaseDataUploadsSection', () => {
     totalRows: 100,
   };
 
+  const testValidReplacementPlan: DataReplacementPlan = {
+    valid: true,
+    dataBlocks: [],
+    footnotes: [],
+    originalSubjectId: 'subject-1',
+    replacementSubjectId: 'subject-1',
+    apiDataSetVersionPlan: {
+      id: '',
+      dataSetId: '',
+      name: '',
+      version: '',
+      status: '',
+      valid: false,
+    },
+  };
+
   test('renders uploaded data files table', async () => {
     releaseDataFileService.getDataFiles.mockResolvedValue(testDataFiles);
     releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
@@ -152,11 +173,25 @@ describe('ReleaseDataUploadsSection', () => {
   test('renders data files replacements table', async () => {
     releaseDataFileService.getDataFiles.mockResolvedValue([
       { ...testDataFiles[0], replacedBy: 'data-replacement-1' },
-      { ...testDataFiles[1], replacedBy: 'data-replacement-1' },
+      { ...testDataFiles[1], replacedBy: 'data-replacement-2' },
     ]);
 
     releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
       testCompleteImportStatus,
+    );
+
+    releaseDataFileService.getDataFile.mockResolvedValueOnce({
+      ...testDataFiles[0],
+      id: 'data-replacement-1',
+    });
+
+    releaseDataFileService.getDataFile.mockResolvedValueOnce({
+      ...testDataFiles[1],
+      id: 'data-replacement-2',
+    });
+
+    dataReplacementService.getReplacementPlan.mockResolvedValue(
+      testValidReplacementPlan,
     );
 
     render(
@@ -171,6 +206,8 @@ describe('ReleaseDataUploadsSection', () => {
 
     expect(await screen.findByText('Uploaded data files')).toBeInTheDocument();
 
+    expect(await screen.findByText('Test data 2')).toBeInTheDocument();
+
     const replacementRows = getAllFileTableRows('Data file replacements');
 
     expect(replacementRows).toHaveLength(3);
@@ -181,9 +218,7 @@ describe('ReleaseDataUploadsSection', () => {
       'Test data 1',
     );
     expect(replacementRow1.getByTestId('Size')).toHaveTextContent('50 Kb');
-    expect(replacementRow1.getByTestId('Status')).toHaveTextContent(
-      'Replacement in progress',
-    );
+    expect(replacementRow1.getByTestId('Status')).toHaveTextContent('Complete');
 
     const replacementRow2 = within(replacementRows[2]);
 
@@ -191,9 +226,7 @@ describe('ReleaseDataUploadsSection', () => {
       'Test data 2',
     );
     expect(replacementRow2.getByTestId('Size')).toHaveTextContent('100 Kb');
-    expect(replacementRow2.getByTestId('Status')).toHaveTextContent(
-      'Replacement in progress',
-    );
+    expect(replacementRow2.getByTestId('Status')).toHaveTextContent('Complete');
   });
 
   test('renders data files and data file replacements tables', async () => {
@@ -206,6 +239,15 @@ describe('ReleaseDataUploadsSection', () => {
       testCompleteImportStatus,
     );
 
+    releaseDataFileService.getDataFile.mockResolvedValue({
+      ...testDataFiles[0],
+      id: 'data-replacement-1',
+    });
+
+    dataReplacementService.getReplacementPlan.mockResolvedValue(
+      testValidReplacementPlan,
+    );
+
     render(
       <MemoryRouter>
         <ReleaseDataUploadsSection
@@ -217,6 +259,7 @@ describe('ReleaseDataUploadsSection', () => {
     );
 
     expect(await screen.findByText('Uploaded data files')).toBeInTheDocument();
+    expect(await screen.findByText('Test data 1')).toBeInTheDocument();
 
     const replacementRows = getAllFileTableRows('Data file replacements');
 
@@ -228,9 +271,7 @@ describe('ReleaseDataUploadsSection', () => {
       'Test data 1',
     );
     expect(replacementRow1.getByTestId('Size')).toHaveTextContent('50 Kb');
-    expect(replacementRow1.getByTestId('Status')).toHaveTextContent(
-      'Replacement in progress',
-    );
+    expect(replacementRow1.getByTestId('Status')).toHaveTextContent('Complete');
 
     const fileTableRows = getAllFileTableRows('Data files');
 
@@ -323,75 +364,6 @@ describe('ReleaseDataUploadsSection', () => {
 
       expect(modal.getByTestId('Date uploaded')).toHaveTextContent(
         '1 July 2020, 12:00',
-      );
-    });
-
-    test('renders details of data file replacement when opened', async () => {
-      releaseDataFileService.getDataFiles.mockResolvedValue([
-        {
-          ...testDataFiles[0],
-          replacedBy: 'data-replacement-1',
-        },
-      ]);
-      releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
-        testCompleteImportStatus,
-      );
-
-      const { user } = render(
-        <MemoryRouter>
-          <ReleaseDataUploadsSection
-            publicationId="publication-1"
-            releaseVersionId="release-1"
-            canUpdateRelease
-          />
-        </MemoryRouter>,
-      );
-
-      expect(releaseDataFileService.getDataFiles).toHaveBeenCalledWith(
-        'release-1',
-      );
-
-      expect(
-        await screen.findByText('Uploaded data files'),
-      ).toBeInTheDocument();
-
-      const replacementRows = getAllFileTableRows('Data file replacements');
-
-      expect(replacementRows).toHaveLength(2);
-
-      const replacementRow = within(replacementRows[1]);
-
-      await user.click(
-        replacementRow.getByRole('button', { name: 'View details' }),
-      );
-
-      expect(await screen.findByText('Data file details')).toBeInTheDocument();
-
-      const modal = within(screen.getByRole('dialog'));
-
-      expect(modal.getByTestId('Title')).toHaveTextContent('Test data 1');
-
-      expect(
-        within(modal.getByTestId('Data file')).getByRole('button'),
-      ).toHaveTextContent('data-1.csv');
-      expect(
-        within(modal.getByTestId('Meta file')).getByRole('button'),
-      ).toHaveTextContent('data-1.meta.csv');
-
-      expect(modal.getByTestId('Size')).toHaveTextContent('50 Kb');
-      expect(modal.getByTestId('Number of rows')).toHaveTextContent('100');
-      expect(modal.getByTestId('Status')).toHaveTextContent(
-        'Replacement in progress',
-      );
-
-      expect(
-        within(modal.getByTestId('Uploaded by')).getByRole('link', {
-          name: 'user1@test.com',
-        }),
-      ).toHaveAttribute('href', 'mailto:user1@test.com');
-
-      expect(modal.getByTestId('Date uploaded')).toHaveTextContent(
-        '12 June 2020, 12:00',
       );
     });
   });

--- a/src/explore-education-statistics-admin/src/queries/dataFileReplacementQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/dataFileReplacementQueries.ts
@@ -1,0 +1,22 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+import dataReplacementService from '@admin/services/dataReplacementService';
+
+const dataFileReplacementQueries = createQueryKeys('user', {
+  getReplacementPlan(
+    releaseVersionId: string,
+    dataFileId: string,
+    replacementDataFileId: string,
+  ) {
+    return {
+      queryKey: [replacementDataFileId],
+      queryFn: () =>
+        dataReplacementService.getReplacementPlan(
+          releaseVersionId,
+          dataFileId,
+          replacementDataFileId,
+        ),
+    };
+  },
+});
+
+export default dataFileReplacementQueries;

--- a/src/explore-education-statistics-admin/src/queries/releaseDataFileQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/releaseDataFileQueries.ts
@@ -8,6 +8,13 @@ const releaseDataFileQueries = createQueryKeys('releaseDataFile', {
       queryFn: () => releaseDataFileService.getDataFiles(releaseId),
     };
   },
+  getDataFile(releaseVersionId: string, dataFileId: string) {
+    return {
+      queryKey: [releaseVersionId, dataFileId],
+      queryFn: () =>
+        releaseDataFileService.getDataFile(releaseVersionId, dataFileId),
+    };
+  },
   getDeleteFilePlan(releaseVersionId: string, dataFileId: string) {
     return {
       queryKey: [releaseVersionId, dataFileId],

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -342,13 +342,7 @@ Validate checklist errors
 Navigate to data upload and confirm data replacement
     user clicks link    Data and files
     user waits until page contains element    testid:Data file replacements table
-    user clicks link    Replace data
-    user waits until h2 is visible    Data file details
-    user waits until page contains    Footnotes: OK
-    user waits until page contains    Data blocks: OK
-    user waits until button is enabled    Confirm data replacement
-    user clicks button    Confirm data replacement
-    user waits until h2 is visible    Data replacement complete    %{WAIT_MEDIUM}
+    user clicks button    Confirm replacement
 
 Upload the larger data file via data upload
     user uploads subject and waits until importing


### PR DESCRIPTION
Adds functionality to confirm or cancel valid data replacements from the data and files page.

Some preparatory work has been added and commented out for adding a bulk confirm button, this will be picked up in a subsequent ticket.

![Screenshot 2025-06-05 121816](https://github.com/user-attachments/assets/be07eddd-36e2-42ce-8c71-29d4f5b03f5a)
