### PR TITLE
EES-6324 make sure the add comment form is always visible

### DIFF
--- a/src/explore-education-statistics-common/src/hooks/usePinElementToContainer.module.scss
+++ b/src/explore-education-statistics-common/src/hooks/usePinElementToContainer.module.scss
@@ -1,3 +1,5 @@
 .fixPosition {
   position: fixed;
+  // Allow space for sticky edit mode bar height
+  top: 60px;
 }


### PR DESCRIPTION
Previously the comment form could be obscured by the sticky edit mode bar, this makes sure it's always visible.

Before:
<img width="1306" height="732" alt="Screenshot 2025-07-24 155651" src="https://github.com/user-attachments/assets/fee68272-0233-4433-8940-098e7a79eb8d" />

After:
<img width="1299" height="758" alt="Screenshot 2025-07-24 155612" src="https://github.com/user-attachments/assets/0b67e08a-6f8a-41fc-a907-e7c1d79bc3f5" />
