### PR TITLE
EES-6253 Add event handling to Search function app for deleting publications

### DIFF
--- a/infrastructure/templates/search/application/searchDocsFunction.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunction.bicep
@@ -49,6 +49,7 @@ param functionAppExists bool
 param storageQueueNames SearchStorageQueueNames = {
   publicationArchived: 'publication-archived-queue'
   publicationChanged: 'publication-changed-queue'
+  publicationDeleted: 'publication-deleted-queue'
   publicationLatestPublishedReleaseReordered: 'publication-latest-published-release-reordered-queue'
   publicationRestored: 'publication-restored-queue'
   refreshSearchableDocument: 'refresh-searchable-document-queue'
@@ -134,6 +135,10 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
       {
         name: 'PublicationChangedQueueName'
         value: storageQueueNames.publicationChanged
+      }
+      {
+        name: 'PublicationDeletedQueueName'
+        value: storageQueueNames.publicationDeleted
       }
       {
         name: 'PublicationLatestPublishedReleaseReorderedQueueName'

--- a/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunctionEventSubscriptions.bicep
@@ -28,6 +28,11 @@ var eventGridCustomTopicSubscriptions = [
         queueName: storageQueueNames.publicationChanged
       }
       {
+        name: 'publication-deleted'
+        includedEventTypes: ['publication-deleted']
+        queueName: storageQueueNames.publicationDeleted
+      }
+      {
         name: 'publication-latest-published-release-reordered'
         includedEventTypes: ['publication-latest-published-release-reordered']
         queueName: storageQueueNames.publicationLatestPublishedReleaseReordered

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -26,6 +26,8 @@ type SearchStorageQueueNames = {
   publicationArchived: string
   @description('Queue name for when a publication is changed.')
   publicationChanged: string
+  @description('Queue name for when a publication is deleted.')
+  publicationDeleted: string
   @description('Queue name for when the latest published release of a publication changes due to reordering.')
   publicationLatestPublishedReleaseReordered: string
   @description('Queue name for when an archived publication is restored.')

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationDeleted/OnPublicationDeletedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/OnPublicationDeleted/OnPublicationDeletedFunctionTests.cs
@@ -1,0 +1,43 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemoveSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationDeleted;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationDeleted.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDataHelpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.OnPublicationDeleted;
+
+public class OnPublicationDeletedFunctionTests
+{
+    private OnPublicationDeletedFunction GetSut() => new(
+        new EventGridEventHandler(new NullLogger<EventGridEventHandler>()));
+
+    [Fact]
+    public void CanInstantiateSut() => Assert.NotNull(GetSut());
+
+    [Fact]
+    public async Task GivenEvent_WhenPayloadContainsReleaseId_ReturnsExpectedDto()
+    {
+        var payload = new PublicationDeletedEventDto { LatestPublishedReleaseId = Guid.NewGuid() };
+        var eventGridEvent = new EventGridEventBuilder().WithPayload(payload).Build();
+        var expected = new RemoveSearchableDocumentDto { ReleaseId = payload.LatestPublishedReleaseId };
+
+        var response = await GetSut().OnPublicationDeleted(eventGridEvent, new FunctionContextMockBuilder().Build());
+
+        var actual = Assert.Single(response);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(TheoryDatas.Blank.Guids), MemberType = typeof(TheoryDatas.Blank))]
+    public async Task GivenEvent_WhenPayloadDoesNotContainReleaseId_ThenNothingIsReturned(Guid? blankReleaseId)
+    {
+        var payload = new PublicationDeletedEventDto { LatestPublishedReleaseId = blankReleaseId };
+        var eventGridEvent = new EventGridEventBuilder().WithPayload(payload).Build();
+
+        var response = await GetSut().OnPublicationDeleted(eventGridEvent, new FunctionContextMockBuilder().Build());
+
+        Assert.Empty(response);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationDeleted/Dtos/PublicationDeletedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationDeleted/Dtos/PublicationDeletedEventDto.cs
@@ -1,0 +1,10 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationDeleted.Dtos;
+
+public record PublicationDeletedEventDto
+{
+    public string? PublicationSlug { get; init; }
+
+    public Guid? LatestPublishedReleaseId { get; init; }
+
+    public Guid? LatestPublishedReleaseVersionId { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationDeleted/OnPublicationDeletedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationDeleted/OnPublicationDeletedFunction.cs
@@ -1,0 +1,25 @@
+﻿using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemoveSearchableDocument.Dto;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationDeleted.Dtos;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
+using Microsoft.Azure.Functions.Worker;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationDeleted;
+
+public class OnPublicationDeletedFunction(IEventGridEventHandler eventGridEventHandler)
+{
+    [Function(nameof(OnPublicationDeleted))]
+    [QueueOutput("%RemoveSearchableDocumentQueueName%")]
+    public async Task<RemoveSearchableDocumentDto[]> OnPublicationDeleted(
+        [QueueTrigger("%PublicationDeletedQueueName%")] EventGridEvent eventDto,
+        FunctionContext context) =>
+        await eventGridEventHandler.Handle<PublicationDeletedEventDto, RemoveSearchableDocumentDto[]>(
+            context,
+            eventDto,
+            (payload, _) =>
+                Task.FromResult<RemoveSearchableDocumentDto[]>(
+                    payload.LatestPublishedReleaseId.IsBlank()
+                        ? []
+                        : [new RemoveSearchableDocumentDto { ReleaseId = payload.LatestPublishedReleaseId }]));
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/local.settings.json
@@ -5,6 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "PublicationArchivedQueueName": "publication-archived-queue",
     "PublicationChangedQueueName": "publication-changed-queue",
+    "PublicationDeletedQueueName": "publication-deleted-queue",
     "PublicationLatestPublishedReleaseReorderedQueueName" : "publication-latest-published-release-reordered-queue",
     "PublicationRestoredQueueName": "publication-restored-queue",
     "RefreshSearchableDocumentQueueName": "refresh-searchable-document-queue",

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationDeletedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationDeletedEvent.cs
@@ -1,0 +1,48 @@
+﻿using Azure.Messaging.EventGrid;
+using GovUk.Education.ExploreEducationStatistics.Events.EventGrid;
+
+namespace GovUk.Education.ExploreEducationStatistics.Events;
+
+public record PublicationDeletedEvent : IEvent
+{
+    public PublicationDeletedEvent(
+        Guid publicationId,
+        string publicationSlug,
+        Guid latestPublishedReleaseId,
+        Guid latestPublishedReleaseVersionId)
+    {
+        Subject = publicationId.ToString();
+        Payload = new EventPayload
+        {
+            PublicationSlug = publicationSlug,
+            LatestPublishedReleaseId = latestPublishedReleaseId,
+            LatestPublishedReleaseVersionId = latestPublishedReleaseVersionId
+        };
+    }
+
+    // Changes to this event should also increment the version accordingly.
+    private const string DataVersion = "1.0";
+    private const string EventType = "publication-deleted";
+
+    // Which Topic endpoint to use from the appsettings
+    public static string EventTopicOptionsKey => "PublicationChangedEvent";
+
+    /// <summary>
+    /// The PublicationId is the subject
+    /// </summary>
+    public string Subject { get; }
+
+    /// <summary>
+    /// The event payload
+    /// </summary>
+    public EventPayload Payload { get; }
+
+    public record EventPayload
+    {
+        public required string PublicationSlug { get; init; }
+        public required Guid LatestPublishedReleaseId { get; init; }
+        public required Guid LatestPublishedReleaseVersionId { get; init; }
+    }
+
+    public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);
+}


### PR DESCRIPTION
This PR adds event handling to the Search Function App for deleting publications.

When a theme is deleted (which only happens for UI Test themes in the Dev environment), the Admin will publish an event with type 'publication-deleted' onto the 'publication-changed' topic endpoint for every publication in the theme.

A new 'OnPublicationDeleted' event handler function has been added to the Search Function App and is subscribed to this event type via a new `publication-deleted-queue' Storage queue with a queue trigger binding.

On deletion of a publication, the 'OnPublicationDeleted' in turn triggers the existing 'RemoveSearchableDocument' command handler function to remove the searchable document for the latest published release of the publication. The payload of the event will contain the publication's latest published release id.

This PR also makes the related infrastructure changes to:

- Add the Event Grid 'publication-deleted' subscription
- Add the Storage queue 'publication-deleted-queue' in the Search Function App's own storage account.
- Add the 'PublicationDeletedQueueName' app setting to the Search Function App.