### PR TITLE
EES-6243 Allow data label colour choice for line chart

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/Charts.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/Charts.cs
@@ -22,6 +22,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
         Above, Below
     }
 
+    [JsonConverter(typeof(StringEnumConverter), typeof(CamelCaseNamingStrategy))]
+    public enum LineChartDataLabelColour
+    {
+        Inherit, Black
+    }
+
     [JsonConverter(typeof(ContentBlockChartConverter))]
     public interface IChart
     {
@@ -58,6 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
         public override ChartType Type => Line;
         public bool ShowDataLabels { get; set; }
         public LineChartDataLabelPosition? DataLabelPosition { get; set; }
+        public LineChartDataLabelColour? DataLabelColour { get; set; }
     }
 
     public class HorizontalBarChart : Chart

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -17,9 +17,13 @@ import {
   BarChartDataLabelPosition,
   LineChartDataLabelPosition,
 } from '@common/modules/charts/types/chart';
-import { LegendPosition } from '@common/modules/charts/types/legend';
+import {
+  LegendLabelColour,
+  LegendPosition,
+} from '@common/modules/charts/types/legend';
 import {
   barChartDataLabelPositions,
+  legendLabelColours,
   lineChartDataLabelPositions,
 } from '@common/modules/charts/util/chartUtils';
 import { ValidationProblemDetails } from '@common/services/types/problemDetails';
@@ -32,6 +36,7 @@ import Yup from '@common/validation/yup';
 import capitalize from 'lodash/capitalize';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
+import upperFirst from 'lodash/upperFirst';
 import React, {
   ChangeEvent,
   ReactNode,
@@ -96,6 +101,11 @@ const ChartConfiguration = ({
       return { label: capitalize(position), value: position };
     });
   }, [definition.type]);
+
+  const legendLabelOptions = legendLabelColours.map(position => ({
+    label: upperFirst(position),
+    value: position,
+  }));
 
   const titleMaxLength = 220;
   const altTextMaxLength = 220;
@@ -207,10 +217,19 @@ const ChartConfiguration = ({
       });
     }
 
+    if (definition.capabilities.canSetDataLabelColour) {
+      schema = schema.shape({
+        dataLabelColour: Yup.string()
+          .oneOf<LegendLabelColour>(['inherit', 'black'])
+          .optional(),
+      });
+    }
+
     return schema;
   }, [
     definition.capabilities.canIncludeNonNumericData,
     definition.capabilities.canSetBarThickness,
+    definition.capabilities.canSetDataLabelColour,
     definition.capabilities.canSetDataLabelPosition,
     definition.capabilities.canShowDataLabels,
     definition.capabilities.stackable,
@@ -428,14 +447,24 @@ const ChartConfiguration = ({
                 label="Show data labels"
                 showError={!!formState.errors.showDataLabels}
                 conditional={
-                  validationSchema.fields.dataLabelPosition && (
-                    <FormFieldSelect<FormValues>
-                      label="Data label position"
-                      name="dataLabelPosition"
-                      order={[]}
-                      options={dataLabelPositionOptions}
-                    />
-                  )
+                  <>
+                    {validationSchema.fields.dataLabelPosition && (
+                      <FormFieldSelect<FormValues>
+                        label="Data label position"
+                        name="dataLabelPosition"
+                        order={[]}
+                        options={dataLabelPositionOptions}
+                      />
+                    )}
+                    {validationSchema.fields.dataLabelColour && (
+                      <FormFieldSelect<FormValues>
+                        label="Data label colour"
+                        name="dataLabelColour"
+                        order={[]}
+                        options={legendLabelOptions}
+                      />
+                    )}
+                  </>
                 }
               />
             )}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartConfiguration.test.tsx
@@ -18,6 +18,7 @@ describe('ChartConfiguration', () => {
     canIncludeNonNumericData: true,
     canPositionLegendInline: true,
     canSetBarThickness: false,
+    canSetDataLabelColour: true,
     canSetDataLabelPosition: true,
     canShowDataLabels: true,
     canShowAllMajorAxisTicks: false,
@@ -36,6 +37,7 @@ describe('ChartConfiguration', () => {
     canIncludeNonNumericData: true,
     canPositionLegendInline: true,
     canSetBarThickness: true,
+    canSetDataLabelColour: false,
     canSetDataLabelPosition: true,
     canShowDataLabels: true,
     canShowAllMajorAxisTicks: false,
@@ -306,6 +308,7 @@ describe('ChartConfiguration', () => {
       expect(handleSubmit).toHaveBeenCalledWith({
         alt: 'This is the alt text',
         boundaryLevel: undefined,
+        dataLabelColour: 'black',
         dataLabelPosition: 'above',
         height: 300,
         includeNonNumericData: false,
@@ -337,6 +340,7 @@ describe('ChartConfiguration', () => {
       expect(handleChange).toHaveBeenCalledWith({
         alt: 'This is the alt text',
         boundaryLevel: undefined,
+        dataLabelColour: 'black',
         dataLabelPosition: 'above',
         height: 300,
         includeNonNumericData: false,
@@ -400,6 +404,7 @@ describe('ChartConfiguration', () => {
       expect(handleSubmit).toHaveBeenCalledWith({
         alt: 'This is the alt text',
         boundaryLevel: undefined,
+        dataLabelColour: 'black',
         dataLabelPosition: 'above',
         height: 300,
         includeNonNumericData: false,
@@ -431,6 +436,10 @@ describe('ChartConfiguration', () => {
       'below',
     ]);
 
+    await user.selectOptions(screen.getByLabelText('Data label colour'), [
+      'inherit',
+    ]);
+
     await user.click(
       screen.getByRole('button', { name: 'Save chart options' }),
     );
@@ -439,6 +448,7 @@ describe('ChartConfiguration', () => {
       expect(handleSubmit).toHaveBeenCalledWith({
         alt: 'This is the alt text',
         boundaryLevel: undefined,
+        dataLabelColour: 'inherit',
         dataLabelPosition: 'below',
         height: 300,
         includeNonNumericData: false,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/__tests__/chartBuilderReducer.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/__tests__/chartBuilderReducer.test.ts
@@ -29,6 +29,7 @@ describe('chartBuilderReducer', () => {
       canPositionLegendInline: true,
       canIncludeNonNumericData: true,
       canSetBarThickness: true,
+      canSetDataLabelColour: true,
       canSetDataLabelPosition: true,
       canShowDataLabels: true,
       canShowAllMajorAxisTicks: false,

--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -267,6 +267,7 @@ export const horizontalBarBlockDefinition: ChartDefinition = {
     canIncludeNonNumericData: true,
     canPositionLegendInline: false,
     canSetBarThickness: true,
+    canSetDataLabelColour: false,
     canSetDataLabelPosition: true,
     canShowDataLabels: true,
     canShowAllMajorAxisTicks: false,

--- a/src/explore-education-statistics-common/src/modules/charts/components/InfographicBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/InfographicBlock.tsx
@@ -68,6 +68,7 @@ export const infographicBlockDefinition: ChartDefinition = {
     canIncludeNonNumericData: false,
     canPositionLegendInline: false,
     canSetBarThickness: false,
+    canSetDataLabelColour: false,
     canSetDataLabelPosition: false,
     canShowDataLabels: false,
     canShowAllMajorAxisTicks: false,

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -10,7 +10,10 @@ import {
   LineChartDataLabelPosition,
 } from '@common/modules/charts/types/chart';
 import { DataSetCategory } from '@common/modules/charts/types/dataSet';
-import { LegendConfiguration } from '@common/modules/charts/types/legend';
+import {
+  LegendConfiguration,
+  LegendLabelColour,
+} from '@common/modules/charts/types/legend';
 import { axisTickStyle } from '@common/modules/charts/util/chartUtils';
 import createDataSetCategories, {
   toChartData,
@@ -52,6 +55,7 @@ const lineStyles: Dictionary<string> = {
 };
 
 export interface LineChartProps extends ChartProps {
+  dataLabelColour?: LegendLabelColour;
   dataLabelPosition?: LineChartDataLabelPosition;
   legend: LegendConfiguration;
   axes: {
@@ -70,6 +74,7 @@ const LineChartBlock = ({
   width,
   includeNonNumericData,
   showDataLabels,
+  dataLabelColour = 'inherit',
   dataLabelPosition,
 }: LineChartProps) => {
   const [legendProps, renderLegend] = useLegend();
@@ -206,7 +211,9 @@ const LineChartBlock = ({
                   isDataLabel={showDataLabels}
                   isLastItem={props.index === chartData.length - 1}
                   isLegendLabel={legend.position === 'inline'}
-                  labelColour={config.labelColour}
+                  labelColour={
+                    showDataLabels ? dataLabelColour : config.labelColour
+                  }
                   name={config.label}
                   position={
                     showDataLabels ? dataLabelPosition : config.inlinePosition
@@ -267,6 +274,7 @@ export const lineChartBlockDefinition: ChartDefinition = {
     canIncludeNonNumericData: true,
     canPositionLegendInline: true,
     canSetBarThickness: false,
+    canSetDataLabelColour: true,
     canSetDataLabelPosition: true,
     canShowDataLabels: true,
     canShowAllMajorAxisTicks: false,

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartLabel.tsx
@@ -55,7 +55,7 @@ export default function LineChartLabel({
     return (
       <text
         dy={position === 'above' ? '-10' : '20'}
-        fill={colour}
+        fill={labelColour === 'black' ? '#000' : colour}
         fontSize={14}
         textAnchor={getTextAnchor()}
         x={x}

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
@@ -71,6 +71,7 @@ export const mapBlockDefinition: ChartDefinition = {
     canIncludeNonNumericData: false,
     canPositionLegendInline: false,
     canSetBarThickness: false,
+    canSetDataLabelColour: false,
     canSetDataLabelPosition: false,
     canShowDataLabels: false,
     canShowAllMajorAxisTicks: false,

--- a/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
@@ -330,6 +330,7 @@ export const verticalBarBlockDefinition: ChartDefinition = {
     canIncludeNonNumericData: true,
     canPositionLegendInline: false,
     canSetBarThickness: true,
+    canSetDataLabelColour: false,
     canSetDataLabelPosition: false,
     canShowDataLabels: true,
     canShowAllMajorAxisTicks: true,

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -4,7 +4,10 @@ import { lineChartBlockDefinition } from '@common/modules/charts/components/Line
 import { mapBlockDefinition } from '@common/modules/charts/components/MapBlock';
 import { verticalBarBlockDefinition } from '@common/modules/charts/components/VerticalBarBlock';
 import { DataSet } from '@common/modules/charts/types/dataSet';
-import { LegendConfiguration } from '@common/modules/charts/types/legend';
+import {
+  LegendConfiguration,
+  LegendLabelColour,
+} from '@common/modules/charts/types/legend';
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import { TableDataResult } from '@common/services/tableBuilderService';
 import { NestedPartial } from '@common/types';
@@ -137,6 +140,7 @@ export interface ChartCapabilities {
   canIncludeNonNumericData: boolean;
   canPositionLegendInline: boolean;
   canSetBarThickness: boolean;
+  canSetDataLabelColour: boolean;
   canSetDataLabelPosition: boolean;
   canShowDataLabels: boolean;
   canShowAllMajorAxisTicks: boolean;
@@ -164,6 +168,7 @@ export interface ChartDefinitionOptions {
   includeNonNumericData?: boolean;
   showDataLabels?: boolean;
   dataLabelPosition?: BarChartDataLabelPosition | LineChartDataLabelPosition;
+  dataLabelColour?: LegendLabelColour;
   // Map options
   boundaryLevel?: number;
   dataClassification?: DataGroupingType;


### PR DESCRIPTION
This allows a colour choice between 'inherit' and 'black' for data labels on line charts, with default rendering of 'inherit' to avoid changing existing charts. Previously the colours of data labels were the same as the line colour.
This change is in line with the recent change to allow colour choice for legend labels.
The colour choice for data labels should only be available on line charts. I have added a new capability to the chart definition to set this.

![Screenshot 2025-06-20 145405](https://github.com/user-attachments/assets/c393feb6-dc52-481b-be15-21020fd3557f)
![Screenshot 2025-06-20 145358](https://github.com/user-attachments/assets/7c6f81c8-a9d9-465e-b57c-bb0d73a09691)
