### PR TITLE
Fix first release bug

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseVersionPublished/OnReleaseVersionPublishedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnReleaseVersionPublished/OnReleaseVersionPublishedFunctionTests.cs
@@ -99,6 +99,25 @@ public class OnReleaseVersionPublishedFunctionTests
         // the previous searchable document does not need to be removed.
         Assert.Empty(response.RemoveSearchableDocuments);
     }
+    
+    [Fact]
+    public async Task GivenEvent_WhenPublishedReleaseVersionIsTheFirstRelease_ThenNoSearchableDocumentIsRemoved()
+    {
+        // ARRANGE
+        var payload = NewReleaseVersionPublishedEvents.NewlyPublishedIsTheFirstRelease;
+        
+        var eventGridEvent = new EventGridEventBuilder()
+            .WithPayload(payload)
+            .Build();
+
+        var sut = GetSut();
+        
+        // ACT
+        var response = await sut.OnReleaseVersionPublished(eventGridEvent, new FunctionContextMockBuilder().Build());
+        
+        // ASSERT
+        Assert.Empty(response.RemoveSearchableDocuments);
+    }
 
     private static class NewReleaseVersionPublishedEvents
     {
@@ -145,5 +164,11 @@ public class OnReleaseVersionPublishedFunctionTests
             };
 
         public static ReleaseVersionPublishedEventDto NewlyPublishedIsForSameRelease => Base;
+        
+        public static ReleaseVersionPublishedEventDto NewlyPublishedIsTheFirstRelease => Base with
+        {
+            PreviousLatestPublishedReleaseId = null,
+            PreviousLatestPublishedReleaseVersionId = null
+        };
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/OnReleaseVersionPublishedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnReleaseVersionPublished/OnReleaseVersionPublishedFunction.cs
@@ -23,12 +23,21 @@ public class OnReleaseVersionPublishedFunction(IEventGridEventHandler eventGridE
                         ? OnReleaseVersionPublishedOutput.Empty
                         : new OnReleaseVersionPublishedOutput
                         {
-                            RefreshSearchableDocumentMessages = 
-                                [ new RefreshSearchableDocumentMessageDto { PublicationSlug = payload.PublicationSlug } ],
-                            RemoveSearchableDocuments = payload.NewlyPublishedReleaseVersionIsForDifferentRelease
-                                ? [ new RemoveSearchableDocumentDto { ReleaseId = payload.PreviousLatestPublishedReleaseId } ]
-                                : []
+                            RefreshSearchableDocumentMessages = BuildRefreshSearchableDocumentMessages(payload),
+                            RemoveSearchableDocuments = BuildRemoveSearchableDocumentsCommands(payload)
                         }));
+
+    private static RefreshSearchableDocumentMessageDto[] BuildRefreshSearchableDocumentMessages(ReleaseVersionPublishedEventDto payload) => 
+        [ new() { PublicationSlug = payload.PublicationSlug } ];
+
+    private static RemoveSearchableDocumentDto[] BuildRemoveSearchableDocumentsCommands(ReleaseVersionPublishedEventDto payload) =>
+        payload is
+        {
+            NewlyPublishedReleaseVersionIsForDifferentRelease: true, 
+            PreviousLatestPublishedReleaseId: not null
+        }
+            ? [ new RemoveSearchableDocumentDto { ReleaseId = payload.PreviousLatestPublishedReleaseId } ]
+            : [];
 }
 
 public record OnReleaseVersionPublishedOutput


### PR DESCRIPTION
If the release being published is the first one, then there is no previous searchable document to remove. Therefore do not attempt to remove one.
