### PR TITLE
EES-6317 Add publishing organisations to release version model

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
@@ -73,6 +73,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .WithApprovalStatus(ReleaseApprovalStatus.Approved)
                 .WithPreviousVersionId(Guid.NewGuid())
                 .WithType(ReleaseType.OfficialStatistics)
+                .WithPublishingOrganisations(_fixture.DefaultOrganisation()
+                    .Generate(2))
                 .WithReleaseStatuses(_fixture
                     .DefaultReleaseStatus()
                     .Generate(1))
@@ -704,6 +706,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Include(releaseVersion => releaseVersion.PreviousVersion)
                 .Include(releaseVersion => releaseVersion.Publication)
                 .Include(releaseVersion => releaseVersion.Release)
+                .Include(releaseVersion => releaseVersion.PublishingOrganisations)
                 .Include(releaseVersion => releaseVersion.Content)
                 .ThenInclude(section => section.Content)
                 .ThenInclude(section => section.Comments)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250714103833_EES6317_AddReleaseVersionPublishingOrganisations.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250714103833_EES6317_AddReleaseVersionPublishingOrganisations.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250714103833_EES6317_AddReleaseVersionPublishingOrganisations")]
+    partial class EES6317_AddReleaseVersionPublishingOrganisations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250714103833_EES6317_AddReleaseVersionPublishingOrganisations.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250714103833_EES6317_AddReleaseVersionPublishingOrganisations.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations;
+
+/// <inheritdoc />
+[ExcludeFromCodeCoverage]
+public partial class EES6317_AddReleaseVersionPublishingOrganisations : Migration
+{
+    private const string MigrationId = "20250714103833";
+
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Organisations",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Title = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                Url = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: false),
+                Created = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                Updated = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Organisations", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "ReleaseVersionPublishingOrganisations",
+            columns: table => new
+            {
+                OrganisationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                ReleaseVersionId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_ReleaseVersionPublishingOrganisations",
+                    x => new
+                    {
+                        x.OrganisationId,
+                        x.ReleaseVersionId
+                    });
+                table.ForeignKey(
+                    name: "FK_ReleaseVersionPublishingOrganisations_Organisations_OrganisationId",
+                    column: x => x.OrganisationId,
+                    principalTable: "Organisations",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_ReleaseVersionPublishingOrganisations_ReleaseVersions_ReleaseVersionId",
+                    column: x => x.ReleaseVersionId,
+                    principalTable: "ReleaseVersions",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Organisations_Title",
+            table: "Organisations",
+            column: "Title",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ReleaseVersionPublishingOrganisations_ReleaseVersionId",
+            table: "ReleaseVersionPublishingOrganisations",
+            column: "ReleaseVersionId");
+
+        migrationBuilder.Sql("GRANT SELECT ON dbo.Organisations TO [content];");
+        migrationBuilder.Sql("GRANT SELECT ON dbo.ReleaseVersionPublishingOrganisations TO [content];");
+        migrationBuilder.Sql("GRANT SELECT ON dbo.Organisations TO [publisher];");
+        migrationBuilder.Sql("GRANT SELECT ON dbo.ReleaseVersionPublishingOrganisations TO [publisher];");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql("REVOKE SELECT ON dbo.Organisations TO [content];");
+        migrationBuilder.Sql("REVOKE SELECT ON dbo.ReleaseVersionPublishingOrganisations TO [content];");
+        migrationBuilder.Sql("REVOKE SELECT ON dbo.Organisations TO [publisher];");
+        migrationBuilder.Sql("REVOKE SELECT ON dbo.ReleaseVersionPublishingOrganisations TO [publisher];");
+
+        migrationBuilder.DropTable(
+            name: "ReleaseVersionPublishingOrganisations");
+
+        migrationBuilder.DropTable(
+            name: "Organisations");
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250714103833_EES6317_AddReleaseVersionPublishingOrganisations.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250714103833_EES6317_AddReleaseVersionPublishingOrganisations.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -74,6 +75,11 @@ public partial class EES6317_AddReleaseVersionPublishingOrganisations : Migratio
         migrationBuilder.Sql("GRANT SELECT ON dbo.ReleaseVersionPublishingOrganisations TO [content];");
         migrationBuilder.Sql("GRANT SELECT ON dbo.Organisations TO [publisher];");
         migrationBuilder.Sql("GRANT SELECT ON dbo.ReleaseVersionPublishingOrganisations TO [publisher];");
+
+        // Insert seed Organisations
+        migrationBuilder.SqlFromFile(
+            MigrationConstants.ContentMigrationsPath,
+            $"{MigrationId}_{nameof(EES6317_AddReleaseVersionPublishingOrganisations)}.sql");
     }
 
     /// <inheritdoc />

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250714103833_EES6317_AddReleaseVersionPublishingOrganisations.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250714103833_EES6317_AddReleaseVersionPublishingOrganisations.sql
@@ -1,0 +1,3 @@
+﻿-- Insert seed Organisations
+INSERT INTO dbo.Organisations (Id, Title, Url, Created, Updated) VALUES (N'5E089801-CF1A-B375-ACD3-88E9D8AECE66', N'Department for Education', N'https://www.gov.uk/government/organisations/department-for-education', N'2025-07-14 09:57:21.7710656 +00:00', null);
+INSERT INTO dbo.Organisations (Id, Title, Url, Created, Updated) VALUES (N'5E089801-CE1A-E274-9915-E83F3E978699', N'Skills England', N'https://www.gov.uk/government/organisations/skills-england', N'2025-07-14 09:57:21.7710656 +00:00', null);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseAmendmentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseAmendmentService.cs
@@ -87,11 +87,12 @@ public class ReleaseAmendmentService : IReleaseAmendmentService
             // Assign this Release amendment a new Id.
             Id = amendmentReleaseVersionId,
 
-            // Copy various fields directly from the originalRelease.
+            // Copy various fields directly from the original release version.
             Release = originalReleaseVersion.Release,
             Publication = originalReleaseVersion.Publication,
             Type = originalReleaseVersion.Type,
             ApprovalStatus = ReleaseApprovalStatus.Draft,
+            PublishingOrganisations = originalReleaseVersion.PublishingOrganisations,
             DataGuidance = originalReleaseVersion.DataGuidance,
             PreReleaseAccessList = originalReleaseVersion.PreReleaseAccessList,
             NextReleaseDate = originalReleaseVersion.NextReleaseDate,
@@ -651,6 +652,7 @@ internal static class ReleaseAmendmentQueryableExtensions
             .AsSplitQuery()
             .Include(releaseVersion => releaseVersion.Publication)
             .Include(releaseVersion => releaseVersion.Release)
+            .Include(releaseVersion => releaseVersion.PublishingOrganisations)
             .Include(releaseVersion => releaseVersion.Content)
             .ThenInclude(section => section.Content)
             .ThenInclude(block => (block as EmbedBlockLink)!.EmbedBlock)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/OrganisationGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/OrganisationGeneratorExtensions.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+
+public static class OrganisationGeneratorExtensions
+{
+    public static Generator<Organisation> DefaultOrganisation(this DataFixture fixture)
+        => fixture.Generator<Organisation>().WithDefaults();
+
+    public static Generator<Organisation> WithDefaults(this Generator<Organisation> generator)
+        => generator.ForInstance(d => d.SetDefaults());
+
+    public static InstanceSetters<Organisation> SetDefaults(this InstanceSetters<Organisation> setters)
+        => setters
+            .SetDefault(t => t.Id)
+            .SetDefault(t => t.Title)
+            .SetDefault(t => t.Url)
+            .Set(p => p.Created, f => f.Date.Past());
+
+    public static Generator<Organisation> WithId(
+        this Generator<Organisation> generator,
+        Guid id)
+        => generator.ForInstance(s => s.SetId(id));
+
+    public static Generator<Organisation> WithTitle(
+        this Generator<Organisation> generator,
+        string title)
+        => generator.ForInstance(s => s.SetTitle(title));
+
+    public static Generator<Organisation> WithUrl(
+        this Generator<Organisation> generator,
+        string url)
+        => generator.ForInstance(s => s.SetUrl(url));
+
+    public static Generator<Organisation> WithCreated(
+        this Generator<Organisation> generator,
+        DateTimeOffset created) => generator.ForInstance(s => s.SetCreated(created));
+
+    public static Generator<Organisation> WithUpdated(
+        this Generator<Organisation> generator,
+        DateTimeOffset? updated) => generator.ForInstance(s => s.SetUpdated(updated));
+
+    public static InstanceSetters<Organisation> SetId(
+        this InstanceSetters<Organisation> setters,
+        Guid id)
+        => setters.Set(o => o.Id, id);
+
+    public static InstanceSetters<Organisation> SetTitle(
+        this InstanceSetters<Organisation> setters,
+        string title)
+        => setters.Set(o => o.Title, title);
+
+    public static InstanceSetters<Organisation> SetUrl(
+        this InstanceSetters<Organisation> setters,
+        string url)
+        => setters.Set(o => o.Url, url);
+
+    public static InstanceSetters<Organisation> SetCreated(
+        this InstanceSetters<Organisation> setters,
+        DateTimeOffset created)
+        => setters.Set(o => o.Created, created);
+
+    public static InstanceSetters<Organisation> SetUpdated(
+        this InstanceSetters<Organisation> setters,
+        DateTimeOffset? updated)
+        => setters.Set(o => o.Updated, updated);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/ReleaseVersionGeneratorExtensions.cs
@@ -63,6 +63,11 @@ public static class ReleaseVersionGeneratorExtensions
         DateTime publishScheduled)
         => generator.ForInstance(releaseVersion => releaseVersion.SetPublishScheduled(publishScheduled));
 
+    public static Generator<ReleaseVersion> WithPublishingOrganisations(
+        this Generator<ReleaseVersion> generator,
+        IEnumerable<Organisation> publishingOrganisations)
+        => generator.ForInstance(releaseVersion => releaseVersion.SetPublishingOrganisations(publishingOrganisations));
+
     public static Generator<ReleaseVersion> WithApprovalStatuses(
         this Generator<ReleaseVersion> generator,
         IEnumerable<ReleaseApprovalStatus> statuses)
@@ -293,6 +298,11 @@ public static class ReleaseVersionGeneratorExtensions
         this InstanceSetters<ReleaseVersion> setters,
         DateTime publishScheduled)
         => setters.Set(releaseVersion => releaseVersion.PublishScheduled, publishScheduled);
+
+    public static InstanceSetters<ReleaseVersion> SetPublishingOrganisations(
+        this InstanceSetters<ReleaseVersion> setters,
+        IEnumerable<Organisation> publishingOrganisations)
+        => setters.Set(releaseVersion => releaseVersion.PublishingOrganisations, publishingOrganisations.ToList());
 
     public static InstanceSetters<ReleaseVersion> SetNextReleaseDate(
         this InstanceSetters<ReleaseVersion> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -75,6 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
         public virtual DbSet<EmbedBlockLink> EmbedBlockLinks { get; set; }
         public virtual DbSet<FeaturedTable> FeaturedTables { get; set; }
         public virtual DbSet<MethodologyNote> MethodologyNotes { get; set; }
+        public virtual DbSet<Organisation> Organisations { get; set; } = null!;
         public virtual DbSet<Permalink> Permalinks { get; set; } = null!;
         public virtual DbSet<Contact> Contacts { get; set; }
         public virtual DbSet<Update> Update { get; set; }
@@ -563,6 +564,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .HasConversion(
                     v => v,
                     v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
+
+            modelBuilder.Entity<ReleaseVersion>()
+                .HasMany(rv => rv.PublishingOrganisations)
+                .WithMany()
+                .UsingEntity("ReleaseVersionPublishingOrganisations",
+                    rv =>
+                        rv.HasOne(typeof(Organisation))
+                            .WithMany()
+                            .HasForeignKey("OrganisationId"),
+                    o => o.HasOne(typeof(ReleaseVersion))
+                        .WithMany()
+                        .HasForeignKey("ReleaseVersionId"));
 
             modelBuilder.Entity<ReleaseVersion>()
                 .HasQueryFilter(rv => !rv.SoftDeleted);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Organisation.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Organisation.cs
@@ -1,0 +1,35 @@
+﻿#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+public class Organisation : ICreatedUpdatedTimestamps<DateTimeOffset, DateTimeOffset?>
+{
+    public Guid Id { get; set; }
+
+    public required string Title { get; set; }
+
+    public required string Url { get; set; }
+
+    public DateTimeOffset Created { get; set; }
+
+    public DateTimeOffset? Updated { get; set; }
+
+    internal class Config : IEntityTypeConfiguration<Organisation>
+    {
+        public void Configure(EntityTypeBuilder<Organisation> builder)
+        {
+            builder.Property(o => o.Title)
+                .HasMaxLength(100);
+
+            builder.Property(o => o.Url)
+                .HasMaxLength(1024);
+
+            builder.HasIndex(o => o.Title)
+                .IsUnique();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseVersion.cs
@@ -62,6 +62,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public DateTime? NotifiedOn { get; set; }
 
+        public List<Organisation> PublishingOrganisations { get; set; } = [];
+
         public bool UpdatePublishedDate { get; set; }
 
         public ReleaseVersion? PreviousVersion { get; set; }


### PR DESCRIPTION
This PR contains the backend changes to add publishing organisations to the release version model.

- Add a new type `Organisation` with properties `Id`, `Title`, `Url`, `Created`, and `Updated`.
- Add a unique index on `Title` to prevent duplication organisations being created.
- Add a new property `List<Organisation> PublishingOrganisations` to `ReleaseVersion`.
- Alter the Content database context, setting up a unidirectional many-to-many relationship, override the join table name, and alter the default foreign key column names.
- Add the database migration including granting permission for the content and publisher database users.
- Insert seed data into the database for the 'Department for Education' and 'Skills England' organisations.
- Copy the value of any `PublishingOrganisations` on a release version when creating a new amendment release version.