### PR TITLE
EES-5999: Remove blob auto-deletion after 24h rule, correct resource name

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2342,38 +2342,6 @@
           "dependsOn": [
             "[variables('coreStorageAccountName')]"
           ]
-        },
-        {
-          "name": "default",
-          "type": "managementPolicies",
-          "apiVersion": "2019-04-01",
-          "properties": {
-            "policy": {
-              "rules": [
-                {
-                  "enabled": true,
-                  "type": "Lifecycle",
-                  "name": "Delete temp data/meta files after a day",
-                  "definition": {
-                    "actions": {
-                      "baseBlob": {
-                        "delete": {
-                          "daysAfterModificationGreaterThan": 1
-                        }
-                      }
-                    },
-                    "filters": {
-                      "blobTypes": ["blockBlob"],
-                      "prefixMatch": ["releases-temp"]
-                    }
-                  }
-                }
-              ]
-            }
-          },
-          "dependsOn": [
-            "[variables('coreStorageAccountName')]"
-          ]
         }
       ],
       "tags": {

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -815,7 +815,7 @@
     "publisherStorageAccountId": "[concat(resourceGroup().id,'/providers/','Microsoft.Storage/storageAccounts/', variables('publisherStorageAccountName'))]",
     "loggingStorageAccountName": "[concat(parameters('subscription'), 'saeeslogging')]",
     "publicDataProcessorName": "[concat(parameters('subscription'), '-', parameters('environment'), '-papi-fa-processor')]",
-    "dataScreenerName": "[concat(parameters('subscription'), '-', parameters('environment'), '-sapi')]",
+    "dataScreenerName": "[concat(parameters('subscription'), '-', parameters('environment'), '-sapi-fa-screener')]",
     "logicAppSlackAlerts": "[concat(parameters('subscription'), '-la-', parameters('environment'), '-slackwebhook')]",
     "actionGroupAlerts": "[concat(parameters('subscription'), '-ag-', parameters('environment'), '-alertedusers')]",
     "metricAlerts": [


### PR DESCRIPTION
The previous changes associated with this work display a list of data set uploads in the UI, and allow manual deletion. Uploads are stored in the temporary `releases-temp` blob storage container, and the import process transfers them from the temporary container to the permanent `releases` container. As such, if an import is triggered on an auto-deleted blob it will generate an error in the app.

Since users can now see uploads (i.e. incomplete imports) in the data uploads section, there's no need to ensure that they are tidied up periodically, this work removes the auto-deletion lifecycle policy.

[[PR which adds the configuration](https://github.com/dfe-analytical-services/explore-education-statistics/pull/5669/files)]

This PR also corrects the Azure Function App resource name.