### PR TITLE
EES-6245 fix weird behaviour when reversing chart major axis

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -79,11 +79,18 @@ const HorizontalBarBlock = ({
     dataSetCategory => dataSetCategory.filter.group,
   );
 
-  const chartData = axes.major.groupByFilterGroups
+  const chartDataUnsorted = axes.major.groupByFilterGroups
     ? Object.entries(groupedDataSetCategories).map(([groupKey, group]) =>
         Object.assign({}, ...group.map(toChartData), { name: groupKey }),
       )
     : dataSetCategories.map(toChartData);
+  // If no `sortAsc` has been set, we should default
+  // to true as it's not really natural to sort in
+  // descending order most of the time.
+  const chartData =
+    axes.major.sortAsc ?? true
+      ? chartDataUnsorted
+      : chartDataUnsorted.reverse();
 
   const minorDomainTicks = getMinorAxisDomainTicks(chartData, axes.minor);
   const majorDomainTicks = getMajorAxisDomainTicks(chartData, axes.major);

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -86,7 +86,14 @@ const LineChartBlock = ({
     includeNonNumericData,
   });
 
-  const chartData = dataSetCategories.map(toChartData);
+  const chartDataUnsorted = dataSetCategories.map(toChartData);
+  // If no `sortAsc` has been set, we should default
+  // to true as it's not really natural to sort in
+  // descending order most of the time.
+  const chartData =
+    axes.major.sortAsc ?? true
+      ? chartDataUnsorted
+      : chartDataUnsorted.reverse();
 
   const minorDomainTicks = getMinorAxisDomainTicks(chartData, axes.minor);
   const majorDomainTicks = getMajorAxisDomainTicks(chartData, axes.major);

--- a/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
@@ -94,11 +94,18 @@ const VerticalBarBlock = ({
     dataSetCategory => dataSetCategory.filter.group,
   );
 
-  const chartData = axes.major.groupByFilterGroups
+  const chartDataUnsorted = axes.major.groupByFilterGroups
     ? Object.entries(groupedDataSetCategories).map(([groupKey, group]) =>
         Object.assign({}, ...group.map(toChartData), { name: groupKey }),
       )
     : dataSetCategories.map(toChartData);
+  // If no `sortAsc` has been set, we should default
+  // to true as it's not really natural to sort in
+  // descending order most of the time.
+  const chartData =
+    axes.major.sortAsc ?? true
+      ? chartDataUnsorted
+      : chartDataUnsorted.reverse();
 
   const majorAxisCategories = chartData.map(({ name }) => name);
   const minorDomainTicks = getMinorAxisDomainTicks(chartData, axes.minor);

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
@@ -1844,24 +1844,6 @@ describe('createDataSetCategories', () => {
       expect(dataSetCategories[0].filter.value).toBe('barnet');
       expect(dataSetCategories[1].filter.value).toBe('barnsley');
     });
-
-    test('reversed when `sortAsc` = false', () => {
-      const axisConfiguration: AxisConfiguration = {
-        ...testOrderedAxisConfiguration,
-        groupBy: 'filters',
-        sortAsc: false,
-      };
-      const fullTable = mapFullTable(testTable);
-      const dataSetCategories = createDataSetCategories({
-        axisConfiguration,
-        data: fullTable.results,
-        meta: fullTable.subjectMeta,
-      });
-
-      expect(dataSetCategories).toHaveLength(2);
-      expect(dataSetCategories[0].filter.label).toBe('State-funded primary');
-      expect(dataSetCategories[1].filter.label).toBe('Ethnicity Major Chinese');
-    });
   });
 
   describe('ordering for older charts with no `order` property', () => {
@@ -2007,25 +1989,6 @@ describe('createDataSetCategories', () => {
       expect(dataSetCategories).toHaveLength(2);
       expect(dataSetCategories[0].filter.label).toBe('2014/15');
       expect(dataSetCategories[1].filter.label).toBe('2015/16');
-    });
-
-    test('reversed when `sortAsc` = false', () => {
-      const axisConfiguration: AxisConfiguration = {
-        ...testUnorderedAxisConfiguration,
-        groupBy: 'filters',
-        sortAsc: false,
-      };
-
-      const fullTable = mapFullTable(testTable);
-      const dataSetCategories = createDataSetCategories({
-        axisConfiguration,
-        data: fullTable.results,
-        meta: fullTable.subjectMeta,
-      });
-
-      expect(dataSetCategories).toHaveLength(2);
-      expect(dataSetCategories[0].filter.label).toBe('State-funded primary');
-      expect(dataSetCategories[1].filter.label).toBe('Ethnicity Major Chinese');
     });
   });
 });

--- a/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
@@ -270,12 +270,7 @@ function getSortedDataSetCategoryRange(
     (axisConfiguration.max ?? dataSetCategories.length) + 1,
   );
 
-  // If no `sortAsc` has been set, we should default
-  // to true as it's not really natural to sort in
-  // descending order most of the time.
-  return axisConfiguration.sortAsc ?? true
-    ? sortedDataSetCategoriesRange
-    : sortedDataSetCategoriesRange.reverse();
+  return sortedDataSetCategoriesRange;
 }
 
 interface Options {


### PR DESCRIPTION
Fixes a bug where clicking 'sort ascending' in the chart major axis configuration tab could cause the order of the bars within groups and the legend to change. This only happened if the data sets had been reordered as that could effect the order of the data sets withing the groupings.

It's a bit hard to explain what was happening, but I'll try...

Example A - the chart is grouped by filter (school type) and the first data set has the filter primary, so it's the first group in the axis. 
![Screenshot 2025-06-26 161903](https://github.com/user-attachments/assets/e00f8c22-e1dd-4544-8c36-ad2b8dfaaa6b)

Example B - the chart is also grouped by filter (school type) and the data sets have been reordered so the first one has the filter secondary, so it's first in the axis.  
![Screenshot 2025-06-26 164526](https://github.com/user-attachments/assets/2eee8421-8551-4694-890f-272a258032b3)

The ordering of the bars & legend comes from the ordering of the (in this case) indicators in the data sets for the first group in the axis.

In example A, the data sets for the groups are in the same order - for both, it's Authorised then Overall. So when the axis is reversed this order is the same.

In example B, the data sets for the groups are in different orders - for secondary it's Overall then Authorised, for primary it's  Authorised then Overall. So when the axis is reversed the order changes.

Once I'd figured this out the fix was fairly simple - I've moved the reversing to happen later on, when the `chartData` is created for the chart. This means it doesn't effect the ordering of the bars and legend.

While I was there I noticed a couple of other things but didn't have time to fix them:
- the sort ascending checkbox should be checked by default as that's the default behaviour, at the moment it doesn't do anything the first time you click it
- the sort ascending checkbox on the minor axis doesn't seem to do anything. I think it's probably not meant to be there as I can't see any code related to ordering that axis and it seems a weird thing to do.