### PR TITLE
EES-6113 show warning before edit prerelease status

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/__tests__/ReleaseStatusPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/__tests__/ReleaseStatusPage.test.tsx
@@ -7,8 +7,9 @@ import _permissionService, {
 import _releaseVersionService, {
   ReleaseVersion,
 } from '@admin/services/releaseVersionService';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import mockDate from '@common-test/mockDate';
+import render from '@common-test/render';
+import { screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import ReleaseStatusPage from '../ReleaseStatusPage';
@@ -33,9 +34,7 @@ describe('ReleaseStatusPage', () => {
   test('renders public release link correctly', async () => {
     renderPage();
 
-    await waitFor(() => {
-      expect(screen.getByText('Sign off')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Sign off')).toBeInTheDocument();
 
     expect(screen.getByLabelText('URL')).toHaveValue(
       'http://localhost/find-statistics/publication-1-slug/release-1-slug',
@@ -45,9 +44,7 @@ describe('ReleaseStatusPage', () => {
   test('renders Draft status details correctly', async () => {
     renderPage();
 
-    await waitFor(() => {
-      expect(screen.getByText('Sign off')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Sign off')).toBeInTheDocument();
 
     expect(screen.getByTestId('Current status-value')).toHaveTextContent(
       'In draft',
@@ -78,9 +75,7 @@ describe('ReleaseStatusPage', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(screen.getByText('Sign off')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Sign off')).toBeInTheDocument();
 
     expect(screen.getByTestId('Current status')).toHaveTextContent('Approved');
     expect(
@@ -100,7 +95,7 @@ describe('ReleaseStatusPage', () => {
       testStatusPermissions,
     );
 
-    renderPage();
+    const { user } = renderPage();
 
     await waitFor(() => {
       expect(
@@ -108,7 +103,7 @@ describe('ReleaseStatusPage', () => {
       ).toBeInTheDocument();
     });
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Edit release status' }),
     );
 
@@ -129,11 +124,98 @@ describe('ReleaseStatusPage', () => {
 
     renderPage();
 
-    await waitFor(() => {
-      expect(screen.getByText('Sign off')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Sign off')).toBeInTheDocument();
 
     expect(screen.queryByText('Edit release status')).not.toBeInTheDocument();
+  });
+
+  describe('scheduled release warning modal', () => {
+    test('shows the warning modal if edit a pre-release on release day', async () => {
+      mockDate.set('2045-07-18 09:29');
+      permissionService.getReleaseStatusPermissions.mockResolvedValue(
+        testStatusPermissions,
+      );
+      releaseVersionService.getReleaseVersionStatus.mockResolvedValue({
+        overallStage: 'Scheduled',
+      });
+
+      const { user } = renderPage({
+        ...testRelease,
+        approvalStatus: 'Approved',
+        publishScheduled: '2045-07-18',
+      });
+      expect(await screen.findByText('Sign off')).toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole('button', { name: 'Edit release status' }),
+      );
+
+      expect(await screen.findByText('Important')).toBeInTheDocument();
+
+      const modal = within(screen.getByRole('dialog'));
+      expect(modal.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+      expect(
+        modal.getByRole('button', { name: 'Continue' }),
+      ).toBeInTheDocument();
+    });
+
+    test('renders the status form when click continue on the warning modal', async () => {
+      mockDate.set('2045-07-18 09:29');
+      permissionService.getReleaseStatusPermissions.mockResolvedValue(
+        testStatusPermissions,
+      );
+      releaseVersionService.getReleaseVersionStatus.mockResolvedValue({
+        overallStage: 'Scheduled',
+      });
+
+      const { user } = renderPage({
+        ...testRelease,
+        approvalStatus: 'Approved',
+        publishScheduled: '2045-07-18',
+      });
+
+      expect(await screen.findByText('Sign off')).toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole('button', { name: 'Edit release status' }),
+      );
+
+      expect(await screen.findByText('Important')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+      expect(
+        screen.getByRole('button', { name: 'Update status' }),
+      ).toBeInTheDocument();
+    });
+
+    test('does not show the warning modal if edit a pre-release before release day', async () => {
+      mockDate.set('2045-07-17 23:00');
+      permissionService.getReleaseStatusPermissions.mockResolvedValue(
+        testStatusPermissions,
+      );
+      releaseVersionService.getReleaseVersionStatus.mockResolvedValue({
+        overallStage: 'Scheduled',
+      });
+
+      const { user } = renderPage({
+        ...testRelease,
+        approvalStatus: 'Approved',
+        publishScheduled: '2045-07-18',
+      });
+
+      expect(await screen.findByText('Sign off')).toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole('button', { name: 'Edit release status' }),
+      );
+
+      expect(screen.queryByText('Important')).not.toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', { name: 'Update status' }),
+      ).toBeInTheDocument();
+    });
   });
 
   function renderPage(releaseVersion: ReleaseVersion = testRelease) {

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -656,6 +656,7 @@ user puts release into draft
     ...    ${expected_next_release_date}=Not set
 
     user clicks button    Edit release status
+    user clicks element if exists    xpath=//button[text()="Continue"]
     user waits until h2 is visible    Edit release status    %{WAIT_SMALL}
     user clicks radio    In draft
     user enters text into element    id:releaseStatusForm-internalReleaseNote    ${release_note}


### PR DESCRIPTION
Shows a warning modal if you try to edit the release status of a scheduled release between midnight and 9:30am on the day of the release.

This might affect UI tests that test scheduled releases if they're run in this time window, I found one case (`prerelease.robot`) where it did and have added a fix for that, but generally had problems running UI tests locally so I'm not entirely sure it won't cause issues in other tests. If it does, the same fix can be applied.

<img width="1355" height="804" alt="Screenshot 2025-07-17 164814" src="https://github.com/user-attachments/assets/5d88ebe0-52ab-458a-af6b-d78976ae6eca" />
