### PR TITLE
Add jobshare warning to PreReleaseUserAccessForm

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseUserAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseUserAccessForm.tsx
@@ -176,7 +176,7 @@ export default function PreReleaseUserAccessForm({
                   label="Invite new users by email"
                   name="emails"
                   className="govuk-!-width-one-third"
-                  hint={`Invite up to ${inviteLimit} users at a time. Enter each email address on a new line.`}
+                  hint={`Invite up to ${inviteLimit} users at a time. Enter each email address on a new line. Jobshare and mailbox accounts will not be able to access EES pre-release, use individual accounts where possible.`}
                   rows={15}
                 />
 


### PR DESCRIPTION
Quick suggested content change as we have some analysts still adding jobshare or mailbox accounts instead of individual emails and then finding on pre-release day people can't access the preview.

Needs a dev to pick up and make sure builds / tests run, and formatting is appropriate (line might want splitting into two depending on our styling rules).