### PR TITLE
EES-6347 permalink warning UI tweak

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -64,20 +64,20 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
 
       {data.status === 'SubjectRemoved' && (
         <WarningMessage error testId="permalink-warning">
-          WARNING - The data used in this table is no longer valid.
+          The data used in this table is no longer valid.
         </WarningMessage>
       )}
       {(data.status === 'NotForLatestRelease' ||
         data.status === 'PublicationSuperseded') && (
-        <WarningMessage error testId="permalink-warning">
-          WARNING - The data used in this table may now be out-of-date as a new
-          release has been published since its creation.
+        <WarningMessage testId="permalink-warning">
+          A newer release of this publication is available and may include
+          updated figures.
         </WarningMessage>
       )}
       {data.status === 'SubjectReplacedOrRemoved' && (
         <WarningMessage error testId="permalink-warning">
-          WARNING - The data used in this table may be invalid as the subject
-          file has been amended or removed since its creation.
+          The data used in this table may be invalid as the subject file has
+          been amended or removed since its creation.
         </WarningMessage>
       )}
 

--- a/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/PermalinkPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/PermalinkPage.test.tsx
@@ -43,7 +43,7 @@ describe('PermalinkPage', () => {
   test('renders no warning message with permalink status Current', () => {
     render(<PermalinkPage data={testPermalinkSnapshot} />);
 
-    expect(screen.queryByText(/WARNING/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/warning/)).not.toBeInTheDocument();
 
     // Table still renders
     expect(screen.getByRole('table')).toBeInTheDocument();
@@ -61,9 +61,7 @@ describe('PermalinkPage', () => {
     );
 
     expect(
-      screen.getByText(
-        'WARNING - The data used in this table is no longer valid.',
-      ),
+      screen.getByText('The data used in this table is no longer valid.'),
     ).toBeInTheDocument();
 
     // Table still renders
@@ -83,7 +81,7 @@ describe('PermalinkPage', () => {
 
     expect(
       screen.getByText(
-        'WARNING - The data used in this table may be invalid as the subject file has been amended or removed since its creation.',
+        'The data used in this table may be invalid as the subject file has been amended or removed since its creation.',
       ),
     ).toBeInTheDocument();
 
@@ -104,7 +102,7 @@ describe('PermalinkPage', () => {
 
     expect(
       screen.getByText(
-        'WARNING - The data used in this table may now be out-of-date as a new release has been published since its creation.',
+        'A newer release of this publication is available and may include updated figures.',
       ),
     ).toBeInTheDocument();
 
@@ -125,7 +123,7 @@ describe('PermalinkPage', () => {
 
     expect(
       screen.getByText(
-        'WARNING - The data used in this table may now be out-of-date as a new release has been published since its creation.',
+        'A newer release of this publication is available and may include updated figures.',
       ),
     ).toBeInTheDocument();
 

--- a/tests/robot-tests/scripts/permalink_snapshots/check_permalinks.py
+++ b/tests/robot-tests/scripts/permalink_snapshots/check_permalinks.py
@@ -189,7 +189,7 @@ class PermalinkChecker:
                 print(f"Permalink {permalink_id} has a warning")
                 if (
                     permalink_warning_message
-                    == "WarningWARNING - The data used in this table may now be out-of-date as a new release has been published since its creation"
+                    == "Warning A newer release of this publication is available and may include updated figures."
                 ):
                     permalink_out_of_date = True
 

--- a/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
@@ -326,7 +326,7 @@ Check archive-publication permalink has out-of-date warning
     ...    '${SUBJECT_NAME_ARCHIVE}' from '${PUBLICATION_NAME_ARCHIVE}'
 
     user waits until page contains
-    ...    WARNING - The data used in this table may now be out-of-date as a new release has been published since its creation.
+    ...    A newer release of this publication is available and may include updated figures.
 
 Set archive-publication to be no longer be superseded
     [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-4269
@@ -438,4 +438,4 @@ Check archive-publication permalink no longer has out-of-date warning after arch
     ...    '${SUBJECT_NAME_ARCHIVE}' from '${PUBLICATION_NAME_ARCHIVE}'
 
     user checks page does not contain
-    ...    WARNING - The data used in this table may now be out-of-date as a new release has been published since its creation.
+    ...    A newer release of this publication is available and may include updated figures.

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
@@ -316,7 +316,7 @@ Check new release status history entry is present
 Go to permalink page & check for error element to be present
     user navigates to    ${PERMA_LOCATION_URL}
     user waits until page contains
-    ...    WARNING - The data used in this table may be invalid as the subject file has been amended or removed since its creation.
+    ...    A newer release of this publication is available and may include updated figures.
 
 Check the table has the same results as original table
     user checks table row heading contains    1    1    Total

--- a/tests/robot-tests/tests/general_public/prod_only/old_fast_track.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/old_fast_track.robot
@@ -38,7 +38,7 @@ Visit featured table and generate a permalink
 Open shareable link and check outdated warning
     user clicks link    View share link
     user waits until page contains
-    ...    WARNING - The data used in this table may now be out-of-date as a new release has been published since its creation.
+    ...    A newer release of this publication is available and may include updated figures.
 
 Validate that View latest data link takes user to the latest release page
     user goes back


### PR DESCRIPTION
Removed the error styling as it was a little too dramatic, updated warning text and removed "WARNING - " warning message prefixes as icon and hidden text implied as much

<img width="955" height="1181" alt="image" src="https://github.com/user-attachments/assets/46f7b7b2-0d55-497e-9476-c0c7c8c3eaa7" />
