### PR TITLE
EES-6269 Fix GetAccoutrementsSummary bug

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
@@ -154,6 +154,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return await persistenceHelper
                 .CheckEntityExists<ReleaseFile>(q => q
                     .Include(releaseFile => releaseFile.File)
+                    .Include(releaseFile => releaseFile.ReleaseVersion)
                     .Where(releaseFile =>
                         releaseFile.ReleaseVersionId == releaseVersionId
                         && releaseFile.FileId == fileId


### PR DESCRIPTION
This PR fixes a bug where the auth for the GetDataSetAccoutrementsSummary endpoint was always failing as the db query didn't include `ReleaseFile.ReleaseVersion`. That's it!