### PR TITLE
EES-6320 Allow setting publishing organisations when creating and updating a release version

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/OrganisationsValidatorMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/OrganisationsValidatorMockBuilder.cs
@@ -1,0 +1,68 @@
+#nullable enable
+using System;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using ValidationUtils = GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
+
+public class OrganisationsValidatorMockBuilder
+{
+    private readonly Mock<IOrganisationsValidator> _mock = new(MockBehavior.Strict);
+
+    private Organisation[]? _organisations;
+    private ErrorViewModel[]? _validationErrors;
+
+    private static readonly Expression<Func<IOrganisationsValidator, Task<Either<ActionResult, Organisation[]>>>>
+        ValidateOrganisations =
+            m => m.ValidateOrganisations(
+                It.IsAny<Guid[]?>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>());
+
+    public IOrganisationsValidator Build()
+    {
+        _mock.Setup(ValidateOrganisations)
+            .ReturnsAsync(_validationErrors?.Length > 0
+                ? ValidationUtils.ValidationResult(_validationErrors)
+                : _organisations ?? []);
+
+        return _mock.Object;
+    }
+
+    public OrganisationsValidatorMockBuilder WhereHasOrganisations(Organisation[] organisations)
+    {
+        _organisations = organisations;
+        return this;
+    }
+
+    public OrganisationsValidatorMockBuilder WhereHasValidationErrors(ErrorViewModel[] validationErrors)
+    {
+        _validationErrors = validationErrors;
+        return this;
+    }
+
+    public Asserter Assert => new(_mock);
+
+    public class Asserter(Mock<IOrganisationsValidator> mock)
+    {
+        public void ValidateOrganisationsWasCalled(
+            Guid[]? expectedOrganisationIds = null,
+            string? expectedPath = null) =>
+            mock.Verify(m => m.ValidateOrganisations(
+                    It.Is<Guid[]?>(organisationIds =>
+                        expectedOrganisationIds == null || organisationIds == expectedOrganisationIds),
+                    It.Is<string?>(path => expectedPath == null || path == expectedPath),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+
+        public void ValidateOrganisationsWasNotCalled() => mock.Verify(ValidateOrganisations, Times.Never);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -104,6 +104,7 @@ public class ReleaseServicePermissionTests
             redirectsCacheService: redirectsCacheService ?? Mock.Of<IRedirectsCacheService>(),
             adminEventRaiser: new AdminEventRaiserMockBuilder().Build(),
             guidGenerator: new SequentialGuidGenerator(),
+            organisationsValidator: new OrganisationsValidatorMockBuilder().Build(),
             releaseSlugValidator: releaseSlugValidator ?? Mock.Of<IReleaseSlugValidator>()
         );
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServicePermissionTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.Options;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -385,6 +386,7 @@ public class ReleaseVersionServicePermissionTests
             Mock.Of<IDataSetVersionService>(),
             Mock.Of<IProcessorClient>(),
             Mock.Of<IPrivateBlobCacheService>(),
+            new OrganisationsValidatorMockBuilder().Build(),
             Mock.Of<IReleaseSlugValidator>(),
              featureFlags: Microsoft.Extensions.Options.Options.Create(new FeatureFlagsOptions()
              {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServiceTests.cs
@@ -61,6 +61,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 public abstract class ReleaseVersionServiceTests
 {
     private readonly DataFixture _dataFixture = new();
+    private readonly OrganisationsValidatorMockBuilder _organisationsValidator = new();
     private static readonly User User = new() { Id = Guid.NewGuid() };
 
     public class GetDeleteDataFilePlanTests : ReleaseVersionServiceTests
@@ -849,11 +850,15 @@ public abstract class ReleaseVersionServiceTests
                             Year = release.Year,
                             TimePeriodCoverage = release.TimePeriodCoverage,
                             PreReleaseAccessList = "New access list",
-                            Label = newLabel
+                            Label = newLabel,
+                            PublishingOrganisations = null
                         }
                     );
 
                 VerifyAllMocks(dataSetVersionService);
+                _organisationsValidator.Assert.ValidateOrganisationsWasCalled(
+                    expectedOrganisationIds: null,
+                    expectedPath: nameof(ReleaseVersionUpdateRequest.PublishingOrganisations).ToLowerFirst());
 
                 var viewModel = result.AssertRight();
 
@@ -875,6 +880,7 @@ public abstract class ReleaseVersionServiceTests
                 var actualReleaseVersion = await context.ReleaseVersions
                     .Include(rv => rv.Release)
                     .Include(rv => rv.ReleaseStatuses)
+                    .Include(rv => rv.PublishingOrganisations)
                     .SingleAsync(rv => rv.Id == releaseVersion.Id);
 
                 var actualRelease = actualReleaseVersion.Release;
@@ -889,6 +895,282 @@ public abstract class ReleaseVersionServiceTests
                 Assert.Equal("New access list", actualReleaseVersion.PreReleaseAccessList);
 
                 Assert.Empty(actualReleaseVersion.ReleaseStatuses);
+                Assert.Empty(actualReleaseVersion.PublishingOrganisations);
+            }
+        }
+
+        [Fact]
+        public async Task WhenPublishingOrganisationsHasValidationErrors_ReturnsValidationErrors()
+        {
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 0, draftVersion: true)]);
+
+            var releaseVersion = publication.Releases[0].Versions[0];
+
+            ErrorViewModel[] expectedValidationErrors =
+            [
+                new() { Message = "Validation error 1" },
+                new() { Message = "Validation error 2" }
+            ];
+
+            _organisationsValidator.WhereHasValidationErrors(expectedValidationErrors);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var releaseVersionService = BuildService(
+                    contentDbContext: context);
+
+                var result = await releaseVersionService
+                    .UpdateReleaseVersion(
+                        releaseVersion.Id,
+                        new ReleaseVersionUpdateRequest
+                        {
+                            Type = releaseVersion.Type,
+                            Year = releaseVersion.Release.Year,
+                            TimePeriodCoverage = releaseVersion.Release.TimePeriodCoverage,
+                            PublishingOrganisations = [Guid.NewGuid(), Guid.NewGuid()]
+                        }
+                    );
+
+                _organisationsValidator.Assert.ValidateOrganisationsWasCalled(
+                    expectedPath: nameof(ReleaseVersionUpdateRequest.PublishingOrganisations).ToLowerFirst());
+
+                var validationProblem = result.AssertBadRequestWithValidationProblem();
+                validationProblem.AssertHasErrors(expectedValidationErrors.ToList());
+            }
+        }
+
+        [Fact]
+        public async Task
+            GivenReleaseVersionHasPublishingOrganisations_WhenRequestHasPublishingOrganisations_UpdatesOrganisations()
+        {
+            var updatedOrganisations = _dataFixture.DefaultOrganisation()
+                .GenerateArray(2);
+            var updatedOrganisationIds = updatedOrganisations.Select(o => o.Id).ToArray();
+
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ =>
+                [
+                    _dataFixture.DefaultRelease()
+                        .WithVersions(_ =>
+                        [
+                            _dataFixture.DefaultReleaseVersion()
+                                .WithPublishingOrganisations(_dataFixture.DefaultOrganisation()
+                                    .Generate(2))
+                        ])
+                ]);
+
+            var releaseVersion = publication.Releases[0].Versions[0];
+
+            _organisationsValidator.WhereHasOrganisations(updatedOrganisations);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                context.Organisations.AddRange(updatedOrganisations);
+                context.Publications.Add(publication);
+                await context.SaveChangesAsync();
+            }
+
+            var dataSetVersionService = new Mock<IDataSetVersionService>(Strict);
+            dataSetVersionService.Setup(service => service.UpdateVersionsForReleaseVersion(
+                    releaseVersion.Id,
+                    releaseVersion.Release.Slug,
+                    releaseVersion.Release.Title,
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var releaseVersionService = BuildService(
+                    contentDbContext: context,
+                    dataSetVersionService: dataSetVersionService.Object);
+
+                var result = await releaseVersionService
+                    .UpdateReleaseVersion(
+                        releaseVersion.Id,
+                        new ReleaseVersionUpdateRequest
+                        {
+                            Type = releaseVersion.Type,
+                            Year = releaseVersion.Release.Year,
+                            TimePeriodCoverage = releaseVersion.Release.TimePeriodCoverage,
+                            PublishingOrganisations = updatedOrganisationIds
+                        }
+                    );
+
+                _organisationsValidator.Assert.ValidateOrganisationsWasCalled(
+                    expectedOrganisationIds: updatedOrganisationIds,
+                    expectedPath: nameof(ReleaseVersionUpdateRequest.PublishingOrganisations).ToLowerFirst());
+
+                var viewModel = result.AssertRight();
+
+                Assert.Equal(updatedOrganisations.Length, viewModel.PublishingOrganisations.Count);
+                Assert.All(updatedOrganisations,
+                    expectedOrganisation => Assert.Contains(viewModel.PublishingOrganisations,
+                        ovm => expectedOrganisation.Id == ovm.Id));
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var actualReleaseVersion = await context.ReleaseVersions
+                    .Include(rv => rv.PublishingOrganisations)
+                    .FirstAsync(rv => rv.Id == releaseVersion.Id);
+
+                Assert.Equal(updatedOrganisations.Length, actualReleaseVersion.PublishingOrganisations.Count);
+                Assert.All(updatedOrganisations,
+                    expectedOrganisation => Assert.Contains(actualReleaseVersion.PublishingOrganisations,
+                        o => expectedOrganisation.Id == o.Id));
+            }
+        }
+
+        [Fact]
+        public async Task
+            GivenReleaseVersionHasNoPublishingOrganisations_WhenRequestHasPublishingOrganisations_UpdatesOrganisations()
+        {
+            var updatedOrganisations = _dataFixture.DefaultOrganisation()
+                .GenerateArray(2);
+            var updatedOrganisationIds = updatedOrganisations.Select(o => o.Id).ToArray();
+
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases([_dataFixture.DefaultRelease(publishedVersions: 0, draftVersion: true)]);
+
+            var releaseVersion = publication.Releases[0].Versions[0];
+
+            _organisationsValidator.WhereHasOrganisations(updatedOrganisations);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                context.Organisations.AddRange(updatedOrganisations);
+                context.Publications.Add(publication);
+                await context.SaveChangesAsync();
+            }
+
+            var dataSetVersionService = new Mock<IDataSetVersionService>(Strict);
+            dataSetVersionService.Setup(service => service.UpdateVersionsForReleaseVersion(
+                    releaseVersion.Id,
+                    releaseVersion.Release.Slug,
+                    releaseVersion.Release.Title,
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var releaseVersionService = BuildService(
+                    contentDbContext: context,
+                    dataSetVersionService: dataSetVersionService.Object);
+
+                var result = await releaseVersionService
+                    .UpdateReleaseVersion(
+                        releaseVersion.Id,
+                        new ReleaseVersionUpdateRequest
+                        {
+                            Type = releaseVersion.Type,
+                            Year = releaseVersion.Release.Year,
+                            TimePeriodCoverage = releaseVersion.Release.TimePeriodCoverage,
+                            PublishingOrganisations = updatedOrganisationIds
+                        }
+                    );
+
+                _organisationsValidator.Assert.ValidateOrganisationsWasCalled(
+                    expectedOrganisationIds: updatedOrganisationIds,
+                    expectedPath: nameof(ReleaseVersionUpdateRequest.PublishingOrganisations).ToLowerFirst());
+
+                var viewModel = result.AssertRight();
+
+                Assert.Equal(updatedOrganisations.Length, viewModel.PublishingOrganisations.Count);
+                Assert.All(updatedOrganisations,
+                    expectedOrganisation => Assert.Contains(viewModel.PublishingOrganisations,
+                        ovm => expectedOrganisation.Id == ovm.Id));
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var actualReleaseVersion = await context.ReleaseVersions
+                    .Include(rv => rv.PublishingOrganisations)
+                    .FirstAsync(rv => rv.Id == releaseVersion.Id);
+
+                Assert.Equal(updatedOrganisations.Length, actualReleaseVersion.PublishingOrganisations.Count);
+                Assert.All(updatedOrganisations,
+                    expectedOrganisation => Assert.Contains(actualReleaseVersion.PublishingOrganisations,
+                        o => expectedOrganisation.Id == o.Id));
+            }
+        }
+
+        [Fact]
+        public async Task
+            GivenReleaseVersionHasPublishingOrganisations_WhenRequestHasNoPublishingOrganisations_RemovesOrganisations()
+        {
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ =>
+                [
+                    _dataFixture.DefaultRelease()
+                        .WithVersions(_ =>
+                        [
+                            _dataFixture.DefaultReleaseVersion()
+                                .WithPublishingOrganisations(_dataFixture.DefaultOrganisation()
+                                    .Generate(2))
+                        ])
+                ]);
+
+            var releaseVersion = publication.Releases[0].Versions[0];
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                await context.SaveChangesAsync();
+            }
+
+            var dataSetVersionService = new Mock<IDataSetVersionService>(Strict);
+            dataSetVersionService.Setup(service => service.UpdateVersionsForReleaseVersion(
+                    releaseVersion.Id,
+                    releaseVersion.Release.Slug,
+                    releaseVersion.Release.Title,
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var releaseVersionService = BuildService(
+                    contentDbContext: context,
+                    dataSetVersionService: dataSetVersionService.Object);
+
+                var result = await releaseVersionService
+                    .UpdateReleaseVersion(
+                        releaseVersion.Id,
+                        new ReleaseVersionUpdateRequest
+                        {
+                            Type = releaseVersion.Type,
+                            Year = releaseVersion.Release.Year,
+                            TimePeriodCoverage = releaseVersion.Release.TimePeriodCoverage,
+                            PublishingOrganisations = null
+                        }
+                    );
+
+                _organisationsValidator.Assert.ValidateOrganisationsWasCalled(
+                    expectedOrganisationIds: null,
+                    expectedPath: nameof(ReleaseVersionUpdateRequest.PublishingOrganisations).ToLowerFirst());
+
+                var viewModel = result.AssertRight();
+
+                Assert.Empty(viewModel.PublishingOrganisations);
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var actualReleaseVersion = await context.ReleaseVersions
+                    .Include(rv => rv.PublishingOrganisations)
+                    .FirstAsync(rv => rv.Id == releaseVersion.Id);
+
+                Assert.Empty(actualReleaseVersion.PublishingOrganisations);
             }
         }
 
@@ -2563,7 +2845,7 @@ public abstract class ReleaseVersionServiceTests
         }
     }
 
-    private static ReleaseVersionService BuildService(
+    private ReleaseVersionService BuildService(
         ContentDbContext contentDbContext,
         StatisticsDbContext? statisticsDbContext = null,
         IReleaseVersionRepository? releaseVersionRepository = null,
@@ -2608,8 +2890,9 @@ public abstract class ReleaseVersionServiceTests
             dataSetVersionService ?? Mock.Of<IDataSetVersionService>(Strict),
             processorClient ?? Mock.Of<IProcessorClient>(Strict),
             privateCacheService ?? Mock.Of<IPrivateBlobCacheService>(Strict),
+            _organisationsValidator.Build(),
             releaseSlugValidator ?? new ReleaseSlugValidatorMockBuilder().Build(),
-            featureFlags: Microsoft.Extensions.Options.Options.Create(new FeatureFlagsOptions()
+            featureFlags: Microsoft.Extensions.Options.Options.Create(new FeatureFlagsOptions
             {
                 EnableReplacementOfPublicApiDataSets = enableReplacementOfPublicApiDataSets
             }),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Validators/OrganisationsValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Validators/OrganisationsValidatorTests.cs
@@ -1,0 +1,199 @@
+﻿#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using Moq;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Validators;
+
+public abstract class OrganisationsValidatorTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    public class ValidateOrganisationsTests : OrganisationsValidatorTests
+    {
+        [Fact]
+        public async Task WhenOrganisationIdsIsNull_ReturnsEmpty()
+        {
+            // Arrange
+            await using var context = InMemoryApplicationDbContext();
+            var sut = BuildService(context);
+
+            // Act
+            var result = await sut.ValidateOrganisations(organisationIds: null);
+
+            // Assert
+            var actualOrganisations = result.AssertRight();
+            Assert.Empty(actualOrganisations);
+        }
+
+        [Fact]
+        public async Task WhenOrganisationIdsIsEmpty_ReturnsEmpty()
+        {
+            // Arrange
+            await using var context = InMemoryApplicationDbContext();
+            var sut = BuildService(context);
+
+            // Act
+            var result = await sut.ValidateOrganisations(organisationIds: []);
+
+            // Assert
+            var actualOrganisations = result.AssertRight();
+            Assert.Empty(actualOrganisations);
+        }
+
+        [Fact]
+        public async Task WhenOrganisationIdsExist_ReturnsOrganisations()
+        {
+            // Arrange
+            var organisations = _dataFixture.DefaultOrganisation()
+                .GenerateArray(2);
+            var organisationIds = GetOrganisationIds(organisations);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                context.Organisations.AddRange(organisations);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var result = await sut.ValidateOrganisations(organisationIds);
+
+                // Assert
+                var actualOrganisations = result.AssertRight();
+                Assert.Equal(organisations.Length, actualOrganisations.Length);
+                Assert.All(organisations, organisation => Assert.Contains(organisation, actualOrganisations));
+            }
+        }
+
+        [Fact]
+        public async Task WhenOrganisationIdsDoNotExist_ReturnsValidationErrors()
+        {
+            // Arrange
+            var organisations = _dataFixture.DefaultOrganisation()
+                .GenerateArray(2);
+            Guid[] organisationIdsNotExisting = [Guid.NewGuid(), Guid.NewGuid()];
+            const string errorPath = "testPath";
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                context.Organisations.AddRange(organisations);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var result = await sut.ValidateOrganisations(
+                    organisationIds: organisationIdsNotExisting,
+                    path: errorPath);
+
+                // Assert
+                var validationProblem = result.AssertBadRequestWithValidationProblem();
+                Assert.Equal(organisationIdsNotExisting.Length, validationProblem.Errors.Count);
+                Assert.All(organisationIdsNotExisting,
+                    organisationId =>
+                    {
+                        validationProblem.AssertHasError(
+                            expectedCode: ValidationMessages.OrganisationNotFound.Code,
+                            expectedMessage: ValidationMessages.OrganisationNotFound.Message,
+                            expectedPath: errorPath,
+                            expectedDetail: new InvalidErrorDetail<Guid>(organisationId));
+                    });
+            }
+        }
+
+        [Fact]
+        public async Task WhenOrganisationIdsPartiallyExist_ReturnsValidationErrors()
+        {
+            // Arrange
+            var organisations = _dataFixture.DefaultOrganisation()
+                .GenerateArray(2);
+            var organisationIds = GetOrganisationIds(organisations);
+            var organisationIdNotExisting = Guid.NewGuid();
+            const string errorPath = "testPath";
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                context.Organisations.AddRange(organisations);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var result = await sut.ValidateOrganisations(
+                    organisationIds: [.. organisationIds, organisationIdNotExisting],
+                    path: errorPath);
+
+                // Assert
+                var validationProblem = result.AssertBadRequestWithValidationProblem();
+                Assert.Single(validationProblem.Errors);
+                validationProblem.AssertHasError(
+                    expectedCode: ValidationMessages.OrganisationNotFound.Code,
+                    expectedMessage: ValidationMessages.OrganisationNotFound.Message,
+                    expectedPath: errorPath,
+                    expectedDetail: new InvalidErrorDetail<Guid>(organisationIdNotExisting));
+            }
+        }
+
+        [Fact]
+        public async Task WhenOrganisationIdsHasDuplicates_ReturnsUniqueOrganisations()
+        {
+            // Arrange
+            var organisations = _dataFixture.DefaultOrganisation()
+                .GenerateArray(2);
+            var organisationIds = GetOrganisationIds(organisations);
+            Guid[] organisationIdsWithDuplicates = [.. organisationIds, .. organisationIds];
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                context.Organisations.AddRange(organisations);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var result = await sut.ValidateOrganisations(organisationIdsWithDuplicates);
+
+                // Assert
+                var actualOrganisations = result.AssertRight();
+                Assert.Equal(organisations.Length, actualOrganisations.Length);
+                Assert.All(organisations, organisation => Assert.Contains(organisation, actualOrganisations));
+            }
+        }
+    }
+
+    private static Guid[] GetOrganisationIds(Organisation[] organisations) =>
+        organisations.Select(o => o.Id).ToArray();
+
+    private static OrganisationsValidator BuildService(ContentDbContext? context = null)
+    {
+        return new OrganisationsValidator(
+            context ?? Mock.Of<ContentDbContext>(MockBehavior.Strict)
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseRequests.cs
@@ -28,6 +28,8 @@ public record ReleaseCreateRequest
     [MaxLength(20)]
     public string? Label { get; init; }
 
+    public Guid[]? PublishingOrganisations { get; init; }
+
     public Guid? TemplateReleaseId { get; init; }
 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseVersionRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/ReleaseVersionRequests.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.ComponentModel.DataAnnotations;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -26,4 +27,6 @@ public record ReleaseVersionUpdateRequest
 
     [MaxLength(50)]
     public string? Label { get; init; }
+
+    public Guid[]? PublishingOrganisations { get; init; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
@@ -63,6 +63,7 @@ public class ReleaseVersionService(
     IDataSetVersionService dataSetVersionService,
     IProcessorClient processorClient,
     IPrivateBlobCacheService privateCacheService,
+    IOrganisationsValidator organisationsValidator,
     IReleaseSlugValidator releaseSlugValidator,
     IOptions<FeatureFlagsOptions> featureFlags,
     ILogger<ReleaseVersionService> logger) : IReleaseVersionService
@@ -402,6 +403,7 @@ public class ReleaseVersionService(
         return await ReleaseVersionUpdateRequestValidator.Validate(request)
             .OnSuccess(async () => await context.ReleaseVersions
                 .Include(rv => rv.Release)
+                .Include(rv => rv.PublishingOrganisations)
                 .SingleOrNotFoundAsync(rv => rv.Id == releaseVersionId))
             .OnSuccess(userService.CheckCanUpdateReleaseVersion)
             .OnSuccessDo(releaseVersion => ValidateUpdateRequest(releaseVersion, request))
@@ -410,11 +412,17 @@ public class ReleaseVersionService(
                     newReleaseSlug: request.Slug,
                     publicationId: releaseVersion.Release.PublicationId,
                     releaseId: releaseVersion.ReleaseId))
-            .OnSuccessDo(async releaseVersion =>
-                await context.RequireTransaction(() =>
-                    UpdateReleaseAndVersion(request, releaseVersion)
-                        .OnSuccessDo(async () => await UpdateApiDataSetVersions(releaseVersion)))
-            )
+            .OnSuccessCombineWith(async _ =>
+                await organisationsValidator.ValidateOrganisations(
+                    organisationIds: request.PublishingOrganisations,
+                    path: nameof(ReleaseVersionUpdateRequest.PublishingOrganisations).ToLowerFirst()))
+            .OnSuccessDo(async releaseVersionAndPublishingOrganisations =>
+            {
+                var (releaseVersion, publishingOrganisations) = releaseVersionAndPublishingOrganisations;
+                return await context.RequireTransaction(() =>
+                    UpdateReleaseAndVersion(request, releaseVersion, publishingOrganisations)
+                        .OnSuccessDo(async () => await UpdateApiDataSetVersions(releaseVersion)));
+            })
             .OnSuccess(async () => await GetRelease(releaseVersionId));
     }
 
@@ -746,13 +754,17 @@ public class ReleaseVersionService(
             : Unit.Instance;
     }
 
-    private async Task<Either<ActionResult, Unit>> UpdateReleaseAndVersion(ReleaseVersionUpdateRequest request, ReleaseVersion releaseVersion)
+    private async Task<Either<ActionResult, Unit>> UpdateReleaseAndVersion(
+        ReleaseVersionUpdateRequest request,
+        ReleaseVersion releaseVersion,
+        Organisation[] publishingOrganisations)
     {
         releaseVersion.Release.Year = request.Year;
         releaseVersion.Release.TimePeriodCoverage = request.TimePeriodCoverage;
         releaseVersion.Release.Slug = request.Slug;
         releaseVersion.Release.Label = string.IsNullOrWhiteSpace(request.Label) ? null : request.Label.Trim();
 
+        releaseVersion.PublishingOrganisations = [.. publishingOrganisations];
         releaseVersion.Type = request.Type!.Value;
         releaseVersion.PreReleaseAccessList = request.PreReleaseAccessList;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -446,6 +446,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin;
             services.AddTransient<IPublicationService, PublicationService>();
             services.AddTransient<IPublicationRepository, PublicationRepository>();
             services.AddTransient<IMetaService, MetaService>();
+            services.AddTransient<IOrganisationsValidator, OrganisationsValidator>();
             services.AddTransient<IReleaseSlugValidator, ReleaseSlugValidator>();
             services.AddTransient<IReleaseVersionService, ReleaseVersionService>();
             services.AddTransient<IReleaseService, ReleaseService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/IOrganisationsValidator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/IOrganisationsValidator.cs
@@ -1,0 +1,17 @@
+﻿#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators;
+
+public interface IOrganisationsValidator
+{
+    Task<Either<ActionResult, Organisation[]>> ValidateOrganisations(
+        Guid[]? organisationIds,
+        string? path = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/OrganisationsValidator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/OrganisationsValidator.cs
@@ -1,0 +1,64 @@
+﻿#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators.ErrorDetails;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using LinqToDB.Common;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators;
+
+public class OrganisationsValidator(ContentDbContext context) : IOrganisationsValidator
+{
+    /// <summary>
+    /// Validates a list of organisation id's by checking for existing organisations matching those id's.
+    /// Returns either a list of organisations or a list of validation errors.
+    /// </summary>
+    /// <param name="organisationIds">An array of organisation id's to validate.</param>
+    /// <param name="path">An optional path to a property in a request that the error relates to include in error details for context.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    /// An <see cref="Either{TLeft, TRight}"/> containing:
+    /// - A list of <see cref="Organisation"/> objects if all id's are valid.
+    /// - A Bad Request <see cref="ActionResult"/> if any id's are invalid.
+    /// </returns>
+    public async Task<Either<ActionResult, Organisation[]>> ValidateOrganisations(
+        Guid[]? organisationIds,
+        string? path = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (organisationIds.IsNullOrEmpty())
+        {
+            return Array.Empty<Organisation>();
+        }
+
+        var organisations = await context.Organisations
+            .Where(o => organisationIds.Contains(o.Id))
+            .Distinct()
+            .ToArrayAsync(cancellationToken: cancellationToken);
+
+        var organisationNotFoundErrors = organisationIds
+            .Except(organisations.Select(o => o.Id))
+            .Select(organisationId => new ErrorViewModel
+            {
+                Code = ValidationMessages.OrganisationNotFound.Code,
+                Message = ValidationMessages.OrganisationNotFound.Message,
+                Path = path,
+                Detail = new InvalidErrorDetail<Guid>(organisationId)
+            })
+            .ToArray();
+
+        if (organisationNotFoundErrors.Length > 0)
+        {
+            return Common.Validators.ValidationUtils.ValidationResult(organisationNotFoundErrors);
+        }
+
+        return organisations;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -443,6 +443,11 @@ public static class ValidationMessages
         };
     }
 
+    public static readonly LocalizableMessage OrganisationNotFound = new(
+        Code: nameof(OrganisationNotFound),
+        Message: "The specified organisation could not be found."
+    );
+
     public static readonly LocalizableMessage PreviewTokenExpired = new(
         Code: nameof(PreviewTokenExpired),
         Message: "The preview token is expired."


### PR DESCRIPTION
This PR makes changes to the following Admin API methods to allow optionally setting and updating publishing organisations when creating a new release or updating an existing release version.

```http
POST /api/releases
PATCH /api/releaseVersions/{releaseVersionId}
```

The `ReleaseCreateRequest` and `ReleaseVersionUpdateRequest` request types have been changed to accept an optional `publishingOrganisations` array of type Guid, representing organisation id’s.

It silently ignore duplicates, associating the release version with a distinct list of the publishing organisations.

<img width="1083" height="756" alt="image" src="https://github.com/user-attachments/assets/265a156b-833b-4b7b-829e-f5c272377458" />
<sub>* Screenshot shows a result using the Admin with the frontend changes from EES-6316 combined with this change.</sub>.

### Validation

Both methods return a list of validation errors if any of the organisations cannot be found.

```
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=utf-8

{
  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
  "title": "One or more validation errors occurred.",
  "status": 400,
  "errors": [
    {
      "message": "The specified organisation could not be found.",
      "path": "publishingOrganisations",
      "code": "OrganisationNotFound",
      "detail": {
        "value": "ea1c8b2f-0d3e-4a5c-9f6b-08ddc9b4bf09"
      }
    },
    {
      "message": "The specified organisation could not be found.",
      "path": "publishingOrganisations",
      "code": "OrganisationNotFound",
      "detail": {
        "value": "c4a02e1b-4748-4a6e-a656-b40a8e0e84f0"
      }
    }
  ]
}
```