### PR TITLE
EES-6248 Add new search banners to home and search pages

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/Page.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Page.tsx
@@ -20,6 +20,7 @@ type Props = {
   pageMeta?: PageMetaProps;
   className?: string;
   children?: ReactNode;
+  customBannerContent?: ReactNode;
   wide?: boolean;
   isHomepage?: boolean;
 } & BreadcrumbsProps;
@@ -34,6 +35,7 @@ const Page = ({
   pageMeta,
   className,
   children = null,
+  customBannerContent = null,
   wide = false,
   isHomepage = false,
   breadcrumbs = [],
@@ -57,6 +59,8 @@ const Page = ({
         })}
       >
         <PhaseBanner url="https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-XMiKzsnr8xJoWM_DeGwIu9UNDJHOEJDRklTNVA1SDdLOFJITEwyWU1OQS4u" />
+
+        {customBannerContent}
 
         <Breadcrumbs
           breadcrumbs={

--- a/src/explore-education-statistics-frontend/src/components/TryNewSearchBanner.tsx
+++ b/src/explore-education-statistics-frontend/src/components/TryNewSearchBanner.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import NotificationBanner from '@common/components/NotificationBanner';
+import Link from '@frontend/components/Link';
+
+const TryNewSearchBanner = () => {
+  return (
+    <NotificationBanner
+      className="govuk-!-margin-top-6"
+      fullWidthContent
+      title="New improved search"
+    >
+      <p>
+        Try out our{' '}
+        <Link to="/find-statistics?azsearch=true">new improved search</Link> and
+        give us feedback
+      </p>
+    </NotificationBanner>
+  );
+};
+
+export default TryNewSearchBanner;

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
@@ -9,12 +9,14 @@ import GoToTopLink from '@common/components/GoToTopLink';
 import ScreenReaderMessage from '@common/components/ScreenReaderMessage';
 import ButtonText from '@common/components/ButtonText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
+import NotificationBanner from '@common/components/NotificationBanner';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import WarningMessage from '@common/components/WarningMessage';
 import { useMobileMedia } from '@common/hooks/useMedia';
 import { ReleaseType, releaseTypes } from '@common/services/types/releaseType';
 import FilterResetButtonAzureSearch from '@frontend/components/FilterResetButtonAzureSearch';
 import FiltersMobile from '@frontend/components/FiltersMobile';
+import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
 import Pagination from '@frontend/components/Pagination';
 import SearchForm from '@frontend/components/SearchFormAzure';
@@ -233,6 +235,20 @@ const FindStatisticsPage: NextPage = () => {
   return (
     <Page
       title={defaultPageTitle}
+      customBannerContent={
+        <NotificationBanner
+          className="govuk-!-margin-top-6"
+          fullWidthContent
+          title="New improved search"
+        >
+          <p>
+            This is our new search, help us improve it by completing{' '}
+            <Link to="https://forms.office.com/e/KjpABWF8kA" target="_blank">
+              our feedback form (opens in new window)
+            </Link>
+          </p>
+        </NotificationBanner>
+      }
       // Don't include the default meta title when filtered to prevent too much screen reader noise.
       includeDefaultMetaTitle={pageTitle === defaultPageTitle}
       metaTitle={pageTitle}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageCurrent.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageCurrent.tsx
@@ -22,6 +22,7 @@ import Page from '@frontend/components/Page';
 import Pagination from '@frontend/components/Pagination';
 import SearchForm from '@frontend/components/SearchForm';
 import SortControls, { SortOption } from '@frontend/components/SortControls';
+import TryNewSearchBanner from '@frontend/components/TryNewSearchBanner';
 import Filters from '@frontend/modules/find-statistics/components/Filters';
 import PublicationSummary from '@frontend/modules/find-statistics/components/PublicationSummary';
 import { getParamsFromQuery } from '@frontend/modules/find-statistics/utils/createPublicationListRequest';
@@ -181,6 +182,7 @@ const FindStatisticsPage: NextPage = () => {
   return (
     <Page
       title={defaultPageTitle}
+      customBannerContent={<TryNewSearchBanner />}
       // Don't include the default meta title when filtered to prevent too much screen reader noise.
       includeDefaultMetaTitle={pageTitle === defaultPageTitle}
       metaTitle={pageTitle}

--- a/src/explore-education-statistics-frontend/src/pages/index.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import HomepageCard from '@frontend/components/HomepageCard';
 import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
+import TryNewSearchBanner from '@frontend/components/TryNewSearchBanner';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
 import React from 'react';
 
@@ -13,7 +14,11 @@ function HomePage() {
     });
 
   return (
-    <Page title="Explore our statistics and data" isHomepage>
+    <Page
+      title="Explore our statistics and data"
+      isHomepage
+      customBannerContent={<TryNewSearchBanner />}
+    >
       <div className="govuk-grid-row dfe-card__container">
         <HomepageCard
           title="Find statistics and data"


### PR DESCRIPTION
This PR adds a banner to the home page, the current find stats page, and the new find stats page

![image](https://github.com/user-attachments/assets/495cb8ae-e617-4180-8b25-5a420cd81091)
