### PR TITLE
EES-6358 - manages file missing error, avoids 404 error by refreshing the datafiles data

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesReplacementTableRow.tsx
@@ -9,7 +9,6 @@ import releaseDataFileQueries from '@admin/queries/releaseDataFileQueries';
 import releaseDataFileService, {
   DataFile,
   DataFileImportStatus,
-  ReplacementDataFile,
 } from '@admin/services/releaseDataFileService';
 import dataReplacementService from '@admin/services/dataReplacementService';
 import useToggle from '@common/hooks/useToggle';

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -94,62 +94,54 @@ export default function ReleaseDataUploadsSection({
 
   const handleStatusChange = useCallback(
     async (dataFile: DataFile, importStatus: DataFileImportStatus) => {
-      // EES-5732 UI tests related to data replacement sometimes fail
-      // because of a permission call for the replaced file being called,
-      // probably caused by the speed of the tests.
-      // This prevents this happening.
-      if (importStatus?.status === 'NOT_FOUND') {
-        return;
+      try {
+        const permissions = await permissionService.getDataFilePermissions(
+          releaseVersionId,
+          dataFile.id,
+        );
+
+        setAllDataFiles(currentDataFiles =>
+          currentDataFiles.map(file =>
+            file.fileName !== dataFile.fileName
+              ? file
+              : {
+                  ...dataFile,
+                  rows: importStatus.totalRows,
+                  status: importStatus.status,
+                  permissions,
+                },
+          ),
+        );
+      } catch {
+        refetchDataFiles();
       }
-
-      const permissions = await permissionService.getDataFilePermissions(
-        releaseVersionId,
-        dataFile.id,
-      );
-
-      setAllDataFiles(currentDataFiles =>
-        currentDataFiles.map(file =>
-          file.fileName !== dataFile.fileName
-            ? file
-            : {
-                ...dataFile,
-                rows: importStatus.totalRows,
-                status: importStatus.status,
-                permissions,
-              },
-        ),
-      );
     },
-    [releaseVersionId, setAllDataFiles],
+    [releaseVersionId, setAllDataFiles, refetchDataFiles],
   );
 
   const handleReplacementStatusChange = useCallback(
     async (updatedDataFile: DataFile) => {
-      // EES-5732 UI tests related to data replacement sometimes fail
-      // because of a permission call for the replaced file being called,
-      // probably caused by the speed of the tests.
-      // This prevents this happening.
-      if (updatedDataFile.replacedByDataFile?.status === 'NOT_FOUND') {
-        return;
+      try {
+        const permissions = await permissionService.getDataFilePermissions(
+          releaseVersionId,
+          updatedDataFile.id,
+        );
+
+        setAllDataFiles(currentDataFiles =>
+          currentDataFiles.map(file =>
+            file.fileName !== updatedDataFile.fileName
+              ? file
+              : {
+                  ...updatedDataFile,
+                  permissions,
+                },
+          ),
+        );
+      } catch {
+        refetchDataFiles();
       }
-
-      const permissions = await permissionService.getDataFilePermissions(
-        releaseVersionId,
-        updatedDataFile.id,
-      );
-
-      setAllDataFiles(currentDataFiles =>
-        currentDataFiles.map(file =>
-          file.fileName !== updatedDataFile.fileName
-            ? file
-            : {
-                ...updatedDataFile,
-                permissions,
-              },
-        ),
-      );
     },
-    [releaseVersionId, setAllDataFiles],
+    [releaseVersionId, setAllDataFiles, refetchDataFiles],
   );
 
   const handleDataSetImport = useCallback(


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/EES-6358

In a unique instance, the FE was attemping to get permissions on a file that no longer existed, causing a 404 error and erroring the page. I've updated the code so if this happens to simply refetch all dataFiles.

For more information as to why this is happening I've written a comment about it here: https://exploreeducationstats.slack.com/archives/C08US9M1G3V/p1753354297276129?thread_ts=1753353842.037289&cid=C08US9M1G3V
