### PR TITLE
EES-XXXX - adding simpler Docker solution for building and running Public API docs locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,9 @@
     "test:snapshot": "pnpm -r --no-bail test:snapshot",
     "test:ci": "pnpm -r --no-bail --aggregate-output --reporter=append-only test:ci",
     "test:coverage": "pnpm -r --no-bail test:coverage",
-    "tsc": "pnpm -r --aggregate-output --reporter=append-only --no-bail tsc"
+    "tsc": "pnpm -r --aggregate-output --reporter=append-only --no-bail tsc",
+    "api-docs:build": "docker rm -f ees-api-docs-builder-container && cd src/explore-education-statistics-api-docs && docker build -f docker/Dockerfile -t ees-api-docs-builder . && docker run --rm -v .:/home/ubuntu/docs --name ees-api-docs-builder-container ees-api-docs-builder ./docker/build-docs.sh",
+    "api-docs:run": "docker rm -f ees-api-docs-builder-container && cd src/explore-education-statistics-api-docs && docker build -f docker/Dockerfile -t ees-api-docs-builder . && docker run --rm -v .:/home/ubuntu/docs -p4567:4567 -p35729:35729 --name ees-api-docs-builder-container ees-api-docs-builder ./docker/run-docs.sh" 
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/src/explore-education-statistics-api-docs/README.md
+++ b/src/explore-education-statistics-api-docs/README.md
@@ -3,7 +3,31 @@
 This repository is used to generate the documentation website for the Explore education statistics API.
 It is based on the GOV.UK [Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/)
 
-## Pre-requisites
+## Building and running with Docker
+
+### Building
+
+To build the API docs, run:
+
+```shell
+pnpm api-docs:build
+```
+
+### Building and running for development
+
+To build and run the API docs using the Middleman development server and LiveReload, run:
+
+```shell
+pnpm api-docs:run
+```
+
+This will start the Middleman development server on [https://localhost:4567](https://localhost:4567).
+
+**Optional** - To automatically refresh the browser upon code changes, install the [LiveReload browser extension](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en).
+
+## Manually building and running without Docker
+
+### Pre-requisites
 
 The following pre-requisite dependencies are required to get started:
 
@@ -13,7 +37,7 @@ The following pre-requisite dependencies are required to get started:
 As always, it's advisable to install any versions using a version manager to make it easier to upgrade 
 and keep aligned with the project.
 
-### Ubuntu
+#### Ubuntu
 
 If you are using Ubuntu, you may need to install the following dependencies before you can install
 Ruby and its required gems:
@@ -22,7 +46,13 @@ Ruby and its required gems:
 sudo apt install build-essential zlib1g-dev libssl-dev libyaml-dev
 ```
 
-## Getting started
+You may also require the Ruby development package in order to compile Gems:
+
+```shell
+sudo apt install ruby-dev
+```
+
+### Getting started
 
 Once the pre-requisites have been installed, follow these steps:
 

--- a/src/explore-education-statistics-api-docs/docker/Dockerfile
+++ b/src/explore-education-statistics-api-docs/docker/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:24.04
+
+ENV NVM_DIR=/usr/local/nvm
+ENV NODE_VERSION=22.18.0
+ENV RUBY_VERSION=3.2.0
+ENV NODE_PATH=$NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:/home/ubuntu/.local/share/gem/ruby/$RUBY_VERSION/bin:$PATH
+
+# Install dependencies for installing packages and developing with Ruby. 
+RUN apt update && \
+    apt install -y gpg curl \
+    build-essential zlib1g-dev libssl-dev libyaml-dev \
+    ruby-dev && \
+    apt clean
+
+# Install NVM and Node. 
+RUN mkdir /usr/local/nvm && \
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash && \
+    . $NVM_DIR/nvm.sh && \
+    nvm install v$NODE_VERSION
+
+# Create a temporary staging area to run `bundle install` during the Docker image build.
+# This will be based upon the current state of `Gemfile` and `Gemfile.lock`.
+# This allows us to cache all the required Gem dependencies in the Docker image itself
+# so that subsequent image builds and container creations will have the Gems already cached
+# in the image, thus allowing much faster doc builds and hosting.
+RUN mkdir /tmp/gemfile-cache
+COPY Gemfile Gemfile.lock /tmp/gemfile-cache/
+RUN chown -R ubuntu:ubuntu /tmp/gemfile-cache
+
+# Use the default `ubuntu` user (which maps to the same user as on the host machine,
+# thus allowing appropriate write access to the build folders).
+USER ubuntu
+WORKDIR /home/ubuntu/docs
+
+# Cache the appropriate Gems in the Docker image based on the current state of the 
+# `Gemfile` and `Gemfile.lock` that was copied to a temporary staging area in a
+# previous step above.
+RUN gem install bundler -v 2.5.22 --user-install && \
+    cd /tmp/gemfile-cache && \
+    bundle config set --local path '/home/ubuntu/.local/share/gem' && \
+    bundle install

--- a/src/explore-education-statistics-api-docs/docker/build-docs.sh
+++ b/src/explore-education-statistics-api-docs/docker/build-docs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+bundle exec middleman build --verbose

--- a/src/explore-education-statistics-api-docs/docker/run-docs.sh
+++ b/src/explore-education-statistics-api-docs/docker/run-docs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+bundle exec middleman


### PR DESCRIPTION
# Overview

This PR was created off the back of investigating some build failures for the Public API docs on a feature branch.

During this investigation, I found that the setup process was a bit tricky and polluted my local dev machine quite a bit, so I figured it'd be a good candidate to have a Dockerized process as well as the manual one.

# New commands

This PR:
- introduces `pnpm api-docs:build` which uses Docker to build the API docs locally.
- introduces `pnpm api-docs:run` which uses Docker to build and run the API docs locally with the Middleman development server.

## Build

`pnpm api-docs:build` will validate and build the API docs, generating the built files in the `src/explore-education-statistics-api-docs/.build` folder.

## Run

`pnpm api-docs:run` will validate, build and run the API docs using Middleman, hosting  the API docs on http://localhost:4567 and exposing LiveReload on http://localhost:35729.

# Not covered in this PR

We currently aren't using this in the build and deploy pipeline.  Should we...?