### PR TITLE
EES-5999 - added OnSuccessAll() variant for non-Task based Eithers

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetValidator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetValidator.cs
@@ -75,7 +75,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 {
                     await GetReplacingFileIfExists(dataSet.ReleaseVersionId, dataSet.Title)
                         .OnFailureDo(errors.Add)
-                        .OnSuccessVoid(file => fileToBeReplaced = file);
+                        .OnSuccessDo(file => fileToBeReplaced = file)
+                        .OnSuccessVoid();
                 }
             }
 
@@ -134,7 +135,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                 await GetReplacingFileIfExists(releaseVersionId, dataSetName)
                     .OnFailureDo(errors.Add)
-                    .OnSuccessVoid(fileToBeReplaced =>
+                    .OnSuccessDo(fileToBeReplaced =>
                     {
                         dataSetIndex.DataSetIndexItems.Add(new()
                         {
@@ -145,7 +146,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         });
 
                         indexFileEntries.Add((BaseFilename: dataFileName, Title: dataSetName));
-                    });
+                    })
+                    .OnSuccessVoid();
             }
 
             if (errors.Count != 0)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
@@ -520,14 +520,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(dataSetUploads => dataSetUploads
                     .Select(ValidateDataSetCanBeImported)
                     .OnSuccessAll())
-                .OnSuccessVoid(async dataSetUploads =>
+                .OnSuccessDo(async dataSetUploads =>
                 {
                     await dataSetFileStorage.MoveDataSetsToPermanentStorage(releaseVersionId, dataSetUploads, cancellationToken);
 
                     // Upload records are no longer needed once the files have been queued for import
                     contentDbContext.DataSetUploads.RemoveRange(dataSetUploads);
                     await contentDbContext.SaveChangesAsync(cancellationToken);
-                });
+                })
+                .OnSuccessVoid();
         }
 
         private async Task<Either<ActionResult, DataSetUpload>> ValidateDataSetUploadExistence(
@@ -551,7 +552,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         // TODO: This doesn't need to be an async task. Find out expected pattern for use with results pattern
-        private static async Task<Either<ActionResult, DataSetUpload>> ValidateDataSetCanBeImported(DataSetUpload dataSetUpload)
+        private static Either<ActionResult, DataSetUpload> ValidateDataSetCanBeImported(DataSetUpload dataSetUpload)
         {
             return dataSetUpload.Status is not DataSetUploadStatus.PENDING_REVIEW and not DataSetUploadStatus.PENDING_IMPORT
                 ? Common.Validators.ValidationUtils.ValidationResult(ValidationMessages.GenerateErrorDataSetIsNotInAnImportableState())

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/EitherTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/EitherTest.cs
@@ -337,7 +337,37 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model
             Assert.True(aggregate.IsLeft);
             Assert.Equal(["failure 1"], aggregate.Left);
         }
+        
+        [Fact]
+        public void OnSuccessAll()
+        {
+            var either1 = new Either<int, string>("either1");
+            var either2 = new Either<int, string>("either2");
+            var either3 = new Either<int, string>("either3");
 
+            var eitherList = ListOf(either1, either2, either3);
+
+            var results = eitherList.OnSuccessAll();
+
+            Assert.True(results.IsRight);
+            Assert.Equal(["either1", "either2", "either3"], results.Right);
+        }
+
+        [Fact]
+        public void OnSuccessAll_Left()
+        {
+            var either1 = new Either<int, string>("either1");
+            var either2 = new Either<int, string>(2);
+            var either3 = new Either<int, string>(3);
+
+            var eitherList = ListOf(either1, either2, either3);
+
+            var results = eitherList.OnSuccessAll();
+
+            Assert.True(results.IsLeft);
+            Assert.Equal(2, results.Left);
+        }
+        
         [Fact]
         public void OnSuccessAllReturnVoid()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -109,15 +109,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         }
 
         /// <summary>
-        /// If all Eithers in the provided list are successful, return Unit.Instance. Otherwise, return the first
+        /// If all Eithers in the provided list are successful, return a list of successes. Otherwise, return the first
         /// failure.
         /// </summary>
-        public static Either<TFailure, Unit> OnSuccessAllReturnVoid<TFailure, TSuccess>(
+        public static Either<TFailure, List<TSuccess>> OnSuccessAll<TFailure, TSuccess>(
             this IEnumerable<Either<TFailure, TSuccess>> items)
         {
             var result = items
-                .AggregateSuccessesAndFailures()
-                .OnSuccessVoid();
+                .AggregateSuccessesAndFailures();
 
             if (result.IsLeft)
             {
@@ -125,6 +124,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
             }
 
             return result.Right;
+        }
+        
+        /// <summary>
+        /// If all Eithers in the provided list are successful, return Unit.Instance. Otherwise, return the first
+        /// failure.
+        /// </summary>
+        public static Either<TFailure, Unit> OnSuccessAllReturnVoid<TFailure, TSuccess>(
+            this IEnumerable<Either<TFailure, TSuccess>> items)
+        {
+            return items.OnSuccessAll().OnSuccessVoid();
         }
 
         public static Either<TFailure, Unit> OnSuccessVoid<TFailure, TSuccess>(
@@ -253,26 +262,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
             }
 
             await func();
-
-            return Unit.Instance;
-        }
-
-        /**
-         * Convenience method so that the chained function can be
-         * void and doesn't have to explicitly return a Unit.
-         */
-        public static async Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess>(
-            this Task<Either<TFailure, TSuccess>> task,
-            Action<TSuccess> action)
-        {
-            var firstResult = await task;
-
-            if (firstResult.IsLeft)
-            {
-                return firstResult.Left;
-            }
-
-            action(firstResult.Right);
 
             return Unit.Instance;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -88,8 +88,9 @@ internal class DataSetVersionService(
                         cancellationToken))
                 .OnSuccessDo(async releaseFilesAndDataSetVersions =>
                     await DeleteDataSetVersions(releaseFilesAndDataSetVersions.dataSetVersions, cancellationToken))
-                .OnSuccessVoid(releaseFilesAndDataSetVersions =>
-                    DeleteDuckDbFiles(releaseFilesAndDataSetVersions.dataSetVersions)));
+                .OnSuccessDo(releaseFilesAndDataSetVersions =>
+                    DeleteDuckDbFiles(releaseFilesAndDataSetVersions.dataSetVersions))
+                .OnSuccessVoid());
     }
 
     public async Task<Either<ActionResult, Unit>> DeleteVersion(
@@ -103,7 +104,8 @@ internal class DataSetVersionService(
                     forceDeleteAll: false))
                 .OnSuccessDo(async dataSetVersion => await UpdateReleaseFiles(dataSetVersion, cancellationToken))
                 .OnSuccessDo(async dataSetVersion => await DeleteDataSetVersion(dataSetVersion, cancellationToken))
-                .OnSuccessVoid(DeleteDuckDbFiles));
+                .OnSuccessDo(DeleteDuckDbFiles)
+                .OnSuccessVoid());
     }
 
     private async Task<Either<ActionResult, IReadOnlyList<DataSetVersion>>> GetDataSetVersions(


### PR DESCRIPTION
Added support for `OnSuccessAll()` when using bare Eithers, rather than Task<Eithers>.

Removed slightly ambiguous and very rarely-used variant of `OnSuccessVoid(...)` which can be replaced with an `OnSuccessDo(...).OnSuccessVoid()`.