### PR TITLE
Fix frontend formatting

### DIFF
--- a/src/explore-education-statistics-frontend/src/pages/index.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/index.tsx
@@ -91,7 +91,6 @@ function HomePage() {
             Find out how to automate access to statistics and data through our
             API (application programming interface).
           </p>
-
         </div>
       </div>
 


### PR DESCRIPTION
This PR formats `src/explore-education-statistics-frontend/src/pages/index.tsx`.

It was failing the prettier format check in the build pipeline after #6158.

```
$ pnpm format:check

> explore-education-statistics@ format:check C:\Users\BenOutram\dev\ees
> prettier --list-different "**/*.{js,jsx,ts,tsx,css,scss,html}"

src/explore-education-statistics-frontend/src/pages/index.tsx
```