### PR TITLE
EES-6333: Disable screening functionality to return an automatic pass until further work has been completed

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetScreenerClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetScreenerClientTests.cs
@@ -1,10 +1,4 @@
 #nullable enable
-using System;
-using System.Net;
-using System.Net.Http;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Options;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
@@ -12,6 +6,12 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Authentication;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Moq;
 using RichardSzalay.MockHttp;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 
@@ -23,7 +23,7 @@ public class DataSetScreenerClientTests
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase, // API is case sensitive
     };
-    
+
     protected DataSetScreenerClientTests()
     {
         _mockHttp = new MockHttpMessageHandler();
@@ -31,7 +31,7 @@ public class DataSetScreenerClientTests
 
     public class AuthenticationTests : DataSetScreenerClientTests
     {
-        [Fact]
+        [Fact(Skip = "EES-6341: Skip until screener has been re-enabled")]
         public async Task AuthenticationManagerCalled()
         {
             var responseBody = new DataSetScreenerResponse
@@ -68,10 +68,10 @@ public class DataSetScreenerClientTests
                 m.AddAuthentication(It.IsAny<HttpClient>(), It.IsAny<CancellationToken>()), Times.Once);
         }
     }
-    
+
     public class ScreenDataSetTests : DataSetScreenerClientTests
     {
-        [Fact]
+        [Fact(Skip = "EES-6341: Skip until screener has been re-enabled")]
         public async Task Success()
         {
             var request = new DataSetScreenerRequest
@@ -82,7 +82,7 @@ public class DataSetScreenerClientTests
                 MetaFilePath = "meta-file-path",
                 StorageContainerName = "storage-container-name"
             };
-            
+
             var responseBody = new DataSetScreenerResponse
             {
                 Message = "A message",
@@ -112,9 +112,9 @@ public class DataSetScreenerClientTests
             var dataSetScreenerClient = BuildService();
 
             var response = await dataSetScreenerClient.ScreenDataSet(request, default);
-            
+
             _mockHttp.VerifyNoOutstandingExpectation();
-            
+
             Assert.Equivalent(responseBody, response);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetScreenerClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetScreenerClient.cs
@@ -1,15 +1,12 @@
-using System;
-using System.Net.Http;
-using System.Net.Http.Json;
-using System.Text;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Options;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Authentication;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
@@ -26,16 +23,32 @@ public class DataSetScreenerClient(
         DataSetScreenerRequest dataSetRequest,
         CancellationToken cancellationToken)
     {
-        await authenticationManager.AddAuthentication(httpClient, cancellationToken);
-        
-        var json = JsonSerializer.Serialize(dataSetRequest, _jsonSerializerOptions);
-        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        // TODO (EES-6341): Re-enable screening once fully implemented.
+        return new DataSetScreenerResponse
+        {
+            OverallResult = ScreenerResult.Passed,
+            Message = "This data set has not been screened.",
+            TestResults =
+            [
+                new()
+                {
+                    Result = TestResult.WARNING,
+                    TestFunctionName = "N/A",
+                    Stage = Stage.PreScreening1,
+                    Notes = "Screening has been bypassed awaiting full implementation. Please ensure data sets pass screening using the external app prior to importing.",
+                }
+            ]
+        };
+        //await authenticationManager.AddAuthentication(httpClient, cancellationToken);
 
-        // TODO (EES-5353): Add cancellation token handling logic to terminate Azure Function processes
-        var response = await httpClient.PostAsync(httpClient.BaseAddress, content, CancellationToken.None);
+        //var json = JsonSerializer.Serialize(dataSetRequest, _jsonSerializerOptions);
+        //var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-        return response.IsSuccessStatusCode
-            ? await response.Content.ReadFromJsonAsync<DataSetScreenerResponse>(cancellationToken)
-            : throw new Exception($"Screening process failed with status {response.StatusCode}");
+        //// TODO (EES-5353): Add cancellation token handling logic to terminate Azure Function processes
+        //var response = await httpClient.PostAsync(httpClient.BaseAddress, content, CancellationToken.None);
+
+        //return response.IsSuccessStatusCode
+        //    ? await response.Content.ReadFromJsonAsync<DataSetScreenerResponse>(cancellationToken)
+        //    : throw new Exception($"Screening process failed with status {response.StatusCode}");
     }
 }

--- a/tests/robot-tests/tests/admin/bau/screener_errors.robot
+++ b/tests/robot-tests/tests/admin/bau/screener_errors.robot
@@ -7,7 +7,17 @@ Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
 Test Setup          fail test fast if required
 
-Force Tags          Admin    Local    Dev    AltersData
+# Skip entire suite until Screener is re-enabled
+Force Tags
+...                 Admin
+...                 Local
+...                 Dev
+...                 AltersData
+...                 NotAgainstLocal
+...                 NotAgainstDev
+...                 NotAgainstTest
+...                 NotAgainstPreProd
+...                 NotAgainstProd
 
 
 *** Variables ***

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -43,10 +43,11 @@ Upload a ZIP file
 
 Check the screening results
     user clicks button in table cell    1    4    View details    testid:Data files table
-
     user waits until modal is visible    Data set details
-    User waits until h3 is visible    Full breakdown of 3 tests checked against this file
 
+    Skip    msg=Skip result checking until Screener is re-enabled
+
+    User waits until h3 is visible    Full breakdown of 3 tests checked against this file
     user checks screener results in modal    1    check_filename_spaces
     ...    'absence_in_prus.csv' does not have spaces in the filename.    Pass
     user checks screener results in modal    2    check_filename_spaces


### PR DESCRIPTION
Return an automatic pass result (with a warning) to remove potential issues processing uploads which may arise from an incomplete screening test suite.

To be re-enabled in [EES-6341](https://dfedigital.atlassian.net/browse/EES-6341).