### PR TITLE
EES-6315 publishing orgs display

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/__tests__/ReleaseContentPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/__tests__/ReleaseContentPage.test.tsx
@@ -139,6 +139,18 @@ describe('ReleaseContentPage', () => {
       },
       methodologies: [],
     },
+    publishingOrganisations: [
+      {
+        id: 'org-id-1',
+        title: 'Department for Education',
+        url: 'https://www.gov.uk/government/organisations/department-for-education',
+      },
+      {
+        id: 'org-id-2',
+        title: 'Other Organisation',
+        url: 'https://example.com',
+      },
+    ],
     relatedInformation: [],
     slug: '2020-21',
     summarySection: {
@@ -607,6 +619,10 @@ describe('ReleaseContentPage', () => {
 
       expect(screen.getByTestId('Release type-value')).toHaveTextContent(
         'Official statistics',
+      );
+
+      expect(screen.getByTestId('Produced by-value')).toHaveTextContent(
+        'Department for Education and Other Organisation',
       );
 
       expect(

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -31,7 +31,13 @@ import Tag from '@common/components/Tag';
 import ReleaseSummarySection from '@common/modules/release/components/ReleaseSummarySection';
 import ReleaseDataAndFiles from '@common/modules/release/components/ReleaseDataAndFiles';
 import useDebouncedCallback from '@common/hooks/useDebouncedCallback';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import { generatePath, useLocation } from 'react-router';
 import { useConfig } from '@admin/contexts/ConfigContext';
 
@@ -200,12 +206,25 @@ const ReleaseContent = ({
               </a>
             }
             renderProducerLink={
-              <Link
-                unvisited
-                to="https://www.gov.uk/government/organisations/department-for-education"
-              >
-                Department for Education
-              </Link>
+              release.publishingOrganisations ? (
+                <span>
+                  {release.publishingOrganisations.map((org, index) => (
+                    <Fragment key={org.id}>
+                      {index > 0 && ' and '}
+                      <Link unvisited to={org.url}>
+                        {org.title}
+                      </Link>
+                    </Fragment>
+                  ))}
+                </span>
+              ) : (
+                <Link
+                  unvisited
+                  to="https://www.gov.uk/government/organisations/department-for-education"
+                >
+                  Department for Education
+                </Link>
+              )
             }
             trackScroll
           />

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -9,6 +9,7 @@ import {
   MethodologySummary,
   ExternalMethodology,
 } from '@common/services/types/methodology';
+import { Organisation } from '@common/services/types/organisation';
 import { PaginatedList } from '@common/services/types/pagination';
 import { SortDirection } from '@common/services/types/sort';
 import { PartialDate } from '@common/utils/date/partialDate';
@@ -159,6 +160,7 @@ export interface ReleaseVersion<
   headlinesSection: ContentSection<ContentBlockType>;
   relatedDashboardsSection?: ContentSection<ContentBlockType>; // optional because older releases may not have this section
   publication: Publication;
+  publishingOrganisations?: Organisation[];
   latestRelease: boolean;
   nextReleaseDate?: PartialDate;
   relatedInformation: BasicLink[];

--- a/src/explore-education-statistics-common/src/services/types/organisation.ts
+++ b/src/explore-education-statistics-common/src/services/types/organisation.ts
@@ -1,0 +1,5 @@
+export interface Organisation {
+  id: string;
+  title: string;
+  url: string;
+}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -28,7 +28,7 @@ import styles from '@frontend/modules/find-statistics/PublicationReleasePage.mod
 import classNames from 'classnames';
 import orderBy from 'lodash/orderBy';
 import { GetServerSideProps, NextPage } from 'next';
-import React from 'react';
+import React, { Fragment } from 'react';
 import Button from '@common/components/Button';
 import downloadService from '@frontend/services/downloadService';
 
@@ -162,12 +162,25 @@ const PublicationReleasePage: NextPage<Props> = ({ releaseVersion }) => {
               </Link>
             }
             renderProducerLink={
-              <Link
-                unvisited
-                to="https://www.gov.uk/government/organisations/department-for-education"
-              >
-                Department for Education
-              </Link>
+              releaseVersion.publishingOrganisations ? (
+                <span>
+                  {releaseVersion.publishingOrganisations.map((org, index) => (
+                    <Fragment key={org.id}>
+                      {index > 0 && ' and '}
+                      <Link unvisited to={org.url}>
+                        {org.title}
+                      </Link>
+                    </Fragment>
+                  ))}
+                </span>
+              ) : (
+                <Link
+                  unvisited
+                  to="https://www.gov.uk/government/organisations/department-for-education"
+                >
+                  Department for Education
+                </Link>
+              )
             }
             onShowReleaseTypeModal={() =>
               logEvent({

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
@@ -466,4 +466,55 @@ describe('PublicationReleasePage', () => {
       }),
     ).toHaveAttribute('href', 'http://gov.uk');
   });
+
+  test('renders default publishing organisation text', () => {
+    render(<PublicationReleasePage releaseVersion={testRelease} />);
+    const producedBy = screen.getByTestId('Produced by-value');
+
+    expect(screen.getByTestId('Produced by-value')).toHaveTextContent(
+      'Department for Education',
+    );
+
+    expect(
+      within(producedBy).getByRole('link', {
+        name: 'Department for Education',
+      }),
+    ).toHaveAttribute(
+      'href',
+      'https://www.gov.uk/government/organisations/department-for-education',
+    );
+  });
+
+  test('renders custom publishing organisation text correctly if set', () => {
+    render(
+      <PublicationReleasePage
+        releaseVersion={{
+          ...testRelease,
+          publishingOrganisations: [
+            {
+              id: 'org-id-1',
+              title: 'Department for Education',
+              url: 'https://www.gov.uk/government/organisations/department-for-education',
+            },
+            {
+              id: 'org-id-2',
+              title: 'Other Organisation',
+              url: 'https://example.com',
+            },
+          ],
+        }}
+      />,
+    );
+    const producedBy = screen.getByTestId('Produced by-value');
+
+    expect(screen.getByTestId('Produced by-value')).toHaveTextContent(
+      'Department for Education and Other Organisation',
+    );
+
+    expect(
+      within(producedBy).getByRole('link', {
+        name: 'Other Organisation',
+      }),
+    ).toHaveAttribute('href', 'https://example.com');
+  });
 });


### PR DESCRIPTION
Add optional `publishingOrganisations` property to a release version and display this on the frontend and in the admin when present.
If not present (as it won't be for existing release versions) we fallback to showing the current hardcoded DfE link.

This work will allow multiple organisations to appear in the 'published by' row of a release.