### PR TITLE
Fix PreviewToken timing issue

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/PreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api/Services/PreviewTokenService.cs
@@ -79,12 +79,13 @@ public class PreviewTokenService(
         Guid previewTokenId,
         CancellationToken cancellationToken)
     {
+        var timestamp = DateTimeOffset.UtcNow; // Capture UtcNow and pass into query as a literal to avoid bizarre timing issues in tests.
         return await publicDataDbContext
             .PreviewTokens
             .Where(pt => pt.Id == previewTokenId)
             .Where(pt => pt.DataSetVersionId == dataSetVersionId)
             .Where(pt => pt.DataSetVersion.Status == DataSetVersionStatus.Draft)
-            .Where(pt => pt.Expiry > DateTimeOffset.UtcNow)
+            .Where(pt => pt.Expiry > timestamp)
             .AnyAsync(cancellationToken: cancellationToken);
     }
     


### PR DESCRIPTION
I don't fully understand this issue but I was able to reliably reproduce it locally. I believe that DateTimeOffset.UTC is captured as an expression within the query and then evaluated elsewhere, perhaps? Could it be that it is in a container that has a different time?
