### PR TITLE
Remove test.only and lint issues fix

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
@@ -504,7 +504,7 @@ describe('ChartAxisConfiguration', () => {
       ).toHaveAttribute('href', '#chartBuilder-minor-decimalPlaces');
     });
 
-    test.only('allows decimal places to be set to 0', async () => {
+    test('allows decimal places to be set to 0', async () => {
       const { user } = render(
         <ChartBuilderFormsContextProvider initialForms={testFormState}>
           <ChartAxisConfiguration

--- a/src/explore-education-statistics-frontend/src/components/Page.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Page.tsx
@@ -1,5 +1,4 @@
 import PhaseBanner from '@common/components/PhaseBanner';
-import NotificationBanner from '@common/components/NotificationBanner';
 import CookieBanner from '@frontend/components/CookieBanner';
 import UserTestingBanner from '@frontend/components/UserTestingBanner';
 import classNames from 'classnames';
@@ -10,7 +9,6 @@ import PageHeader from './PageHeader';
 import PageMeta, { PageMetaProps } from './PageMeta';
 import PageTitle from './PageTitle';
 import Feedback from './Feedback';
-import Link from './Link';
 
 type Props = {
   includeDefaultMetaTitle?: boolean;


### PR DESCRIPTION
- Replace a `test.only(` with `test(` . This will stop Jest skipping most tests in the `ChartAxisConfiguration.test.tsx` suite
- Remove unused imports to fix lint errors

I missed these issues when reviewing and merging Amy's PRs last week but are quick minor fixes.