### PR TITLE
EES-6319 Add new Admin API endpoint to get all organisations

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/OrganisationsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/OrganisationsControllerTests.cs
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
@@ -28,7 +27,7 @@ public abstract class OrganisationsControllerTests
             var sut = BuildController();
 
             // Act
-            var result = await sut.GetAllOrganisations().ToArrayAsync();
+            var result = await sut.GetAllOrganisations();
 
             // Assert
             _organisationService.Assert.GetAllOrganisationsWasCalled();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/OrganisationsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/OrganisationsControllerTests.cs
@@ -1,0 +1,53 @@
+﻿#nullable enable
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api;
+
+public abstract class OrganisationsControllerTests
+{
+    private readonly DataFixture _dataFixture = new();
+    private readonly OrganisationServiceMockBuilder _organisationService = new();
+
+    public class GetAllOrganisationsTests : OrganisationsControllerTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(10)]
+        public async Task GetAllOrganisations_ReturnsExpectedOrganisations(int numOrganisations)
+        {
+            // Arrange
+            var organisations = _dataFixture.DefaultOrganisation()
+                .GenerateArray(numOrganisations);
+            _organisationService.WhereHasOrganisations(organisations);
+            var sut = BuildController();
+
+            // Act
+            var result = await sut.GetAllOrganisations().ToArrayAsync();
+
+            // Assert
+            _organisationService.Assert.GetAllOrganisationsWasCalled();
+            Assert.Equal(numOrganisations, result.Length);
+            Assert.All(result,
+                (organisation, index) =>
+                {
+                    var expectedOrganisation = organisations[index];
+                    Assert.Equal(expectedOrganisation.Id, organisation.Id);
+                    Assert.Equal(expectedOrganisation.Title, organisation.Title);
+                    Assert.Equal(expectedOrganisation.Url, organisation.Url);
+                });
+        }
+    }
+
+    private OrganisationsController BuildController()
+    {
+        return new OrganisationsController(
+            _organisationService.Build()
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/OrganisationServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/OrganisationServiceMockBuilder.cs
@@ -1,5 +1,5 @@
 ﻿#nullable enable
-using System.Linq;
+using System.Threading;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Moq;
@@ -14,8 +14,8 @@ public class OrganisationServiceMockBuilder
 
     public IOrganisationService Build()
     {
-        _mock.Setup(m => m.GetAllOrganisations())
-            .Returns(_organisations?.ToAsyncEnumerable() ?? AsyncEnumerable.Empty<Organisation>());
+        _mock.Setup(m => m.GetAllOrganisations(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_organisations ?? []);
 
         return _mock.Object;
     }
@@ -32,7 +32,7 @@ public class OrganisationServiceMockBuilder
     {
         public void GetAllOrganisationsWasCalled()
         {
-            mock.Verify(m => m.GetAllOrganisations(), Times.Once);
+            mock.Verify(m => m.GetAllOrganisations(It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/OrganisationServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/OrganisationServiceMockBuilder.cs
@@ -1,0 +1,38 @@
+﻿#nullable enable
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Moq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
+
+public class OrganisationServiceMockBuilder
+{
+    private readonly Mock<IOrganisationService> _mock = new(MockBehavior.Strict);
+
+    private Organisation[]? _organisations;
+
+    public IOrganisationService Build()
+    {
+        _mock.Setup(m => m.GetAllOrganisations())
+            .Returns(_organisations?.ToAsyncEnumerable() ?? AsyncEnumerable.Empty<Organisation>());
+
+        return _mock.Object;
+    }
+
+    public OrganisationServiceMockBuilder WhereHasOrganisations(Organisation[] organisations)
+    {
+        _organisations = organisations;
+        return this;
+    }
+
+    public Asserter Assert => new(_mock);
+
+    public class Asserter(Mock<IOrganisationService> mock)
+    {
+        public void GetAllOrganisationsWasCalled()
+        {
+            mock.Verify(m => m.GetAllOrganisations(), Times.Once);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/OrganisationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/OrganisationServiceTests.cs
@@ -40,7 +40,7 @@ public abstract class OrganisationServiceTests
                 var sut = BuildService(context);
 
                 // Act
-                var result = await sut.GetAllOrganisations().ToArrayAsync();
+                var result = await sut.GetAllOrganisations();
 
                 // Assert
                 Assert.Equal(organisations.OrderBy(o => o.Title), result);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/OrganisationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/OrganisationServiceTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using Moq;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+public abstract class OrganisationServiceTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    public class GetAllOrganisationTests : OrganisationServiceTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(10)]
+        public async Task GetAllOrganisations_ReturnsExpectedOrganisationsInOrderByTitle(int numOrganisations)
+        {
+            // Arrange
+            var organisations = _dataFixture.DefaultOrganisation()
+                .GenerateArray(numOrganisations)
+                .Shuffle();
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                context.Organisations.AddRange(organisations);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var result = await sut.GetAllOrganisations().ToArrayAsync();
+
+                // Assert
+                Assert.Equal(organisations.OrderBy(o => o.Title), result);
+            }
+        }
+    }
+
+    private static OrganisationService BuildService(ContentDbContext context = null)
+    {
+        return new OrganisationService(
+            context ?? Mock.Of<ContentDbContext>(MockBehavior.Strict)
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/OrganisationsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/OrganisationsController.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
-using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using Microsoft.AspNetCore.Authorization;
@@ -14,7 +15,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
 public class OrganisationsController(IOrganisationService organisationService) : ControllerBase
 {
     [HttpGet("organisations")]
-    public IAsyncEnumerable<OrganisationViewModel> GetAllOrganisations() =>
-        organisationService.GetAllOrganisations()
-            .Select(OrganisationViewModel.FromOrganisation);
+    public async Task<OrganisationViewModel[]> GetAllOrganisations(CancellationToken cancellationToken = default) =>
+        (await organisationService.GetAllOrganisations(cancellationToken))
+        .Select(OrganisationViewModel.FromOrganisation)
+        .ToArray();
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/OrganisationsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/OrganisationsController.cs
@@ -1,0 +1,20 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
+
+[ApiController]
+[Authorize]
+[Route("api")]
+public class OrganisationsController(IOrganisationService organisationService) : ControllerBase
+{
+    [HttpGet("organisations")]
+    public IAsyncEnumerable<OrganisationViewModel> GetAllOrganisations() =>
+        organisationService.GetAllOrganisations()
+            .Select(OrganisationViewModel.FromOrganisation);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IOrganisationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IOrganisationService.cs
@@ -1,10 +1,11 @@
 ﻿#nullable enable
-using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 
 public interface IOrganisationService
 {
-    IAsyncEnumerable<Organisation> GetAllOrganisations();
+    Task<Organisation[]> GetAllOrganisations(CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IOrganisationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IOrganisationService.cs
@@ -1,0 +1,10 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+
+public interface IOrganisationService
+{
+    IAsyncEnumerable<Organisation> GetAllOrganisations();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/OrganisationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/OrganisationService.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
-using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -10,8 +11,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 
 public class OrganisationService(ContentDbContext contentDbContext) : IOrganisationService
 {
-    public IAsyncEnumerable<Organisation> GetAllOrganisations() =>
-        contentDbContext.Organisations
+    public async Task<Organisation[]> GetAllOrganisations(CancellationToken cancellationToken = default) =>
+        await contentDbContext.Organisations
             .OrderBy(o => o.Title)
-            .AsAsyncEnumerable();
+            .ToArrayAsync(cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/OrganisationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/OrganisationService.cs
@@ -1,0 +1,17 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
+
+public class OrganisationService(ContentDbContext contentDbContext) : IOrganisationService
+{
+    public IAsyncEnumerable<Organisation> GetAllOrganisations() =>
+        contentDbContext.Organisations
+            .OrderBy(o => o.Title)
+            .AsAsyncEnumerable();
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -600,6 +600,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin;
             services.AddTransient<IDataGuidanceService, DataGuidanceService>();
             services.AddTransient<IDataGuidanceDataSetService, DataGuidanceDataSetService>();
             services.AddTransient<IObservationService, ObservationService>();
+            services.AddTransient<IOrganisationService, OrganisationService>();
             services.AddTransient<Data.Services.Interfaces.IReleaseService, Data.Services.ReleaseService>();
             services.AddTransient<IContentSectionRepository, ContentSectionRepository>();
             services.AddTransient<IReleaseNoteService, ReleaseNoteService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/OrganisationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/OrganisationViewModel.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
@@ -10,4 +11,12 @@ public record OrganisationViewModel
     public required string Title { get; init; }
 
     public required string Url { get; init; }
+
+    public static OrganisationViewModel FromOrganisation(Organisation organisation) =>
+        new()
+        {
+            Id = organisation.Id,
+            Title = organisation.Title,
+            Url = organisation.Url
+        };
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ArrayExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ArrayExtensions.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics.Contracts;
 using System.Linq;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Extensions;
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 
 public static class ArrayExtensions
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ArrayExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ArrayExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using Xunit;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Extensions;
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 
 public class ArrayExtensionsTests
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Organisation.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Organisation.cs
@@ -1,12 +1,14 @@
 ﻿#nullable enable
 using System;
+using Generator.Equals;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
-public class Organisation : ICreatedUpdatedTimestamps<DateTimeOffset, DateTimeOffset?>
+[Equatable]
+public partial class Organisation : ICreatedUpdatedTimestamps<DateTimeOffset, DateTimeOffset?>
 {
     public Guid Id { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/PublicationServiceTests.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.Extensions;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.SortDirection;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;


### PR DESCRIPTION
This PR adds a new Admin API endpoint to get all organisations.

Request:

```http
GET https://admin.url/api/organisations
Authorization: Bearer <token>
```

Response:

```http
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8

[
  {
    "id": "5e089801-cf1a-b375-acd3-88e9d8aece66",
    "title": "Department for Education",
    "url": "https://www.gov.uk/government/organisations/department-for-education"
  },
  {
    "id": "5e089801-ce1a-e274-9915-e83f3e978699",
    "title": "Skills England",
    "url": "https://www.gov.uk/government/organisations/skills-england"
  }
]
```

It will be used when creating or updating release versions in the Admin UI to list the organisations as options, allowing selecting one or more publishing organisations of the release. This is a change being made to the Admin by #6139.