### PR TITLE
EES-6246 Only show counts next to filter options if no filter currently applied

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
@@ -67,39 +67,52 @@ const FindStatisticsPage: NextPage = () => {
   const { themeId: themeFacetResults, releaseType: releaseTypeFacetResults } =
     facets;
 
-  const themesWithResultCounts = themes
-    .map(theme => {
-      const facetedResult = themeFacetResults?.find(
-        result => theme.id === result.value,
-      );
-      const count = facetedResult?.count ?? 0;
-      return {
-        label: `${theme.title} (${count})`,
-        value: theme.id,
-        count,
-      };
-    })
-    .sort((a, b) => b.count - a.count);
-
-  const releaseTypesWithResultCounts = Object.keys(releaseTypes)
-    .map(type => {
-      const facetedResult = releaseTypeFacetResults?.find(
-        result => type === result.value,
-      );
-
-      const title = releaseTypes[type as ReleaseType];
-      const count = facetedResult?.count ?? 0;
-      return {
-        label: `${title} (${count})`,
-        value: type,
-        count,
-      };
-    })
-    .sort((a, b) => b.count - a.count);
-
   const { releaseType, search, sortBy, themeId } = getParamsFromQuery(
     router.query,
   );
+
+  const themesWithResultCounts = !themeId
+    ? themes
+        .map(theme => {
+          const facetedResult = themeFacetResults?.find(
+            result => theme.id === result.value,
+          );
+          const count = facetedResult?.count ?? 0;
+          return {
+            label: `${theme.title} (${count})`,
+            value: theme.id,
+            count,
+          };
+        })
+        .sort((a, b) => b.count - a.count)
+    : themes.map(theme => ({
+        label: theme.title,
+        value: theme.id,
+      }));
+
+  const releaseTypesWithResultCounts = !releaseType
+    ? Object.keys(releaseTypes)
+        .map(type => {
+          const facetedResult = releaseTypeFacetResults?.find(
+            result => type === result.value,
+          );
+
+          const title = releaseTypes[type as ReleaseType];
+          const count = facetedResult?.count ?? 0;
+          return {
+            label: `${title} (${count})`,
+            value: type,
+            count,
+          };
+        })
+        .sort((a, b) => b.count - a.count)
+    : Object.keys(releaseTypes).map(type => {
+        const title = releaseTypes[type as ReleaseType];
+        return {
+          label: title,
+          value: type,
+        };
+      });
 
   const isFiltered = !!search || !!releaseType || !!themeId;
 

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPageAzure.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPageAzure.test.tsx
@@ -698,12 +698,10 @@ describe('FindStatisticsPageAzure', () => {
     expect(releaseTypes[0]).toHaveTextContent('All release types');
     expect(releaseTypes[0].selected).toBe(false);
 
-    expect(releaseTypes[1]).toHaveTextContent(
-      'Accredited official statistics (1)',
-    );
+    expect(releaseTypes[1]).toHaveTextContent('Accredited official statistics');
     expect(releaseTypes[1].selected).toBe(true);
 
-    expect(releaseTypes[2]).toHaveTextContent('Official statistics (0)');
+    expect(releaseTypes[2]).toHaveTextContent('Official statistics');
     expect(releaseTypes[2].selected).toBe(false);
 
     // remove release type filter


### PR DESCRIPTION
Currently, if you filter by a facet (theme, release type), the remaining items in the filter dropdown show '(0)' after them (as there are no results returned with the current filter applied!)

This PR changes this, so that if you filter by one dimension, we don't append any counts to the other items in the dropdown for that dimension.

So if you filter by theme, the dropdown for 'theme' will list themes without counts, but the release version dropdown will show counts. Vice versa,
If you filter by both facets, no items will have counts next to them.