### PR TITLE
EES-6252 Force sortBy to be 'relevance' when searching by search term

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
@@ -165,13 +165,17 @@ const FindStatisticsPage: NextPage = () => {
     filterType: PublicationFilter;
     nextValue: string;
   }) => {
+    // If performing a search (by search term), reset sortBy to relevance
+    const nextSortBy =
+      filterType === 'search' && nextValue.length > 0 ? 'relevance' : sortBy;
+
     const newParams =
       nextValue === 'all'
         ? omit(router.query, 'page', filterType)
         : {
             ...omit(router.query, 'page'),
             [filterType]: nextValue,
-            sortBy,
+            sortBy: nextSortBy,
           };
 
     await updateQueryParams(newParams);

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPageAzure.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPageAzure.test.tsx
@@ -219,7 +219,9 @@ describe('FindStatisticsPageAzure', () => {
   });
 
   test('renders correctly when searched and has results', async () => {
-    mockRouter.setCurrentUrl('/find-statistics?search=Find+me');
+    mockRouter.setCurrentUrl(
+      '/find-statistics?search=Find+me&sortBy=relevance',
+    );
     publicationService.listPublications.mockResolvedValue({
       results: [testPublications[1], testPublications[2]],
       paging: { ...testPaging, totalPages: 1, totalResults: 2 },
@@ -273,7 +275,7 @@ describe('FindStatisticsPageAzure', () => {
     expect(sortOptions).toHaveLength(4);
     expect(sortOptions[3]).toHaveTextContent('Relevance');
     expect(sortOptions[3]).toHaveValue('relevance');
-    expect(sortOptions[3].selected).toBe(false);
+    expect(sortOptions[3].selected).toBe(true);
 
     const themesSelect = screen.getByLabelText('Filter by Theme');
     const themes = within(themesSelect).getAllByRole(
@@ -819,7 +821,7 @@ describe('FindStatisticsPageAzure', () => {
 
     expect(mockRouter).toMatchObject({
       pathname: '/find-statistics',
-      query: { search: 'Find me', sortBy: 'newest' },
+      query: { search: 'Find me', sortBy: 'relevance' },
     });
 
     expect(await screen.findByText('2 results')).toBeInTheDocument();
@@ -983,7 +985,7 @@ describe('FindStatisticsPageAzure', () => {
     expect(updatedSortOptions).toHaveLength(4);
     expect(updatedSortOptions[3]).toHaveTextContent('Relevance');
     expect(updatedSortOptions[3]).toHaveValue('relevance');
-    expect(updatedSortOptions[3].selected).toBe(false);
+    expect(updatedSortOptions[3].selected).toBe(true);
   });
 
   test('Reset filters', async () => {


### PR DESCRIPTION
Currently, default 'Sort by' value is 'Newest'. 'Relevance' is available as an option when a search term is entered.

This PR changes 'Relevance' to be the _default_ when a search term is entered. Even if a user orders results differently, if a new search is performed with a search term present, we now reset orderby to 'relevance'.