### PR TITLE
EES-5369 adds dataset rich meta

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import PageMetaItem, { PageMetaItemType } from './PageMetaItem';
 
 export interface PageMetaProps {
   includeDefaultMetaTitle?: boolean;
@@ -8,6 +9,7 @@ export interface PageMetaProps {
   title?: string;
   description?: string;
   imgUrl?: string;
+  additionalMeta?: PageMetaItemType[];
 }
 
 const defaultPageTitle = 'Explore education statistics - GOV.UK';
@@ -18,6 +20,7 @@ const PageMeta = ({
   title = defaultPageTitle,
   description = 'Find, download and explore official Department for Education (DfE) statistics and data in England.',
   imgUrl,
+  additionalMeta = [],
 }: PageMetaProps) => {
   // Generate canonical link
   const router = useRouter();
@@ -75,6 +78,9 @@ const PageMeta = ({
           content={process.env.PUBLIC_URL + imgUrl}
         />
       )}
+
+      {/* <!-- Additional Meta Tags --> */}
+      {additionalMeta.map(PageMetaItem)}
     </Head>
   );
 };

--- a/src/explore-education-statistics-frontend/src/components/PageMetaItem.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageMetaItem.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import { Dictionary } from '@common/types';
+import React from 'react';
+
+export interface ScriptMetaItem {
+  type: 'script';
+  attributes?: Dictionary<string>;
+  content?: string;
+}
+export interface MetaMetaItem {
+  type: 'meta';
+  attributes: Dictionary<string>;
+  content?: undefined;
+}
+
+export type PageMetaItemType = ScriptMetaItem | MetaMetaItem;
+
+export default function PageMetaItem({
+  type,
+  attributes,
+  content,
+}: PageMetaItemType) {
+  switch (type) {
+    case 'meta':
+      return (
+        <meta key={JSON.stringify({ type, attributes })} {...attributes} />
+      );
+    case 'script':
+      return (
+        <script key={JSON.stringify({ type, attributes })} {...attributes}>
+          {content}
+        </script>
+      );
+    default:
+      return null;
+  }
+}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataSetFilePage.tsx
@@ -9,32 +9,33 @@ import useToggle from '@common/hooks/useToggle';
 import { ApiDataSetVersionChanges } from '@common/services/types/apiDataSetChanges';
 import { Dictionary } from '@common/types';
 import Page from '@frontend/components/Page';
+import SubscribeLink from '@frontend/components/SubscribeLink';
 import withAxiosHandler from '@frontend/middleware/ssr/withAxiosHandler';
 import DataSetFileApiChangelog from '@frontend/modules/data-catalogue/components/DataSetFileApiChangelog';
 import DataSetFileApiQuickStart from '@frontend/modules/data-catalogue/components/DataSetFileApiQuickStart';
 import DataSetFileApiVersionHistory from '@frontend/modules/data-catalogue/components/DataSetFileApiVersionHistory';
 import DataSetFileDetails from '@frontend/modules/data-catalogue/components/DataSetFileDetails';
+import DataSetFileFootnotes from '@frontend/modules/data-catalogue/components/DataSetFileFootnotes';
 import DataSetFilePreview from '@frontend/modules/data-catalogue/components/DataSetFilePreview';
 import DataSetFileUsage from '@frontend/modules/data-catalogue/components/DataSetFileUsage';
 import DataSetFileVariables from '@frontend/modules/data-catalogue/components/DataSetFileVariables';
-import DataSetFileFootnotes from '@frontend/modules/data-catalogue/components/DataSetFileFootnotes';
 import styles from '@frontend/modules/data-catalogue/DataSetPage.module.scss';
 import NotFoundPage from '@frontend/modules/NotFoundPage';
 import apiDataSetQueries from '@frontend/queries/apiDataSetQueries';
 import dataSetFileQueries from '@frontend/queries/dataSetFileQueries';
-import SubscribeLink from '@frontend/components/SubscribeLink';
 import {
   ApiDataSet,
   ApiDataSetVersion,
 } from '@frontend/services/apiDataSetService';
 import { DataSetFile } from '@frontend/services/dataSetFileService';
+import downloadService from '@frontend/services/downloadService';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
+import omit from 'lodash/omit';
 import { GetServerSideProps } from 'next';
 import React, { useEffect, useMemo, useState } from 'react';
-import omit from 'lodash/omit';
-import downloadService from '@frontend/services/downloadService';
+import getDataSetFileMetaCSVW from './utils/getDataSetFileMetaCSVW';
 
 export const pageBaseSections = {
   dataSetDetails: 'Data set details',
@@ -156,6 +157,9 @@ export default function DataSetFilePage({
       caption={`Data set from ${release.publication.title}`}
       breadcrumbs={[{ name: 'Data catalogue', link: '/data-catalogue' }]}
       wide={fullScreenPreview}
+      pageMeta={{
+        additionalMeta: [getDataSetFileMetaCSVW({ dataSetFile })],
+      }}
     >
       {fullScreenPreview ? (
         <DataSetFilePreview

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/getDataSetFileMetaCSVW.ts
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/utils/getDataSetFileMetaCSVW.ts
@@ -1,0 +1,86 @@
+import { ScriptMetaItem } from '@frontend/components/PageMetaItem';
+import { DataSetFile } from '@frontend/services/dataSetFileService';
+
+interface Props {
+  dataSetFile: DataSetFile;
+}
+
+/**
+ * Used to set CSVW (CSV on the Web) meta data to help make datasets more findable in terms of SEO
+ */
+export default function getDataSetFileMetaCSVW({
+  dataSetFile,
+}: Props): ScriptMetaItem {
+  const { file, release, summary, title, id } = dataSetFile;
+
+  const dataSetFileMeta = {
+    '@context': [
+      'https://schema.org ',
+      { csvw: 'https://www.w3.org/ns/csvw ' },
+    ],
+    '@type': 'Dataset',
+    name: `${release.publication.title} - ${title}`,
+    alternateName: [title, file.name],
+    description: summary,
+    url: `https://explore-education-statistics.service.gov.uk/data-catalogue/data-set/${id}`,
+    sameAs: `https://explore-education-statistics.service.gov.uk/data-catalogue/data-set/${id}`,
+    isAccessibleForFree: true,
+    license:
+      'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ ',
+    includedInDataCatalog: {
+      '@type': 'DataCatalog',
+      name: 'Explore education statistics datasets',
+      description:
+        'A http://GOV.UK  Department for Education repository for education statistics',
+      url: 'https://explore-education-statistics.service.gov.uk/data-catalogue ',
+    },
+    creator: [
+      {
+        '@type': 'GovernmentOrganization',
+        name: 'Department for Education',
+        description:
+          'The Department for Education is responsible for children’s services and education, including early years, schools, higher and further education policy, apprenticeships and wider skills in England.',
+        url: 'https://www.gov.uk/government/organisations/department-for-education ',
+        sameAs: 'https://ror.org/0320bge18 ',
+      },
+      //   {
+      //     '@type': 'Person',
+      //     name: release.publication.Contact.ContactName,
+      //     telephone: Publication.Contact.ContactTelNo,
+      //     email: Publication.Contact.TeamEmail,
+      //   },
+    ],
+    publisher: {
+      '@type': 'GovernmentOrganization',
+      name: 'Department for Education',
+      description:
+        'The Department for Education is responsible for children’s services and education, including early years, schools, higher and further education policy, apprenticeships and wider skills in England.',
+      url: 'https://www.gov.uk/government/organisations/department-for-education ',
+      sameAs: 'https://ror.org/0320bge18 ',
+    },
+    temporalCoverage: `${file.meta.timePeriodRange.from}/${file.meta.timePeriodRange.to}`,
+    mainEntity: !file.dataCsvPreview
+      ? undefined
+      : {
+          '@type': 'csvw:Table',
+          'csvw:tableSchema': {
+            'csvw:columns': file.dataCsvPreview.headers.map((header, index) => {
+              return {
+                'csvw:name': header,
+                'csvw:cells': file.dataCsvPreview.rows.map(row => {
+                  return {
+                    'csvw:value': row[index],
+                  };
+                }),
+              };
+            }),
+          },
+        },
+  };
+
+  return {
+    type: 'script',
+    attributes: { type: 'application/ld+json' },
+    content: JSON.stringify(dataSetFileMeta),
+  };
+}


### PR DESCRIPTION
To help with site SEO, we can add rich data set metadata to help users find data that's useful to them, and to allow our dataset files to be indexed in google etc. [Here's the ticket: 5369](https://dfedigital.atlassian.net/browse/EES-5369), there was a [related investigation (ticket)](https://dfedigital.atlassian.net/browse/EES-4864) completed which helped direct this implementation.

I've added a "additionalMeta" prop to our PageMeta component to allow bespoke metadata to be added to pages when needed.