### PR TITLE
EES-6270 don't show cancel and confirm replacement buttons while processing

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTable.tsx
@@ -29,7 +29,9 @@ export default function DataFilesReplacementTable({
           <th scope="col">Title</th>
           <th scope="col">Size</th>
           <th scope="col">Replacement status</th>
-          <th scope="col">Actions</th>
+          <th className={styles.actionsColumn} scope="col">
+            Actions
+          </th>
         </tr>
       </thead>
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
@@ -36,6 +36,7 @@ export default function DataFilesReplacementTableRow({
   onConfirmAction,
 }: Props) {
   const [fetchPlan, toggleFetchPlan] = useToggle(false);
+  const [canCancel, toggleCanCancel] = useToggle(false);
 
   const { data: replacementDataFile, isLoading } = useQuery(
     releaseDataFileQueries.getDataFile(
@@ -57,7 +58,7 @@ export default function DataFilesReplacementTableRow({
     if (replacementDataFile?.status === 'COMPLETE') {
       toggleFetchPlan.on();
     }
-  }, [replacementDataFile?.status, toggleFetchPlan]);
+  }, [replacementDataFile?.status, toggleFetchPlan, toggleCanCancel]);
 
   const handleStatusChange = (
     _file: DataFile,
@@ -65,13 +66,14 @@ export default function DataFilesReplacementTableRow({
   ) => {
     if (importStatus.status === 'COMPLETE') {
       toggleFetchPlan.on();
+      toggleCanCancel.on();
     }
   };
 
   if (!replacementDataFile) {
     return (
       <tr>
-        <td>
+        <td colSpan={4}>
           <LoadingSpinner loading={isLoading} />
         </td>
       </tr>
@@ -120,24 +122,28 @@ export default function DataFilesReplacementTableRow({
             View details
           </Link>
           <>
-            <ModalConfirm
-              title="Cancel data replacement"
-              triggerButton={
-                <ButtonText variant="secondary">Cancel replacement</ButtonText>
-              }
-              onConfirm={async () => {
-                await releaseDataFileService.deleteDataFiles(
-                  releaseVersionId,
-                  replacementDataFile.id,
-                );
-                onConfirmAction?.();
-              }}
-            >
-              <p>
-                Are you sure you want to cancel this data replacement? The
-                pending replacement data file will be deleted.
-              </p>
-            </ModalConfirm>
+            {(canCancel || replacementDataFile.status === 'COMPLETE') && (
+              <ModalConfirm
+                title="Cancel data replacement"
+                triggerButton={
+                  <ButtonText variant="secondary">
+                    Cancel replacement
+                  </ButtonText>
+                }
+                onConfirm={async () => {
+                  await releaseDataFileService.deleteDataFiles(
+                    releaseVersionId,
+                    replacementDataFile.id,
+                  );
+                  onConfirmAction?.();
+                }}
+              >
+                <p>
+                  Are you sure you want to cancel this data replacement? The
+                  pending replacement data file will be deleted.
+                </p>
+              </ModalConfirm>
+            )}
             {plan?.valid && (
               <ButtonText
                 onClick={async () => {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.module.scss
@@ -28,3 +28,7 @@
   margin-bottom: 0;
   white-space: nowrap;
 }
+
+.actionsColumn {
+  width: 37%;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.tsx
@@ -39,7 +39,9 @@ export default function DataFilesTable({
           <th scope="col">Title</th>
           <th scope="col">Size</th>
           <th scope="col">Status</th>
-          <th scope="col">Actions</th>
+          <th className={styles.actionsColumn} scope="col">
+            Actions
+          </th>
         </tr>
       </thead>
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesReplacementTableRow.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesReplacementTableRow.test.tsx
@@ -130,4 +130,47 @@ describe('DataFilesReplacementTableRow', () => {
       within(cells[3]).queryByRole('button', { name: 'Confirm replacement' }),
     ).not.toBeInTheDocument();
   });
+
+  test('does not show the confirm and cancel buttons while the replacement is being processed', async () => {
+    releaseDataFileService.getDataFile.mockResolvedValue({
+      ...testReplacementDataFile,
+      status: 'STAGE_3',
+    });
+
+    releaseDataFileService.getDataFileImportStatus.mockResolvedValue({
+      errors: [],
+      percentageComplete: 67,
+      stagePercentageComplete: 59,
+      status: 'STAGE_3',
+      totalRows: 5904158,
+    });
+
+    render(
+      <MemoryRouter>
+        <DataFilesReplacementTableRow
+          dataFile={testDataFile}
+          publicationId="test-publication"
+          releaseVersionId="test-release-version"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Test File')).toBeInTheDocument();
+    expect(await screen.findByText('Importing')).toBeInTheDocument();
+    expect(screen.queryByText('Ready')).not.toBeInTheDocument();
+
+    const cells = screen.getAllByRole('cell');
+    expect(cells[0]).toHaveTextContent('Test File');
+    expect(cells[1]).toHaveTextContent('1,000 B');
+    expect(cells[2]).toHaveTextContent('Importing');
+    expect(
+      within(cells[3]).getByRole('link', { name: 'View details' }),
+    ).toBeInTheDocument();
+    expect(
+      within(cells[3]).queryByRole('button', { name: 'Confirm replacement' }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(cells[3]).queryByRole('button', { name: 'Cancel replacement' }),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
The cancel and confirm buttons for data replacements shouldn't appear until the file has finished processing.