### PR TITLE
EES-5779/EES-6363 - Show more specific error messages in the API details page (for incomplete manual mapping vs for major version change found).

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -286,25 +286,20 @@ export default function ReleaseApiDataSetDetailsPage() {
     (!dataSet.draftVersion.mappingStatus.filtersComplete ||
       !dataSet.draftVersion.mappingStatus.locationsComplete);
 
-  const errorSummaryHeadingPrefix =
-    'This API data set can not be published because it has ';
-
-  const errorSummaryHeading = incompletesFound
-    ? `${errorSummaryHeadingPrefix} incomplete location or filter manual mapping.`
-    : `${errorSummaryHeadingPrefix} major changes that are not allowed.`;
-
-  const errorBody = incompletesFound
-    ? 'The data file uploaded has not been able to be fully auto mapped and as a result has incomplete location or filter manual mapping.'
-    : 'The data file uploaded has resulted in a major version update which is not allowed in release amendments. Major version type changes can only be made as part of new releases.';
-
   const majorVersionErrorSummary = (
     <InsetText variant="error">
       <h2 className="govuk-error-summary__title" id="error-summary-title">
-        {errorSummaryHeading}
+        {incompletesFound
+          ? 'This API data set can not be published because it has incomplete location or filter manual mapping.'
+          : 'This API data set can not be published because it has major changes that are not allowed.'}
       </h2>
       <div className="govuk-error-summary__body">
         <ul className="govuk-list govuk-error-summary__list">
-          <li>{errorBody}</li>
+          <li>
+            {incompletesFound
+              ? 'The data file uploaded has not been able to be fully auto mapped and as a result has incomplete location or filter manual mapping.'
+              : 'The data file uploaded has resulted in a major version update which is not allowed in release amendments. Major version type changes can only be made as part of new releases.'}
+          </li>
           <li>
             Please select a mapping configuration that does not result in a
             major version.

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -279,19 +279,30 @@ export default function ReleaseApiDataSetDetailsPage() {
         replaceRouteParams,
       )}`
     : '';
+
+  const incompletesFound =
+    dataSet?.draftVersion?.mappingStatus &&
+    (!dataSet.draftVersion.mappingStatus.filtersComplete ||
+      !dataSet.draftVersion.mappingStatus.locationsComplete);
+
+  const errorSummaryHeadingPrefix =
+    'This API data set can not be published because it has ';
+
+  const errorSummaryHeading = incompletesFound
+    ? `${errorSummaryHeadingPrefix} incomplete location or filter manual mapping.`
+    : `${errorSummaryHeadingPrefix} major changes that are not allowed.`;
+
+  const errorBody = incompletesFound
+    ? 'The data file uploaded has not been able to be fully auto mapped and as a result has incomplete location or filter manual mapping.'
+    : 'The data file uploaded has resulted in a major version update which is not allowed in release amendments. Major version type changes can only be made as part of new releases.';
   const majorVersionErrorSummary = (
     <div className="govuk-inset-text InsetText_error__ZDwli" role="alert">
       <h2 className="govuk-error-summary__title" id="error-summary-title">
-        This API data set can not be published because it is either incomplete
-        or has a major version update.
+        {errorSummaryHeading}
       </h2>
       <div className="govuk-error-summary__body">
         <ul className="govuk-list govuk-error-summary__list">
-          <li>
-            The data file uploaded has incomplete sections or has resulted in a
-            major version update which is not allowed in release amendments.
-            Major version type changes can only be made as part of new releases.
-          </li>
+          <li>{errorBody}</li>
           <li>
             Please select a mapping configuration that does not result in a
             major version.

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -34,6 +34,7 @@ import { useQuery } from '@tanstack/react-query';
 import React, { useEffect, useState } from 'react';
 import { generatePath, useHistory, useParams } from 'react-router-dom';
 import isPatchVersion from '@common/utils/isPatchVersion';
+import InsetText from '@common/components/InsetText';
 import shouldShowDraftActions from '@admin/pages/release/data/utils/shouldShowDraftActions';
 
 export type DataSetFinalisingStatus = 'finalising' | 'finalised' | undefined;
@@ -295,8 +296,9 @@ export default function ReleaseApiDataSetDetailsPage() {
   const errorBody = incompletesFound
     ? 'The data file uploaded has not been able to be fully auto mapped and as a result has incomplete location or filter manual mapping.'
     : 'The data file uploaded has resulted in a major version update which is not allowed in release amendments. Major version type changes can only be made as part of new releases.';
+
   const majorVersionErrorSummary = (
-    <div className="govuk-inset-text InsetText_error__ZDwli" role="alert">
+    <InsetText variant="error">
       <h2 className="govuk-error-summary__title" id="error-summary-title">
         {errorSummaryHeading}
       </h2>
@@ -319,7 +321,7 @@ export default function ReleaseApiDataSetDetailsPage() {
           <li>For further guidance, contact the EES team.</li>
         </ul>
       </div>
-    </div>
+    </InsetText>
   );
   return (
     <>

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -963,7 +963,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     await waitFor(() => {
       expect(
         screen.queryByText(
-          'This API data set can not be published because it has Major changes that are not allowed.',
+          'This API data set can not be published because it has major changes that are not allowed.',
           {
             selector: 'h2',
           },

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -941,7 +941,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     });
   });
 
-  test('renders error summary when draft version has a major version update and feature flag for replacement is turned on', async () => {
+  test('renders error summary for when draft version has a major version update and feature flag for replacement is turned on', async () => {
     apiDataSetService.getDataSet.mockResolvedValue({
       ...testDataSet,
       draftVersion: {
@@ -951,6 +951,47 @@ describe('ReleaseApiDataSetDetailsPage', () => {
           isMajorVersionUpdate: true,
           locationsComplete: true,
           filtersComplete: true,
+          filtersHaveMajorChange: true,
+          locationsHaveMajorChange: true,
+        },
+      },
+    });
+
+    const options = { enableReplacementOfPublicApiDataSets: true };
+    renderPage(options);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          'This API data set can not be published because it has Major changes that are not allowed.',
+          {
+            selector: 'h2',
+          },
+        ),
+      ).toBeInTheDocument();
+
+      expect(() =>
+        screen.getByText('Draft API data set version is ready to be published'),
+      ).toThrow('Unable to find an element');
+
+      expect(() =>
+        screen.getByText(
+          'This API data set can not be published because it has incomplete location or filter manual mapping.',
+        ),
+      ).toThrow('Unable to find an element');
+    });
+  });
+
+  test('renders error summary for incomplete when draft version doesnt have major version update but is incomplete and feature flag for replacement is turned on', async () => {
+    apiDataSetService.getDataSet.mockResolvedValue({
+      ...testDataSet,
+      draftVersion: {
+        ...testDraftVersion,
+        version: '2.0.1',
+        mappingStatus: {
+          isMajorVersionUpdate: true,
+          locationsComplete: false,
+          filtersComplete: false,
           filtersHaveMajorChange: false,
           locationsHaveMajorChange: false,
         },
@@ -963,7 +1004,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     await waitFor(() => {
       expect(
         screen.queryByText(
-          'This API data set can not be published because it is either incomplete or has a major version update.',
+          'This API data set can not be published because it has incomplete location or filter manual mapping.',
           {
             selector: 'h2',
           },
@@ -972,6 +1013,12 @@ describe('ReleaseApiDataSetDetailsPage', () => {
 
       expect(() =>
         screen.getByText('Draft API data set version is ready to be published'),
+      ).toThrow('Unable to find an element');
+
+      expect(() =>
+        screen.getByText(
+          'This API data set can not be published because it has Major changes that are not allowed',
+        ),
       ).toThrow('Unable to find an element');
     });
   });
@@ -998,7 +1045,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     await waitFor(() => {
       expect(
         screen.queryByText(
-          'This API data set can not be published because it is either incomplete or has a major version update.',
+          'This API data set can not be published because it has incomplete location or filter manual mapping.',
           {
             selector: 'h2',
           },
@@ -1047,7 +1094,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     await waitFor(() => {
       expect(
         screen.queryByText(
-          'This API data set can not be published because it is either incomplete or has a major version update.',
+          'This API data set can not be published because it has incomplete location or filter manual mapping.',
           {
             selector: 'h2',
           },


### PR DESCRIPTION
This PR Improves the content design of the error summary displayed in the API data set details page.

It does this by making the message more specific to the error at hand. 
If the error summary for patch versions that result in incomplete automapping display a message for incomplete mapping, otherwise if it results in a major change, the error summary is more specific for major change.

e.g.,
<img width="1309" height="256" alt="image" src="https://github.com/user-attachments/assets/540a469e-0ef6-4761-b9fc-d102b2e4ddbf" />

<img width="1324" height="281" alt="image" src="https://github.com/user-attachments/assets/2e22c093-180b-4ce9-9ce4-516e5950daec" />

We are also adding the use of component InsetText with variant="error" when rendering error summary for the API details page