### PR TITLE
Fix potentially null config

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Extensions/ConfigurationExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Extensions/ConfigurationExtensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Configuration;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Extensions;
+
+public static class ConfigurationExtensions
+{
+    public static string GetRequiredValue(this IConfiguration configuration, string key) =>
+        configuration.GetValue<string>(key)
+            .ThrowIfBlank(
+                configuration is IConfigurationSection configurationSection
+                    ? $"{configurationSection.Path}.{key}"
+                    : key);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Extensions/StringExtensions.cs
@@ -1,0 +1,12 @@
+#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Extensions;
+
+public static class StringExtensions
+{
+    public static string ThrowIfBlank(this string? value, string description) =>
+        string.IsNullOrWhiteSpace(value)
+            ? throw new ArgumentNullException($"Value is missing:{description}")
+            : value;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -128,7 +128,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
 
             // Services
             services.AddSingleton<IPublicBlobStorageService, PublicBlobStorageService>(provider =>
-                new PublicBlobStorageService(configuration.GetValue<string>("PublicStorage"),
+                new PublicBlobStorageService(configuration.GetRequiredValue("PublicStorage"),
                     provider.GetRequiredService<ILogger<IBlobStorageService>>()));
             services.AddTransient<IBlobCacheService, BlobCacheService>(provider => new BlobCacheService(
                 provider.GetRequiredService<IPublicBlobStorageService>(),
@@ -190,7 +190,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app,
             IWebHostEnvironment env,
-            ILogger<Startup> logger)
+            ILogger<Startup> _)
         {
             // Enable caching and register any caching services
             CacheAspect.Enabled = true;


### PR DESCRIPTION
Public Storage config is not optional - so added guard, instead of allowing a null value to be passed in and throw..
