### PR TITLE
EES-4846 Fix CodeQL alerts

### DIFF
--- a/src/explore-education-statistics-admin/src/prototypes/PrototypeDataCatalog.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/PrototypeDataCatalog.tsx
@@ -1014,9 +1014,9 @@ const PrototypeDataCatalogue = () => {
                     <li>
                       <hr />
                       <h3>
-                        <a href={`./data-selected?dataType=${dataType}`}>
+                        <Link to={`./data-selected?dataType=${dataType}`}>
                           Apprenticeship Achievement Rates Detailed Series
-                        </a>
+                        </Link>
                       </h3>
                       <p className="govuk-!-margin-bottom-2">
                         Apprenticeship national achievement rate tables
@@ -1615,9 +1615,9 @@ const PrototypeDataCatalogue = () => {
                     <li>
                       <hr />
                       <h3>
-                        <a href={`./data-selected?dataType=${dataType}`}>
+                        <Link to={`./data-selected?dataType=${dataType}`}>
                           Apprenticeship Achievement Rates Detailed Series
-                        </a>
+                        </Link>
                       </h3>
                       <p className="govuk-!-margin-bottom-2">
                         Apprenticeship national achievement rate tables
@@ -2172,9 +2172,9 @@ const PrototypeDataCatalogue = () => {
                 <li>
                   <hr />
                   <h3>
-                    <a href={`./data-selected?dataType=${dataType}`}>
+                    <Link to={`./data-selected?dataType=${dataType}`}>
                       Apprenticeship Achievement Rates Detailed Series
-                    </a>
+                    </Link>
                   </h3>
                   <p className="govuk-!-margin-bottom-2">
                     Apprenticeship national achievement rate tables

--- a/src/explore-education-statistics-common/src/utils/url/allowedHosts.ts
+++ b/src/explore-education-statistics-common/src/utils/url/allowedHosts.ts
@@ -1,0 +1,7 @@
+const allowedHosts = [
+  'cexplore-education-statistics.service.gov.uk',
+  'test.explore-education-statistics.service.gov.uk',
+  'pre-production.explore-education-statistics.service.gov.uk',
+  'explore-education-statistics.service.gov.uk',
+];
+export default allowedHosts;

--- a/src/explore-education-statistics-common/src/utils/url/formatContentLink.ts
+++ b/src/explore-education-statistics-common/src/utils/url/formatContentLink.ts
@@ -1,13 +1,12 @@
+import allowedHosts from '@common/utils/url/allowedHosts';
+
 // Format links in content to ensure they are valid.
 // Make sure any internal links are lower case, excluding query params.
 export default function formatContentLink(urlString: string) {
   try {
     const url = new URL(urlString);
-    if (
-      url.origin
-        .toLowerCase()
-        .includes('explore-education-statistics.service.gov.uk')
-    ) {
+
+    if (allowedHosts.includes(url.host.toLowerCase())) {
       url.pathname = url.pathname.toLowerCase();
     }
     return url.href;

--- a/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
+++ b/src/explore-education-statistics-frontend/src/components/SearchFormAzure.tsx
@@ -2,6 +2,7 @@ import SearchIcon from '@common/components/SearchIcon';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import styles from '@common/components/form/FormSearchBar.module.scss';
 import logger from '@common/services/logger';
+import sanitizeHtml from '@common/utils/sanitizeHtml';
 import { createAzurePublicationSuggestRequest } from '@frontend/modules/find-statistics/utils/createAzurePublicationListRequest';
 import azurePublicationService, {
   AzurePublicationSuggestResult,
@@ -84,10 +85,9 @@ export default function SearchForm({ label = 'Search', onSubmit }: Props) {
     // The result has a `highlightedMatch` property with HTML tags which could
     // either be from the `title` or the `summary`. So we will strip out the HTML
     // tags to be able to check which field it is from, and use accordingly.
-    const highlightMatchWithoutTags = result.highlightedMatch.replaceAll(
-      /<[^>]*>/g,
-      '',
-    );
+    const highlightMatchWithoutTags = sanitizeHtml(result.highlightedMatch, {
+      allowedTags: [],
+    });
 
     // We also need to find out which term was highlighted in order to manually
     // add highlights to the other field.


### PR DESCRIPTION
Fixes a few CodeQL alerts, I don't think any of them were real risks but this should at least reduce the noise.

- Incomplete URL substring sanitization (https://github.com/dfe-analytical-services/explore-education-statistics/security/code-scanning/38 and https://github.com/dfe-analytical-services/explore-education-statistics/security/code-scanning/21)
- DOM text reinterpreted as HTML (https://github.com/dfe-analytical-services/explore-education-statistics/security/code-scanning/26, https://github.com/dfe-analytical-services/explore-education-statistics/security/code-scanning/27, https://github.com/dfe-analytical-services/explore-education-statistics/security/code-scanning/28)
- Incomplete multi-character sanitization (https://github.com/dfe-analytical-services/explore-education-statistics/security/code-scanning/46) 