### PR TITLE
EES-6371 permalink error styling update

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -63,7 +63,7 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
       </div>
 
       {data.status === 'SubjectRemoved' && (
-        <WarningMessage error testId="permalink-warning">
+        <WarningMessage testId="permalink-warning">
           The data used in this table is no longer valid.
         </WarningMessage>
       )}
@@ -75,7 +75,7 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
         </WarningMessage>
       )}
       {data.status === 'SubjectReplacedOrRemoved' && (
-        <WarningMessage error testId="permalink-warning">
+        <WarningMessage testId="permalink-warning">
           The data used in this table may be invalid as the subject file has
           been amended or removed since its creation.
         </WarningMessage>


### PR DESCRIPTION
We want to remove the red styling of permalink errors, here's an example of how they render now:
<img width="1502" height="1258" alt="image" src="https://github.com/user-attachments/assets/c82daf35-60b1-4088-a6f0-b77952f35639" />
