### PR TITLE
EES-5779/EES-6379 The "cancel ongoing replacement" link should point to the correct release version ID BUG FIX

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseApiDataSetDetailsPage.tsx
@@ -270,7 +270,7 @@ export default function ReleaseApiDataSetDetailsPage() {
   const replaceRouteParams = dataSet?.draftVersion?.originalFileId
     ? {
         publicationId: releaseVersion.publicationId,
-        releaseVersionId: releaseVersion.id,
+        releaseVersionId: dataSet?.draftVersion?.releaseVersion.id,
         fileId: dataSet?.draftVersion?.originalFileId as string,
       }
     : undefined;

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseApiDataSetDetailsPage.test.tsx
@@ -1244,7 +1244,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
 
       expect(() =>
         screen.getByText(
-          'The data file uploaded has incomplete sections or has resulted in a major version update which is not allowed in release amendments.',
+          'This API data set can not be published because it has major changes that are not allowed.',
         ),
       ).toThrow('Unable to find an element');
     });
@@ -1301,7 +1301,7 @@ describe('ReleaseApiDataSetDetailsPage', () => {
     await waitFor(() => {
       expect(() =>
         screen.getByText(
-          'The data file uploaded has incomplete sections or has resulted in a major version update which is not allowed in release amendments.',
+          'This API data set can not be published because it has major changes that are not allowed.',
         ),
       ).toThrow('Unable to find an element');
     });


### PR DESCRIPTION
EES-5779/EES-6379 The "cancel ongoing replacement" link should point to the correct release version ID. 

Please see bug details for ticket number EES-6379.

This PR also cleans up some test assertions (please see second commit) for tests that are unrelated to this new change.