### PR TITLE
EES-6217 FIXED: created datablock maps now load with geoJson on render

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -15,6 +15,7 @@ import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import getMapInitialBoundaryLevel from '@common/modules/charts/components/utils/getMapInitialBoundaryLevel';
 import isOrphanedDataSet from '@common/modules/charts/util/isOrphanedDataSet';
 import { InitialTableToolState } from '@common/modules/table-tool/components/TableToolWizard';
 import getInitialStepSubjectMeta from '@common/modules/table-tool/components/utils/getInitialStepSubjectMeta';
@@ -100,7 +101,21 @@ const DataBlockPageTabs = ({
       };
     }
 
-    const table = mapFullTable(tableData);
+    const table = mapFullTable({
+      ...tableData,
+      subjectMeta: {
+        ...tableData.subjectMeta,
+        locations:
+          dataBlock.charts[0]?.type !== 'map'
+            ? tableData.subjectMeta.locations
+            : // for maps, set TableDataSubjectMeta location values to LocationGeoJsonOption[], instead of LocationOption[]
+              await tableBuilderService.getDataBlockGeoJson(
+                releaseVersionId,
+                dataBlock.dataBlockParentId,
+                getMapInitialBoundaryLevel(dataBlock.charts[0]),
+              ),
+      },
+    });
 
     try {
       const tableHeaders = mapTableHeadersConfig(


### PR DESCRIPTION
Previously, the tableBuilderService getTableData query would return geoJson in the response's subjectMeta locations
This is removed in prior work, and this left our chart builder without geoJson information when loading an already created datablock with a map.
This now fixes that issue, when loading a datablock with chart of type "map", we now fetch the geoJson and add it to the subjectMeta locations