### PR TITLE
EES-6318 Update Admin and Content API Release version view models to include publishing organisations

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
@@ -44,6 +44,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
 
             var releaseVersion = publication.Releases.Single().Versions.Single();
 
+            releaseVersion.PublishingOrganisations = _dataFixture.DefaultOrganisation()
+                .GenerateList(2);
+
             releaseVersion.RelatedInformation.Add(
                 new Link
                 {
@@ -249,7 +252,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
                 Assert.Equal(releaseVersion.Type, contentRelease.Type);
                 Assert.Equal(releaseVersion.Release.YearTitle, contentRelease.YearTitle);
                 Assert.Empty(contentRelease.Updates);
-                
+
+                Assert.Equal(releaseVersion.PublishingOrganisations.Count,
+                    contentRelease.PublishingOrganisations.Count);
+                Assert.All(releaseVersion.PublishingOrganisations,
+                    (expectedOrganisation, index) =>
+                    {
+                        var actualOrganisation = contentRelease.PublishingOrganisations[index];
+                        Assert.Equal(expectedOrganisation.Id, actualOrganisation.Id);
+                        Assert.Equal(expectedOrganisation.Title, actualOrganisation.Title);
+                        Assert.Equal(expectedOrganisation.Url, actualOrganisation.Url);
+                    });
+
                 var contentDownloadFiles = contentRelease.DownloadFiles.ToList();
                 Assert.Equal(2, contentDownloadFiles.Count);
                 Assert.Equal(files[0].Id, contentDownloadFiles[0].Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServiceTests.cs
@@ -1018,6 +1018,8 @@ public abstract class ReleaseVersionServiceTests
                                 .WithApprovalStatus(ReleaseApprovalStatus.Approved)
                                 .WithPublished(DateTime.UtcNow)
                                 .WithPublishScheduled(DateTime.UtcNow)
+                                .WithPublishingOrganisations(_dataFixture.DefaultOrganisation()
+                                    .Generate(2))
                                 .WithReleaseStatuses(_dataFixture.DefaultReleaseStatus()
                                     .Generate(2))
                         ])
@@ -1075,6 +1077,16 @@ public abstract class ReleaseVersionServiceTests
                 Assert.Equal(releaseVersion.Release.TimePeriodCoverage, viewModel.TimePeriodCoverage);
                 Assert.Equal(releaseVersion.NotifySubscribers, viewModel.NotifySubscribers);
                 Assert.Equal(releaseVersion.UpdatePublishedDate, viewModel.UpdatePublishedDate);
+
+                Assert.Equal(releaseVersion.PublishingOrganisations.Count, viewModel.PublishingOrganisations.Count);
+                Assert.All(releaseVersion.PublishingOrganisations,
+                    (expectedOrganisation, index) =>
+                    {
+                        var actualOrganisation = viewModel.PublishingOrganisations[index];
+                        Assert.Equal(expectedOrganisation.Id, actualOrganisation.Id);
+                        Assert.Equal(expectedOrganisation.Title, actualOrganisation.Title);
+                        Assert.Equal(expectedOrganisation.Url, actualOrganisation.Url);
+                    });
 
                 Assert.Null(viewModel.PreviousVersionId);
                 Assert.True(viewModel.LatestRelease);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -27,6 +27,7 @@ using KeyStatisticViewModel = GovUk.Education.ExploreEducationStatistics.Admin.V
 using MarkDownBlockViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.MarkDownBlockViewModel;
 using MethodologyNoteViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology.MethodologyNoteViewModel;
 using MethodologyVersionViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology.MethodologyVersionViewModel;
+using OrganisationViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.OrganisationViewModel;
 using PublicationViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.PublicationViewModel;
 using ReleaseNoteViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent.ReleaseNoteViewModel;
 using ReleaseVersionSummaryViewModel = GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ReleaseVersionSummaryViewModel;
@@ -70,6 +71,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                         rv.PublishScheduled.HasValue
                             ? rv.PublishScheduled.Value.ConvertUtcToUkTimeZone()
                     : (DateTime?)null))
+                .ForMember(dest => dest.PublishingOrganisations,
+                    m => m.MapFrom(rv => rv.PublishingOrganisations.OrderBy(o => o.Title)))
                 .ForMember(dest => dest.Label,
                     m => m.MapFrom(rv => rv.Release.Label));
 
@@ -139,6 +142,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
             CreateMap<ContentSection, ContentSectionViewModel>().ForMember(dest => dest.Content,
                 m => m.MapFrom(section => section.Content.OrderBy(contentBlock => contentBlock.Order)));
 
+            CreateMap<Organisation, OrganisationViewModel>();
+
             CreateMap<ReleaseVersion, ManageContentPageViewModel.ReleaseViewModel>()
                 .ForMember(dest => dest.CoverageTitle,
                     m => m.MapFrom(rv => rv.Release.TimePeriodCoverage.GetEnumLabel()))
@@ -183,7 +188,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                     m => m.MapFrom(rv =>
                         rv.PublishScheduled.HasValue
                             ? rv.PublishScheduled.Value.ConvertUtcToUkTimeZone()
-                            : (DateTime?)null));
+                            : (DateTime?)null))
+                .ForMember(dest => dest.PublishingOrganisations,
+                    m => m.MapFrom(rv => rv.PublishingOrganisations.OrderBy(o => o.Title)));
 
             CreateMap<Update, ReleaseNoteViewModel>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
@@ -165,6 +165,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                 .Include(rv => rv.Release)
                 .ThenInclude(r => r.Publication)
                 .ThenInclude(p => p.Theme)
+                .Include(rv => rv.PublishingOrganisations)
                 .Include(rv => rv.Content)
                 .ThenInclude(cs => cs.Content)
                 .ThenInclude(cb => cb.Comments)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
@@ -73,6 +73,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .ReleaseVersions
                 .Include(rv => rv.Release)
                 .ThenInclude(r => r.Publication)
+                .Include(rv => rv.PublishingOrganisations)
                 .Include(rv => rv.ReleaseStatuses)
                 .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId)
                 .OnSuccess(userService.CheckCanViewReleaseVersion)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ManageContent/ManageContentPageViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ManageContent/ManageContentPageViewModel.cs
@@ -44,15 +44,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageCont
             [JsonConverter(typeof(StringEnumConverter))]
             public ReleaseType Type { get; set; }
 
-            public List<ReleaseNoteViewModel> Updates { get; set; } = new();
+            public List<OrganisationViewModel> PublishingOrganisations { get; set; } = [];
 
-            public List<ContentSectionViewModel> Content { get; set; } = new();
+            public List<ReleaseNoteViewModel> Updates { get; set; } = [];
+
+            public List<ContentSectionViewModel> Content { get; set; } = [];
 
             public ContentSectionViewModel SummarySection { get; set; } = new();
 
             public ContentSectionViewModel HeadlinesSection { get; set; } = new();
 
-            public List<KeyStatisticViewModel> KeyStatistics { get; set; } = new();
+            public List<KeyStatisticViewModel> KeyStatistics { get; set; } = [];
 
             public ContentSectionViewModel KeyStatisticsSecondarySection { get; set; } = new();
 
@@ -69,7 +71,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageCont
 
             public PartialDate NextReleaseDate { get; set; }
 
-            public List<Link> RelatedInformation { get; set; } = new List<Link>();
+            public List<Link> RelatedInformation { get; set; } = [];
         }
 
         public class PublicationViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/OrganisationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/OrganisationViewModel.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+
+public record OrganisationViewModel
+{
+    public required Guid Id { get; init; }
+
+    public required string Title { get; init; }
+
+    public required string Url { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -55,6 +56,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         [JsonConverter(typeof(DateTimeToDateJsonConverter))]
         public DateTime? PublishScheduled { get; set; }
+
+        public List<OrganisationViewModel> PublishingOrganisations { get; set; } = [];
 
         public DateTime? Published { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/ReleaseCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Cache/ReleaseCacheServiceTests.cs
@@ -29,70 +29,68 @@ public class ReleaseCacheServiceTests : CacheServiceTestFixture
     {
         NextReleaseDate = new PartialDate(),
         Published = DateTime.UtcNow,
-        Updates = new List<ReleaseNoteViewModel>
-        {
-            new()
+        PublishingOrganisations =
+        [
+            new OrganisationViewModel
+            {
+                Id = Guid.NewGuid(),
+                Title = "Test Organisation",
+                Url = "https://test-organisation"
+            }
+        ],
+        Updates =
+        [
+            new ReleaseNoteViewModel
             {
                 Id = Guid.NewGuid(),
                 On = DateTime.UtcNow,
             }
-        },
-        Content = new List<ContentSectionViewModel>
-        {
-            new()
+        ],
+        Content =
+        [
+            new ContentSectionViewModel
             {
                 Id = Guid.NewGuid(),
                 Order = 1,
-                Content = new List<IContentBlockViewModel>
-                {
-                    new HtmlBlockViewModel
-                    {
-                        Id = Guid.NewGuid()
-                    },
-                    new MarkDownBlockViewModel
-                    {
-                        Id = Guid.NewGuid()
-                    },
+                Content =
+                [
+                    new HtmlBlockViewModel { Id = Guid.NewGuid() },
+
+                    new MarkDownBlockViewModel { Id = Guid.NewGuid() },
+
                     new DataBlockViewModel
                     {
                         Id = Guid.NewGuid(),
-                        Charts = new List<IChart>
-                        {
-                            new LineChart()
-                        }
-                    },
-                }
+                        Charts = [new LineChart()]
+                    }
+                ]
             }
-        },
+        ],
         SummarySection = ContentSectionWithHtmlBlock(),
         HeadlinesSection = ContentSectionWithHtmlBlock(),
-        KeyStatistics = new List<KeyStatisticViewModel>
-        {
+        KeyStatistics =
+        [
             new KeyStatisticTextViewModel(),
-            new KeyStatisticDataBlockViewModel(),
-        },
+            new KeyStatisticDataBlockViewModel()
+        ],
         KeyStatisticsSecondarySection = ContentSectionWithHtmlBlock(),
         RelatedDashboardsSection = ContentSectionWithHtmlBlock(),
-        DownloadFiles = new List<FileInfo>
-        {
-            new()
+        DownloadFiles =
+        [
+            new FileInfo
             {
                 Id = Guid.NewGuid(),
                 Name = "Test file",
                 FileName = "test-file.txt",
                 Size = "10 Kb",
                 Type = FileType.Ancillary,
-
             }
-        },
+        ],
         Type = ReleaseType.AccreditedOfficialStatistics,
-        RelatedInformation = new List<LinkViewModel>
-        {
-            new()
-            {
-                Id = Guid.NewGuid()
-            }
-        }
+        RelatedInformation =
+        [
+            new LinkViewModel { Id = Guid.NewGuid() }
+        ]
     };
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Mappings/MappingProfiles.cs
@@ -54,6 +54,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Mappings
                     m => m.MapFrom(rv => rv.Release.Title))
                 .ForMember(dest => dest.YearTitle,
                     m => m.MapFrom(rv => rv.Release.YearTitle))
+                .ForMember(dest => dest.PublishingOrganisations,
+                    m => m.MapFrom(rv => rv.PublishingOrganisations.OrderBy(o => o.Title)))
                 .ForMember(dest => dest.Updates,
                     m => m.MapFrom(rv => rv.Updates.OrderByDescending(update => update.On)))
                 .ForMember(dest => dest.Content,
@@ -62,6 +64,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Mappings
                     m => m.MapFrom(rv => rv.KeyStatistics.OrderBy(ks => ks.Order)));
 
             CreateMap<Link, LinkViewModel>();
+
+            CreateMap<Organisation, OrganisationViewModel>();
 
             CreateMap<Update, ReleaseNoteViewModel>();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseService.cs
@@ -77,6 +77,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             var releaseVersion = await _contentDbContext
                 .ReleaseVersions
                 .Include(rv => rv.Release)
+                .Include(rv => rv.PublishingOrganisations)
                 .Include(rv => rv.Content)
                 .ThenInclude(cs => cs.Content)
                 .ThenInclude(cb => (cb as EmbedBlockLink)!.EmbedBlock)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/OrganisationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/OrganisationViewModel.cs
@@ -1,0 +1,10 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+
+public record OrganisationViewModel
+{
+    public required Guid Id { get; init; }
+
+    public required string Title { get; init; }
+
+    public required string Url { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseCacheViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseCacheViewModel.cs
@@ -31,25 +31,27 @@ public record ReleaseCacheViewModel(Guid Id)
 
     public DateTime? Published { get; set; }
 
-    public List<ReleaseNoteViewModel> Updates { get; set; } = new();
+    public List<OrganisationViewModel> PublishingOrganisations { get; init; } = [];
 
-    public List<ContentSectionViewModel> Content { get; set; } = new();
+    public List<ReleaseNoteViewModel> Updates { get; set; } = [];
+
+    public List<ContentSectionViewModel> Content { get; set; } = [];
 
     public ContentSectionViewModel SummarySection { get; set; } = null!;
 
     public ContentSectionViewModel HeadlinesSection { get; set; } = null!;
 
-    public List<KeyStatisticViewModel> KeyStatistics { get; set; } = new();
+    public List<KeyStatisticViewModel> KeyStatistics { get; set; } = [];
 
     public ContentSectionViewModel KeyStatisticsSecondarySection { get; set; } = null!;
 
     public ContentSectionViewModel? RelatedDashboardsSection { get; set; }
 
-    public List<Common.Model.FileInfo> DownloadFiles { get; set; } = new();
+    public List<Common.Model.FileInfo> DownloadFiles { get; set; } = [];
 
     public string DataGuidance { get; set; } = string.Empty;
 
     public string PreReleaseAccessList { get; set; } = string.Empty;
 
-    public List<LinkViewModel> RelatedInformation { get; set; } = new();
+    public List<LinkViewModel> RelatedInformation { get; set; } = [];
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseViewModel.cs
@@ -25,6 +25,8 @@ public record ReleaseViewModel
     [JsonConverter(typeof(StringEnumConverter))]
     public ReleaseType Type { get; }
 
+    public List<OrganisationViewModel> PublishingOrganisations { get; }
+
     public List<ReleaseNoteViewModel> Updates { get; }
 
     public List<ContentSectionViewModel> Content { get; }
@@ -61,6 +63,7 @@ public record ReleaseViewModel
         Published = release.Published;
         Slug = release.Slug;
         Type = release.Type;
+        PublishingOrganisations = release.PublishingOrganisations;
         Updates = release.Updates;
         Content = release.Content;
         SummarySection = release.SummarySection;


### PR DESCRIPTION
This is a PR to update the Admin and Content API's release version view models to include publishing organisations.

With the model changes already in place after #6133, with this PR, combined with the frontend changes in #6131, it should be possible for the Public site frontend to display publishing organisations on the release content page.

Here we can see this working where the release version was manually linked to the 'Department for Education' and 'Skills England' seed data organisations prior to publishing.

<img width="653" height="401" alt="image (3)" src="https://github.com/user-attachments/assets/34539a19-2dcc-4e54-b49a-52f18a654ce1" />
