### PR TITLE
EES-6308 - fix Screener URL as used by Admin, and whitelist Screener's subnet with storage

### DIFF
--- a/infrastructure/templates/screener/application/screenerApplicationInsights.bicep
+++ b/infrastructure/templates/screener/application/screenerApplicationInsights.bicep
@@ -13,11 +13,17 @@ param location string
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
+// Shared log analytics workspace. Currently the Public API deployment is responsible for creating this.
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-02-01' existing = {
+  name: resourceNames.existingResources.logAnalyticsWorkspace
+}
+
 module applicationInsightsModule '../../public-api/components/appInsights.bicep' = {
   name: 'applicationInsightsModuleDeploy'
   params: {
     location: location
     appInsightsName: '${resourcePrefix}-${abbreviations.insightsComponents}-screener'
+    logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     alerts: {
       exceptionCount: true
       exceptionServerCount: true

--- a/infrastructure/templates/screener/main.bicep
+++ b/infrastructure/templates/screener/main.bicep
@@ -60,7 +60,7 @@ module applicationInsightsModule 'application/screenerApplicationInsights.bicep'
   name: 'screenerApplicationInsightsModule'
   params: {
     location: location
-    resourcePrefix: resourcePrefix
+    resourcePrefix: screenerResourcePrefix
     resourceNames: resourceNames
     tagValues: tagValues
   }
@@ -112,27 +112,31 @@ var tagValues = union(resourceTags ?? {}, {
 // The resource prefix for resources created in the ARM template.
 var legacyResourcePrefix = subscription
 
+// The resource prefix for more recent resources created in Bicep templates.
+var resourcePrefix = '${subscription}-ees'
+
 // The resource prefix for anything specific to the Screener API.
-var resourcePrefix = '${subscription}-ees-sapi'
+var screenerResourcePrefix = '${subscription}-ees-sapi'
 
 var resourceNames = {
   existingResources: {
     adminApp: '${legacyResourcePrefix}-as-ees-admin'
     keyVault: '${legacyResourcePrefix}-kv-ees-01'
+    logAnalyticsWorkspace: '${resourcePrefix}-${abbreviations.operationalInsightsWorkspaces}'
     vNet: '${legacyResourcePrefix}-vnet-ees'
     alertsGroup: '${legacyResourcePrefix}-ag-ees-alertedusers'
     subnets: {
       adminApp: '${legacyResourcePrefix}-snet-ees-admin'
-      screenerFunction: '${resourcePrefix}-snet-${abbreviations.webSitesFunctions}-screener'
-      screenerFunctionPrivateEndpoints: '${resourcePrefix}-snet-${abbreviations.storageStorageAccounts}-screener-pep'
+      screenerFunction: '${screenerResourcePrefix}-snet-${abbreviations.webSitesFunctions}-screener'
+      screenerFunctionPrivateEndpoints: '${screenerResourcePrefix}-snet-${abbreviations.storageStorageAccounts}-screener-pep'
     }
     coreStorageAccount: subscription == 's101t01' || subscription == 's101p02'
       ? '${legacyResourcePrefix}storageeescore'
       : '${legacyResourcePrefix}saeescore'
   }
   screener: {
-    screenerFunction: '${resourcePrefix}-${abbreviations.webSitesFunctions}-screener'
-    screenerFunctionStorageAccount: '${replace(resourcePrefix, '-', '')}${abbreviations.storageStorageAccounts}fn'
+    screenerFunction: '${screenerResourcePrefix}-${abbreviations.webSitesFunctions}-screener'
+    screenerFunctionStorageAccount: '${replace(screenerResourcePrefix, '-', '')}${abbreviations.storageStorageAccounts}fn'
   }
 }
 

--- a/infrastructure/templates/screener/types.bicep
+++ b/infrastructure/templates/screener/types.bicep
@@ -2,6 +2,7 @@
 type ResourceNames = {
   existingResources: {
     keyVault: string
+    logAnalyticsWorkspace: string
     vNet: string
     adminApp: string
     alertsGroup: string

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1917,7 +1917,7 @@
         "PublicDataApi__AppRegistrationClientId": "[parameters('apiAppRegistrationClientId')]",
         "PublicDataProcessor__Url": "[concat('https://', variables('publicDataProcessorName'), '.azurewebsites.net')]",
         "PublicDataProcessor__AppRegistrationClientId": "[parameters('publicDataProcessorAppRegistrationClientId')]",
-        "DataScreener__Url": "[concat('https://', variables('dataScreenerName'), '.azurewebsites.net')]",
+        "DataScreener__Url": "[concat('https://', variables('dataScreenerName'), '.azurewebsites.net', '/api/screen')]",
         "FeatureFlags__EnableReplacementOfPublicApiDataSets": "[parameters('enableReplacementOfPublicApiDataSets')]"
         // "DataScreener__AppRegistrationClientId": "[parameters('dataScreenerAppRegistrationClientId')]"
       }
@@ -2329,6 +2329,11 @@
             {
               "condition": "[parameters('useSubnets')]",
               "id": "[variables('publicApiDataProcessorSubnetRef')]",
+              "action": "Allow"
+            },
+            {
+              "condition": "[parameters('useSubnets')]",
+              "id": "[variables('screenerFunctionAppSubnetName')]",
               "action": "Allow"
             }
           ],


### PR DESCRIPTION
This PR:
- fixes the Screener URL as used by Admin, by appending `/api/screen` to the end of the URL.
- whitelists the Screener Function App's subnet with Core Storage to allow calls through.

In addition to the above changes, this PR also links Screener's App Insights up with our shared Log Analytics Workspace. 