### PR TITLE
EES-6362 - Fix chart rendering with filter names containing apostrophes (punctuation)

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
@@ -147,17 +147,17 @@ const ChartDataSetsConfiguration = ({
           <div className={styles.formSelectRow}>
             {orderBy(Object.entries(meta.filters), ([_, value]) => value.order)
               .filter(([, filters]) => filters.options.length > 1)
-              .map(([categoryName, filters]) => (
+              .map(([categoryKey, category]) => (
                 <FormFieldSelect
-                  key={categoryName}
-                  name={`filters.${categoryName}`}
-                  label={categoryName}
+                  key={categoryKey}
+                  name={`filters.${categoryKey}`}
+                  label={category.legend}
                   formGroupClass={styles.formSelectGroup}
                   className="govuk-!-width-full"
                   placeholder={
-                    filters.options.length > 1 ? 'All options' : undefined
+                    category.options.length > 1 ? 'All options' : undefined
                   }
-                  options={filters.options}
+                  options={category.options}
                   order={FormSelect.unordered}
                 />
               ))}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/utils/__tests__/getSelectedDataSets.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/utils/__tests__/getSelectedDataSets.test.ts
@@ -9,6 +9,7 @@ import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 describe('getSelectedDataSets', () => {
   const testOneFilterMeta: FullTableMeta['filters'] = {
     'School type': {
+      legend: 'School type',
       name: 'School type',
       options: [
         {
@@ -31,6 +32,7 @@ describe('getSelectedDataSets', () => {
   const testTwoFilterMeta: FullTableMeta['filters'] = {
     ...testOneFilterMeta,
     'Another category1': {
+      legend: 'Another category1',
       name: 'Another category1',
       options: [
         {
@@ -49,6 +51,7 @@ describe('getSelectedDataSets', () => {
   const testThreeFilterMeta: FullTableMeta['filters'] = {
     ...testTwoFilterMeta,
     'Another category2': {
+      legend: 'Another category2',
       name: 'Another category2',
       options: [
         {

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
@@ -965,6 +965,7 @@ export const testSubjectMeta: FullTableMeta = {
   boundaryLevels: [],
   filters: {
     Filter1: {
+      legend: 'Filter 1 ',
       name: 'filter-1',
       options: [testFilter1],
       order: 0,

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/getDataSetCategoryConfigs.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/getDataSetCategoryConfigs.test.ts
@@ -62,6 +62,7 @@ describe('getDataSetCategoryConfigs', () => {
     boundaryLevels: [],
     filters: {
       Filter1: {
+        legend: 'Filter 1',
         name: 'filter-1',
         options: [
           testFilterGroup1Item1,

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/getMapDataSetCategoryConfigs.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/getMapDataSetCategoryConfigs.test.ts
@@ -52,11 +52,13 @@ describe('getMapDataSetCategoryConfigs', () => {
     boundaryLevels: [],
     filters: {
       Filter1: {
+        legend: 'Filter 1',
         name: 'filter-1',
         options: [testFilterGroupItem],
         order: 0,
       },
       Filter2: {
+        legend: 'Filter 2',
         name: 'filter-2',
         options: [testFilterGroupItem2],
         order: 0,

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DataTableCaption.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DataTableCaption.test.tsx
@@ -18,6 +18,7 @@ describe('DataTableCaption', () => {
     boundaryLevels: [],
     filters: {
       Characteristic: {
+        legend: 'Characteristic',
         name: 'characteristic',
         options: [
           new CategoryFilter({

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DownloadTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DownloadTable.test.tsx
@@ -33,6 +33,7 @@ describe('DownloadTable', () => {
     boundaryLevels: [],
     filters: {
       Characteristic: {
+        legend: 'Characteristic',
         name: 'characteristic',
         options: [
           new CategoryFilter({

--- a/src/explore-education-statistics-common/src/modules/table-tool/types/fullTable.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/types/fullTable.ts
@@ -16,6 +16,7 @@ export interface FullTableMeta {
   locations: LocationFilter[];
   timePeriodRange: TimePeriodFilter[];
   filters: Dictionary<{
+    legend: string;
     name: string;
     options: CategoryFilter[];
     order: number;

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableData.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableData.ts
@@ -119,12 +119,14 @@ const testSubjectMeta1: FullTable['subjectMeta'] = {
   ...testInitialTableSubjectMeta,
   filters: {
     Category1: {
+      legend: 'Category 1',
       name: 'category_1',
       options: [category1GroupTotalFilter1],
       order: 0,
     },
     Category2: {
-      name: 'category_1',
+      legend: 'Category 2',
+      name: 'category_2',
       options: [category2GroupDefaultFilter1, category2GroupDefaultFilter2],
       order: 1,
     },
@@ -289,11 +291,13 @@ export const testTableWithThreeLevelsOfRowAndColHeaders: FullTable = {
     ...testInitialTableSubjectMeta,
     filters: {
       Category1: {
+        legend: 'Category 1',
         name: 'category_1',
         options: [category1Group1Filter2, category1Group1Filter3],
         order: 0,
       },
       Category2: {
+        legend: 'Category 2',
         name: 'category_2',
         options: [category2GroupDefaultFilter1, category2GroupDefaultFilter2],
         order: 1,

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableDataWithDuplicateLabels.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableDataWithDuplicateLabels.ts
@@ -116,11 +116,13 @@ export const testTableWithDuplicateFilterLabels: FullTable = {
     ...testInitialTableSubjectMeta,
     filters: {
       Category1: {
+        legend: 'Category 1',
         name: 'category_1',
         options: [category1Filter1, category1Filter2],
         order: 0,
       },
       Category2: {
+        legend: 'Category 2',
         name: 'category_2',
         options: [category2Filter1, category2Filter2],
         order: 0,
@@ -177,11 +179,13 @@ export const testTableWithDuplicateFilterLabelsAndMissingData: FullTable = {
     ...testInitialTableSubjectMeta,
     filters: {
       Category1: {
+        legend: 'Category 1',
         name: 'category_1',
         options: [category1Filter1, category1Filter2],
         order: 0,
       },
       Category2: {
+        legend: 'Category 2',
         name: 'category_2',
         options: [category2Filter1, category2Filter2],
         order: 0,
@@ -240,11 +244,13 @@ export const testTableWithMultipleGroupsWithSameLabels: FullTable = {
     ...testInitialTableSubjectMeta,
     filters: {
       Category3: {
+        legend: 'Category 3',
         name: 'category_3',
         options: [category3Group1Filter1, category3Group2Filter1],
         order: 1,
       },
       Category4: {
+        legend: 'Category 4',
         name: 'category_4',
         options: [category4Group1Filter1, category4Group2Filter1],
         order: 0,

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableDataWithMergedCells.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__data__/testTableDataWithMergedCells.ts
@@ -107,6 +107,7 @@ export const testTableWithOnlyMergedCellsInHeaders: FullTable = {
     ...testInitialTableSubjectMeta,
     filters: {
       Category1: {
+        legend: 'Category 1',
         name: 'category_1',
         options: [category1Group1Filter1, category1Group2Filter2],
         order: 0,
@@ -159,6 +160,7 @@ export const testTableWithMergedAndUnMergedCellsInHeaders: FullTable = {
     ...testInitialTableSubjectMeta,
     filters: {
       Category1: {
+        legend: 'Category 1',
         name: 'category_1',
         options: [category1Group1Filter1, category1Group2Filter1],
         order: 0,
@@ -214,11 +216,13 @@ export const testTableWithOnlyMergedCellsInFirstLevelOfHeaders: FullTable = {
     ...testInitialTableSubjectMeta,
     filters: {
       Category1: {
+        legend: 'Category 1',
         name: 'category_1',
         options: [category1Group1Filter1, category1Group2Filter2],
         order: 0,
       },
       Category2: {
+        legend: 'Category 2',
         name: 'category_2',
         options: [category2Group1Filter1, category2Group1Filter2],
         order: 0,
@@ -293,11 +297,13 @@ export const testTableWithMergedAndUnmergedCellsInFirstLevelOfHeaders: FullTable
       ...testInitialTableSubjectMeta,
       filters: {
         Category1: {
+          legend: 'Category 1',
           name: 'category_1',
           options: [category1Group1Filter1, category1Group2Filter1],
           order: 0,
         },
         Category2: {
+          legend: 'Category 2',
           name: 'category_2',
           options: [category2Group1Filter1, category2Group1Filter2],
           order: 0,
@@ -371,11 +377,13 @@ export const testTableWithOnlyMergedCellsInMiddleLevelOfHeaders: FullTable = {
     ...testInitialTableSubjectMeta,
     filters: {
       Category1: {
+        legend: 'Category 1',
         name: 'category_1',
         options: [category1Group1Filter1, category1Group2Filter2],
         order: 0,
       },
       Category2: {
+        legend: 'Category 2',
         name: 'category_2',
         options: [category2Group1Filter1, category2Group1Filter2],
         order: 1,
@@ -450,6 +458,7 @@ export const testTableWithMergedAndUnmergedCellsInMiddleLevelOfHeaders: FullTabl
       ...testInitialTableSubjectMeta,
       filters: {
         Category1: {
+          legend: 'Category 1',
           name: 'category_1',
           options: [
             category1Group1Filter1,
@@ -459,6 +468,7 @@ export const testTableWithMergedAndUnmergedCellsInMiddleLevelOfHeaders: FullTabl
           order: 0,
         },
         Category2: {
+          legend: 'Category 2',
           name: 'category_2',
           options: [category2Group1Filter1, category2Group1Filter2],
           order: 1,
@@ -552,11 +562,13 @@ export const testTableWithOnlyMergedCellsInLastLevelOfHeaders: FullTable = {
     ...testInitialTableSubjectMeta,
     filters: {
       Category1: {
+        legend: 'Category 1',
         name: 'category_1',
         options: [category1Group1Filter1, category1Group2Filter2],
         order: 0,
       },
       Category2: {
+        legend: 'Category 2',
         name: 'category_2',
         options: [category2Group1Filter1, category2Group1Filter2],
         order: 0,
@@ -631,11 +643,13 @@ export const testTableWithMergedAndUnmergedCellsInLastLevelOfHeaders: FullTable 
       ...testInitialTableSubjectMeta,
       filters: {
         Category1: {
+          legend: 'Category 1',
           name: 'category_1',
           options: [category1Group1Filter1, category1Group2Filter1],
           order: 0,
         },
         Category2: {
+          legend: 'Category 2',
           name: 'category_2',
           options: [category2Group1Filter1, category2Group1Filter2],
           order: 0,
@@ -706,11 +720,13 @@ export const testTableWithMergedCellsAndMissingData: FullTable = {
     ...testInitialTableSubjectMeta,
     filters: {
       Category1: {
+        legend: 'Category 1',
         name: 'category_1',
         options: [category1Group1Filter1, category1Group2Filter1],
         order: 0,
       },
       Category2: {
+        legend: 'Category 2',
         name: 'category_2',
         options: [category2Group1Filter1, category2Group1Filter2],
         order: 0,
@@ -780,11 +796,13 @@ export const testTableWithMergedCellsAndMissingData2: FullTable = {
     ...testInitialTableSubjectMeta,
     filters: {
       Category2: {
+        legend: 'Category 2',
         name: 'category_2',
         options: [category2Group1Filter1, category2Group1Filter2],
         order: 2,
       },
       Category1: {
+        legend: 'Category 1',
         name: 'category_1',
         options: [
           category1Group1Filter1,
@@ -794,6 +812,7 @@ export const testTableWithMergedCellsAndMissingData2: FullTable = {
         order: 5,
       },
       Category3: {
+        legend: 'Category 3',
         name: 'category_3',
         options: [category3Group1Filter1, category3Group1Filter2],
         order: 6,

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/generateTableTitle.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/generateTableTitle.test.ts
@@ -16,6 +16,7 @@ describe('generateTableTitle', () => {
     boundaryLevels: [],
     filters: {
       Characteristic: {
+        legend: 'Characteristic',
         name: 'characteristic',
         options: [
           new CategoryFilter({
@@ -59,6 +60,7 @@ describe('generateTableTitle', () => {
       filters: {
         ...testMeta.filters,
         Characteristic: {
+          legend: 'Characteristic',
           name: 'characteristic',
           options: [
             new CategoryFilter({
@@ -71,6 +73,7 @@ describe('generateTableTitle', () => {
           order: 0,
         },
         'School Type': {
+          legend: 'School Type',
           name: 'school_type',
           options: [
             new CategoryFilter({
@@ -118,6 +121,7 @@ describe('generateTableTitle', () => {
           order: 0,
         },
         'School Type': {
+          legend: 'School Type',
           name: 'school_type',
           options: [
             new CategoryFilter({
@@ -171,6 +175,7 @@ describe('generateTableTitle', () => {
           order: 0,
         },
         'School Type': {
+          legend: 'School Type',
           name: 'school_type',
           options: [
             new CategoryFilter({
@@ -236,6 +241,7 @@ describe('generateTableTitle', () => {
           order: 0,
         },
         'School Type': {
+          legend: 'School Type',
           name: 'school_type',
           options: [
             new CategoryFilter({
@@ -296,6 +302,7 @@ describe('generateTableTitle', () => {
           order: 0,
         },
         'School Type': {
+          legend: 'School type',
           name: 'school_type',
           options: [
             new CategoryFilter({

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/mapFullTableMeta.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/mapFullTableMeta.ts
@@ -10,10 +10,10 @@ import { TableDataSubjectMeta } from '@common/services/tableBuilderService';
 export default function mapFullTableMeta(
   subjectMeta: TableDataSubjectMeta,
 ): FullTableMeta {
-  const filters = Object.values(subjectMeta.filters).reduce<
+  const filters = Object.entries(subjectMeta.filters).reduce<
     FullTableMeta['filters']
-  >((acc, category) => {
-    acc[category.legend] = {
+  >((acc, [categoryKey, category]) => {
+    acc[categoryKey] = {
       name: category.name,
       options: Object.values(category.options).flatMap(filterGroup =>
         filterGroup.options.map(

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/mapFullTableMeta.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/mapFullTableMeta.ts
@@ -15,6 +15,7 @@ export default function mapFullTableMeta(
   >((acc, [categoryKey, category]) => {
     acc[categoryKey] = {
       name: category.name,
+      legend: category.legend,
       options: Object.values(category.options).flatMap(filterGroup =>
         filterGroup.options.map(
           option =>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__data__/tableData.ts
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__data__/tableData.ts
@@ -34,6 +34,7 @@ export const testTable: FullTable = {
   subjectMeta: {
     filters: {
       Date: {
+        legend: 'Date',
         name: 'date',
         options: [
           new CategoryFilter({


### PR DESCRIPTION
Ticket https://dfedigital.atlassian.net/browse/EES-6362

in `mapFullTableMeta` the filters were keyed by their legend (which react hook form wasn't happy with), which contains plain text, including punctuation. This change makes the filters arranged and keyed by their original filter key, which is in camel case with no punctuation.

I've given this a test and ran UI tests and this change didn't seem to create any issue, however I suggest this be rigorously tested to prevent any potential bugs around existing datablocks and chart rendering on both admin and public sites