### PR TITLE
EES-6370 - added new fields to ReleasePublishingFeedback for easier reporting

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Migrations/PopulateReleasePublishingFeedbackReportingFieldsMigrationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Migrations/PopulateReleasePublishingFeedbackReportingFieldsMigrationControllerTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Migrations;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Migrations;
+
+public class PopulateReleasePublishingFeedbackReportingFieldsMigrationControllerTests
+{
+    private readonly DataFixture _fixture = new();
+    
+    [Fact]
+    public async Task PopulateFields()
+    {
+        ReleaseVersion releaseVersion1 = _fixture
+            .DefaultReleaseVersion()
+            .WithRelease(_fixture
+                .DefaultRelease()
+                .WithPublication(_fixture.DefaultPublication()));
+
+        // This feedback entry has been responded to and is fully populated aside
+        // from the fields that still need migrated.
+        var releaseVersion1Feedback = new ReleasePublishingFeedback
+        {
+            Created = DateTime.UtcNow.AddDays(-2),
+            EmailToken = Guid.NewGuid().ToString(),
+            ReleaseVersion = releaseVersion1,
+            ReleaseVersionId = releaseVersion1.Id,
+            Response = ReleasePublishingFeedbackResponse.Satisfied,
+            AdditionalFeedback = "Amazing experience!",
+            FeedbackReceived = DateTime.UtcNow.AddDays(-1),
+            UserPublicationRole = PublicationRole.Allower
+        };
+
+        ReleaseVersion releaseVersion2 = _fixture
+            .DefaultReleaseVersion()
+            .WithRelease(_fixture
+                .DefaultRelease()
+                .WithPublication(_fixture.DefaultPublication()));
+
+        // This feedback entry has not yet been responded to.
+        var releaseVersion2Feedback1 = new ReleasePublishingFeedback
+        {
+            ReleaseVersion = releaseVersion2,
+            ReleaseVersionId = releaseVersion2.Id,
+            EmailToken = Guid.NewGuid().ToString(),
+            UserPublicationRole = PublicationRole.Owner
+        };
+
+        // This feedback entry has already been migrated.
+        var releaseVersion2Feedback2 = new ReleasePublishingFeedback
+        {
+            ReleaseVersion = releaseVersion2,
+            ReleaseVersionId = releaseVersion2.Id,
+            EmailToken = Guid.NewGuid().ToString(),
+            UserPublicationRole = PublicationRole.Owner,
+            ReleaseTitle = releaseVersion2.Release.Title,
+            PublicationTitle = releaseVersion2.Release.Publication.Title,
+        };
+
+        var contextId = Guid.NewGuid().ToString();
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            context.ReleaseVersions.AddRange(releaseVersion1, releaseVersion2);
+            context.ReleasePublishingFeedback.AddRange(
+                releaseVersion1Feedback, releaseVersion2Feedback1, releaseVersion2Feedback2);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            var controller = new PopulateReleasePublishingFeedbackReportingFieldsMigrationController(context);
+            var result = await controller.PopulateFields(cancellationToken: default);
+            Assert.Equal(3, result.Processed);
+        }
+        
+        await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
+        {
+            var feedbackEntries = context
+                .ReleasePublishingFeedback
+                .ToList();
+            
+            Assert.Equal(3, feedbackEntries.Count);
+            var releaseVersion1FeedbackUpdated = feedbackEntries[0];
+            var releaseVersion2Feedback1Updated = feedbackEntries[1];
+            var releaseVersion2Feedback2Updated = feedbackEntries[2];
+
+            AssertFeedbackEntryUpdateSuccessfully(
+                originalFeedback: releaseVersion1Feedback,
+                updatedFeedback: releaseVersion1FeedbackUpdated);
+            
+            AssertFeedbackEntryUpdateSuccessfully(
+                originalFeedback: releaseVersion2Feedback1,
+                updatedFeedback: releaseVersion2Feedback1Updated);
+            
+            AssertFeedbackEntryUpdateSuccessfully(
+                originalFeedback: releaseVersion2Feedback2,
+                updatedFeedback: releaseVersion2Feedback2Updated);
+        }
+    }
+
+    private void AssertFeedbackEntryUpdateSuccessfully(
+        ReleasePublishingFeedback originalFeedback,
+        ReleasePublishingFeedback updatedFeedback)
+    {
+        // Assert that the fields which should have remained untouched have not been updated.
+        Assert.Equal(originalFeedback.Id, updatedFeedback.Id);
+        Assert.Equal(originalFeedback.Created, updatedFeedback.Created);
+        Assert.Equal(originalFeedback.EmailToken, updatedFeedback.EmailToken);
+        Assert.Equal(originalFeedback.ReleaseVersionId, updatedFeedback.ReleaseVersionId);
+        Assert.Equal(originalFeedback.Response, updatedFeedback.Response);
+        Assert.Equal(originalFeedback.AdditionalFeedback, updatedFeedback.AdditionalFeedback);
+        Assert.Equal(originalFeedback.FeedbackReceived, updatedFeedback.FeedbackReceived);
+        Assert.Equal(originalFeedback.UserPublicationRole, updatedFeedback.UserPublicationRole);
+
+        // Assert that the migrated fields have been successfully filled in.
+        Assert.Equal(originalFeedback.ReleaseVersion.Release.Title, updatedFeedback.ReleaseTitle);
+        Assert.Equal(originalFeedback.ReleaseVersion.Release.Publication.Title, updatedFeedback.PublicationTitle);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Migrations/PopulateReleasePublishingFeedbackReportingFieldsMigrationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Migrations/PopulateReleasePublishingFeedbackReportingFieldsMigrationController.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Migrations;
+
+/// <summary>
+/// Migration endpoint for EES-6370.  To be removed as part of EES-6416.
+/// </summary>
+[Route("api")]
+[ApiController]
+[Authorize(Roles = GlobalRoles.RoleNames.BauUser)]
+public class PopulateReleasePublishingFeedbackReportingFieldsMigrationController(
+    ContentDbContext context) : ControllerBase
+{
+    public class MigrationResult
+    {
+        // ReSharper disable once NotAccessedField.Global
+        public int Processed;
+    }
+
+    [HttpPut("bau/populate-release-publishing-feedback-reporting-fields")]
+    public async Task<MigrationResult> PopulateFields(
+        CancellationToken cancellationToken = default)
+    {
+        var feedbackRows = context
+            .ReleasePublishingFeedback
+            .Include(f => f.ReleaseVersion)
+            .ThenInclude(rv => rv.Release)
+            .ThenInclude(r => r.Publication)
+            .ToList();
+
+        feedbackRows.ForEach(feedback =>
+        {
+            feedback.ReleaseTitle = feedback.ReleaseVersion.Release.Title;
+            feedback.PublicationTitle = feedback.ReleaseVersion.Release.Publication.Title;
+        });
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        return new MigrationResult { Processed = feedbackRows.Count };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250811120206_EES6370_AddAdditionalReportingFieldsToReleasePublishingFeedback.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250811120206_EES6370_AddAdditionalReportingFieldsToReleasePublishingFeedback.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250811120206_EES6370_AddAdditionalReportingFieldsToReleasePublishingFeedback")]
+    partial class EES6370_AddAdditionalReportingFieldsToReleasePublishingFeedback
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1144,7 +1147,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<string>("PublicationTitle")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("ReleaseTitle")
+                    b.Property<string>("ReleaseLabel")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("ReleaseTimePeriod")
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<Guid>("ReleaseVersionId")

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250811120206_EES6370_AddAdditionalReportingFieldsToReleasePublishingFeedback.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250811120206_EES6370_AddAdditionalReportingFieldsToReleasePublishingFeedback.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES6370_AddAdditionalReportingFieldsToReleasePublishingFeedback : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // These new columns are nullable right now until a manual
+            // migration endpoint is run to populate them.
+            //
+            // EES-6416 will handle making them non-nullable when all
+            // rows are migrated.
+            migrationBuilder.AddColumn<string>(
+                name: "PublicationTitle",
+                table: "ReleasePublishingFeedback",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ReleaseTitle",
+                table: "ReleasePublishingFeedback",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PublicationTitle",
+                table: "ReleasePublishingFeedback");
+
+            migrationBuilder.DropColumn(
+                name: "ReleaseTitle",
+                table: "ReleasePublishingFeedback");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleasePublishingFeedback.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleasePublishingFeedback.cs
@@ -14,7 +14,19 @@ public record ReleasePublishingFeedback : ICreatedTimestamp<DateTime>
     public required Guid ReleaseVersionId { get; set; }
 
     public ReleaseVersion ReleaseVersion { get; set; } = null!;
-    
+
+    /// <summary>
+    /// This field is optional until a manual migration populates the fields.
+    /// EES-6416 will handle making them non-nullable when all rows are migrated.
+    /// </summary>
+    public string? PublicationTitle { get; set; }
+
+    /// <summary>
+    /// This field is optional until a manual migration populates the fields.
+    /// EES-6416 will handle making them non-nullable when all rows are migrated.
+    /// </summary>
+    public string? ReleaseTitle { get; set; }
+
     public required PublicationRole UserPublicationRole { get; set; }
     
     public ReleasePublishingFeedbackResponse? Response { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/NotificationsServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/NotificationsServiceTests.cs
@@ -204,7 +204,9 @@ public abstract class NotificationsServiceTests
                 AssertNewFeedbackRecordCreatedOk(
                     feedbackEntry: ownerFeedbackEntry,
                     expectedReleaseVersionId: releaseVersionBeingPublished.Id,
-                    expectedRole: PublicationRole.Owner);
+                    expectedRole: PublicationRole.Owner,
+                    expectedReleaseTimePeriod: releaseVersionBeingPublished.Release.Title,
+                    expectedPublicationTitle: releaseVersionBeingPublished.Release.Publication.Title);
                 
                 var approverFeedbackEntry1 = feedbackEntries
                     .First(f => f.UserPublicationRole == PublicationRole.Allower);
@@ -212,7 +214,9 @@ public abstract class NotificationsServiceTests
                 AssertNewFeedbackRecordCreatedOk(
                     feedbackEntry: approverFeedbackEntry1,
                     expectedReleaseVersionId: releaseVersionBeingPublished.Id,
-                    expectedRole: PublicationRole.Allower);
+                    expectedRole: PublicationRole.Allower,
+                    expectedReleaseTimePeriod: releaseVersionBeingPublished.Release.Title,
+                    expectedPublicationTitle: releaseVersionBeingPublished.Release.Publication.Title);
                 
                 var approverFeedbackEntry2 = feedbackEntries
                     .Last(f => f.UserPublicationRole == PublicationRole.Allower);
@@ -220,7 +224,9 @@ public abstract class NotificationsServiceTests
                 AssertNewFeedbackRecordCreatedOk(
                     feedbackEntry: approverFeedbackEntry2,
                     expectedReleaseVersionId: releaseVersionBeingPublished.Id,
-                    expectedRole: PublicationRole.Allower);
+                    expectedRole: PublicationRole.Allower,
+                    expectedReleaseTimePeriod: releaseVersionBeingPublished.Release.Title,
+                    expectedPublicationTitle: releaseVersionBeingPublished.Release.Publication.Title);
 
                 notifierClient.Verify(mock => mock.NotifyReleasePublishingFeedbackUsers(
                         new List<ReleasePublishingFeedbackMessage>
@@ -303,7 +309,9 @@ public abstract class NotificationsServiceTests
                 AssertNewFeedbackRecordCreatedOk(
                     feedbackEntry: release1OwnerFeedbackEntry,
                     expectedReleaseVersionId: release1Version.Id,
-                    expectedRole: PublicationRole.Owner);
+                    expectedRole: PublicationRole.Owner,
+                    expectedReleaseTimePeriod: release1Version.Release.Title,
+                    expectedPublicationTitle: release1Version.Release.Publication.Title);
 
                 var release2OwnerFeedbackEntry = feedbackEntries
                     .Single(f => f.ReleaseVersionId == release2Version.Id);
@@ -311,7 +319,9 @@ public abstract class NotificationsServiceTests
                 AssertNewFeedbackRecordCreatedOk(
                     feedbackEntry: release2OwnerFeedbackEntry,
                     expectedReleaseVersionId: release2Version.Id,
-                    expectedRole: PublicationRole.Owner);
+                    expectedRole: PublicationRole.Owner,
+                    expectedReleaseTimePeriod: release2Version.Release.Title,
+                    expectedPublicationTitle: release2Version.Release.Publication.Title);
 
                 notifierClient.Verify(mock => mock.NotifyReleasePublishingFeedbackUsers(
                         new List<ReleasePublishingFeedbackMessage>
@@ -434,7 +444,9 @@ public abstract class NotificationsServiceTests
         private static void AssertNewFeedbackRecordCreatedOk(
             ReleasePublishingFeedback feedbackEntry,
             Guid expectedReleaseVersionId,
-            PublicationRole expectedRole)
+            PublicationRole expectedRole,
+            string expectedReleaseTimePeriod,
+            string expectedPublicationTitle)
         {
             feedbackEntry.Created.AssertUtcNow();
             Assert.NotEmpty(feedbackEntry.EmailToken);
@@ -442,6 +454,8 @@ public abstract class NotificationsServiceTests
             Assert.Null(feedbackEntry.AdditionalFeedback);
             Assert.Equal(expectedReleaseVersionId, feedbackEntry.ReleaseVersionId);
             Assert.Equal(expectedRole, feedbackEntry.UserPublicationRole);
+            Assert.Equal(expectedReleaseTimePeriod, feedbackEntry.ReleaseTitle);
+            Assert.Equal(expectedPublicationTitle, feedbackEntry.PublicationTitle);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/NotificationsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/NotificationsService.cs
@@ -65,6 +65,8 @@ public class NotificationsService(
                         {
                             ReleaseVersion = releaseVersion,
                             ReleaseVersionId = releaseVersion.Id,
+                            ReleaseTitle = releaseVersion.Release.Title,
+                            PublicationTitle = releaseVersion.Release.Publication.Title,
                             UserPublicationRole = upr.Role,
                             EmailToken = Guid.NewGuid().ToString()
                         };


### PR DESCRIPTION
This PR:
- adds a new PublicationTitle column to the ReleasePublishingFeedback table for easier reporting for Cam.
- adds a new combined ReleaseTitle ("<TimeIdentifier> <Year> <Label>") column to the ReleasePublishingFeedback table for easier reporting for Cam.
- adds a manual migration endpoint for updating existing feedback entries.

The reason that we have a manual migration endpoint is that the database has no notion of the plain-English labels that we use to refer to the different TimeIdentifiers.  E.g. we typically would store "AY" in the db which in code is then surfaced as "Academic year".  A SQL migration would require a monster case statement!

After this code is deployed, we need to call the following manual migration endpoint:

`PUT /api/bau/populate-release-publishing-feedback-reporting-fields`

When the manual migration endpoint has run, we can merge in the PR for EES-6416, which will allow us to set these new fields to being non-nullable.  