### PR TITLE
EES-6434 Changes to `pl_purge_subjects_statistics` pipeline

### DIFF
--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -28,8 +28,8 @@
     "factoryId": "[concat('Microsoft.DataFactory/factories/', parameters('factoryName'))]",
     "fragmentationTables": "Observation,ObservationFilterItem",
     "removeSoftDeletedSubjectsObservationLimit": "20000000",
-    "removeSoftDeletedSubjectsObservationCommitBatchSize": "1000",
-    "removeSoftDeletedSubjectsObservationFilterItemCommitBatchSize": "20000"
+    "removeSoftDeletedSubjectsObservationCommitBatchSize": "500000",
+    "removeSoftDeletedSubjectsObservationFilterItemCommitBatchSize": "500000"
   },
   "resources": [
     {


### PR DESCRIPTION
This PR changes the parameters of the `pl_purge_subjects_statistics` Data Factory pipeline which deletes soft-deleted Subjects from the statistics database.

- Changes the frequency of the schedule trigger to be daily at 7pm rather than on weekdays at 7pm.
- Changes the `ObservationCommitBatchSize` parameter of the stored procedure to be 500,000 rather than 1000.
- Changes the `ObservationFilterItemCommitBatchSize` parameter of the stored procedure to be 500,000 rather than 20,000.

Testing with manual runs of the SP in Prod, I found that a batch of 500,000 ObservationFilterItem rows could be deleted in a similar time to 20,000, so increasing the batch size made it around 25 times faster. I think an even bigger batch size would be ok (I also tried it with a batch size of 1,000,000 which finished deleting several million rows even faster), but I'm aware that not all the environments use the same scale and this could cause a problem in a non-Prod environment where a database has a reduced scale.