### PR TITLE
EES-6141 line chart legend label position

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartLegend.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartLegend.cs
@@ -22,11 +22,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
         inline
     }
 
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum ChartLegendLabelColour
+    {
+        black, inherit
+    }
+
     public class ChartLegendItem
     {
         public ChartBaseDataSet DataSet;
         public string Label;
         public string Colour;
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ChartLegendLabelColour? LabelColour;
 
         [JsonConverter(typeof(StringEnumConverter))]
         public ChartLineSymbol? Symbol;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartLegend.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartLegend.cs
@@ -36,5 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
 
         [JsonConverter(typeof(StringEnumConverter))]
         public ChartInlinePosition? InlinePosition;
+
+        public int? InlinePositionOffset;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartLineEnums.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartLineEnums.cs
@@ -26,6 +26,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public enum ChartInlinePosition
     {
-        above, below
+        above, below, right
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.module.scss
@@ -13,16 +13,20 @@
 .configurationInput {
   align-items: center;
   display: flex;
-  margin-right: govuk-spacing(4);
+  flex-shrink: 0;
+  margin-right: govuk-spacing(6);
 
   label {
     margin-right: govuk-spacing(2);
+  }
+
+  select {
+    min-width: 6em;
   }
 }
 
 .numberInput {
   composes: configurationInput;
-  flex-grow: 1;
   min-width: 140px;
 
   input {
@@ -32,7 +36,6 @@
 
 .labelInput {
   composes: configurationInput;
-  flex-grow: 1;
   min-width: 200px;
 }
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.module.scss
@@ -20,6 +20,16 @@
   }
 }
 
+.numberInput {
+  composes: configurationInput;
+  flex-grow: 1;
+  min-width: 140px;
+
+  input {
+    width: 5ch;
+  }
+}
+
 .labelInput {
   composes: configurationInput;
   flex-grow: 1;

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
@@ -18,6 +18,7 @@ import {
   LegendItemConfiguration,
   LegendPosition,
   LegendInlinePosition,
+  LegendLabelColour,
 } from '@common/modules/charts/types/legend';
 import { legendPositions } from '@common/modules/charts/util/chartUtils';
 import createDataSetCategories from '@common/modules/charts/util/createDataSetCategories';
@@ -99,6 +100,7 @@ const ChartLegendConfiguration = ({
     const defaultConfig: Partial<LegendItemConfiguration> = {
       symbol: capabilities.hasSymbols ? 'none' : undefined,
       lineStyle: capabilities.hasLineStyle ? 'solid' : undefined,
+      labelColour: capabilities.canPositionLegendInline ? 'black' : undefined,
       inlinePosition: capabilities.canPositionLegendInline
         ? 'right'
         : undefined,
@@ -140,7 +142,7 @@ const ChartLegendConfiguration = ({
             params.path as string,
           )}`,
       ),
-      labelColour: Yup.boolean().optional(),
+      labelColour: Yup.string<LegendLabelColour>().optional(),
       symbol: Yup.string<ChartSymbol>().optional(),
       lineStyle: Yup.string<LineStyle>().optional(),
       inlinePosition: Yup.string<LegendInlinePosition>().optional(),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
@@ -143,6 +143,10 @@ const ChartLegendConfiguration = ({
       symbol: Yup.string<ChartSymbol>().optional(),
       lineStyle: Yup.string<LineStyle>().optional(),
       inlinePosition: Yup.string<LegendInlinePosition>().optional(),
+      inlinePositionOffset: Yup.number()
+        .min(-30, 'Offset must be between -30 and 30')
+        .max(30, 'Offset must be between -30 and 30')
+        .optional(),
     });
 
     if (capabilities.canPositionLegendInline) {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
@@ -100,7 +100,7 @@ const ChartLegendConfiguration = ({
       symbol: capabilities.hasSymbols ? 'none' : undefined,
       lineStyle: capabilities.hasLineStyle ? 'solid' : undefined,
       inlinePosition: capabilities.canPositionLegendInline
-        ? 'above'
+        ? 'right'
         : undefined,
     };
 
@@ -148,7 +148,7 @@ const ChartLegendConfiguration = ({
     if (capabilities.canPositionLegendInline) {
       itemSchema = itemSchema.shape({
         inlinePosition: Yup.string().oneOf<LegendInlinePosition>(
-          ['above', 'below'],
+          ['above', 'below', 'right'],
           params =>
             `Choose a valid position for legend item ${getLegendItemNumber(
               params.path as string,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
@@ -140,12 +140,13 @@ const ChartLegendConfiguration = ({
             params.path as string,
           )}`,
       ),
+      labelColour: Yup.boolean().optional(),
       symbol: Yup.string<ChartSymbol>().optional(),
       lineStyle: Yup.string<LineStyle>().optional(),
       inlinePosition: Yup.string<LegendInlinePosition>().optional(),
       inlinePositionOffset: Yup.number()
-        .min(-30, 'Offset must be between -30 and 30')
-        .max(30, 'Offset must be between -30 and 30')
+        .min(-100, 'Offset must be between -100 and 100')
+        .max(100, 'Offset must be between -100 and 100')
         .optional(),
     });
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendItems.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendItems.tsx
@@ -14,6 +14,7 @@ import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
 import FormFieldColourInput from '@common/components/form/FormFieldColourInput';
 import Effect from '@common/components/Effect';
 import useDebouncedCallback from '@common/hooks/useDebouncedCallback';
+import FormFieldNumberInput from '@common/components/form/FormFieldNumberInput';
 import FormFieldset from '@common/components/form/FormFieldset';
 import FormFieldSelect from '@common/components/form/FormFieldSelect';
 import FormSelect, { SelectOption } from '@common/components/form/FormSelect';
@@ -139,16 +140,28 @@ export default function ChartLegendItems({
                     )}
 
                     {position === 'inline' && (
-                      <div className={styles.configurationInput}>
-                        <FormFieldSelect
-                          name={`items.${index}.inlinePosition`}
-                          label="Position"
-                          order={FormSelect.unordered}
-                          formGroup={false}
-                          showError={false}
-                          options={inlinePositionOptions}
-                        />
-                      </div>
+                      <>
+                        <div className={styles.configurationInput}>
+                          <FormFieldSelect
+                            name={`items.${index}.inlinePosition`}
+                            label="Position"
+                            order={FormSelect.unordered}
+                            formGroup={false}
+                            showError={false}
+                            options={inlinePositionOptions}
+                          />
+                        </div>
+                        <div className={styles.numberInput}>
+                          <FormFieldNumberInput
+                            name={`items.${index}.inlinePositionOffset`}
+                            label="Y Offset"
+                            formGroup={false}
+                            showError={false}
+                            min={-30}
+                            max={30}
+                          />
+                        </div>
+                      </>
                     )}
                   </div>
                 </FormFieldset>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendItems.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendItems.tsx
@@ -157,8 +157,8 @@ export default function ChartLegendItems({
                             label="Y Offset"
                             formGroup={false}
                             showError={false}
-                            min={-30}
-                            max={30}
+                            min={-100}
+                            max={100}
                           />
                         </div>
                       </>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendItems.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendItems.tsx
@@ -5,6 +5,7 @@ import {
   colours,
   lineStyles,
   symbols,
+  legendLabelColours,
 } from '@common/modules/charts/util/chartUtils';
 import {
   LegendConfiguration,
@@ -33,6 +34,13 @@ const lineStyleOptions: SelectOption[] = lineStyles.map(lineStyle => ({
   label: upperFirst(lineStyle),
   value: lineStyle,
 }));
+
+const legendLabelColourOptions: SelectOption[] = legendLabelColours.map(
+  colour => ({
+    label: upperFirst(colour),
+    value: colour,
+  }),
+);
 
 const inlinePositionOptions: SelectOption[] = legendInlinePositions.map(
   position => ({
@@ -95,7 +103,7 @@ export default function ChartLegendItems({
                     fieldErrorDetails[0] ? fieldErrorDetails[0].message : ''
                   }
                 >
-                  <div className="dfe-flex dfe-justify-content--space-between">
+                  <div className="dfe-flex">
                     <div className={styles.labelInput}>
                       <FormFieldTextInput
                         name={`items.${index}.label`}
@@ -107,12 +115,24 @@ export default function ChartLegendItems({
                     <div className={styles.colourInput}>
                       <FormFieldColourInput
                         name={`items.${index}.colour`}
-                        label="Colour"
+                        label="Line Colour"
                         colours={colours}
                         formGroup={false}
                         showError={false}
                       />
                     </div>
+
+                    {capabilities.hasLineStyle && position === 'inline' && (
+                      <div className={styles.configurationInput}>
+                        <FormFieldSelect
+                          name={`items.${index}.labelColour`}
+                          label="Label Colour"
+                          formGroup={false}
+                          showError={false}
+                          options={legendLabelColourOptions}
+                        />
+                      </div>
+                    )}
 
                     {capabilities.hasSymbols && (
                       <div className={styles.configurationInput}>
@@ -139,7 +159,7 @@ export default function ChartLegendItems({
                       </div>
                     )}
 
-                    {position === 'inline' && (
+                    {capabilities.hasLineStyle && position === 'inline' && (
                       <>
                         <div className={styles.configurationInput}>
                           <FormFieldSelect

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendItems.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendItems.tsx
@@ -115,7 +115,7 @@ export default function ChartLegendItems({
                     <div className={styles.colourInput}>
                       <FormFieldColourInput
                         name={`items.${index}.colour`}
-                        label="Line Colour"
+                        label="Colour"
                         colours={colours}
                         formGroup={false}
                         showError={false}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilder.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartBuilder.test.tsx
@@ -464,6 +464,7 @@ describe('ChartBuilder', () => {
               timePeriod: '2014_AY',
             },
             inlinePosition: undefined,
+            labelColour: undefined,
             label:
               'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, 2014/15)',
             lineStyle: undefined,
@@ -477,6 +478,7 @@ describe('ChartBuilder', () => {
               timePeriod: '2015_AY',
             },
             inlinePosition: undefined,
+            labelColour: undefined,
             label:
               'Number of authorised absence sessions (Ethnicity Major Chinese, State-funded primary, 2015/16)',
             lineStyle: undefined,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartLegendConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartLegendConfiguration.test.tsx
@@ -545,7 +545,7 @@ describe('ChartLegendConfiguration', () => {
     expect(legendItem1.queryByLabelText('Style')).not.toBeInTheDocument();
   });
 
-  test('renders the item position field when the legend position is `inline`', () => {
+  test('renders the item position, label colour and y offset fields when the legend position is `inline`', () => {
     render(
       <ChartBuilderFormsContextProvider initialForms={testFormState}>
         <ChartLegendConfiguration
@@ -600,9 +600,11 @@ describe('ChartLegendConfiguration', () => {
 
     expect(legendItem1.getByLabelText('Label')).toHaveValue('Legend item 1');
     expect(legendItem1.getByLabelText('Colour')).toHaveValue('#ff0000');
+    expect(legendItem1.getByLabelText('Label Colour')).toHaveValue('black');
     expect(legendItem1.getByLabelText('Symbol')).toHaveValue('none');
     expect(legendItem1.getByLabelText('Style')).toHaveValue('solid');
-    expect(legendItem1.getByLabelText('Position')).toHaveValue('above');
+    expect(legendItem1.getByLabelText('Position')).toHaveValue('right');
+    expect(legendItem1.queryByLabelText('Y Offset')).toBeInTheDocument();
   });
 
   test('calls `onChange` handler if form values change', async () => {
@@ -656,6 +658,9 @@ describe('ChartLegendConfiguration', () => {
       'Updated legend item 1',
     );
 
+    await user.clear(legendItem1.getByLabelText('Y Offset'));
+    await user.type(legendItem1.getByLabelText('Y Offset'), '20');
+
     await user.selectOptions(legendItem1.getByLabelText('Position'), 'below');
 
     expect(handleChange).toHaveBeenCalledWith<[LegendConfiguration]>({
@@ -665,9 +670,11 @@ describe('ChartLegendConfiguration', () => {
           dataSet,
           label: 'Updated legend item 1',
           colour: '#12436D',
+          labelColour: 'black',
           lineStyle: 'solid',
           symbol: 'none',
           inlinePosition: 'below',
+          inlinePositionOffset: 20,
         },
       ],
     });
@@ -960,9 +967,11 @@ describe('ChartLegendConfiguration', () => {
             },
             label: 'Updated legend item 1',
             colour: '#d53880',
+            labelColour: 'black',
             lineStyle: 'dotted',
             symbol: 'diamond',
             inlinePosition: 'below',
+            inlinePositionOffset: undefined,
           },
         ],
       };

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/chartBuilderReducer.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/chartBuilderReducer.ts
@@ -299,6 +299,10 @@ export function chartBuilderReducer(
             ...defaultLegend,
             ...(action.payload.legend.defaults ?? {}),
             ...(draft.legend ?? {}),
+            ...(!action.payload.capabilities.canPositionLegendInline &&
+            draft.legend?.position === 'inline'
+              ? { position: action.payload.legend.defaults?.position }
+              : {}),
           };
         } else {
           draft.legend = undefined;

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -196,12 +196,12 @@ const LineChartBlock = ({
                   decimalPlaces={dataSet.indicator.decimalPlaces}
                   index={props.index}
                   isDataLabel={showDataLabels}
+                  isLastItem={props.index === chartData.length - 1}
                   isLegendLabel={legend.position === 'inline'}
                   name={config.label}
                   position={
                     showDataLabels ? dataLabelPosition : config.inlinePosition
                   }
-                  totalDataPoints={chartData.length}
                   unit={dataSet.indicator.unit}
                   value={props.value}
                   x={props.x}
@@ -281,7 +281,7 @@ export const lineChartBlockDefinition: ChartDefinition = {
   },
   legend: {
     defaults: {
-      position: 'bottom',
+      position: 'inline',
     },
   },
   axes: {

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -105,6 +105,12 @@ const LineChartBlock = ({
   const chartHasNegativeValues =
     (parseNumber(minorDomainTicks.domain?.[0]) ?? 0) < 0;
 
+  const rightMargin =
+    legend.position === 'inline' &&
+    legend.items.some(legendItem => legendItem.inlinePosition === 'right')
+      ? 160 // Arbitrary number that covers max width of labels
+      : 0;
+
   if (!chartData.length) {
     return <p className="govuk-!-margin-top-5">No data to display.</p>;
   }
@@ -128,6 +134,7 @@ const LineChartBlock = ({
           margin={{
             left: 30,
             top: 20,
+            right: rightMargin,
           }}
         >
           <Tooltip

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -195,6 +195,7 @@ const LineChartBlock = ({
                   colour={config.colour}
                   decimalPlaces={dataSet.indicator.decimalPlaces}
                   index={props.index}
+                  inlinePositionOffset={config.inlinePositionOffset}
                   isDataLabel={showDataLabels}
                   isLastItem={props.index === chartData.length - 1}
                   isLegendLabel={legend.position === 'inline'}

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -206,6 +206,7 @@ const LineChartBlock = ({
                   isDataLabel={showDataLabels}
                   isLastItem={props.index === chartData.length - 1}
                   isLegendLabel={legend.position === 'inline'}
+                  labelColour={config.labelColour}
                   name={config.label}
                   position={
                     showDataLabels ? dataLabelPosition : config.inlinePosition

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartLabel.tsx
@@ -90,7 +90,6 @@ export default function LineChartLabel({
         textAnchor={isPositionRight ? 'start' : 'end'}
         x={x}
         y={y}
-        data-testid="inline-legend-label"
       >
         {isPositionRight ? (
           // SVG <text> does not line wrap automatically :(

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartLabel.tsx
@@ -9,9 +9,9 @@ interface Props {
   index: number;
   isDataLabel?: boolean;
   isLegendLabel?: boolean;
+  isLastItem?: boolean;
   name: string;
   position?: LineChartDataLabelPosition | LegendInlinePosition;
-  totalDataPoints: number;
   unit?: string;
   value?: string | number;
   x?: string | number;
@@ -24,16 +24,16 @@ export default function LineChartLabel({
   index,
   isDataLabel = false,
   isLegendLabel = false,
+  isLastItem = false,
   name,
   position,
-  totalDataPoints,
   unit,
   value,
   x,
   y,
 }: Props) {
   const getTextAnchor = () => {
-    if (index === totalDataPoints - 1) {
+    if (isLastItem) {
       return 'end';
     }
     if (index === 0) {
@@ -62,7 +62,7 @@ export default function LineChartLabel({
   }
 
   // Legend as the label - only render for the last data point in the line.
-  if (isLegendLabel && index === totalDataPoints - 1) {
+  if (isLegendLabel && isLastItem) {
     return (
       <text
         dy={position === 'above' ? '-6' : '16'}

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartLabel.tsx
@@ -7,6 +7,7 @@ interface Props {
   colour: string;
   decimalPlaces?: number;
   index: number;
+  inlinePositionOffset?: number;
   isDataLabel?: boolean;
   isLegendLabel?: boolean;
   isLastItem?: boolean;
@@ -22,6 +23,7 @@ export default function LineChartLabel({
   colour,
   decimalPlaces,
   index,
+  inlinePositionOffset = 0,
   isDataLabel = false,
   isLegendLabel = false,
   isLastItem = false,
@@ -63,9 +65,11 @@ export default function LineChartLabel({
 
   // Legend as the label - only render for the last data point in the line.
   if (isLegendLabel && isLastItem) {
+    const defaultDy = position === 'below' ? 16 : -6;
+
     return (
       <text
-        dy={position === 'above' ? '-6' : '16'}
+        dy={defaultDy + inlinePositionOffset * -1}
         fill={colour}
         fontSize={14}
         textAnchor="end"

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartLabel.tsx
@@ -1,6 +1,9 @@
 import chunkLabelToFitCharLimit from '@common/modules/charts/components/utils/chunkLabelToFitCharLimit';
 import { LineChartDataLabelPosition } from '@common/modules/charts/types/chart';
-import { LegendInlinePosition } from '@common/modules/charts/types/legend';
+import {
+  LegendInlinePosition,
+  LegendLabelColour,
+} from '@common/modules/charts/types/legend';
 import formatPretty from '@common/utils/number/formatPretty';
 import React from 'react';
 
@@ -12,6 +15,7 @@ interface Props {
   isDataLabel?: boolean;
   isLegendLabel?: boolean;
   isLastItem?: boolean;
+  labelColour?: LegendLabelColour;
   name: string;
   position?: LineChartDataLabelPosition | LegendInlinePosition;
   unit?: string;
@@ -28,6 +32,7 @@ export default function LineChartLabel({
   isDataLabel = false,
   isLegendLabel = false,
   isLastItem = false,
+  labelColour = 'inherit',
   name,
   position,
   unit,
@@ -80,7 +85,7 @@ export default function LineChartLabel({
     return (
       <text
         dy={dy}
-        fill={colour}
+        fill={labelColour === 'black' ? '#000' : colour}
         fontSize={14}
         textAnchor={isPositionRight ? 'start' : 'end'}
         x={x}

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartLabel.tsx
@@ -90,6 +90,7 @@ export default function LineChartLabel({
         textAnchor={isPositionRight ? 'start' : 'end'}
         x={x}
         y={y}
+        data-testid="inline-legend-label"
       >
         {isPositionRight ? (
           // SVG <text> does not line wrap automatically :(

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/__tests__/chunkLabelToFitCharLimit.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/__tests__/chunkLabelToFitCharLimit.test.ts
@@ -1,0 +1,32 @@
+import chunkLabelToFitCharLimit from '@common/modules/charts/components/utils/chunkLabelToFitCharLimit';
+
+describe('chunkLabelToFitCharLimit', () => {
+  test('splits a long string into an array of smaller strings', () => {
+    expect(
+      chunkLabelToFitCharLimit('Label with long string to test splitting'),
+    ).toStrictEqual(['Label with long', 'string to test', 'splitting']);
+  });
+
+  test('splits a long string into an array of smaller strings with different char limit', () => {
+    expect(
+      chunkLabelToFitCharLimit('Label with long string to test splitting', 30),
+    ).toStrictEqual(['Label with long string to test', 'splitting']);
+  });
+
+  test(`doesn't break words londer than char limit`, () => {
+    expect(
+      chunkLabelToFitCharLimit(
+        'Sutton-under-Whitestonecliffe (North Yorkshire) - antidisestablishmentarianism',
+        30,
+      ),
+    ).toStrictEqual([
+      'Sutton-under-Whitestonecliffe',
+      '(North Yorkshire) -',
+      'antidisestablishmentarianism',
+    ]);
+  });
+
+  test('returns array with empty string if empty string provided', () => {
+    expect(chunkLabelToFitCharLimit('')).toStrictEqual(['']);
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/charts/components/utils/chunkLabelToFitCharLimit.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/utils/chunkLabelToFitCharLimit.ts
@@ -1,0 +1,31 @@
+/**
+ * Custom text wrapping: creates an array of lines of words
+ * from a single string to fit a character limit per line
+ */
+export default function chunkLabelToFitCharLimit(
+  label: string,
+  maxLineChars: number = 20,
+): string[] {
+  return label
+    .split(' ') // split into words
+    .reduce(
+      (wordArrays: string[][], word) => {
+        const lastArray = wordArrays.at(-1);
+        // Get the length of the last array (joined)
+        const currLen = lastArray!.join(' ').length;
+
+        // If the length of that content and the new word
+        // exceeds maxLineChars push the word to a new array
+        if (currLen + 1 + word.length > maxLineChars) {
+          wordArrays.push([word]);
+        } else {
+          // otherwise add it to the existing array
+          lastArray!.push(word);
+        }
+
+        return wordArrays;
+      },
+      [[]],
+    )
+    .map(words => words.join(' ')); // Join up arrays into lines of words
+}

--- a/src/explore-education-statistics-common/src/modules/charts/types/legend.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/legend.ts
@@ -14,6 +14,7 @@ export interface LegendItemConfiguration {
   symbol?: ChartSymbol;
   lineStyle?: LineStyle;
   inlinePosition?: LegendInlinePosition;
+  inlinePositionOffset?: number;
 }
 
 export interface LegendItem extends LegendItemConfiguration {

--- a/src/explore-education-statistics-common/src/modules/charts/types/legend.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/legend.ts
@@ -20,4 +20,4 @@ export interface LegendItem extends LegendItemConfiguration {
   dataSet: DataSet;
 }
 
-export type LegendInlinePosition = 'above' | 'below';
+export type LegendInlinePosition = 'above' | 'below' | 'right';

--- a/src/explore-education-statistics-common/src/modules/charts/types/legend.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/legend.ts
@@ -11,6 +11,7 @@ export interface LegendConfiguration {
 export interface LegendItemConfiguration {
   label: string;
   colour: string;
+  labelColour?: LegendLabelColour;
   symbol?: ChartSymbol;
   lineStyle?: LineStyle;
   inlinePosition?: LegendInlinePosition;
@@ -22,3 +23,5 @@ export interface LegendItem extends LegendItemConfiguration {
 }
 
 export type LegendInlinePosition = 'above' | 'below' | 'right';
+
+export type LegendLabelColour = 'black' | 'inherit';

--- a/src/explore-education-statistics-common/src/modules/charts/util/chartUtils.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/chartUtils.ts
@@ -35,9 +35,9 @@ export const symbols: ChartSymbol[] = [
 export const lineStyles: LineStyle[] = ['dashed', 'dotted', 'solid'];
 
 export const legendInlinePositions: LegendInlinePosition[] = [
+  'right',
   'above',
   'below',
-  'right',
 ];
 
 export const lineChartDataLabelPositions = ['above', 'below'];

--- a/src/explore-education-statistics-common/src/modules/charts/util/chartUtils.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/chartUtils.ts
@@ -15,10 +15,10 @@ export const colours: string[] = [
 ];
 
 export const legendPositions: LegendPosition[] = [
+  'inline',
   'bottom',
   'top',
   'none',
-  'inline',
 ];
 
 export const symbols: ChartSymbol[] = [

--- a/src/explore-education-statistics-common/src/modules/charts/util/chartUtils.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/chartUtils.ts
@@ -1,6 +1,7 @@
 import { ChartSymbol, LineStyle } from '@common/modules/charts/types/chart';
 import {
   LegendInlinePosition,
+  LegendLabelColour,
   LegendPosition,
 } from '@common/modules/charts/types/legend';
 
@@ -39,6 +40,8 @@ export const legendInlinePositions: LegendInlinePosition[] = [
   'above',
   'below',
 ];
+
+export const legendLabelColours: LegendLabelColour[] = ['black', 'inherit'];
 
 export const lineChartDataLabelPositions = ['above', 'below'];
 

--- a/src/explore-education-statistics-common/src/modules/charts/util/chartUtils.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/chartUtils.ts
@@ -34,7 +34,11 @@ export const symbols: ChartSymbol[] = [
 
 export const lineStyles: LineStyle[] = ['dashed', 'dotted', 'solid'];
 
-export const legendInlinePositions: LegendInlinePosition[] = ['above', 'below'];
+export const legendInlinePositions: LegendInlinePosition[] = [
+  'above',
+  'below',
+  'right',
+];
 
 export const lineChartDataLabelPositions = ['above', 'below'];
 

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -460,9 +460,9 @@ Validate changing data sets
     user clicks button    Add data set
 
     user checks chart inline legend item contains    id:chartBuilderPreview    1
-    ...    Admission Numbers (Nailsea Youngwood)
-    user checks chart inline legend item contains    id:chartBuilderPreview    2    Admission Numbers (Syon)
-    user checks chart inline legend item contains    id:chartBuilderPreview    3    Admission Numbers (Barnsley)
+    ...    Admission Numbers(Nailsea Youngwood)
+    user checks chart inline legend item contains    id:chartBuilderPreview    2    Admission Numbers(Syon)
+    user checks chart inline legend item contains    id:chartBuilderPreview    3    Admission Numbers(Barnsley)
 
     user checks table body has x rows    3    testid:chart-data-sets
 
@@ -477,7 +477,8 @@ Configure line chart data sets
     user chooses select option    id:chartDataSetsConfigurationForm-location    Nailsea Youngwood
     user clicks button    Add data set
 
-    user checks chart legend item contains    id:chartBuilderPreview    1    Admission Numbers (Nailsea Youngwood)
+    user checks chart inline legend item contains    id:chartBuilderPreview    1
+    ...    Admission Numbers(Nailsea Youngwood)
 
     user clicks link    Legend
     user chooses select option    id:chartLegendConfigurationForm-items-0-symbol    Circle
@@ -496,7 +497,8 @@ Validate basic line chart preview
 
     user checks chart title contains    id:chartBuilderPreview    Test chart title
     user checks chart subtitle contains    id:chartBuilderPreview    Test chart subtitle
-    user checks chart legend item contains    id:chartBuilderPreview    1    Admission Numbers (Nailsea Youngwood)
+    user checks chart inline legend item contains    id:chartBuilderPreview    1
+    ...    Admission Numbers(Nailsea Youngwood)
 
     user checks chart height    id:chartBuilderPreview    400
     user checks chart width    id:chartBuilderPreview    900
@@ -571,7 +573,7 @@ Validate line chart embeds correctly
 
     user checks chart title contains    ${datablock}    Test chart title
     user checks chart subtitle contains    ${datablock}    Test chart subtitle
-    user checks chart legend item contains    ${datablock}    1    Admission Numbers (Nailsea Youngwood)
+    user checks chart inline legend item contains    ${datablock}    1    Admission Numbers(Nailsea Youngwood)
 
     user checks chart height    ${datablock}    400
     user checks chart width    ${datablock}    900

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -459,9 +459,10 @@ Validate changing data sets
     user chooses select option    id:chartDataSetsConfigurationForm-location    Barnsley
     user clicks button    Add data set
 
-    user checks chart legend item contains    id:chartBuilderPreview    1    Admission Numbers (Nailsea Youngwood)
-    user checks chart legend item contains    id:chartBuilderPreview    2    Admission Numbers (Syon)
-    user checks chart legend item contains    id:chartBuilderPreview    3    Admission Numbers (Barnsley)
+    user checks chart inline legend item contains    id:chartBuilderPreview    1
+    ...    Admission Numbers (Nailsea Youngwood)
+    user checks chart inline legend item contains    id:chartBuilderPreview    2    Admission Numbers (Syon)
+    user checks chart inline legend item contains    id:chartBuilderPreview    3    Admission Numbers (Barnsley)
 
     user checks table body has x rows    3    testid:chart-data-sets
 

--- a/tests/robot-tests/tests/libs/charts.robot
+++ b/tests/robot-tests/tests/libs/charts.robot
@@ -80,6 +80,15 @@ user checks chart legend item contains
     user waits until element is visible    ${element}
     user waits until element contains    ${element}    ${text}
 
+user checks chart inline legend item contains
+    [Arguments]    ${locator}    ${item}    ${text}
+    user waits until parent contains element    ${locator}
+    ...    xpath://*[@class="recharts-layer recharts-line"][${item}]//*[@class="recharts-layer recharts-label-list"]
+    ${element}=    get child element    ${locator}
+    ...    xpath://*[@class="recharts-layer recharts-line"][${item}]//*[@class="recharts-layer recharts-label-list"]
+    user waits until element is visible    ${element}
+    user waits until element contains    ${element}    ${text}
+
 user checks chart y axis tick contains
     [Arguments]    ${locator}    ${tick}    ${text}
     user waits until parent contains element    ${locator}

--- a/tests/robot-tests/tests/libs/charts.robot
+++ b/tests/robot-tests/tests/libs/charts.robot
@@ -83,11 +83,7 @@ user checks chart legend item contains
 user checks chart inline legend item contains
     [Arguments]    ${locator}    ${item}    ${text}
     user waits until parent contains element    ${locator}
-    ...    xpath://*[@class="recharts-layer recharts-line"][${item}]//*[@class="recharts-layer recharts-label-list"]
-    ${element}=    get child element    ${locator}
-    ...    xpath://*[@class="recharts-layer recharts-line"][${item}]//*[@class="recharts-layer recharts-label-list"]
-    user waits until element is visible    ${element}
-    user waits until element contains    ${element}    ${text}
+    ...    xpath://*[@class="recharts-layer recharts-line"][${item}]//*[@class="recharts-layer recharts-label-list"]//*[normalize-space() = "${text}"]
 
 user checks chart y axis tick contains
     [Arguments]    ${locator}    ${tick}    ${text}


### PR DESCRIPTION
This PR makes amends to line chart legends.

- Set `inline` as default position for line charts (and fix a bug when switching chart type, when position was inline)
- Add a new position option of `right` to each legend item, when legend position is `inline`, and set this as default
  - If there are any legend items positioned `right`, add space to the right of the line chart for them to display
  - This requires a new custom text-wrapping function as svg text doesn't line wrap automatically
- Add an option for each legend item **label colour** to be black (as default), or inherit from the chosen line colour
- Add an optional 'Y offset' for legend items when legend position is `inline`, so they can be moved up or down individually
- Amends jest and robot tests

NB These changes should not affect pre-existing charts, only affecting charts being edited/created.

As part of this work, I've had to make a few changes on the backend too, following precedence of other existing fields.

Example image showing changes:
<img width="611" alt="image" src="https://github.com/user-attachments/assets/95c14e3c-0343-40d3-8ccc-55d0ecba89a3" />
