### PR TITLE
EES-6411 - (STEP 4) Adding unique indexes for (`PublicationId`, `Email`, `Role`) for Publication Invites & (`ReleaseVersionId`, `Email`, `Role`) for Release Invites

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPublicationInviteRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserPublicationInviteRepositoryTests.cs
@@ -97,7 +97,7 @@ public abstract class UserPublicationInviteRepositoryTests
     public class RemoveTests : UserPublicationInviteRepositoryTests
     {
         [Fact]
-        public async Task TargetInvitesExist_RemovesTargetedInvites()
+        public async Task TargetInviteExists_RemovesTargetedInvites()
         {
             var targetEmail = "test1@test.com";
             var otherEmail = "test2@test.com";
@@ -109,26 +109,23 @@ public abstract class UserPublicationInviteRepositoryTests
                 .Generate();
 
             var userPublicationInvites = _fixture.DefaultUserPublicationInvite()
-                // These 2 invites should be removed
+                // This invite should be removed
                 .ForIndex(0, s => s.SetPublication(targetPublication))
                 .ForIndex(0, s => s.SetEmail(targetEmail))
                 .ForIndex(0, s => s.SetRole(targetRole))
-                .ForIndex(1, s => s.SetPublication(targetPublication))
+                // This invite is for a different publication and should not be removed
+                .ForIndex(1, s => s.SetPublication(otherPublication))
                 .ForIndex(1, s => s.SetEmail(targetEmail))
                 .ForIndex(1, s => s.SetRole(targetRole))
-                // This invite is for a different publication and should not be removed
-                .ForIndex(2, s => s.SetPublication(otherPublication))
-                .ForIndex(2, s => s.SetEmail(targetEmail))
-                .ForIndex(2, s => s.SetRole(targetRole))
                 // This invite is for a different email and should not be removed
-                .ForIndex(3, s => s.SetPublication(targetPublication))
-                .ForIndex(3, s => s.SetEmail(otherEmail))
-                .ForIndex(3, s => s.SetRole(targetRole))
+                .ForIndex(2, s => s.SetPublication(targetPublication))
+                .ForIndex(2, s => s.SetEmail(otherEmail))
+                .ForIndex(2, s => s.SetRole(targetRole))
                 // This invite is for a different role and should not be removed
-                .ForIndex(4, s => s.SetPublication(targetPublication))
-                .ForIndex(4, s => s.SetEmail(targetEmail))
-                .ForIndex(4, s => s.SetRole(otherRole))
-                .GenerateList(5);
+                .ForIndex(3, s => s.SetPublication(targetPublication))
+                .ForIndex(3, s => s.SetEmail(targetEmail))
+                .ForIndex(3, s => s.SetRole(otherRole))
+                .GenerateList(4);
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
@@ -170,7 +167,7 @@ public abstract class UserPublicationInviteRepositoryTests
         }
 
         [Fact]
-        public async Task NoInvitesExist_DoesNothing()
+        public async Task InviteDoesNotExist_DoesNothing()
         {
             var contentDbContextId = Guid.NewGuid().ToString();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseInviteRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseInviteRepositoryTests.cs
@@ -242,7 +242,7 @@ public abstract class UserReleaseInviteRepositoryTests
     public class RemoveTests : UserReleaseInviteRepositoryTests
     {
         [Fact]
-        public async Task TargetInvitesExist_RemovesTargetedInvites()
+        public async Task TargetInviteExists_RemovesTargetedInvites()
         {
             var targetEmail = "test1@test.com";
             var otherEmail = "test2@test.com";
@@ -260,26 +260,23 @@ public abstract class UserReleaseInviteRepositoryTests
                 .Generate();
 
             var userReleaseInvites = _fixture.DefaultUserReleaseInvite()
-                // These 2 invites should be removed
+                // This invite should be removed
                 .ForIndex(0, s => s.SetReleaseVersion(targetReleaseVersion))
                 .ForIndex(0, s => s.SetEmail(targetEmail))
                 .ForIndex(0, s => s.SetRole(targetRole))
-                .ForIndex(1, s => s.SetReleaseVersion(targetReleaseVersion))
+                // This invite is for a different release version and should not be removed
+                .ForIndex(1, s => s.SetReleaseVersion(otherReleaseVersion))
                 .ForIndex(1, s => s.SetEmail(targetEmail))
                 .ForIndex(1, s => s.SetRole(targetRole))
-                // This invite is for a different release version and should not be removed
-                .ForIndex(2, s => s.SetReleaseVersion(otherReleaseVersion))
-                .ForIndex(2, s => s.SetEmail(targetEmail))
-                .ForIndex(2, s => s.SetRole(targetRole))
                 // This invite is for a different email and should not be removed
-                .ForIndex(3, s => s.SetReleaseVersion(targetReleaseVersion))
-                .ForIndex(3, s => s.SetEmail(otherEmail))
-                .ForIndex(3, s => s.SetRole(targetRole))
+                .ForIndex(2, s => s.SetReleaseVersion(targetReleaseVersion))
+                .ForIndex(2, s => s.SetEmail(otherEmail))
+                .ForIndex(2, s => s.SetRole(targetRole))
                 // This invite is for a different role and should not be removed
-                .ForIndex(4, s => s.SetReleaseVersion(targetReleaseVersion))
-                .ForIndex(4, s => s.SetEmail(targetEmail))
-                .ForIndex(4, s => s.SetRole(otherRole))
-                .GenerateList(5);
+                .ForIndex(3, s => s.SetReleaseVersion(targetReleaseVersion))
+                .ForIndex(3, s => s.SetEmail(targetEmail))
+                .ForIndex(3, s => s.SetRole(otherRole))
+                .GenerateList(4);
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
@@ -321,7 +318,7 @@ public abstract class UserReleaseInviteRepositoryTests
         }
 
         [Fact]
-        public async Task NoInvitesExist_DoesNothing()
+        public async Task InviteDoesNotExist_DoesNothing()
         {
             var contentDbContextId = Guid.NewGuid().ToString();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250812152120_EES6411_AddingUniqueContraintsToRoleInviteTables.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250812152120_EES6411_AddingUniqueContraintsToRoleInviteTables.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250812152120_EES6411_AddingUniqueContraintsToRoleInviteTables")]
+    partial class EES6411_AddingUniqueContraintsToRoleInviteTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250812152120_EES6411_AddingUniqueContraintsToRoleInviteTables.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20250812152120_EES6411_AddingUniqueContraintsToRoleInviteTables.cs
@@ -1,0 +1,120 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class EES6411_AddingUniqueContraintsToRoleInviteTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_UserReleaseInvites_ReleaseVersionId",
+                table: "UserReleaseInvites");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserPublicationInvites_PublicationId",
+                table: "UserPublicationInvites");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Role",
+                table: "UserReleaseInvites",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "UserReleaseInvites",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Role",
+                table: "UserPublicationInvites",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "UserPublicationInvites",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserReleaseInvites_ReleaseVersionId_Email_Role",
+                table: "UserReleaseInvites",
+                columns: new[] { "ReleaseVersionId", "Email", "Role" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPublicationInvites_PublicationId_Email_Role",
+                table: "UserPublicationInvites",
+                columns: new[] { "PublicationId", "Email", "Role" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_UserReleaseInvites_ReleaseVersionId_Email_Role",
+                table: "UserReleaseInvites");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserPublicationInvites_PublicationId_Email_Role",
+                table: "UserPublicationInvites");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Role",
+                table: "UserReleaseInvites",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "UserReleaseInvites",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Role",
+                table: "UserPublicationInvites",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "UserPublicationInvites",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserReleaseInvites_ReleaseVersionId",
+                table: "UserReleaseInvites",
+                column: "ReleaseVersionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserPublicationInvites_PublicationId",
+                table: "UserPublicationInvites",
+                column: "PublicationId");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationInviteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationInviteRepository.cs
@@ -63,7 +63,7 @@ public class UserPublicationInviteRepository(ContentDbContext contentDbContext) 
             .Where(uri =>
                 uri.PublicationId == publicationId
                 && uri.Role == role
-                && uri.Email.ToLower().Equals(email!.ToLower())) // DB comparison is case insensitive
+                && uri.Email.ToLower().Equals(email!.ToLower()))
             .SingleOrDefaultAsync(cancellationToken);
 
         if (invite is null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseInviteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseInviteRepository.cs
@@ -114,15 +114,21 @@ public class UserReleaseInviteRepository(
         ReleaseRole role,
         CancellationToken cancellationToken = default)
     {
-        var invites = await contentDbContext.UserReleaseInvites
+        var invite = await contentDbContext.UserReleaseInvites
             .AsQueryable()
             .Where(uri =>
                 uri.ReleaseVersionId == releaseVersionId
                 && uri.Role == role
                 && uri.Email.ToLower().Equals(email!.ToLower()))
-            .ToListAsync(cancellationToken);
+            .SingleOrDefaultAsync(cancellationToken);
 
-        await RemoveMany(invites, cancellationToken);
+        if (invite is null)
+        {
+            return;
+        }
+
+        contentDbContext.UserReleaseInvites.Remove(invite);
+        await contentDbContext.SaveChangesAsync(cancellationToken);
     }
 
     public async Task RemoveMany(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -1,3 +1,4 @@
+using AngleSharp.Dom;
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -748,7 +749,7 @@ public class ContentDbContext : DbContext
     private static void ConfigureUserReleaseInvite(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<UserReleaseInvite>()
-            .Property(r => r.Role)
+            .Property(uri => uri.Role)
             .HasConversion(new EnumToStringConverter<ReleaseRole>());
 
         modelBuilder.Entity<UserReleaseInvite>()
@@ -762,12 +763,21 @@ public class ContentDbContext : DbContext
             .HasConversion(
                 v => v,
                 v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
+
+        modelBuilder.Entity<UserReleaseInvite>()
+            .HasIndex(uri => new
+            {
+                uri.ReleaseVersionId,
+                uri.Email,
+                uri.Role
+            })
+            .IsUnique();
     }
 
     private static void ConfigureUserPublicationInvite(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<UserPublicationInvite>()
-            .Property(r => r.Role)
+            .Property(upi => upi.Role)
             .HasConversion(new EnumToStringConverter<PublicationRole>());
 
         modelBuilder.Entity<UserPublicationInvite>()
@@ -775,6 +785,15 @@ public class ContentDbContext : DbContext
             .HasConversion(
                 v => v,
                 v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+
+        modelBuilder.Entity<UserPublicationInvite>()
+            .HasIndex(upi => new
+                {
+                    upi.PublicationId,
+                    upi.Email,
+                    upi.Role
+                })
+            .IsUnique();
     }
 
     private static void ConfigureGlossaryEntry(ModelBuilder modelBuilder)


### PR DESCRIPTION
Prior to this PR, it was possible to create duplicate entries into the `UserPublicationInvites` & `UserReleaseInvites` tables based on the (`PublicationId`, `Email`, `Role`)  & (`ReleaseVersionId`, `Email`, `Role`) combinations respectively.

This, in theory, should not be possible. There is actually only 1 duplicate that exists in the production database, which will be removed before this change is merged.

This PR introduces the unique constraints to stop this from happening again, and simplifies the code accordingly.