### PR TITLE
EES-6036 Configure private endpoints for Event Grid topics and restrict access to private endpoints only

### DIFF
--- a/infrastructure/templates/common/application/privateDnsZones.bicep
+++ b/infrastructure/templates/common/application/privateDnsZones.bicep
@@ -25,6 +25,16 @@ module sitesPrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
   }
 }
 
+// Set up a Private DNS zone for handling private endpoints for Event Grid custom topic resources.
+module eventGridTopicPrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
+  name: 'eventGridTopicPrivateDnsZoneDeploy'
+  params: {
+    zoneType: 'eventGridTopic'
+    vnetName: vnetName
+    tagValues: tagValues
+  }
+}
+
 // Set up a Private DNS zone for handling private endpoints for Storage Account File Services.
 module fileServicePrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
   name: 'fileServicePrivateDnsZoneDeploy'

--- a/infrastructure/templates/common/application/privateDnsZones.bicep
+++ b/infrastructure/templates/common/application/privateDnsZones.bicep
@@ -1,68 +1,66 @@
-import { ResourceNames } from '../../types.bicep'
-
-@description('Specifies common resource naming variables.')
-param resourceNames ResourceNames
+@description('Specifies the name of the virtual network that DNS zones will be attached to.')
+param vnetName string
 
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
 // Set up a Private DNS zone for handling private endpoints for PostgreSQL resources.
-module postgreSqlPrivateDnsZoneModule '../../components/privateDnsZone.bicep' = {
+module postgreSqlPrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
   name: 'postgresPrivateDnsZoneDeploy'
   params: {
     zoneType: 'postgres'
-    vnetName: resourceNames.existingResources.vNet
+    vnetName: vnetName
     tagValues: tagValues
   }
 }
 
 // Set up a Private DNS zone for handling private endpoints for site resources
 // (e.g. App Services, Function Apps, Container Apps).
-module sitesPrivateDnsZoneModule '../../components/privateDnsZone.bicep' = {
+module sitesPrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
   name: 'sitesPrivateDnsZoneDeploy'
   params: {
     zoneType: 'sites'
-    vnetName: resourceNames.existingResources.vNet
+    vnetName: vnetName
     tagValues: tagValues
   }
 }
 
 // Set up a Private DNS zone for handling private endpoints for Storage Account File Services.
-module fileServicePrivateDnsZoneModule '../../components/privateDnsZone.bicep' = {
+module fileServicePrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
   name: 'fileServicePrivateDnsZoneDeploy'
   params: {
     zoneType: 'fileService'
-    vnetName: resourceNames.existingResources.vNet
+    vnetName: vnetName
     tagValues: tagValues
   }
 }
 
 // Set up a Private DNS zone for handling private endpoints for Storage Account Blob Storage.
-module blobStoragePrivateDnsZoneModule '../../components/privateDnsZone.bicep' = {
+module blobStoragePrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
   name: 'blobStoragePrivateDnsZoneDeploy'
   params: {
     zoneType: 'blobStorage'
-    vnetName: resourceNames.existingResources.vNet
+    vnetName: vnetName
     tagValues: tagValues
   }
 }
 
 // Set up a Private DNS zone for handling private endpoints for Storage Account Queues.
-module queuePrivateDnsZoneModule '../../components/privateDnsZone.bicep' = {
+module queuePrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
   name: 'queuePrivateDnsZoneDeploy'
   params: {
     zoneType: 'queue'
-    vnetName: resourceNames.existingResources.vNet
+    vnetName: vnetName
     tagValues: tagValues
   }
 }
 
 // Set up a Private DNS zone for handling private endpoints for Storage Account Table Storage.
-module tableStoragePrivateDnsZoneModule '../../components/privateDnsZone.bicep' = {
+module tableStoragePrivateDnsZoneModule '../components/privateDnsZone.bicep' = {
   name: 'tableStoragePrivateDnsZoneDeploy'
   params: {
     zoneType: 'tableStorage'
-    vnetName: resourceNames.existingResources.vNet
+    vnetName: vnetName
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/common/components/containerisedFunctionApp.bicep
+++ b/infrastructure/templates/common/components/containerisedFunctionApp.bicep
@@ -342,7 +342,7 @@ resource azureStorageAccountsConfig 'Microsoft.Web/sites/config@2023-12-01' = {
   )
 }
 
-module privateEndpointModule '../../public-api/components/privateEndpoint.bicep' = if (privateEndpoints.?functionApp != null) {
+module privateEndpointModule 'privateEndpoint.bicep' = if (privateEndpoints.?functionApp != null) {
   name: '${functionAppName}PrivateEndpointDeploy'
   params: {
     serviceId: functionApp.id

--- a/infrastructure/templates/common/components/event-grid/eventGridCustomTopic.bicep
+++ b/infrastructure/templates/common/components/event-grid/eventGridCustomTopic.bicep
@@ -9,18 +9,14 @@ param name string
 @description('Location for all resources.')
 param location string
 
-@description('A list IP network rules to allow access to the Search Service from specific public internet IP address ranges. These rules are applied only when \'publicNetworkAccess\' is \'Enabled\'.')
+@description('A list IP network rules to allow access to the Search Service from specific public internet IP address ranges. These rules are applied only when \'publicNetworkAccessEnabled\' is \'true\'.')
 param ipRules IpRange[] = []
 
 @description('Specifies whether to enable local authentication. Microsoft Entra access authentication is always enabled.')
 param localAuthenticationEnabled bool = false
 
-@description('Specifies whether traffic is allowed over the public interface.')
-@allowed([
-  'Disabled'
-  'Enabled'
-])
-param publicNetworkAccess string = 'Disabled'
+@description('Specifies whether the resource can be accessed from public networks, including the internet or is restricted to private endpoints only.')
+param publicNetworkAccessEnabled bool = false
 
 @description('Indicates whether the resource should have a system-assigned managed identity.')
 param systemAssignedIdentity bool = false
@@ -59,7 +55,7 @@ resource topic 'Microsoft.EventGrid/topics@2025-02-15' = {
   properties: {
     minimumTlsVersionAllowed: '1.2'
     inputSchema: 'EventGridSchema'
-    publicNetworkAccess: publicNetworkAccess
+    publicNetworkAccess: publicNetworkAccessEnabled ? 'Enabled' : 'Disabled'
     inboundIpRules: [
       for ipRule in ipRules: {
         action: 'Allow'

--- a/infrastructure/templates/common/components/event-grid/eventGridCustomTopic.bicep
+++ b/infrastructure/templates/common/components/event-grid/eventGridCustomTopic.bicep
@@ -87,7 +87,7 @@ module deadLetteredCountAlert '../../../public-api/components/alerts/staticMetri
   }
 }
 
-module droppedEventCount '../../../public-api/components/alerts/staticMetricAlert.bicep' = if (alerts != null) {
+module droppedEventCountAlert '../../../public-api/components/alerts/staticMetricAlert.bicep' = if (alerts != null) {
   name: '${name}DropEvntDeploy'
   params: {
     enabled: alerts!.droppedEventCount

--- a/infrastructure/templates/common/components/event-grid/eventGridCustomTopic.bicep
+++ b/infrastructure/templates/common/components/event-grid/eventGridCustomTopic.bicep
@@ -18,6 +18,9 @@ param localAuthenticationEnabled bool = false
 @description('Specifies whether the resource can be accessed from public networks, including the internet or is restricted to private endpoints only.')
 param publicNetworkAccessEnabled bool = false
 
+@description('The resource id of the subnet in which a private endpoint will be created.')
+param privateEndpointSubnetId string?
+
 @description('Indicates whether the resource should have a system-assigned managed identity.')
 param systemAssignedIdentity bool = false
 
@@ -66,6 +69,18 @@ resource topic 'Microsoft.EventGrid/topics@2025-02-15' = {
     dataResidencyBoundary: 'WithinRegion'
   }
   tags: tagValues
+}
+
+module privateEndpointModule '../privateEndpoint.bicep' = if (privateEndpointSubnetId != null) {
+  name: '${name}PrivEpDeploy'
+  params: {
+    serviceId: topic.id
+    serviceName: topic.name
+    serviceType: 'eventGridTopic'
+    subnetId: privateEndpointSubnetId!
+    location: location
+    tagValues: tagValues
+  }
 }
 
 module deadLetteredCountAlert '../../../public-api/components/alerts/staticMetricAlert.bicep' = if (alerts != null) {

--- a/infrastructure/templates/common/components/event-grid/eventGridMessaging.bicep
+++ b/infrastructure/templates/common/components/event-grid/eventGridMessaging.bicep
@@ -7,8 +7,11 @@ param resourcePrefix string
 @description('Location for all resources.')
 param location string
 
-@description('A list of IP network rules to allow access to the resource from specific public internet IP address ranges.')
-param ipRules IpRange[]
+@description('A list of IP network rules to allow access to resources from specific public internet IP address ranges.')
+param ipRules IpRange[] = []
+
+@description('Specifies whether resources can be accessed from public networks, including the internet or are restricted to private endpoints only.')
+param publicNetworkAccessEnabled bool = false
 
 @description('Specifies which custom topic alert rules to enable. If the optional alerts parameter is not provided, no alert rules will be created or updated.')
 param customTopicAlerts {
@@ -20,7 +23,7 @@ param customTopicAlerts {
   alertsGroupName: string
 }?
 
-@description('Specifies a set of tags with which to tag the resource in Azure.')
+@description('Specifies a set of tags with which to tag resources in Azure.')
 param tagValues object
 
 @description('A list of custom topic names to create.')
@@ -34,7 +37,7 @@ module eventGridCustomTopicModule 'eventGridCustomTopic.bicep' = [
       name: buildFullyQualifiedTopicName(resourcePrefix, topicName)
       location: location
       ipRules: ipRules
-      publicNetworkAccess: 'Enabled'
+      publicNetworkAccessEnabled: publicNetworkAccessEnabled
       systemAssignedIdentity: true
       alerts: customTopicAlerts
       tagValues: tagValues

--- a/infrastructure/templates/common/components/functionApp.bicep
+++ b/infrastructure/templates/common/components/functionApp.bicep
@@ -337,7 +337,7 @@ module storageAccountQueueRoleAssignmentModule 'storageAccountRoleAssignment.bic
   }
 }
 
-module privateEndpointModule '../../public-api/components/privateEndpoint.bicep' = if (privateEndpoints.?functionApp != null) {
+module privateEndpointModule 'privateEndpoint.bicep' = if (privateEndpoints.?functionApp != null) {
   name: '${functionAppName}PrivateEndpointModuleDeploy'
   params: {
     serviceId: functionApp.id

--- a/infrastructure/templates/common/components/privateDnsZone.bicep
+++ b/infrastructure/templates/common/components/privateDnsZone.bicep
@@ -1,4 +1,5 @@
-import { PrivateDnsZone, dnsZones } from '../types.bicep'
+import { PrivateDnsZone } from '../types.bicep'
+import { dnsZones } from '../dnsZones.bicep'
 
 @description('Specifies the type of zone to create')
 param zoneType PrivateDnsZone

--- a/infrastructure/templates/common/components/privateEndpoint.bicep
+++ b/infrastructure/templates/common/components/privateEndpoint.bicep
@@ -1,4 +1,5 @@
-import { PrivateDnsZone, dnsZones } from '../types.bicep'
+import { PrivateDnsZone } from '../types.bicep'
+import { dnsZones } from '../dnsZones.bicep'
 
 @description('Specifies the name of the service being connected via private endpoint')
 @minLength(0)

--- a/infrastructure/templates/common/dnsZones.bicep
+++ b/infrastructure/templates/common/dnsZones.bicep
@@ -1,0 +1,27 @@
+@export()
+var dnsZones = {
+  blobStorage: {
+    zoneName: 'privatelink.blob.${environment().suffixes.storage}'
+    dnsGroup: 'blob'
+  }
+  fileService: {
+    zoneName: 'privatelink.file.${environment().suffixes.storage}'
+    dnsGroup: 'file'
+  }
+  postgres: {
+    zoneName: 'privatelink.postgres.database.azure.com'
+    dnsGroup: 'postgresqlServer'
+  }
+  queue: {
+    zoneName: 'privatelink.queue.${environment().suffixes.storage}'
+    dnsGroup: 'queue'
+  }
+  sites: {
+    zoneName: 'privatelink.azurewebsites.net'
+    dnsGroup: 'sites'
+  }
+  tableStorage: {
+    zoneName: 'privatelink.table.${environment().suffixes.storage}'
+    dnsGroup: 'table'
+  }
+}

--- a/infrastructure/templates/common/dnsZones.bicep
+++ b/infrastructure/templates/common/dnsZones.bicep
@@ -4,6 +4,10 @@ var dnsZones = {
     zoneName: 'privatelink.blob.${environment().suffixes.storage}'
     dnsGroup: 'blob'
   }
+  eventGridTopic: {
+    zoneName: 'privatelink.eventgrid.azure.net'
+    dnsGroup: 'topic'
+  }
   fileService: {
     zoneName: 'privatelink.file.${environment().suffixes.storage}'
     dnsGroup: 'file'

--- a/infrastructure/templates/common/types.bicep
+++ b/infrastructure/templates/common/types.bicep
@@ -22,7 +22,21 @@ type FirewallRule = {
 }
 
 @export()
-type StorageAccountRole = 'Storage Blob Data Contributor' | 'Storage Blob Data Owner' | 'Storage Blob Data Reader' | 'Storage Queue Data Contributor'
+type PrivateDnsZone =
+  | 'blobStorage'
+  | 'fileService'
+  | 'postgres'
+  | 'queue'
+  | 'sites'
+  | 'tableStorage'
+  | 'custom'
+
+@export()
+type StorageAccountRole =
+  | 'Storage Blob Data Contributor'
+  | 'Storage Blob Data Owner'
+  | 'Storage Blob Data Reader'
+  | 'Storage Queue Data Contributor'
 
 @export()
 type StorageAccountConfig = {

--- a/infrastructure/templates/common/types.bicep
+++ b/infrastructure/templates/common/types.bicep
@@ -24,6 +24,7 @@ type FirewallRule = {
 @export()
 type PrivateDnsZone =
   | 'blobStorage'
+  | 'eventGridTopic'
   | 'fileService'
   | 'postgres'
   | 'queue'

--- a/infrastructure/templates/public-api/components/containerAppPrivateDns.bicep
+++ b/infrastructure/templates/public-api/components/containerAppPrivateDns.bicep
@@ -10,7 +10,7 @@ param ipAddress string
 @description('Tags to assign to resources')
 param tagValues object
 
-module privateDnsZoneModule './privateDnsZone.bicep' = {
+module privateDnsZoneModule '../../common/components/privateDnsZone.bicep' = {
   name: '${domain}Deploy'
   params: {
     vnetName: vnetName

--- a/infrastructure/templates/public-api/components/durableFunctionApp.bicep
+++ b/infrastructure/templates/public-api/components/durableFunctionApp.bicep
@@ -3,7 +3,6 @@ import {
   IpRange
   AzureFileShareMount
   EntraIdAuthentication
-  StorageAccountPrivateEndpoints
 } from '../types.bicep'
 
 import { staticAverageLessThanHundred, staticMinGreaterThanZero } from 'alerts/staticAlertConfig.bicep'
@@ -461,7 +460,7 @@ module functionAppSlotSettings 'appServiceSlotConfig.bicep' = {
   ]
 }
 
-module privateEndpointModule 'privateEndpoint.bicep' = if (privateEndpoints.?functionApp != null) {
+module privateEndpointModule '../../common/components/privateEndpoint.bicep' = if (privateEndpoints.?functionApp != null) {
   name: '${functionAppName}PrivateEndpointDeploy'
   params: {
     serviceId: functionApp.id

--- a/infrastructure/templates/public-api/components/postgreSqlFlexibleServer.bicep
+++ b/infrastructure/templates/public-api/components/postgreSqlFlexibleServer.bicep
@@ -132,7 +132,7 @@ resource firewallRuleAssignments 'Microsoft.DBforPostgreSQL/flexibleServers/fire
   }
 ]
 
-module privateEndpointModule 'privateEndpoint.bicep' = {
+module privateEndpointModule '../../common/components/privateEndpoint.bicep' = {
   name: 'postgresPrivateEndpointDeploy'
   params: {
     serviceId: postgreSQLDatabase.id

--- a/infrastructure/templates/public-api/components/storageAccount.bicep
+++ b/infrastructure/templates/public-api/components/storageAccount.bicep
@@ -68,7 +68,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   tags: tagValues
 }
 
-module fileServicePrivateEndpointModule 'privateEndpoint.bicep' = if (privateEndpointSubnetIds.?file != null) {
+module fileServicePrivateEndpointModule '../../common/components/privateEndpoint.bicep' = if (privateEndpointSubnetIds.?file != null) {
   name: '${storageAccountName}FileServicePrivateEndpointDeploy'
   params: {
     serviceId: storageAccount.id
@@ -81,7 +81,7 @@ module fileServicePrivateEndpointModule 'privateEndpoint.bicep' = if (privateEnd
   }
 }
 
-module blobStoragePrivateEndpointModule 'privateEndpoint.bicep' = if (privateEndpointSubnetIds.?blob != null) {
+module blobStoragePrivateEndpointModule '../../common/components/privateEndpoint.bicep' = if (privateEndpointSubnetIds.?blob != null) {
   name: '${storageAccountName}BlobStoragePrivateEndpointDeploy'
   params: {
     serviceId: storageAccount.id
@@ -94,7 +94,7 @@ module blobStoragePrivateEndpointModule 'privateEndpoint.bicep' = if (privateEnd
   }
 }
 
-module queuePrivateEndpointModule 'privateEndpoint.bicep' = if (privateEndpointSubnetIds.?queue != null) {
+module queuePrivateEndpointModule '../../common/components/privateEndpoint.bicep' = if (privateEndpointSubnetIds.?queue != null) {
   name: '${storageAccountName}QueuePrivateEndpointDeploy'
   params: {
     serviceId: storageAccount.id
@@ -107,7 +107,7 @@ module queuePrivateEndpointModule 'privateEndpoint.bicep' = if (privateEndpointS
   }
 }
 
-module tableStoragePrivateEndpointModule 'privateEndpoint.bicep' = if (privateEndpointSubnetIds.?table != null) {
+module tableStoragePrivateEndpointModule '../../common/components/privateEndpoint.bicep' = if (privateEndpointSubnetIds.?table != null) {
   name: '${storageAccountName}TableStoragePrivateEndpointDeploy'
   params: {
     serviceId: storageAccount.id

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -248,10 +248,10 @@ module coreStorage 'application/shared/coreStorage.bicep' = {
   }
 }
 
-module privateDnsZonesModule 'application/shared/privateDnsZones.bicep' = if (deploySharedPrivateDnsZones) {
+module privateDnsZonesModule '../common/application/privateDnsZones.bicep' = if (deploySharedPrivateDnsZones) {
   name: 'privateDnsZonesApplicationModuleDeploy'
   params: {
-    resourceNames: resourceNames
+    vnetName: resourceNames.existingResources.vNet
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/public-api/types.bicep
+++ b/infrastructure/templates/public-api/types.bicep
@@ -326,44 +326,6 @@ type ContainerAppWorkloadProfile = {
 }
 
 @export()
-type PrivateDnsZone = 
-  | 'fileService'
-  | 'blobStorage'
-  | 'queue'
-  | 'tableStorage'
-  | 'postgres'
-  | 'sites'
-  | 'custom'
-
-@export()
-var dnsZones = {
-  sites: {
-    zoneName: 'privatelink.azurewebsites.net'
-    dnsGroup: 'sites'
-  }
-  postgres: {
-    zoneName: 'privatelink.postgres.database.azure.com'
-    dnsGroup: 'postgresqlServer'
-  }
-  fileService: {
-    zoneName: 'privatelink.file.${environment().suffixes.storage}'
-    dnsGroup: 'file'
-  }
-  blobStorage: {
-    zoneName: 'privatelink.blob.${environment().suffixes.storage}'
-    dnsGroup: 'blob'
-  }
-  queue: {
-    zoneName: 'privatelink.queue.${environment().suffixes.storage}'
-    dnsGroup: 'queue'
-  }
-  tableStorage: {
-    zoneName: 'privatelink.table.${environment().suffixes.storage}'
-    dnsGroup: 'table'
-  }
-}
-
-@export()
 type StorageAccountPrivateEndpoints = {
   file: string?
   blob: string?

--- a/infrastructure/templates/search/application/eventMessaging.bicep
+++ b/infrastructure/templates/search/application/eventMessaging.bicep
@@ -15,6 +15,9 @@ param location string
 @description('A list of IP network rules to allow access to Event Grid resources from specific public internet IP address ranges.')
 param ipRules IpRange[] = []
 
+@description('Specifies whether Event Grid resources can be accessed from public networks, including the internet or are restricted to private endpoints only.')
+param publicNetworkAccessEnabled bool = false
+
 @description('Specifies common resource naming variables.')
 param resourceNames ResourceNames
 
@@ -40,6 +43,7 @@ module eventGridMessagingModule '../../common/components/event-grid/eventGridMes
     location: location
     customTopicNames: topicNames
     ipRules: ipRules
+    publicNetworkAccessEnabled: publicNetworkAccessEnabled
     resourcePrefix: resourcePrefix
     customTopicAlerts: {
       deadLetteredCount: true

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -66,6 +66,7 @@ var resourceNames = {
     vNet: '${subscription}-${abbreviations.networkVirtualNetworks}-ees'
     alertsGroup: '${subscription}-${abbreviations.insightsActionGroups}-ees-alertedusers'
     subnets: {
+      eventGridCustomTopicPrivateEndpoints: '${resourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-${abbreviations.eventGridTopics}-pep'
       searchDocsFunction: '${resourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-${abbreviations.webSitesFunctions}-searchdocs'
       searchDocsFunctionPrivateEndpoints: '${resourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-${abbreviations.webSitesFunctions}-searchdocs-pep'
       searchStoragePrivateEndpoints: '${resourcePrefix}-${abbreviations.networkVirtualNetworksSubnets}-${abbreviations.storageStorageAccounts}-search-pep'
@@ -97,6 +98,10 @@ module eventMessagingModule '../common/application/eventMessaging.bicep' = {
       adminApp: resourceNames.existingResources.adminApp
       alertsGroup: resourceNames.existingResources.alertsGroup
       publisherFunction: resourceNames.existingResources.publisherFunction
+      vNet: resourceNames.existingResources.vNet
+      subnets: {
+        eventGridCustomTopicPrivateEndpoints: resourceNames.existingResources.subnets.eventGridCustomTopicPrivateEndpoints
+      }
     }
     tagValues: tagValues
   }

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -92,7 +92,6 @@ module eventMessagingModule 'application/eventMessaging.bicep' = {
   name: 'eventMessagingModuleDeploy'
   params: {
     location: location
-    ipRules: [] // TODO EES-6036 Should be maintenanceIpRanges
     resourcePrefix: resourcePrefix
     resourceNames: resourceNames
     tagValues: tagValues

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -88,12 +88,16 @@ module monitoringModule 'application/monitoring.bicep' = {
 // other services that publish events but are not yet defined in Bicep such as the Admin App Service
 // and the Publisher Function App.
 // The Search Service relies on this infrastructure to subscribe to events.
-module eventMessagingModule 'application/eventMessaging.bicep' = {
+module eventMessagingModule '../common/application/eventMessaging.bicep' = {
   name: 'eventMessagingModuleDeploy'
   params: {
     location: location
     resourcePrefix: resourcePrefix
-    resourceNames: resourceNames
+    resourceNames: {
+      adminApp: resourceNames.existingResources.adminApp
+      alertsGroup: resourceNames.existingResources.alertsGroup
+      publisherFunction: resourceNames.existingResources.publisherFunction
+    }
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/search/types.bicep
+++ b/infrastructure/templates/search/types.bicep
@@ -8,6 +8,7 @@ type ResourceNames = {
     vNet: string
     alertsGroup: string
     subnets: {
+      eventGridCustomTopicPrivateEndpoints: string
       searchDocsFunction: string
       searchDocsFunctionPrivateEndpoints: string
       searchStoragePrivateEndpoints: string

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1145,6 +1145,7 @@
     "searchDocsFunctionPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-fa-searchdocs-pep')]",
     "searchStoragePrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-sa-search-pep')]",
     "containerAppEnvironmentSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-cae-01')]",
+    "eventGridCustomTopicPrivateEndpointsSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-evgt-pep')]",
     "applicationGatewaySubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-agw-01')]",
     "psqlFlexibleServerSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-psql-flexibleserver')]",
     "screenerFunctionAppSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-sapi-snet-fa-screener')]",
@@ -3876,6 +3877,12 @@
                   }
                 }
               ]
+            }
+          },
+          {
+            "name": "[variables('eventGridCustomTopicPrivateEndpointsSubnetName')]",
+            "properties": {
+              "addressPrefix": "10.0.20.0/24"
             }
           }
         ]


### PR DESCRIPTION
This PR configures private endpoints for the Azure Event Grid custom topics used for publishing events.

It disables access to topics from public networks. Access is now restricted to private endpoints only. Private endpoints allow ingress of events directly from the virtual network to the custom topics securely over a private link without going through the public internet.

This change involves:

- Creating a subnet within the virtual network to assign private IP addresses to Event Grid custom topics.
- Creating a private DNS zone allowing applications in the virtual network to connect to the Event Grid using the same connection string and role based authorization that was already in place.
- Creating private endpoints for each Event Grid custom topic.

⚠️ The order of deploying is important for this change. Search infrastructure which creates the private endpoints must be deployed **after**:

- EES (main service) infrastructure deploy - It is responsible for creating subnets in the virtual network.
- Public API - It is responsible for creating the shared private DNS zones.

### Other changes

- Move `eventMessaging.bicep` and , `privateDnsZones.bicep` to `common\application` templates folder.
- Move `privateDnsZone.bicep`, and `privateEndpoint.bicep` to `common\components` templates folder.
- Fix `droppedEventCountAlert` module name.