### PR TITLE
EES-6345 - removing redundant include of users within ReleaseFiles

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/QueryableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/QueryableExtensions.cs
@@ -75,10 +75,17 @@ public static class QueryableExtensions
     /// <param name="predicate">If the predicate resolves to true, the Where clause will be appended to the query</param>
     /// <typeparam name="T">The type of the data in the data source.</typeparam>
     /// <returns>An IQueryable&lt;out T&gt; optionally filtered by the specified Where clause depending on the value of predicate.</returns>
-    public static ConditionalQueryable<T> If<T>(this IQueryable<T> source, bool predicate) => new(source, predicate);
+    public static ConditionalQueryable<T> If<T>(this IQueryable<T> source, bool predicate) 
+        where T : class => new(source, predicate);
     
     public class ConditionalQueryable<T>(IQueryable<T> source, bool predicate)
+        where T : class
     {
+        public IQueryable<T> Include<TProperty>(Expression<Func<T, TProperty>> includeClause) =>
+            predicate
+                ? source.Include(includeClause)
+                : source;
+        
         public IQueryable<T> ThenWhere(Expression<Func<T, bool>> whereClause) =>
             predicate
                 ? source.Where(whereClause) 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IReleaseFileRepository.cs
@@ -30,7 +30,8 @@ public interface IReleaseFileRepository
     Task<Either<ActionResult, ReleaseFile>> FindOrNotFound(Guid releaseVersionId,
         Guid fileId);
 
-    Task<List<ReleaseFile>> GetByFileType(Guid releaseVersionId,
+    Task<List<ReleaseFile>> GetByFileType(
+        Guid releaseVersionId,
         CancellationToken cancellationToken = default,
         params FileType[] types);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseFileRepository.cs
@@ -98,12 +98,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
             return await Find(releaseVersionId, fileId) ?? new Either<ActionResult, ReleaseFile>(new NotFoundResult());
         }
 
-        public async Task<List<ReleaseFile>> GetByFileType(Guid releaseVersionId,
+        public async Task<List<ReleaseFile>> GetByFileType(
+            Guid releaseVersionId,
             CancellationToken cancellationToken = default,
             params FileType[] types)
         {
-            return await _contentDbContext.ReleaseFiles
-                .Include(f => f.File.CreatedBy)
+            return await _contentDbContext
+                .ReleaseFiles
+                .Include(f => f.File)
                 .Where(releaseFile =>
                     releaseFile.ReleaseVersionId == releaseVersionId
                     && types.Contains(releaseFile.File.Type))

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/ReleaseSummaryViewModel.cs
@@ -35,6 +35,8 @@ public record ReleaseSummaryViewModel
 
     public PublicationSummaryViewModel? Publication { get; init; }
 
+    // ReSharper disable once UnusedMember.Global
+    // Used by JSON serialisation.
     public ReleaseSummaryViewModel()
     {
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Services/DataSetVersionService.cs
@@ -248,7 +248,10 @@ internal class DataSetVersionService(
         Guid releaseVersionId,
         CancellationToken cancellationToken)
     {
-        return await releaseFileRepository.GetByFileType(releaseVersionId, cancellationToken, FileType.Data);
+        return await releaseFileRepository.GetByFileType(
+            releaseVersionId: releaseVersionId,
+            cancellationToken: cancellationToken,
+            types: FileType.Data);
     }
 
     private async Task UnlinkReleaseFilesFromApiDataSets(


### PR DESCRIPTION
This PR:
- removes a redundant include of "CreatedBy" users from ReleaseFiles, as the Users who are actually used to create ViewModels in the end come from a separate DataImports query later in the code (ReleaseDataFileService line 649). 

When first attempting to fix this, I originally added support for optional Includes, using the `ConditionalQueryable` that @leeoades added.  I've left the optional Include method there in case it is useful in the future.