### PR TITLE
EES-6330 - increasing Pre-Prod stats DB capacity following testing with multiple large file uploads

### DIFF
--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -93,7 +93,7 @@
       "value": 1073741824
     },
     "maxStatsDbSizeBytes": {
-      "value": 375809638400
+      "value": 536870912000
     },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "value": true


### PR DESCRIPTION
Upping from 350GB to 500GB.