### PR TITLE
EES-6199 Fix link on homepage

### DIFF
--- a/src/explore-education-statistics-frontend/src/pages/index.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/index.tsx
@@ -26,7 +26,7 @@ function HomePage() {
           title="Browse data catalogue"
           text="Browse all of the available open data and choose files to explore
           or download."
-          destination="/data-tables"
+          destination="/data-catalogue"
           buttonText="Browse"
         />
         <HomepageCard


### PR DESCRIPTION
After merging the work for EES-6199 Nusrath found I'd put in the wrong link 🤦 😳 

This fixes that and points the data catalogue CTA to the data catalogue page instead of the table tool.
