### PR TITLE
EES-6205 Make DataSetFileMeta.NumDataFileRows non-optional

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataImport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataImport.cs
@@ -45,7 +45,7 @@ public class DataImport
 
     public Guid? ZipFileId { get; set; }
 
-    public int? TotalRows { get; set; }
+    public int? TotalRows { get; set; } // Must be optional for failed imports
 
     /// <summary>
     /// Note that this means "importable row count" rather than indicating the actual number of rows

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetFileMeta.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 public class DataSetFileMeta
 {
-    public required int? NumDataFileRows { get; set; }
+    public required int NumDataFileRows { get; set; }
 
     // NOTE: GeographicLevels aren't in DataSetFileMeta JSON because they need to queryable
     // So that meta data lives in the DataSetFileVersionGeographicLevels table

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.ViewModels/DataSetFileMetaViewModel.cs
@@ -2,7 +2,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 
 public record DataSetFileMetaViewModel
 {
-    public required int? NumDataFileRows { get; set; }
+    public required int NumDataFileRows { get; set; }
     public required List<string> GeographicLevels { get; set; }
     public required DataSetFileTimePeriodRangeViewModel TimePeriodRange { get; init; }
     public required List<string> Filters { get; init; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
@@ -63,7 +63,7 @@ public class FileImportServiceTests
             .Setup(s => s.WriteDataSetFileMeta(
                 import.FileId,
                 import.SubjectId,
-                import.TotalRows))
+                import.TotalRows!.Value))
             .Returns(Task.CompletedTask);
 
         var statisticsDbContextId = Guid.NewGuid().ToString();
@@ -235,7 +235,7 @@ public class FileImportServiceTests
                     dataImportService.Setup(mock => mock.WriteDataSetFileMeta(
                             import.FileId,
                             import.SubjectId,
-                            import.TotalRows))
+                            import.TotalRows!.Value))
                         .Returns(Task.CompletedTask);
                 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -151,7 +151,7 @@ public class DataImportService : IDataImportService
         await context.SaveChangesAsync();
     }
 
-    public async Task WriteDataSetFileMeta(Guid fileId, Guid subjectId, int? numDataFileRows)
+    public async Task WriteDataSetFileMeta(Guid fileId, Guid subjectId, int numDataFileRows)
     {
         await using var contentDbContext = _dbContextSupplier.CreateDbContext<ContentDbContext>();
         await using var statisticsDbContext = _dbContextSupplier.CreateDbContext<StatisticsDbContext>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -105,7 +105,7 @@ public class FileImportService : IFileImportService
 
             if (import.Status == COMPLETE)
             {
-                await _dataImportService.WriteDataSetFileMeta(import.FileId, import.SubjectId, import.TotalRows);
+                await _dataImportService.WriteDataSetFileMeta(import.FileId, import.SubjectId, import.TotalRows!.Value);
             }
 
             return;
@@ -139,7 +139,7 @@ public class FileImportService : IFileImportService
             if (import.Errors.Count == 0)
             {
                 await _dataImportService.UpdateStatus(import.Id, COMPLETE, 100);
-                await _dataImportService.WriteDataSetFileMeta(import.FileId, import.SubjectId, import.TotalRows);
+                await _dataImportService.WriteDataSetFileMeta(import.FileId, import.SubjectId, import.TotalRows!.Value);
             }
             else
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
@@ -19,7 +19,7 @@ public interface IDataImportService
 
     Task UpdateStatus(Guid id, DataImportStatus newStatus, double percentageComplete);
 
-    Task WriteDataSetFileMeta(Guid fileId, Guid subjectId, int? numDataFileRows);
+    Task WriteDataSetFileMeta(Guid fileId, Guid subjectId, int numDataFileRows);
 
     Task Update(
         Guid id,

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileDetails.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileDetails.tsx
@@ -81,11 +81,10 @@ export default function DataSetFileDetails({
           </Modal>
         </SummaryListItem>
 
-        {numDataFileRows && (
-          <SummaryListItem term="Number of rows">
-            {formatPretty(numDataFileRows)}
-          </SummaryListItem>
-        )}
+        <SummaryListItem term="Number of rows">
+          {formatPretty(numDataFileRows)}
+        </SummaryListItem>
+
         {geographicLevels && geographicLevels.length > 0 && (
           <SummaryListItem term="Geographic levels">
             {orderBy(geographicLevels).join(', ')}

--- a/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
+++ b/src/explore-education-statistics-frontend/src/services/dataSetFileService.ts
@@ -28,7 +28,7 @@ export interface DataSetFile {
     name: string;
     size: string;
     meta: {
-      numDataFileRows?: number;
+      numDataFileRows: number;
       geographicLevels: string[];
       timePeriodRange: {
         from: string;
@@ -87,7 +87,7 @@ export interface DataSetFileSummary {
   lastUpdated: string;
   api?: DataSetFileApi;
   meta: {
-    numDataFileRows?: number;
+    numDataFileRows: number;
     geographicLevels: string[];
     timePeriodRange: {
       from: string;


### PR DESCRIPTION
When DataSetFileMeta.NumDataFileRows was introduced, it was made optional since existing data had null values. However, this is no longer the case and we can finally set this value to be mandatory. Likewise, a DataImport must have TotalRows

Could someone with access to all of the DBs please confirm that this is the case - that there are no longer any rows that are missing this value?

Also, can anyone with more knowledge of this area think of any other issues with setting this to mandatory?

Thanks.