### PR TITLE
EES-6307 Allow configuring availability and pricing plan of semantic ranking in different environments

### DIFF
--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -35,6 +35,14 @@ param searchableDocumentsContainerName string = 'searchable-documents'
 @description('A list of IP network rules to allow access to the Search Service from specific public internet IP address ranges.')
 param searchServiceIpRules IpRange[]
 
+@description('Controls the availability of semantic ranking for all indexes. Set to \'free\' for limited query volume on the free plan, \'standard\' for unlimited volume on the standard pricing plan, or \'disabled\' to turn it off.')
+@allowed([
+  'disabled'
+  'free'
+  'standard'
+])
+param semanticRankerAvailability string
+
 @description('A list of IP network rules to allow access to the Search storage account from specific public internet IP address ranges.')
 param storageIpRules IpRange[]
 
@@ -66,6 +74,7 @@ module searchServiceModule '../components/searchService.bicep' = {
     location: location
     ipRules: searchServiceIpRules
     publicNetworkAccess: 'Enabled'
+    semanticRankerAvailability: semanticRankerAvailability
     sku: 'basic'
     systemAssignedIdentity: true
     alerts: {

--- a/infrastructure/templates/search/components/searchService.bicep
+++ b/infrastructure/templates/search/components/searchService.bicep
@@ -53,6 +53,14 @@ param hostingMode string = 'default'
 ])
 param publicNetworkAccess string = 'Disabled'
 
+@description('Controls the availability of semantic ranking for all indexes. Set to \'free\' for limited query volume on the free plan, \'standard\' for unlimited volume on the standard pricing plan, or \'disabled\' to turn it off.')
+@allowed([
+  'disabled'
+  'free'
+  'standard'
+])
+param semanticRankerAvailability string = 'free'
+
 @description('Indicates whether the resource should have a system-assigned managed identity.')
 param systemAssignedIdentity bool = false
 
@@ -108,6 +116,7 @@ resource searchService 'Microsoft.Search/searchServices@2025-02-01-preview' = {
     }
     partitionCount: partitionCount
     publicNetworkAccess: publicNetworkAccess
+    semanticSearch: semanticRankerAvailability
     hostingMode: hostingMode
   }
   tags: tagValues

--- a/infrastructure/templates/search/components/searchService.bicep
+++ b/infrastructure/templates/search/components/searchService.bicep
@@ -73,7 +73,9 @@ param alerts {
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object
 
-var identityType = systemAssignedIdentity ? (!empty(userAssignedIdentityName) ? 'SystemAssigned, UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentityName) ? 'UserAssigned' : 'None')
+var identityType = systemAssignedIdentity
+  ? (!empty(userAssignedIdentityName) ? 'SystemAssigned, UserAssigned' : 'SystemAssigned')
+  : (!empty(userAssignedIdentityName) ? 'UserAssigned' : 'None')
 
 resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' existing = if (!empty(userAssignedIdentityName)) {
   name: userAssignedIdentityName
@@ -98,9 +100,11 @@ resource searchService 'Microsoft.Search/searchServices@2025-02-01-preview' = {
     replicaCount: replicaCount
     networkRuleSet: {
       bypass: length(ipRules) > 0 ? 'AzureServices' : 'None'
-      ipRules: [for ipRule in ipRules: {
-        value: ipRule.cidr
-      }]
+      ipRules: [
+        for ipRule in ipRules: {
+          value: ipRule.cidr
+        }
+      ]
     }
     partitionCount: partitionCount
     publicNetworkAccess: publicNetworkAccess

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -35,6 +35,14 @@ param publicSiteUrl string
 @description('Specifies whether or not the Search Docs Function App already exists.')
 param searchDocsFunctionAppExists bool = true
 
+@description('Controls the availability of semantic ranking for all indexes. Set to \'free\' for limited query volume on the free plan, \'standard\' for unlimited volume on the standard pricing plan, or \'disabled\' to turn it off.')
+@allowed([
+  'disabled'
+  'free'
+  'standard'
+])
+param searchServiceSemanticRankerAvailability string
+
 @description('Provides access to resources for specific IP address ranges used for service maintenance.')
 param maintenanceIpRanges IpRange[] = []
 
@@ -160,6 +168,7 @@ module searchServiceModule 'application/searchService.bicep' = {
     resourceNames: resourceNames
     resourcePrefix: resourcePrefix
     searchServiceIpRules: [] // No restrictions applied as the resource is intended to be publicly accessible.
+    semanticRankerAvailability: searchServiceSemanticRankerAvailability
     storageIpRules: maintenanceIpRanges
     deploySearchConfig: deploySearchConfig
     tagValues: tagValues

--- a/infrastructure/templates/search/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/search/parameters/main-dev.bicepparam
@@ -5,3 +5,4 @@ param environmentName = 'Development'
 
 param contentApiUrl = 'https://content.dev.explore-education-statistics.service.gov.uk'
 param publicSiteUrl = 'https://dev.explore-education-statistics.service.gov.uk'
+param searchServiceSemanticRankerAvailability = 'free'

--- a/infrastructure/templates/search/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/search/parameters/main-preprod.bicepparam
@@ -5,3 +5,4 @@ param environmentName = 'Pre-Production'
 
 param contentApiUrl = 'https://content.pre-production.explore-education-statistics.service.gov.uk'
 param publicSiteUrl = 'https://pre-production.explore-education-statistics.service.gov.uk'
+param searchServiceSemanticRankerAvailability = 'free'

--- a/infrastructure/templates/search/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/search/parameters/main-prod.bicepparam
@@ -5,3 +5,4 @@ param environmentName = 'Production'
 
 param contentApiUrl = 'https://content.explore-education-statistics.service.gov.uk'
 param publicSiteUrl = 'https://explore-education-statistics.service.gov.uk'
+param searchServiceSemanticRankerAvailability = 'standard'

--- a/infrastructure/templates/search/parameters/main-test.bicepparam
+++ b/infrastructure/templates/search/parameters/main-test.bicepparam
@@ -5,3 +5,4 @@ param environmentName = 'Test'
 
 param contentApiUrl = 'https://content.test.explore-education-statistics.service.gov.uk'
 param publicSiteUrl = 'https://test.explore-education-statistics.service.gov.uk'
+param searchServiceSemanticRankerAvailability = 'free'


### PR DESCRIPTION
This PR adds support for configuring the availability and pricing plan of semantic ranking in Azure AI Search in different environments.

Semantic ranking can be

- Disabled
- Available on the free pricing plan
- Available on the standard pricing plan for higher query volumes

The setting applies to all indexes.

The availability is configured for each Azure environment.

### Other changes

- Format file searchService.bicep.