### PR TITLE
EES-6348 Change 'this is (not) the latest release' tag on release pages

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -135,9 +135,9 @@ const PublicationReleasePage: NextPage<Props> = ({ releaseVersion }) => {
                 {!releaseVersion.publication.isSuperseded && (
                   <>
                     {releaseVersion.latestRelease ? (
-                      <Tag>This is the latest data</Tag>
+                      <Tag>This is the latest release</Tag>
                     ) : (
-                      <Tag colour="orange">This is not the latest data</Tag>
+                      <Tag colour="orange">This is not the latest release</Tag>
                     )}
                   </>
                 )}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
@@ -9,10 +9,12 @@ describe('PublicationReleasePage', () => {
   test('renders latest data tag', () => {
     render(<PublicationReleasePage releaseVersion={testRelease} />);
 
-    expect(screen.queryByText('This is the latest data')).toBeInTheDocument();
+    expect(
+      screen.queryByText('This is the latest release'),
+    ).toBeInTheDocument();
 
     expect(
-      screen.queryByText('This is not the latest data'),
+      screen.queryByText('This is not the latest release'),
     ).not.toBeInTheDocument();
   });
 
@@ -24,7 +26,7 @@ describe('PublicationReleasePage', () => {
     render(<PublicationReleasePage releaseVersion={testReleaseSuperseded} />);
 
     expect(
-      screen.queryByText('This is the latest data'),
+      screen.queryByText('This is the latest release'),
     ).not.toBeInTheDocument();
   });
 
@@ -35,9 +37,11 @@ describe('PublicationReleasePage', () => {
     };
     render(<PublicationReleasePage releaseVersion={testReleaseNotLatest} />);
 
-    expect(screen.getByText('This is not the latest data')).toBeInTheDocument();
     expect(
-      screen.queryByText('This is the latest data'),
+      screen.getByText('This is not the latest release'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('This is the latest release'),
     ).not.toBeInTheDocument();
 
     expect(

--- a/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
@@ -107,7 +107,7 @@ Verify that archive-publication is publicly accessible
     ...    ${PUBLICATION_URL_ARCHIVE}
     ...    ${PUBLICATION_NAME_ARCHIVE}
     ...    ${RELEASE_NAME_ARCHIVE}
-    user waits until page contains    This is the latest data
+    user waits until page contains    This is the latest release
 
 Check that archive-publication subject appears correctly on Data tables page
     user navigates to data tables page on public frontend
@@ -235,14 +235,14 @@ Check public superseding-publication release page displays correctly
     ...    ${PUBLICATION_URL_SUPERSEDE}
     ...    ${PUBLICATION_NAME_SUPERSEDE}
     ...    ${RELEASE_NAME_SUPERSEDE}
-    user waits until page contains    This is the latest data
+    user waits until page contains    This is the latest release
 
 Check public archive-publication release page displays correctly
     user waits for caches to expire
 
     user navigates to    ${PUBLICATION_URL_ARCHIVE}
     user waits until h1 is visible    ${PUBLICATION_NAME_ARCHIVE}    %{WAIT_MEDIUM}
-    user checks page does not contain    This is the latest data
+    user checks page does not contain    This is the latest release
 
 Check public archive-publication release page displays superseded warning
     user checks page contains element    testid:superseded-warning
@@ -255,7 +255,7 @@ Check superseded warning link takes user to superseding-publication release page
     user clicks element    testid:superseded-by-link
 
     user waits until h1 is visible    ${PUBLICATION_NAME_SUPERSEDE}    %{WAIT_MEDIUM}
-    user checks page contains    This is the latest data
+    user checks page contains    This is the latest release
 
     user checks page does not contain element    testid:superseded-warning
     user checks page does not contain element    testid:superseded-by-link

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
@@ -92,7 +92,7 @@ Verify newly published release is public
     user navigates to public release page    ${PUBLIC_RELEASE_LINK}    ${PUBLICATION_NAME}    ${RELEASE_NAME}
 
 Check latest release is correct
-    user checks page contains    This is the latest data
+    user checks page contains    This is the latest release
 
 Check latest release contains related dashboards section
     user checks there are x accordion sections    1    id:data-accordion

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -533,7 +533,7 @@ Verify newly published release is public
     user navigates to public release page    ${PUBLIC_RELEASE_LINK}    ${PUBLICATION_NAME}    ${RELEASE_2_NAME}
 
 Check latest release is correct
-    user checks page contains    This is the latest data
+    user checks page contains    This is the latest release
     user checks page contains    View releases (1)
 
     user opens details dropdown    View releases (1)

--- a/tests/robot-tests/tests/admin_and_public/bau/release_reordering.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/release_reordering.robot
@@ -136,8 +136,8 @@ Validate first release has latest release status in publication release order
 Navigate to first published release on public frontend
     user navigates to    ${PUBLIC_RELEASE_1_URL}
 
-Validate first published release on public frontend is the latest data
-    user checks page contains    This is the latest data
+Validate first published release on public frontend is the latest release
+    user checks page contains    This is the latest release
 
 Validate other releases section of first published release includes legacy releases
     user checks number of other releases is correct    2
@@ -235,8 +235,8 @@ Validate reordered publication releases
 Navigate to first published release on public frontend after reordering
     user navigates to    ${PUBLIC_RELEASE_1_URL}
 
-Validate first published release is the latest data after reordering
-    user checks page contains    This is the latest data
+Validate first published release is the latest release after reordering
+    user checks page contains    This is the latest release
 
 Validate other releases section of first published release contains updated legacy release in expected order
     user checks number of other releases is correct    2
@@ -326,8 +326,8 @@ Validate second release has latest release status in publication release order
 Navigate to second published release on public frontend
     user navigates to    ${PUBLIC_RELEASE_2_URL}
 
-Validate second published release is the latest data
-    user checks page contains    This is the latest data
+Validate second published release is the latest release
+    user checks page contains    This is the latest release
 
 Validate other releases section of second published release includes first release with expected order
     user checks number of other releases is correct    3
@@ -454,12 +454,12 @@ Validate first release has latest release status in publication release order af
 Navigate to first published release on public frontend after changing the latest release
     user navigates to    ${PUBLIC_RELEASE_1_URL}
 
-Validate first published release is the latest data after changing the latest release
-    user checks page contains    This is the latest data
+Validate first published release is the latest release after changing the latest release
+    user checks page contains    This is the latest release
 
 Navigate to second published release on public frontend after changing the latest release
     user navigates to    ${PUBLIC_RELEASE_2_URL}
 
-Validate second published release is not the latest data after changing the latest release
-    user checks page contains    This is not the latest data
+Validate second published release is not the latest release after changing the latest release
+    user checks page contains    This is not the latest release
     user waits until page contains link    View latest data: ${RELEASE_1_NAME}

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_methodology_publication_update.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_methodology_publication_update.robot
@@ -198,18 +198,18 @@ Get public third release link
     ${PUBLIC_RELEASE_3_LINK}=    user gets url public release will be accessible at
     Set Suite Variable    ${PUBLIC_RELEASE_3_LINK}
 
-Check that second release does not contains the latest data
+Check that second release does not contains the latest release
     user navigates to public release page
     ...    ${PUBLIC_RELEASE_2_LINK}
     ...    ${PUBLICATION_NAME_UPDATED}
     ...    ${RELEASE_2_NAME}
-    user checks page does not contain    This is the latest data
-    user checks page contains    This is not the latest data
+    user checks page does not contain    This is the latest release
+    user checks page contains    This is not the latest release
 
-Check that third release contains the latest data
+Check that third release contains the latest release
     user navigates to public release page
     ...    ${PUBLIC_RELEASE_3_LINK}
     ...    ${PUBLICATION_NAME_UPDATED}
     ...    ${RELEASE_3_NAME}
-    user checks page does not contain    This is not the latest data
-    user checks page contains    This is the latest data
+    user checks page does not contain    This is not the latest release
+    user checks page contains    This is the latest release

--- a/tests/robot-tests/tests/general_public/prod_only/old_fast_track.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/old_fast_track.robot
@@ -12,7 +12,7 @@ Test Setup          fail test fast if required
 Navigate to Absence publication
     user navigates to    %{PUBLIC_URL}/find-statistics/further-education-and-skills/2019-20
     user waits until h1 is visible    Further education and skills    %{WAIT_MEDIUM}
-    user checks page contains    This is not the latest data
+    user checks page contains    This is not the latest release
 
 Open Overall absence accordion
     user opens accordion section    About these statistics    id:content-1
@@ -45,11 +45,11 @@ Validate that View latest data link takes user to the latest release page
     user waits until page contains    This data is not from the latest release
     user clicks element    css:[data-testid="View latest data link"]
     user waits until h1 is visible    Further education and skills
-    user checks page contains    This is the latest data
+    user checks page contains    This is the latest release
 
  Validate that Publication link in Related information takes user to the latest release page
     user goes back
     user waits until page finishes loading
     user clicks link containing text    Further education and skills
     user waits until h1 is visible    Further education and skills
-    user checks page contains    This is the latest data
+    user checks page contains    This is the latest release


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/EES-6348

A quick change to make this messaging more correct
Previously:
> This is (not) the latest _data_

Now reads:
> This is (not) the latest _release_