### PR TITLE
EES-6254 Raise an event when a publication is deleted

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserMockBuilder.cs
@@ -33,6 +33,13 @@ public class AdminEventRaiserMockBuilder
     private static readonly Expression<Func<IAdminEventRaiser, Task>> OnPublicationChanged =
         m => m.OnPublicationChanged(It.IsAny<Publication>());
 
+    private static readonly Expression<Func<IAdminEventRaiser, Task>> OnPublicationDeleted =
+        m => m.OnPublicationDeleted(
+            It.IsAny<Guid>(),
+            It.IsAny<string>(),
+            It.IsAny<Guid?>(),
+            It.IsAny<Guid?>());
+
     private static readonly Expression<Func<IAdminEventRaiser, Task>> OnPublicationLatestPublishedReleaseReordered =
         m => m.OnPublicationLatestPublishedReleaseReordered(
             It.IsAny<Publication>(),
@@ -67,6 +74,10 @@ public class AdminEventRaiserMockBuilder
             .Returns(Task.CompletedTask);
 
         _mock
+            .Setup(OnPublicationDeleted)
+            .Returns(Task.CompletedTask);
+
+        _mock
             .Setup(m => m.OnPublicationLatestPublishedReleaseReordered(
                 It.IsAny<Publication>(),
                 It.IsAny<Guid>(),
@@ -96,7 +107,7 @@ public class AdminEventRaiserMockBuilder
 
     public class Asserter(AdminEventRaiserMockBuilder mockBuilder)
     {
-        public void ThatOnThemeUpdatedRaised(Func<Theme, bool>? predicate = null) =>
+        public void OnThemeUpdatedWasRaised(Func<Theme, bool>? predicate = null) =>
             mockBuilder._mock.Verify(m => m.OnThemeUpdated(It.Is<Theme>(t => predicate == null || predicate(t))),
                 Times.Once);
 
@@ -152,6 +163,22 @@ public class AdminEventRaiserMockBuilder
         private void OnPublicationChangedWasNotRaised() =>
             mockBuilder._mock.Verify(OnPublicationChanged, Times.Never);
 
+        public void OnPublicationDeletedWasRaised(
+            Guid? publicationId = null,
+            string? publicationSlug = null,
+            Guid? latestPublishedReleaseId = null,
+            Guid? latestPublishedReleaseVersionId = null) =>
+            mockBuilder._mock.Verify(m => m.OnPublicationDeleted(
+                    It.Is<Guid>(actual => publicationId == null || actual == publicationId),
+                    It.Is<string>(actual => publicationSlug == null || actual == publicationSlug),
+                    It.Is<Guid?>(actual => latestPublishedReleaseId == null || actual == latestPublishedReleaseId),
+                    It.Is<Guid?>(actual =>
+                        latestPublishedReleaseVersionId == null || actual == latestPublishedReleaseVersionId)),
+                Times.Once);
+
+        private void OnPublicationDeletedWasNotRaised() =>
+            mockBuilder._mock.Verify(OnPublicationDeleted, Times.Never);
+
         public void OnPublicationLatestPublishedReleaseReorderedWasRaised(
             Publication publication,
             Guid previousReleaseId,
@@ -203,6 +230,7 @@ public class AdminEventRaiserMockBuilder
         {
             OnPublicationArchivedWasNotRaised();
             OnPublicationChangedWasNotRaised();
+            OnPublicationDeletedWasNotRaised();
             OnPublicationLatestPublishedReleaseReorderedWasNotRaised();
             OnPublicationRestoredWasNotRaised();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/AdminEventRaiserMockBuilder.cs
@@ -37,8 +37,7 @@ public class AdminEventRaiserMockBuilder
         m => m.OnPublicationDeleted(
             It.IsAny<Guid>(),
             It.IsAny<string>(),
-            It.IsAny<Guid?>(),
-            It.IsAny<Guid?>());
+            It.IsAny<LatestPublishedReleaseInfo?>());
 
     private static readonly Expression<Func<IAdminEventRaiser, Task>> OnPublicationLatestPublishedReleaseReordered =
         m => m.OnPublicationLatestPublishedReleaseReordered(
@@ -166,14 +165,12 @@ public class AdminEventRaiserMockBuilder
         public void OnPublicationDeletedWasRaised(
             Guid? publicationId = null,
             string? publicationSlug = null,
-            Guid? latestPublishedReleaseId = null,
-            Guid? latestPublishedReleaseVersionId = null) =>
+            LatestPublishedReleaseInfo? latestPublishedRelease = null) =>
             mockBuilder._mock.Verify(m => m.OnPublicationDeleted(
                     It.Is<Guid>(actual => publicationId == null || actual == publicationId),
                     It.Is<string>(actual => publicationSlug == null || actual == publicationSlug),
-                    It.Is<Guid?>(actual => latestPublishedReleaseId == null || actual == latestPublishedReleaseId),
-                    It.Is<Guid?>(actual =>
-                        latestPublishedReleaseVersionId == null || actual == latestPublishedReleaseVersionId)),
+                    It.Is<LatestPublishedReleaseInfo?>(actual =>
+                        latestPublishedRelease == null || actual == latestPublishedRelease)),
                 Times.Once);
 
         private void OnPublicationDeletedWasNotRaised() =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserTests.cs
@@ -159,16 +159,16 @@ public class AdminEventRaiserTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task WhenOnPublicationDeleted_ThenEventPublished(bool hasPublishedReleaseVersion)
+    public async Task WhenOnPublicationDeleted_ThenEventPublished(bool hasPublishedRelease)
     {
         // ARRANGE
         var publicationId = Guid.NewGuid();
         const string publicationSlug = "publication-slug";
-        var latestPublishedReleaseVersion = hasPublishedReleaseVersion
-            ? new ReleaseVersion
+        var latestPublishedRelease = hasPublishedRelease
+            ? new LatestPublishedReleaseInfo
             {
-                Id = Guid.NewGuid(),
-                ReleaseId = Guid.NewGuid()
+                LatestPublishedReleaseId = Guid.NewGuid(),
+                LatestPublishedReleaseVersionId = Guid.NewGuid()
             }
             : null;
 
@@ -178,15 +178,13 @@ public class AdminEventRaiserTests
         await sut.OnPublicationDeleted(
             publicationId,
             publicationSlug,
-            latestPublishedReleaseId: latestPublishedReleaseVersion?.ReleaseId,
-            latestPublishedReleaseVersionId: latestPublishedReleaseVersion?.Id);
+            latestPublishedRelease);
 
         // ASSERT
         var expectedEvent = new PublicationDeletedEvent(
             publicationId,
             publicationSlug,
-            latestPublishedReleaseVersion?.ReleaseId,
-            latestPublishedReleaseVersion?.Id);
+            latestPublishedRelease);
         _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/AdminEventRaiserTests.cs
@@ -156,17 +156,57 @@ public class AdminEventRaiserTests
         _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WhenOnPublicationDeleted_ThenEventPublished(bool hasPublishedReleaseVersion)
+    {
+        // ARRANGE
+        var publicationId = Guid.NewGuid();
+        const string publicationSlug = "publication-slug";
+        var latestPublishedReleaseVersion = hasPublishedReleaseVersion
+            ? new ReleaseVersion
+            {
+                Id = Guid.NewGuid(),
+                ReleaseId = Guid.NewGuid()
+            }
+            : null;
+
+        var sut = GetSut();
+
+        // ACT
+        await sut.OnPublicationDeleted(
+            publicationId,
+            publicationSlug,
+            latestPublishedReleaseId: latestPublishedReleaseVersion?.ReleaseId,
+            latestPublishedReleaseVersionId: latestPublishedReleaseVersion?.Id);
+
+        // ASSERT
+        var expectedEvent = new PublicationDeletedEvent(
+            publicationId,
+            publicationSlug,
+            latestPublishedReleaseVersion?.ReleaseId,
+            latestPublishedReleaseVersion?.Id);
+        _eventRaiserMockBuilder.Assert.EventRaised(expectedEvent);
+    }
+
     [Fact]
     public async Task WhenOnPublicationLatestPublishedReleaseReordered_ThenEventPublished()
     {
         // ARRANGE
+        var latestPublishedReleaseVersion = new ReleaseVersion
+        {
+            Id = Guid.NewGuid(),
+            ReleaseId = Guid.NewGuid()
+        };
+
         var publication = new Publication
         {
             Id = Guid.NewGuid(),
             Title = "Publication title",
             Slug = "publication-slug",
-            LatestPublishedReleaseVersionId = Guid.NewGuid(),
-            LatestPublishedReleaseVersion = new ReleaseVersion{ ReleaseId = Guid.NewGuid() }
+            LatestPublishedReleaseVersionId = latestPublishedReleaseVersion.Id,
+            LatestPublishedReleaseVersion = latestPublishedReleaseVersion
         };
         var previousLatestPublishedReleaseId = Guid.NewGuid();
         var previousLatestPublishedReleaseVersionId = Guid.NewGuid();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Options;
 using GovUk.Education.ExploreEducationStatistics.Admin.Repositories;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
@@ -17,6 +18,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Secu
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
@@ -24,6 +26,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cac
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -142,17 +145,17 @@ public class ThemeServiceTests
         {
             // Arrange
             var publishingService = new Mock<IPublishingService>(Strict);
-                publishingService
-                    .Setup(s => s.TaxonomyChanged(It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(Unit.Instance);
+            publishingService
+                .Setup(s => s.TaxonomyChanged(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Unit.Instance);
 
-            var eventRaiser = new AdminEventRaiserMockBuilder();
+            var adminEventRaiser = new AdminEventRaiserMockBuilder();
             var publicationCacheService = new PublicationCacheServiceMockBuilder();
-            
+
             var service = SetupThemeService(
                 contentDbContext: context,
                 publishingService: publishingService.Object,
-                adminEventRaiser: eventRaiser.Build(),
+                adminEventRaiser: adminEventRaiser.Build(),
                 publicationCacheService: publicationCacheService.Build());
 
             // Act
@@ -180,8 +183,8 @@ public class ThemeServiceTests
             Assert.Equal("Updated theme", savedTheme.Title);
             Assert.Equal("updated-theme", savedTheme.Slug);
             Assert.Equal("Updated summary", savedTheme.Summary);
-            
-            eventRaiser.Assert.ThatOnThemeUpdatedRaised(actual => actual == savedTheme);
+
+            adminEventRaiser.Assert.OnThemeUpdatedWasRaised(actual => actual == savedTheme);
 
             Assert.All(
                 expectedPublicationSlugs,
@@ -299,58 +302,66 @@ public class ThemeServiceTests
     [Fact]
     public async Task DeleteTheme()
     {
-        var releaseVersionId = Guid.NewGuid();
+        Theme theme = _fixture.DefaultTheme()
+            .WithTitle("UI test theme to delete");
 
-        var theme = new Theme
-        {
-            Id = Guid.NewGuid(),
-            Title = "UI test theme to delete"
-        };
+        Publication publication1 = _fixture.DefaultPublication()
+            .WithReleases([
+                _fixture.DefaultRelease(publishedVersions: 1),
+                _fixture.DefaultRelease(publishedVersions: 1)
+            ])
+            .WithTheme(theme);
 
-        ReleaseVersion releaseVersion = _fixture
-            .DefaultReleaseVersion()
-            .WithId(releaseVersionId)
-            .WithRelease(_fixture.DefaultRelease()
-                .WithPublication(_fixture
-                    .DefaultPublication()
-                    .WithTheme(theme)));
+        Publication publication2 = _fixture.DefaultPublication()
+            .WithReleases([_fixture.DefaultRelease(publishedVersions: 0, draftVersion: true)])
+            .WithTheme(theme);
+        
+        Publication publication3 = _fixture.DefaultPublication()
+            .WithTheme(theme);
+
+        Publication[] publications =
+        [
+            publication1,
+            publication2,
+            publication3
+        ];
 
         Methodology methodology = _fixture
             .DefaultMethodology()
-            .WithOwningPublication(releaseVersion.Publication);
+            .WithOwningPublication(publication1);
 
         var contextId = Guid.NewGuid().ToString();
 
         await using (var contentContext = InMemoryApplicationDbContext(contextId))
         {
-            contentContext.ReleaseVersions.Add(releaseVersion);
+            contentContext.Publications.AddRange(publications);
             contentContext.Methodologies.Add(methodology);
             await contentContext.SaveChangesAsync();
         }
 
         await using (var contentContext = InMemoryApplicationDbContext(contextId))
         {
-            Assert.Equal(1, contentContext.Publications.Count());
+            Assert.Equal(1, contentContext.Themes.Count());
+            Assert.Equal(3, contentContext.Publications.Count());
+            Assert.Equal(3, contentContext.Contacts.Count());
             Assert.Equal(1, contentContext.PublicationMethodologies.Count());
-            Assert.Equal(1, contentContext.ReleaseVersions.Count());
+            Assert.Equal(1, contentContext.Methodologies.Count());
+            Assert.Equal(3, contentContext.Releases.Count());
+            Assert.Equal(3, contentContext.ReleaseVersions.Count());
         }
 
-        var releaseDataFileService = new Mock<IReleaseDataFileService>(Strict);
+        var adminEventRaiser = new AdminEventRaiserMockBuilder();
         var methodologyService = new Mock<IMethodologyService>(Strict);
         var publishingService = new Mock<IPublishingService>(Strict);
-        var releaseVersionService = new Mock<IReleaseVersionService>(Strict);
 
         await using (var contentContext = InMemoryApplicationDbContext(contextId))
         {
             var service = SetupThemeService(
                 contentContext,
+                adminEventRaiser: adminEventRaiser.Build(),
                 methodologyService: methodologyService.Object,
                 publishingService: publishingService.Object,
-                releaseVersionService: releaseVersionService.Object);
-
-            releaseVersionService
-                .Setup(s => s.DeleteTestReleaseVersion(releaseVersionId, CancellationToken.None))
-                .ReturnsAsync(Unit.Instance);
+                releaseVersionService: new TestReleaseVersionService(contentContext));
 
             methodologyService
                 .Setup(s => s.DeleteMethodology(methodology.Id, true))
@@ -361,14 +372,29 @@ public class ThemeServiceTests
 
             var result = await service.DeleteTheme(theme.Id);
 
-            VerifyAllMocks(releaseDataFileService,
+            VerifyAllMocks(
                 methodologyService,
-                publishingService,
-                releaseVersionService);
+                publishingService);
 
             result.AssertRight();
 
+            foreach (var publication in publications)
+            {
+                adminEventRaiser.Assert.OnPublicationDeletedWasRaised(
+                    publication.Id,
+                    publication.Slug,
+                    publication.LatestPublishedReleaseVersion?.ReleaseId,
+                    publication.LatestPublishedReleaseVersionId
+                );
+            }
+        }
+
+        await using (var contentContext = InMemoryApplicationDbContext(contextId))
+        {
+            Assert.Empty(contentContext.Themes);
             Assert.Empty(contentContext.Publications);
+            Assert.Empty(contentContext.ReleaseVersions);
+            Assert.Empty(contentContext.Contacts);
         }
     }
 
@@ -768,7 +794,7 @@ public class ThemeServiceTests
 
         Methodology methodology = _fixture
             .DefaultMethodology()
-            .WithOwningPublication(releaseVersion.Publication);
+            .WithOwningPublication(releaseVersion.Release.Publication);
 
         var otherReleaseVersionId = Guid.NewGuid();
 
@@ -788,7 +814,7 @@ public class ThemeServiceTests
 
         Methodology otherMethodology = _fixture
             .DefaultMethodology()
-            .WithOwningPublication(otherReleaseVersion.Publication);
+            .WithOwningPublication(otherReleaseVersion.Release.Publication);
 
         var contextId = Guid.NewGuid().ToString();
 
@@ -1113,5 +1139,59 @@ public class ThemeServiceTests
             publicationCacheService ?? new PublicationCacheServiceMockBuilder().Build(),
             NullLogger<ThemeService>.Instance
         );
+    }
+
+    private class TestReleaseVersionService(ContentDbContext context) : IReleaseVersionService
+    {
+        public async Task<Either<ActionResult, Unit>> DeleteTestReleaseVersion(Guid releaseVersionId, CancellationToken cancellationToken)
+        {
+            var releaseVersion = await context.ReleaseVersions
+                .FirstAsync(rv => rv.Id == releaseVersionId, cancellationToken);
+            context.ReleaseVersions.Remove(releaseVersion);
+            await context.SaveChangesAsync(cancellationToken);
+            return Unit.Instance;
+        }
+
+        public Task<Either<ActionResult, DeleteReleasePlanViewModel>> GetDeleteReleaseVersionPlan(
+            Guid releaseVersionId, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<Either<ActionResult, Unit>> DeleteReleaseVersion(
+            Guid releaseVersionId, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task<Either<ActionResult, ReleaseVersionViewModel>> GetRelease(Guid releaseVersionId) =>
+            throw new NotImplementedException();
+
+        public Task<Either<ActionResult, ReleasePublicationStatusViewModel>> GetReleasePublicationStatus(
+            Guid releaseVersionId) => throw new NotImplementedException();
+
+        public Task<Either<ActionResult, ReleaseVersionViewModel>> UpdateReleaseVersion(
+            Guid releaseVersionId, ReleaseVersionUpdateRequest request) => throw new NotImplementedException();
+
+        public Task<Either<ActionResult, Unit>> UpdateReleasePublished(
+            Guid releaseVersionId, ReleasePublishedUpdateRequest request) => throw new NotImplementedException();
+
+        public Task<Either<ActionResult, IdTitleViewModel>> GetLatestPublishedRelease(Guid publicationId) =>
+            throw new NotImplementedException();
+
+        public Task<Either<ActionResult, List<ReleaseVersionSummaryViewModel>>> ListReleasesWithStatuses(
+            params ReleaseApprovalStatus[] releaseApprovalStatues) => throw new NotImplementedException();
+
+        public Task<Either<ActionResult, List<ReleaseVersionSummaryViewModel>>> ListUsersReleasesForApproval() =>
+            throw new NotImplementedException();
+
+        public Task<Either<ActionResult, List<ReleaseVersionSummaryViewModel>>> ListScheduledReleases() =>
+            throw new NotImplementedException();
+
+        public Task<Either<ActionResult, DeleteDataFilePlanViewModel>> GetDeleteDataFilePlan(
+            Guid releaseVersionId, Guid fileId, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task<Either<ActionResult, Unit>> RemoveDataFiles(Guid releaseVersionId, Guid fileId) =>
+            throw new NotImplementedException();
+
+        public Task<Either<ActionResult, DataImportStatusViewModel>> GetDataFileImportStatus(
+            Guid releaseVersionId, Guid fileId) => throw new NotImplementedException();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -23,6 +23,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
+using GovUk.Education.ExploreEducationStatistics.Events;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.Fixtures;
@@ -383,8 +384,13 @@ public class ThemeServiceTests
                 adminEventRaiser.Assert.OnPublicationDeletedWasRaised(
                     publication.Id,
                     publication.Slug,
-                    publication.LatestPublishedReleaseVersion?.ReleaseId,
-                    publication.LatestPublishedReleaseVersionId
+                    publication.LatestPublishedReleaseVersion != null
+                        ? new LatestPublishedReleaseInfo
+                        {
+                            LatestPublishedReleaseId = publication.LatestPublishedReleaseVersion.ReleaseId,
+                            LatestPublishedReleaseVersionId = publication.LatestPublishedReleaseVersion.Id
+                        }
+                        : null
                 );
             }
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiser.cs
@@ -73,6 +73,27 @@ public class AdminEventRaiser(IEventRaiser eventRaiser) : IAdminEventRaiser
         ));
 
     /// <summary>
+    /// Publishes an event when a publication is deleted.
+    /// </summary>
+    /// <param name="publicationId">The unique identifier of the publication that has been deleted.</param>
+    /// <param name="publicationSlug">The slug of the publication that has been deleted.</param>
+    /// <param name="latestPublishedReleaseId">The unique identifier of the latest published release associated with the publication.</param>
+    /// <param name="latestPublishedReleaseVersionId">The unique identifier of the latest published release version associated with the publication.</param>
+    public async Task OnPublicationDeleted(
+        Guid publicationId,
+        string publicationSlug,
+        Guid? latestPublishedReleaseId,
+        Guid? latestPublishedReleaseVersionId)
+    {
+        await eventRaiser.RaiseEvent(new PublicationDeletedEvent(
+            publicationId,
+            publicationSlug,
+            latestPublishedReleaseId: latestPublishedReleaseId,
+            latestPublishedReleaseVersionId: latestPublishedReleaseVersionId
+        ));
+    }
+
+    /// <summary>
     /// On Publication Latest Published Release Reordered.
     /// It is assumed that the publication LatestPublishedReleaseVersionId has a value assigned to it.
     /// If it is null, then no event will be raised.

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/AdminEventRaiser.cs
@@ -77,19 +77,18 @@ public class AdminEventRaiser(IEventRaiser eventRaiser) : IAdminEventRaiser
     /// </summary>
     /// <param name="publicationId">The unique identifier of the publication that has been deleted.</param>
     /// <param name="publicationSlug">The slug of the publication that has been deleted.</param>
-    /// <param name="latestPublishedReleaseId">The unique identifier of the latest published release associated with the publication.</param>
-    /// <param name="latestPublishedReleaseVersionId">The unique identifier of the latest published release version associated with the publication.</param>
+    /// <param name="latestPublishedRelease">
+    /// Details of the latest published release associated with the publication that has been deleted.
+    /// </param>
     public async Task OnPublicationDeleted(
         Guid publicationId,
         string publicationSlug,
-        Guid? latestPublishedReleaseId,
-        Guid? latestPublishedReleaseVersionId)
+        LatestPublishedReleaseInfo? latestPublishedRelease)
     {
         await eventRaiser.RaiseEvent(new PublicationDeletedEvent(
             publicationId,
             publicationSlug,
-            latestPublishedReleaseId: latestPublishedReleaseId,
-            latestPublishedReleaseVersionId: latestPublishedReleaseVersionId
+            latestPublishedRelease
         ));
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiser.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Events;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 
@@ -26,8 +27,7 @@ public interface IAdminEventRaiser
     Task OnPublicationDeleted(
         Guid publicationId,
         string publicationSlug,
-        Guid? latestPublishedReleaseId,
-        Guid? latestPublishedReleaseVersionId);
+        LatestPublishedReleaseInfo? latestPublishedRelease);
 
     Task OnPublicationLatestPublishedReleaseReordered(
         Publication publication,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiser.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IAdminEventRaiser.cs
@@ -23,6 +23,12 @@ public interface IAdminEventRaiser
 
     Task OnPublicationChanged(Publication publication);
 
+    Task OnPublicationDeleted(
+        Guid publicationId,
+        string publicationSlug,
+        Guid? latestPublishedReleaseId,
+        Guid? latestPublishedReleaseVersionId);
+
     Task OnPublicationLatestPublishedReleaseReordered(
         Publication publication,
         Guid previousLatestPublishedReleaseId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
@@ -11,6 +11,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Metho
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -196,10 +197,9 @@ public class ThemeService : IThemeService
         CancellationToken cancellationToken = default)
     {
         return await _userService.CheckCanManageAllTaxonomy()
-            .OnSuccess(() =>
-                _persistenceHelper.CheckEntityExists<Theme>(themeId, q => q.Include(t => t.Publications)))
+            .OnSuccess(() => _contentDbContext.Themes.FirstOrNotFoundAsync(t => t.Id == themeId, cancellationToken))
             .OnSuccessDo(CheckCanDeleteTheme)
-            .OnSuccessDo(theme => DeletePublicationsForTheme(theme, cancellationToken))
+            .OnSuccessDo(() => DeletePublicationsForTheme(themeId, cancellationToken))
             .OnSuccessVoid(async theme =>
             {
                 _contentDbContext.Themes.Remove(theme);
@@ -210,19 +210,19 @@ public class ThemeService : IThemeService
     }
 
     private async Task<Either<List<ActionResult>, Unit>> DeletePublicationsForTheme(
-        Theme theme, CancellationToken cancellationToken)
+        Guid themeId,
+        CancellationToken cancellationToken)
     {
-        var publicationIds = theme
-            .Publications
-            .Select(publication => publication.Id)
-            .ToList();
+        var publicationIds = await _contentDbContext.Publications
+            .Where(p => p.ThemeId == themeId)
+            .Select(p => p.Id)
+            .ToListAsync(cancellationToken);
 
         var deletePublicationResults = await publicationIds
             .ToAsyncEnumerable()
             .SelectAwait(async publicationId =>
-                await DeleteMethodologiesForPublication(publicationId)
-                    .OnSuccess(() => DeleteReleaseVersionsForPublication(publicationId))
-                    .OnSuccess(() => DeletePublication(publicationId)))
+                await DeleteMethodologiesForPublication(publicationId, cancellationToken)
+                    .OnSuccess(() => DeletePublication(publicationId, cancellationToken)))
             .ToListAsync(cancellationToken);
 
         return deletePublicationResults
@@ -231,35 +231,33 @@ public class ThemeService : IThemeService
     }
 
     private async Task<Either<ActionResult, Unit>> DeleteMethodologiesForPublication(
-        Guid publicationId)
+        Guid publicationId,
+        CancellationToken cancellationToken)
     {
         var methodologyIdsToDelete = await _contentDbContext
             .PublicationMethodologies
-            .AsQueryable()
             .Where(pm => pm.Owner && pm.PublicationId == publicationId)
             .Select(pm => pm.MethodologyId)
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 
         return await methodologyIdsToDelete
             .Select(methodologyId => _methodologyService.DeleteMethodology(methodologyId, true))
             .OnSuccessAllReturnVoid();
     }
 
-    private async Task<Either<ActionResult, Unit>> DeleteReleaseVersionsForPublication(Guid publicationId)
+    private async Task<Either<ActionResult, Unit>> DeletePublication(
+        Guid publicationId,
+        CancellationToken cancellationToken)
     {
-        var publications = await _contentDbContext
+        var publication = await _contentDbContext
             .Publications
-            .Where(publication => publication.Id == publicationId)
-            .ToListAsync();
+            .Include(p => p.LatestPublishedReleaseVersion)
+            .Include(p => p.Contact)
+            .FirstAsync(p => p.Id == publicationId, cancellationToken);
 
-        publications.ForEach(publication =>
-        {
-            publication.LatestPublishedReleaseVersion = null;
-            publication.LatestPublishedReleaseVersionId = null;
-        });
-
-        _contentDbContext.UpdateRange(publications);
-        await _contentDbContext.SaveChangesAsync();
+        // Capture the latest publication release version before it is deleted
+        // so that it can be used to raise an event after the publication is deleted.
+        var latestPublicationReleaseVersion = publication.LatestPublishedReleaseVersion;
 
         // Some Content Db Releases may be soft-deleted and therefore not visible.
         // Ignore the query filter to make sure they are found
@@ -268,8 +266,8 @@ public class ThemeService : IThemeService
             .AsNoTracking()
             .IgnoreQueryFilters()
             .Include(rv => rv.Release)
-            .Where(rv => rv.PublicationId == publicationId)
-            .ToListAsync();
+            .Where(rv => rv.Release.PublicationId == publicationId)
+            .ToListAsync(cancellationToken);
 
         var releaseVersionsAndDataSetVersions = await releaseVersionsToDelete
             .ToAsyncEnumerable()
@@ -281,7 +279,7 @@ public class ThemeService : IThemeService
                     ReleaseVersion: rv,
                     DataSetVersions: dataSetVersions);
             })
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 
         var releaseVersionIdsInDeleteOrder = releaseVersionsAndDataSetVersions
             .Order(new DependentReleaseVersionDeleteOrderComparator())
@@ -289,21 +287,21 @@ public class ThemeService : IThemeService
             .ToList();
 
         return await releaseVersionIdsInDeleteOrder
-            .Select(releaseVersionId => _releaseVersionService.DeleteTestReleaseVersion(releaseVersionId))
-            .OnSuccessAllReturnVoid();
-    }
+            .Select(releaseVersionId =>
+                _releaseVersionService.DeleteTestReleaseVersion(releaseVersionId, cancellationToken))
+            .OnSuccessAll()
+            .OnSuccessVoid(async () =>
+            {
+                _contentDbContext.Publications.Remove(publication);
+                _contentDbContext.Contacts.Remove(publication.Contact);
+                await _contentDbContext.SaveChangesAsync(cancellationToken);
 
-    private async Task<Either<ActionResult, Unit>> DeletePublication(Guid publicationId)
-    {
-        var publication = await _contentDbContext
-            .Publications
-            .Include(publication => publication.Contact)
-            .SingleAsync(publication => publication.Id == publicationId);
-
-        _contentDbContext.Publications.RemoveRange(publication);
-        _contentDbContext.Contacts.RemoveRange(publication.Contact);
-        await _contentDbContext.SaveChangesAsync();
-        return Unit.Instance;
+                await _eventRaiser.OnPublicationDeleted(
+                    publication.Id,
+                    publication.Slug,
+                    latestPublicationReleaseVersion?.ReleaseId,
+                    latestPublicationReleaseVersion?.Id);
+            });
     }
 
     public async Task<Either<ActionResult, Unit>> DeleteUITestThemes(CancellationToken cancellationToken = default)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/PublicationGeneratorExtensions.cs
@@ -21,12 +21,12 @@ public static class PublicationGeneratorExtensions
             .SetDefault(p => p.Slug)
             .SetDefault(p => p.Summary)
             .SetDefault(p => p.Title)
-            .Set((_, p) => p.Contact = new Contact
+            .SetContact(new Contact
             {
-                Id = p.Id,
-                ContactName = $"Contact name for {p.Id}",
+                Id = Guid.NewGuid(),
+                ContactName = "Contact name",
                 TeamEmail = "test@example.com",
-                TeamName = $"Team name for {p.Id}",
+                TeamName = "Team name",
                 ContactTelNo = "01234 567890"
             });
 
@@ -221,7 +221,13 @@ public static class PublicationGeneratorExtensions
     private static InstanceSetters<Publication> SetContact(
         this InstanceSetters<Publication> setters,
         Contact contact)
-        => setters.Set(p => p.Contact, contact);
+        => setters.Set(p => p.Contact, contact)
+            .SetContactId(contact.Id);
+
+    private static InstanceSetters<Publication> SetContactId(
+        this InstanceSetters<Publication> setters,
+        Guid contactId)
+        => setters.Set(p => p.ContactId, contactId);
 
     private static InstanceSetters<Publication> SetExternalMethodology(
         this InstanceSetters<Publication> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/EventHandlers/OnPublicationDeleted/OnPublicationDeletedFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/EventHandlers/OnPublicationDeleted/OnPublicationDeletedFunctionTests.cs
@@ -1,9 +1,9 @@
-﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemoveSearchableDocument.Dto;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Domain;
+using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemoveSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationDeleted;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationDeleted.Dtos;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Builders;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.TheoryDataHelpers;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.Functions.EventHandlers.OnPublicationDeleted;
@@ -17,11 +17,21 @@ public class OnPublicationDeletedFunctionTests
     public void CanInstantiateSut() => Assert.NotNull(GetSut());
 
     [Fact]
-    public async Task GivenEvent_WhenPayloadContainsReleaseId_ReturnsExpectedDto()
+    public async Task GivenEvent_WhenPayloadContainsLatestPublishedRelease_ReturnsExpectedDto()
     {
-        var payload = new PublicationDeletedEventDto { LatestPublishedReleaseId = Guid.NewGuid() };
+        var payload = new PublicationDeletedEventDto
+        {
+            LatestPublishedRelease = new LatestPublishedReleaseInfo
+            {
+                LatestPublishedReleaseId = Guid.NewGuid(),
+                LatestPublishedReleaseVersionId = Guid.NewGuid()
+            }
+        };
         var eventGridEvent = new EventGridEventBuilder().WithPayload(payload).Build();
-        var expected = new RemoveSearchableDocumentDto { ReleaseId = payload.LatestPublishedReleaseId };
+        var expected = new RemoveSearchableDocumentDto
+        {
+            ReleaseId = payload.LatestPublishedRelease.LatestPublishedReleaseId
+        };
 
         var response = await GetSut().OnPublicationDeleted(eventGridEvent, new FunctionContextMockBuilder().Build());
 
@@ -29,11 +39,10 @@ public class OnPublicationDeletedFunctionTests
         Assert.Equal(expected, actual);
     }
 
-    [Theory]
-    [MemberData(nameof(TheoryDatas.Blank.Guids), MemberType = typeof(TheoryDatas.Blank))]
-    public async Task GivenEvent_WhenPayloadDoesNotContainReleaseId_ThenNothingIsReturned(Guid? blankReleaseId)
+    [Fact]
+    public async Task GivenEvent_WhenPayloadDoesNotContainReleaseId_ThenNothingIsReturned()
     {
-        var payload = new PublicationDeletedEventDto { LatestPublishedReleaseId = blankReleaseId };
+        var payload = new PublicationDeletedEventDto();
         var eventGridEvent = new EventGridEventBuilder().WithPayload(payload).Build();
 
         var response = await GetSut().OnPublicationDeleted(eventGridEvent, new FunctionContextMockBuilder().Build());

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Domain/LatestPublishedReleaseInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Domain/LatestPublishedReleaseInfo.cs
@@ -1,0 +1,8 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Domain;
+
+public record LatestPublishedReleaseInfo
+{
+    public required Guid LatestPublishedReleaseId { get; init; }
+
+    public required Guid LatestPublishedReleaseVersionId { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationDeleted/Dtos/PublicationDeletedEventDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationDeleted/Dtos/PublicationDeletedEventDto.cs
@@ -1,10 +1,10 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationDeleted.Dtos;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Domain;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationDeleted.Dtos;
 
 public record PublicationDeletedEventDto
 {
     public string? PublicationSlug { get; init; }
 
-    public Guid? LatestPublishedReleaseId { get; init; }
-
-    public Guid? LatestPublishedReleaseVersionId { get; init; }
+    public LatestPublishedReleaseInfo? LatestPublishedRelease { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationDeleted/OnPublicationDeletedFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/EventHandlers/OnPublicationDeleted/OnPublicationDeletedFunction.cs
@@ -1,5 +1,4 @@
 ﻿using Azure.Messaging.EventGrid;
-using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.CommandHandlers.RemoveSearchableDocument.Dto;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Functions.EventHandlers.OnPublicationDeleted.Dtos;
 using GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Services.Core;
@@ -19,7 +18,13 @@ public class OnPublicationDeletedFunction(IEventGridEventHandler eventGridEventH
             eventDto,
             (payload, _) =>
                 Task.FromResult<RemoveSearchableDocumentDto[]>(
-                    payload.LatestPublishedReleaseId.IsBlank()
-                        ? []
-                        : [new RemoveSearchableDocumentDto { ReleaseId = payload.LatestPublishedReleaseId }]));
+                    payload.LatestPublishedRelease != null
+                        ?
+                        [
+                            new RemoveSearchableDocumentDto
+                            {
+                                ReleaseId = payload.LatestPublishedRelease.LatestPublishedReleaseId
+                            }
+                        ]
+                        : []));
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/LatestPublishedReleaseInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/LatestPublishedReleaseInfo.cs
@@ -1,0 +1,17 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Events;
+
+/// <summary>
+/// Information about the latest published release associated with a publication.
+/// </summary>
+public record LatestPublishedReleaseInfo
+{
+    /// <summary>
+    /// The unique identifier of the latest published release associated with a publication.
+    /// </summary>
+    public required Guid LatestPublishedReleaseId { get; init; }
+
+    /// <summary>
+    /// The unique identifier of the latest published release version associated with a publication.
+    /// </summary>
+    public required Guid LatestPublishedReleaseVersionId { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationDeletedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationDeletedEvent.cs
@@ -8,15 +8,13 @@ public record PublicationDeletedEvent : IEvent
     public PublicationDeletedEvent(
         Guid publicationId,
         string publicationSlug,
-        Guid? latestPublishedReleaseId,
-        Guid? latestPublishedReleaseVersionId)
+        LatestPublishedReleaseInfo? latestPublishedRelease)
     {
         Subject = publicationId.ToString();
         Payload = new EventPayload
         {
             PublicationSlug = publicationSlug,
-            LatestPublishedReleaseId = latestPublishedReleaseId,
-            LatestPublishedReleaseVersionId = latestPublishedReleaseVersionId
+            LatestPublishedRelease = latestPublishedRelease
         };
     }
 
@@ -40,8 +38,7 @@ public record PublicationDeletedEvent : IEvent
     public record EventPayload
     {
         public required string PublicationSlug { get; init; }
-        public required Guid? LatestPublishedReleaseId { get; init; }
-        public required Guid? LatestPublishedReleaseVersionId { get; init; }
+        public required LatestPublishedReleaseInfo? LatestPublishedRelease { get; init; }
     }
 
     public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);

--- a/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationDeletedEvent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Events/PublicationDeletedEvent.cs
@@ -8,8 +8,8 @@ public record PublicationDeletedEvent : IEvent
     public PublicationDeletedEvent(
         Guid publicationId,
         string publicationSlug,
-        Guid latestPublishedReleaseId,
-        Guid latestPublishedReleaseVersionId)
+        Guid? latestPublishedReleaseId,
+        Guid? latestPublishedReleaseVersionId)
     {
         Subject = publicationId.ToString();
         Payload = new EventPayload
@@ -40,8 +40,8 @@ public record PublicationDeletedEvent : IEvent
     public record EventPayload
     {
         public required string PublicationSlug { get; init; }
-        public required Guid LatestPublishedReleaseId { get; init; }
-        public required Guid LatestPublishedReleaseVersionId { get; init; }
+        public required Guid? LatestPublishedReleaseId { get; init; }
+        public required Guid? LatestPublishedReleaseVersionId { get; init; }
     }
 
     public EventGridEvent ToEventGridEvent() => new(Subject, EventType, DataVersion, Payload);


### PR DESCRIPTION
This PR changes the Admin to publish an event of type `PublicationDeletedEvent` for every publication that is deleted when deleting a theme.

The Search Function App has already been subscribed to this event by changes made in https://github.com/dfe-analytical-services/explore-education-statistics/pull/6050, and will remove any searchable document for the deleted publication’s latest published release.

### UI Test result

<img width="425" alt="image" src="https://github.com/user-attachments/assets/368263e9-1917-4a22-9744-d449485baaf2" />
