### PR TITLE
EES-6199 homepage data catalogue link

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/HomepageCard.module.scss
+++ b/src/explore-education-statistics-frontend/src/components/HomepageCard.module.scss
@@ -1,0 +1,8 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.cardTitle {
+  margin-bottom: 0 !important;
+  @include govuk-media-query($from: tablet, $until: desktop) {
+    @include govuk-font-size(27);
+  }
+}

--- a/src/explore-education-statistics-frontend/src/components/HomepageCard.tsx
+++ b/src/explore-education-statistics-frontend/src/components/HomepageCard.tsx
@@ -1,22 +1,16 @@
 import React from 'react';
+import { logEvent } from '@frontend/services/googleAnalyticsService';
 import ButtonLink from './ButtonLink';
 import styles from './HomepageCard.module.scss';
 
 interface Props {
-  buttonTestId: string;
   buttonText: string;
   destination: string;
   text: string;
   title: string;
 }
 
-const HomepageCard = ({
-  buttonTestId,
-  buttonText,
-  destination,
-  text,
-  title,
-}: Props) => {
+const HomepageCard = ({ buttonText, destination, text, title }: Props) => {
   return (
     <div className="govuk-grid-column-one-third dfe-card__item">
       <div className="dfe-card">
@@ -24,8 +18,14 @@ const HomepageCard = ({
         <p className="govuk-!-margin-top-2">{text}</p>
         <ButtonLink
           to={destination}
-          data-testid={buttonTestId}
           className="govuk-button--start"
+          onClick={() =>
+            logEvent({
+              category: 'Homepage',
+              action: 'Homepage link clicked',
+              label: title,
+            })
+          }
         >
           {buttonText}
           <svg

--- a/src/explore-education-statistics-frontend/src/components/HomepageCard.tsx
+++ b/src/explore-education-statistics-frontend/src/components/HomepageCard.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import ButtonLink from './ButtonLink';
+import styles from './HomepageCard.module.scss';
+
+interface Props {
+  buttonTestId: string;
+  buttonText: string;
+  destination: string;
+  text: string;
+  title: string;
+}
+
+const HomepageCard = ({
+  buttonTestId,
+  buttonText,
+  destination,
+  text,
+  title,
+}: Props) => {
+  return (
+    <div className="govuk-grid-column-one-third dfe-card__item">
+      <div className="dfe-card">
+        <h2 className={styles.cardTitle}>{title}</h2>
+        <p className="govuk-!-margin-top-2">{text}</p>
+        <ButtonLink
+          to={destination}
+          data-testid={buttonTestId}
+          className="govuk-button--start"
+        >
+          {buttonText}
+          <svg
+            className="govuk-button__start-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="17.5"
+            height="19"
+            viewBox="0 0 33 40"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+          </svg>
+        </ButtonLink>
+      </div>
+    </div>
+  );
+};
+
+export default HomepageCard;

--- a/src/explore-education-statistics-frontend/src/pages/index.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import ButtonLink from '@frontend/components/ButtonLink';
+import HomepageCard from '@frontend/components/HomepageCard';
 import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
 import React from 'react';
@@ -7,62 +7,29 @@ function HomePage() {
   return (
     <Page title="Explore our statistics and data" isHomepage>
       <div className="govuk-grid-row dfe-card__container">
-        <div className="govuk-grid-column-one-half dfe-card__item">
-          <div className="dfe-card">
-            <h2 className="govuk-!-margin-bottom-0">
-              Find statistics and data
-            </h2>
-            <p className="govuk-!-margin-top-2">
-              Browse statistical summaries and download associated data to help
-              you understand and analyse our range of statistics.
-            </p>
-            <ButtonLink
-              to="/find-statistics"
-              data-testid="home--find-statistics-link"
-              className="govuk-button--start"
-            >
-              Explore
-              <svg
-                className="govuk-button__start-icon"
-                xmlns="http://www.w3.org/2000/svg"
-                width="17.5"
-                height="19"
-                viewBox="0 0 33 40"
-                aria-hidden="true"
-                focusable="false"
-              >
-                <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-              </svg>
-            </ButtonLink>
-          </div>
-        </div>
-        <div className="govuk-grid-column-one-half dfe-card__item">
-          <div className="dfe-card">
-            <h2 className="govuk-!-margin-bottom-0">Create your own tables</h2>
-
-            <p className="govuk-!-margin-top-2">
-              Explore our range of data and build your own tables from it.
-            </p>
-            <ButtonLink
-              to="/data-tables"
-              data-testid="home--table-tool-link"
-              className="govuk-button--start"
-            >
-              Create
-              <svg
-                className="govuk-button__start-icon"
-                xmlns="http://www.w3.org/2000/svg"
-                width="17.5"
-                height="19"
-                viewBox="0 0 33 40"
-                aria-hidden="true"
-                focusable="false"
-              >
-                <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-              </svg>
-            </ButtonLink>
-          </div>
-        </div>
+        <HomepageCard
+          title="Find statistics and data"
+          text="Find statistical summaries to help you understand and analyse our
+              range of statistics."
+          destination="/find-statistics"
+          buttonTestId="home--find-statistics-link"
+          buttonText="Explore"
+        />
+        <HomepageCard
+          title="Browse data catalogue"
+          text="Browse all of the available open data and choose files to explore
+          or download."
+          destination="/data-tables"
+          buttonTestId="home--data-catalogue-link"
+          buttonText="Browse"
+        />
+        <HomepageCard
+          title="Create your own tables"
+          text="Explore our range of data and build your own tables from it."
+          destination="/data-tables"
+          buttonTestId="home--table-tool-link"
+          buttonText="Create"
+        />
       </div>
 
       <h2 className="govuk-!-margin-top-6">Supporting information</h2>
@@ -77,13 +44,6 @@ function HomePage() {
           <p className="govuk-caption-m">
             Browse our upcoming official statistics releases and their expected
             publication dates.
-          </p>
-
-          <h3 className="govuk-!-margin-bottom-1">
-            <Link to="/data-catalogue">Data catalogue</Link>
-          </h3>
-          <p className="govuk-caption-m">
-            View all of the open data available and choose files to download.
           </p>
 
           <h3 className="govuk-!-margin-bottom-1">

--- a/src/explore-education-statistics-frontend/src/pages/index.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/index.tsx
@@ -1,9 +1,17 @@
 import HomepageCard from '@frontend/components/HomepageCard';
 import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
+import { logEvent } from '@frontend/services/googleAnalyticsService';
 import React from 'react';
 
 function HomePage() {
+  const logLinkClick = (label: string) =>
+    logEvent({
+      category: 'Homepage',
+      action: 'Homepage link clicked',
+      label,
+    });
+
   return (
     <Page title="Explore our statistics and data" isHomepage>
       <div className="govuk-grid-row dfe-card__container">
@@ -12,7 +20,6 @@ function HomePage() {
           text="Find statistical summaries to help you understand and analyse our
               range of statistics."
           destination="/find-statistics"
-          buttonTestId="home--find-statistics-link"
           buttonText="Explore"
         />
         <HomepageCard
@@ -20,14 +27,12 @@ function HomePage() {
           text="Browse all of the available open data and choose files to explore
           or download."
           destination="/data-tables"
-          buttonTestId="home--data-catalogue-link"
           buttonText="Browse"
         />
         <HomepageCard
           title="Create your own tables"
           text="Explore our range of data and build your own tables from it."
           destination="/data-tables"
-          buttonTestId="home--table-tool-link"
           buttonText="Create"
         />
       </div>
@@ -37,7 +42,10 @@ function HomePage() {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h3 className="govuk-!-margin-bottom-1">
-            <Link to="https://www.gov.uk/search/research-and-statistics?content_store_document_type=upcoming_statistics&organisations%5B%5D=department-for-education&order=updated-newest">
+            <Link
+              to="https://www.gov.uk/search/research-and-statistics?content_store_document_type=upcoming_statistics&organisations%5B%5D=department-for-education&order=updated-newest"
+              onClick={() => logLinkClick('Statistics release calendar')}
+            >
               Statistics release calendar
             </Link>
           </h3>
@@ -47,7 +55,9 @@ function HomePage() {
           </p>
 
           <h3 className="govuk-!-margin-bottom-1">
-            <Link to="/methodology">Methodology</Link>
+            <Link to="/methodology" onClick={() => logLinkClick('Methodology')}>
+              Methodology
+            </Link>
           </h3>
           <p className="govuk-caption-m">
             Browse to find out more about the methodology behind our statistics
@@ -55,7 +65,9 @@ function HomePage() {
           </p>
 
           <h3 className="govuk-!-margin-bottom-1">
-            <Link to="/glossary">Glossary</Link>
+            <Link to="/glossary" onClick={() => logLinkClick('Glossary')}>
+              Glossary
+            </Link>
           </h3>
           <p className="govuk-caption-m">
             Browse our A to Z list of definitions for terms used across our
@@ -75,7 +87,10 @@ function HomePage() {
             services provided by the Department for Education (DfE):
           </p>
           <h3 className="govuk-heading-s govuk-!-margin-bottom-0">
-            <a href="https://www.gov.uk/government/organisations/department-for-education/about/statistics">
+            <a
+              href="https://www.gov.uk/government/organisations/department-for-education/about/statistics"
+              onClick={() => logLinkClick('Statistics at DfE')}
+            >
               Statistics at DfE
             </a>
           </h3>
@@ -84,7 +99,12 @@ function HomePage() {
             and ad hoc publications, as well as related education statistics.
           </p>
           <h3 className="govuk-heading-s govuk-!-margin-bottom-0">
-            <a href="https://www.gov.uk/school-performance-tables">
+            <a
+              href="https://www.gov.uk/school-performance-tables"
+              onClick={() =>
+                logLinkClick('Compare school and college performance')
+              }
+            >
               Compare school and college performance
             </a>
           </h3>
@@ -93,7 +113,10 @@ function HomePage() {
             special needs schools and colleges.
           </p>
           <h3 className="govuk-heading-s govuk-!-margin-bottom-0">
-            <a href="https://www.get-information-schools.service.gov.uk/">
+            <a
+              href="https://www.get-information-schools.service.gov.uk/"
+              onClick={() => logLinkClick('Get information about schools')}
+            >
               Get information about schools
             </a>
           </h3>
@@ -102,7 +125,12 @@ function HomePage() {
             educational organisations and governors in England.
           </p>
           <h3 className="govuk-heading-s govuk-!-margin-bottom-0">
-            <a href="https://financial-benchmarking-and-insights-tool.education.gov.uk/">
+            <a
+              href="https://financial-benchmarking-and-insights-tool.education.gov.uk/"
+              onClick={() =>
+                logLinkClick('Financial Benchmarking and Insights Tool')
+              }
+            >
               Financial Benchmarking and Insights Tool
             </a>
           </h3>

--- a/tests/robot-tests/tests/general_public/miscellaneous.robot
+++ b/tests/robot-tests/tests/general_public/miscellaneous.robot
@@ -28,6 +28,7 @@ Verify can accept cookie banner
 
 Validate homepage
     user checks page contains element    link:Explore
+    user checks page contains element    link:Browse
     user checks page contains element    link:Create
 
     user waits until h2 is visible    Supporting information


### PR DESCRIPTION
This PR moves the data catalogue page link on the homepage from under 'Supporting information' to be a CTA box alongside the other two boxes.

As part of this work, I have pulled the homepage box links out into a separate component to reduce repetition. 

It also adds google analytics tracking for when the homepage links are clicked on. N.b I haven't tested the GA tracking locally as don't have the config set up, but am 90% sure it should work as the same function is used elsewhere in the codebase - we should be able to test it easily on the dev environment.

