### PR TITLE
EES-6261 show publication title in data set heading on data catalogue

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import PageMetaItem, { PageMetaItemType } from './PageMetaItem';

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
@@ -606,6 +606,7 @@ const DataCataloguePage: NextPage<Props> = ({ showTypeFilter }) => {
                           expanded={showAllDetails}
                           headingTag={selectedPublication ? 'h4' : 'h3'}
                           showLatestDataTag={!selectedRelease}
+                          showPublicationTitle={!selectedPublication}
                         />
                       ))}
                     </ul>

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataCataloguePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataCataloguePage.test.tsx
@@ -97,13 +97,19 @@ describe('DataCataloguePage', () => {
     expect(dataSets).toHaveLength(3);
 
     expect(
-      within(dataSets[0]).getByRole('heading', { name: 'Data set 1' }),
+      within(dataSets[0]).getByRole('heading', {
+        name: 'Publication 1 Data set 1',
+      }),
     ).toBeInTheDocument();
     expect(
-      within(dataSets[1]).getByRole('heading', { name: 'Data set 2' }),
+      within(dataSets[1]).getByRole('heading', {
+        name: 'Publication 1 Data set 2',
+      }),
     ).toBeInTheDocument();
     expect(
-      within(dataSets[2]).getByRole('heading', { name: 'Data set 3' }),
+      within(dataSets[2]).getByRole('heading', {
+        name: 'Publication 2 Data set 3',
+      }),
     ).toBeInTheDocument();
 
     const pagination = within(

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.module.scss
@@ -1,3 +1,6 @@
+@import '~govuk-frontend/dist/govuk/base';
+@import '~govuk-frontend/dist/govuk/core/links';
+
 .content {
   /* stylelint-disable-next-line value-no-vendor-prefix */
   display: -webkit-box;
@@ -7,5 +10,19 @@
 
   &.expanded {
     -webkit-line-clamp: unset;
+  }
+}
+
+.heading {
+  text-decoration: none;
+
+  &:hover {
+    /* stylelint-disable-next-line max-nesting-depth */
+    .title {
+      text-decoration: underline;
+      text-decoration-thickness: $govuk-link-hover-underline-thickness;
+      text-decoration-skip-ink: none;
+      text-decoration-skip: none;
+    }
   }
 }

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
@@ -89,7 +89,18 @@ export default function DataSetFileSummary({
           className: `govuk-heading-m govuk-!-margin-bottom-2`,
           id: `${id}-heading`,
         },
-        <Link to={`/data-catalogue/data-set/${dataSetFileId}`}>{title}</Link>,
+
+        <Link
+          to={`/data-catalogue/data-set/${dataSetFileId}`}
+          className={styles.heading}
+        >
+          {headingTag === 'h3' && (
+            <span className="govuk-caption-m govuk-!-font-size-16">
+              {publication.title}
+            </span>
+          )}
+          <span className={styles.title}>{title}</span>
+        </Link>,
       )}
 
       <ContentHtml
@@ -136,9 +147,6 @@ export default function DataSetFileSummary({
         </SummaryListItem>
         <SummaryListItem term="Last updated">
           <FormattedDate format="d MMM yyyy">{lastUpdated}</FormattedDate>
-        </SummaryListItem>
-        <SummaryListItem term="Publication">
-          {publication.title}
         </SummaryListItem>
         <SummaryListItem term="Release">{release.title}</SummaryListItem>
         {numDataFileRows && (

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DataSetFileSummary.tsx
@@ -27,6 +27,7 @@ interface Props {
   expanded?: boolean;
   headingTag?: 'h3' | 'h4';
   showLatestDataTag?: boolean;
+  showPublicationTitle?: boolean;
 }
 
 export default function DataSetFileSummary({
@@ -34,6 +35,7 @@ export default function DataSetFileSummary({
   expanded = false,
   headingTag = 'h3',
   showLatestDataTag = true,
+  showPublicationTitle = true,
 }: Props) {
   const {
     id: dataSetFileId,
@@ -94,7 +96,7 @@ export default function DataSetFileSummary({
           to={`/data-catalogue/data-set/${dataSetFileId}`}
           className={styles.heading}
         >
-          {headingTag === 'h3' && (
+          {showPublicationTitle && (
             <span className="govuk-caption-m govuk-!-font-size-16">
               {publication.title}
             </span>

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetSummary.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DataSetSummary.test.tsx
@@ -18,7 +18,7 @@ describe('DataSetFileSummary', () => {
     render(<DataSetFileSummary dataSetFile={testDataSetFileSummaries[0]} />);
 
     expect(
-      screen.getByRole('heading', { name: 'Data set 1' }),
+      screen.getByRole('heading', { name: 'Publication 1 Data set 1' }),
     ).toBeInTheDocument();
 
     expect(screen.getByText('Data set summary 1')).toBeInTheDocument();
@@ -28,9 +28,6 @@ describe('DataSetFileSummary', () => {
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId('Published')).getByText('1 Jan 2020'),
-    ).toBeInTheDocument();
-    expect(
-      within(screen.getByTestId('Publication')).getByText('Publication 1'),
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId('Release')).getByText('Release 1'),

--- a/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/archive_publication.robot
@@ -312,7 +312,7 @@ Check data catalogue page contains archive and superseding publication subjects
     user waits until page contains    ${SUBJECT_NAME_ARCHIVE}
 
 Check data set page shows 'Not the latest data' for archived publication subject
-    user clicks link    ${SUBJECT_NAME_ARCHIVE}
+    user clicks link containing text    ${SUBJECT_NAME_ARCHIVE}
     user waits until page contains    Data set from ${PUBLICATION_NAME_ARCHIVE}
     user checks page contains    Not the latest data
 

--- a/tests/robot-tests/tests/general_public/data_set_page_absence_in_prus.robot
+++ b/tests/robot-tests/tests/general_public/data_set_page_absence_in_prus.robot
@@ -13,7 +13,7 @@ Force Tags          GeneralPublic    Local    Dev    Preprod
 Navigate to Absence in PRUs data set from data catalogue
     user navigates to data catalogue page on public frontend
     user chooses select option    id:filters-form-theme    ${PUPILS_AND_SCHOOLS_THEME_TITLE}
-    user clicks link    Absence in PRUs
+    user clicks link containing text    Absence in PRUs
 
 Validate title
     user waits until h1 is visible    Absence in PRUs    %{WAIT_MEDIUM}

--- a/tests/robot-tests/tests/public_api/public_api_major_auto_changes.robot
+++ b/tests/robot-tests/tests/public_api/public_api_major_auto_changes.robot
@@ -225,7 +225,7 @@ Search for the new data set version
     user checks page contains link    ${SUBJECT_2_NAME}
 
 User clicks on the new data set version link
-    user clicks link    ${SUBJECT_2_NAME}
+    user clicks link containing text    ${SUBJECT_2_NAME}
     user waits until page finishes loading
     user waits until h1 is visible    ${SUBJECT_2_NAME}
 

--- a/tests/robot-tests/tests/public_api/public_api_minor_manual_changes.robot
+++ b/tests/robot-tests/tests/public_api/public_api_minor_manual_changes.robot
@@ -326,7 +326,7 @@ Search for the new API data set version
     user checks page contains link    ${SUBJECT_2_NAME}
 
 User clicks on the new data set version link
-    user clicks link    ${SUBJECT_2_NAME}
+    user clicks link containing text    ${SUBJECT_2_NAME}
     user waits until page finishes loading
     user waits until h1 is visible    ${SUBJECT_2_NAME}
 

--- a/tests/robot-tests/tests/public_api/public_api_preview_token.robot
+++ b/tests/robot-tests/tests/public_api/public_api_preview_token.robot
@@ -275,7 +275,7 @@ Search for API data set
     user checks list item contains    testid:data-set-file-list    1    ${SUBJECT_NAME_1}
 
 User clicks on API data set link
-    user clicks link    ${SUBJECT_NAME_1}
+    user clicks link containing text    ${SUBJECT_NAME_1}
     user waits until page finishes loading
 
     user waits until h1 is visible    ${SUBJECT_NAME_1}


### PR DESCRIPTION
Moves the publication title to above the data set name in the list on the data catalogue page. To make sure it's accessible the publication name is included in the heading and link, which required a bit of CSS re-jigging to make it look right.

When the list is filtered by publication the publication title doesn't show on the data sets as it's shown as a heading on the page so there's no need.

I think I've caught all the places this would cause UI tests to break, apologies if not (I can't get clean runs because of other failures).

Also, removes an unused import in PageMeta as the build was complaining about it.

<img width="654" height="395" alt="Screenshot 2025-07-24 144322" src="https://github.com/user-attachments/assets/333a1ff5-755f-4fde-9933-7e883e86237d" />
