### PR TITLE
EES-6421: Prevent data replacements when an import is still in progress

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -352,6 +352,20 @@ public static class ValidationMessages
         };
     }
 
+    public static readonly LocalizableMessage DataSetImportInProgress = new(
+        Code: nameof(DataSetImportInProgress),
+        Message: "File '{0}' cannot be replaced until the current import is complete."
+    );
+
+    public static ErrorViewModel GenerateErrorDataSetImportInProgress(string fileName)
+    {
+        return new ErrorViewModel
+        {
+            Code = DataSetImportInProgress.Code,
+            Message = string.Format(DataSetImportInProgress.Message, fileName),
+        };
+    }
+
     public static readonly LocalizableMessage FileSizeMustNotBeZero = new(
         Code: nameof(FileSizeMustNotBeZero),
         Message: "File '{0}' either empty or not found."

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -65,6 +65,7 @@ const fileErrorMappings = {
   AnalystCannotReplaceApiDataSet: 'AnalystCannotReplaceApiDataSet',
   CannotCreateMultipleDraftApiDataSet: 'CannotCreateMultipleDraftApiDataSet',
   DataReplacementAlreadyInProgress: 'DataReplacementAlreadyInProgress',
+  DataSetImportInProgress: 'DataSetImportInProgress',
 };
 
 function baseErrorMappings(


### PR DESCRIPTION
This PR:
- consolidates various replacement-based validation checks to a shared function
- includes an additional check for in-progress imports
- fixes a missing validation message in the front-end UI.

The UI can only display form submission errors one at a time, so some of these changes are in preparation for a time when the UI can display a list of errors (i.e. the list returned from the back-end, which is visible in the Network tab). The idea being that it would avoid users having to re-upload data sets multiple times if there is a sequence of related errors.