### PR TITLE
EES-5548 - updated UI tests to be in line with UI changes

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
@@ -239,7 +239,7 @@ Replace subject data
     user checks headed table body row cell contains    Metadata file    1    grouped-filters-and-indicators.meta.csv
     user checks headed table body row cell contains    Number of rows    1    100    wait=%{WAIT_SMALL}
     user checks headed table body row cell contains    Data file size    1    13 Kb
-    user checks headed table body row cell contains    Status    1    Replacement in progress    wait=%{WAIT_LONG}
+    user checks headed table body row cell contains    Status    1    Complete    wait=%{WAIT_LONG}
 
     user checks headed table body row cell contains    Title    2    ${SUBJECT_NAME}
     user checks headed table body row cell contains    Data file    2    grouped-filters-and-indicators-replacement.csv

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -519,7 +519,7 @@ Upload replacement data
     user checks headed table body row cell contains    Metadata file    1    dates.meta.csv
     user checks headed table body row cell contains    Number of rows    1    118    wait=%{WAIT_SMALL}
     user checks headed table body row cell contains    Data file size    1    17 Kb    wait=%{WAIT_SMALL}
-    user checks headed table body row cell contains    Status    1    Replacement in progress    wait=%{WAIT_LONG}
+    user checks headed table body row cell contains    Status    1    Complete    wait=%{WAIT_LONG}
 
     user checks headed table body row cell contains    Title    2    Dates test subject
     user checks headed table body row cell contains    Data file    2    dates-replacement.csv


### PR DESCRIPTION
This PR:
- updates expected text on the Data Replacement page in line with the UI changes made in https://github.com/dfe-analytical-services/explore-education-statistics/pull/5977 