### PR TITLE
EES-6296 typeahead for search main functionality

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,7 +620,7 @@ importers:
         version: 1.3.2(@tanstack/query-core@4.32.0)(@tanstack/react-query@4.32.0)
       '@microsoft/applicationinsights-web':
         specifier: ^3.0.2
-        version: 3.0.2(tslib@2.6.0)(typescript@5.5.4)
+        version: 3.0.2(tslib@2.8.1)(typescript@5.5.4)
       '@popperjs/core':
         specifier: ^2.11.8
         version: 2.11.8
@@ -862,6 +862,9 @@ importers:
       '@tanstack/react-query':
         specifier: 4.32.0
         version: 4.32.0(react-dom@18.2.0)(react@18.2.0)
+      accessible-autocomplete:
+        specifier: ^3.0.1
+        version: 3.0.1
       applicationinsights:
         specifier: ^2.7.0
         version: 2.7.0
@@ -5500,52 +5503,52 @@ packages:
       '@tanstack/react-query': 4.32.0(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
-  /@microsoft/applicationinsights-analytics-js@3.0.2(tslib@2.6.0)(typescript@5.5.4):
+  /@microsoft/applicationinsights-analytics-js@3.0.2(tslib@2.8.1)(typescript@5.5.4):
     resolution: {integrity: sha512-vrgEiT6cKC2Yb0Y6rCp9CXjFStlRZLI/IhIiBEGYaUfzoytLxUj6F/AizUDYBuNQfE+CTYe0jNyqf+RJgEMkJQ==}
     peerDependencies:
       tslib: '*'
     dependencies:
-      '@microsoft/applicationinsights-common': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
-      '@microsoft/applicationinsights-core-js': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
+      '@microsoft/applicationinsights-common': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
+      '@microsoft/applicationinsights-core-js': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
       '@microsoft/applicationinsights-shims': 3.0.1(typescript@5.5.4)
       '@microsoft/dynamicproto-js': 2.0.2(typescript@5.5.4)
       '@nevware21/ts-utils': 0.9.8(typescript@5.5.4)
-      tslib: 2.6.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - typescript
     dev: false
 
-  /@microsoft/applicationinsights-channel-js@3.0.2(tslib@2.6.0)(typescript@5.5.4):
+  /@microsoft/applicationinsights-channel-js@3.0.2(tslib@2.8.1)(typescript@5.5.4):
     resolution: {integrity: sha512-jDBNKbCHsJgmpv0CKNhJ/uN9ZphvfGdb93Svk+R4LjO8L3apNNMbDDPxBvXXi0uigRmA1TBcmyBG4IRKjabGhw==}
     peerDependencies:
       tslib: '*'
     dependencies:
-      '@microsoft/applicationinsights-common': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
-      '@microsoft/applicationinsights-core-js': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
+      '@microsoft/applicationinsights-common': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
+      '@microsoft/applicationinsights-core-js': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
       '@microsoft/applicationinsights-shims': 3.0.1(typescript@5.5.4)
       '@microsoft/dynamicproto-js': 2.0.2(typescript@5.5.4)
       '@nevware21/ts-async': 0.2.6(typescript@5.5.4)
       '@nevware21/ts-utils': 0.9.8(typescript@5.5.4)
-      tslib: 2.6.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - typescript
     dev: false
 
-  /@microsoft/applicationinsights-common@3.0.2(tslib@2.6.0)(typescript@5.5.4):
+  /@microsoft/applicationinsights-common@3.0.2(tslib@2.8.1)(typescript@5.5.4):
     resolution: {integrity: sha512-y+WXWop+OVim954Cu1uyYMnNx6PWO8okHpZIQi/1YSqtqaYdtJVPv4P0AVzwJdohxzVfgzKvqj9nec/VWqE2Zg==}
     peerDependencies:
       tslib: '*'
     dependencies:
-      '@microsoft/applicationinsights-core-js': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
+      '@microsoft/applicationinsights-core-js': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
       '@microsoft/applicationinsights-shims': 3.0.1(typescript@5.5.4)
       '@microsoft/dynamicproto-js': 2.0.2(typescript@5.5.4)
       '@nevware21/ts-utils': 0.9.8(typescript@5.5.4)
-      tslib: 2.6.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - typescript
     dev: false
 
-  /@microsoft/applicationinsights-core-js@3.0.2(tslib@2.6.0)(typescript@5.5.4):
+  /@microsoft/applicationinsights-core-js@3.0.2(tslib@2.8.1)(typescript@5.5.4):
     resolution: {integrity: sha512-WQhVhzlRlLDrQzn3OShCW/pL3BW5WC57t0oywSknX3q7lMzI3jDg7Ihh0iuIcNTzGCTbDkuqr4d6IjEDWIMtJQ==}
     peerDependencies:
       tslib: '*'
@@ -5554,38 +5557,38 @@ packages:
       '@microsoft/dynamicproto-js': 2.0.2(typescript@5.5.4)
       '@nevware21/ts-async': 0.2.6(typescript@5.5.4)
       '@nevware21/ts-utils': 0.9.8(typescript@5.5.4)
-      tslib: 2.6.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - typescript
     dev: false
 
-  /@microsoft/applicationinsights-dependencies-js@3.0.2(tslib@2.6.0)(typescript@5.5.4):
+  /@microsoft/applicationinsights-dependencies-js@3.0.2(tslib@2.8.1)(typescript@5.5.4):
     resolution: {integrity: sha512-b/YTonnbghg9DOFsLg4zdbYPafW8fPIzV+nZxfPPpxjA1LGvPhZz/zVx9YYWJg2RBXjojLQoJxLf1ro5eNGVig==}
     peerDependencies:
       tslib: '*'
     dependencies:
-      '@microsoft/applicationinsights-common': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
-      '@microsoft/applicationinsights-core-js': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
+      '@microsoft/applicationinsights-common': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
+      '@microsoft/applicationinsights-core-js': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
       '@microsoft/applicationinsights-shims': 3.0.1(typescript@5.5.4)
       '@microsoft/dynamicproto-js': 2.0.2(typescript@5.5.4)
       '@nevware21/ts-async': 0.2.6(typescript@5.5.4)
       '@nevware21/ts-utils': 0.9.8(typescript@5.5.4)
-      tslib: 2.6.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - typescript
     dev: false
 
-  /@microsoft/applicationinsights-properties-js@3.0.2(tslib@2.6.0)(typescript@5.5.4):
+  /@microsoft/applicationinsights-properties-js@3.0.2(tslib@2.8.1)(typescript@5.5.4):
     resolution: {integrity: sha512-PFqicp8q4Tc0hqfPjwfqKo12gEqTk1l4lMyUUIU7ugE1XOuDkZcMPha05KnZWKj+F4zQXJcetcAHoVkyoyCFQw==}
     peerDependencies:
       tslib: '*'
     dependencies:
-      '@microsoft/applicationinsights-common': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
-      '@microsoft/applicationinsights-core-js': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
+      '@microsoft/applicationinsights-common': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
+      '@microsoft/applicationinsights-core-js': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
       '@microsoft/applicationinsights-shims': 3.0.1(typescript@5.5.4)
       '@microsoft/dynamicproto-js': 2.0.2(typescript@5.5.4)
       '@nevware21/ts-utils': 0.9.8(typescript@5.5.4)
-      tslib: 2.6.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -5602,22 +5605,22 @@ packages:
     resolution: {integrity: sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ==}
     dev: false
 
-  /@microsoft/applicationinsights-web@3.0.2(tslib@2.6.0)(typescript@5.5.4):
+  /@microsoft/applicationinsights-web@3.0.2(tslib@2.8.1)(typescript@5.5.4):
     resolution: {integrity: sha512-pf2zz/3mmGy1RoyaiLZwhHoE2mFZ+AWR3Zf7xPW7HjTG7dEE4BnovNyW3f9Eu6WWkcHUAHmS/ATzqvVlpB3W6A==}
     peerDependencies:
       tslib: '*'
     dependencies:
-      '@microsoft/applicationinsights-analytics-js': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
-      '@microsoft/applicationinsights-channel-js': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
-      '@microsoft/applicationinsights-common': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
-      '@microsoft/applicationinsights-core-js': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
-      '@microsoft/applicationinsights-dependencies-js': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
-      '@microsoft/applicationinsights-properties-js': 3.0.2(tslib@2.6.0)(typescript@5.5.4)
+      '@microsoft/applicationinsights-analytics-js': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
+      '@microsoft/applicationinsights-channel-js': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
+      '@microsoft/applicationinsights-common': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
+      '@microsoft/applicationinsights-core-js': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
+      '@microsoft/applicationinsights-dependencies-js': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
+      '@microsoft/applicationinsights-properties-js': 3.0.2(tslib@2.8.1)(typescript@5.5.4)
       '@microsoft/applicationinsights-shims': 3.0.1(typescript@5.5.4)
       '@microsoft/dynamicproto-js': 2.0.2(typescript@5.5.4)
       '@nevware21/ts-async': 0.2.6(typescript@5.5.4)
       '@nevware21/ts-utils': 0.9.8(typescript@5.5.4)
-      tslib: 2.6.0
+      tslib: 2.8.1
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -7594,6 +7597,15 @@ packages:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+
+  /accessible-autocomplete@3.0.1:
+    resolution: {integrity: sha512-xMshgc2LT5addvvfCTGzIkRrvhbOFeylFSnSMfS/PdjvvvElZkakCwxO3/yJYBWyi1hi3tZloqOJQ5kqqJtH4g==}
+    peerDependencies:
+      preact: ^8.0.0
+    peerDependenciesMeta:
+      preact:
+        optional: true
+    dev: false
 
   /acorn-globals@6.0.0:
     resolution: {integrity: sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==}

--- a/src/explore-education-statistics-frontend/package.json
+++ b/src/explore-education-statistics-frontend/package.json
@@ -8,6 +8,7 @@
     "@next/bundle-analyzer": "^14.2.25",
     "@next/env": "^14.2.25",
     "@tanstack/react-query": "4.32.0",
+    "accessible-autocomplete": "^3.0.1",
     "applicationinsights": "^2.7.0",
     "axios": "^1.4.0",
     "classnames": "^2.3.2",

--- a/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
@@ -16,6 +16,10 @@ interface Props {
   onSubmit: (value: string) => void;
 }
 
+// Nb we are not using tanstack-query or react-hook-form here, as
+// accessible-autocomplete lib is managing its own state, and we can't
+// access the generated text input to be able to hook into its value easily
+
 export default function SearchForm({ label = 'Search', onSubmit }: Props) {
   const router = useRouter();
 
@@ -98,13 +102,20 @@ export default function SearchForm({ label = 'Search', onSubmit }: Props) {
       }}
       ref={wrapper}
     >
-      <label htmlFor="search" className="govuk-label govuk-label--m">
+      <label
+        htmlFor="search"
+        className="govuk-label govuk-label--m"
+        id="search-label"
+      >
         {label}
       </label>
       <div className="autocomplete__item-wrap">
         <Autocomplete
           id="search"
           name="search"
+          menuAttributes={{
+            'aria-labelledby': 'search-label',
+          }}
           minLength={3}
           source={fetchResults}
           templates={{

--- a/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
@@ -1,47 +1,113 @@
-import FormProvider from '@common/components/form/FormProvider';
-import { Form, FormFieldTextInput } from '@common/components/form';
+// import FormProvider from '@common/components/form/FormProvider';
+// import { Form, FormFieldTextInput } from '@common/components/form';
 import SearchIcon from '@common/components/SearchIcon';
 import VisuallyHidden from '@common/components/VisuallyHidden';
-import styles from '@common/components/form/FormSearchBar.module.scss';
 import React from 'react';
+import Autocomplete from 'accessible-autocomplete/react';
+// import publicationQueries from '@frontend/queries/azurePublicationQueries';
+import styles from '@common/components/form/FormSearchBar.module.scss';
+// import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { truncate } from 'lodash';
+import azurePublicationService, {
+  AzurePublicationSuggestResult,
+} from '@frontend/services/azurePublicationService';
+import { createAzurePublicationSuggestRequest } from '@frontend/modules/find-statistics/utils/createAzurePublicationListRequest';
+import logger from '@common/services/logger';
 
 interface Props {
   label?: string;
-  value?: string;
+  // value?: string;
   onSubmit: (value: string) => void;
 }
 
 export default function SearchForm({
   label = 'Search',
-  value: initialValue = '',
+  // value: initialValue = '',
   onSubmit,
 }: Props) {
+  const router = useRouter();
+
+  // const { data: suggestions } = useQuery({
+  //   ...publicationQueries.suggestPublications(router.query, term),
+  //   keepPreviousData: true,
+  //   staleTime: 60000,
+  // });
+
+  const fetchResults = (
+    enteredText: string,
+    populateResults: (suggestions: AzurePublicationSuggestResult[]) => void,
+  ) => {
+    azurePublicationService
+      .suggestPublications(
+        createAzurePublicationSuggestRequest(router.query, enteredText),
+      )
+      .then(populateResults)
+      .catch(error => {
+        populateResults([]);
+        logger.error(error);
+      });
+  };
+
+  const suggestionTemplate = (
+    result: AzurePublicationSuggestResult,
+  ) => `<p class="autocomplete__option-item">
+          <span class="autocomplete__option-title">
+            ${result.title}
+          </span>
+          <span class="autocomplete__option-summary">
+            ${truncate(result.summary, { length: 140 })}
+          </span>
+        </p>`;
+
   return (
-    <FormProvider
-      initialValues={{
-        search: initialValue,
+    <form
+      id="searchForm"
+      onSubmit={event => {
+        event.preventDefault();
+        const searchTerm = new FormData(event.currentTarget).get(
+          'search',
+        ) as string;
+        onSubmit(searchTerm || '');
       }}
     >
-      <Form
-        id="searchForm"
-        showErrorSummary={false}
-        onSubmit={({ search }) => onSubmit(search)}
-      >
-        <FormFieldTextInput
-          addOn={
-            <button type="submit" className={styles.button}>
-              <SearchIcon className={styles.icon} />
-              <VisuallyHidden>Search</VisuallyHidden>
-            </button>
-          }
-          announceError
+      <label htmlFor="search" className="govuk-label govuk-label--m">
+        {label}
+      </label>
+      <div className="autocomplete__item-wrap">
+        <Autocomplete
           id="search"
-          label={label}
-          labelSize="m"
           name="search"
-          type="search"
+          minLength={3}
+          source={fetchResults}
+          templates={{
+            inputValue: result => result?.title,
+            suggestion: suggestionTemplate,
+          }}
+          confirmOnBlur={false}
+          showNoOptionsFound={false}
+          // defaultValue={initialValue}
+          onConfirm={result => {
+            if (result) {
+              return router.push(
+                `/find-statistics/${result.publicationSlug}/${result.releaseSlug}`,
+              );
+            }
+            return null;
+          }}
+          tNoResults={() => 'No search suggestions found'}
+          tAssistiveHint={() =>
+            'When search suggestions are available use up and down arrows to review and enter to select. Touch device users, explore by touch or with swipe gestures.'
+          }
         />
-      </Form>
-    </FormProvider>
+        <button
+          type="submit"
+          className={`${styles.button} autocomplete__submit-button`}
+        >
+          <SearchIcon className={styles.icon} />
+          <VisuallyHidden>Search</VisuallyHidden>
+        </button>
+      </div>
+    </form>
   );
 }

--- a/src/explore-education-statistics-frontend/src/components/__tests__/SearchFormAzure.test.tsx
+++ b/src/explore-education-statistics-frontend/src/components/__tests__/SearchFormAzure.test.tsx
@@ -1,0 +1,81 @@
+import SearchFormAzure from '@frontend/components/SearchFormAzure';
+import _publicationService from '@frontend/services/azurePublicationService';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import noop from 'lodash/noop';
+import userEvent from '@testing-library/user-event';
+import { testPublicationSuggestions } from '@frontend/modules/find-statistics/__tests__/__data__/testPublicationSuggestions';
+import mockRouter from 'next-router-mock';
+
+jest.mock('@azure/search-documents', () => ({
+  SearchClient: jest.fn(),
+  AzureKeyCredential: jest.fn(),
+  odata: jest.fn(),
+}));
+
+jest.mock('@frontend/services/azurePublicationService');
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
+
+describe('SearchFormAzure', () => {
+  test('renders correctly', () => {
+    render(<SearchFormAzure onSubmit={noop} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveAttribute('type', 'search');
+    expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox')).toHaveClass(
+      'autocomplete__menu--hidden',
+    );
+  });
+
+  test('calls onSubmit when submitted', async () => {
+    publicationService.suggestPublications.mockResolvedValue(
+      testPublicationSuggestions,
+    );
+    const handleSubmit = jest.fn();
+    render(<SearchFormAzure onSubmit={handleSubmit} />);
+    await userEvent.type(screen.getByRole('combobox'), 'find me');
+    await userEvent.click(screen.getByRole('button', { name: 'Search' }));
+    expect(handleSubmit).toHaveBeenCalledWith('find me');
+  });
+
+  test('shows suggestions when entered term is at least 3 characters with results', async () => {
+    publicationService.suggestPublications.mockResolvedValue(
+      testPublicationSuggestions,
+    );
+    render(<SearchFormAzure onSubmit={noop} />);
+    await userEvent.type(screen.getByRole('combobox'), 'find me');
+    expect(screen.getByRole('listbox')).not.toHaveClass(
+      'autocomplete__menu--hidden',
+    );
+  });
+
+  test('shows suggestions when entered term is at least 3 characters with no results', async () => {
+    publicationService.suggestPublications.mockResolvedValue([]);
+    render(<SearchFormAzure onSubmit={noop} />);
+    await userEvent.type(screen.getByRole('combobox'), 'find me');
+    expect(screen.getByRole('listbox')).toHaveClass(
+      'autocomplete__menu--hidden',
+    );
+  });
+
+  test("doesn't show suggestions when entered term is less than 3 characters", async () => {
+    render(<SearchFormAzure onSubmit={noop} />);
+    await userEvent.type(screen.getByRole('combobox'), 'fi');
+    expect(screen.getByRole('listbox')).toHaveClass(
+      'autocomplete__menu--hidden',
+    );
+  });
+
+  test('submits the form when enter is pressed', async () => {
+    publicationService.suggestPublications.mockResolvedValue(
+      testPublicationSuggestions,
+    );
+    const handleSubmit = jest.fn();
+    render(<SearchFormAzure onSubmit={handleSubmit} />);
+    await userEvent.type(screen.getByRole('combobox'), 'find me');
+    await userEvent.keyboard('[Enter]');
+    expect(handleSubmit).toHaveBeenCalledWith('find me');
+  });
+});

--- a/src/explore-education-statistics-frontend/src/components/__tests__/SearchFormAzure.test.tsx
+++ b/src/explore-education-statistics-frontend/src/components/__tests__/SearchFormAzure.test.tsx
@@ -24,6 +24,7 @@ describe('SearchFormAzure', () => {
     expect(screen.getByRole('combobox')).toBeInTheDocument();
     expect(screen.getByRole('combobox')).toHaveAttribute('type', 'search');
     expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
+    // N.b checking by 'not.toBeVisible' doesn't work as Jest isn't loading the global CSS
     expect(screen.getByRole('listbox')).toHaveClass(
       'autocomplete__menu--hidden',
     );

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
@@ -245,7 +245,7 @@ const FindStatisticsPage: NextPage = () => {
           </p>
           <SearchForm
             label="Search publications"
-            value={search}
+            // value={search}
             onSubmit={nextValue =>
               handleChangeFilter({ filterType: 'search', nextValue })
             }

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
@@ -245,7 +245,6 @@ const FindStatisticsPage: NextPage = () => {
           </p>
           <SearchForm
             label="Search publications"
-            // value={search}
             onSubmit={nextValue =>
               handleChangeFilter({ filterType: 'search', nextValue })
             }

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPageAzure.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/FindStatisticsPageAzure.test.tsx
@@ -10,6 +10,7 @@ import {
   testFacetResultsSearchedOneResult,
 } from '@frontend/modules/find-statistics/__tests__/__data__/testFacetData';
 import { testPublications } from '@frontend/modules/find-statistics/__tests__/__data__/testPublications';
+import { testPublicationSuggestions } from '@frontend/modules/find-statistics/__tests__/__data__/testPublicationSuggestions';
 import { testThemeSummaries } from '@frontend/modules/find-statistics/__tests__/__data__/testThemeData';
 import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
@@ -76,7 +77,9 @@ describe('FindStatisticsPageAzure', () => {
       ),
     ).toBeInTheDocument();
 
-    expect(screen.getByLabelText('Search publications')).toBeInTheDocument();
+    expect(
+      screen.getByRole('combobox', { name: 'Search publications' }),
+    ).toBeInTheDocument();
 
     const sortSelect = screen.getByLabelText('Sort by');
     const sortOptions = within(sortSelect).getAllByRole(
@@ -790,6 +793,10 @@ describe('FindStatisticsPageAzure', () => {
   });
 
   test('searching', async () => {
+    publicationService.suggestPublications.mockResolvedValue(
+      testPublicationSuggestions,
+    );
+
     publicationService.listPublications
       .mockResolvedValueOnce({
         results: testPublications,
@@ -813,8 +820,10 @@ describe('FindStatisticsPageAzure', () => {
     expect(
       within(screen.getByTestId('publicationsList')).getAllByRole('listitem'),
     ).toHaveLength(3);
-
-    await user.type(screen.getByLabelText('Search publications'), 'Find me');
+    await user.type(
+      screen.getByRole('combobox', { name: 'Search publications' }),
+      'Find me',
+    );
     await user.click(screen.getByRole('button', { name: 'Search' }));
 
     expect(mockRouter).toMatchObject({
@@ -939,6 +948,10 @@ describe('FindStatisticsPageAzure', () => {
   });
 
   test('adds the relevance sort option when applying a search filter', async () => {
+    publicationService.suggestPublications.mockResolvedValue(
+      testPublicationSuggestions,
+    );
+
     publicationService.listPublications
       .mockResolvedValueOnce({
         results: testPublications,
@@ -967,7 +980,10 @@ describe('FindStatisticsPageAzure', () => {
     expect(sortOptions[2]).toHaveTextContent('A to Z');
     expect(sortOptions[2].selected).toBe(false);
 
-    await user.type(screen.getByLabelText('Search publications'), 'Find me');
+    await user.type(
+      screen.getByRole('combobox', { name: 'Search publications' }),
+      'Find me',
+    );
     await user.click(screen.getByRole('button', { name: 'Search' }));
 
     expect(await screen.findByText('2 results')).toBeInTheDocument();

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testPublicationSuggestions.ts
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testPublicationSuggestions.ts
@@ -1,0 +1,23 @@
+import { AzurePublicationSuggestResult } from '@frontend/services/azurePublicationService';
+
+// eslint-disable-next-line import/prefer-default-export
+export const testPublicationSuggestions: AzurePublicationSuggestResult[] = [
+  {
+    summary: 'Publication 1 summary',
+    title: 'Publication 1',
+    releaseSlug: 'latest-release-slug-1',
+    publicationSlug: 'publication-1-slug',
+  },
+  {
+    summary: 'Publication 2 summary',
+    title: 'Publication 2',
+    releaseSlug: 'latest-release-slug-2',
+    publicationSlug: 'publication-2-slug',
+  },
+  {
+    summary: 'Publication 3 summary',
+    title: 'Publication 3',
+    releaseSlug: 'latest-release-slug-3',
+    publicationSlug: 'publication-3-slug',
+  },
+];

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/utils/createAzurePublicationListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/utils/createAzurePublicationListRequest.ts
@@ -52,6 +52,32 @@ export default function createAzurePublicationListRequest(
   );
 }
 
+export function createAzurePublicationSuggestRequest(
+  query: FindStatisticsPageQuery,
+  searchTerm: string,
+): AzurePublicationListRequest {
+  const { releaseType, themeId } = getParamsFromQuery(query);
+
+  let filter: string | undefined;
+  if (releaseType && themeId) {
+    filter = odata`releaseType eq ${releaseType} and themeId eq ${themeId}`;
+  } else if (releaseType) {
+    filter = odata`releaseType eq ${releaseType}`;
+  } else if (themeId) {
+    filter = odata`themeId eq ${themeId}`;
+  }
+
+  return omitBy(
+    {
+      filter,
+      releaseType,
+      search: searchTerm,
+      themeId,
+    },
+    value => typeof value === 'undefined',
+  );
+}
+
 function getSortParam(
   sortBy: PublicationSortOption,
 ): AzurePublicationOrderByParam {

--- a/src/explore-education-statistics-frontend/src/queries/azurePublicationQueries.ts
+++ b/src/explore-education-statistics-frontend/src/queries/azurePublicationQueries.ts
@@ -1,8 +1,11 @@
-import createAzurePublicationListRequest from '@frontend/modules/find-statistics/utils/createAzurePublicationListRequest';
+import createAzurePublicationListRequest, {
+  createAzurePublicationSuggestRequest,
+} from '@frontend/modules/find-statistics/utils/createAzurePublicationListRequest';
 import { ParsedUrlQuery } from 'querystring';
 import { UseQueryOptions } from '@tanstack/react-query';
 import { PublicationListSummary } from '@common/services/publicationService';
 import azurePublicationService, {
+  AzurePublicationSuggestResult,
   PaginatedListWithAzureFacets,
 } from '@frontend/services/azurePublicationService';
 
@@ -15,6 +18,19 @@ const azurePublicationQueries = {
       queryFn: async () =>
         azurePublicationService.listPublications(
           createAzurePublicationListRequest(query),
+        ),
+    };
+  },
+  // TODO use or remove
+  suggestPublications(
+    query: ParsedUrlQuery,
+    searchTerm: string,
+  ): UseQueryOptions<AzurePublicationSuggestResult[]> {
+    return {
+      queryKey: ['suggestPublicationsAzure', query, searchTerm],
+      queryFn: async () =>
+        azurePublicationService.suggestPublications(
+          createAzurePublicationSuggestRequest(query, searchTerm),
         ),
     };
   },

--- a/src/explore-education-statistics-frontend/src/queries/azurePublicationQueries.ts
+++ b/src/explore-education-statistics-frontend/src/queries/azurePublicationQueries.ts
@@ -1,11 +1,8 @@
-import createAzurePublicationListRequest, {
-  createAzurePublicationSuggestRequest,
-} from '@frontend/modules/find-statistics/utils/createAzurePublicationListRequest';
+import createAzurePublicationListRequest from '@frontend/modules/find-statistics/utils/createAzurePublicationListRequest';
 import { ParsedUrlQuery } from 'querystring';
 import { UseQueryOptions } from '@tanstack/react-query';
 import { PublicationListSummary } from '@common/services/publicationService';
 import azurePublicationService, {
-  AzurePublicationSuggestResult,
   PaginatedListWithAzureFacets,
 } from '@frontend/services/azurePublicationService';
 
@@ -18,19 +15,6 @@ const azurePublicationQueries = {
       queryFn: async () =>
         azurePublicationService.listPublications(
           createAzurePublicationListRequest(query),
-        ),
-    };
-  },
-  // TODO use or remove
-  suggestPublications(
-    query: ParsedUrlQuery,
-    searchTerm: string,
-  ): UseQueryOptions<AzurePublicationSuggestResult[]> {
-    return {
-      queryKey: ['suggestPublicationsAzure', query, searchTerm],
-      queryFn: async () =>
-        azurePublicationService.suggestPublications(
-          createAzurePublicationSuggestRequest(query, searchTerm),
         ),
     };
   },

--- a/src/explore-education-statistics-frontend/src/styles/_all.scss
+++ b/src/explore-education-statistics-frontend/src/styles/_all.scss
@@ -2,3 +2,5 @@
 @import '~explore-education-statistics-common/src/styles/breakpoints';
 @import '~govuk-frontend/dist/govuk/index';
 @import '~explore-education-statistics-common/src/styles/all';
+
+@import './autocomplete';

--- a/src/explore-education-statistics-frontend/src/styles/_autocomplete.scss
+++ b/src/explore-education-statistics-frontend/src/styles/_autocomplete.scss
@@ -1,0 +1,131 @@
+@import '~govuk-frontend/dist/govuk/base';
+// These styles are adapted from the original Accessible Autocomplete component stylesheet, mostly
+// to remove superfluous styles that are already provided by the GOV.UK Design System, and to adapt
+// the styling to match the new GOV.UK search box designs (e.g. to remove the zebra striping on
+// rows, adjust whitespace, and manage the tweaked markup we use in the suggestion template).
+//
+// Some of these amends have been made by the govuk_publishing_components search-with-autocomplete
+//
+// see https://github.com/alphagov/accessible-autocomplete/blob/main/src/autocomplete.css
+// and https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/stylesheets/govuk_publishing_components/components/_search-with-autocomplete.scss
+
+// Helps to make the autocomplete menu as wide as the entire search box _including_ the submit
+// button, not just the width of the input field.
+@mixin enhance-autocomplete-menu-width($button-size) {
+  margin-right: -$button-size;
+}
+
+$input-size: 40px;
+
+.autocomplete__item-wrap {
+  position: relative;
+}
+
+.autocomplete__wrapper {
+  position: relative;
+}
+
+.autocomplete__input {
+  appearance: none;
+  border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+  border-radius: 0;
+  box-sizing: border-box;
+  margin-bottom: 0;
+  width: calc(100% - #{$input-size});
+  background-color: transparent;
+  padding: govuk-spacing(1);
+  position: relative;
+  height: $input-size;
+}
+
+.autocomplete__input--focused {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline-offset: 0;
+  box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+}
+
+.autocomplete__submit-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: $input-size;
+  height: $input-size;
+}
+
+.autocomplete__menu {
+  background-color: govuk-colour('white');
+  border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+  border: $govuk-border-width-form-element solid govuk-colour('dark-grey');
+  border-top: 0;
+  color: $govuk-text-colour;
+  margin: 0;
+  max-height: 342px;
+  overflow-x: hidden;
+  padding: 0;
+  width: 100%;
+  @include enhance-autocomplete-menu-width($input-size);
+}
+
+.autocomplete__menu--visible {
+  display: block;
+}
+
+.autocomplete__menu--hidden {
+  display: none;
+}
+
+.autocomplete__option {
+  border-bottom: solid govuk-colour('mid-grey');
+  border-width: 1px 0;
+  cursor: pointer;
+  display: block;
+  position: relative;
+  margin-bottom: 0;
+}
+
+.autocomplete__option > * {
+  pointer-events: none;
+}
+
+.autocomplete__option:first-of-type {
+  border-top-width: 0;
+}
+
+.autocomplete__option:last-of-type {
+  border-bottom-width: 0;
+}
+
+.autocomplete__option-summary {
+  color: govuk-colour('dark-grey');
+}
+
+// .autocomplete__option--odd {
+//   background-color: govuk-colour('light-grey');
+// }
+
+.autocomplete__option--focused,
+.autocomplete__option:focus-visible,
+.autocomplete__option:hover {
+  background-color: govuk-colour('blue');
+  outline: 0;
+
+  .autocomplete__option-summary,
+  .autocomplete__option-title {
+    color: govuk-colour('white');
+    pointer-events: none;
+  }
+}
+
+.autocomplete__option-item {
+  display: grid;
+  margin-bottom: 0;
+}
+
+.autocomplete__input,
+.autocomplete__option {
+  @include govuk-font(19);
+}
+
+.autocomplete__option {
+  padding: govuk-spacing(1);
+}

--- a/src/explore-education-statistics-frontend/src/types/accessible-autocomplete.ts
+++ b/src/explore-education-statistics-frontend/src/types/accessible-autocomplete.ts
@@ -56,8 +56,9 @@ declare module 'accessible-autocomplete/react' {
    */
   interface AccessibleAutocompleteProps {
     /**
-     * The `id` attribute for the generated input field.
-     * If not provided, a unique ID will be generated.
+     * The id to assign to the autocomplete input field,
+     * to use with a <label for=id>.
+     * Not required if using enhanceSelectElement
      */
     id?: string;
     /**
@@ -88,10 +89,27 @@ declare module 'accessible-autocomplete/react' {
      * Controls how the dropdown menu is displayed.
      * - `'inline'`: The dropdown appears directly below the input.
      * - `'overlay'`: The dropdown appears as an overlay over other content.
-     * - `'hidden'`: The dropdown is visually hidden but still accessible (e.g., for screen readers).
-     * Defaults to `'overlay'`.
+     * Defaults to `'inline'`.
      */
-    displayMenu?: 'inline' | 'overlay' | 'hidden';
+    displayMenu?: 'inline' | 'overlay';
+    /**
+     * Sets html attributes and their values on the generated ul menu element.
+     * Useful for adding aria-labelledby and setting to the value of the id attribute on your existing label,to provide context to an assistive technology user.
+     */
+    menuAttributes?: Record<string, string | boolean>;
+    /**
+     * Adds custom html classes to the generated ul menu element.
+     */
+    menuClasses?: string;
+    /**
+     * Adds custom html classes to the generated input element.
+     */
+    inputClasses?: string;
+    /**
+     * Adds custom html classes to the additional input element that appears
+     * when what the user typed matches the start of a suggestion.
+     */
+    hintClasses?: string;
     /**
      * A callback function that is triggered when a suggestion is confirmed (selected by user or on blur).
      * @param query The confirmed suggestion (string or object from the source), or `undefined` if nothing was selected.
@@ -143,11 +161,6 @@ declare module 'accessible-autocomplete/react' {
      * The `placeholder` attribute for the generated text input field.
      */
     placeholder?: string;
-    /**
-     * If `true`, the form containing the autocomplete will be submitted when a suggestion is confirmed.
-     * Defaults to `false`.
-     */
-    autoSubmit?: boolean;
     /**
      * Optional `className` to apply to the top-level autocomplete wrapper div.
      */

--- a/src/explore-education-statistics-frontend/src/types/accessible-autocomplete.ts
+++ b/src/explore-education-statistics-frontend/src/types/accessible-autocomplete.ts
@@ -1,0 +1,164 @@
+declare module 'accessible-autocomplete/react' {
+  import React from 'react';
+
+  /**
+   * Type for a single suggestion item in accessible-autocomplete.
+   * It can be a string or an object, depending on the source data and `templates.inputValue`.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type AutocompleteSuggestion = string | object | any;
+
+  /**
+   * Defines custom template functions for accessible-autocomplete.
+   */
+  interface AutocompleteTemplates {
+    /**
+     * A function that returns the string to be displayed in the input field when a suggestion is selected.
+     * If your `source` provides objects, this function tells the autocomplete how to convert
+     * that object into the text shown in the input.
+     * @param result The selected suggestion item (string or object).
+     * @returns The string to display in the input.
+     */
+    inputValue?: (result: AutocompleteSuggestion) => string;
+    /**
+     * A function that returns the HTML string for a suggestion as it appears in the dropdown menu.
+     * This allows for rich HTML formatting of suggestions.
+     * @param result The suggestion item (string or object).
+     * @returns The HTML string for the suggestion.
+     */
+    suggestion?: (result: AutocompleteSuggestion) => string;
+  }
+
+  /**
+   * Type for the dropdown arrow SVG generator.
+   * This function receives a configuration object and should return an SVG string.
+   */
+  type DropdownArrowRenderer = (config: { className: string }) => string;
+
+  /**
+   * Defines the source of suggestions for the autocomplete.
+   * Can be:
+   * - An array of strings or objects.
+   * - A synchronous function that takes a query and a `populateResults` callback.
+   * - An asynchronous function that takes a query and returns a Promise resolving to suggestions.
+   */
+  type AutocompleteSource =
+    | AutocompleteSuggestion[]
+    | ((
+        query: string,
+        populateResults: (suggestions: AutocompleteSuggestion[]) => void,
+      ) => void)
+    | ((query: string) => Promise<AutocompleteSuggestion[]>);
+
+  /**
+   * Options for configuring the `AccessibleAutocomplete` React component.
+   * These largely mirror the options for the core `accessible-autocomplete` library.
+   */
+  interface AccessibleAutocompleteProps {
+    /**
+     * The `id` attribute for the generated input field.
+     * If not provided, a unique ID will be generated.
+     */
+    id?: string;
+    /**
+     * The source of suggestions for the autocomplete.
+     */
+    source: AutocompleteSource;
+    /**
+     * The minimum number of characters the user must type before suggestions are shown.
+     * Defaults to `0`.
+     */
+    minLength?: number;
+    /**
+     * The debounce delay in milliseconds for the `source` function.
+     * Suggestions will only be fetched after the user stops typing for this duration.
+     * Defaults to `0`.
+     */
+    debounce?: number;
+    /**
+     * If `true`, the first suggestion will be automatically highlighted when the dropdown appears.
+     * Defaults to `false`.
+     */
+    autoselect?: boolean;
+    /**
+     * The initial value of the input field.
+     */
+    defaultValue?: string;
+    /**
+     * Controls how the dropdown menu is displayed.
+     * - `'inline'`: The dropdown appears directly below the input.
+     * - `'overlay'`: The dropdown appears as an overlay over other content.
+     * - `'hidden'`: The dropdown is visually hidden but still accessible (e.g., for screen readers).
+     * Defaults to `'overlay'`.
+     */
+    displayMenu?: 'inline' | 'overlay' | 'hidden';
+    /**
+     * A callback function that is triggered when a suggestion is confirmed (selected by user or on blur).
+     * @param query The confirmed suggestion (string or object from the source), or `undefined` if nothing was selected.
+     */
+    onConfirm?: (query: AutocompleteSuggestion | undefined) => void;
+    /**
+     * If `true`, `onConfirm` will be triggered when the input field loses focus,
+     * even if no suggestion was explicitly selected.
+     * Defaults to `false`.
+     */
+    confirmOnBlur?: boolean;
+    /**
+     * Custom template functions to control how suggestions are displayed and how the input value is set.
+     */
+    templates?: AutocompleteTemplates;
+    /**
+     * If `true` and the `source` is an array, all values will be shown in the dropdown immediately
+     * when the input is focused, without needing to type.
+     * Defaults to `false`.
+     */
+    showAllValues?: boolean;
+    /**
+     * The autocomplete will display a "No results found" template when there are no results.
+     * Defaults to `false`.
+     */
+    showNoOptionsFound?: boolean;
+    /**
+     * A function that returns the SVG string for the dropdown arrow icon.
+     * Useful for custom arrow icons.
+     * @param config Configuration object, currently only includes `className`.
+     * @returns An SVG string.
+     */
+    dropdownArrow?: DropdownArrowRenderer;
+    /**
+     * A function that returns the text to display when no results are found.
+     * Defaults to a predefined message.
+     */
+    tNoResults?: () => string;
+    /**
+     * A function that returns the assistive hint text for screen readers.
+     * Defaults to a predefined string.
+     */
+    tAssistiveHint?: () => string;
+    /**
+     * The `name` attribute for the generated hidden input field that typically holds the confirmed value.
+     */
+    name?: string;
+    /**
+     * The `placeholder` attribute for the generated text input field.
+     */
+    placeholder?: string;
+    /**
+     * If `true`, the form containing the autocomplete will be submitted when a suggestion is confirmed.
+     * Defaults to `false`.
+     */
+    autoSubmit?: boolean;
+    /**
+     * Optional `className` to apply to the top-level autocomplete wrapper div.
+     */
+    className?: string;
+  }
+
+  /**
+   * The Accessible Autocomplete React component.
+   * This component wraps the core accessible-autocomplete library to provide a React-friendly interface.
+   */
+  const AccessibleAutocomplete: React.FC<AccessibleAutocompleteProps>;
+
+  export default AccessibleAutocomplete;
+}

--- a/tests/robot-tests/tests/general_public/statistics_page_azure_search.robot
+++ b/tests/robot-tests/tests/general_public/statistics_page_azure_search.robot
@@ -35,7 +35,7 @@ Validate publications list exists and all publications are shown
     user checks page contains    showing all publications
 
 Search publications
-    user clicks element    id:searchForm-search
+    user clicks element    id:search
     user presses keys    pupil absence
     user clicks button    Search
     user checks page contains button    pupil absence


### PR DESCRIPTION
### Summary
This PR adds the bulk of the typeahead functionality to the new find stats page search.

Following the search examples on www.gov.uk and design-system.service.gov.uk, we have used the [accessible-autocomplete](https://github.com/alphagov/accessible-autocomplete) package.

As this package is managing the input itself, we are not using react-hook-form or tanstack-query, as we do on other forms around the service. We have also had to make a couple of tweaks to the generated input, too, to handle 'enter' to submit the form and change to `type="search"`

![image](https://github.com/user-attachments/assets/a8364f35-9b41-4d2a-a70d-f9971b27c1b4)

### Notes
- I have generated the type definition for the accessible-autocomplete component as it doesn't exist.
- I couldn't find a way to prepopulate the input value and not have errors appearing. There is a prop for 'defaultValue' but it caused me errors. As it stands, when the page loads, the input always starts empty, but I don't _think_ this is a terrible user experience.

### To be done in other PRs: 
- Add analytics
- Add highlighting on the typeahead results