### PR TITLE
EES-6250 find stats pagination fix

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
@@ -372,7 +372,7 @@ const FindStatisticsPage: NextPage = () => {
                 )}
               </>
             )}
-            {page && totalPages && (
+            {page && !!totalPages && (
               <Pagination
                 currentPage={page}
                 shallow

--- a/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
+++ b/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
@@ -93,13 +93,14 @@ const azurePublicationService = {
     });
 
     // Transform response into <PaginatedListWithAzureFacets<PublicationListSummary>>
-    const { count, results, facets = {} } = searchResults;
+    const { count = 0, results, facets = {} } = searchResults;
+    const pageSize = 10;
     const publicationsResult = {
       paging: {
-        totalPages: Math.floor((count || 0) / 10) + 1,
-        totalResults: count || 0,
+        totalPages: count === 0 ? 0 : Math.floor((count - 1) / pageSize) + 1,
+        totalResults: count,
         page,
-        pageSize: 10,
+        pageSize,
       },
       results: [] as PublicationListSummary[],
       facets,


### PR DESCRIPTION
There was an off by one error on the pagination. Now fixed so that we don't think there's an extra page when totalResults is 10, 20, 30 etc
![image](https://github.com/user-attachments/assets/ec5e0f14-37f1-4de3-8593-4342646281de)
