### PR TITLE
EES-6168 Use common appInsights for analytics

### DIFF
--- a/infrastructure/templates/analytics/application/analyticsApplicationInsights.bicep
+++ b/infrastructure/templates/analytics/application/analyticsApplicationInsights.bicep
@@ -13,11 +13,17 @@ param location string
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
+// Shared log analytics workspace. Currently the Public API deployment is responsible for creating this.
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-02-01' existing = {
+  name: resourceNames.existingResources.logAnalyticsWorkspace
+}
+
 module applicationInsightsModule '../../public-api/components/appInsights.bicep' = {
   name: 'applicationInsightsModuleDeploy'
   params: {
     location: location
     appInsightsName: '${resourcePrefix}-${abbreviations.insightsComponents}-analytics'
+    logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     alerts: {
       exceptionCount: true
       exceptionServerCount: true

--- a/infrastructure/templates/analytics/application/analyticsFunctionApp.bicep
+++ b/infrastructure/templates/analytics/application/analyticsFunctionApp.bicep
@@ -56,6 +56,11 @@ resource storagePrivateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets
   parent: vNet
 }
 
+// Shared log analytics workspace. Currently the Public API deployment is responsible for creating this.
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-02-01' existing = {
+  name: resourceNames.existingResources.logAnalyticsWorkspace
+}
+
 var fileShareMountPath = '/data/analytics'
 
 module functionAppModule '../../common/components/functionApp.bicep' = {
@@ -64,6 +69,8 @@ module functionAppModule '../../common/components/functionApp.bicep' = {
     functionAppName: '${resourcePrefix}-${abbreviations.webSitesFunctions}-analytics'
     location: location
     applicationInsightsConnectionString: applicationInsightsConnectionString
+    diagnosticSettingEnabled: true
+    logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     appServicePlanName: '${resourcePrefix}-${abbreviations.webServerFarms}-analytics'
     appSettings: [
       {

--- a/infrastructure/templates/analytics/main.bicep
+++ b/infrastructure/templates/analytics/main.bicep
@@ -53,6 +53,7 @@ var resourceNames = {
     keyVault: '${subscription}-kv-ees-01'
     vNet: '${subscription}-vnet-ees'
     alertsGroup: '${subscription}-ag-ees-alertedusers'
+    logAnalyticsWorkspace: '${resourcePrefix}-log'
     subnets: {
       analyticsFunctionApp: '${resourcePrefix}-snet-${abbreviations.webSitesFunctions}-analytics'
       storagePrivateEndpoints: '${resourcePrefix}-snet-${abbreviations.storageStorageAccounts}-anlyt-${abbreviations.privateEndpoints}'

--- a/infrastructure/templates/analytics/types.bicep
+++ b/infrastructure/templates/analytics/types.bicep
@@ -4,6 +4,7 @@ type ResourceNames = {
     keyVault: string
     vNet: string
     alertsGroup: string
+    logAnalyticsWorkspace: string
     subnets: {
       analyticsFunctionApp: string
       storagePrivateEndpoints: string


### PR DESCRIPTION
This PR uses the new common LogAnalyticsWorkspace with the analytics appInsights instance. I have already manually migrated the app insights instance via the azure portal - this is to check that everything still works after having updated the bicep template.