### PR TITLE
EES-6349 - adding missing analytics processors into startup

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Analytics.Consumer/ProcessorHostBuilder.cs
@@ -50,6 +50,8 @@ public static class ProcessorHostBuilder
                     .AddTransient<IRequestFileProcessor, PublicApiQueriesProcessor>()
                     .AddTransient<IRequestFileProcessor, PublicZipDownloadsProcessor>()
                     .AddTransient<IRequestFileProcessor, PublicCsvDownloadsProcessor>()
+                    .AddTransient<IRequestFileProcessor, TableToolDownloadsProcessor>()
+                    .AddTransient<IRequestFileProcessor, PermalinksTableDownloadsProcessor>()
                     .AddTransient<IProcessRequestFilesWorkflow, ProcessRequestFilesWorkflow>()
                     .AddTransient<IFileAccessor, FilesystemFileAccessor>()
                     .AddTransient<DateTimeProvider>()


### PR DESCRIPTION
This PR:
- registers the 2 analytics report processors that Lee added for the Data API JSON files. 