### PR TITLE
Stops recording user's emails in the logs

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/LoggingEmailService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/Services/LoggingEmailService.cs
@@ -13,12 +13,11 @@ public class LoggingEmailService(ILogger<IEmailService> logger) : IEmailService
     {
         logger.LogInformation(
             """
-            Sending email to "{EmailAddress}" 
+            Sending email to a recipient
             with template Id "{TemplateId}" and
             the following template values: 
             {TemplateValues}
             """,
-            email,
             templateId,
             values);
     }


### PR DESCRIPTION
This came out of a Github Copilot recommendation 
<img width="403" height="720" alt="image" src="https://github.com/user-attachments/assets/13e323be-f1e0-40b3-ad01-ec9c48ae6d01" />
