### PR TITLE
EES-6240 - suppressing errors from invalid email recipients when using team-only Notify API keys on non-Prod environments.

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -112,6 +112,9 @@
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
+    },
+    "notifierSuppressExceptionsForTeamOnlyApiKeyErrors": {
+      "value": true
     }
   }
 }

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -97,6 +97,9 @@
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
+    },
+    "notifierSuppressExceptionsForTeamOnlyApiKeyErrors": {
+      "value": true
     }
   }
 }

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -94,6 +94,9 @@
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true
+    },
+    "notifierSuppressExceptionsForTeamOnlyApiKeyErrors": {
+      "value": true
     }
   }
 }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -767,6 +767,13 @@
       "metadata": {
         "description": "Where analytics request files are saved before being processed"
       }
+    },
+    "notifierSuppressExceptionsForTeamOnlyApiKeyErrors": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Replaces Notify exceptions with logged messages only when team-only API keys are used and a recipient email address is not valid for that key."
+      }
     }
   },
   "variables": {
@@ -3091,6 +3098,7 @@
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(resourceId('microsoft.insights/components/', variables('notificationsAppInsights')), '2020-02-02').InstrumentationKey]",
         "App__EmailEnabled": "true",
+        "App__SuppressExceptionsForTeamOnlyApiKeyErrors": "[parameters('notifierSuppressExceptionsForTeamOnlyApiKeyErrors')]",
         "App__Url": "[concat(concat('https://', variables('notificationsAppName')), '.azurewebsites.net/api')]",
         "App__PublicAppUrl": "[variables('publicAppUrl')]",
         "App__NotifierStorageConnectionString": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-notifications')).secretUriWithVersion, ')')]",

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Services/EmailServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Tests/Services/EmailServiceTests.cs
@@ -1,0 +1,227 @@
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Options;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Notify.Exceptions;
+using Notify.Interfaces;
+using Notify.Models.Responses;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Notifier.Tests.Services;
+
+public class EmailServiceTests
+{
+    private const string TestApiKeyErrorMessage =
+        "Can't send to this recipient using a team-only API key";
+
+    private static readonly AppOptions DefaultAppOptions = new() { SuppressExceptionsForTeamOnlyApiKeyErrors = false };
+
+    [Fact]
+    public void SendEmail_Success()
+    {
+        var email = "test@test.com";
+        var templateId = "test-template-id";
+        var values = new Dictionary<string, dynamic>
+        {
+            { "test-key", "test-value" },
+            { "test-key-2", 2 }
+        };
+
+        var notificationClient = new Mock<INotificationClient>(MockBehavior.Strict);
+
+        notificationClient
+            .Setup(s =>
+                s.SendEmail(
+                    email,
+                    templateId,
+                    values,
+                    null,
+                    null,
+                    null))
+            .Returns(new EmailNotificationResponse());
+
+        var service = BuildService(
+            notificationClient: notificationClient.Object);
+
+        service.SendEmail(
+            email: email,
+            templateId: templateId,
+            values: values);
+
+        notificationClient.Verify(
+            s => s.SendEmail(
+                email,
+                templateId,
+                values,
+                null,
+                null,
+                null)
+            , Times.Once);
+    }
+
+    [Fact]
+    public void SendEmail_GenericNotifyClientExceptionRaised_RethrowsException()
+    {
+        var email = "test@test.com";
+        var templateId = "test-template-id";
+        var values = new Dictionary<string, dynamic>
+        {
+            { "test-key", "test-value" },
+            { "test-key-2", 2 }
+        };
+
+        var notificationClient = new Mock<INotificationClient>(MockBehavior.Strict);
+
+        var originalException = new NotifyClientException("Generic error");
+
+        notificationClient
+            .Setup(s =>
+                s.SendEmail(
+                    email,
+                    templateId,
+                    values,
+                    null,
+                    null,
+                    null))
+            .Throws(originalException);
+
+        var service = BuildService(
+            notificationClient: notificationClient.Object);
+
+        var exception = Assert.Throws<NotifyClientException>(() =>
+            service.SendEmail(
+                email: email,
+                templateId: templateId,
+                values: values));
+
+        notificationClient.Verify(
+            s => s.SendEmail(
+                email,
+                templateId,
+                values,
+                null,
+                null,
+                null)
+            , Times.Once);
+
+        Assert.Equal(originalException, exception);
+    }
+
+    [Fact]
+    public void SendEmail_TestApiNotifyClientExceptionRaised_SuppressionDisabled_RethrowsException()
+    {
+        var email = "test@test.com";
+        var templateId = "test-template-id";
+        var values = new Dictionary<string, dynamic>
+        {
+            { "test-key", "test-value" },
+            { "test-key-2", 2 }
+        };
+
+        var notificationClient = new Mock<INotificationClient>(MockBehavior.Strict);
+
+        var originalException = new NotifyClientException(TestApiKeyErrorMessage);
+
+        notificationClient
+            .Setup(s =>
+                s.SendEmail(
+                    email,
+                    templateId,
+                    values,
+                    null,
+                    null,
+                    null))
+            .Throws(originalException);
+
+        var service = BuildService(
+            notificationClient: notificationClient.Object);
+
+        var exception = Assert.Throws<NotifyClientException>(() =>
+            service.SendEmail(
+                email: email,
+                templateId: templateId,
+                values: values));
+
+        notificationClient.Verify(
+            s => s.SendEmail(
+                email,
+                templateId,
+                values,
+                null,
+                null,
+                null)
+            , Times.Once);
+
+        Assert.Equal(originalException, exception);
+    }
+
+    [Fact]
+    public void SendEmail_TestApiNotifyClientExceptionRaised_SuppressionEnabled_SuppressesException()
+    {
+        var email = "test@test.com";
+        var templateId = "test-template-id";
+        var values = new Dictionary<string, dynamic>
+        {
+            { "test-key", "test-value" },
+            { "test-key-2", 2 }
+        };
+
+        var notificationClient = new Mock<INotificationClient>(MockBehavior.Strict);
+
+        var originalException = new NotifyClientException(TestApiKeyErrorMessage);
+
+        notificationClient
+            .Setup(s =>
+                s.SendEmail(
+                    email,
+                    templateId,
+                    values,
+                    null,
+                    null,
+                    null))
+            .Throws(originalException);
+
+        var logger = new Mock<ILogger<EmailService>>(MockBehavior.Strict);
+
+        ExpectLogMessage(
+            logger,
+            LogLevel.Information,
+            """Email could not be sent to "test@test.com" as they are not a valid recipient for this team-only API key.""");
+
+        var service = BuildService(
+            notificationClient: notificationClient.Object,
+            options: new AppOptions { SuppressExceptionsForTeamOnlyApiKeyErrors = true },
+            logger: logger.Object);
+
+        service.SendEmail(
+            email: email,
+            templateId: templateId,
+            values: values);
+
+        notificationClient.Verify(
+            s => s.SendEmail(
+                email,
+                templateId,
+                values,
+                null,
+                null,
+                null),
+            Times.Once);
+
+        VerifyAllMocks(logger);
+    }
+
+    private static EmailService BuildService(
+        INotificationClient? notificationClient = null,
+        AppOptions? options = null,
+        ILogger<EmailService>? logger = null)
+    {
+        return new EmailService(
+            notificationClient: notificationClient ?? Mock.Of<INotificationClient>(MockBehavior.Strict),
+            appOptions: (options ?? DefaultAppOptions).ToOptionsWrapper(),
+            logger: logger ?? Mock.Of<ILogger<EmailService>>());
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ReleasePublishingFeedbackFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Functions/ReleasePublishingFeedbackFunction.cs
@@ -9,8 +9,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Options;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Options/AppOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Options/AppOptions.cs
@@ -6,6 +6,8 @@ public class AppOptions
     
     public bool EmailEnabled { get; init; }
 
+    public bool SuppressExceptionsForTeamOnlyApiKeyErrors { get; init; }
+
     public string Url { get; init; } = null!;
 
     public string PublicAppUrl { get; init; } = null!;

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/EmailService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/EmailService.cs
@@ -1,22 +1,56 @@
 using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Options;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Notify.Exceptions;
 using Notify.Interfaces;
 
 namespace GovUk.Education.ExploreEducationStatistics.Notifier.Services;
 
-public class EmailService(INotificationClient notificationClient) : IEmailService
+public class EmailService(
+    INotificationClient notificationClient,
+    IOptions<AppOptions> appOptions,
+    ILogger<EmailService> logger) : IEmailService
 {
     public void SendEmail(
         string email,
         string templateId,
         Dictionary<string, dynamic> values)
     {
-        notificationClient.SendEmail(
-            emailAddress: email,
-            templateId: templateId, 
-            personalisation: values,
-            clientReference: null,
-            emailReplyToId: null,
-            oneClickUnsubscribeURL: null);
+        try
+        {
+            notificationClient.SendEmail(
+                emailAddress: email,
+                templateId: templateId,
+                personalisation: values,
+                clientReference: null,
+                emailReplyToId: null,
+                oneClickUnsubscribeURL: null);
+        }
+        catch (NotifyClientException e)
+        {
+            // In non-Production environments, we use team-only API keys which are limited
+            // to sending emails only to people in our team within GovUK Notify.
+            //
+            // On non-Production environments, we have test users who don't form a part of
+            // that team and so for each of them being targeted as recipients of emails,
+            // we will receive an error detailing that an email cannot be sent to them.
+            //
+            // In these instances we will want to catch and log these errors rather than
+            // have them appear in Application Insights as alerts.
+            if (appOptions.Value.SuppressExceptionsForTeamOnlyApiKeyErrors
+                && e.Message.Contains("team-only API key"))
+            {
+                logger.LogInformation(
+                    "Email could not be sent to \"{Email}\" as they are not a valid " +
+                    "recipient for this team-only API key.",
+                    email);
+            }
+            else
+            {
+                throw;
+            }
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/appsettings.Local.json.example
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/appsettings.Local.json.example
@@ -1,6 +1,7 @@
 {
   "App": {
     "EmailEnabled": true
+    "SuppressExceptionsForTeamOnlyApiKeyErrors": true
   },
   "GovUkNotify" : {
     "ApiKey": "add-a-restricted-api-key-here-NOT-A-LIVE-ONE",


### PR DESCRIPTION
This PR:
- adds the ability to suppress exceptions being thrown when emails are sent to recipients that are not within the GovUK Notify team when using Team-only API keys.

This work comes about because alerts were being raised from Notifier on Dev due to it attempting to send to recipients like "ees-test.analyst1@education.gov.uk" when a Release is published.  This came about because of the new email functionality introduced in EES-6240.

Now we support a per-environment flag called `SuppressExceptionsForTeamOnlyApiKeyErrors` which is true for all environments except for Production.

The effect of this flag being true is for team-only API exceptions to be caught and converted to logged messages instead, thus preventing them being seen as real errors:

```
[notifier] [2025-07-02T13:40:49.514Z] Email could not be sent to "ees-test.analyst1@education.gov.uk" as they are not a valid recipient for this team-only API key.
```