### PR TITLE
EES-6305 Shorten UI tests run identifier and publication names

### DIFF
--- a/tests/robot-tests/admin_api.py
+++ b/tests/robot-tests/admin_api.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timezone
 
 import requests
 from scripts.get_auth_tokens import get_local_storage_identity_json
@@ -111,8 +112,11 @@ def create_test_theme(run_id: str):
     test_theme_id = get_test_theme_id()
 
     if not test_theme_id:
-        test_theme_name = f"UI test theme {run_id}"
-        create_theme_resp = send_admin_request("POST", "/api/themes", {"title": test_theme_name, "summary": "Test theme summary"})
+        timestamp_utc_str = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        test_theme_name = f"UI test theme {timestamp_utc_str} {run_id}"
+        create_theme_resp = send_admin_request(
+            "POST", "/api/themes", {"title": test_theme_name, "summary": "Test theme summary"}
+        )
         test_theme_id = create_theme_resp.json()["id"]
 
     os.environ["TEST_THEME_NAME"] = test_theme_name

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -7,7 +7,6 @@ Run 'python run_tests.py -h' to see argument options
 """
 
 import argparse
-import datetime
 import glob
 import os
 import random
@@ -62,10 +61,8 @@ def _install_chromedriver(chromedriver_version: str):
     get_webdriver(chromedriver_version)
 
 
-def _create_run_identifier():
-    # Add randomness to prevent multiple simultaneous run_tests.py generating the same run_identifier value
-    random_str = "".join([random.choice(string.ascii_lowercase + string.digits) for n in range(6)])
-    return datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S-" + random_str)
+def _generate_random_id(size=6):
+    return "".join(random.choices(string.ascii_lowercase + string.digits, k=size))
 
 
 def _clear_files_before_next_test_run_attempt(rerunning_failures: bool):
@@ -120,7 +117,7 @@ def run():
 
     _install_chromedriver(args.chromedriver_version)
 
-    run_identifier_initial_value = _create_run_identifier()
+    run_identifier_initial_value = _generate_random_id()
 
     max_run_attempts = args.rerun_attempts + 1
     test_run_index = 0

--- a/tests/robot-tests/tests/admin/analyst/create_methodology_as_publication_owner.robot
+++ b/tests/robot-tests/tests/admin/analyst/create_methodology_as_publication_owner.robot
@@ -11,7 +11,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - methodology alternative title %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Methodology alternative title %{RUN_IDENTIFIER}
 
 
 *** Test Cases ***

--- a/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
@@ -13,7 +13,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - publication release approver %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Publication release approver %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Financial year 3000-01
 ${DATABLOCK_NAME}=      Dates data block name
 

--- a/tests/robot-tests/tests/admin/analyst/invite_contributor_as_publication_owner.robot
+++ b/tests/robot-tests/tests/admin/analyst/invite_contributor_as_publication_owner.robot
@@ -11,7 +11,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - invite contributor %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Invite contributor %{RUN_IDENTIFIER}
 ${INVITEE_EMAIL}        ees-analyst-%{RUN_IDENTIFIER}@education.gov.uk
 
 

--- a/tests/robot-tests/tests/admin/analyst/manage_approvals_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/manage_approvals_as_publication_approver.robot
@@ -13,7 +13,7 @@ Force Tags          Admin    Local    Dev    AltersData    Footnotes
 
 
 *** Variables ***
-${PUBLICATION_NAME}     UI tests - manage approvals as publication approver %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}     Manage approvals as publication approver %{RUN_IDENTIFIER}
 ${RELEASE_TYPE}         Academic year 2026/27
 ${RELEASE_NAME}         ${PUBLICATION_NAME} - ${RELEASE_TYPE}
 ${SUBJECT_NAME}         UI test subject

--- a/tests/robot-tests/tests/admin/analyst/manage_publication_as_publication_owner.robot
+++ b/tests/robot-tests/tests/admin/analyst/manage_publication_as_publication_owner.robot
@@ -11,7 +11,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - manage publication as publication owner %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Manage publication as publication owner %{RUN_IDENTIFIER}
 
 
 *** Test Cases ***

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -13,7 +13,7 @@ Force Tags          Admin    Local    Dev    AltersData    Footnotes
 
 
 *** Variables ***
-${PUBLICATION_NAME}     UI tests - publication_owner %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}     Publication_owner %{RUN_IDENTIFIER}
 ${RELEASE_TYPE}         Academic year 2025/26
 ${RELEASE_NAME}         ${PUBLICATION_NAME} - ${RELEASE_TYPE}
 ${SUBJECT_NAME}         UI test subject

--- a/tests/robot-tests/tests/admin/authentication/register.robot
+++ b/tests/robot-tests/tests/admin/authentication/register.robot
@@ -11,7 +11,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - register %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Register %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        ${PUBLICATION_NAME} - Academic year 2000/01
 
 

--- a/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
+++ b/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
@@ -11,9 +11,9 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${OWNING_PUBLICATION_NAME}=         UI tests - methodology owning publication %{RUN_IDENTIFIER}
-${ADOPTING_PUBLICATION_NAME}=       UI tests - adopting methodology publication %{RUN_IDENTIFIER}
-${OWNING_PUBLICATION_NAME_2}=       UI tests - publication with unpublished methodology %{RUN_IDENTIFIER}
+${OWNING_PUBLICATION_NAME}=         Methodology owning publication %{RUN_IDENTIFIER}
+${ADOPTING_PUBLICATION_NAME}=       Adopting methodology publication %{RUN_IDENTIFIER}
+${OWNING_PUBLICATION_NAME_2}=       Publication with unpublished methodology %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=                    Calendar year 2000
 
 

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -13,7 +13,7 @@ Force Tags          Admin    Local    AltersData    Dev
 
 
 *** Variables ***
-${PUBLICATION_NAME}=        UI tests - create data block with chart %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=        Create data block with chart %{RUN_IDENTIFIER}
 ${DATABLOCK_NAME}=          UI test data block
 ${CONTENT_SECTION_NAME}=    Test data block section
 ${FOOTNOTE_1}=              Test footnote from bau

--- a/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
@@ -12,7 +12,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - create methodology amendment publication %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Create methodology amendment publication %{RUN_IDENTIFIER}
 
 
 *** Test Cases ***

--- a/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
@@ -11,7 +11,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - create methodology publication %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Create methodology publication %{RUN_IDENTIFIER}
 
 
 *** Test Cases ***

--- a/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
+++ b/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
@@ -10,7 +10,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}         UI tests - create publication %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}         Create publication %{RUN_IDENTIFIER}
 
 ${CREATED_THEME_ID}         ${EMPTY}
 ${CREATED_THEME_NAME}       UI test theme - create publication %{RUN_IDENTIFIER}

--- a/tests/robot-tests/tests/admin/bau/delete_subject.robot
+++ b/tests/robot-tests/tests/admin/bau/delete_subject.robot
@@ -11,7 +11,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}     UI tests - delete subject %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}     Delete subject %{RUN_IDENTIFIER}
 
 
 *** Test Cases ***

--- a/tests/robot-tests/tests/admin/bau/invite_new_users.robot
+++ b/tests/robot-tests/tests/admin/bau/invite_new_users.robot
@@ -11,7 +11,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - invite new users %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Invite new users %{RUN_IDENTIFIER}
 ${RELEASE1_NAME}=       ${PUBLICATION_NAME} - Academic year 2000/01
 ${RELEASE2_NAME}=       ${PUBLICATION_NAME} - Academic year 2001/02
 ${RELEASE3_NAME}=       ${PUBLICATION_NAME} - Academic year 2002/03

--- a/tests/robot-tests/tests/admin/bau/link_publication_to_external_methodology.robot
+++ b/tests/robot-tests/tests/admin/bau/link_publication_to_external_methodology.robot
@@ -10,7 +10,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - link external methodology publication %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Link external methodology publication %{RUN_IDENTIFIER}
 
 
 *** Test Cases ***

--- a/tests/robot-tests/tests/admin/bau/manage_users_page.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_users_page.robot
@@ -12,9 +12,9 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}=        UI tests - manage users %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=        Manage users %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=            Calendar year 2000
-${PUBLICATION_2_NAME}=      UI tests - manage users second %{RUN_IDENTIFIER}
+${PUBLICATION_2_NAME}=      Manage users second %{RUN_IDENTIFIER}
 ${RELEASE_2_NAME}=          Academic year 2000/01
 
 

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -13,7 +13,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=                        UI tests - prerelease %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=                        Prerelease %{RUN_IDENTIFIER}
 ${DATABLOCK_NAME}=                          UI test table
 ${DATABLOCK_FEATURED_NAME}=                 UI test featured table name
 ${DATABLOCK_FEATURED_TABLE_DESCRIPTION}=    UI test featured table description

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -13,7 +13,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=                UI tests - prerelease and amend %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=                Prerelease and amend %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=                    Calendar year 2000
 ${SCHEDULED_PRERELEASE_WARNING}=
 ...                                 Pre-release users will have access to a preview of the release 24 hours before the scheduled publish date.

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -12,7 +12,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}                 UI tests - release content %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}                 Release content %{RUN_IDENTIFIER}
 ${SECONDARY_STATS_TABLE_TAB_ID}     releaseHeadlines-dataBlock-tables-tab
 
 

--- a/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content_authoring.robot
@@ -10,7 +10,7 @@ Test Setup          fail test fast if required
 
 *** Variables ***
 ${RELEASE_NAME}=        Academic year Q1 2020/21
-${PUBLICATION_NAME}=    UI tests - release content authoring %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Release content authoring %{RUN_IDENTIFIER}
 ${SECTION_1_TITLE}=     First content section
 ${SECTION_2_TITLE}=     Second content section
 ${BLOCK_1_CONTENT}=     Block 1 content

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -12,11 +12,11 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}                 UI tests - release status %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}                 Release status %{RUN_IDENTIFIER}
 ${RELEASE_1_NAME}                   Academic year Q1 2200/01
 ${RELEASE_2_NAME}                   Calendar year 2001
 ${RELEASE_3_NAME}                   Financial year 2300-01
-${ADOPTED_PUBLICATION_NAME}         UI tests - release status publication with adoptable methodology %{RUN_IDENTIFIER}
+${ADOPTED_PUBLICATION_NAME}         Release status publication with adoptable methodology %{RUN_IDENTIFIER}
 ${PUBLICATION_NAME_DATAFILES}       ${PUBLICATION_NAME} -    datafiles-updated
 ${SUBJECT_NAME}                     Dates test subject
 

--- a/tests/robot-tests/tests/admin/bau/screener_errors.robot
+++ b/tests/robot-tests/tests/admin/bau/screener_errors.robot
@@ -11,7 +11,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - screener errors %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Screener errors %{RUN_IDENTIFIER}
 
 
 *** Test Cases ***

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -12,7 +12,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - upload files %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Upload files %{RUN_IDENTIFIER}
 
 
 *** Test Cases ***

--- a/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
@@ -12,11 +12,11 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME_ARCHIVE}=        UI tests - archived publication %{RUN_IDENTIFIER}
+${PUBLICATION_NAME_ARCHIVE}=        Archived publication %{RUN_IDENTIFIER}
 ${RELEASE_NAME_ARCHIVE}=            Financial year 3000-01
 ${SUBJECT_NAME_ARCHIVE}=            Subject for archived publication
 
-${PUBLICATION_NAME_SUPERSEDE}=      UI tests - superseding publication %{RUN_IDENTIFIER}
+${PUBLICATION_NAME_SUPERSEDE}=      Superseding publication %{RUN_IDENTIFIER}
 ${RELEASE_NAME_SUPERSEDE}=          Financial year 2000-01
 ${SUBJECT_NAME_SUPERSEDE}=          Subject for superseding publication
 
@@ -116,7 +116,7 @@ Check that archive-publication subject appears correctly on Data tables page
 
     user waits until page contains    Select a publication    %{WAIT_SMALL}
 
-    user checks page does not contain element    Radio item for UI tests - ${PUBLICATION_NAME_SUPERSEDE}
+    user checks page does not contain element    Radio item for ${PUBLICATION_NAME_SUPERSEDE}
 
     user clicks radio    ${PUBLICATION_NAME_ARCHIVE}
     user clicks element    id:publicationForm-submit

--- a/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
@@ -14,7 +14,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - data catalogue %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Data catalogue %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Academic year Q1
 ${SUBJECT_NAME_1}=      UI test subject 1
 ${SUBJECT_NAME_2}=      UI test subject 2
@@ -147,7 +147,7 @@ Validate zip contains correct files
     [Documentation]    EES-4147
     sleep    8    # wait for file to download
     ${list}=    create list    data/dates.csv    data-guidance/data-guidance.txt
-    zip should contain directories and files    ui-tests-data-catalogue-%{RUN_IDENTIFIER}_2021-22-q1.zip    ${list}
+    zip should contain directories and files    data-catalogue-%{RUN_IDENTIFIER}_2021-22-q1.zip    ${list}
 
 Validate sort controls exist
     user checks radio is checked    Newest

--- a/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_reordering.robot
@@ -13,7 +13,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}     UI tests - data reordering %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}     Data reordering %{RUN_IDENTIFIER}
 ${RELEASE_NAME}         Calendar year 2022
 ${SUBJECT_NAME}         UI test subject
 

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -13,7 +13,7 @@ Test Setup          fail test fast if required
 
 *** Variables ***
 ${RELEASE_NAME}=        Calendar year 2000
-${PUBLICATION_NAME}=    UI tests - public release visibility %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Public release visibility %{RUN_IDENTIFIER}
 
 
 *** Test Cases ***

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
@@ -12,7 +12,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - publish content %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Publish content %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Calendar year 2001
 
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -12,7 +12,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=                    UI tests - publish data %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=                    Publish data %{RUN_IDENTIFIER}
 ${RELEASE_1_NAME}=                      Financial year 3000-01
 ${RELEASE_2_NAME}=                      Financial year 3001-02 provisional
 ${SUBJECT_1_NAME}=                      UI test subject 1

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -12,9 +12,9 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=                    UI tests - publish methodology %{RUN_IDENTIFIER}
-${PUBLICATION_URL}=                     /find-statistics/ui-tests-publish-methodology-%{RUN_IDENTIFIER}/2021-22
-${PUBLIC_METHODOLOGY_URL_ENDING}=       /methodology/ui-tests-publish-methodology-%{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=                    Publish methodology %{RUN_IDENTIFIER}
+${PUBLICATION_URL}=                     /find-statistics/publish-methodology-%{RUN_IDENTIFIER}/2021-22
+${PUBLIC_METHODOLOGY_URL_ENDING}=       /methodology/publish-methodology-%{RUN_IDENTIFIER}
 ${RELEASE_NAME}=                        Academic year 2021/22
 
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
@@ -12,8 +12,8 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=                UI tests - publish publication update %{RUN_IDENTIFIER}
-${PUBLIC_PUBLICATION_URL_ENDING}    /find-statistics/ui-tests-publish-publication-update-%{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=                Publish publication update %{RUN_IDENTIFIER}
+${PUBLIC_PUBLICATION_URL_ENDING}    /find-statistics/publish-publication-update-%{RUN_IDENTIFIER}
 ${ACADEMIC_YEAR}                    /2046-47
 ${PUBLICATION_NAME_UPDATED}=        ${PUBLICATION_NAME} updated
 ${RELEASE_NAME}=                    Academic year 2046/47

--- a/tests/robot-tests/tests/admin_and_public/bau/release_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/release_reordering.robot
@@ -12,8 +12,8 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}=                        UI tests - legacy releases %{RUN_IDENTIFIER}
-${PUBLICATION_SLUG}=                        ui-tests-legacy-releases-%{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=                        Legacy releases %{RUN_IDENTIFIER}
+${PUBLICATION_SLUG}=                        legacy-releases-%{RUN_IDENTIFIER}
 ${RELEASE_1_NAME}=                          Academic year 2020/21
 ${RELEASE_2_NAME}=                          Academic year Q1 2022/23
 ${LEGACY_RELEASE_1_DESCRIPTION}=            legacy release 1

--- a/tests/robot-tests/tests/admin_and_public/bau/subject_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/subject_reordering.robot
@@ -12,7 +12,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}     UI tests - subject reordering %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}     Subject reordering %{RUN_IDENTIFIER}
 ${RELEASE_NAME}         Calendar year 2000
 
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/create_table_tool_with_filter_hierarchy.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/create_table_tool_with_filter_hierarchy.robot
@@ -12,7 +12,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}     UI tests - filter hierarchy %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}     Filter hierarchy %{RUN_IDENTIFIER}
 ${RELEASE_NAME}         Calendar year 2022
 ${SUBJECT_NAME}         UI test subject
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/maps_across_time.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/maps_across_time.robot
@@ -13,7 +13,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}     UI tests - maps across time %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}     Maps across time %{RUN_IDENTIFIER}
 ${RELEASE_NAME}         Financial year 3000-01
 ${DATABLOCK_NAME}=      Dates data block name
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -13,7 +13,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - publish amend and cancel %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Publish amend and cancel %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Financial year 3000-01
 ${DATABLOCK_NAME}=      Dates data block name
 
@@ -193,7 +193,7 @@ Verify newly published release is public
     user navigates to public release page    ${PUBLIC_RELEASE_LINK}    ${PUBLICATION_NAME}    ${RELEASE_NAME}
 
 Verify release URL
-    user checks url contains    %{PUBLIC_URL}/find-statistics/ui-tests-publish-amend-and-cancel-%{RUN_IDENTIFIER}
+    user checks url contains    %{PUBLIC_URL}/find-statistics/publish-amend-and-cancel-%{RUN_IDENTIFIER}
 
 Return to Admin and create amendment
     user navigates to admin dashboard    Bau1

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_methodology_publication_update.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_methodology_publication_update.robot
@@ -12,11 +12,11 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=                    UI tests - publish methodology publication update %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=                    Publish methodology publication update %{RUN_IDENTIFIER}
 ${PUBLICATION_NAME_UPDATED}=            ${PUBLICATION_NAME} updated
-${PUBLIC_METHODOLOGY_URL}=              %{PUBLIC_URL}/methodology/ui-tests-publish-methodology-publication-update-%{RUN_IDENTIFIER}
+${PUBLIC_METHODOLOGY_URL}=              %{PUBLIC_URL}/methodology/publish-methodology-publication-update-%{RUN_IDENTIFIER}
 ${PUBLIC_METHODOLOGY_URL_UPDATED}=      ${PUBLIC_METHODOLOGY_URL}-methodology-update
-${PUBLIC_PUBLICATION_URL}=              %{PUBLIC_URL}/find-statistics/ui-tests-publish-methodology-publication-update-%{RUN_IDENTIFIER}
+${PUBLIC_PUBLICATION_URL}=              %{PUBLIC_URL}/find-statistics/publish-methodology-publication-update-%{RUN_IDENTIFIER}
 ${PUBLIC_PUBLICATION_URL_UPDATED}=      ${PUBLIC_PUBLICATION_URL}-updated
 ${RELEASE_1_NAME}=                      Academic year 2046/47
 ${RELEASE_2_NAME}=                      Academic year Q1 2050/51

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -15,7 +15,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - publish release and amend %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Publish release and amend %{RUN_IDENTIFIER}
 ${RELEASE_LABEL}=       provisional
 ${RELEASE_NAME}=        Financial year 3000-01 ${RELEASE_LABEL}
 ${DATABLOCK_NAME}=      Dates data block name
@@ -291,7 +291,7 @@ Verify release page meta
     ...    ${PUBLICATION_NAME} summary
 
 Verify release URL
-    user checks url contains    %{PUBLIC_URL}/find-statistics/ui-tests-publish-release-and-amend-%{RUN_IDENTIFIER}
+    user checks url contains    %{PUBLIC_URL}/find-statistics/publish-release-and-amend-%{RUN_IDENTIFIER}
 
 Verify publish and update dates
     user checks summary list contains    Published    ${EXPECTED_PUBLISHED_DATE}
@@ -782,7 +782,7 @@ Verify amendment is on Find Statistics page again
 Navigate to amendment release page
     user navigates to public release page    ${PUBLIC_RELEASE_LINK}    ${PUBLICATION_NAME}    ${RELEASE_NAME}
 
-    user checks url contains    %{PUBLIC_URL}/find-statistics/ui-tests-publish-release-and-amend-%{RUN_IDENTIFIER}
+    user checks url contains    %{PUBLIC_URL}/find-statistics/publish-release-and-amend-%{RUN_IDENTIFIER}
 
     user checks breadcrumb count should be    3
     user checks nth breadcrumb contains    1    Home

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
@@ -13,7 +13,7 @@ Test Setup          fail test fast if required
 
 *** Variables ***
 ${RELEASE_NAME}         Academic year Q1 2020/21
-${PUBLICATION_NAME}     UI tests - publish release and amend 2 %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}     Publish release and amend 2 %{RUN_IDENTIFIER}
 ${SUBJECT_NAME}         Seven filters
 ${SECOND_SUBJECT}       upload file test
 ${THIRD_SUBJECT}        upload file test with filter subject

--- a/tests/robot-tests/tests/public_api/public_api_cancel_and_removal.robot
+++ b/tests/robot-tests/tests/public_api/public_api_cancel_and_removal.robot
@@ -13,7 +13,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - Public API - cancel and removal %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Public API - cancel and removal %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=        Financial year 3000-01
 ${SUBJECT_NAME_1}=      ${PUBLICATION_NAME} - Subject 1
 ${SUBJECT_NAME_2}=      ${PUBLICATION_NAME} - Subject 2

--- a/tests/robot-tests/tests/public_api/public_api_major_auto_changes.robot
+++ b/tests/robot-tests/tests/public_api/public_api_major_auto_changes.robot
@@ -14,7 +14,7 @@ Test Teardown       Run Keyword If Test Failed    record test failure
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - Public API - major auto changes %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Public API - major auto changes %{RUN_IDENTIFIER}
 ${RELEASE_1_NAME}=      Financial year 3000-01
 ${RELEASE_2_NAME}=      Academic year 3010/11
 ${SUBJECT_1_NAME}=      ${PUBLICATION_NAME} - Subject 1

--- a/tests/robot-tests/tests/public_api/public_api_minor_manual_changes.robot
+++ b/tests/robot-tests/tests/public_api/public_api_minor_manual_changes.robot
@@ -14,7 +14,7 @@ Test Teardown       Run Keyword If Test Failed    record test failure
 
 
 *** Variables ***
-${PUBLICATION_NAME}=    UI tests - Public API - minor manual changes %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=    Public API - minor manual changes %{RUN_IDENTIFIER}
 ${RELEASE_1_NAME}=      Financial year 3000-01
 ${RELEASE_2_NAME}=      Academic year 3010/11
 ${SUBJECT_1_NAME}=      ${PUBLICATION_NAME} - Subject 1

--- a/tests/robot-tests/tests/public_api/public_api_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_preview_token.robot
@@ -13,7 +13,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}=        UI tests - Public API - preview token %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}=        Public API - preview token %{RUN_IDENTIFIER}
 ${RELEASE_NAME}=            Academic year Q1 3000/01
 ${SUBJECT_NAME_1}=          ${PUBLICATION_NAME} - Subject 1
 ${PREVIEW_TOKEN_NAME}=      Test token

--- a/tests/robot-tests/tests/public_api/public_api_restricted.robot
+++ b/tests/robot-tests/tests/public_api/public_api_restricted.robot
@@ -12,7 +12,7 @@ Test Setup          fail test fast if required
 
 
 *** Variables ***
-${PUBLICATION_NAME}     UI tests - Public API - restricted %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}     Public API - restricted %{RUN_IDENTIFIER}
 ${RELEASE_NAME}         Financial year 3000-01
 ${SUBJECT_NAME_1}       ${PUBLICATION_NAME} - Subject 1
 ${SUBJECT_NAME_2}       ${PUBLICATION_NAME} - Subject 2

--- a/tests/robot-tests/tests/seed_data/seed_data_generation_mechanism.robot
+++ b/tests/robot-tests/tests/seed_data/seed_data_generation_mechanism.robot
@@ -22,7 +22,7 @@ Force Tags          Local    Dev
 
 
 *** Variables ***
-${PUBLICATION_NAME}     UI tests - seed data mechanism publication %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}     Seed data mechanism publication %{RUN_IDENTIFIER}
 
 
 *** Test Cases ***


### PR DESCRIPTION
This PR shortens the UI tests run identifier by removing the timestamp.

Current format of the `RUN_IDENTIFIER` environment variable:

```
{timestamp}-{6_char_random_id}-{test_run_attempt_index}
```

New format of the `RUN_IDENTIFIER` environment variable:
```
{6_char_random_id}-{test_run_attempt_index}
```

Since a test theme is created per test run, and the timestamp is still handy to identify a particular UI test theme by when browsing through them, timestamp is retained in the title when creating the theme.

Current format of UI test theme names:

```
UI test theme {timestamp}-{6_char_random_id}-{test_run_attempt_index}
```

New format of UI test theme names:
```
UI test theme {timestamp} {6_char_random_id}-{test_run_attempt_index}
```

This change is being made due to the run identifier being appended to publication titles, necessary for uniqueness, but since #6098 publication titles must be 65 characters or less.

It also shortens all publication titles by removing the prefix `UI tests - `. Publications should still be identifiable as UI tests since they are associated with a UI test theme.

### Other changes

- Fix a problem in `archive_publication.robot` where 'UI tests - ' was repeated twice.

```robot
user checks page does not contain element    Radio item for UI tests - ${PUBLICATION_NAME_SUPERSEDE}
```

### UI test report

![image](https://github.com/user-attachments/assets/2ddd7861-83c2-4da5-96b9-53219313fd04)

