### PR TITLE
EES-6127 - (STEP 4) Add the new Publication roles, `Approver` and `Drafter`, to the `PublicationRole` enum

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/PublicationRole.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/PublicationRole.cs
@@ -3,6 +3,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
     public enum PublicationRole
     {
         Owner,
-        Allower
+        Allower,
+        Approver,
+        Drafter
     }
 }


### PR DESCRIPTION
### STEP 4 of the Permissions Rework

This is a very small PR which just adds the `Approver` and `Drafter` options to the `PublicationRole` enum in the BE. Neither are being used yet, but will start being used in the next step (**STEP 5**).