### PR TITLE
EES-6297 highlights for typeahead

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
@@ -79,16 +79,32 @@ export default function SearchForm({ label = 'Search', onSubmit }: Props) {
       });
   };
 
-  const suggestionTemplate = (
-    result: AzurePublicationSuggestResult,
-  ) => `<p class="autocomplete__option-item">
-          <span class="autocomplete__option-title">
-            ${result.title}
-          </span>
-          <span class="autocomplete__option-summary">
-            ${truncate(result.summary, { length: 140 })}
-          </span>
-        </p>`;
+  const suggestionTemplate = (result: AzurePublicationSuggestResult) => {
+    // The result has a highlightedMatch with HTML tags which could either be
+    // from the title or the summary. So we will strip out the HTML tags
+    // to be able to check which field it is from, and use accordingly.
+    const highlightMatchWithoutTags = result.highlightedMatch.replaceAll(
+      /<[^>]*>/g,
+      '',
+    );
+
+    return `<p class="autocomplete__option-item">
+      <span class="autocomplete__option-title">
+        ${
+          result.title.includes(highlightMatchWithoutTags)
+            ? result.highlightedMatch
+            : result.title
+        }
+      </span>
+      <span class="autocomplete__option-summary">
+      ${
+        result.summary.includes(highlightMatchWithoutTags)
+          ? result.highlightedMatch
+          : truncate(result.summary, { length: 140 })
+      }
+      </span>
+    </p>`;
+  };
 
   return (
     <form

--- a/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
@@ -94,7 +94,7 @@ export default function SearchForm({ label = 'Search', onSubmit }: Props) {
       /(?<=<strong>)(.*?)(?=<\/strong>)/,
     );
 
-    const addstrongToString = (snippet: string) =>
+    const wrapHighlightedTermWithTag = (snippet: string) =>
       highlightedTerm
         ? snippet.replaceAll(
             highlightedTerm[0],
@@ -110,14 +110,16 @@ export default function SearchForm({ label = 'Search', onSubmit }: Props) {
         ${
           result.title.includes(highlightMatchWithoutTags)
             ? result.highlightedMatch
-            : addstrongToString(result.title)
+            : wrapHighlightedTermWithTag(result.title)
         }
       </span>
       <span class="autocomplete__option-summary">
       ${
         result.summary.includes(highlightMatchWithoutTags)
           ? result.highlightedMatch
-          : addstrongToString(truncate(result.summary, { length: 140 }))
+          : wrapHighlightedTermWithTag(
+              truncate(result.summary, { length: 140 }),
+            )
       }
       </span>
     </p>`;

--- a/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
@@ -91,14 +91,14 @@ export default function SearchForm({ label = 'Search', onSubmit }: Props) {
     // We also need to find out which term was highlighted in order to manually
     // add highlights to the other field.
     const highlightedTerm = result.highlightedMatch.match(
-      /(?<=<mark>)(.*?)(?=<\/mark>)/,
+      /(?<=<strong>)(.*?)(?=<\/strong>)/,
     );
 
-    const addMarkToString = (snippet: string) =>
+    const addstrongToString = (snippet: string) =>
       highlightedTerm
         ? snippet.replaceAll(
             highlightedTerm[0],
-            match => `<mark>${match}</mark>`,
+            match => `<strong>${match}</strong>`,
           )
         : snippet;
 
@@ -110,14 +110,14 @@ export default function SearchForm({ label = 'Search', onSubmit }: Props) {
         ${
           result.title.includes(highlightMatchWithoutTags)
             ? result.highlightedMatch
-            : addMarkToString(result.title)
+            : addstrongToString(result.title)
         }
       </span>
       <span class="autocomplete__option-summary">
       ${
         result.summary.includes(highlightMatchWithoutTags)
           ? result.highlightedMatch
-          : addMarkToString(truncate(result.summary, { length: 140 }))
+          : addstrongToString(truncate(result.summary, { length: 140 }))
       }
       </span>
     </p>`;

--- a/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
@@ -80,27 +80,44 @@ export default function SearchForm({ label = 'Search', onSubmit }: Props) {
   };
 
   const suggestionTemplate = (result: AzurePublicationSuggestResult) => {
-    // The result has a highlightedMatch with HTML tags which could either be
-    // from the title or the summary. So we will strip out the HTML tags
-    // to be able to check which field it is from, and use accordingly.
+    // The result has a `highlightedMatch` property with HTML tags which could
+    // either be from the `title` or the `summary`. So we will strip out the HTML
+    // tags to be able to check which field it is from, and use accordingly.
     const highlightMatchWithoutTags = result.highlightedMatch.replaceAll(
       /<[^>]*>/g,
       '',
     );
 
+    // We also need to find out which term was highlighted in order to manually
+    // add highlights to the other field.
+    const highlightedTerm = result.highlightedMatch.match(
+      /(?<=<mark>)(.*?)(?=<\/mark>)/,
+    );
+
+    const addMarkToString = (snippet: string) =>
+      highlightedTerm
+        ? snippet.replaceAll(
+            highlightedTerm[0],
+            match => `<mark>${match}</mark>`,
+          )
+        : snippet;
+
+    // For both title and summary, render the `highlightedMatch` from azure
+    // if it is from this field.
+    // Otherwise, render the field with highlights manually added.
     return `<p class="autocomplete__option-item">
       <span class="autocomplete__option-title">
         ${
           result.title.includes(highlightMatchWithoutTags)
             ? result.highlightedMatch
-            : result.title
+            : addMarkToString(result.title)
         }
       </span>
       <span class="autocomplete__option-summary">
       ${
         result.summary.includes(highlightMatchWithoutTags)
           ? result.highlightedMatch
-          : truncate(result.summary, { length: 140 })
+          : addMarkToString(truncate(result.summary, { length: 140 }))
       }
       </span>
     </p>`;

--- a/src/explore-education-statistics-frontend/src/components/__tests__/SearchFormAzure.test.tsx
+++ b/src/explore-education-statistics-frontend/src/components/__tests__/SearchFormAzure.test.tsx
@@ -1,11 +1,10 @@
 import SearchFormAzure from '@frontend/components/SearchFormAzure';
 import _publicationService from '@frontend/services/azurePublicationService';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import noop from 'lodash/noop';
 import userEvent from '@testing-library/user-event';
 import { testPublicationSuggestions } from '@frontend/modules/find-statistics/__tests__/__data__/testPublicationSuggestions';
-import mockRouter from 'next-router-mock';
 
 jest.mock('@azure/search-documents', () => ({
   SearchClient: jest.fn(),

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testPublicationSuggestions.ts
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testPublicationSuggestions.ts
@@ -7,20 +7,20 @@ export const testPublicationSuggestions: AzurePublicationSuggestResult[] = [
     title: 'Publication 1',
     releaseSlug: 'latest-release-slug-1',
     publicationSlug: 'publication-1-slug',
-    highlightedMatch: 'Publication <mark>1</mark>',
+    highlightedMatch: 'Publication <strong>1</strong>',
   },
   {
     summary: 'Publication 2 summary',
     title: 'Publication 2',
     releaseSlug: 'latest-release-slug-2',
     publicationSlug: 'publication-2-slug',
-    highlightedMatch: 'Publication <mark>2</mark> summary',
+    highlightedMatch: 'Publication <strong>2</strong> summary',
   },
   {
     summary: 'Publication 3 summary',
     title: 'Publication 3',
     releaseSlug: 'latest-release-slug-3',
     publicationSlug: 'publication-3-slug',
-    highlightedMatch: 'Publication <mark>3</mark>',
+    highlightedMatch: 'Publication <strong>3</strong>',
   },
 ];

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testPublicationSuggestions.ts
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/__data__/testPublicationSuggestions.ts
@@ -7,17 +7,20 @@ export const testPublicationSuggestions: AzurePublicationSuggestResult[] = [
     title: 'Publication 1',
     releaseSlug: 'latest-release-slug-1',
     publicationSlug: 'publication-1-slug',
+    highlightedMatch: 'Publication <mark>1</mark>',
   },
   {
     summary: 'Publication 2 summary',
     title: 'Publication 2',
     releaseSlug: 'latest-release-slug-2',
     publicationSlug: 'publication-2-slug',
+    highlightedMatch: 'Publication <mark>2</mark> summary',
   },
   {
     summary: 'Publication 3 summary',
     title: 'Publication 3',
     releaseSlug: 'latest-release-slug-3',
     publicationSlug: 'publication-3-slug',
+    highlightedMatch: 'Publication <mark>3</mark>',
   },
 ];

--- a/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
+++ b/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
@@ -158,8 +158,8 @@ const azurePublicationService = {
             searchFields: ['title', 'summary'],
             useFuzzyMatching: true,
             top: 3,
-            highlightPostTag: '</mark>',
-            highlightPreTag: '<mark>',
+            highlightPostTag: '</strong>',
+            highlightPreTag: '<strong>',
           })
         : null;
 

--- a/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
+++ b/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
@@ -155,6 +155,7 @@ const azurePublicationService = {
         ? await azureSearchClient.suggest(search, 'suggester-1', {
             select: ['releaseSlug', 'title', 'summary', 'publicationSlug'],
             filter,
+            searchFields: ['title', 'summary'],
             useFuzzyMatching: true,
             top: 3,
             highlightPostTag: '</mark>',

--- a/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
+++ b/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
@@ -30,6 +30,7 @@ export interface AzurePublicationSearchResult {
 }
 
 export interface AzurePublicationSuggestResult {
+  highlightedMatch: string;
   releaseSlug: string;
   publicationSlug: string;
   summary: string;
@@ -163,9 +164,12 @@ const azurePublicationService = {
 
     let resultsToReturn = [] as AzurePublicationSuggestResult[];
     if (suggestResults?.results) {
-      resultsToReturn = suggestResults?.results.map(
-        result => result.document as AzurePublicationSuggestResult,
-      );
+      resultsToReturn = suggestResults?.results.map(result => {
+        return {
+          ...result.document,
+          highlightedMatch: result.text,
+        } as AzurePublicationSuggestResult;
+      });
     }
     return resultsToReturn;
   },


### PR DESCRIPTION
This PR adds highlighting for the autocomplete results, showing matching terms in bold.

Annoyingly, azure returns highlighted content for each result, but it is either the `title` or `summary`, and we don't know which it is.

So when rendering the results, we figure out which field has been returned with highlights already and try to apply manual highlights to the other field, by working out which highlighted term has been returned by Azure.
Hopefully this process is clear in the code.

Please see [this slack thread](https://exploreeducationstats.slack.com/archives/C065M8V6HRC/p1751637731621039) for more discussion about this issue.

![image](https://github.com/user-attachments/assets/abbb3bb3-6e9d-4e35-98b6-be131de09504)
