### PR TITLE
EES-6289 Allow completion of multiple replacements at once

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api;
 
@@ -118,7 +119,7 @@ public abstract class DataReplacementControllerTests
 
             var result = await controller.Replace(
                 releaseVersionId: releaseVersionId,
-                originalFileId: originalFileId);
+                new ReplacementRequest { OriginalFileIds = [originalFileId] });
 
             MockUtils.VerifyAllMocks(replacementService);
 
@@ -144,7 +145,7 @@ public abstract class DataReplacementControllerTests
 
             var result = await controller.Replace(
                 releaseVersionId: releaseVersionId,
-                originalFileId: originalFileId);
+                new ReplacementRequest { OriginalFileIds = [originalFileId] });
 
             MockUtils.VerifyAllMocks(replacementService);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
@@ -103,25 +103,25 @@ public abstract class DataReplacementControllerTests
         [Fact]
         public async Task Success()
         {
-            var replacementService = new Mock<IReplacementService>(MockBehavior.Strict);
+            var replacementBatchService = new Mock<IReplacementBatchService>(MockBehavior.Strict);
 
             var releaseVersionId = Guid.NewGuid();
             var originalFileId = Guid.NewGuid();
 
-            replacementService
+            replacementBatchService
                 .Setup(service => service.Replace(
                     releaseVersionId,
-                    new List<Guid>{ originalFileId },
+                    new List<Guid> { originalFileId },
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Unit.Instance);
 
-            var controller = BuildController(replacementService: replacementService.Object);
+            var controller = BuildController(replacementBatchService: replacementBatchService.Object);
 
             var result = await controller.Replace(
                 releaseVersionId: releaseVersionId,
                 new ReplacementRequest { OriginalFileIds = [originalFileId] });
 
-            MockUtils.VerifyAllMocks(replacementService);
+            MockUtils.VerifyAllMocks(replacementBatchService);
 
             result.AssertOkResult();
         }
@@ -129,33 +129,36 @@ public abstract class DataReplacementControllerTests
         [Fact]
         public async Task ValidationProblem()
         {
-            var replacementService = new Mock<IReplacementService>(MockBehavior.Strict);
+            var replacementBatchService = new Mock<IReplacementBatchService>(MockBehavior.Strict);
 
             var releaseVersionId = Guid.NewGuid();
             var originalFileId = Guid.NewGuid();
 
-            replacementService
+            replacementBatchService
                 .Setup(service => service.Replace(
                     releaseVersionId,
-                    new List<Guid>{ originalFileId } ,
+                    new List<Guid> { originalFileId },
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ValidationUtils.ValidationActionResult(ValidationErrorMessages.ReplacementMustBeValid));
 
-            var controller = BuildController(replacementService: replacementService.Object);
+            var controller = BuildController(replacementBatchService: replacementBatchService.Object);
 
             var result = await controller.Replace(
                 releaseVersionId: releaseVersionId,
                 new ReplacementRequest { OriginalFileIds = [originalFileId] });
 
-            MockUtils.VerifyAllMocks(replacementService);
+            MockUtils.VerifyAllMocks(replacementBatchService);
 
             result.AssertValidationProblem(ValidationErrorMessages.ReplacementMustBeValid);
         }
     }
 
-    private static DataReplacementController BuildController(IReplacementService? replacementService = null)
+    private static DataReplacementController BuildController(
+        IReplacementService? replacementService = null,
+        IReplacementBatchService? replacementBatchService = null)
     {
         return new DataReplacementController(
-            replacementService ?? Mock.Of<IReplacementService>(MockBehavior.Strict));
+            replacementService ?? Mock.Of<IReplacementService>(MockBehavior.Strict),
+            replacementBatchService ?? Mock.Of<IReplacementBatchService>(MockBehavior.Strict));
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
@@ -27,7 +27,6 @@ public abstract class DataReplacementControllerTests
 
             var releaseVersionId = Guid.NewGuid();
             var originalFileId = Guid.NewGuid();
-            var replacementFileId = Guid.NewGuid();
 
             var dataReplacementPlan = new DataReplacementPlanViewModel
             {
@@ -77,7 +76,6 @@ public abstract class DataReplacementControllerTests
                 .Setup(s => s.GetReplacementPlan(
                     releaseVersionId, 
                     originalFileId, 
-                    replacementFileId, 
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dataReplacementPlan);
 
@@ -85,8 +83,7 @@ public abstract class DataReplacementControllerTests
 
             var result = await controller.GetReplacementPlan(
                 releaseVersionId: releaseVersionId,
-                fileId: originalFileId,
-                replacementFileId: replacementFileId);
+                originalFileId: originalFileId);
 
             MockUtils.VerifyAllMocks(replacementService);
 
@@ -109,21 +106,18 @@ public abstract class DataReplacementControllerTests
 
             var releaseVersionId = Guid.NewGuid();
             var originalFileId = Guid.NewGuid();
-            var replacementFileId = Guid.NewGuid();
 
             replacementService
                 .Setup(service => service.Replace(
                     releaseVersionId,
-                    originalFileId,
-                    replacementFileId))
+                    originalFileId))
                 .ReturnsAsync(Unit.Instance);
 
             var controller = BuildController(replacementService: replacementService.Object);
 
             var result = await controller.Replace(
                 releaseVersionId: releaseVersionId,
-                fileId: originalFileId,
-                replacementFileId: replacementFileId);
+                originalFileId: originalFileId);
 
             MockUtils.VerifyAllMocks(replacementService);
 
@@ -137,21 +131,18 @@ public abstract class DataReplacementControllerTests
 
             var releaseVersionId = Guid.NewGuid();
             var originalFileId = Guid.NewGuid();
-            var replacementFileId = Guid.NewGuid();
 
             replacementService
                 .Setup(service => service.Replace(
                     releaseVersionId,
-                    originalFileId,
-                    replacementFileId))
+                    originalFileId))
                 .ReturnsAsync(ValidationUtils.ValidationActionResult(ValidationErrorMessages.ReplacementMustBeValid));
 
             var controller = BuildController(replacementService: replacementService.Object);
 
             var result = await controller.Replace(
                 releaseVersionId: releaseVersionId,
-                fileId: originalFileId,
-                replacementFileId: replacementFileId);
+                originalFileId: originalFileId);
 
             MockUtils.VerifyAllMocks(replacementService);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
@@ -110,7 +110,8 @@ public abstract class DataReplacementControllerTests
             replacementService
                 .Setup(service => service.Replace(
                     releaseVersionId,
-                    originalFileId))
+                    originalFileId,
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Unit.Instance);
 
             var controller = BuildController(replacementService: replacementService.Object);
@@ -135,7 +136,8 @@ public abstract class DataReplacementControllerTests
             replacementService
                 .Setup(service => service.Replace(
                     releaseVersionId,
-                    originalFileId))
+                    originalFileId,
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ValidationUtils.ValidationActionResult(ValidationErrorMessages.ReplacementMustBeValid));
 
             var controller = BuildController(replacementService: replacementService.Object);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
@@ -110,7 +110,7 @@ public abstract class DataReplacementControllerTests
             replacementService
                 .Setup(service => service.Replace(
                     releaseVersionId,
-                    originalFileId,
+                    new List<Guid>{ originalFileId },
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Unit.Instance);
 
@@ -136,7 +136,7 @@ public abstract class DataReplacementControllerTests
             replacementService
                 .Setup(service => service.Replace(
                     releaseVersionId,
-                    originalFileId,
+                    new List<Guid>{ originalFileId } ,
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ValidationUtils.ValidationActionResult(ValidationErrorMessages.ReplacementMustBeValid));
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementBatchServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementBatchServiceTests.cs
@@ -1,0 +1,173 @@
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Moq;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using Microsoft.AspNetCore.Mvc;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+public class ReplacementBatchServiceTests
+{
+    private readonly DataFixture _fixture = new();
+
+    [Fact]
+    public async Task Replace_Success()
+    {
+        var releaseVersion = _fixture.DefaultReleaseVersion().Generate();
+
+        var originalFileValid1Id = Guid.NewGuid();
+        var originalFileValid2Id = Guid.NewGuid();
+
+        var replacementService = new Mock<IReplacementService>(Strict);
+
+        replacementService.Setup(mock => mock.Replace(
+                releaseVersion.Id, originalFileValid1Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Unit.Instance);
+
+        replacementService.Setup(mock => mock.Replace(
+                releaseVersion.Id, originalFileValid2Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Unit.Instance);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var replacementBatchService = BuildReplacementBatchService(
+                contentDbContext,
+                replacementService.Object);
+
+            var result = await replacementBatchService.Replace(
+                releaseVersionId: releaseVersion.Id,
+                [originalFileValid1Id, originalFileValid2Id],
+                default);
+
+            result.AssertRight();
+
+            VerifyAllMocks(replacementService);
+        }
+    }
+
+    [Fact]
+    public async Task Replace_ReleaseVersionNotFound()
+    {
+        var replacementService = new Mock<IReplacementService>(Strict);
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using var contentDbContext = InMemoryApplicationDbContext(contentDbContextId);
+        var replacementBatchService = BuildReplacementBatchService(
+            contentDbContext,
+            replacementService.Object);
+
+        var result = await replacementBatchService.Replace(
+            releaseVersionId: Guid.NewGuid(), // releaseVersion does not exist
+            [Guid.NewGuid()],
+            default);
+
+        result.AssertNotFound();
+
+        VerifyAllMocks(replacementService);
+    }
+
+    [Fact]
+    public async Task Replace_OneValidThreeErrors()
+    {
+        var releaseVersion = _fixture.DefaultReleaseVersion().Generate();
+
+        var originalFileValidId = Guid.NewGuid();
+        var originalFileNotFoundId = Guid.NewGuid();
+        var originalFileInvalidId = Guid.NewGuid();
+        var originalFileImportNotCompleteId = Guid.NewGuid();
+
+        var replacementService = new Mock<IReplacementService>(Strict);
+
+        replacementService.Setup(mock => mock.Replace(
+                releaseVersion.Id, originalFileValidId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Unit.Instance);
+
+        replacementService.Setup(mock => mock.Replace(
+                releaseVersion.Id, originalFileNotFoundId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NotFoundResult());
+
+        replacementService.Setup(mock => mock.Replace(
+                releaseVersion.Id, originalFileInvalidId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ValidationUtils.ValidationActionResult(ReplacementMustBeValid));
+
+        replacementService.Setup(mock => mock.Replace(
+                releaseVersion.Id, originalFileImportNotCompleteId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ValidationUtils.ValidationActionResult(ReplacementImportMustBeComplete));
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.ReleaseVersions.Add(releaseVersion);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var replacementBatchService = BuildReplacementBatchService(
+                contentDbContext,
+                replacementService.Object);
+
+            var result = await replacementBatchService.Replace(
+                releaseVersionId: releaseVersion.Id,
+                [originalFileValidId, originalFileInvalidId, originalFileNotFoundId, originalFileImportNotCompleteId],
+                default);
+
+            // The valid replacement completes, but we still return errors for the invalid and not found
+            // replacements as in normal usage the user should never see one of these errors.
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+            validationProblem.AssertHasErrors([
+                new ErrorViewModel
+                {
+                    Code = "ReplacementNotFound",
+                    Message =
+                        $"Linked original and replacement file(s) not found. OriginalFileId: {originalFileNotFoundId}"
+                },
+                new ErrorViewModel
+                {
+                    Code = "ReplacementMustBeValid",
+                    Message = $"Replacement not valid. OriginalFileId: {originalFileInvalidId}"
+                },
+                new ErrorViewModel
+                {
+                    Code = "ReplacementImportMustBeComplete",
+                    Message = $"Replacement import not complete. OriginalFileId: {originalFileImportNotCompleteId}"
+                },
+            ]);
+
+            VerifyAllMocks(replacementService);
+        }
+    }
+
+    private static ReplacementBatchService BuildReplacementBatchService(
+        ContentDbContext contentDbContext,
+        IReplacementService? replacementService = null
+    )
+    {
+        return new ReplacementBatchService(
+            contentDbContext,
+            AlwaysTrueUserService().Object,
+            replacementService ?? Mock.Of<IReplacementService>(Strict)
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -2575,8 +2575,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    default);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(locationRepository,
                     timePeriodService);
@@ -2996,8 +2995,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    default);
+                    originalFileId: originalFile.Id);
 
                 result.AssertBadRequest(ReplacementImportMustBeComplete);
 
@@ -3077,8 +3075,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                         releaseVersionId: releaseVersion.Id,
-                        originalFileId: originalReleaseFile.FileId,
-                        default);
+                        originalFileId: originalReleaseFile.FileId);
 
                 result.AssertNotFound();
             }
@@ -3155,8 +3152,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalReleaseFile.FileId,
-                    default);
+                    originalFileId: originalReleaseFile.FileId);
 
                 result.AssertNotFound();
             }
@@ -3282,8 +3278,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    default);
+                    originalFileId: originalFile.Id);
 
                 if (enableReplacementOfPublicApiDataSets)
                 {
@@ -3734,8 +3729,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    default);
+                    originalFileId: originalFile.Id);
 
                 result.AssertRight();
 
@@ -4252,8 +4246,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    default);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(privateBlobCacheService,
                     cacheKeyService,
@@ -4635,8 +4628,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    default);
+                    originalFileId: originalFile.Id);
 
                 result.AssertRight();
 
@@ -4933,8 +4925,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    default);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(privateBlobCacheService,
                     cacheKeyService,
@@ -5148,8 +5139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    default);
+                    originalFileId: originalFile.Id);
 
                 result.AssertRight();
 
@@ -5348,8 +5338,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: contentRelease.Id,
-                    originalFileId: originalFile.Id,
-                    default);
+                    originalFileId: originalFile.Id);
 
                 result.AssertRight();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -2575,7 +2575,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id);
+                    originalFileId: originalFile.Id,
+                    default);
 
                 VerifyAllMocks(locationRepository,
                     timePeriodService);
@@ -2653,7 +2654,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                         releaseVersionId: releaseVersion.Id,
-                        originalFileId: originalReleaseFile.FileId);
+                        originalFileId: originalReleaseFile.FileId,
+                        default);
 
                 result.AssertNotFound();
             }
@@ -2730,7 +2732,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalReleaseFile.FileId);
+                    originalFileId: originalReleaseFile.FileId,
+                    default);
 
                 result.AssertNotFound();
             }
@@ -2851,7 +2854,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id);
+                    originalFileId: originalFile.Id,
+                    default);
 
                 if (enableReplacementOfPublicApiDataSets)
                 {
@@ -3296,7 +3300,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id);
+                    originalFileId: originalFile.Id,
+                    default);
 
                 VerifyAllMocks(privateBlobCacheService,
                     cacheKeyService,
@@ -3806,7 +3811,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id);
+                    originalFileId: originalFile.Id,
+                    default);
 
                 VerifyAllMocks(privateBlobCacheService,
                     cacheKeyService,
@@ -4181,7 +4187,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id);
+                    originalFileId: originalFile.Id,
+                    default);
 
                 VerifyAllMocks(privateBlobCacheService,
                     cacheKeyService,
@@ -4471,7 +4478,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id);
+                    originalFileId: originalFile.Id,
+                    default);
 
                 VerifyAllMocks(privateBlobCacheService,
                     cacheKeyService,
@@ -4678,7 +4686,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id);
+                    originalFileId: originalFile.Id,
+                    default);
 
                 VerifyAllMocks(locationRepository,
                     releaseVersionService,
@@ -4871,7 +4880,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: contentRelease.Id,
-                    originalFileId: originalFile.Id);
+                    originalFileId: originalFile.Id,
+                    default);
 
                 VerifyAllMocks(locationRepository,
                     releaseVersionService,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -65,7 +65,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 File = new File
                 {
                     Type = FileType.Data,
-                    SubjectId = Guid.NewGuid()
+                    SubjectId = Guid.NewGuid(),
+                    ReplacedById = Guid.NewGuid(), // nonexistent fileId
                 }
             };
 
@@ -87,8 +88,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.GetReplacementPlan(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalReleaseFile.FileId,
-                    replacementFileId: Guid.NewGuid());
+                    originalFileId: originalReleaseFile.FileId);
 
                 result.AssertNotFound();
             }
@@ -99,23 +99,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var releaseVersion = _fixture.DefaultReleaseVersion().Generate();
 
-            var replacementReleaseFile = new ReleaseFile
-            {
-                ReleaseVersion = releaseVersion,
-                File = new File
-                {
-                    Type = FileType.Data,
-                    SubjectId = Guid.NewGuid()
-                }
-            };
-
             var contentDbContextId = Guid.NewGuid().ToString();
             var statisticsDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 contentDbContext.ReleaseVersions.AddRange(releaseVersion);
-                contentDbContext.ReleaseFiles.AddRange(replacementReleaseFile);
                 await contentDbContext.SaveChangesAsync();
             }
 
@@ -127,8 +116,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.GetReplacementPlan(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: Guid.NewGuid(),
-                    replacementFileId: replacementReleaseFile.FileId);
+                    originalFileId: Guid.NewGuid());
 
                 result.AssertNotFound();
             }
@@ -140,14 +128,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var originalFile = new File
             {
                 Type = FileType.Data,
-                SubjectId = Guid.NewGuid()
+                SubjectId = Guid.NewGuid(),
             };
 
             var replacementFile = new File
             {
                 Type = FileType.Data,
                 SubjectId = Guid.NewGuid(),
+                Replacing = originalFile,
             };
+
+            originalFile.ReplacedBy = replacementFile;
 
             var contentDbContextId = Guid.NewGuid().ToString();
             var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -166,8 +157,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.GetReplacementPlan(
                     releaseVersionId: Guid.NewGuid(),
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 result.AssertNotFound();
             }
@@ -221,8 +211,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.GetReplacementPlan(
                     releaseVersionId: release1.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 result.AssertNotFound();
             }
@@ -251,8 +240,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var replacementFile = new File
             {
                 Type = FileType.Data,
-                SubjectId = replacementReleaseSubject.SubjectId
+                SubjectId = replacementReleaseSubject.SubjectId,
+                Replacing = originalFile,
             };
+
+            originalFile.ReplacedBy = replacementFile;
 
             var originalReleaseFile = new ReleaseFile
             {
@@ -303,8 +295,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.GetReplacementPlan(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(locationRepository,
                     timePeriodService);
@@ -343,8 +334,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var replacementFile = new File
             {
                 Type = FileType.Data,
-                SubjectId = replacementReleaseSubject.SubjectId
+                SubjectId = replacementReleaseSubject.SubjectId,
+                Replacing = originalFile,
             };
+
+            originalFile.ReplacedBy = replacementFile;
 
             var originalReleaseFile = new ReleaseFile
             {
@@ -559,8 +553,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.GetReplacementPlan(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(locationRepository,
                     timePeriodService);
@@ -776,14 +769,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var originalFile = new File
             {
                 Type = FileType.Data,
-                SubjectId = originalReleaseSubject.SubjectId
+                SubjectId = originalReleaseSubject.SubjectId,
             };
 
             var replacementFile = new File
             {
                 Type = FileType.Data,
-                SubjectId = replacementReleaseSubject.SubjectId
+                SubjectId = replacementReleaseSubject.SubjectId,
+                Replacing = originalFile,
             };
+
+            originalFile.ReplacedBy = replacementFile;
 
             var originalReleaseFile = new ReleaseFile
             {
@@ -970,8 +966,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.GetReplacementPlan(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(locationRepository,
                     timePeriodService);
@@ -1003,14 +998,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var originalFile = new File
             {
                 Type = FileType.Data,
-                SubjectId = originalReleaseSubject.SubjectId
+                SubjectId = originalReleaseSubject.SubjectId,
             };
 
             var replacementFile = new File
             {
                 Type = FileType.Data,
-                SubjectId = replacementReleaseSubject.SubjectId
+                SubjectId = replacementReleaseSubject.SubjectId,
+                Replacing = originalFile,
             };
+
+            originalFile.ReplacedBy = replacementFile;
 
             var originalReleaseFile = new ReleaseFile
             {
@@ -1189,8 +1187,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.GetReplacementPlan(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(locationRepository,
                     timePeriodService);
@@ -1228,8 +1225,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var replacementFile = new File
             {
                 Type = FileType.Data,
-                SubjectId = replacementReleaseSubject.SubjectId
+                SubjectId = replacementReleaseSubject.SubjectId,
+                Replacing = originalFile,
             };
+
+            originalFile.ReplacedBy = replacementFile;
 
             var originalReleaseFile = new ReleaseFile
             {
@@ -1434,8 +1434,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.GetReplacementPlan(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(locationRepository,
                     timePeriodService);
@@ -1467,14 +1466,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var originalFile = new File
             {
                 Type = FileType.Data,
-                SubjectId = originalReleaseSubject.SubjectId
+                SubjectId = originalReleaseSubject.SubjectId,
             };
 
             var replacementFile = new File
             {
                 Type = FileType.Data,
-                SubjectId = replacementReleaseSubject.SubjectId
+                SubjectId = replacementReleaseSubject.SubjectId,
+                Replacing = originalFile,
             };
+
+            originalFile.ReplacedBy = replacementFile;
 
             var originalReleaseFile = new ReleaseFile
             {
@@ -1658,8 +1660,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.GetReplacementPlan(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(locationRepository,
                     timePeriodService);
@@ -1764,7 +1765,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             File replacementFile = _fixture
                 .DefaultFile()
                 .WithSubjectId(replacementReleaseSubject.SubjectId)
-                .WithType(FileType.Data);
+                .WithType(FileType.Data)
+                .WithReplacing(originalFile);
+
+            originalFile.ReplacedBy = replacementFile;
 
             var (originalReleaseFile, replacementReleaseFile) = _fixture.DefaultReleaseFile()
                 .WithReleaseVersion(releaseVersion)
@@ -1836,8 +1840,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.GetReplacementPlan(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(dataSetVersionService);
 
@@ -1881,14 +1884,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var originalFile = new File
             {
                 Type = FileType.Data,
-                SubjectId = originalReleaseSubject.SubjectId
+                SubjectId = originalReleaseSubject.SubjectId,
             };
 
             var replacementFile = new File
             {
                 Type = FileType.Data,
-                SubjectId = replacementReleaseSubject.SubjectId
+                SubjectId = replacementReleaseSubject.SubjectId,
+                Replacing = originalFile,
             };
+
+            originalFile.ReplacedBy = replacementFile;
 
             var originalReleaseFile = new ReleaseFile
             {
@@ -2198,8 +2204,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.GetReplacementPlan(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(locationRepository,
                     timePeriodService);
@@ -2570,8 +2575,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(locationRepository,
                     timePeriodService);
@@ -2622,14 +2626,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 File = replacementFile
             };
 
-            var locationRepository = new Mock<ILocationRepository>(Strict);
-            locationRepository.Setup(service => service.GetDistinctForSubject(replacementReleaseSubject.SubjectId))
-                .ReturnsAsync(new List<Location>());
-
-            var timePeriodService = new Mock<ITimePeriodService>(Strict);
-            timePeriodService.Setup(service => service.GetTimePeriods(replacementReleaseSubject.SubjectId))
-                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>());
-
             var contentDbContextId = Guid.NewGuid().ToString();
             var statisticsDbContextId = Guid.NewGuid().ToString();
 
@@ -2651,21 +2647,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                var replacementService = BuildReplacementService(contentDbContext,
-                    statisticsDbContext,
-                    locationRepository: locationRepository.Object,
-                    timePeriodService: timePeriodService.Object);
+                var replacementService = BuildReplacementService(
+                    contentDbContext: contentDbContext,
+                    statisticsDbContext: statisticsDbContext);
 
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                    replacementService.Replace(
+                var result = await replacementService.Replace(
                         releaseVersionId: releaseVersion.Id,
-                        originalFileId: originalReleaseFile.FileId,
-                        replacementFileId: replacementReleaseFile.FileId));
+                        originalFileId: originalReleaseFile.FileId);
 
-                VerifyAllMocks(locationRepository,
-                    timePeriodService);
-
-                Assert.Equal("Original file has no link with the replacement file", exception.Message);
+                result.AssertNotFound();
             }
         }
 
@@ -2713,14 +2703,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 File = replacementFile
             };
 
-            var locationRepository = new Mock<ILocationRepository>(Strict);
-            locationRepository.Setup(service => service.GetDistinctForSubject(replacementReleaseSubject.SubjectId))
-                .ReturnsAsync(new List<Location>());
-
-            var timePeriodService = new Mock<ITimePeriodService>(Strict);
-            timePeriodService.Setup(service => service.GetTimePeriods(replacementReleaseSubject.SubjectId))
-                .ReturnsAsync(new List<(int Year, TimeIdentifier TimeIdentifier)>());
-
             var contentDbContextId = Guid.NewGuid().ToString();
             var statisticsDbContextId = Guid.NewGuid().ToString();
 
@@ -2742,21 +2724,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                var replacementService = BuildReplacementService(contentDbContext,
-                    statisticsDbContext,
-                    locationRepository: locationRepository.Object,
-                    timePeriodService: timePeriodService.Object);
+                var replacementService = BuildReplacementService(
+                    contentDbContext: contentDbContext,
+                    statisticsDbContext: statisticsDbContext);
 
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                    replacementService.Replace(
-                        releaseVersionId: releaseVersion.Id,
-                        originalFileId: originalReleaseFile.FileId,
-                        replacementFileId: replacementReleaseFile.FileId));
+                var result = await replacementService.Replace(
+                    releaseVersionId: releaseVersion.Id,
+                    originalFileId: originalReleaseFile.FileId);
 
-                VerifyAllMocks(locationRepository,
-                    timePeriodService);
-
-                Assert.Equal("Replacement file has no link with the original file", exception.Message);
+                result.AssertNotFound();
             }
         }
 
@@ -2792,11 +2768,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             File originalFile = _fixture
                 .DefaultFile()
-                .WithReplacedBy(replacementFile).WithReplacedById(replacementFile.Id)
+                .WithReplacedBy(replacementFile)
                 .WithSubjectId(originalReleaseSubject.SubjectId)
                 .WithType(FileType.Data);
 
-            replacementFile.ReplacingId = originalFile.Id;
+            replacementFile.Replacing = originalFile;
 
             var (originalReleaseFile, replacementReleaseFile) = _fixture.DefaultReleaseFile()
                 .WithReleaseVersion(releaseVersion)
@@ -2844,8 +2820,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 EnableReplacementOfPublicApiDataSets = enableReplacementOfPublicApiDataSets
             });
             
-            var contentDbContextId = Guid.NewGuid().ToString();
-            var statisticsDbContextId = Guid.NewGuid().ToString();
             var releaseVersionService = new Mock<IReleaseVersionService>(Strict);
             if (enableReplacementOfPublicApiDataSets)
             {
@@ -2853,6 +2827,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReturnsAsync(Unit.Instance);
             }
 
+            var contentDbContextId = Guid.NewGuid().ToString();
+            var statisticsDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 contentDbContext.ReleaseVersions.Add(releaseVersion);
@@ -2875,9 +2851,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
-              
+                    originalFileId: originalFile.Id);
+
                 if (enableReplacementOfPublicApiDataSets)
                 {
                     VerifyAllMocks(
@@ -2922,7 +2897,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Type = FileType.Data,
                 SubjectId = replacementReleaseSubject.SubjectId,
-                Replacing = originalFile
+                Replacing = originalFile,
             };
 
             originalFile.ReplacedBy = replacementFile;
@@ -3321,8 +3296,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(privateBlobCacheService,
                     cacheKeyService,
@@ -3832,8 +3806,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(privateBlobCacheService,
                     cacheKeyService,
@@ -4208,8 +4181,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(privateBlobCacheService,
                     cacheKeyService,
@@ -4499,8 +4471,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(privateBlobCacheService,
                     cacheKeyService,
@@ -4707,8 +4678,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: releaseVersion.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(locationRepository,
                     releaseVersionService,
@@ -4901,8 +4871,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await replacementService.Replace(
                     releaseVersionId: contentRelease.Id,
-                    originalFileId: originalFile.Id,
-                    replacementFileId: replacementFile.Id);
+                    originalFileId: originalFile.Id);
 
                 VerifyAllMocks(locationRepository,
                     releaseVersionService,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataReplacementController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataReplacementController.cs
@@ -14,21 +14,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
 [Route("api")]
 [Authorize]
 [ApiController]
-public class DataReplacementController : ControllerBase
+public class DataReplacementController(
+    IReplacementService replacementService,
+    IReplacementBatchService replacementBatchService)
+    : ControllerBase
 {
-    private readonly IReplacementService _replacementService;
-
-    public DataReplacementController(IReplacementService replacementService)
-    {
-        _replacementService = replacementService;
-    }
-
     [HttpGet("releases/{releaseVersionId:guid}/data/{originalFileId:guid}/replacement-plan")]
     public async Task<ActionResult<DataReplacementPlanViewModel>> GetReplacementPlan(Guid releaseVersionId,
         Guid originalFileId,
         CancellationToken cancellationToken = default)
     {
-        return await _replacementService.GetReplacementPlan(
+        return await replacementService.GetReplacementPlan(
                 releaseVersionId: releaseVersionId,
                 originalFileId: originalFileId,
                 cancellationToken: cancellationToken
@@ -43,7 +39,7 @@ public class DataReplacementController : ControllerBase
         [FromBody] ReplacementRequest request,
         CancellationToken cancellationToken = default)
     {
-        return await _replacementService.Replace(
+        return await replacementBatchService.Replace(
                 releaseVersionId: releaseVersionId,
                 originalFileIds: request.OriginalFileIds,
                 cancellationToken: cancellationToken

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataReplacementController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataReplacementController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -36,15 +37,15 @@ public class DataReplacementController : ControllerBase
             .HandleFailuresOrOk();
     }
 
-    [HttpPost("releases/{releaseVersionId:guid}/data/{originalFileId:guid}/replacement")]
+    [HttpPost("releases/{releaseVersionId:guid}/data/replacements")]
     public async Task<ActionResult<Unit>> Replace(
-        Guid releaseVersionId,
-        Guid originalFileId,
+        [FromRoute] Guid releaseVersionId,
+        [FromBody] ReplacementRequest request,
         CancellationToken cancellationToken = default)
     {
         return await _replacementService.Replace(
                 releaseVersionId: releaseVersionId,
-                originalFileIds: [originalFileId], // @MarkFix turn into a list
+                originalFileIds: request.OriginalFileIds,
                 cancellationToken: cancellationToken
             )
             .HandleFailuresOrOk();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataReplacementController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataReplacementController.cs
@@ -37,11 +37,15 @@ public class DataReplacementController : ControllerBase
     }
 
     [HttpPost("releases/{releaseVersionId:guid}/data/{originalFileId:guid}/replacement")]
-    public async Task<ActionResult<Unit>> Replace(Guid releaseVersionId, Guid originalFileId)
+    public async Task<ActionResult<Unit>> Replace(
+        Guid releaseVersionId,
+        Guid originalFileId,
+        CancellationToken cancellationToken = default)
     {
         return await _replacementService.Replace(
                 releaseVersionId: releaseVersionId,
-                originalFileId: originalFileId // @MarkFix turn into a list
+                originalFileId: originalFileId, // @MarkFix turn into a list
+                cancellationToken: cancellationToken
             )
             .HandleFailuresOrOk();
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataReplacementController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataReplacementController.cs
@@ -8,47 +8,41 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
+
+[Route("api")]
+[Authorize]
+[ApiController]
+public class DataReplacementController : ControllerBase
 {
-    [Route("api")]
-    [Authorize]
-    [ApiController]
-    public class DataReplacementController : ControllerBase
+    private readonly IReplacementService _replacementService;
+
+    public DataReplacementController(IReplacementService replacementService)
     {
-        private readonly IReplacementService _replacementService;
+        _replacementService = replacementService;
+    }
 
-        public DataReplacementController(IReplacementService replacementService)
-        {
-            _replacementService = replacementService;
-        }
+    [HttpGet("releases/{releaseVersionId:guid}/data/{originalFileId:guid}/replacement-plan")]
+    public async Task<ActionResult<DataReplacementPlanViewModel>> GetReplacementPlan(Guid releaseVersionId,
+        Guid originalFileId,
+        CancellationToken cancellationToken = default)
+    {
+        return await _replacementService.GetReplacementPlan(
+                releaseVersionId: releaseVersionId,
+                originalFileId: originalFileId,
+                cancellationToken: cancellationToken
+            )
+            .OnSuccess(plan => plan.ToSummary())
+            .HandleFailuresOrOk();
+    }
 
-        [HttpGet("releases/{releaseVersionId:guid}/data/{fileId:guid}/replacement-plan/{replacementFileId:guid}")]
-        public async Task<ActionResult<DataReplacementPlanViewModel>> GetReplacementPlan(Guid releaseVersionId,
-            Guid fileId,
-            Guid replacementFileId,
-            CancellationToken cancellationToken = default)
-        {
-            return await _replacementService.GetReplacementPlan(
-                    releaseVersionId: releaseVersionId,
-                    originalFileId: fileId,
-                    replacementFileId: replacementFileId,
-                    cancellationToken: cancellationToken
-                )
-                .OnSuccess(plan => plan.ToSummary())
-                .HandleFailuresOrOk();
-        }
-
-        [HttpPost("releases/{releaseVersionId:guid}/data/{fileId:guid}/replacement/{replacementFileId:guid}")]
-        public async Task<ActionResult<Unit>> Replace(Guid releaseVersionId,
-            Guid fileId,
-            Guid replacementFileId)
-        {
-            return await _replacementService.Replace(
-                    releaseVersionId: releaseVersionId,
-                    originalFileId: fileId,
-                    replacementFileId: replacementFileId
-                )
-                .HandleFailuresOrOk();
-        }
+    [HttpPost("releases/{releaseVersionId:guid}/data/{originalFileId:guid}/replacement")]
+    public async Task<ActionResult<Unit>> Replace(Guid releaseVersionId, Guid originalFileId)
+    {
+        return await _replacementService.Replace(
+                releaseVersionId: releaseVersionId,
+                originalFileId: originalFileId // @MarkFix turn into a list
+            )
+            .HandleFailuresOrOk();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataReplacementController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataReplacementController.cs
@@ -44,7 +44,7 @@ public class DataReplacementController : ControllerBase
     {
         return await _replacementService.Replace(
                 releaseVersionId: releaseVersionId,
-                originalFileId: originalFileId, // @MarkFix turn into a list
+                originalFileIds: [originalFileId], // @MarkFix turn into a list
                 cancellationToken: cancellationToken
             )
             .HandleFailuresOrOk();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReplacementRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReplacementRequest.cs
@@ -1,0 +1,10 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+
+public class ReplacementRequest
+{
+    public List<Guid> OriginalFileIds { get; set; } = [];
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementBatchService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementBatchService.cs
@@ -6,13 +6,11 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+
+public interface IReplacementBatchService
 {
-    public interface IReplacementBatchService
-    {
-        Task<Either<ActionResult, Unit>> Replace(
-            Guid releaseVersionId,
-            List<Guid> originalFileIds,
-            CancellationToken cancellationToken);
-    }
+    Task<Either<ActionResult, Unit>> Replace(Guid releaseVersionId,
+        IEnumerable<Guid> originalFileIds,
+        CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementBatchService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementBatchService.cs
@@ -1,23 +1,18 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
-    public interface IReplacementService
+    public interface IReplacementBatchService
     {
-        Task<Either<ActionResult, DataReplacementPlanViewModel>> GetReplacementPlan(
-            Guid releaseVersionId,
-            Guid originalFileId,
-            CancellationToken cancellationToken = default);
-
         Task<Either<ActionResult, Unit>> Replace(
             Guid releaseVersionId,
-            Guid originalFileId,
+            List<Guid> originalFileIds,
             CancellationToken cancellationToken);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementService.cs
@@ -18,6 +18,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, Unit>> Replace(
             Guid releaseVersionId,
             Guid originalFileId,
-            CancellationToken cancellationToken);
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementService.cs
@@ -17,6 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, Unit>> Replace(
             Guid releaseVersionId,
-            Guid originalFileId);
+            Guid originalFileId,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementService.cs
@@ -13,12 +13,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, DataReplacementPlanViewModel>> GetReplacementPlan(
             Guid releaseVersionId,
             Guid originalFileId,
-            Guid replacementFileId,
             CancellationToken cancellationToken = default);
 
         Task<Either<ActionResult, Unit>> Replace(
             Guid releaseVersionId,
-            Guid originalFileId,
-            Guid replacementFileId);
+            Guid originalFileId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementService.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
@@ -17,7 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, Unit>> Replace(
             Guid releaseVersionId,
-            Guid originalFileId,
+            List<Guid> originalFileIds,
             CancellationToken cancellationToken);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementBatchService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementBatchService.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -16,85 +17,64 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.Validat
 using Unit = GovUk.Education.ExploreEducationStatistics.Common.Model.Unit;
 using ValidationUtils = GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+public class ReplacementBatchService(
+    ContentDbContext contentDbContext,
+    IUserService userService,
+    IReplacementService replacementService) : IReplacementBatchService
 {
-    public class ReplacementBatchService(
-        ContentDbContext contentDbContext,
-        IUserService userService,
-        IReplacementService replacementService)
-        : IReplacementBatchService
+    public async Task<Either<ActionResult, Unit>> Replace(Guid releaseVersionId,
+        IEnumerable<Guid> originalFileIds,
+        CancellationToken cancellationToken = default)
     {
-        public async Task<Either<ActionResult, Unit>> Replace(
-            Guid releaseVersionId,
-            List<Guid> originalFileIds,
-            CancellationToken cancellationToken)
-        {
-            return await contentDbContext.ReleaseVersions
-                .FirstOrNotFoundAsync(rv => rv.Id == releaseVersionId,
-                    cancellationToken: cancellationToken)
-                .OnSuccess(userService.CheckCanUpdateReleaseVersion)
-                .OnSuccess(async _ =>
+        return await contentDbContext.ReleaseVersions
+            .FirstOrNotFoundAsync(rv => rv.Id == releaseVersionId, cancellationToken: cancellationToken)
+            .OnSuccess(userService.CheckCanUpdateReleaseVersion)
+            .OnSuccess(async _ =>
+            {
+                var errors = new List<ErrorViewModel>();
+
+                foreach (var originalFileId in originalFileIds)
                 {
-                    var errors = new List<ErrorViewModel>();
+                    var replacementResult = await replacementService.Replace(
+                        releaseVersionId: releaseVersionId,
+                        originalFileId: originalFileId,
+                        cancellationToken);
 
-                    foreach (var originalFileId in originalFileIds)
+                    if (replacementResult.IsLeft)
                     {
-                        var replacementResult = await replacementService.Replace(
-                            releaseVersionId: releaseVersionId,
-                            originalFileId: originalFileId,
-                            cancellationToken);
-
-                        if (replacementResult.IsLeft)
-                        {
-                            var error = GetReplaceError(replacementResult.Left, originalFileId);
-                            errors.Add(error);
-                        }
+                        var error = GetReplaceError(replacementResult.Left, originalFileId);
+                        errors.Add(error);
                     }
+                }
 
-                    if (errors.Count > 0)
-                    {
-                        return new Either<ActionResult, Unit>(ValidationUtils.ValidationResult(errors));
-                    }
+                if (errors.Count > 0)
+                {
+                    return new Either<ActionResult, Unit>(ValidationUtils.ValidationResult(errors));
+                }
 
-                    return Unit.Instance;
+                return Unit.Instance;
+            });
+    }
 
-                });
+    private ErrorViewModel GetReplaceError(ActionResult actionResult, Guid originalFileId)
+    {
+        if (IsNotFound(actionResult))
+        {
+            return ValidationMessages.GenerateErrorReplacementNotFound(originalFileId);
         }
 
-        private ErrorViewModel GetReplaceError(ActionResult actionResult, Guid originalFileId)
+        if (HasValidationError(actionResult, ReplacementMustBeValid))
         {
-            if (IsNotFound(actionResult))
-            {
-                return new ErrorViewModel
-                {
-                    Code = "ReplacementNotFound",
-                    Message = $"Linked original and replacement file(s) not found. OriginalFileId: {originalFileId}",
-                };
-            }
-
-            if (HasValidationError(actionResult, ReplacementMustBeValid))
-            {
-                return new ErrorViewModel
-                {
-                    Code = "ReplacementMustBeValid",
-                    Message = $"Replacement not valid. OriginalFileId: {originalFileId}",
-                };
-            }
-
-            if (HasValidationError(actionResult, ReplacementImportMustBeComplete))
-            {
-                return new ErrorViewModel
-                {
-                    Code = "ReplacementImportMustBeComplete",
-                    Message = $"Replacement import not complete. OriginalFileId: {originalFileId}",
-                };
-            }
-
-            return new ErrorViewModel
-            {
-                Code = "ReplacementError",
-                Message = $"Replacement error. OriginalFileId: {originalFileId}",
-            };
+            return ValidationMessages.GenerateErrorReplacementMustBeValid(originalFileId);
         }
+
+        if (HasValidationError(actionResult, ReplacementImportMustBeComplete))
+        {
+            return ValidationMessages.GenerateErrorReplacementImportMustBeComplete(originalFileId);
+        }
+
+        return ValidationMessages.GenerateErrorReplacementError(originalFileId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementBatchService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementBatchService.cs
@@ -1,0 +1,100 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Mvc;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
+using Unit = GovUk.Education.ExploreEducationStatistics.Common.Model.Unit;
+using ValidationUtils = GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
+{
+    public class ReplacementBatchService(
+        ContentDbContext contentDbContext,
+        IUserService userService,
+        IReplacementService replacementService)
+        : IReplacementBatchService
+    {
+        public async Task<Either<ActionResult, Unit>> Replace(
+            Guid releaseVersionId,
+            List<Guid> originalFileIds,
+            CancellationToken cancellationToken)
+        {
+            return await contentDbContext.ReleaseVersions
+                .FirstOrNotFoundAsync(rv => rv.Id == releaseVersionId,
+                    cancellationToken: cancellationToken)
+                .OnSuccess(userService.CheckCanUpdateReleaseVersion)
+                .OnSuccess(async _ =>
+                {
+                    var errors = new List<ErrorViewModel>();
+
+                    foreach (var originalFileId in originalFileIds)
+                    {
+                        var replacementResult = await replacementService.Replace(
+                            releaseVersionId: releaseVersionId,
+                            originalFileId: originalFileId,
+                            cancellationToken);
+
+                        if (replacementResult.IsLeft)
+                        {
+                            var error = GetReplaceError(replacementResult.Left, originalFileId);
+                            errors.Add(error);
+                        }
+                    }
+
+                    if (errors.Count > 0)
+                    {
+                        return new Either<ActionResult, Unit>(ValidationUtils.ValidationResult(errors));
+                    }
+
+                    return Unit.Instance;
+
+                });
+        }
+
+        private ErrorViewModel GetReplaceError(ActionResult actionResult, Guid originalFileId)
+        {
+            if (IsNotFound(actionResult))
+            {
+                return new ErrorViewModel
+                {
+                    Code = "ReplacementNotFound",
+                    Message = $"Linked original and replacement file(s) not found. OriginalFileId: {originalFileId}",
+                };
+            }
+
+            if (HasValidationError(actionResult, ReplacementMustBeValid))
+            {
+                return new ErrorViewModel
+                {
+                    Code = "ReplacementMustBeValid",
+                    Message = $"Replacement not valid. OriginalFileId: {originalFileId}",
+                };
+            }
+
+            if (HasValidationError(actionResult, ReplacementImportMustBeComplete))
+            {
+                return new ErrorViewModel
+                {
+                    Code = "ReplacementImportMustBeComplete",
+                    Message = $"Replacement import not complete. OriginalFileId: {originalFileId}",
+                };
+            }
+
+            return new ErrorViewModel
+            {
+                Code = "ReplacementError",
+                Message = $"Replacement error. OriginalFileId: {originalFileId}",
+            };
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -59,21 +59,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, DataReplacementPlanViewModel>> GetReplacementPlan(
             Guid releaseVersionId,
             Guid originalFileId,
-            Guid replacementFileId,
             CancellationToken cancellationToken = default)
         {
             return await contentDbContext.ReleaseVersions
                 .FirstOrNotFoundAsync(rv => rv.Id == releaseVersionId, cancellationToken: cancellationToken)
                 .OnSuccess(userService.CheckCanUpdateReleaseVersion)
-                .OnSuccess(() => CheckReleaseFilesExist(releaseVersionId: releaseVersionId,
-                    originalFileId: originalFileId,
-                    replacementFileId: replacementFileId))
+                .OnSuccess(() => CheckLinkedOriginalAndReplacementReleaseFilesExist(
+                        releaseVersionId: releaseVersionId,
+                        originalFileId: originalFileId))
                 .OnSuccess(async tuple =>
                 {
-                    var (originalReleaseFile, replacementReleaseFile) = tuple;
+                    var originalReleaseFile = tuple.originalReleaseFile;
+                    var replacementReleaseFile = tuple.replacementReleaseFile;
 
-                    return await GetLinkedDataSetVersion(featureFlags.Value.EnableReplacementOfPublicApiDataSets ? replacementReleaseFile : originalReleaseFile, cancellationToken)
-                        .OnSuccess(replacementApiDataSetVersion => (originalReleaseFile, replacementReleaseFile, replacementApiDataSetVersion));
+                    return await GetLinkedDataSetVersion( // @MarkFix pull out this and below into GenerateReplacementPlan method
+                            featureFlags.Value.EnableReplacementOfPublicApiDataSets
+                                ? replacementReleaseFile
+                                : originalReleaseFile,
+                            cancellationToken)
+                        .OnSuccess(replacementApiDataSetVersion =>
+                            (originalReleaseFile, replacementReleaseFile, replacementApiDataSetVersion));
                 })
                 .OnSuccess(async tuple =>
                 {
@@ -85,14 +90,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     var replacementSubjectMeta = await GetReplacementSubjectMeta(replacementSubjectId);
 
-                    var dataBlocks = ValidateDataBlocks(releaseVersionId: releaseVersionId,
+                    var dataBlocks = ValidateDataBlocks(
+                        releaseVersionId: releaseVersionId,
                         subjectId: originalSubjectId,
                         replacementSubjectMeta);
-                    var footnotes = await ValidateFootnotes(releaseVersionId: releaseVersionId,
+                    var footnotes = await ValidateFootnotes(
+                        releaseVersionId: releaseVersionId,
                         subjectId: originalSubjectId,
                         replacementSubjectMeta);
 
-                    var apiDataSetVersionPlan = tuple.replacementApiDataSetVersion is null ? null 
+                    var apiDataSetVersionPlan = tuple.replacementApiDataSetVersion is null
+                        ? null
                         : await GetApiVersionPlanViewModel(tuple.replacementApiDataSetVersion, cancellationToken);
 
                     return new DataReplacementPlanViewModel
@@ -104,8 +112,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         ReplacementSubjectId = replacementSubjectId,
                     };
                 });
-
-            
         }
         
         private async Task<ReplaceApiDataSetVersionPlanViewModel?> GetApiVersionPlanViewModel(DataSetVersion replacementApiDataSetVersion, CancellationToken cancellationToken)
@@ -137,58 +143,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 LocationsComplete = true,
                 LocationsHaveMajorChange = false,
                 HasDeletionChanges = false
-            }; 
-            
+            };
+
             return apiDataSetVersionPlan with
             {
-                MappingStatus = mappingStatus 
-                                ?? (apiDataSetVersionPlan.ReadyToPublish 
-                                    ? completeStatusResult 
-                                    : null),// If no mapping is found, this data set version was deleted and recreated (& no mapping was necessary)  
-                Valid = (isPatch 
-                            ? mappingStatus is { IsMajorVersionUpdate: false } && apiDataSetVersionPlan.ReadyToPublish 
-                            : apiDataSetVersionPlan.ReadyToPublish) 
+                MappingStatus = mappingStatus
+                                ?? (apiDataSetVersionPlan.ReadyToPublish
+                                    ? completeStatusResult
+                                    : null),// If no mapping is found, this data set version was deleted and recreated (& no mapping was necessary)
+                Valid = (isPatch
+                            ? mappingStatus is { IsMajorVersionUpdate: false } && apiDataSetVersionPlan.ReadyToPublish
+                            : apiDataSetVersionPlan.ReadyToPublish)
                         || (mappingStatus is null && apiDataSetVersionPlan.ReadyToPublish) // Data set version was deleted and recreated (as opposed to as a patch increment of a previous data set version)
             };
         }
         
         public async Task<Either<ActionResult, Unit>> Replace(
             Guid releaseVersionId,
-            Guid originalFileId,
-            Guid replacementFileId)
+            Guid originalFileId)
         {
-            return await GetReplacementPlan(releaseVersionId, originalFileId, replacementFileId)
+            return await GetReplacementPlan(
+                    releaseVersionId: releaseVersionId,
+                    originalFileId: originalFileId)
                 .OnSuccessDo<ActionResult, DataReplacementPlanViewModel, Unit>(plan =>
                     !plan.Valid ? ValidationActionResult(ReplacementMustBeValid) : Unit.Instance)
-                .OnSuccessCombineWith(_ => CheckReleaseFilesExist(releaseVersionId: releaseVersionId,
-                    originalFileId: originalFileId,
-                    replacementFileId: replacementFileId))
-                .OnSuccess(planAndReleaseFiles =>
-                {
-                    var (plan, (originalReleaseFile, replacementReleaseFile)) = planAndReleaseFiles;
-
-                    // It should be possible to replace a file with any other file provided there is a valid plan,
-                    // but we want to ensure that the replacement file has been created through the designated process.
-                    // The replacement upload process links the replacement file to the original, allowing us to
-                    // identify files with ongoing data replacements and filter out replacement files from the regular
-                    // data files view.
-                    if (originalReleaseFile.File.ReplacedById != replacementFileId)
-                    {
-                        throw new InvalidOperationException(
-                            "Original file has no link with the replacement file");
-                    }
-
-                    if (replacementReleaseFile.File.ReplacingId != originalFileId)
-                    {
-                        throw new InvalidOperationException(
-                            "Replacement file has no link with the original file");
-                    }
-
-                    return (plan, originalReleaseFile, replacementReleaseFile);
-                })
+                .OnSuccessCombineWith(_ => CheckLinkedOriginalAndReplacementReleaseFilesExist(
+                    releaseVersionId: releaseVersionId,
+                    originalFileId: originalFileId))
                 .OnSuccess(async planAndReleaseFiles =>
                 {
-                    var (plan, originalReleaseFile, replacementReleaseFile) = planAndReleaseFiles;
+                    var (plan, (originalReleaseFile, replacementReleaseFile)) = planAndReleaseFiles;
 
                     var originalSubjectId = plan.OriginalSubjectId;
                     var replacementSubjectId = plan.ReplacementSubjectId;
@@ -211,14 +195,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     replacementReleaseFile.IndicatorSequence =
                         await ReplaceIndicatorSequence(originalReleaseFile, replacementReleaseFile);
 
-                    // Replace data guidance
-                    replacementReleaseFile.Summary = originalReleaseFile.Summary;
+                    replacementReleaseFile.Summary = originalReleaseFile.Summary; // Set Data guidance
+
+                    // To remove original, we first unlink the files. If we don't do this,
+                    // ReleaseVersionService.RemoveDataFiles will remove the replacement file as well!
+                    originalReleaseFile.File.ReplacedById = null;
+                    replacementReleaseFile.File.ReplacingId = null;
 
                     await contentDbContext.SaveChangesAsync();
-                    await statisticsDbContext.SaveChangesAsync();
+                    await statisticsDbContext.SaveChangesAsync(); // For footnotes
 
-                    return await RemoveOriginalSubjectAndFileFromRelease(releaseVersionId, originalFileId,
-                        replacementFileId);
+                    return await releaseVersionService.RemoveDataFiles(
+                        releaseVersionId: releaseVersionId,
+                        fileId: originalReleaseFile.FileId);
                 });
         }
 
@@ -241,21 +230,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         private async Task<Either<ActionResult, (ReleaseFile originalReleaseFile, ReleaseFile replacementReleaseFile)>>
-            CheckReleaseFilesExist(
-                Guid releaseVersionId,
-                Guid originalFileId,
-                Guid replacementFileId)
+            CheckLinkedOriginalAndReplacementReleaseFilesExist(Guid releaseVersionId, Guid originalFileId)
         {
             return await contentDbContext.ReleaseFiles
                 .Include(rf => rf.File)
-                .FirstOrNotFoundAsync(rf => rf.ReleaseVersionId == releaseVersionId
-                                            && rf.FileId == originalFileId
-                                            && rf.File.Type == FileType.Data)
-                .OnSuccessCombineWith(async _ => await contentDbContext.ReleaseFiles
-                    .Include(rf => rf.File)
-                    .FirstOrNotFoundAsync(rf => rf.ReleaseVersionId == releaseVersionId
-                                                && rf.FileId == replacementFileId
-                                                && rf.File.Type == FileType.Data))
+                .FirstOrNotFoundAsync(originalReleaseFile =>
+                    originalReleaseFile.ReleaseVersionId == releaseVersionId
+                    && originalReleaseFile.FileId == originalFileId
+                    && originalReleaseFile.File.Type == FileType.Data
+                    && originalReleaseFile.File.ReplacedById != null)
+                .OnSuccessCombineWith(async originalReleaseFile =>
+                    await contentDbContext.ReleaseFiles
+                        .Include(rf => rf.File)
+                        .FirstOrNotFoundAsync(replacementReleaseFile =>
+                            replacementReleaseFile.ReleaseVersionId == releaseVersionId
+                            && replacementReleaseFile.FileId == originalReleaseFile.File.ReplacedById
+                            && replacementReleaseFile.File.Type == FileType.Data
+                            && originalReleaseFile.FileId == replacementReleaseFile.File.ReplacingId))
                 .OnSuccess(releaseFiles => releaseFiles.ToValueTuple());
         }
 
@@ -556,7 +547,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             return new TimePeriodRangeReplacementViewModel(
                 start: ValidateTimePeriodForReplacement(
-                    dataBlock.Query.TimePeriod.StartYear,
+                    dataBlock.Query.TimePeriod!.StartYear,
                     dataBlock.Query.TimePeriod.StartCode,
                     replacementSubjectMeta
                 ),
@@ -1245,33 +1236,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 originalIndicatorGroups: originalIndicatorGroups,
                 replacementIndicatorGroups: replacementIndicatorGroups,
                 originalReleaseFile);
-        }
-
-        private async Task<Either<ActionResult, Unit>> RemoveOriginalSubjectAndFileFromRelease(
-            Guid releaseVersionId,
-            Guid originalFileId,
-            Guid replacementFileId)
-        {
-            // First, unlink the original file from the replacement before removing it.
-            // Ordinarily, removing a file from a Release deletes any associated replacement
-            // so that there's no possibility of abandoned replacements being orphaned from their original files.
-            return await CheckReleaseFilesExist(releaseVersionId: releaseVersionId,
-                    originalFileId: originalFileId,
-                    replacementFileId: replacementFileId)
-                .OnSuccess(async releaseFiles =>
-                {
-                    var originalFile = releaseFiles.originalReleaseFile.File;
-                    var replacementFile = releaseFiles.replacementReleaseFile.File;
-
-                    originalFile.ReplacedById = null;
-                    replacementFile.ReplacingId = null;
-
-                    await contentDbContext.SaveChangesAsync();
-
-                    return await releaseVersionService.RemoveDataFiles(
-                        releaseVersionId: releaseVersionId,
-                        fileId: originalFileId);
-                });
         }
 
         private Task<Either<ActionResult, Unit>> InvalidateDataBlockCachedResults(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -17,7 +17,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Options;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
-using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -34,7 +33,6 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.Validat
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using IReleaseVersionService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseVersionService;
 using Unit = GovUk.Education.ExploreEducationStatistics.Common.Model.Unit;
-using ValidationUtils = GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 {
@@ -128,43 +126,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         public async Task<Either<ActionResult, Unit>> Replace(
-            Guid releaseVersionId,
-            List<Guid> originalFileIds,
-            CancellationToken cancellationToken)
-        {
-            return await contentDbContext.ReleaseVersions
-                .FirstOrNotFoundAsync(rv => rv.Id == releaseVersionId,
-                    cancellationToken: cancellationToken)
-                .OnSuccess(userService.CheckCanUpdateReleaseVersion)
-                .OnSuccess(async _ =>
-                {
-                    var errors = new List<ErrorViewModel>();
-
-                    foreach (var originalFileId in originalFileIds)
-                    {
-                        var replacementResult = await Replace(
-                            releaseVersionId: releaseVersionId,
-                            originalFileId: originalFileId,
-                            cancellationToken);
-
-                        if (replacementResult.IsLeft)
-                        {
-                            var error = GetReplaceError(replacementResult.Left, originalFileId);
-                            errors.Add(error);
-                        }
-                    }
-
-                    if (errors.Count > 0)
-                    {
-                        return new Either<ActionResult, Unit>(ValidationUtils.ValidationResult(errors));
-                    }
-
-                    return Unit.Instance;
-
-                });
-        }
-
-        private async Task<Either<ActionResult, Unit>> Replace(
                 Guid releaseVersionId,
                 Guid originalFileId,
                 CancellationToken cancellationToken)
@@ -245,42 +206,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         releaseVersionId: releaseVersionId,
                         fileId: originalReleaseFile.FileId);
                 });
-        }
-
-        private ErrorViewModel GetReplaceError(ActionResult actionResult, Guid originalFileId)
-        {
-            if (IsNotFound(actionResult))
-            {
-                return new ErrorViewModel
-                {
-                    Code = "ReplacementNotFound",
-                    Message = $"Linked original and replacement file(s) not found. OriginalFileId: {originalFileId}",
-                };
-            }
-
-            if (HasValidationError(actionResult, ReplacementMustBeValid))
-            {
-                return new ErrorViewModel
-                {
-                    Code = "ReplacementMustBeValid",
-                    Message = $"Replacement not valid. OriginalFileId: {originalFileId}",
-                };
-            }
-
-            if (HasValidationError(actionResult, ReplacementImportMustBeComplete))
-            {
-                return new ErrorViewModel
-                {
-                    Code = "ReplacementImportMustBeComplete",
-                    Message = $"Replacement import not complete. OriginalFileId: {originalFileId}",
-                };
-            }
-
-            return new ErrorViewModel
-            {
-                Code = "ReplacementError",
-                Message = $"Replacement error. OriginalFileId: {originalFileId}",
-            };
         }
 
         private async Task<Either<ActionResult, DataReplacementPlanViewModel>> GenerateReplacementPlan(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -479,6 +479,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<ICommentService, CommentService>();
             services.AddTransient<IRelatedInformationService, RelatedInformationService>();
             services.AddTransient<IReplacementService, ReplacementService>();
+            services.AddTransient<IReplacementBatchService, ReplacementBatchService>();
             services.AddTransient<IUserRoleService, UserRoleService>();
             services.AddTransient<IUserReleaseRoleService, UserReleaseRoleService>();
             services.AddTransient<IUserPublicationRoleRepository, UserPublicationRoleRepository>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -68,6 +68,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
 
         // Data replacement
         ReplacementMustBeValid,
+        ReplacementImportMustBeComplete,
 
         // Release
         ReleaseTypeInvalid,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -446,4 +447,60 @@ public static class ValidationMessages
         Code: nameof(PreviewTokenExpired),
         Message: "The preview token is expired."
     );
+
+    public static readonly LocalizableMessage ReplacementNotFound = new(
+        Code: nameof(ReplacementNotFound),
+        Message: "Linked original and replacement file(s) not found. OriginalFileId: {0}"
+    );
+
+    public static ErrorViewModel GenerateErrorReplacementNotFound(Guid originalFileId)
+    {
+        return new ErrorViewModel
+        {
+            Code = ReplacementNotFound.Code,
+            Message = string.Format(ReplacementNotFound.Message, originalFileId),
+        };
+    }
+
+    public static readonly LocalizableMessage ReplacementMustBeValid = new(
+        Code: nameof(ReplacementMustBeValid),
+        Message: "Replacement not valid. OriginalFileId: {0}"
+    );
+
+    public static ErrorViewModel GenerateErrorReplacementMustBeValid(Guid originalFileId)
+    {
+        return new ErrorViewModel
+        {
+            Code = ReplacementMustBeValid.Code,
+            Message = string.Format(ReplacementMustBeValid.Message, originalFileId),
+        };
+    }
+
+    public static readonly LocalizableMessage ReplacementImportMustBeComplete = new(
+        Code: nameof(ReplacementImportMustBeComplete),
+        Message: "Replacement import not complete. OriginalFileId: {0}"
+    );
+
+    public static ErrorViewModel GenerateErrorReplacementImportMustBeComplete(Guid originalFileId)
+    {
+        return new ErrorViewModel
+        {
+            Code = ReplacementImportMustBeComplete.Code,
+            Message = string.Format(ReplacementImportMustBeComplete.Message, originalFileId),
+        };
+    }
+
+    public static readonly LocalizableMessage ReplacementError = new(
+        Code: nameof(ReplacementError),
+        Message: "Replacement error. OriginalFileId: {0}"
+    );
+
+    public static ErrorViewModel GenerateErrorReplacementError(Guid originalFileId)
+    {
+        return new ErrorViewModel
+        {
+            Code = ReplacementError.Code,
+            Message = string.Format(ReplacementError.Message, originalFileId),
+        };
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -1,6 +1,8 @@
 #nullable enable
 using System.Collections.Generic;
+using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
@@ -20,6 +22,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         public static Either<ActionResult, T> NotFound<T>()
         {
             return new NotFoundResult();
+        }
+
+        public static bool IsNotFound(ActionResult actionResult)
+        {
+            return actionResult is NotFoundResult;
+        }
+
+        public static bool HasValidationError(ActionResult actionResult, ValidationErrorMessages validationMessage)
+        {
+            var badRequest = actionResult as BadRequestObjectResult;
+            var validationProblem = badRequest?.Value as ValidationProblemViewModel;
+            var validationErrors = validationProblem?.Errors;
+            return validationErrors != null && validationErrors
+                .Select(error => error.Code)
+                .Contains(validationMessage.ToString());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -34,9 +34,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
             var badRequest = actionResult as BadRequestObjectResult;
             var validationProblem = badRequest?.Value as ValidationProblemViewModel;
             var validationErrors = validationProblem?.Errors;
-            return validationErrors != null && validationErrors
-                .Select(error => error.Code)
-                .Contains(validationMessage.ToString());
+            return validationErrors != null
+                   && validationErrors.Any(error => error.Code == validationMessage.ToString());
         }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
@@ -61,7 +61,7 @@ const DataFileReplacementPlan = ({
     retry: reloadPlan,
   } = useAsyncRetry(
     () => dataReplacementService.getReplacementPlan(releaseVersionId, fileId),
-    [releaseVersionId, fileId, replacementFileId], // @MarkFix we want to update the replacement plan if replacementFileId changes?
+    [releaseVersionId, fileId, replacementFileId], // Include replacementFileId because the plan could change even if fileId has not!
   );
 
   const hasInvalidDataBlocks = useMemo<boolean>(

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
@@ -581,10 +581,9 @@ const DataFileReplacementPlan = ({
                 onClick={async () => {
                   toggleSubmitting.on();
 
-                  await dataReplacementService.replaceData(
-                    releaseVersionId,
+                  await dataReplacementService.replaceData(releaseVersionId, [
                     fileId,
-                  );
+                  ]);
 
                   if (onReplacement) {
                     onReplacement();

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
@@ -60,13 +60,8 @@ const DataFileReplacementPlan = ({
     error,
     retry: reloadPlan,
   } = useAsyncRetry(
-    () =>
-      dataReplacementService.getReplacementPlan(
-        releaseVersionId,
-        fileId,
-        replacementFileId,
-      ),
-    [releaseVersionId, fileId, replacementFileId],
+    () => dataReplacementService.getReplacementPlan(releaseVersionId, fileId),
+    [releaseVersionId, fileId, replacementFileId], // @MarkFix we want to update the replacement plan if replacementFileId changes?
   );
 
   const hasInvalidDataBlocks = useMemo<boolean>(
@@ -589,7 +584,6 @@ const DataFileReplacementPlan = ({
                   await dataReplacementService.replaceData(
                     releaseVersionId,
                     fileId,
-                    replacementFileId,
                   );
 
                   if (onReplacement) {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
@@ -49,7 +49,6 @@ export default function DataFilesReplacementTableRow({
     ...dataFileReplacementQueries.getReplacementPlan(
       releaseVersionId,
       dataFile.id,
-      dataFile.replacedBy ?? '',
     ),
     enabled: fetchPlan,
   });
@@ -147,10 +146,9 @@ export default function DataFilesReplacementTableRow({
             {plan?.valid && (
               <ButtonText
                 onClick={async () => {
-                  await dataReplacementService.replaceData(
-                    releaseVersionId,
+                  await dataReplacementService.replaceData(releaseVersionId, [
                     dataFile.id,
-                  );
+                  ]);
 
                   onConfirmAction?.();
                 }}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
@@ -49,6 +49,7 @@ export default function DataFilesReplacementTableRow({
     ...dataFileReplacementQueries.getReplacementPlan(
       releaseVersionId,
       dataFile.id,
+      dataFile.replacedBy ?? '',
     ),
     enabled: fetchPlan,
   });

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
@@ -150,7 +150,6 @@ export default function DataFilesReplacementTableRow({
                   await dataReplacementService.replaceData(
                     releaseVersionId,
                     dataFile.id,
-                    replacementDataFile.id,
                   );
 
                   onConfirmAction?.();

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -76,7 +76,7 @@ export default function ReleaseDataUploadsSection({
 
   // TODO - EES-6244 bulk confirmation of replacements
   //  const validReplacedDataFiles = replacedDataFiles.filter(
-  //   file => file.status === 'COMPLETE',
+  //   file => file.status === 'COMPLETE', // this checks the original file status, not the replacement!
   // );
   // const allowBulkConfirm = validReplacedDataFiles.length > 1;
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -74,7 +74,7 @@ export default function ReleaseDataUploadsSection({
     [allDataFiles],
   );
 
-  // TODO - bulk confirmation of replacements
+  // TODO - EES-6244 bulk confirmation of replacements
   //  const validReplacedDataFiles = replacedDataFiles.filter(
   //   file => file.status === 'COMPLETE',
   // );
@@ -207,7 +207,7 @@ export default function ReleaseDataUploadsSection({
     [releaseVersionId, toggleReordering],
   );
 
-  // TODO - bulk confirmation of replacements
+  // TODO - EES-6244 bulk confirmation of replacements
   // const handleConfirmAllReplacements = () => {};
 
   return (
@@ -261,7 +261,7 @@ export default function ReleaseDataUploadsSection({
                 <Button onClick={toggleReordering.on} variant="secondary">
                   Reorder data files
                 </Button>
-                {/* TODO - bulk confirmation of replacements */}
+                {/* TODO - EES-6244 bulk confirmation of replacements */}
                 {/* {allowBulkConfirm && (
                   <Button onClick={handleConfirmAllReplacements}>
                     Confirm all valid replacements

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
@@ -1488,7 +1488,7 @@ describe('DataReplacementPlan', () => {
 
     expect(dataReplacementService.replaceData).toHaveBeenCalledWith(
       'release-id',
-      'original-file-id',
+      ['original-file-id'],
     );
   });
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
@@ -1464,10 +1464,10 @@ describe('DataReplacementPlan', () => {
       <MemoryRouter>
         <DataFileReplacementPlan
           cancelButton={<button type="button">Cancel</button>}
-          publicationId="publication-1"
-          releaseVersionId="release-1"
-          fileId="file-1"
-          replacementFileId="file-2"
+          publicationId="publication-id"
+          releaseVersionId="release-id"
+          fileId="original-file-id"
+          replacementFileId="replacement-file-id"
         />
       </MemoryRouter>,
     );
@@ -1487,9 +1487,8 @@ describe('DataReplacementPlan', () => {
     );
 
     expect(dataReplacementService.replaceData).toHaveBeenCalledWith(
-      'release-1',
-      'file-1',
-      'file-2',
+      'release-id',
+      'original-file-id',
     );
   });
 

--- a/src/explore-education-statistics-admin/src/queries/dataFileReplacementQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/dataFileReplacementQueries.ts
@@ -2,9 +2,16 @@ import { createQueryKeys } from '@lukemorales/query-key-factory';
 import dataReplacementService from '@admin/services/dataReplacementService';
 
 const dataFileReplacementQueries = createQueryKeys('user', {
-  getReplacementPlan(releaseVersionId: string, dataFileId: string) {
+  getReplacementPlan(
+    releaseVersionId: string,
+    dataFileId: string,
+    // We pass in the replacementDataFileId even though it isn't used in the request, as it is possible someone could
+    // import a replacement, cancel it, and then import a new replacement, but as the dataFileId hasn't changed, could
+    // receive a cached version of the replacement plan. Hence why we include replacementDataFileId in the queryKey
+    replacementDataFileId: string,
+  ) {
     return {
-      queryKey: [dataFileId],
+      queryKey: [dataFileId, replacementDataFileId],
       queryFn: () =>
         dataReplacementService.getReplacementPlan(releaseVersionId, dataFileId),
     };

--- a/src/explore-education-statistics-admin/src/queries/dataFileReplacementQueries.ts
+++ b/src/explore-education-statistics-admin/src/queries/dataFileReplacementQueries.ts
@@ -2,19 +2,11 @@ import { createQueryKeys } from '@lukemorales/query-key-factory';
 import dataReplacementService from '@admin/services/dataReplacementService';
 
 const dataFileReplacementQueries = createQueryKeys('user', {
-  getReplacementPlan(
-    releaseVersionId: string,
-    dataFileId: string,
-    replacementDataFileId: string,
-  ) {
+  getReplacementPlan(releaseVersionId: string, dataFileId: string) {
     return {
-      queryKey: [replacementDataFileId],
+      queryKey: [dataFileId],
       queryFn: () =>
-        dataReplacementService.getReplacementPlan(
-          releaseVersionId,
-          dataFileId,
-          replacementDataFileId,
-        ),
+        dataReplacementService.getReplacementPlan(releaseVersionId, dataFileId),
     };
   },
 });

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -132,10 +132,9 @@ const dataReplacementService = {
     releaseVersionId: string,
     originalFileIds: string[],
   ): Promise<void> {
-    return client.post(
-      `releases/${releaseVersionId}/data/replacements`,
+    return client.post(`releases/${releaseVersionId}/data/replacements`, {
       originalFileIds,
-    );
+    });
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -128,9 +128,13 @@ const dataReplacementService = {
       `releases/${releaseVersionId}/data/${originalFileId}/replacement-plan`,
     );
   },
-  replaceData(releaseVersionId: string, originalFileId: string): Promise<void> {
+  replaceData(
+    releaseVersionId: string,
+    originalFileIds: string[],
+  ): Promise<void> {
     return client.post(
-      `releases/${releaseVersionId}/data/${originalFileId}/replacement`,
+      `releases/${releaseVersionId}/data/replacements`,
+      originalFileIds,
     );
   },
 };

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -122,20 +122,15 @@ export interface DataReplacementPlan {
 const dataReplacementService = {
   getReplacementPlan(
     releaseVersionId: string,
-    fileId: string,
-    replacementFileId: string,
+    originalFileId: string,
   ): Promise<DataReplacementPlan> {
     return client.get(
-      `releases/${releaseVersionId}/data/${fileId}/replacement-plan/${replacementFileId}`,
+      `releases/${releaseVersionId}/data/${originalFileId}/replacement-plan`,
     );
   },
-  replaceData(
-    releaseVersionId: string,
-    fileId: string,
-    replacementFileId: string,
-  ): Promise<void> {
+  replaceData(releaseVersionId: string, originalFileId: string): Promise<void> {
     return client.post(
-      `releases/${releaseVersionId}/data/${fileId}/replacement/${replacementFileId}`,
+      `releases/${releaseVersionId}/data/${originalFileId}/replacement`,
     );
   },
 };


### PR DESCRIPTION
This PR changes the backend's replacement completion endpoint to accept multiple fileIds, allowing the frontend to complete multiple replacements in a single request to the backend.

This ability to complete multiple replacements in a single request isn't yet being utilised. But it will be when the "Confirm all valid replacements" button is added to the Data and files page as part of EES-6244.

The endpoint has been coded such that if multiple replacements are provided and one errors, the others will still be completed. Despite some of them being successfully replaced, the backend endpoint still returns an error for any that have failed. We do this because in the frontend we would expect none to fail, and so would want to be made aware of any issues, so therefore considered it wiser to blow up in this scenario, even if some of the replacements do complete successfully.

I've updated a few things:
- Now the backend only needs the originalFileId, rather than both the original and the replacementFileId. The backend can work out the replacementFileId from the originalFileId.
- Jiggled some of the replacement code around so we're not repeating the same authorisation checks or fetching/checking for the same database entires.
- The replacement completions now fail if the replacement file hasn't finished importing. 