### PR TITLE
Update snapshot approvers

### DIFF
--- a/.github/workflows/validate-snapshots.yml
+++ b/.github/workflows/validate-snapshots.yml
@@ -73,7 +73,7 @@ jobs:
           branch: chore/update-test-snapshots
           add-paths: |
             tests/robot-tests/tests/snapshots
-          reviewers: rmbielby, lauraselby, cjrace, chfoster, jen-machin
+          reviewers: rmbielby, lauraselby, cjrace, chfoster
           title: ${{ steps.vars.outputs.pr_title }}
           body: ${{ steps.vars.outputs.pr_body }}
           draft: false


### PR DESCRIPTION
Quick one to remove Jen from the approvers of snapshots as she's not in the team at the moment.

## Related changes

Not applicable 

## Screenshots

No need