### PR TITLE
EES-6302: Remove DataSetUpload (and associated blob storage objects) when a release version is deleted

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetUploadRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetUploadRepositoryTests.cs
@@ -1,0 +1,154 @@
+#nullable enable
+using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Moq;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+
+public class DataSetUploadRepositoryTests
+{
+    [Fact]
+    public async Task ListAll_Success_ReturnsListOfVms()
+    {
+        // Arrange
+        var releaseVersionId = Guid.NewGuid();
+
+        var builder = new DataSetUploadMockBuilder();
+        var upload1 = builder.WithReleaseVersionId(releaseVersionId).BuildEntity();
+        var upload2 = builder.WithReleaseVersionId(releaseVersionId).BuildEntity();
+        var upload3 = builder.WithReleaseVersionId(releaseVersionId).BuildEntity();
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contextId))
+        {
+            contentDbContext.DataSetUploads.AddRange(upload1, upload2, upload3);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contextId))
+        {
+            var service = BuildService(contentDbContext);
+
+            // Act
+            var result = await service.ListAll(releaseVersionId, default);
+
+            // Assert
+            var uploads = result.AssertRight();
+
+            Assert.Equal(3, uploads.Count);
+        }
+    }
+
+    [Fact]
+    public async Task Delete_Success_ObjectRemovedFromDb()
+    {
+        // Arrange
+        var releaseVersionId = Guid.NewGuid();
+
+        var builder = new DataSetUploadMockBuilder();
+        var upload1 = builder.WithReleaseVersionId(releaseVersionId).BuildEntity();
+        var upload2 = builder.WithReleaseVersionId(releaseVersionId).BuildEntity();
+        var upload3 = builder.WithReleaseVersionId(releaseVersionId).BuildEntity();
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contextId))
+        {
+            contentDbContext.DataSetUploads.AddRange(upload1, upload2, upload3);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contextId))
+        {
+            var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(Strict);
+
+            privateBlobStorageService
+                .Setup(mock => mock.DeleteBlob(
+                    PrivateReleaseTempFiles,
+                    It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            var service = BuildService(
+                contentDbContext,
+                privateBlobStorageService.Object);
+
+            // Act
+            var result = await service.Delete(releaseVersionId, upload2.Id, default);
+
+            // Assert
+            privateBlobStorageService
+                .Verify(mock => mock.DeleteBlob(
+                    PrivateReleaseTempFiles,
+                    It.IsAny<string>()),
+                Times.Exactly(2));
+
+            result.AssertRight();
+            Assert.Equal(2, contentDbContext.DataSetUploads.Count());
+            Assert.Null(await contentDbContext.DataSetUploads.FindAsync(upload2.Id));
+        }
+    }
+
+    [Fact]
+    public async Task DeleteAll_Success_ObjectsRemovedFromDb()
+    {
+        // Arrange
+        var releaseVersionId = Guid.NewGuid();
+
+        var builder = new DataSetUploadMockBuilder();
+        var upload1 = builder.WithReleaseVersionId(releaseVersionId).BuildEntity();
+        var upload2 = builder.WithReleaseVersionId(releaseVersionId).BuildEntity();
+        var upload3 = builder.WithReleaseVersionId(releaseVersionId).BuildEntity();
+
+        var contextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contextId))
+        {
+            contentDbContext.DataSetUploads.AddRange(upload1, upload2, upload3);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contextId))
+        {
+            var privateBlobStorageService = new Mock<IPrivateBlobStorageService>(Strict);
+
+            privateBlobStorageService
+                .Setup(mock => mock.DeleteBlob(
+                    PrivateReleaseTempFiles,
+                    It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            var service = BuildService(
+                contentDbContext,
+                privateBlobStorageService.Object);
+
+            // Act
+            var result = await service.DeleteAll(releaseVersionId, default);
+
+            // Assert
+            privateBlobStorageService
+                .Verify(mock => mock.DeleteBlob(
+                    PrivateReleaseTempFiles,
+                    It.IsAny<string>()),
+                Times.Exactly(6));
+
+            result.AssertRight();
+            Assert.Empty(contentDbContext.DataSetUploads);
+        }
+    }
+
+    private static DataSetUploadRepository BuildService(
+        ContentDbContext context,
+        IPrivateBlobStorageService? privateBlobStorageService = null,
+        IMapper? mapper = null)
+    {
+        return new DataSetUploadRepository(
+            context,
+            privateBlobStorageService ?? Mock.Of<IPrivateBlobStorageService>(),
+            mapper ?? Mock.Of<IMapper>());
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServicePermissionTests.cs
@@ -376,6 +376,7 @@ public class ReleaseVersionServicePermissionTests
             Mock.Of<IReleaseFileRepository>(),
             Mock.Of<IReleaseDataFileService>(),
             Mock.Of<IReleaseFileService>(),
+            Mock.Of<IDataSetUploadRepository>(),
             Mock.Of<IDataImportService>(),
             Mock.Of<IFootnoteRepository>(),
             Mock.Of<IDataBlockService>(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataSetUploadRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataSetUploadRepository.cs
@@ -15,4 +15,8 @@ public interface IDataSetUploadRepository
         Guid releaseVersionId,
         Guid dataSetUploadId,
         CancellationToken cancellationToken = default);
+
+    Task<Either<ActionResult, Unit>> DeleteAll(
+        Guid releaseVersionId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
@@ -1,4 +1,9 @@
 #nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
@@ -49,6 +54,7 @@ public class ReleaseVersionService(
     IReleaseFileRepository releaseFileRepository,
     IReleaseDataFileService releaseDataFileService,
     IReleaseFileService releaseFileService,
+    IDataSetUploadRepository dataSetUploadRepository,
     IDataImportService dataImportService,
     IFootnoteRepository footnoteRepository,
     IDataBlockService dataBlockService,
@@ -188,6 +194,9 @@ public class ReleaseVersionService(
             .OnSuccessDo(() => releaseFileService.DeleteAll(
                 releaseVersionId: releaseVersion.Id,
                 forceDelete: forceDeleteRelatedData))
+            .OnSuccessDo(() => dataSetUploadRepository.DeleteAll(
+                releaseVersion.Id,
+                cancellationToken))
             .OnSuccessDo(async _ =>
             {
                 if (hardDeleteContentReleaseVersion)


### PR DESCRIPTION
This PR adds a convenience method implementing existing repository methods to remove data set upload records from the database, alongside the files associated to those records in blob storage, when a release version is deleted.

> [!IMPORTANT]
> This is currently a bit awkward to test locally (and not possible to test remotely) because database records are deleted immediately, and the files moved to permanent storage due to the screener bypass. This can be tested locally by preventing the call to `ReleaseDataFileService.SaveDataSetsFromTemporaryBlobStorage`.