### PR TITLE
EES-5999: Rename appsettings section for the Screener API.

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -742,7 +742,7 @@
         "description": "The Client ID of a manually-created App Registration that represents the Public API Data Processor Function App in Entra ID"
       }
     },
-    // "screenerApiAppRegistrationClientId": {
+    // "dataScreenerAppRegistrationClientId": {
     //   "type": "string",
     //   "metadata": {
     //     "description": "The Client ID of a manually-created App Registration that represents the Screener API Function App in Entra ID"
@@ -815,7 +815,7 @@
     "publisherStorageAccountId": "[concat(resourceGroup().id,'/providers/','Microsoft.Storage/storageAccounts/', variables('publisherStorageAccountName'))]",
     "loggingStorageAccountName": "[concat(parameters('subscription'), 'saeeslogging')]",
     "publicDataProcessorName": "[concat(parameters('subscription'), '-', parameters('environment'), '-papi-fa-processor')]",
-    "screenerApiName": "[concat(parameters('subscription'), '-', parameters('environment'), '-sapi')]",
+    "dataScreenerName": "[concat(parameters('subscription'), '-', parameters('environment'), '-sapi')]",
     "logicAppSlackAlerts": "[concat(parameters('subscription'), '-la-', parameters('environment'), '-slackwebhook')]",
     "actionGroupAlerts": "[concat(parameters('subscription'), '-ag-', parameters('environment'), '-alertedusers')]",
     "metricAlerts": [
@@ -1910,8 +1910,8 @@
         "PublicDataApi__AppRegistrationClientId": "[parameters('apiAppRegistrationClientId')]",
         "PublicDataProcessor__Url": "[concat('https://', variables('publicDataProcessorName'), '.azurewebsites.net')]",
         "PublicDataProcessor__AppRegistrationClientId": "[parameters('publicDataProcessorAppRegistrationClientId')]",
-        "ScreenerApi__Url": "[concat('https://', variables('screenerApiName'), '.azurewebsites.net')]"
-        // "ScreenerApi__AppRegistrationClientId": "[parameters('screenerApiAppRegistrationClientId')]"
+        "DataScreener__Url": "[concat('https://', variables('dataScreenerName'), '.azurewebsites.net')]"
+        // "DataScreener__AppRegistrationClientId": "[parameters('dataScreenerAppRegistrationClientId')]"
       }
     },
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/appsettings.IntegrationTest.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/appsettings.IntegrationTest.json
@@ -44,7 +44,7 @@
   "PublicDataProcessor": {
     "Url": "http://localhost:7074"
   },
-  "DataSetScreener": {
+  "DataScreener": {
     "Url": "http://localhost:7078/api/screen"
   },
   "PublicDataApi": {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Options/DataScreenerClientOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Options/DataScreenerClientOptions.cs
@@ -1,8 +1,8 @@
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Options;
 
-public class DataSetScreenerClientOptions
+public class DataScreenerClientOptions
 {
-    public const string Section = "DataSetScreener";
+    public const string Section = "DataScreener";
 
     public string Url { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -396,8 +396,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.Configure<FeatureFlagsOptions>(
                 configuration.GetSection(FeatureFlagsOptions.Section));
             services.Configure<RouteOptions>(options => options.LowercaseUrls = true);
-            services.Configure<DataSetScreenerClientOptions>(
-                configuration.GetRequiredSection(DataSetScreenerClientOptions.Section));
+            services.Configure<DataScreenerClientOptions>(
+                configuration.GetRequiredSection(DataScreenerClientOptions.Section));
 
             StartupSecurityConfiguration.ConfigureAuthorizationPolicies(services);
 
@@ -511,7 +511,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
 
                 services.AddHttpClient<IDataSetScreenerClient, DataSetScreenerClient>((provider, httpClient) =>
                 {
-                    var options = provider.GetRequiredService<IOptions<DataSetScreenerClientOptions>>();
+                    var options = provider.GetRequiredService<IOptions<DataScreenerClientOptions>>();
                     httpClient.BaseAddress = new Uri(options.Value.Url);
                 });
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -54,7 +54,7 @@
   "PublicDataProcessor": {
     "Url": "http://localhost:7074"
   },
-  "DataSetScreener": {
+  "DataScreener": {
     "Url": "http://localhost:7078/api/screen"
   },
   "EventGrid": {


### PR DESCRIPTION
Dev environment is referencing the wrong appsettings section name, this PR amends the mixed naming to "DataScreener".