### PR TITLE
Rename FeatureFlags.cs to FeatureFlagsOptions.cs across the codebase to abide by convention in place.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetFileStorageTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetFileStorageTests.cs
@@ -143,7 +143,7 @@ public class DataSetFileStorageTests
                });
         }
 
-        var featureFlagOptions = Microsoft.Extensions.Options.Options.Create(new FeatureFlags()
+        var featureFlagOptions = Microsoft.Extensions.Options.Options.Create(new FeatureFlagsOptions()
         {
             EnableReplacementOfPublicApiDataSets = false
         });
@@ -404,7 +404,7 @@ public class DataSetFileStorageTests
         IDataImportService? dataImportService = null,
         IUserService? userService = null,
         IDataSetVersionService? dataSetVersionService = null,
-        IOptions<FeatureFlags>? featureFlags = null,
+        IOptions<FeatureFlagsOptions>? featureFlags = null,
         bool addDefaultUser = true)
     {
         if (addDefaultUser)
@@ -421,7 +421,7 @@ public class DataSetFileStorageTests
             dataImportService ?? Mock.Of<IDataImportService>(Strict),
             userService ?? MockUtils.AlwaysTrueUserService(_user.Id).Object,
             dataSetVersionService ?? Mock.Of<IDataSetVersionService>(Strict),
-            featureFlags ?? Mock.Of<IOptions<FeatureFlags>>(Strict),
+            featureFlags ?? Mock.Of<IOptions<FeatureFlagsOptions>>(Strict),
             Mock.Of<ILogger<DataSetFileStorage>>(Strict));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetValidatorTests.cs
@@ -274,7 +274,7 @@ public class DataSetValidatorTests
         context.ReleaseFiles.AddRange(existingDataReleaseFile, existingMetaReleaseFile);
         await context.SaveChangesAsync();
 
-        var featureFlagOptions = Microsoft.Extensions.Options.Options.Create(new FeatureFlags()
+        var featureFlagOptions = Microsoft.Extensions.Options.Options.Create(new FeatureFlagsOptions()
         {
             EnableReplacementOfPublicApiDataSets = false
         });
@@ -578,7 +578,7 @@ public class DataSetValidatorTests
 
     private static DataSetValidator BuildService(
         ContentDbContext? contentDbContext = null,
-        IOptions<FeatureFlags>? featureFlags = null)
+        IOptions<FeatureFlagsOptions>? featureFlags = null)
     {
         return new DataSetValidator(
             contentDbContext!,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetVersionMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetVersionMappingServiceTests.cs
@@ -167,7 +167,7 @@ public class DataSetVersionMappingServiceTests
         IPostgreSqlRepository? mockPostgreSqlRepository = null,
         IUserService? mockUserService = null,
         IMappingTypesRepository? mockMappingTypesRepository = null,
-        IOptions<FeatureFlags>? mockFeatureFlags = null)
+        IOptions<FeatureFlagsOptions>? mockFeatureFlags = null)
     {
         return new DataSetVersionMappingService(
             mockPostgreSqlRepository ?? Mock.Of<IPostgreSqlRepository>(behavior: MockBehavior.Strict),
@@ -175,7 +175,7 @@ public class DataSetVersionMappingServiceTests
             publicDataDbContext,
             contentDbContext,
             mockMappingTypesRepository ?? Mock.Of<IMappingTypesRepository>(behavior: MockBehavior.Strict),
-            mockFeatureFlags ?? Microsoft.Extensions.Options.Options.Create(new FeatureFlags
+            mockFeatureFlags ?? Microsoft.Extensions.Options.Options.Create(new FeatureFlagsOptions
             {
                 EnableReplacementOfPublicApiDataSets = false
             }));

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServicePermissionTests.cs
@@ -386,7 +386,7 @@ public class ReleaseVersionServicePermissionTests
             Mock.Of<IProcessorClient>(),
             Mock.Of<IPrivateBlobCacheService>(),
             Mock.Of<IReleaseSlugValidator>(),
-             featureFlags: Microsoft.Extensions.Options.Options.Create(new FeatureFlags()
+             featureFlags: Microsoft.Extensions.Options.Options.Create(new FeatureFlagsOptions()
              {
                  EnableReplacementOfPublicApiDataSets = enableReplacementOfPublicApiDataSets
              }),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServiceTests.cs
@@ -2613,7 +2613,7 @@ public abstract class ReleaseVersionServiceTests
             processorClient ?? Mock.Of<IProcessorClient>(Strict),
             privateCacheService ?? Mock.Of<IPrivateBlobCacheService>(Strict),
             releaseSlugValidator ?? new ReleaseSlugValidatorMockBuilder().Build(),
-            featureFlags: Microsoft.Extensions.Options.Options.Create(new FeatureFlags()
+            featureFlags: Microsoft.Extensions.Options.Options.Create(new FeatureFlagsOptions()
             {
                 EnableReplacementOfPublicApiDataSets = enableReplacementOfPublicApiDataSets
             }),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -1804,7 +1804,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     HasMajorVersionUpdate = majorVersionUpdate
                 });
             
-            var options = Microsoft.Extensions.Options.Options.Create(new FeatureFlags()
+            var options = Microsoft.Extensions.Options.Options.Create(new FeatureFlagsOptions()
             {
                 EnableReplacementOfPublicApiDataSets = enableReplacementOfPublicApiDataSets
             });
@@ -2835,7 +2835,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     LocationsComplete = true,
                     HasMajorVersionUpdate = false
                 });
-            var options = Microsoft.Extensions.Options.Options.Create(new FeatureFlags()
+            var options = Microsoft.Extensions.Options.Options.Create(new FeatureFlagsOptions()
             {
                 EnableReplacementOfPublicApiDataSets = enableReplacementOfPublicApiDataSets
             });
@@ -4593,10 +4593,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             ICacheKeyService? cacheKeyService = null,
             IPrivateBlobCacheService? privateBlobCacheService = null,
             IDataSetVersionMappingService? dataSetVersionMappingService = null,
-            IOptions<FeatureFlags>? featureFlags = null
+            IOptions<FeatureFlagsOptions>? featureFlags = null
             )
         {
-            featureFlags ??= Microsoft.Extensions.Options.Options.Create(new FeatureFlags()
+            featureFlags ??= Microsoft.Extensions.Options.Options.Create(new FeatureFlagsOptions()
             {
                 EnableReplacementOfPublicApiDataSets = false
             });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetFileStorage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetFileStorage.cs
@@ -34,7 +34,7 @@ public class DataSetFileStorage(
     IDataImportService dataImportService,
     IUserService userService,
     IDataSetVersionService dataSetVersionService,
-    IOptions<FeatureFlags> featureFlags, 
+    IOptions<FeatureFlagsOptions> featureFlags, 
     ILogger<DataSetFileStorage> logger) : IDataSetFileStorage
 {
     public async Task<DataFileInfo> UploadDataSet(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetValidator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetValidator.cs
@@ -22,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 {
     public class DataSetValidator(
         ContentDbContext context,
-        IOptions<FeatureFlags> featureFlags) : IDataSetValidator
+        IOptions<FeatureFlagsOptions> featureFlags) : IDataSetValidator
     {
         public const int MaxFilenameSize = 150;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetVersionMappingService.cs
@@ -33,7 +33,7 @@ public class DataSetVersionMappingService(
     PublicDataDbContext publicDataDbContext,
     ContentDbContext contentDbContext,
     IMappingTypesRepository mappingTypesRepository,
-    IOptions<FeatureFlags> featureFlags)
+    IOptions<FeatureFlagsOptions> featureFlags)
     : IDataSetVersionMappingService
 {
     private static readonly MappingType[] IncompleteMappingTypes =

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
@@ -64,7 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         IProcessorClient processorClient,
         IPrivateBlobCacheService privateCacheService,
         IReleaseSlugValidator releaseSlugValidator,
-        IOptions<FeatureFlags> featureFlags,
+        IOptions<FeatureFlagsOptions> featureFlags,
         ILogger<ReleaseVersionService> logger) : IReleaseVersionService
     {
         public async Task<Either<ActionResult, ReleaseVersionViewModel>> GetRelease(Guid releaseVersionId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -49,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         ICacheKeyService cacheKeyService,
         IPrivateBlobCacheService privateCacheService,
         IDataSetVersionMappingService dataSetVersionMappingService,
-        IOptions<FeatureFlags> featureFlags)
+        IOptions<FeatureFlagsOptions> featureFlags)
         : IReplacementService
     {
         private static IComparer<string> LabelComparer { get; } = new LabelRelationalComparer();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -391,8 +391,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                 configuration.GetRequiredSection(TableBuilderOptions.Section));
             services.Configure<OpenIdConnectSpaClientOptions>(
                 configuration.GetSection(OpenIdConnectSpaClientOptions.Section));
-            services.Configure<FeatureFlags>(
-                configuration.GetSection(FeatureFlags.Section));
+            services.Configure<FeatureFlagsOptions>(
+                configuration.GetSection(FeatureFlagsOptions.Section));
             services.Configure<RouteOptions>(options => options.LowercaseUrls = true);
 
             StartupSecurityConfiguration.ConfigureAuthorizationPolicies(services);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/FunctionsIntegrationTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/FunctionsIntegrationTest.cs
@@ -96,7 +96,7 @@ public abstract class FunctionsIntegrationTest<TFunctionsIntegrationTestFixture>
 
     protected void SetDataSetVersionReplacementFeatureFlag(bool flag)
     {
-        var options = GetRequiredService<IOptions<FeatureFlags>>().Value;
+        var options = GetRequiredService<IOptions<FeatureFlagsOptions>>().Value;
         options.EnableReplacementOfPublicApiDataSets = flag;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Options/FeatureFlagsOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Options/FeatureFlagsOptions.cs
@@ -1,6 +1,6 @@
 ﻿namespace GovUk.Education.ExploreEducationStatistics.Common.Options;
 
-public class FeatureFlags
+public class FeatureFlagsOptions
 {
     /// <summary>
     /// Whilst EES-5779 is being developed, this prevents

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateNextDataSetVersionMappingsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CreateNextDataSetVersionMappingsFunction.cs
@@ -20,7 +20,7 @@ public class CreateNextDataSetVersionMappingsFunction(
     ILogger<CreateNextDataSetVersionMappingsFunction> logger,
     IDataSetVersionService dataSetVersionService,
     IValidator<NextDataSetVersionMappingsCreateRequest> requestValidator,
-    IOptions<FeatureFlags> featureFlags)
+    IOptions<FeatureFlagsOptions> featureFlags)
 {
     [Function(nameof(CreateNextDataSetVersionMappings))]
     public async Task<IActionResult> CreateNextDataSetVersionMappings(

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/ProcessorHostBuilder.cs
@@ -97,8 +97,8 @@ public static class ProcessorHostBuilder
                             provider.GetRequiredService<ILogger<IBlobStorageService>>()))
                     .Configure<AppOptions>(
                         hostBuilderContext.Configuration.GetSection(AppOptions.Section))
-                    .Configure<FeatureFlags>(
-                        hostBuilderContext.Configuration.GetSection(FeatureFlags.Section))
+                    .Configure<FeatureFlagsOptions>(
+                        hostBuilderContext.Configuration.GetSection(FeatureFlagsOptions.Section))
                     .Configure<DataFilesOptions>(
                         hostBuilderContext.Configuration.GetSection(DataFilesOptions.Section));
                 

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionMappingService.cs
@@ -22,7 +22,7 @@ internal class DataSetVersionMappingService(
     IDataSetMetaService dataSetMetaService,
     PublicDataDbContext publicDataDbContext,
     ContentDbContext contentDbContext,
-    IOptions<FeatureFlags> featureFlags)
+    IOptions<FeatureFlagsOptions> featureFlags)
     : IDataSetVersionMappingService
 {
     private static readonly MappingType[] IncompleteMappingTypes =

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -28,7 +28,7 @@ internal class DataSetVersionService(
     PublicDataDbContext publicDataDbContext,
     IReleaseFileRepository releaseFileRepository,
     IDataSetVersionPathResolver dataSetVersionPathResolver,
-    IOptions<FeatureFlags> featureFlags,
+    IOptions<FeatureFlagsOptions> featureFlags,
     IOptions<AppOptions> options) : IDataSetVersionService
 {
     public async Task<Either<ActionResult, Guid>> CreateInitialVersion(


### PR DESCRIPTION
This PR renames the config options class FeatureFlags to FeatureFlagsOptions.

This PR simplifies the PR https://github.com/dfe-analytical-services/explore-education-statistics/pull/6035/commits/20d0a46370220ccff9adb78caa3ce2c86d36cef2 by not polluting that PR with these changes where FeatureFlags is renamed to FeatureFlagsOptions