### PR TITLE
EES-6235 Release Version Published Event - Add Is Publication Archived flag

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/PublicationExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/PublicationExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+
+public static class PublicationExtensions
+{
+    public static bool IsArchived(this Publication publication) =>
+        !publication.SupersededById.IsBlank()
+        && (publication.SupersededBy?.LatestPublishedReleaseVersionId.HasValue
+            ?? throw new ArgumentException(
+                $"{nameof(Publication)}.{nameof(publication.SupersededBy)} has not been populated. Ensure it is Included in the entity in the query."));
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
@@ -105,7 +105,7 @@ public record ReleaseVersionPublishedEvent : IEvent
         public required Guid? PreviousLatestPublishedReleaseVersionId { get; init; }
         
         /// <summary>
-        /// Indicates whether the parent publication is archived
+        /// Indicates whether the associated publication is archived
         /// </summary>
         public required bool IsPublicationArchived { get; init; }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
@@ -18,7 +18,8 @@ public record ReleaseVersionPublishedEvent : IEvent
             LatestPublishedReleaseId = eventInfo.LatestPublishedReleaseId,
             LatestPublishedReleaseVersionId = eventInfo.LatestPublishedReleaseVersionId,
             PreviousLatestPublishedReleaseId = eventInfo.PreviousLatestPublishedReleaseId,
-            PreviousLatestPublishedReleaseVersionId = eventInfo.PreviousLatestPublishedReleaseVersionId
+            PreviousLatestPublishedReleaseVersionId = eventInfo.PreviousLatestPublishedReleaseVersionId,
+            IsPublicationArchived = eventInfo.IsPublicationArchived
         };
     }
 
@@ -48,6 +49,7 @@ public record ReleaseVersionPublishedEvent : IEvent
         public required Guid LatestPublishedReleaseVersionId { get; init; }
         public required Guid? PreviousLatestPublishedReleaseId { get; init; }
         public required Guid? PreviousLatestPublishedReleaseVersionId { get; init; }
+        public required bool IsPublicationArchived { get; init; }
     }
     public EventPayload Payload { get; }
     
@@ -101,5 +103,10 @@ public record ReleaseVersionPublishedEvent : IEvent
         /// The latest published release version id of the publication's latest published release before the release version was published.
         /// </summary>
         public required Guid? PreviousLatestPublishedReleaseVersionId { get; init; }
+        
+        /// <summary>
+        /// Indicates whether the parent publication is archived
+        /// </summary>
+        public required bool IsPublicationArchived { get; init; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Models/PublicationBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Models/PublicationBuilder.cs
@@ -6,6 +6,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Mo
 public class PublicationBuilder(Guid publicationId, string publicationSlug)
 {
     private Guid? _supersededByPublicationId;
+    private Publication? _supersededByPublication;
+    private bool _hasPublishedReleaseVersion;
 
     public Publication Build()
     {
@@ -13,14 +15,29 @@ public class PublicationBuilder(Guid publicationId, string publicationSlug)
         {
             Id = publicationId,
             Slug = publicationSlug,
-            SupersededById = _supersededByPublicationId
+            LatestPublishedReleaseVersionId = _hasPublishedReleaseVersion ? Guid.NewGuid() : null,
+            SupersededById = _supersededByPublicationId,
+            SupersededBy = _supersededByPublication
         };
         return publication;
     }
 
+    public PublicationBuilder HasPublishedReleaseVersion()
+    {
+        _hasPublishedReleaseVersion = true;
+        return this;
+    }
+    
     public PublicationBuilder SupersededBy(Guid supersededByPublicationId)
     {
         _supersededByPublicationId = supersededByPublicationId;
+        return this;
+    }
+    
+    public PublicationBuilder SupersededBy(Publication supersededByPublication)
+    {
+        _supersededByPublication = supersededByPublication;
+        _supersededByPublicationId = supersededByPublication.Id;
         return this;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ContentDbContextMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ContentDbContextMockBuilder.cs
@@ -9,11 +9,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Builders.Se
 
 public class ContentDbContextMockBuilder
 {
-    private readonly ContentDbContext _inMemoryContentDbContext = ContentDbUtils.InMemoryContentDbContext();
+    private readonly string _dbContextId = Guid.NewGuid().ToString(); 
+    private ContentDbContext _inMemoryContentDbContext;
 
+    public ContentDbContextMockBuilder()
+    {
+        // Create a db context for the ARRANGE phase
+        _inMemoryContentDbContext = ContentDbUtils.InMemoryContentDbContext(_dbContextId);
+    }
     public Asserter Assert => new(_inMemoryContentDbContext);
     public ContentDbContext Build()
     {
+        // Dispose of the ARRANGE db context
+        _inMemoryContentDbContext.Dispose();
+        
+        // Create a new db context for the ACT and ASSERT phase.
+        // This ensures any queries performed by the SUT are correctly rehydrating any
+        // child entities through .Include declarations.
+        _inMemoryContentDbContext = ContentDbUtils.InMemoryContentDbContext(_dbContextId);
         return _inMemoryContentDbContext;
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ContentDbContextMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ContentDbContextMockBuilder.cs
@@ -18,14 +18,20 @@ public class ContentDbContextMockBuilder
         _inMemoryContentDbContext = ContentDbUtils.InMemoryContentDbContext(_dbContextId);
     }
     public Asserter Assert => new(_inMemoryContentDbContext);
+    
+    /// <summary>
+    /// Note: It is intended that this method is called during the creation of the SUT, at the last moment
+    /// before the ACT phase. This is because the in-memory db context that was created for the ARRANGE phase
+    /// is disposed and a new instance created. This ensures that any queries performed by the SUT are correctly
+    /// rehydrating any child entities through .Include declarations. 
+    /// </summary>
+    /// <returns></returns>
     public ContentDbContext Build()
     {
         // Dispose of the ARRANGE db context
         _inMemoryContentDbContext.Dispose();
         
         // Create a new db context for the ACT and ASSERT phase.
-        // This ensures any queries performed by the SUT are correctly rehydrating any
-        // child entities through .Include declarations.
         _inMemoryContentDbContext = ContentDbUtils.InMemoryContentDbContext(_dbContextId);
         return _inMemoryContentDbContext;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublisherEventRaiserTests.cs
@@ -60,8 +60,10 @@ public class PublisherEventRaiserTests
 
     public class RaiseReleaseVersionPublishedPublisherEvents : PublisherEventRaiserTests
     {
-        [Fact]
-        public async Task WhenOnePublishedReleaseVersion_ThenEventRaised()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WhenOnePublishedReleaseVersion_ThenEventRaised(bool isPublicationArchived)
         {
             // ARRANGE
             var publicationId = Guid.NewGuid();
@@ -82,7 +84,8 @@ public class PublisherEventRaiserTests
                         ReleaseVersionId = Guid.NewGuid(),
                         PublicationId = publicationId
                     }
-                ]
+                ],
+                IsPublicationArchived = isPublicationArchived
             };
 
             // ACT
@@ -100,13 +103,16 @@ public class PublisherEventRaiserTests
                     PreviousLatestPublishedReleaseId = info.PreviousLatestPublishedReleaseId,
                     PreviousLatestPublishedReleaseVersionId = info.PreviousLatestPublishedReleaseVersionId,
                     LatestPublishedReleaseId = info.LatestPublishedReleaseId,
-                    LatestPublishedReleaseVersionId = info.LatestPublishedReleaseVersionId
+                    LatestPublishedReleaseVersionId = info.LatestPublishedReleaseVersionId,
+                    IsPublicationArchived = isPublicationArchived
                 });
             _eventRaiserMockBuilder.Assert.EventsRaised([expectedEvent]);
         }
 
-        [Fact]
-        public async Task WhenMultiplePublishedReleaseVersions_ThenEventsRaised()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WhenMultiplePublishedReleaseVersions_ThenEventsRaised(bool isPublicationArchived)
         {
             // ARRANGE
             var sut = GetSut();
@@ -138,7 +144,8 @@ public class PublisherEventRaiserTests
                             ReleaseVersionId = Guid.NewGuid(),
                             PublicationId = publication1Id
                         }
-                    ]
+                    ],
+                    IsPublicationArchived = isPublicationArchived
                 },
                 new PublishedPublicationInfo
                 {
@@ -164,7 +171,8 @@ public class PublisherEventRaiserTests
                             ReleaseVersionId = Guid.NewGuid(),
                             PublicationId = publication2Id
                         }
-                    ]
+                    ],
+                    IsPublicationArchived = isPublicationArchived
                 }
             };
 
@@ -185,7 +193,8 @@ public class PublisherEventRaiserTests
                             PreviousLatestPublishedReleaseId = info.PreviousLatestPublishedReleaseId,
                             PreviousLatestPublishedReleaseVersionId = info.PreviousLatestPublishedReleaseVersionId,
                             LatestPublishedReleaseId = info.LatestPublishedReleaseId,
-                            LatestPublishedReleaseVersionId = info.LatestPublishedReleaseVersionId
+                            LatestPublishedReleaseVersionId = info.LatestPublishedReleaseVersionId,
+                            IsPublicationArchived = isPublicationArchived
                         }))).ToList();
 
             _eventRaiserMockBuilder.Assert.EventsRaised(expectedEvents);
@@ -256,7 +265,8 @@ public class PublisherEventRaiserTests
                         ReleaseVersionId = Guid.NewGuid(),
                         PublicationId = publicationId
                     }
-                ]
+                ],
+                IsPublicationArchived = false
             };
 
             // ACT

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedPublicationInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedPublicationInfo.cs
@@ -46,7 +46,7 @@ public partial record PublishedPublicationInfo
     public bool WasAlreadyPublished => PreviousLatestPublishedReleaseVersionId != null;
     
     /// <summary>
-    /// Indicated whether the publication is archived/superseded
+    /// Indicates whether the publication is archived/superseded
     /// </summary>
     public required bool IsPublicationArchived { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedPublicationInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishedPublicationInfo.cs
@@ -44,4 +44,9 @@ public partial record PublishedPublicationInfo
     /// </summary>
     ///
     public bool WasAlreadyPublished => PreviousLatestPublishedReleaseVersionId != null;
+    
+    /// <summary>
+    /// Indicated whether the publication is archived/superseded
+    /// </summary>
+    public required bool IsPublicationArchived { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublisherEventRaiser.cs
@@ -50,7 +50,8 @@ public class PublisherEventRaiser(IEventRaiser eventRaiser) : IPublisherEventRai
                         PreviousLatestPublishedReleaseId = publication.PreviousLatestPublishedReleaseId,
                         PreviousLatestPublishedReleaseVersionId = publication.PreviousLatestPublishedReleaseVersionId,
                         LatestPublishedReleaseId = publication.LatestPublishedReleaseId,
-                        LatestPublishedReleaseVersionId = publication.LatestPublishedReleaseVersionId
+                        LatestPublishedReleaseVersionId = publication.LatestPublishedReleaseVersionId,
+                        IsPublicationArchived = publication.IsPublicationArchived
                     })))
             .ToList();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
@@ -136,6 +137,7 @@ public class PublishingCompletionService(
     {
         var publication = await contentDbContext.Publications
             .Include(p => p.LatestPublishedReleaseVersion)
+            .Include(p => p.SupersededBy)
             .SingleAsync(p => p.Id == publicationId);
 
         var previousLatestPublishedReleaseVersion = publication.LatestPublishedReleaseVersion;
@@ -156,7 +158,8 @@ public class PublishingCompletionService(
             LatestPublishedReleaseVersionId = latestPublishedReleaseVersion.Id,
             PreviousLatestPublishedReleaseId = previousLatestPublishedReleaseVersion?.ReleaseId,
             PreviousLatestPublishedReleaseVersionId = previousLatestPublishedReleaseVersion?.Id,
-            PublishedReleaseVersions = publishedReleaseVersions
+            PublishedReleaseVersions = publishedReleaseVersions,
+            IsPublicationArchived = publication.IsArchived()
         };
     }
 


### PR DESCRIPTION
When a release is published, add a flag to the event to indicate whether the parent publication is archived.
This is because the search functionality does not want to create searchable documents for archived publications.