### PR TITLE
EES-6247 Show better facet counts in filter dropdowns

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPageAzure.tsx
@@ -73,48 +73,35 @@ const FindStatisticsPage: NextPage = () => {
     router.query,
   );
 
-  const themesWithResultCounts = !themeId
-    ? themes
-        .map(theme => {
-          const facetedResult = themeFacetResults?.find(
-            result => theme.id === result.value,
-          );
-          const count = facetedResult?.count ?? 0;
-          return {
-            label: `${theme.title} (${count})`,
-            value: theme.id,
-            count,
-          };
-        })
-        .sort((a, b) => b.count - a.count)
-    : themes.map(theme => ({
-        label: theme.title,
+  const themesWithResultCounts = themes
+    .map(theme => {
+      const facetedResult = themeFacetResults?.find(
+        result => theme.id === result.value,
+      );
+      const count = facetedResult?.count ?? 0;
+      return {
+        label: `${theme.title} (${count})`,
         value: theme.id,
-      }));
+        count,
+      };
+    })
+    .sort((a, b) => b.count - a.count);
 
-  const releaseTypesWithResultCounts = !releaseType
-    ? Object.keys(releaseTypes)
-        .map(type => {
-          const facetedResult = releaseTypeFacetResults?.find(
-            result => type === result.value,
-          );
+  const releaseTypesWithResultCounts = Object.keys(releaseTypes)
+    .map(type => {
+      const facetedResult = releaseTypeFacetResults?.find(
+        result => type === result.value,
+      );
 
-          const title = releaseTypes[type as ReleaseType];
-          const count = facetedResult?.count ?? 0;
-          return {
-            label: `${title} (${count})`,
-            value: type,
-            count,
-          };
-        })
-        .sort((a, b) => b.count - a.count)
-    : Object.keys(releaseTypes).map(type => {
-        const title = releaseTypes[type as ReleaseType];
-        return {
-          label: title,
-          value: type,
-        };
-      });
+      const title = releaseTypes[type as ReleaseType];
+      const count = facetedResult?.count ?? 0;
+      return {
+        label: `${title} (${count})`,
+        value: type,
+        count,
+      };
+    })
+    .sort((a, b) => b.count - a.count);
 
   const isFiltered = !!search || !!releaseType || !!themeId;
 

--- a/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
+++ b/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
@@ -2,13 +2,15 @@
 import { env } from 'process';
 import { PublicationListSummary } from '@common/services/publicationService';
 import { PaginatedList } from '@common/services/types/pagination';
+import { ReleaseType } from '@common/services/types/releaseType';
+import { SortDirection } from '@common/services/types/sort';
 import {
   AzureKeyCredential,
   FacetResult,
+  odata,
   SearchClient,
+  SearchOptions,
 } from '@azure/search-documents';
-import { ReleaseType } from '@common/services/types/releaseType';
-import { SortDirection } from '@common/services/types/sort';
 
 export interface AzurePublicationSearchResult {
   '@search.score': string;
@@ -51,11 +53,13 @@ export type AzurePublicationOrderByParam =
 
 export interface AzurePublicationListRequest {
   filter?: string;
+  orderBy?: AzurePublicationOrderByParam;
   page?: number;
   pageSize?: number;
+  releaseType?: string;
   search?: string;
-  orderBy?: AzurePublicationOrderByParam;
   sortDirection?: SortDirection;
+  themeId?: string;
 }
 
 const { AZURE_SEARCH_ENDPOINT, AZURE_SEARCH_INDEX, AZURE_SEARCH_QUERY_KEY } =
@@ -71,22 +75,44 @@ const azurePublicationService = {
   async listPublications(
     params: AzurePublicationListRequest,
   ): Promise<PaginatedListWithAzureFacets<PublicationListSummary>> {
-    const { filter, orderBy, page = 1, search } = params;
+    const {
+      filter,
+      orderBy,
+      page = 1,
+      pageSize = 10,
+      releaseType,
+      search = '',
+      themeId,
+    } = params;
 
-    const searchResults = await azureSearchClient.search(search || '', {
+    const searchOptionsBase = {
       includeTotalCount: true,
-      top: 10,
-      skip: page > 1 ? (page - 1) * 10 : 0,
+      orderBy: orderBy ? [orderBy] : undefined,
       queryType: !orderBy ? 'semantic' : undefined,
+      searchMode: 'any',
       semanticSearchOptions: {
         configurationName: 'semantic-configuration-1',
       },
-      searchMode: 'any',
       scoringProfile: 'scoring-profile-1',
+      skip: page > 1 ? (page - 1) * 10 : 0,
+      top: 10,
+    } as Pick<
+      SearchOptions<AzurePublicationSearchResult>,
+      | 'includeTotalCount'
+      | 'orderBy'
+      | ('queryType' & 'semanticSearchOptions')
+      | 'scoringProfile'
+      | 'searchMode'
+      | 'skip'
+      | 'top'
+    >;
+
+    // Get all search results
+    const searchResults = await azureSearchClient.search(search, {
+      ...searchOptionsBase,
       highlightFields: 'title,summary,content-3',
       facets: ['themeId,count:150,sort:count', 'releaseType'],
       filter,
-      orderBy: orderBy ? [orderBy] : undefined,
       select: [
         'content',
         'releaseSlug',
@@ -100,9 +126,39 @@ const azurePublicationService = {
       ],
     });
 
-    // Transform response into <PaginatedListWithAzureFacets<PublicationListSummary>>
+    // If a theme filter is selected - let's get the facet counts
+    // for as if we hadn't filtered by theme too
+    const themeFacetResults = themeId
+      ? await azureSearchClient.search(search, {
+          ...searchOptionsBase,
+          facets: ['themeId,count:150,sort:count'],
+          select: [],
+          // Filter still needs to account for releaseType if it is present
+          filter: releaseType
+            ? odata`releaseType eq ${releaseType}`
+            : undefined,
+        })
+      : null;
+
+    // If a releaseType filter is selected - let's get the facet counts
+    // for as if we hadn't filtered by releaseType too
+    const releaseTypeFacetResults = releaseType
+      ? await azureSearchClient.search(search, {
+          ...searchOptionsBase,
+          facets: ['releaseType'],
+          select: [],
+          // Filter still needs to account for themeId if it is present
+          filter: themeId ? odata`themeId eq ${themeId}` : undefined,
+        })
+      : null;
+
+    // Now transform response into <PaginatedListWithAzureFacets<PublicationListSummary>>
     const { count = 0, results, facets = {} } = searchResults;
-    const pageSize = 10;
+    const facetsCombined = {
+      ...facets,
+      ...themeFacetResults?.facets,
+      ...releaseTypeFacetResults?.facets,
+    };
     const publicationsResult = {
       paging: {
         totalPages: count === 0 ? 0 : Math.floor((count - 1) / pageSize) + 1,
@@ -111,7 +167,7 @@ const azurePublicationService = {
         pageSize,
       },
       results: [] as PublicationListSummary[],
-      facets,
+      facets: facetsCombined,
     };
 
     for await (const result of results) {


### PR DESCRIPTION
When a filter is applied (theme or releaseType), we need to show how many items there are for the _other_ filter item options of the same filter type. So we now make an extra request to azure _per applied filter_. Currently, if a filter is applied, we don't show counts next to the items in the dropdowns, as they are all 0 except for the applied filter.

e.g. If we are filtering by theme: we need to show the counts of items in other themes, so request the same search but without the theme filter applied, too.

Details are in [the JIRA ticket](https://dfedigital.atlassian.net/browse/EES-6247).

### Screenshots to demo

**Example 1:** We are filtering by search term and theme. There are 6 results total with the current search. But other themes have different results, reflected in the numbers next to them in the dropdown.

![image](https://github.com/user-attachments/assets/405149eb-bcac-4e62-b677-052ec4922860)

**Example 2:** We are filtering by search term and theme and release type. There are 2 results total with current filters. Release type dropdown shows number of results for other release types, with the same theme and search filters applied.

![image](https://github.com/user-attachments/assets/e474128f-e517-49fb-b334-ffb082ae0501)

