### PR TITLE
EES-6134 remove option to rotate chart axis labels

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
@@ -60,7 +60,6 @@ export interface ChartAxisConfigurationFormValues
     AxisConfiguration,
     'dataSets' | 'type' | 'label' | 'referenceLines'
   > {
-  labelRotated?: boolean;
   labelText?: string;
   labelWidth?: number | null;
   referenceLines?: FormReferenceLine[];
@@ -228,7 +227,6 @@ const ChartAxisConfiguration = ({
         // set using the `type` prop (which uses the axis key)
         // type,
         label: {
-          rotated: values.labelRotated,
           text: values.labelText,
           width: values.labelWidth,
         },
@@ -238,7 +236,7 @@ const ChartAxisConfiguration = ({
       });
       // referenceLines are removable, so don't merge - update instead
       result.referenceLines = [...refLines];
-      return omit(result, ['labelRotated', 'labelText', 'labelWidth']);
+      return omit(result, ['labelText', 'labelWidth']);
     },
     [axisConfiguration],
   );
@@ -292,12 +290,6 @@ const ChartAxisConfiguration = ({
           'Choose a valid group by',
         ),
         groupByFilter: Yup.string(),
-      });
-    }
-
-    if (axisDefinition?.capabilities.canRotateLabel) {
-      schema = schema.shape({
-        labelRotated: Yup.boolean(),
       });
     }
 
@@ -442,7 +434,6 @@ const ChartAxisConfiguration = ({
     return schema;
   }, [
     axisDefinition?.axis,
-    axisDefinition?.capabilities.canRotateLabel,
     capabilities.canShowAllMajorAxisTicks,
     capabilities.canSort,
     capabilities.hasGridLines,
@@ -464,7 +455,6 @@ const ChartAxisConfiguration = ({
           type === 'major' && !values?.max
             ? parseNumber(limitOptions[limitOptions.length - 1]?.value)
             : values?.max,
-        labelRotated: values?.label?.rotated ?? false,
         labelText: values?.label?.text ?? '',
         labelWidth: values?.label?.width ?? undefined,
         decimalPlaces: values?.decimalPlaces ?? undefined,
@@ -639,13 +629,6 @@ const ChartAxisConfiguration = ({
                       width={5}
                       min={0}
                     />
-
-                    {validationSchema.fields.labelRotated && (
-                      <FormFieldCheckbox
-                        name="labelRotated"
-                        label="Rotate 90 degrees"
-                      />
-                    )}
                   </FormFieldset>
                 </FormFieldset>
               </div>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
@@ -239,7 +239,7 @@ describe('ChartAxisConfiguration', () => {
     expect(handleChange).toHaveBeenCalledWith<[AxisConfiguration]>({
       ...testMajorAxisConfiguration,
       groupByFilterGroups: undefined,
-      label: { rotated: false, text: '', width: undefined },
+      label: { text: '', width: undefined },
       max: 1,
       size: 20,
     });
@@ -425,7 +425,6 @@ describe('ChartAxisConfiguration', () => {
         visible: true,
         unit: '',
         label: {
-          rotated: false,
           text: '',
           width: undefined,
         },
@@ -550,7 +549,6 @@ describe('ChartAxisConfiguration', () => {
           unit: '',
           label: {
             text: '',
-            rotated: false,
             width: undefined,
           },
         };
@@ -606,7 +604,6 @@ describe('ChartAxisConfiguration', () => {
           unit: '',
           label: {
             text: '',
-            rotated: false,
             width: undefined,
           },
         };
@@ -750,7 +747,7 @@ describe('ChartAxisConfiguration', () => {
           unit: '',
           label: {
             text: '',
-            rotated: false,
+
             widht: undefined,
           },
         });
@@ -927,7 +924,6 @@ describe('ChartAxisConfiguration', () => {
           unit: '',
           label: {
             text: '',
-            rotated: false,
             width: undefined,
           },
         };
@@ -1051,7 +1047,6 @@ describe('ChartAxisConfiguration', () => {
           unit: '',
           label: {
             text: '',
-            rotated: false,
             width: undefined,
           },
         };
@@ -1141,7 +1136,7 @@ describe('ChartAxisConfiguration', () => {
         unit: '',
         label: {
           text: '',
-          rotated: false,
+
           width: undefined,
         },
       };
@@ -1213,7 +1208,6 @@ describe('ChartAxisConfiguration', () => {
           unit: '',
           label: {
             text: '',
-            rotated: false,
             width: undefined,
           },
         };

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartConfiguration.test.tsx
@@ -70,9 +70,6 @@ describe('ChartConfiguration', () => {
         id: 'xaxis',
         title: 'X Axis (major axis)',
         type: 'major',
-        capabilities: {
-          canRotateLabel: false,
-        },
         defaults: {
           groupBy: 'timePeriod',
           min: 0,
@@ -89,9 +86,6 @@ describe('ChartConfiguration', () => {
         id: 'yaxis',
         title: 'Y Axis (minor axis)',
         type: 'minor',
-        capabilities: {
-          canRotateLabel: true,
-        },
         defaults: {
           min: 0,
           showGrid: true,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartReferenceLinesConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartReferenceLinesConfiguration.test.tsx
@@ -72,18 +72,12 @@ describe('ChartReferenceLinesConfiguration', () => {
     id: 'xaxis',
     title: 'X Axis (major axis)',
     type: 'major',
-    capabilities: {
-      canRotateLabel: false,
-    },
   };
   const testMinorAxisDefinition: ChartDefinitionAxis = {
     axis: 'y',
     id: 'yaxis',
     title: 'Y Axis (minor axis)',
     type: 'minor',
-    capabilities: {
-      canRotateLabel: true,
-    },
   };
 
   const testTable = testFullTable;

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/contexts/__tests__/ChartBuilderFormsContext.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/contexts/__tests__/ChartBuilderFormsContext.test.tsx
@@ -254,9 +254,6 @@ describe('useChartBuilderFormsContext', () => {
               id: 'major',
               title: 'Major axis',
               defaults: {},
-              capabilities: {
-                canRotateLabel: false,
-              },
             },
           },
           name: '',
@@ -321,9 +318,6 @@ describe('useChartBuilderFormsContext', () => {
             id: 'major',
             title: 'Major axis',
             defaults: {},
-            capabilities: {
-              canRotateLabel: false,
-            },
           },
         },
         name: '',
@@ -420,9 +414,6 @@ describe('useChartBuilderFormsContext', () => {
             id: 'major',
             title: 'Major axis',
             defaults: {},
-            capabilities: {
-              canRotateLabel: false,
-            },
           },
         },
         name: '',
@@ -472,9 +463,6 @@ describe('useChartBuilderFormsContext', () => {
                 id: 'major',
                 title: 'Major axis',
                 defaults: {},
-                capabilities: {
-                  canRotateLabel: false,
-                },
               },
             },
             name: '',
@@ -547,9 +535,6 @@ describe('useChartBuilderFormsContext', () => {
               id: 'minor',
               title: 'Minor axis',
               defaults: {},
-              capabilities: {
-                canRotateLabel: false,
-              },
             },
           },
           name: '',
@@ -608,9 +593,6 @@ describe('useChartBuilderFormsContext', () => {
             id: 'minor',
             title: 'Minor axis',
             defaults: {},
-            capabilities: {
-              canRotateLabel: false,
-            },
           },
         },
         name: '',
@@ -689,9 +671,6 @@ describe('useChartBuilderFormsContext', () => {
             id: 'minor',
             title: 'Minor axis',
             defaults: {},
-            capabilities: {
-              canRotateLabel: false,
-            },
           },
         },
         name: '',
@@ -735,9 +714,6 @@ describe('useChartBuilderFormsContext', () => {
                 id: 'minor',
                 title: 'Minor axis',
                 defaults: {},
-                capabilities: {
-                  canRotateLabel: false,
-                },
               },
             },
             name: '',

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/__tests__/chartBuilderReducer.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/__tests__/chartBuilderReducer.test.ts
@@ -59,9 +59,6 @@ describe('chartBuilderReducer', () => {
         id: 'xaxis',
         title: 'X Axis',
         type: 'major',
-        capabilities: {
-          canRotateLabel: false,
-        },
         defaults: {
           groupBy: 'timePeriod',
           min: 0,
@@ -79,9 +76,6 @@ describe('chartBuilderReducer', () => {
         id: 'yaxis',
         title: 'Y Axis',
         type: 'minor',
-        capabilities: {
-          canRotateLabel: true,
-        },
       },
     },
   };

--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -300,9 +300,6 @@ export const horizontalBarBlockDefinition: ChartDefinition = {
       id: 'major',
       title: 'Y Axis (major axis)',
       type: 'major',
-      capabilities: {
-        canRotateLabel: true,
-      },
       defaults: {
         groupBy: 'timePeriod',
         min: 0,
@@ -323,9 +320,6 @@ export const horizontalBarBlockDefinition: ChartDefinition = {
       id: 'minor',
       title: 'X Axis (minor axis)',
       type: 'minor',
-      capabilities: {
-        canRotateLabel: false,
-      },
       defaults: {
         showGrid: true,
         size: 50,

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -290,9 +290,6 @@ export const lineChartBlockDefinition: ChartDefinition = {
       id: 'xaxis',
       title: 'X Axis (major axis)',
       type: 'major',
-      capabilities: {
-        canRotateLabel: false,
-      },
       defaults: {
         groupBy: 'timePeriod',
         min: 0,
@@ -310,9 +307,6 @@ export const lineChartBlockDefinition: ChartDefinition = {
       id: 'yaxis',
       title: 'Y Axis (minor axis)',
       type: 'minor',
-      capabilities: {
-        canRotateLabel: true,
-      },
       defaults: {
         showGrid: true,
         tickConfig: 'default',

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
@@ -99,9 +99,6 @@ export const mapBlockDefinition: ChartDefinition = {
       title: 'GeoJSON (major axis)',
       type: 'major',
       hide: true,
-      capabilities: {
-        canRotateLabel: false,
-      },
       defaults: {
         groupBy: 'locations',
       },

--- a/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
@@ -363,9 +363,6 @@ export const verticalBarBlockDefinition: ChartDefinition = {
       id: 'major',
       title: 'X Axis (major axis)',
       type: 'major',
-      capabilities: {
-        canRotateLabel: false,
-      },
       defaults: {
         groupBy: 'timePeriod',
         groupByFilter: '',
@@ -385,9 +382,6 @@ export const verticalBarBlockDefinition: ChartDefinition = {
       id: 'minor',
       title: 'Y Axis (minor axis)',
       type: 'minor',
-      capabilities: {
-        canRotateLabel: true,
-      },
       defaults: {
         tickConfig: 'default',
         tickSpacing: 1,

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -52,6 +52,7 @@ export interface ReferenceLine {
 
 export interface Label {
   text: string;
+  // This property can't be set on new charts since EES-6134.
   rotated?: boolean;
   width?: number;
 }
@@ -184,17 +185,12 @@ export interface ChartDefinition {
   };
 }
 
-export interface ChartDefinitionAxisCapabilities {
-  canRotateLabel: boolean;
-}
-
 export interface ChartDefinitionAxis {
   axis?: Axis;
   id: string;
   title: string;
   type: AxisType;
   hide?: boolean;
-  capabilities: ChartDefinitionAxisCapabilities;
   defaults?: NestedPartial<AxisConfiguration>;
   constants?: {
     groupBy?: AxisGroupBy;


### PR DESCRIPTION
because rotated text is bad for accessibility.