### PR TITLE
Log event grid event payloads

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/EventGridEventHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/Core/EventGridEventHandler.cs
@@ -11,12 +11,15 @@ public class EventGridEventHandler(ILogger<EventGridEventHandler> logger) : IEve
         EventGridEvent eventGridEvent,
         Func<TPayload, CancellationToken, Task<TResponse>> handler)
     {
-        logger.LogDebug("{FunctionName} triggered: {@EventGridEvent}", context.FunctionDefinition.Name, eventGridEvent);
-        
-        var payload = eventGridEvent.Data.ToObjectFromJson<TPayload>() 
-                      ?? throw new Exception(
-                          $"Unable to deserialise the payload of event into type {typeof(TPayload).Name}");
+        var payload = eventGridEvent.Data.ToObjectFromJson<TPayload>(); 
 
+        logger.LogDebug("{FunctionName} triggered: {@EventGridEvent} {@Payload}", context.FunctionDefinition.Name, eventGridEvent, payload);
+
+        if (payload is null)
+        {
+            throw new Exception($"Unable to deserialise the payload of event into type {typeof(TPayload).Name}");
+        }
+        
         try
         {
             var response = await handler(payload, context.CancellationToken);


### PR DESCRIPTION
Logging the EventGridEvent works, but the payload is still in binary form at this point. Therefore, deserialise the payload first so we can log that too.

![image](https://github.com/user-attachments/assets/6afca243-3334-45bc-8a9f-07c75302da6e)
