### PR TITLE
EES-6396 scrollable methodology nav on small screens

### DIFF
--- a/src/explore-education-statistics-common/src/components/ContentSectionIndex.tsx
+++ b/src/explore-education-statistics-common/src/components/ContentSectionIndex.tsx
@@ -183,6 +183,8 @@ const ContentSectionIndex = ({
         <div
           ref={ref}
           style={{
+            maxHeight: '100vh',
+            overflowY: 'auto',
             width: width === 0 ? '100%' : width,
             ...getStyle(),
           }}


### PR DESCRIPTION
Long section navigation lists on methodology page can get cut off on small screens, this makes them scrollable if needed.