### PR TITLE
EES-6316 Add ability to set `publishingOrganisations` in admin

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseCreatePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseCreatePage.tsx
@@ -64,6 +64,7 @@ const ReleaseCreatePage = ({
       templateReleaseId:
         values.templateReleaseId !== 'new' ? values.templateReleaseId : '',
       label: values.releaseLabel,
+      publishingOrganisations: values.publishingOrganisations,
     });
 
     history.push(

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
@@ -46,6 +46,7 @@ export default function ReleaseSummaryEditPage({
       type: values.releaseType ?? 'AdHocStatistics',
       preReleaseAccessList: releaseVersion.preReleaseAccessList,
       label: values.releaseLabel,
+      publishingOrganisations: values.publishingOrganisations,
     });
 
     onReleaseChange();
@@ -84,6 +85,10 @@ export default function ReleaseSummaryEditPage({
               timePeriodCoverageStartYear: releaseVersion.year.toString(),
               releaseType: releaseVersion.type,
               releaseLabel: releaseVersion.label,
+              publishingOrganisations:
+                releaseVersion.publishingOrganisations?.map(
+                  organisation => organisation.id,
+                ),
             }}
             releaseVersion={releaseVersion.version}
             onSubmit={handleSubmit}

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryPage.tsx
@@ -56,6 +56,13 @@ const ReleaseSummaryPage = () => {
             <SummaryListItem term="Release label">
               {releaseVersion.label ?? ''}
             </SummaryListItem>
+            <SummaryListItem term="Published by">
+              {releaseVersion.publishingOrganisations?.length
+                ? releaseVersion.publishingOrganisations
+                    .map(org => org.title)
+                    .join(' and ')
+                : 'Department for Education'}
+            </SummaryListItem>
           </SummaryList>
 
           <Gate

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
@@ -1,10 +1,15 @@
 import metaService, {
   TimePeriodCoverageGroup,
 } from '@admin/services/metaService';
+import organisationService from '@admin/services/organisationService';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
-import { FormFieldset, FormFieldTextInput } from '@common/components/form';
+import {
+  FormFieldCheckboxGroup,
+  FormFieldset,
+  FormFieldTextInput,
+} from '@common/components/form';
 import FormFieldNumberInput from '@common/components/form/FormFieldNumberInput';
 import { SelectOption } from '@common/components/form/FormSelect';
 import FormProvider from '@common/components/form/FormProvider';
@@ -14,6 +19,7 @@ import FormFieldSelect from '@common/components/form/FormFieldSelect';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import { Organisation } from '@common/services/types/organisation';
 import { ReleaseType, releaseTypes } from '@common/services/types/releaseType';
 import { Dictionary } from '@common/types';
 import { IdTitlePair } from '@admin/services/types/common';
@@ -28,6 +34,7 @@ export interface ReleaseSummaryFormValues {
   timePeriodCoverageCode: string;
   timePeriodCoverageStartYear: string;
   releaseLabel?: string;
+  publishingOrganisations?: string[];
 }
 
 const formId = 'releaseSummaryForm';
@@ -60,9 +67,17 @@ export default function ReleaseSummaryForm({
   onSubmit,
   onCancel,
 }: Props) {
-  const { value: timePeriodCoverageGroups, isLoading } = useAsyncRetry<
-    TimePeriodCoverageGroup[]
-  >(() => metaService.getTimePeriodCoverageGroups());
+  const {
+    value: timePeriodCoverageGroups,
+    isLoading: timePeriodCoverageGroupsLoading,
+  } = useAsyncRetry<TimePeriodCoverageGroup[]>(() =>
+    metaService.getTimePeriodCoverageGroups(),
+  );
+
+  const { value: organisations, isLoading: organisationsLoading } =
+    useAsyncRetry<Organisation[]>(() =>
+      organisationService.listOrganisations(),
+    );
 
   // Can't create new releases with type Experimental statistics.
   const permittedReleaseTypes = useMemo(
@@ -92,10 +107,21 @@ export default function ReleaseSummaryForm({
         /* eslint-disable no-template-curly-in-string */
         'Release label must be no longer than ${max} characters',
       ),
+      publishingOrganisations: Yup.array()
+        .of(Yup.string().required().uuid())
+        .transform((value, originalValue) => {
+          // If the original value is falsy (e.g., false), transform it to undefined
+          // needed as react-hook-form casts no checkbox selection to false
+          if (!originalValue) {
+            return undefined;
+          }
+          return value;
+        })
+        .optional(),
     });
   }, [permittedReleaseTypes]);
 
-  if (isLoading) {
+  if (timePeriodCoverageGroupsLoading || organisationsLoading) {
     return <LoadingSpinner />;
   }
 
@@ -206,6 +232,23 @@ export default function ReleaseSummaryForm({
                 ]}
               />
             )}
+
+            {organisations && (
+              <FormFieldCheckboxGroup<ReleaseSummaryFormValues>
+                hint="Optional - select which organisations are responsible for publishing this release"
+                legend="Publishing Organisations"
+                legendSize="m"
+                name="publishingOrganisations"
+                options={organisations.map(org => {
+                  return {
+                    label: org.title,
+                    value: org.id,
+                  };
+                })}
+                small
+              />
+            )}
+
             <ButtonGroup>
               <Button type="submit">{submitText}</Button>
               <ButtonText onClick={onCancel}>Cancel</ButtonText>

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
@@ -108,7 +108,7 @@ export default function ReleaseSummaryForm({
         'Release label must be no longer than ${max} characters',
       ),
       publishingOrganisations: Yup.array()
-        .of(Yup.string().required().uuid())
+        .of(Yup.string().required())
         .transform((value, originalValue) => {
           // If the original value is falsy (e.g., false), transform it to undefined
           // needed as react-hook-form casts no checkbox selection to false

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
@@ -482,6 +482,43 @@ describe('ReleaseSummaryForm', () => {
     expect(publishingOrganisationCheckboxes[1]).not.toBeChecked();
   });
 
+  test('renders with provided initial values with multiple publishing organisations', async () => {
+    metaService.getTimePeriodCoverageGroups.mockResolvedValue(
+      testTimeIdentifiers,
+    );
+
+    render(
+      <ReleaseSummaryForm
+        submitText="Create new release"
+        initialValues={{
+          timePeriodCoverageCode: 'AYQ4',
+          timePeriodCoverageStartYear: '1966',
+          releaseType: 'AccreditedOfficialStatistics',
+          releaseLabel: 'initial',
+          publishingOrganisations: [
+            '466a14bf-4c77-4fb4-beb0-a09065d9ced8',
+            '8d26bfaa-44b8-461e-9260-2b0eed9631e0',
+          ],
+        }}
+        releaseVersion={0}
+        onSubmit={noop}
+        onCancel={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Select time period coverage'),
+      ).toBeInTheDocument();
+    });
+
+    const publishingOrganisationCheckboxes = within(
+      screen.getByRole('group', { name: 'Publishing Organisations' }),
+    ).getAllByRole('checkbox');
+    expect(publishingOrganisationCheckboxes[0]).toBeChecked();
+    expect(publishingOrganisationCheckboxes[1]).toBeChecked();
+  });
+
   test('submits form with valid values', async () => {
     metaService.getTimePeriodCoverageGroups.mockResolvedValue(
       testTimeIdentifiers,

--- a/src/explore-education-statistics-admin/src/services/organisationService.ts
+++ b/src/explore-education-statistics-admin/src/services/organisationService.ts
@@ -1,23 +1,9 @@
-// import client from '@admin/services/utils/service';
+import client from '@admin/services/utils/service';
 import { Organisation } from '@common/services/types/organisation';
 
 const releaseService = {
   listOrganisations(): Promise<Organisation[]> {
-    return new Promise(resolve => {
-      return resolve([
-        {
-          id: '466a14bf-4c77-4fb4-beb0-a09065d9ced8',
-          title: 'Department for Education',
-          url: 'https://www.gov.uk/government/organisations/department-for-education',
-        },
-        {
-          id: '8d26bfaa-44b8-461e-9260-2b0eed9631e0',
-          title: 'Other Organisation name',
-          url: 'https://example.com',
-        },
-      ]);
-    });
-    // return client.get('/organisations');
+    return client.get('/organisations');
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/organisationService.ts
+++ b/src/explore-education-statistics-admin/src/services/organisationService.ts
@@ -1,0 +1,24 @@
+// import client from '@admin/services/utils/service';
+import { Organisation } from '@common/services/types/organisation';
+
+const releaseService = {
+  listOrganisations(): Promise<Organisation[]> {
+    return new Promise(resolve => {
+      return resolve([
+        {
+          id: '466a14bf-4c77-4fb4-beb0-a09065d9ced8',
+          title: 'Department for Education',
+          url: 'https://www.gov.uk/government/organisations/department-for-education',
+        },
+        {
+          id: '8d26bfaa-44b8-461e-9260-2b0eed9631e0',
+          title: 'Other Organisation name',
+          url: 'https://example.com',
+        },
+      ]);
+    });
+    // return client.get('/organisations');
+  },
+};
+
+export default releaseService;

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -11,6 +11,7 @@ export interface CreateReleaseRequest {
   };
   type: ReleaseType;
   label?: string;
+  publishingOrganisations?: string[];
 }
 
 export interface UpdateReleaseRequest {

--- a/src/explore-education-statistics-admin/src/services/releaseVersionService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseVersionService.ts
@@ -8,6 +8,7 @@ import {
   PublicationSummary,
   ReleaseApprovalStatus,
 } from '@common/services/publicationService';
+import { Organisation } from '@common/services/types/organisation';
 import { ReleaseType } from '@common/services/types/releaseType';
 import { PartialDate } from '@common/utils/date/partialDate';
 
@@ -38,6 +39,7 @@ export interface ReleaseVersion {
   timePeriodCoverage: ValueLabelPair;
   title: string;
   type: ReleaseType;
+  publishingOrganisations?: Organisation[];
   publishScheduled?: string;
   published?: string;
   nextReleaseDate?: PartialDate;
@@ -90,6 +92,7 @@ export interface UpdateReleaseVersionRequest {
   };
   type: ReleaseType;
   label?: string;
+  publishingOrganisations?: string[];
 }
 
 export interface CreateReleaseVersionStatusRequest {


### PR DESCRIPTION
Building on the work done in EES-6135, 6137, 6138, this PR allows a user to optionally associate `publishingOrganisations` to a release version (when creating a release, or editing a release version). This value is also displayed on the Release Summary.

We fetch a list of organisations in the ReleaseSummaryForm and present them as checkboxes options.

N.b we need to wait until the BE tasks associated with this work are done before working, and it may need to be amended once the BE is done and we can test it properly, so **it is not ready to merge yet**.



<img width="605" height="469" alt="Screenshot 2025-07-14 141550" src="https://github.com/user-attachments/assets/cf226603-bf7d-4c6f-9cfc-0b41e1ad923e" />

<img width="560" height="461" alt="Screenshot 2025-07-14 141513" src="https://github.com/user-attachments/assets/6716de42-3d4c-4459-a8be-0ff1bb9701ec" />
