### PR TITLE
Group Renovate Ruby gem update PR's

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -93,6 +93,10 @@
       "enabled": false
     },
     {
+      "matchDatasources": ["rubygems"],
+      "groupName": "Ruby dependencies"
+    },
+    {
       "matchDatasources": ["azure-bicep-resource"],
       "groupName": "Azure Bicep resources",
       "description": "Prevent unofficial resource versions being suggested",


### PR DESCRIPTION
This PR is a Renovate config change to group Ruby gem dependency updates.

We might decide to disable Ruby gem updates altogether, schedule them, or automerge them, but this is a first attempt at closing all of the individual update PR's in favour of a single grouped PR.