### PR TITLE
EES-6233 publication title character limit

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/PublicationCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/PublicationCreateRequest.cs
@@ -2,6 +2,7 @@
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using System;
 using System.ComponentModel.DataAnnotations;
+using FluentValidation;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
@@ -24,4 +25,14 @@ public record PublicationCreateRequest
     }
 
     public Guid? SupersededById { get; set; }
+
+     public class Validator : AbstractValidator<PublicationCreateRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.Title)
+                .NotEmpty()
+                .MaximumLength(65);
+        }
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/PublicationSaveRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/PublicationSaveRequest.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using System;
 using System.ComponentModel.DataAnnotations;
 using static System.String;
+using FluentValidation;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
@@ -23,4 +24,14 @@ public record PublicationSaveRequest
     }
 
     public Guid? SupersededById { get; set; }
+
+     public class Validator : AbstractValidator<PublicationSaveRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.Title)
+                .NotEmpty()
+                .MaximumLength(65);
+        }
+    }
 }

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationDetailsForm.tsx
@@ -18,6 +18,8 @@ import { ObjectSchema } from 'yup';
 import PublicationUpdateConfirmModal from '@admin/pages/publication/components/PublicationUpdateConfirmModal';
 
 const id = 'publicationDetailsForm';
+const titleMaxLength = 65;
+const summaryMaxLength = 160;
 
 interface FormValues {
   summary: string;
@@ -82,9 +84,17 @@ export default function PublicationDetailsForm({
     return Yup.object({
       summary: Yup.string()
         .required('Enter a summary')
-        .max(160, 'Summary must be 160 characters or less'),
+        .max(
+          summaryMaxLength,
+          `Summary must be ${summaryMaxLength} characters or fewer`,
+        ),
       supersededById: Yup.string(),
-      title: Yup.string().required('Enter a title'),
+      title: Yup.string()
+        .required('Enter a title')
+        .max(
+          titleMaxLength,
+          `Title must be ${titleMaxLength} characters or fewer`,
+        ),
       themeId: Yup.string().required('Choose a theme'),
     });
   }, []);
@@ -115,6 +125,7 @@ export default function PublicationDetailsForm({
                       name="title"
                       label="Publication title"
                       className="govuk-!-width-one-half"
+                      maxLength={titleMaxLength}
                     />
                   )}
 
@@ -123,7 +134,7 @@ export default function PublicationDetailsForm({
                       name="summary"
                       label="Publication summary"
                       className="govuk-!-width-one-half"
-                      maxLength={160}
+                      maxLength={summaryMaxLength}
                     />
                   )}
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
@@ -11,6 +11,9 @@ import Yup from '@common/validation/yup';
 import React, { ReactNode, useMemo } from 'react';
 import { ObjectSchema } from 'yup';
 
+const titleMaxLength = 65;
+const summaryMaxLength = 160;
+
 interface FormValues {
   title: string;
   summary: string;
@@ -50,10 +53,18 @@ export default function PublicationForm({
 }: Props) {
   const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
     return Yup.object({
-      title: Yup.string().required('Enter a publication title'),
+      title: Yup.string()
+        .required('Enter a publication title')
+        .max(
+          titleMaxLength,
+          `Title must be ${titleMaxLength} characters or fewer`,
+        ),
       summary: Yup.string()
         .required('Enter a publication summary')
-        .max(160, 'Summary must be 160 characters or less'),
+        .max(
+          summaryMaxLength,
+          `Summary must be ${summaryMaxLength} characters or fewer`,
+        ),
       teamName: Yup.string().required('Enter a team name'),
       teamEmail: Yup.string()
         .required('Enter a team email address')
@@ -125,13 +136,14 @@ export default function PublicationForm({
           label="Publication title"
           name="title"
           className="govuk-!-width-two-thirds"
+          maxLength={titleMaxLength}
         />
 
         <FormFieldTextArea<FormValues>
           label="Publication summary"
           name="summary"
           className="govuk-!-width-one-half"
-          maxLength={160}
+          maxLength={summaryMaxLength}
         />
 
         <FormFieldset

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationDetailsForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationDetailsForm.test.tsx
@@ -1,0 +1,268 @@
+import PublicationDetailsForm from '@admin/pages/publication/components/PublicationDetailsForm';
+import _publicationService from '@admin/services/publicationService';
+import _themeService, { Theme } from '@admin/services/themeService';
+import render from '@common-test/render';
+import { PublicationSummary } from '@common/services/publicationService';
+import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
+import { screen, waitFor } from '@testing-library/react';
+import noop from 'lodash/noop';
+import React from 'react';
+
+jest.mock('@admin/services/publicationService');
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
+jest.mock('@admin/services/themeService');
+const themeService = _themeService as jest.Mocked<typeof _themeService>;
+
+describe('PublicationDetailsForm', () => {
+  const testFormValues = {
+    summary: 'Test summary',
+    title: 'Test title',
+    themeId: 'theme-1',
+  };
+
+  const testThemes: Theme[] = [
+    {
+      id: 'theme-1',
+      title: 'Theme 1',
+      slug: 'theme-1',
+      summary: '',
+    },
+    {
+      id: 'theme-2',
+      title: 'Theme 2',
+      slug: 'theme-2',
+      summary: '',
+    },
+  ];
+
+  const testPublicationSummaries: PublicationSummary[] = [
+    {
+      id: 'publication-1',
+      slug: 'publication-1-slug',
+      latestReleaseSlug: 'latest-release-slug-1',
+      title: 'Publication 1',
+      owner: false,
+      contact: {
+        teamName: 'Mock Contact Team Name',
+        teamEmail: 'Mock Contact Team Email',
+        contactName: 'Mock Contact Name',
+      },
+    },
+    {
+      id: 'publication-2',
+      slug: 'publication-2-slug',
+      latestReleaseSlug: 'latest-release-slug-2',
+      title: 'Publication 2',
+      owner: false,
+      contact: {
+        teamName: 'Mock Contact Team Name',
+        teamEmail: 'Mock Contact Team Email',
+        contactName: 'Mock Contact Name',
+      },
+    },
+  ];
+
+  beforeEach(() => {
+    themeService.getThemes.mockResolvedValue(testThemes);
+    publicationService.getPublicationSummaries.mockResolvedValue(
+      testPublicationSummaries,
+    );
+  });
+
+  test('renders with initial values', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText('Publication title')).toHaveValue(
+      'Test title',
+    );
+    expect(screen.getByLabelText('Publication summary')).toHaveValue(
+      'Test summary',
+    );
+    expect(screen.getByLabelText('Select theme')).toHaveValue('theme-1');
+    expect(screen.getByLabelText('Superseding publication')).toHaveValue('');
+  });
+
+  test('shows validation error when there is no title', async () => {
+    const { user } = renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
+
+    await user.clear(screen.getByLabelText('Publication title'));
+
+    await user.click(
+      screen.getByRole('button', { name: 'Update publication details' }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Enter a title', {
+          selector: '#publicationDetailsForm-title-error',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows validation error when the title is too long', async () => {
+    const { user } = renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
+
+    await user.clear(screen.getByLabelText('Publication title'));
+
+    await user.type(
+      screen.getByLabelText('Publication title'),
+      'a long publication title a long publication title a long publication title',
+    );
+
+    expect(
+      await screen.findByText('You have 9 characters too many'),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Update publication details' }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Title must be 65 characters or fewer', {
+          selector: '#publicationDetailsForm-title-error',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows validation error when there is no summary', async () => {
+    const { user } = renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication summary')).toBeInTheDocument();
+    });
+
+    await user.clear(screen.getByLabelText('Publication summary'));
+
+    await user.click(
+      screen.getByRole('button', { name: 'Update publication details' }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Enter a summary', {
+          selector: '#publicationDetailsForm-summary-error',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows validation error when the summary is too long', async () => {
+    const { user } = renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
+
+    await user.clear(screen.getByLabelText('Publication summary'));
+
+    await user.type(
+      screen.getByLabelText('Publication summary'),
+      'a long publication summary a long publication summary a long publication summary a long publication summary a long publication summary a long publication summary',
+    );
+
+    expect(
+      await screen.findByText('You have 1 character too many'),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Update publication details' }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Summary must be 160 characters or fewer', {
+          selector: '#publicationDetailsForm-summary-error',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('cannot submit with invalid values', async () => {
+    const handleSubmit = jest.fn();
+
+    const { user } = renderComponent(handleSubmit);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Update publication details' }),
+      ).toBeInTheDocument();
+    });
+
+    await user.clear(screen.getByLabelText('Publication title'));
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Update publication details' }),
+    );
+
+    await waitFor(() => {
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  test('can submit with updated values', async () => {
+    const handleSubmit = jest.fn();
+
+    const { user } = renderComponent(handleSubmit);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText('Publication title'), ' edited');
+    await user.type(screen.getByLabelText('Publication summary'), ' edited');
+    await user.selectOptions(screen.getByLabelText('Select theme'), 'theme-2');
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Update publication details' }),
+    );
+
+    expect(
+      await screen.getByText('Confirm publication changes'),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalled();
+    });
+  });
+
+  function renderComponent(submitHandler = noop) {
+    return render(
+      <TestConfigContextProvider>
+        <PublicationDetailsForm
+          canUpdatePublication
+          canUpdatePublicationSummary
+          initialValues={testFormValues}
+          publicationId="publication-id"
+          publicationSlug="publication-slug"
+          onCancel={noop}
+          onSubmit={submitHandler}
+        />
+      </TestConfigContextProvider>,
+    );
+  }
+});

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
@@ -31,6 +31,35 @@ describe('PublicationForm', () => {
     });
   });
 
+  test('shows validation error when the title is too long', async () => {
+    const { user } = render(
+      <PublicationForm themeId="theme-id" onSubmit={noop} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
+
+    await user.type(
+      screen.getByLabelText('Publication title'),
+      'a long publication title a long publication title a long publication title',
+    );
+
+    expect(
+      await screen.findByText('You have 9 characters too many'),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Save publication' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Title must be 65 characters or fewer', {
+          selector: '#publicationForm-title-error',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
   test('shows validation error when there is no summary', async () => {
     const { user } = render(
       <PublicationForm themeId="theme-id" onSubmit={noop} />,
@@ -45,6 +74,35 @@ describe('PublicationForm', () => {
     await waitFor(() => {
       expect(
         screen.getByText('Enter a publication summary', {
+          selector: '#publicationForm-summary-error',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows validation error when the summary is too long', async () => {
+    const { user } = render(
+      <PublicationForm themeId="theme-id" onSubmit={noop} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Publication title')).toBeInTheDocument();
+    });
+
+    await user.type(
+      screen.getByLabelText('Publication summary'),
+      'a long publication summary a long publication summary a long publication summary a long publication summary a long publication summary a long publication summary',
+    );
+
+    expect(
+      await screen.findByText('You have 1 character too many'),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Save publication' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Summary must be 160 characters or fewer', {
           selector: '#publicationForm-summary-error',
         }),
       ).toBeInTheDocument();

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
@@ -18,6 +18,8 @@ import Button from '@common/components/Button';
 import { useQueryClient } from '@tanstack/react-query';
 import releaseDataFileQueries from '@admin/queries/releaseDataFileQueries';
 
+const titleMaxLength = 120;
+
 interface FormValues {
   title: string;
 }
@@ -55,8 +57,6 @@ export default function ReleaseDataFilePage({
     );
   };
 
-  const titleMaxLength = 120;
-
   return (
     <>
       <Link
@@ -82,7 +82,7 @@ export default function ReleaseDataFilePage({
                   .required('Enter a title')
                   .max(
                     titleMaxLength,
-                    `Title must be ${titleMaxLength} characters or less`,
+                    `Title must be ${titleMaxLength} characters or fewer`,
                   ),
               })}
             >

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/AncillaryFileForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/AncillaryFileForm.tsx
@@ -81,13 +81,13 @@ export default function AncillaryFileForm({
         })
         .max(
           titleMaxLength,
-          `Title must be ${titleMaxLength} characters or less`,
+          `Title must be ${titleMaxLength} characters or fewer`,
         ),
       summary: Yup.string()
         .required('Enter a summary')
         .max(
           summaryMaxLength,
-          `Summary must be ${summaryMaxLength} characters or less`,
+          `Summary must be ${summaryMaxLength} characters or fewer`,
         ),
       file: Yup.file()
         .minSize(0, 'Choose a file that is not empty')

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -201,7 +201,7 @@ export default function DataFileUploadForm({
               })
               .max(
                 titleMaxLength,
-                `Title must be ${titleMaxLength} characters or less`,
+                `Title must be ${titleMaxLength} characters or fewer`,
               ),
         }),
       });

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataGuidanceSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataGuidanceSection.tsx
@@ -134,7 +134,7 @@ const ReleaseDataGuidanceSection = ({
                         })
                         .max(
                           contentMaxLength,
-                          `File guidance content must be ${contentMaxLength} characters or less`,
+                          `File guidance content must be ${contentMaxLength} characters or fewer`,
                         ),
                     }),
                   ),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDetailsForm.tsx
@@ -66,7 +66,7 @@ const DataBlockDetailsForm = ({
         .required('Enter a table title')
         .max(
           dataBlockTableTitleMaxLength,
-          `Table title must be ${dataBlockTableTitleMaxLength} characters or less`,
+          `Table title must be ${dataBlockTableTitleMaxLength} characters or fewer`,
         ),
       source: Yup.string(),
       highlightName: Yup.string().when('isHighlight', {
@@ -76,7 +76,7 @@ const DataBlockDetailsForm = ({
             .required('Enter a featured table name')
             .max(
               featuredTableNameMaxLength,
-              `Featured table name must be ${featuredTableNameMaxLength} characters or less`,
+              `Featured table name must be ${featuredTableNameMaxLength} characters or fewer`,
             ),
       }),
       highlightDescription: Yup.string().when('isHighlight', {
@@ -86,7 +86,7 @@ const DataBlockDetailsForm = ({
             .required('Enter a featured table description')
             .max(
               featuredTableDescriptionMaxLength,
-              `Featured table description must be ${featuredTableDescriptionMaxLength} characters or less`,
+              `Featured table description must be ${featuredTableDescriptionMaxLength} characters or fewer`,
             ),
       }),
       isHighlight: Yup.boolean(),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -48,6 +48,9 @@ import React, {
 import { Path } from 'react-hook-form';
 import { ObjectSchema } from 'yup';
 
+const titleMaxLength = 220;
+const altTextMaxLength = 220;
+
 type FormValues = Partial<ChartOptions>;
 
 export const errorMappings = [
@@ -107,9 +110,6 @@ const ChartConfiguration = ({
     value: position,
   }));
 
-  const titleMaxLength = 220;
-  const altTextMaxLength = 220;
-
   const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
     let schema: ObjectSchema<FormValues> = Yup.object<FormValues>({
       titleType: Yup.mixed()
@@ -122,7 +122,7 @@ const ChartConfiguration = ({
             .required('Enter chart title')
             .max(
               titleMaxLength,
-              `Chart title must be ${titleMaxLength} characters or less`,
+              `Chart title must be ${titleMaxLength} characters or fewer`,
             ),
         otherwise: s => s.notRequired(),
       }),
@@ -130,7 +130,7 @@ const ChartConfiguration = ({
         .required('Enter chart alt text')
         .max(
           altTextMaxLength,
-          `Alt text must be ${altTextMaxLength} characters or less`,
+          `Alt text must be ${altTextMaxLength} characters or fewer`,
         )
         .test({
           name: 'noRepeatTitle',
@@ -148,7 +148,7 @@ const ChartConfiguration = ({
       width: Yup.number().positive('Chart width must be positive'),
       subtitle: Yup.string().max(
         160,
-        'Subtitle must be 160 characters or less',
+        'Subtitle must be 160 characters or fewer',
       ),
     });
 

--- a/src/explore-education-statistics-common/src/components/form/FormCharacterCount.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCharacterCount.tsx
@@ -7,7 +7,7 @@ interface Props {
   value?: string;
 }
 export default function FormCharacterCount({ id, maxLength, value }: Props) {
-  const remaining = maxLength - (value?.length ?? 0);
+  const remaining = maxLength - (value?.trim().length ?? 0);
 
   return (
     <div

--- a/src/explore-education-statistics-frontend/src/components/PageFeedback.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageFeedback.tsx
@@ -64,15 +64,15 @@ export default function PageFeedback() {
     return Yup.object({
       context: Yup.string().max(
         feedbackLimit,
-        `What were you doing must be ${feedbackLimit} characters or less`,
+        `What were you doing must be ${feedbackLimit} characters or fewer`,
       ),
       issue: Yup.string().max(
         feedbackLimit,
-        `What went wrong must  be ${feedbackLimit} characters or less`,
+        `What went wrong must  be ${feedbackLimit} characters or fewer`,
       ),
       intent: Yup.string().max(
         feedbackLimit,
-        `What were you hoping to achieve must be ${feedbackLimit} characters or less`,
+        `What were you hoping to achieve must be ${feedbackLimit} characters or fewer`,
       ),
     });
   }, []);

--- a/src/explore-education-statistics-frontend/src/modules/release-publishing-feedback/ReleasePublishingFeedbackPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/release-publishing-feedback/ReleasePublishingFeedbackPage.tsx
@@ -17,6 +17,8 @@ import {
 } from '@common/components/form';
 import ButtonGroup from '@common/components/ButtonGroup';
 
+const feedbackMaxLength = 2000;
+
 interface FormValues {
   response: ReleasePublishingFeedbackResponse;
   additionalFeedback?: string;
@@ -73,8 +75,8 @@ const ReleasePublishingFeedbackPage: NextPage<Props> = ({
               'NotSatisfiedAtAll',
             ]),
           additionalFeedback: Yup.string().max(
-            2000,
-            'Additional feedback must be 2000 characters or less',
+            feedbackMaxLength,
+            `Additional feedback must be ${feedbackMaxLength} characters or fewer`,
           ),
         })}
       >
@@ -119,7 +121,7 @@ const ReleasePublishingFeedbackPage: NextPage<Props> = ({
                 <FormFieldTextArea
                   name="additionalFeedback"
                   label="Additional feedback (optional)"
-                  maxLength={2000}
+                  maxLength={feedbackMaxLength}
                 />
                 <ButtonGroup>
                   <Button type="submit" disabled={formState.isSubmitting}>


### PR DESCRIPTION
Adds a character limit for publication titles. @benoutram advised on the back end validation.

Also:
- corrects the grammar on maxLength error messages site wide
- trims text before counting the characters so leading and trailing whitespace isn't included.