### PR TITLE
EES-6240 - additional amendments after talking changes through with Jack. Ignoring Drafter role in addition to Approver role.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ReleasePublishingFeedbackFunctionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Functions/ReleasePublishingFeedbackFunctionTests.cs
@@ -122,14 +122,23 @@ public class ReleasePublishingFeedbackFunctionTests
             ReleasePublishingFeedbackId: feedback.Id,
             EmailAddress: "test@test.com");
 
+        var emailService = new Mock<IEmailService>(MockBehavior.Strict);
+
         await using (var context = ContentDbUtils.InMemoryContentDbContext(contentDbContextId))
         {
-            var function = BuildFunction(contentDbContext: context);
+            var function = BuildFunction(contentDbContext: context, emailService: emailService.Object);
 
             await function.SendReleasePublishingFeedbackEmail(
                 releasePublishingFeedbackMessage,
                 cancellationToken: default);
         }
+
+        emailService
+            .Verify(s => s.SendEmail(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, dynamic>>()
+                ), Times.Never);
     }
 
     private static bool AssertEmailTemplateValues(

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ReleasePublishingFeedbackFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ReleasePublishingFeedbackFunction.cs
@@ -75,13 +75,17 @@ public class ReleasePublishingFeedbackFunction(
         {
             PublicationRole.Owner => "an owner",
             PublicationRole.Allower => "an approver",
-            PublicationRole.Drafter => "a drafter",
+            
             // Note that this function should never be invoked for PublicationRole.Approver
-            // because Publisher is explicitly filtering these out until the permissions
-            // simplification work has been completed.
+            // or PublicationRole.Drafter currently, because Publisher is filtering
+            // these out until the permissions simplification work has been completed.
+            PublicationRole.Drafter => throw new ArgumentException(
+                $"{nameof(ReleasePublishingFeedbackFunction)} should not " +
+                $"have been called for {nameof(PublicationRole.Drafter)}"),
             PublicationRole.Approver => throw new ArgumentException(
                 $"{nameof(ReleasePublishingFeedbackFunction)} should not " +
                 $"have been called for {nameof(PublicationRole.Approver)}"),
+            
             _ => throw new ArgumentOutOfRangeException(nameof(role), role, null)
         };
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/NotificationsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/NotificationsService.cs
@@ -51,12 +51,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 {
                     var publicationRoles = await context
                         .UserPublicationRoles
-                        .IgnoreQueryFilters()
                         .Include(upr => upr.User)
                         .Where(upr =>
                             upr.PublicationId == releaseVersion.Release.PublicationId
-                            && upr.Deleted == null
-                            && upr.Role != PublicationRole.Approver)
+                            && upr.Deleted == null)
                         .ToListAsync();
 
                     return publicationRoles


### PR DESCRIPTION
This PR:
- follows up on work done for EES-6240, specifically ignoring the currently-unused Drafter role as well as the already-ignored Approver role.

This means that the global query filters don't need to be ignored anymore.

I've added some extra tests too, which can go when Jack's permissions simplifications work in complete.  