### PR TITLE
EES-6339 Change download all files button back to link

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -239,6 +239,7 @@ const PublicationReleasePage: NextPage<Props> = ({ releaseVersion }) => {
                           label: `Publication: ${releaseVersion.publication.title}, Release: ${releaseVersion.title}, File: All files`,
                         });
                       }}
+                      id="download-all-data-link"
                     >
                       Download all data (zip)
                     </Link>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -29,8 +29,6 @@ import classNames from 'classnames';
 import orderBy from 'lodash/orderBy';
 import { GetServerSideProps, NextPage } from 'next';
 import React, { Fragment } from 'react';
-import Button from '@common/components/Button';
-import downloadService from '@frontend/services/downloadService';
 
 interface Props {
   releaseVersion: ReleaseVersion;
@@ -232,14 +230,9 @@ const PublicationReleasePage: NextPage<Props> = ({ releaseVersion }) => {
               <ul className="govuk-list">
                 {showAllFilesButton && (
                   <li>
-                    <Button
-                      className="govuk-button  govuk-!-margin-bottom-3"
-                      onClick={async () => {
-                        await downloadService.downloadZip(
-                          releaseVersion.id,
-                          'ReleaseUsefulInfo',
-                        );
-
+                    <Link
+                      to={`${process.env.CONTENT_API_BASE_URL}/releases/${releaseVersion.id}/files?fromPage=ReleaseUsefulInfo`}
+                      onClick={() => {
                         logEvent({
                           category: `${releaseVersion.publication.title} release page - Useful information`,
                           action: 'Download all data button clicked',
@@ -248,7 +241,7 @@ const PublicationReleasePage: NextPage<Props> = ({ releaseVersion }) => {
                       }}
                     >
                       Download all data (zip)
-                    </Button>
+                    </Link>
                   </li>
                 )}
                 {!!releaseVersion.relatedDashboardsSection?.content.length && (
@@ -445,13 +438,9 @@ const PublicationReleasePage: NextPage<Props> = ({ releaseVersion }) => {
           downloadFiles={releaseVersion.downloadFiles}
           hasDataGuidance={releaseVersion.hasDataGuidance}
           renderAllFilesLink={
-            <Button
-              onClick={async () => {
-                await downloadService.downloadZip(
-                  releaseVersion.id,
-                  'ReleaseDownloads',
-                );
-
+            <Link
+              to={`${process.env.CONTENT_API_BASE_URL}/releases/${releaseVersion.id}/files?fromPage=ReleaseDownloads`}
+              onClick={() => {
                 logEvent({
                   category: 'Downloads',
                   action: `Release page all files, Release: ${releaseVersion.title}, File: All files`,
@@ -459,7 +448,7 @@ const PublicationReleasePage: NextPage<Props> = ({ releaseVersion }) => {
               }}
             >
               Download all data (ZIP)
-            </Button>
+            </Link>
           }
           renderCreateTablesLink={
             <Link

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
@@ -121,7 +121,7 @@ describe('PublicationReleasePage', () => {
     expect(quickLinks[2]).toHaveAttribute('href', '#help-and-support');
   });
 
-  test('renders download all files as zip as a link when files present', async () => {
+  test(`renders 'Download all data (zip)' as a link when files present`, async () => {
     render(
       <PublicationReleasePage
         releaseVersion={{

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
@@ -121,6 +121,42 @@ describe('PublicationReleasePage', () => {
     expect(quickLinks[2]).toHaveAttribute('href', '#help-and-support');
   });
 
+  test('renders download all files as zip as a link when files present', async () => {
+    render(
+      <PublicationReleasePage
+        releaseVersion={{
+          ...testRelease,
+          relatedDashboardsSection: undefined,
+          downloadFiles: [
+            {
+              id: 'file-id',
+              extension: 'csv',
+              fileName: 'test-file',
+              name: 'test file',
+              size: '1 MB',
+              type: 'Data',
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole('navigation', { name: 'Quick links' }),
+    ).toBeInTheDocument();
+
+    const quickLinksNav = screen.getByRole('navigation', {
+      name: 'Quick links',
+    });
+
+    const quickLinks = within(quickLinksNav).getAllByRole('link');
+
+    expect(quickLinks).toHaveLength(4);
+
+    expect(quickLinks[0]).toHaveTextContent('Download all data (zip)');
+    expect(quickLinks[0]).toHaveAttribute('href');
+  });
+
   test('does not render release contents link when there is no content', async () => {
     render(
       <PublicationReleasePage


### PR DESCRIPTION
Small PR to change the 'Download all data (ZIP)' from a button to a link, on a release page.

For context, this used to be a link but was changed to a button previously to allow analytics tracking. To preserve this tracking, I have added the `fromPage` query param in line with the button functionality.

<img width="1054" height="634" alt="image" src="https://github.com/user-attachments/assets/80933932-c7a6-4282-828e-d8c95eee7f97" />

<img width="1152" height="583" alt="image" src="https://github.com/user-attachments/assets/42c3873b-a23f-46e5-bbb3-6f31eff6fa6f" />

I've also added an ID attribute to be able to target the link programmatically, which is what analysts are trying to do.