### PR TITLE
EES-6168 Use common Log Analytics Workspace with App Insight instances

### DIFF
--- a/infrastructure/templates/public-api/application/public-api/publicApiAppInsights.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiAppInsights.bicep
@@ -9,11 +9,17 @@ param location string
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
+// Shared log analytics workspace. Currently the Public API deployment is responsible for creating this.
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-02-01' existing = {
+  name: resourceNames.existingResources.logAnalyticsWorkspace
+}
+
 module applicationInsightsModule '../../components/appInsights.bicep' = {
   name: 'appInsightsDeploy'
   params: {
     location: location
     appInsightsName: resourceNames.publicApi.appInsights
+    logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     alerts: {
       exceptionCount: true
       exceptionServerCount: true

--- a/infrastructure/templates/public-api/components/appInsights.bicep
+++ b/infrastructure/templates/public-api/components/appInsights.bicep
@@ -7,7 +7,7 @@ param location string
 param appInsightsName string
 
 @description('Resource Id of the log analytics workspace which the data will be ingested to.')
-param logAnalyticsWorkspaceId string?
+param logAnalyticsWorkspaceId string
 
 @description('Whether to create or update Azure Monitor alerts during this deploy')
 param alerts {

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -204,6 +204,7 @@ var resourceNames = {
       storagePrivateEndpoints: '${publicApiResourcePrefix}-snet-${abbreviations.storageStorageAccounts}-pep'
       psqlFlexibleServer: '${commonResourcePrefix}-snet-${abbreviations.dBforPostgreSQLServers}'
     }
+    logAnalyticsWorkspace: '${commonResourcePrefix}-log'
   }
   sharedResources: {
     appGateway: '${commonResourcePrefix}-${abbreviations.networkApplicationGateways}-01'

--- a/infrastructure/templates/public-api/types.bicep
+++ b/infrastructure/templates/public-api/types.bicep
@@ -32,6 +32,7 @@ type ResourceNames = {
     acr: string
     acrResourceGroup: string
     coreStorageAccount: string
+    logAnalyticsWorkspace: string
     subnets: {
       dataProcessor: string
       dataProcessorPrivateEndpoints: string

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -787,6 +787,7 @@
     "contentDbName": "content",
     "statisticsDbName": "statistics",
     "statisticsReplicaDbName": "statistics",
+    "appInsightsWorkspace": "[concat(parameters('subscription'), '-', parameters('environment'), '-log')]",
     "dataAppName": "[concat(parameters('subscription'), '-as-', parameters('environment'), '-data')]",
     "dataPlanName": "[concat(parameters('subscription'), '-asp-', parameters('environment'), '-data')]",
     "dataAppInsights": "[concat(parameters('subscription'), '-ai-', parameters('environment'), '-data')]",
@@ -1514,7 +1515,8 @@
       },
       "properties": {
         "applicationId": "[variables('dataAppName')]",
-        "Request_Source": "AzureTfsExtensionAzureProject"
+        "Request_Source": "AzureTfsExtensionAzureProject",
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
       }
     },
     {
@@ -1759,7 +1761,8 @@
       },
       "properties": {
         "applicationId": "[variables('contentAppName')]",
-        "Request_Source": "AzureTfsExtensionAzureProject"
+        "Request_Source": "AzureTfsExtensionAzureProject",
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
       }
     },
     {
@@ -2101,7 +2104,8 @@
       },
       "properties": {
         "applicationId": "[variables('adminAppName')]",
-        "Request_Source": "AzureTfsExtensionAzureProject"
+        "Request_Source": "AzureTfsExtensionAzureProject",
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
       }
     },
     {
@@ -2296,7 +2300,8 @@
       },
       "properties": {
         "applicationId": "[variables('publicAppName')]",
-        "Request_Source": "AzureTfsExtensionAzureProject"
+        "Request_Source": "AzureTfsExtensionAzureProject",
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
       }
     },
     {
@@ -2958,7 +2963,8 @@
       },
       "properties": {
         "Application_Type": "web",
-        "ApplicationId": "[variables('notificationsAppName')]"
+        "ApplicationId": "[variables('notificationsAppName')]",
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
       }
     },
     {
@@ -3110,7 +3116,8 @@
       },
       "properties": {
         "Application_Type": "web",
-        "ApplicationId": "[variables('importerAppName')]"
+        "ApplicationId": "[variables('importerAppName')]",
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
       }
     },
     {
@@ -3263,7 +3270,8 @@
       },
       "properties": {
         "Application_Type": "web",
-        "ApplicationId": "[variables('publisherAppName')]"
+        "ApplicationId": "[variables('publisherAppName')]",
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
       }
     },
     {


### PR DESCRIPTION
This PR changes our infrastructure to use a common Log Analytics Workspace for all App Insights instances. This is being done because classic app insight instances are being deprecated. See jira ticket for more info.

This is a hotfix to master because we need to complete this within the next couple of days.

These changes have already been successfully deployed to the dev environment (although they're not all on the dev branch).