### PR TITLE
EES-5322 Allow chart width to be reset to responsive width (undefined)

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -265,8 +265,9 @@ const ChartConfiguration = ({
   );
 
   const handleChange = useCallback(
-    ({ ...values }: FormValues) => {
-      onChange(normalizeValues(values));
+    ({ width, ...values }: FormValues) => {
+      // allow width to be set to undefined
+      onChange({ ...normalizeValues(values), width });
     },
     [normalizeValues, onChange],
   );


### PR DESCRIPTION
[See ticket EES-5322](https://dfedigital.atlassian.net/browse/EES-5322)

Previously the width of a chart configuration couldn't be reset to the default null value, which would allow it to have a responsive width instead of static width. The undefined width value was getting ignored in the `normalizeValues` function, so the changes here circumvents that