### PR TITLE
EES-6326 - data file replacement form cancel button to navigate back to data file uploads

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacePage.tsx
@@ -255,6 +255,14 @@ const ReleaseDataFileReplacePage = ({
                 <DataFileUploadForm
                   isDataReplacement
                   onSubmit={values => handleSubmit(dataFile, values)}
+                  onCancel={() =>
+                    history.push(
+                      generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
+                        publicationId,
+                        releaseVersionId,
+                      }),
+                    )
+                  }
                 />
               </section>
             ) : (

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -122,12 +122,14 @@ interface Props {
   dataFiles?: DataFile[];
   isDataReplacement?: boolean;
   onSubmit: (values: DataFileUploadFormValues) => void | Promise<void>;
+  onCancel?: () => void;
 }
 
 export default function DataFileUploadForm({
   dataFiles,
   isDataReplacement = false,
   onSubmit,
+  onCancel,
 }: Props) {
   const [selectedFileType, setSelectedFileType] = useState<FileType>('csv');
 
@@ -317,6 +319,7 @@ export default function DataFileUploadForm({
                   disabled={formState.isSubmitting}
                   onClick={() => {
                     reset();
+                    onCancel?.();
                   }}
                 >
                   Cancel


### PR DESCRIPTION
Previously this button seemingly didn't do anything, it did however reset the form so any selected files for upload would be cleared, however this seemed uneventful. The cancel button is now wired up to navigated the user back to the data file uploads page