### PR TITLE
EES-6024 Remove `azureSearchExists` flag from infrastructure template

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -101,9 +101,6 @@
     "maxStatsDbSizeBytes": {
       "value": 2199023255552
     },
-    "azureSearchExists": {
-      "value": false
-    },
     "eventGridTopicsExist": {
       "value": false
     }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -722,13 +722,6 @@
         "description": "The password to log in to the Container registry"
       }
     },
-    "azureSearchExists": {
-      "type": "bool",
-      "defaultValue": true,
-      "metadata": {
-        "description": "Flag to determine if the Azure AI Search resource exists. TODO EES-6024 remove this when Azure AI Search is available in every environment"
-      }
-    },
     "eventGridTopicsExist": {
       "type": "bool",
       "defaultValue": true,
@@ -2220,9 +2213,9 @@
       "properties": {
         "APP_ENV": "[parameters('environmentName')]",
         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('microsoft.insights/components/', variables('publicAppInsights')), '2020-02-02').InstrumentationKey]",
-        "AZURE_SEARCH_ENDPOINT": "[if(parameters('azureSearchExists'), reference(resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), variables('searchServiceApiVersion')).endpoint, '')]",
+        "AZURE_SEARCH_ENDPOINT": "[reference(resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), variables('searchServiceApiVersion')).endpoint]",
         "AZURE_SEARCH_INDEX": "[parameters('searchIndexName')]",
-        "AZURE_SEARCH_QUERY_KEY": "[if(parameters('azureSearchExists'), listQueryKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), variables('searchServiceApiVersion')).value[0].key, '')]",
+        "AZURE_SEARCH_QUERY_KEY": "[listQueryKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceName')), variables('searchServiceApiVersion')).value[0].key]",
         "BASIC_AUTH": "[parameters('publicAppBasicAuth')]",
         "BASIC_AUTH_USERNAME": "[parameters('publicAppBasicAuthUsername')]",
         "BASIC_AUTH_PASSWORD": "[parameters('publicAppBasicAuthPassword')]",


### PR DESCRIPTION
This PR removes the `azureSearchExists` flag from the infrastructure ARM template.

It provided a conditional check on the availability of the Azure AI Search resource and can be removed now it is available in all Azure environments.

Removing it will mean that the environment variables `AZURE_SEARCH_ENDPOINT` and `AZURE_SEARCH_QUERY_KEY` will have values set during the next Production deploy. They are needed by the public site frontend for the new Find Statistics search.