### PR TITLE
EES-6222 Increase max search facet terms count from 60 to 150

### DIFF
--- a/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
+++ b/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
@@ -76,7 +76,7 @@ const azurePublicationService = {
       searchMode: 'any',
       scoringProfile: 'scoring-profile-1',
       highlightFields: 'content',
-      facets: ['themeId,count:60,sort:count', 'releaseType'],
+      facets: ['themeId,count:150,sort:count', 'releaseType'],
       filter,
       orderBy: orderBy ? [orderBy] : undefined,
       select: [


### PR DESCRIPTION
This PR increases the maximum number of search facet terms count from 60 to 150 to accommodate for the growing number of themes in the Dev environment. The facet count parameter limits the number of unique facet terms which are returned.

It was set to 60 in the frontend search options, but there are currently 102 unique theme id’s in search results in the Dev environment.

Documentation on `count` from [Faceted navigation examples - Azure AI Search](https://learn.microsoft.com/en-us/azure/search/search-faceted-navigation-examples#facet-parameters-and-syntax):

> Default is 10. There's no upper limit, but higher values degrade performance, especially if the faceted field contains a large number of unique terms. This is due to the way facet queries are distributed across shards. You can set count to zero or to a value that's greater than or equal to the number of unique values in the facetable field to get an accurate count across all shards. The tradeoff is increased latency.

Also see [Discrepancies in facet counts](https://learn.microsoft.com/en-us/azure/search/search-faceted-navigation?tabs=portal-facet%2Cportal-facet-response#discrepancies-in-facet-counts).

Limiting the count to 60 unique terms led to a bug where some theme options were included with counts '(0)' when 'All themes' is selected, but when going on to select them we can see they do have results.

![image (23)](https://github.com/user-attachments/assets/369977ae-d9c7-4021-aca0-cec6562771bc)


![image](https://github.com/user-attachments/assets/99edb588-90bf-44b9-bcf3-324267af9005)
