### PR TITLE
EES-6255 Define event types and event topic options keys as static constants

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Events/EventTopicOptionsKeys.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/EventTopicOptionsKeys.cs
@@ -1,0 +1,16 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Events.EventGrid;
+
+namespace GovUk.Education.ExploreEducationStatistics.Events;
+
+/// <summary>
+/// Defines constants that represent keys for different <see cref="EventTopicOptions"/>.
+/// These keys are used by <see cref="IEvent"/> implementations to resolve the topic endpoint from configuration sources,
+/// including environment variables and the `appsettings.json` file.
+/// </summary>
+public static class EventTopicOptionsKeys
+{
+    public const string PublicationChanged = "PublicationChangedEvent";
+    public const string ReleaseChanged = "ReleaseChangedEvent";
+    public const string ReleaseVersionChanged = "ReleaseVersionChangedEvent";
+    public const string ThemeChanged = "ThemeChangedEvent";
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/EventTypes.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/EventTypes.cs
@@ -1,0 +1,37 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Events;
+
+/// <summary>
+/// Defines constants for event types that are published to the Publication Changed event topic.
+/// </summary>
+public static class PublicationChangedEventTypes
+{
+    public const string PublicationArchived = "publication-archived";
+    public const string PublicationChanged = "publication-changed";
+    public const string PublicationDeleted = "publication-deleted";
+    public const string PublicationLatestPublishedReleaseReordered = "publication-latest-published-release-reordered";
+    public const string PublicationRestored = "publication-restored";
+}
+
+/// <summary>
+/// Defines constants for event types that are published to the Release Changed event topic.
+/// </summary>
+public static class ReleaseChangedEventTypes
+{
+    public const string ReleaseSlugChanged = "release-slug-changed";
+}
+
+/// <summary>
+/// Defines constants for event types that are published to the Release Version Changed event topic.
+/// </summary>
+public static class ReleaseVersionChangedEventTypes
+{
+    public const string ReleaseVersionPublished = "release-version-published";
+}
+
+/// <summary>
+/// Defines constants for event types that are published to the Theme Changed event topic.
+/// </summary>
+public static class ThemeChangedEventTypes
+{
+    public const string ThemeChanged = "theme-changed";
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationArchivedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationArchivedEvent.cs
@@ -23,7 +23,7 @@ public record PublicationArchivedEvent : IEvent
     private const string EventType = PublicationChangedEventTypes.PublicationArchived;
 
     // Which Topic endpoint to use from the appsettings
-    public static string EventTopicOptionsKey => "PublicationChangedEvent";
+    public static string EventTopicOptionsKey => EventTopicOptionsKeys.PublicationChanged;
 
     /// <summary>
     /// The PublicationId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationArchivedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationArchivedEvent.cs
@@ -20,7 +20,7 @@ public record PublicationArchivedEvent : IEvent
 
     // Changes to this event should also increment the version accordingly.
     private const string DataVersion = "1.0";
-    private const string EventType = "publication-archived";
+    private const string EventType = PublicationChangedEventTypes.PublicationArchived;
 
     // Which Topic endpoint to use from the appsettings
     public static string EventTopicOptionsKey => "PublicationChangedEvent";

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationChangedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationChangedEvent.cs
@@ -22,8 +22,8 @@ public record PublicationChangedEvent : IEvent
 
     // Changes to this event should also increment the version accordingly.
     private const string DataVersion = "1.0";
-    private const string EventType = "publication-changed";
-    
+    private const string EventType = PublicationChangedEventTypes.PublicationChanged;
+
     // Which Topic endpoint to use from the appsettings
     public static string EventTopicOptionsKey => "PublicationChangedEvent";
 
@@ -36,7 +36,7 @@ public record PublicationChangedEvent : IEvent
     /// The event payload
     /// </summary>
     public EventPayload Payload { get; }
-    
+
     public record EventPayload
     {
         public required string Title { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationChangedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationChangedEvent.cs
@@ -25,7 +25,7 @@ public record PublicationChangedEvent : IEvent
     private const string EventType = PublicationChangedEventTypes.PublicationChanged;
 
     // Which Topic endpoint to use from the appsettings
-    public static string EventTopicOptionsKey => "PublicationChangedEvent";
+    public static string EventTopicOptionsKey => EventTopicOptionsKeys.PublicationChanged;
 
     /// <summary>
     /// The PublicationId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationDeletedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationDeletedEvent.cs
@@ -22,7 +22,7 @@ public record PublicationDeletedEvent : IEvent
 
     // Changes to this event should also increment the version accordingly.
     private const string DataVersion = "1.0";
-    private const string EventType = "publication-deleted";
+    private const string EventType = PublicationChangedEventTypes.PublicationDeleted;
 
     // Which Topic endpoint to use from the appsettings
     public static string EventTopicOptionsKey => "PublicationChangedEvent";

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationDeletedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationDeletedEvent.cs
@@ -25,7 +25,7 @@ public record PublicationDeletedEvent : IEvent
     private const string EventType = PublicationChangedEventTypes.PublicationDeleted;
 
     // Which Topic endpoint to use from the appsettings
-    public static string EventTopicOptionsKey => "PublicationChangedEvent";
+    public static string EventTopicOptionsKey => EventTopicOptionsKeys.PublicationChanged;
 
     /// <summary>
     /// The PublicationId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationLatestPublishedReleaseReorderedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationLatestPublishedReleaseReorderedEvent.cs
@@ -31,7 +31,7 @@ public record PublicationLatestPublishedReleaseReorderedEvent : IEvent
     private const string EventType = PublicationChangedEventTypes.PublicationLatestPublishedReleaseReordered;
 
     // Which Topic endpoint to use from the appsettings
-    public static string EventTopicOptionsKey => "PublicationChangedEvent";
+    public static string EventTopicOptionsKey => EventTopicOptionsKeys.PublicationChanged;
 
     /// <summary>
     /// The PublicationId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationLatestPublishedReleaseReorderedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationLatestPublishedReleaseReorderedEvent.cs
@@ -28,8 +28,8 @@ public record PublicationLatestPublishedReleaseReorderedEvent : IEvent
 
     // Changes to this event should also increment the version accordingly.
     private const string DataVersion = "1.0";
-    private const string EventType = "publication-latest-published-release-reordered";
-    
+    private const string EventType = PublicationChangedEventTypes.PublicationLatestPublishedReleaseReordered;
+
     // Which Topic endpoint to use from the appsettings
     public static string EventTopicOptionsKey => "PublicationChangedEvent";
 
@@ -42,7 +42,7 @@ public record PublicationLatestPublishedReleaseReorderedEvent : IEvent
     /// The event payload
     /// </summary>
     public EventPayload Payload { get; }
-    
+
     public record EventPayload
     {
         public required string Title { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationRestoredEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationRestoredEvent.cs
@@ -23,7 +23,7 @@ public record PublicationRestoredEvent : IEvent
     private const string EventType = PublicationChangedEventTypes.PublicationRestored;
 
     // Which Topic endpoint to use from the appsettings
-    public static string EventTopicOptionsKey => "PublicationChangedEvent";
+    public static string EventTopicOptionsKey => EventTopicOptionsKeys.PublicationChanged;
 
     /// <summary>
     /// The PublicationId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationRestoredEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationRestoredEvent.cs
@@ -20,7 +20,7 @@ public record PublicationRestoredEvent : IEvent
 
     // Changes to this event should also increment the version accordingly.
     private const string DataVersion = "1.0";
-    private const string EventType = "publication-restored";
+    private const string EventType = PublicationChangedEventTypes.PublicationRestored;
 
     // Which Topic endpoint to use from the appsettings
     public static string EventTopicOptionsKey => "PublicationChangedEvent";

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseSlugChangedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseSlugChangedEvent.cs
@@ -22,8 +22,8 @@ public record ReleaseSlugChangedEvent : IEvent
 
     // Changes to this event should also increment the version accordingly.
     private const string DataVersion = "1.0";
-    private const string EventType = "release-slug-changed";
-    
+    private const string EventType = ReleaseChangedEventTypes.ReleaseSlugChanged;
+
     // Which Topic endpoint to use from the appsettings
     public static string EventTopicOptionsKey => "ReleaseChangedEvent";
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseSlugChangedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseSlugChangedEvent.cs
@@ -25,7 +25,7 @@ public record ReleaseSlugChangedEvent : IEvent
     private const string EventType = ReleaseChangedEventTypes.ReleaseSlugChanged;
 
     // Which Topic endpoint to use from the appsettings
-    public static string EventTopicOptionsKey => "ReleaseChangedEvent";
+    public static string EventTopicOptionsKey => EventTopicOptionsKeys.ReleaseChanged;
 
     /// <summary>
     /// The ThemeId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
@@ -25,11 +25,11 @@ public record ReleaseVersionPublishedEvent : IEvent
 
     // Changes to this event should also increment the version accordingly.
     public const string DataVersion = "1.0";
-    public const string EventType = "release-version-published";
-    
+    public const string EventType = ReleaseVersionChangedEventTypes.ReleaseVersionPublished;
+
     // Which Topic endpoint to use from the appsettings
     public static string EventTopicOptionsKey => "ReleaseVersionChangedEvent";
-    
+
     /// <summary>
     /// The ReleaseVersionId is the subject
     /// </summary>
@@ -51,8 +51,9 @@ public record ReleaseVersionPublishedEvent : IEvent
         public required Guid? PreviousLatestPublishedReleaseVersionId { get; init; }
         public required bool IsPublicationArchived { get; init; }
     }
+
     public EventPayload Payload { get; }
-    
+
     public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);
 
     public record ReleaseVersionPublishedEventInfo

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ReleaseVersionPublishedEvent.cs
@@ -28,7 +28,7 @@ public record ReleaseVersionPublishedEvent : IEvent
     public const string EventType = ReleaseVersionChangedEventTypes.ReleaseVersionPublished;
 
     // Which Topic endpoint to use from the appsettings
-    public static string EventTopicOptionsKey => "ReleaseVersionChangedEvent";
+    public static string EventTopicOptionsKey => EventTopicOptionsKeys.ReleaseVersionChanged;
 
     /// <summary>
     /// The ReleaseVersionId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ThemeChangedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ThemeChangedEvent.cs
@@ -25,7 +25,7 @@ public record ThemeChangedEvent : IEvent
     private const string EventType = ThemeChangedEventTypes.ThemeChanged;
 
     // Which Topic endpoint to use from the appsettings
-    public static string EventTopicOptionsKey => "ThemeChangedEvent";
+    public static string EventTopicOptionsKey => EventTopicOptionsKeys.ThemeChanged;
 
     /// <summary>
     /// The ThemeId is the subject

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/ThemeChangedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/ThemeChangedEvent.cs
@@ -22,8 +22,8 @@ public record ThemeChangedEvent : IEvent
 
     // Changes to this event should also increment the version accordingly.
     private const string DataVersion = "1.0";
-    private const string EventType = "theme-changed";
-    
+    private const string EventType = ThemeChangedEventTypes.ThemeChanged;
+
     // Which Topic endpoint to use from the appsettings
     public static string EventTopicOptionsKey => "ThemeChangedEvent";
 
@@ -36,7 +36,7 @@ public record ThemeChangedEvent : IEvent
     /// The event payload
     /// </summary>
     public EventPayload Payload { get; }
-    
+
     public record EventPayload
     {
         public required string Title { get; init; }


### PR DESCRIPTION
This PR defines event types and event topic options keys as static constants.

This means all the constants are defined in a single place, and options keys which are reused by different event type classes don’t have a possibility of diverging.

This improvement was suggested in a comment by @leeoades in https://github.com/dfe-analytical-services/explore-education-statistics/pull/6050#discussion_r2154886066.