### PR TITLE
🐛 EES-6329 Fix missing search indexer name

### DIFF
--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -20,6 +20,10 @@ jobs:
         value: $(templateDirectory)/parameters
       - name: paramFile
         value: $(paramDirectory)/main-${{ parameters.bicepParamFile }}.bicepparam
+      - name: searchServiceIndexName
+        value: 'index-1'
+      - name: searchServiceIndexerName
+        value: ${{ variables.searchServiceIndexName }}-indexer
     strategy:
       runOnce:
         deploy:
@@ -36,7 +40,7 @@ jobs:
                 action: validate
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
-                searchServiceIndexerName: $(searchServiceIndexerName)
+                searchServiceIndexerName: ${{ variables.searchServiceIndexerName }}
                 searchDocsFunctionAppExists: false
 
             - template: ../../../public-api/ci/tasks/check-function-app-exists.yml
@@ -52,7 +56,7 @@ jobs:
                 action: create
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
-                searchServiceIndexerName: $(searchServiceIndexerName)
+                searchServiceIndexerName: ${{ variables.searchServiceIndexerName }}
                 searchDocsFunctionAppExists: $(searchDocsFunctionAppExists)
 
             - template: ../../../../common/ci/tasks/bicep-output-variables.yml
@@ -68,5 +72,6 @@ jobs:
                   - 'http://localhost:3000'
                 dataSourceConnectionString: $(searchStorageAccountManagedIdentityConnectionString)
                 dataSourceContainerName: $(searchableDocumentsContainerName)
-                indexName: 'index-1'
+                indexName: ${{ variables.searchServiceIndexName }}
+                indexerName: ${{ variables.searchServiceIndexerName }}
                 searchServiceEndpoint: $(searchServiceEndpoint)

--- a/infrastructure/templates/search/ci/tasks/deploy-search-service-config.yml
+++ b/infrastructure/templates/search/ci/tasks/deploy-search-service-config.yml
@@ -24,6 +24,8 @@ parameters:
     type: object
   - name: indexName
     type: string
+  - name: indexerName
+    type: string
   - name: indexerScheduleInterval
     default: 'PT5M'
     type: string
@@ -46,7 +48,7 @@ steps:
         -dataSourceType '${{ parameters.dataSourceType }}' `
         -indexCorsAllowedOrigins '${{ join(''',''', parameters.indexCorsAllowedOrigins) }}' `
         -indexDefinitionFilePath '$(templateDirectory)/application/indexes/${{ parameters.indexName }}.json' `
-        -indexerName '${{ parameters.indexName }}-indexer' `
+        -indexerName '${{ parameters.indexerName }}' `
         -indexerScheduleInterval '${{ parameters.indexerScheduleInterval }}' `
         -searchServiceEndpoint '${{ parameters.searchServiceEndpoint }}'
       errorActionPreference: 'stop'


### PR DESCRIPTION
This PR fixes the value of the `searchServiceIndexerName` parameter of the `deploy-bicep.yml` step in the `deploy-infrastructure.yml` job template.

This is the name of the indexer in the Azure AI Search Service which ultimately gets set as an environment variable **AzureSearch__IndexerName** in the Search Function App.

The value was previously blank after changes made in #6116.