### PR TITLE
EES-6285 Base64 encode `releaseSlug` for safe use in HTTP headers

### DIFF
--- a/infrastructure/templates/search/scripts/SetupSearchService.ps1
+++ b/infrastructure/templates/search/scripts/SetupSearchService.ps1
@@ -83,6 +83,16 @@ switch ($dataSourceType)
                     }
                 }
                 @{
+                    'sourceFieldName' = '/document/releaseSlug'
+                    'targetFieldName' = 'releaseSlug'
+                    'mappingFunction' = @{
+                        'name' = 'base64Decode'
+                        'parameters' = @{
+                            'useHttpServerUtilityUrlTokenDecode' = $false
+                        }
+                    }
+                }
+                @{
                     'sourceFieldName' = '/document/themeTitle'
                     'targetFieldName' = 'themeTitle'
                     'mappingFunction' = @{

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Extensions/ReleaseSearchableDocumentExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Extensions/ReleaseSearchableDocumentExtensionsTests.cs
@@ -33,7 +33,6 @@ public class ReleaseSearchableDocumentExtensionsTests
         AssertAll(
         [
             AssertMetadata(SearchableDocumentAzureBlobMetadataKeys.ReleaseId, "76640d46-3f02-4b08-a4d9-c1fbf1bdd502"),
-            AssertMetadata(SearchableDocumentAzureBlobMetadataKeys.ReleaseSlug, "release-slug"),
             AssertMetadata(SearchableDocumentAzureBlobMetadataKeys.ReleaseVersionId, "5cd3ae70-ff32-409b-aa6b-363b380eb4c8"),
             AssertMetadata(SearchableDocumentAzureBlobMetadataKeys.PublicationId, "caf751b8-5f8c-4526-8b5f-7fd28199866b"),
             AssertMetadata(SearchableDocumentAzureBlobMetadataKeys.ThemeId, "4625ca38-68aa-4d73-a1f9-2aab732aecc2"),
@@ -41,6 +40,7 @@ public class ReleaseSearchableDocumentExtensionsTests
             AssertMetadata(SearchableDocumentAzureBlobMetadataKeys.ReleaseType, "Official Statistics"),
             AssertMetadata(SearchableDocumentAzureBlobMetadataKeys.TypeBoost, "10"),
             AssertEncodedMetadata(SearchableDocumentAzureBlobMetadataKeys.PublicationSlug, "publication-slug"),
+            AssertEncodedMetadata(SearchableDocumentAzureBlobMetadataKeys.ReleaseSlug, "release-slug"),
             AssertEncodedMetadata(SearchableDocumentAzureBlobMetadataKeys.Summary, "This is a summary."),
             AssertEncodedMetadata(SearchableDocumentAzureBlobMetadataKeys.ThemeTitle, "Theme Title"),
             AssertEncodedMetadata(SearchableDocumentAzureBlobMetadataKeys.Title, "Publication Title"),

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ReleaseSearchableDocumentExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Extensions/ReleaseSearchableDocumentExtensions.cs
@@ -30,7 +30,10 @@ public static class ReleaseSearchableDocumentExtensions
         var metadata = new Dictionary<string, string>
         {
             { SearchableDocumentAzureBlobMetadataKeys.ReleaseId, releaseSearchableDocument.ReleaseId.ToString() },
-            { SearchableDocumentAzureBlobMetadataKeys.ReleaseSlug, releaseSearchableDocument.ReleaseSlug },
+            {
+                SearchableDocumentAzureBlobMetadataKeys.ReleaseSlug,
+                releaseSearchableDocument.ReleaseSlug.ToBase64String()
+            },
             {
                 SearchableDocumentAzureBlobMetadataKeys.ReleaseVersionId,
                 releaseSearchableDocument.ReleaseVersionId.ToString()


### PR DESCRIPTION
This PR follows up https://github.com/dfe-analytical-services/explore-education-statistics/pull/6074 with a related bugfix. During testing we discovered that unicode characters can creep into a release slug if they are added to a release label while editing the release in the Admin. This prevents the searchable document blob from being uploaded after the update event is triggered.

As explained in https://github.com/dfe-analytical-services/explore-education-statistics/pull/6074, metadata key/value pairs are set using HTTP headers when the searchable document blobs are uploaded and must be valid headers containing only ASCII characters.

This PR applies the same change that was made for theme title, publication title, publication summary and publication slug by Base64 encoding the release slug.