### PR TITLE
EES-5779/EES-6343 The API details page for a draft API data set version should hide the actions section if its empty

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -34,6 +34,7 @@ import { useQuery } from '@tanstack/react-query';
 import React, { useEffect, useState } from 'react';
 import { generatePath, useHistory, useParams } from 'react-router-dom';
 import isPatchVersion from '@common/utils/isPatchVersion';
+import shouldShowDraftActions from '@admin/pages/release/data/utils/shouldShowDraftActions';
 
 export type DataSetFinalisingStatus = 'finalising' | 'finalised' | undefined;
 
@@ -104,9 +105,11 @@ export default function ReleaseApiDataSetDetailsPage() {
 
   const canUpdateRelease = releaseVersion.approvalStatus !== 'Approved';
 
-  const showDraftVersionActions =
-    dataSet?.draftVersion?.status !== 'Processing';
-
+  const showDraftVersionActions = shouldShowDraftActions(
+    isPatch,
+    canUpdateRelease,
+    dataSet,
+  );
   const draftVersionSummary = dataSet?.draftVersion ? (
     <ApiDataSetVersionSummaryList
       dataSetVersion={dataSet.draftVersion}
@@ -257,7 +260,7 @@ export default function ReleaseApiDataSetDetailsPage() {
     dataSet.draftVersion.mappingStatus.locationsComplete;
 
   const showDraftVersionTasks =
-    showDraftVersionActions &&
+    dataSet?.draftVersion?.status !== 'Processing' &&
     finalisingStatus !== 'finalising' &&
     dataSet?.draftVersion?.mappingStatus &&
     (dataSet?.draftVersion?.status === 'Draft' ||

--- a/src/explore-education-statistics-admin/src/pages/release/data/utils/__tests__/shouldShowDraftActions.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/data/utils/__tests__/shouldShowDraftActions.test.ts
@@ -1,0 +1,77 @@
+import {
+  ApiDataSet,
+  ApiDataSetDraftVersion,
+} from '@admin/services/apiDataSetService';
+import shouldShowDraftActions from '../shouldShowDraftActions';
+
+describe('showDraftVersionActions', () => {
+  const testDraftDataSet: ApiDataSetDraftVersion = {
+    status: 'Draft',
+    id: '',
+    version: '2.0',
+    type: 'Major',
+    file: { id: '', title: '' },
+    releaseVersion: { id: '', title: '' },
+    totalResults: 0,
+  };
+  const testApiDatafile: ApiDataSet = {
+    draftVersion: testDraftDataSet,
+    id: '',
+    title: '',
+    summary: '',
+    status: 'Draft',
+    previousReleaseIds: [],
+  };
+
+  test.each`
+    isPatch  | canUpdateRelease | testCase
+    ${true}  | ${true}          | ${'both isPatch and canUpdateRelease are enabled'}
+    ${true}  | ${false}         | ${'isPatch is enabled but canUpdateRelease is disabled'}
+    ${false} | ${false}         | ${'both isPatch and canUpdateRelease are disabled'}
+  `(
+    'hides the actions section if draftVersion is undefined when $testCase',
+    ({ isPatch, canUpdateRelease, testCase }) => {
+      expect(
+        shouldShowDraftActions(isPatch, canUpdateRelease, {
+          ...testApiDatafile,
+          draftVersion: undefined,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it('hides the actions section if draftVersion.status is Processing', () => {
+    expect(
+      shouldShowDraftActions(false, true, {
+        ...testApiDatafile,
+        draftVersion: { ...testDraftDataSet, status: 'Processing' },
+      }),
+    ).toBe(false);
+  });
+
+  it('shows the actions section if draftVersion.status is not Draft and isPatch is false and canUpdateRelease is true', () => {
+    expect(
+      shouldShowDraftActions(false, true, {
+        ...testApiDatafile,
+        draftVersion: { ...testDraftDataSet, status: 'Mapping' },
+      }),
+    ).toBe(true);
+  });
+
+  it('hides the actions section if draftVersion.status is not Draft and isPatch is true', () => {
+    expect(
+      shouldShowDraftActions(true, true, {
+        ...testApiDatafile,
+        draftVersion: { ...testDraftDataSet, status: 'Mapping' },
+      }),
+    ).toBe(false);
+  });
+
+  it('shows the actions section if status is Draft, isPatch is false, canUpdateRelease is true', () => {
+    expect(shouldShowDraftActions(false, true, testApiDatafile)).toBe(true);
+  });
+
+  it('shows the actions section if status is Draft, isPatch is false, canUpdateRelease is false', () => {
+    expect(shouldShowDraftActions(false, false, testApiDatafile)).toBe(true);
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/data/utils/shouldShowDraftActions.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/data/utils/shouldShowDraftActions.ts
@@ -1,0 +1,15 @@
+import { ApiDataSet } from '@admin/services/apiDataSetService';
+
+export default function shouldShowDraftActions(
+  isPatch: boolean,
+  canUpdateRelease: boolean,
+  dataSet?: ApiDataSet,
+): boolean {
+  if (dataSet?.draftVersion?.status === 'Processing') {
+    return false;
+  }
+
+  return (
+    dataSet?.draftVersion?.status === 'Draft' || (!isPatch && canUpdateRelease)
+  );
+}


### PR DESCRIPTION
# EES-5779/EES-6343 The API details page for a draft API data set version should hide the actions section if its empty
## Summary
This Pull Request introduces a utility function, `shouldShowDraftActions`, to determine if the draft version actions should be displayed on the API details page for a new release. It integrates it into the `ReleaseApiDataSetDetailsPage` component. Additionally, accompanying unit tests are added to ensure the function behaves as expected.
## Main changes:
 - Added the `shouldShowDraftActions` helper function in `utils/shouldShowDraftActions.ts` to encapsulate logic for draft version action visibility.
 - Updated `ReleaseApiDataSetDetailsPage.tsx` to use the new utility function for determining whether to display draft version actions.
 - Added a new test file `__tests__/shouldShowDraftActions.test.ts` with comprehensive test cases to verify the behaviour of `shouldShowDraftActions`.