### PR TITLE
EES-6023 - add entra id authentication between Screener and Admin

### DIFF
--- a/infrastructure/templates/screener/ci/jobs/deploy-screener-function-app.yml
+++ b/infrastructure/templates/screener/ci/jobs/deploy-screener-function-app.yml
@@ -28,4 +28,5 @@ jobs:
               serviceConnection: ${{ parameters.serviceConnection }}
               displayName: Check the Screener API Function App is healthy after deployment
               endpoint: '$(screenerFunctionAppUrl)/api/screen'
+              accessTokenScope: $(screenerAppRegistrationClientId)
               maxAttempts: 50

--- a/infrastructure/templates/screener/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/screener/ci/tasks/deploy-bicep.yml
@@ -36,4 +36,6 @@ steps:
               subscription='$(subscription)' \
               resourceTags='$(resourceTags)' \
               maintenanceIpRanges='$(maintenanceFirewallRules)' \
-              screenerDockerImageTag='$(screenerDockerImageTag)'
+              screenerDockerImageTag='$(screenerDockerImageTag)' \
+              screenerAppRegistrationClientId='$(screenerAppRegistrationClientId)' \
+              devopsServicePrincipalId="$servicePrincipalId"

--- a/infrastructure/templates/screener/main.bicep
+++ b/infrastructure/templates/screener/main.bicep
@@ -23,12 +23,12 @@ param resourceTags {
 @description('Provides access to resources for specific IP address ranges used for service maintenance.')
 param maintenanceIpRanges IpRange[] = []
 
-// @description('Specifies the Application (Client) Id of a pre-existing App Registration used to represent the Screener Function App.')
-// param screenerAppRegistrationClientId string = ''
+@description('Specifies the Application (Client) Id of a pre-existing App Registration used to represent the Screener Function App.')
+param screenerAppRegistrationClientId string = ''
 
-// @description('Specifies the principal id of the Azure DevOps SPN.')
-// @secure()
-// param devopsServicePrincipalId string = ''
+@description('Specifies the principal id of the Azure DevOps SPN.')
+@secure()
+param devopsServicePrincipalId string = ''
 
 @description('Tagging : Date Provisioned. Used for tagging resources created by this infrastructure pipeline.')
 param dateProvisioned string = utcNow('u')
@@ -81,8 +81,8 @@ module screenerFunctionAppModule 'application/screenerContainerisedFunctionApp.b
     coreStorageAccessKeyName: coreStorage.outputs.coreStorageAccessKey
     coreStorageBlobEndpoint: coreStorage.outputs.coreStorageBlobEndpoint
     acrLoginServer: keyVault.getSecret('DOCKER-REGISTRY-SERVER-DOMAIN')
-    // screenerAppRegistrationClientId: screenerAppRegistrationClientId
-    // devopsServicePrincipalId: devopsServicePrincipalId
+    screenerAppRegistrationClientId: screenerAppRegistrationClientId
+    devopsServicePrincipalId: devopsServicePrincipalId
     screenerDockerImageTag: screenerDockerImageTag
     resourceNames: resourceNames
     functionAppExists: screenerFunctionAppExists

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -742,12 +742,12 @@
         "description": "The Client ID of a manually-created App Registration that represents the Public API Data Processor Function App in Entra ID"
       }
     },
-    // "dataScreenerAppRegistrationClientId": {
-    //   "type": "string",
-    //   "metadata": {
-    //     "description": "The Client ID of a manually-created App Registration that represents the Screener API Function App in Entra ID"
-    //   }
-    // },
+    "screenerAppRegistrationClientId": {
+      "type": "string",
+      "metadata": {
+        "description": "The Client ID of a manually-created App Registration that represents the Screener API Function App in Entra ID"
+      }
+    },
     "apiAppRegistrationClientId": {
       "type": "string",
       "metadata": {
@@ -1919,8 +1919,8 @@
         "PublicDataProcessor__Url": "[concat('https://', variables('publicDataProcessorName'), '.azurewebsites.net')]",
         "PublicDataProcessor__AppRegistrationClientId": "[parameters('publicDataProcessorAppRegistrationClientId')]",
         "DataScreener__Url": "[concat('https://', variables('dataScreenerName'), '.azurewebsites.net', '/api/screen')]",
+        "DataScreener__AppRegistrationClientId": "[parameters('screenerAppRegistrationClientId')]",
         "FeatureFlags__EnableReplacementOfPublicApiDataSets": "[parameters('enableReplacementOfPublicApiDataSets')]"
-        // "DataScreener__AppRegistrationClientId": "[parameters('dataScreenerAppRegistrationClientId')]"
       }
     },
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetScreenerClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetScreenerClientTests.cs
@@ -1,0 +1,136 @@
+#nullable enable
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Options;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Authentication;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Moq;
+using RichardSzalay.MockHttp;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+public class DataSetScreenerClientTests
+{
+    private static readonly Uri BaseUri = new("http://localhost/api/screen");
+    private readonly MockHttpMessageHandler _mockHttp;
+    private readonly JsonSerializerOptions _requestSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase, // API is case sensitive
+    };
+    
+    protected DataSetScreenerClientTests()
+    {
+        _mockHttp = new MockHttpMessageHandler();
+    }
+
+    public class AuthenticationTests : DataSetScreenerClientTests
+    {
+        [Fact]
+        public async Task AuthenticationManagerCalled()
+        {
+            var responseBody = new DataSetScreenerResponse
+            {
+                Message = "",
+                OverallResult = ScreenerResult.Failed,
+                TestResults = []
+            };
+
+            _mockHttp.Expect(HttpMethod.Post, BaseUri.AbsoluteUri)
+                .Respond(HttpStatusCode.Accepted, "application/json", JsonSerializer.Serialize(responseBody));
+
+            var authenticationManager =
+                new Mock<IHttpClientAzureAuthenticationManager<DataScreenerClientOptions>>(MockBehavior.Strict);
+
+            authenticationManager
+                .Setup(m =>
+                    m.AddAuthentication(It.IsAny<HttpClient>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var dataSetScreenerClient = BuildService(
+                azureAuthenticationManager: authenticationManager.Object);
+
+            await dataSetScreenerClient.ScreenDataSet(new DataSetScreenerRequest
+            {
+                DataFileName = "",
+                DataFilePath = "",
+                MetaFileName = "",
+                MetaFilePath = "",
+                StorageContainerName = ""
+            }, default);
+
+            authenticationManager.Verify(m =>
+                m.AddAuthentication(It.IsAny<HttpClient>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+    
+    public class ScreenDataSetTests : DataSetScreenerClientTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            var request = new DataSetScreenerRequest
+            {
+                DataFileName = "data-file-name",
+                DataFilePath = "data-file-path",
+                MetaFileName = "meta-file-name",
+                MetaFilePath = "meta-file-path",
+                StorageContainerName = "storage-container-name"
+            };
+            
+            var responseBody = new DataSetScreenerResponse
+            {
+                Message = "A message",
+                OverallResult = ScreenerResult.Failed,
+                TestResults = [
+                    new DataScreenerTestResult
+                    {
+                        Stage = Stage.PreScreening1,
+                        Result = TestResult.WARNING,
+                        Notes = "Some notes",
+                        TestFunctionName = "Test 1"
+                    },
+                    new DataScreenerTestResult
+                    {
+                        Stage = Stage.Passed,
+                        Result = TestResult.PASS,
+                        TestFunctionName = "Test 2"
+                    }
+                ]
+            };
+
+            _mockHttp
+                .Expect(HttpMethod.Post, BaseUri.AbsoluteUri)
+                .WithJsonContent(request, _requestSerializerOptions)
+                .Respond(HttpStatusCode.Accepted, "application/json", JsonSerializer.Serialize(responseBody));
+
+            var dataSetScreenerClient = BuildService();
+
+            var response = await dataSetScreenerClient.ScreenDataSet(request, default);
+            
+            _mockHttp.VerifyNoOutstandingExpectation();
+            
+            Assert.Equivalent(responseBody, response);
+        }
+    }
+
+    private DataSetScreenerClient BuildService(
+        IHttpClientAzureAuthenticationManager<DataScreenerClientOptions>? azureAuthenticationManager = null)
+    {
+        var client = _mockHttp.ToHttpClient();
+        client.BaseAddress = BaseUri;
+
+        var authenticationManager = azureAuthenticationManager ??
+                                    Mock.Of<IHttpClientAzureAuthenticationManager<DataScreenerClientOptions>>(
+                                        MockBehavior.Loose);
+
+        return new DataSetScreenerClient(
+            client,
+            authenticationManager);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Public.Data/PublicDataApiClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Public.Data/PublicDataApiClientTests.cs
@@ -1,0 +1,107 @@
+#nullable enable
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Options;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Authentication;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using RichardSzalay.MockHttp;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Public.Data;
+
+public class PublicDataApiClientTests
+{
+    private static readonly Uri BaseUri = new("http://localhost");
+    private readonly MockHttpMessageHandler _mockHttp;
+
+    protected PublicDataApiClientTests()
+    {
+        _mockHttp = new MockHttpMessageHandler();
+    }
+    
+    public class AuthenticationTests : PublicDataApiClientTests
+    {
+        [Fact]
+        public async Task AuthenticationManagerCalled()
+        {
+            var responseMessage = new HttpResponseMessage();
+
+            var dataSetId = Guid.NewGuid();
+            var dataSetVersion = "1.1";
+            
+            var uri = new Uri(BaseUri, $"v1/data-sets/{dataSetId}/versions/{dataSetVersion}/changes");
+            
+            _mockHttp
+                .Expect(HttpMethod.Get, uri.AbsoluteUri)
+                .Respond(HttpStatusCode.Accepted, "application/json", JsonConvert.SerializeObject(responseMessage));
+
+            var authenticationManager =
+                new Mock<IHttpClientAzureAuthenticationManager<PublicDataApiOptions>>(MockBehavior.Strict);
+
+            authenticationManager
+                .Setup(m =>
+                    m.AddAuthentication(It.IsAny<HttpClient>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            
+            var publicDataApiClient = BuildService(
+                azureAuthenticationManager: authenticationManager.Object);
+            
+            await publicDataApiClient.GetDataSetVersionChanges(
+                dataSetId: dataSetId,
+                dataSetVersion: dataSetVersion);
+
+            authenticationManager.Verify(m => 
+                m.AddAuthentication(It.IsAny<HttpClient>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+
+    public class GetDataSetVersionChangesTests : PublicDataApiClientTests
+    {
+        [Fact]
+        public async Task HttpClientSuccess()
+        {
+            var dataSetId = Guid.NewGuid();
+            var dataSetVersion = "1.1";
+            
+            var uri = new Uri(BaseUri, $"v1/data-sets/{dataSetId}/versions/{dataSetVersion}/changes");
+            
+            _mockHttp
+                .Expect(HttpMethod.Get, uri.AbsoluteUri)
+                .Respond(HttpStatusCode.OK, "application/json", "Response text");
+
+            var publicDataApiClient = BuildService();
+            
+            var response = await publicDataApiClient.GetDataSetVersionChanges(
+                dataSetId: dataSetId,
+                dataSetVersion: dataSetVersion);
+            
+            _mockHttp.VerifyNoOutstandingExpectation();
+
+            var result = response.AssertRight();
+            
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.Equal("Response text", await result.Content.ReadAsStringAsync());
+        }
+    }
+
+    private PublicDataApiClient BuildService(
+        IHttpClientAzureAuthenticationManager<PublicDataApiOptions>? azureAuthenticationManager = null)
+    {
+        var client = _mockHttp.ToHttpClient();
+        client.BaseAddress = BaseUri;
+
+        var authenticationManager = azureAuthenticationManager ??
+                                    Mock.Of<IHttpClientAzureAuthenticationManager<PublicDataApiOptions>>(
+                                        MockBehavior.Loose);
+        return new PublicDataApiClient(
+            Mock.Of<ILogger<PublicDataApiClient>>(),
+            client,
+            authenticationManager);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Options/DataScreenerClientOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Options/DataScreenerClientOptions.cs
@@ -1,8 +1,12 @@
+using System;
+
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Options;
 
-public class DataScreenerClientOptions
+public class DataScreenerClientOptions : IAzureAuthenticationOptions
 {
     public const string Section = "DataScreener";
 
-    public string Url { get; set; }
+    public string Url { get; init; }
+
+    public Guid AppRegistrationClientId { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Options/IAzureAuthenticationOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Options/IAzureAuthenticationOptions.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Options;
+
+public interface IAzureAuthenticationOptions
+{
+    public Guid AppRegistrationClientId { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Options/PublicDataApiOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Options/PublicDataApiOptions.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Options;
 
-public class PublicDataApiOptions
+public class PublicDataApiOptions : IAzureAuthenticationOptions
 {
     public const string Section = "PublicDataApi";
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Options/PublicDataProcessorOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Options/PublicDataProcessorOptions.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Options;
 
-internal class PublicDataProcessorOptions
+internal class PublicDataProcessorOptions : IAzureAuthenticationOptions
 {
     public const string Section = "PublicDataProcessor";
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Authentication/HttpClientAuthenticationManagers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Authentication/HttpClientAuthenticationManagers.cs
@@ -18,7 +18,7 @@ public interface IHttpClientAzureAuthenticationManager<TOptions>
     Task AddAuthentication(HttpClient httpClient, CancellationToken cancellationToken);
 }
 
-public class HttpClientDefaultAzureCredentialAuthenticationManager<TOptions>(
+public class DefaultAzureCredentialHttpClientAuthenticationManager<TOptions>(
     IOptions<TOptions> options) : IHttpClientAzureAuthenticationManager<TOptions>
     where TOptions : class, IAzureAuthenticationOptions
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Authentication/HttpClientAuthenticationManagers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Authentication/HttpClientAuthenticationManagers.cs
@@ -1,0 +1,60 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+using GovUk.Education.ExploreEducationStatistics.Admin.Options;
+using GovUk.Education.ExploreEducationStatistics.Common.Security;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Authentication;
+
+// ReSharper disable once UnusedTypeParameter
+public interface IHttpClientAzureAuthenticationManager<TOptions>
+    where TOptions : class, IAzureAuthenticationOptions
+{
+    Task AddAuthentication(HttpClient httpClient, CancellationToken cancellationToken);
+}
+
+public class HttpClientDefaultAzureCredentialAuthenticationManager<TOptions>(
+    IOptions<TOptions> options) : IHttpClientAzureAuthenticationManager<TOptions>
+    where TOptions : class, IAzureAuthenticationOptions
+{
+    /// <summary>
+    /// Request an access token to authenticate the Admin App Service with the Data Processor using its
+    /// system-assigned identity.
+    ///
+    /// We call this within this class rather than during "AddHttpClient" initialisation
+    /// within <see cref="Startup" /> because adding the call for the Bearer token in there instead would otherwise
+    /// result in a Bearer token unnecessarily being requested every time ProcessorClient was instantiated but not
+    /// used (e.g. by virtue of a Controller using DataSetService as a dependency but not calling any service methods
+    /// that require interaction with ProcessorClient).
+    ///
+    /// The other advantage of requesting the Bearer token here rather than in "AddHttpClient" is that it can be done
+    /// asynchronously here.
+    /// 
+    /// </summary>
+    public async Task AddAuthentication(
+        HttpClient httpClient,
+        CancellationToken cancellationToken)
+    {
+        var accessTokenProvider = new DefaultAzureCredential();
+        var tokenResponse = await accessTokenProvider.GetTokenAsync(
+            new TokenRequestContext([$"api://{options.Value.AppRegistrationClientId}/.default"]),
+            cancellationToken);
+        httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", tokenResponse.Token);
+    }
+}
+
+public class HttpHeaderHttpClientAuthenticationManager<TOptions> : IHttpClientAzureAuthenticationManager<TOptions>
+    where TOptions : class, IAzureAuthenticationOptions
+{
+    public Task AddAuthentication(HttpClient httpClient, CancellationToken cancellationToken)
+    {
+        httpClient.DefaultRequestHeaders.Add(HeaderNames.UserAgent, SecurityConstants.AdminUserAgent);
+        return Task.CompletedTask;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetScreenerClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetScreenerClient.cs
@@ -1,6 +1,3 @@
-using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
-using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using System;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -8,10 +5,17 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Options;
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Authentication;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
-public class DataSetScreenerClient(HttpClient client) : IDataSetScreenerClient
+public class DataSetScreenerClient(
+    HttpClient httpClient,
+    IHttpClientAzureAuthenticationManager<DataScreenerClientOptions> authenticationManager) : IDataSetScreenerClient
 {
     private readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
@@ -22,11 +26,13 @@ public class DataSetScreenerClient(HttpClient client) : IDataSetScreenerClient
         DataSetScreenerRequest dataSetRequest,
         CancellationToken cancellationToken)
     {
+        await authenticationManager.AddAuthentication(httpClient, cancellationToken);
+        
         var json = JsonSerializer.Serialize(dataSetRequest, _jsonSerializerOptions);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
         // TODO (EES-5353): Add cancellation token handling logic to terminate Azure Function processes
-        var response = await client.PostAsync(client.BaseAddress, content, CancellationToken.None);
+        var response = await httpClient.PostAsync(httpClient.BaseAddress, content, CancellationToken.None);
 
         return response.IsSuccessStatusCode
             ? await response.Content.ReadFromJsonAsync<DataSetScreenerResponse>(cancellationToken)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/ProcessorClient.cs
@@ -2,31 +2,25 @@
 using System;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
-using Azure.Identity;
-using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Options;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Authentication;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.Requests;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Processor.ViewModels;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
 
 internal class ProcessorClient(
     ILogger<ProcessorClient> logger,
     HttpClient httpClient,
-    IOptions<PublicDataProcessorOptions> options,
-    IWebHostEnvironment environment) : IProcessorClient
+    IHttpClientAzureAuthenticationManager<PublicDataProcessorOptions> authenticationManager) : IProcessorClient
 {
     public async Task<Either<ActionResult, ProcessDataSetVersionResponseViewModel>> CreateDataSet(
         Guid releaseFileId,
@@ -127,7 +121,7 @@ internal class ProcessorClient(
         CancellationToken cancellationToken = default)
         where TResponse : class
     {
-        await AddBearerToken(cancellationToken);
+        await authenticationManager.AddAuthentication(httpClient, cancellationToken);
 
         var response = await requestFunction.Invoke();
 
@@ -175,34 +169,5 @@ internal class ProcessorClient(
 
         return content
                ?? throw new Exception("Could not deserialize the response from the Public Data Processor.");
-    }
-
-    /// <summary>
-    /// Request an access token to authenticate the Admin App Service with the Data Processor using its
-    /// system-assigned identity.
-    ///
-    /// We call this within this class rather than during "AddHttpClient" initialisation
-    /// within <see cref="Startup" /> because adding the call for the Bearer token in there instead would otherwise
-    /// result in a Bearer token unnecessarily being requested every time ProcessorClient was instantiated but not
-    /// used (e.g. by virtue of a Controller using DataSetService as a dependency but not calling any service methods
-    /// that require interaction with ProcessorClient).
-    ///
-    /// The other advantage of requesting the Bearer token here rather than in "AddHttpClient" is that it can be done
-    /// asynchronously here.
-    /// 
-    /// </summary>
-    private async Task AddBearerToken(CancellationToken cancellationToken)
-    {
-        // If operating within Azure, obtain an access token for authenticating the Admin App Service with
-        // the Public Data Processor using its managed identity.
-        if (environment.IsProduction())
-        {
-            var accessTokenProvider = new DefaultAzureCredential();
-            var tokenResponse = await accessTokenProvider.GetTokenAsync(
-                new TokenRequestContext([$"api://{options.Value.AppRegistrationClientId}/.default"]),
-                cancellationToken);
-            httpClient.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue("Bearer", tokenResponse.Token);
-        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PublicDataApiClient.cs
@@ -2,30 +2,24 @@
 using System;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
-using Azure.Identity;
-using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Options;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Authentication;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Requests;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Public.Data;
 
 public class PublicDataApiClient(
     ILogger<PublicDataApiClient> logger,
     HttpClient httpClient,
-    IOptions<PublicDataApiOptions> options,
-    IWebHostEnvironment environment)
+    IHttpClientAzureAuthenticationManager<PublicDataApiOptions> authenticationManager)
     : IPublicDataApiClient
 {
     public async Task<Either<ActionResult, HttpResponseMessage>> GetDataSetVersionChanges(
@@ -46,7 +40,7 @@ public class PublicDataApiClient(
         Func<Task<HttpResponseMessage>> requestFunction,
         CancellationToken cancellationToken)
     {
-        await AddBearerToken(cancellationToken);
+        await authenticationManager.AddAuthentication(httpClient, cancellationToken);
 
         // Add an HTTP header to signal to the Public API that this call originates from the
         // EES service.
@@ -84,28 +78,5 @@ public class PublicDataApiClient(
         }
 
         return response;
-    }
-
-    /// <summary>
-    /// Request an access token to authenticate the Admin App Service with the Public API using its
-    /// system-assigned identity.
-    /// </summary>
-    private async Task AddBearerToken(CancellationToken cancellationToken)
-    {
-        // If operating within Azure, obtain an access token for authenticating the Admin App Service with
-        // the Public API using its managed identity.
-        //
-        // By virtue of the Admin App's managed identity being granted the "Admin.Access" App Role
-        // on the Public API, the access token retrieved here will have the App Role present in its list
-        // of Role claims.
-        if (environment.IsProduction())
-        {
-            var accessTokenProvider = new DefaultAzureCredential();
-            var tokenResponse = await accessTokenProvider.GetTokenAsync(
-                new TokenRequestContext([$"api://{options.Value.AppRegistrationClientId}/.default"]),
-                cancellationToken);
-            httpClient.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue("Bearer", tokenResponse.Token);
-        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -500,13 +500,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             // authentication managers that simply authenticate themselves via an HTTP header.
             if (hostEnvironment.IsProduction())
             {
-                services.AddTransient(
+                services.AddScoped(
                     typeof(IHttpClientAzureAuthenticationManager<>),
                     typeof(DefaultAzureCredentialHttpClientAuthenticationManager<>));
             }
             else
             {
-                services.AddTransient(
+                services.AddScoped(
                     typeof(IHttpClientAzureAuthenticationManager<>),
                     typeof(HttpHeaderHttpClientAuthenticationManager<>));
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -495,11 +495,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
 
             // If operating within Azure, register authentication managers that obtain access
             // tokens for authenticating the Admin App Service with the target service.
+            //
+            // Otherwise, for non-Azure environments (local and integration test) register
+            // authentication managers that simply authenticate themselves via an HTTP header.
             if (hostEnvironment.IsProduction())
             {
                 services.AddTransient(
                     typeof(IHttpClientAzureAuthenticationManager<>),
-                    typeof(HttpClientDefaultAzureCredentialAuthenticationManager<>));
+                    typeof(DefaultAzureCredentialHttpClientAuthenticationManager<>));
             }
             else
             {


### PR DESCRIPTION
This PR:
- adds EasyAuth security between Admin and Screener.

# The setup

## App Registrations

We have added 4 App Registrations into DfE's Entra ID - these registrations represent the Screener Function App for security and permissions purposes.

## Screener authentication

Screener is set up to enable EasyAuth and to only accept requests from Admin and from the DevOps SPN (for the purposes of pinging its healthcheck endpoint during deployment).  All other requests will receive 401s.  The requests from Admin and DevOps must provide valid access tokens as Bearer tokens.

## Admin changes to provide auth tokens

Admin is set up (via its DataSetScreenerClient) to request Access Tokens in order to talk to Screener via EasyAuth.  Admin requests a valid access token and adds it as a Bearer token to its requests to Screener.

## DevOps pipeline changes

DevOps is set up to request Access Tokens in order to talk to Screener via EasyAuth.  The healthcheck-pinging step in `deploy-screener-function-app.yml` has been updated to request a valid access token and add it as a Bearer token to its requests to Screener's healthcheck endpoint.

# Other misc changes

I added a test suite for `PublicDataApiClient` which was missing any tests.  I updated the 2 other non-Screener Clients to use the new abstracted AuthenticationManager in order to add authentication to their calls.  All 3 Clients in Admin now use a simple `HttpHeaderAuthenticationManager` in non-Production mode which just identifies calls coming from allowed service components with running in a local or integration test environment.