### PR TITLE
EES-6315 Check array length when rendering published by

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -206,7 +206,7 @@ const ReleaseContent = ({
               </a>
             }
             renderProducerLink={
-              release.publishingOrganisations ? (
+              release.publishingOrganisations?.length ? (
                 <span>
                   {release.publishingOrganisations.map((org, index) => (
                     <Fragment key={org.id}>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -162,7 +162,7 @@ const PublicationReleasePage: NextPage<Props> = ({ releaseVersion }) => {
               </Link>
             }
             renderProducerLink={
-              releaseVersion.publishingOrganisations ? (
+              releaseVersion.publishingOrganisations?.length ? (
                 <span>
                   {releaseVersion.publishingOrganisations.map((org, index) => (
                     <Fragment key={org.id}>


### PR DESCRIPTION
Quick fix, as `publishingOrganisations` was being returned as an empty array, so the field was rendering as blank