### PR TITLE
Release Version Published event was missing Release Version Id!

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
@@ -11,6 +11,7 @@ public record ReleaseVersionPublishedEvent : IEvent
         Payload = new EventPayload
         {
             ReleaseId = eventInfo.ReleaseId,
+            ReleaseVersionId = eventInfo.ReleaseVersionId,
             ReleaseSlug = eventInfo.ReleaseSlug,
             PublicationId = eventInfo.PublicationId,
             PublicationSlug = eventInfo.PublicationSlug,
@@ -39,6 +40,7 @@ public record ReleaseVersionPublishedEvent : IEvent
     public record EventPayload
     {
         public required Guid ReleaseId { get; init; }
+        public required Guid ReleaseVersionId { get; set; }
         public required string ReleaseSlug { get; init; }
         public required Guid PublicationId { get; init; }
         public required string PublicationSlug { get; init; }


### PR DESCRIPTION
The reason when a release was being published that nothing was happening was because the event was missing the ReleaseVersionId!

![image](https://github.com/user-attachments/assets/78f06417-2ed6-4d60-b00e-b12f35fdeced)
