### PR TITLE
EES-6455 & EES-6456 Block creation of multiple draft API data set versions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetValidatorTests.cs
@@ -541,49 +541,8 @@ public class DataSetValidatorTests
         
         var dataSetServiceMock = new Mock<IDataSetService>(MockBehavior.Strict);
         dataSetServiceMock
-            .Setup(s => s.GetDataSet(existingDataReleaseFile.PublicApiDataSetId.Value, CancellationToken.None))
-            .ReturnsAsync(new DataSetViewModel
-            {
-                DraftVersion = new DataSetDraftVersionViewModel
-                {
-                    Id = Guid.NewGuid(),
-                    Version = "1.1.1",
-                    Status = DataSetVersionStatus.Draft,
-                    Type = DataSetVersionType.Minor,
-                    File = new IdTitleViewModel(Guid.NewGuid(),
-                        "File title"),
-                    ReleaseVersion = new IdTitleViewModel(Guid.NewGuid(),
-                        "Release version title"),
-                    Notes = "Test note"
-                },
-                Id = existingDataReleaseFile.PublicApiDataSetId.Value,
-                Title = "Test data set",
-                Summary = "Test summary",
-                Status = DataSetStatus.Draft,
-                LatestLiveVersion = new DataSetLiveVersionViewModel
-                {
-                    Published = DateTime.Now,
-                    TotalResults = 10,
-                    TimePeriods = new TimePeriodRangeViewModel
-                    {
-                        Start = "1",
-                        End = "2",
-                    },
-                    GeographicLevels = new []{ "LA" },
-                    Filters = new []{ "F1" },
-                    Indicators = new []{ "I1" },
-                    Id = Guid.NewGuid(),
-                    Version = "1.1",
-                    Status = DataSetVersionStatus.Published,
-                    Type = DataSetVersionType.Minor,
-                    File = new IdTitleViewModel(Guid.NewGuid(),
-                        "Release version title"),
-                    ReleaseVersion = new IdTitleViewModel(Guid.NewGuid(),
-                        "Release version title"),
-                    Notes = "Note"
-                },
-                PreviousReleaseIds = [Guid.NewGuid()]
-            });
+            .Setup(s => s.HasDraftVersion(existingDataReleaseFile.PublicApiDataSetId.Value, CancellationToken.None))
+            .ReturnsAsync(true);
 
         var sut = BuildService(
                 contentDbContext: context, 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetValidatorTests.cs
@@ -8,17 +8,14 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
-using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Options;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
-using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
-using GovUk.Education.ExploreEducationStatistics.Public.Data.Model;
 using Microsoft.Extensions.Options;
 using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
@@ -851,6 +848,16 @@ public class DataSetValidatorTests
                 .Setup(s => s.MatchesPolicy(SecurityPolicies.IsBauUser))
                 .ReturnsAsync(true);
             userService = userServiceMock.Object;
+        }
+
+        if (dataSetService is null)
+        {
+            
+            var dataSetServiceMock = new Mock<IDataSetService>(MockBehavior.Strict);
+            dataSetServiceMock
+                .Setup(s => s.HasDraftVersion(It.IsAny<Guid>(), CancellationToken.None))
+                .ReturnsAsync(false);
+            dataSetService = dataSetServiceMock.Object;
         }
 
         if (featureFlags is null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetValidatorTests.cs
@@ -584,7 +584,6 @@ public class DataSetValidatorTests
                 },
                 PreviousReleaseIds = [Guid.NewGuid()]
             });
-        
 
         var sut = BuildService(
                 contentDbContext: context, 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetValidator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetValidator.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common;
@@ -24,6 +25,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
 public class DataSetValidator(
     ContentDbContext contentDbContext,
     IUserService userService,
+    IDataSetService dataSetService,
     IOptions<FeatureFlagsOptions> featureFlags) : IDataSetValidator
 {
     public async Task<Either<List<ErrorViewModel>, DataSet>> ValidateDataSet(DataSetDto dataSet)
@@ -88,7 +90,19 @@ public class DataSetValidator(
                 if (!releaseFileWithApiDataSet.ReleaseVersion.Amendment)
                 {
                     errors.Add(ValidationMessages.GenerateErrorCannotReplaceDraftApiDataSet(dataSet.Title));
+                    return errors;
                 }
+                
+                await dataSetService
+                    .GetDataSet(releaseFileWithApiDataSet.PublicApiDataSetId!.Value)
+                    .OnSuccessDo(apiDataSet =>
+                    {
+                        if (apiDataSet?.DraftVersion is not null)
+                        {
+                            errors.Add(ValidationMessages.GenerateErrorCannotCreateMultipleDraftApiDataSet(dataSet.Title));
+                        }
+                    });
+
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetValidator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetValidator.cs
@@ -102,7 +102,6 @@ public class DataSetValidator(
                             errors.Add(ValidationMessages.GenerateErrorCannotCreateMultipleDraftApiDataSet(dataSet.Title));
                         }
                     });
-
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetValidator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetValidator.cs
@@ -94,10 +94,10 @@ public class DataSetValidator(
                 }
                 
                 await dataSetService
-                    .GetDataSet(releaseFileWithApiDataSet.PublicApiDataSetId!.Value)
-                    .OnSuccessDo(apiDataSet =>
+                    .HasDraftVersion(releaseFileWithApiDataSet.PublicApiDataSetId!.Value)
+                    .OnSuccessDo(hasDraftVersion =>
                     {
-                        if (apiDataSet?.DraftVersion is not null)
+                        if (hasDraftVersion)
                         {
                             errors.Add(ValidationMessages.GenerateErrorCannotCreateMultipleDraftApiDataSet(dataSet.Title));
                         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Public.Data/IDataSetService.cs
@@ -24,4 +24,8 @@ public interface IDataSetService
     Task<Either<ActionResult, DataSetViewModel>> CreateDataSet(
         Guid releaseFileId,
         CancellationToken cancellationToken = default);
+
+    Task<Either<ActionResult, bool>> HasDraftVersion(
+        Guid dataSetId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/DataSetService.cs
@@ -79,6 +79,18 @@ internal class DataSetService(
             )
             .OnSuccess(async dataSet => await MapDataSet(dataSet, cancellationToken));
     }
+    
+    public async Task<Either<ActionResult, bool>> HasDraftVersion(
+        Guid dataSetId,
+        CancellationToken cancellationToken = default)
+    {
+        return await QueryDataSet(dataSetId)
+            .SingleOrNotFoundAsync(cancellationToken)
+            .OnSuccessDo(dataSet => CheckPublicationExists(dataSet.PublicationId, cancellationToken)
+                .OnSuccess(userService.CheckCanViewPublication)
+            )
+            .OnSuccess(dataSet => dataSet.LatestDraftVersion is not null);
+    }
 
     public async Task<Either<ActionResult, DataSetViewModel>> CreateDataSet(
         Guid releaseFileId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -415,6 +415,21 @@ public static class ValidationMessages
         };
     }
     
+    public static readonly LocalizableMessage CannotCreateMultipleDraftApiDataSet = new(
+        Code: nameof(CannotCreateMultipleDraftApiDataSet),
+        Message: "Data set with title '{0}' cannot be replaced as this would result in creating a new patch draft API data set." +
+                 " There is a draft API version which is not published. Multiple draft API versions at the same time are not permitted in the system." +
+                 " Please contact the explore statistics team at explore.statistics@education.gov.uk for support on completing this action."
+    );
+
+    public static ErrorViewModel GenerateErrorCannotCreateMultipleDraftApiDataSet(string title)
+    {
+        return new ErrorViewModel
+        {
+            Code = CannotCreateMultipleDraftApiDataSet.Code,
+            Message = string.Format(CannotCreateMultipleDraftApiDataSet.Message, title),
+        };
+    }
     public static readonly LocalizableMessage AnalystCannotReplaceApiDataSet = new(
         Code: nameof(AnalystCannotReplaceApiDataSet),
         Message: "You do not have permission to start this data replacement. This is because data set with title '{0}' is linked to an API data set version which can only be modified by BAU users. Please contact the explore statistics team at explore.statistics@education.gov.uk for support on starting this replacement."

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationMessages.cs
@@ -430,6 +430,7 @@ public static class ValidationMessages
             Message = string.Format(CannotCreateMultipleDraftApiDataSet.Message, title),
         };
     }
+
     public static readonly LocalizableMessage AnalystCannotReplaceApiDataSet = new(
         Code: nameof(AnalystCannotReplaceApiDataSet),
         Message: "You do not have permission to start this data replacement. This is because data set with title '{0}' is linked to an API data set version which can only be modified by BAU users. Please contact the explore statistics team at explore.statistics@education.gov.uk for support on starting this replacement."

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -63,6 +63,7 @@ const fileErrorMappings = {
   InvalidFileTypeForReplacement: 'InvalidFileTypeForReplacement',
   DataSetIsNotInAnImportableState: 'DataSetIsNotInAnImportableState',
   AnalystCannotReplaceApiDataSet: 'AnalystCannotReplaceApiDataSet',
+  CannotCreateMultipleDraftApiDataSet: 'CannotCreateMultipleDraftApiDataSet',
 };
 
 function baseErrorMappings(


### PR DESCRIPTION
This Pull Request introduces enhancements to the DataSetValidator for handling scenarios involving draft API data sets. 

It adds a check to prevent creating multiple draft versions of API data sets and includes corresponding updates to validation messages, test cases, and associated files.

Main Changes
 - DataSetValidator Logic Update: New validation logic ensures that no multiple draft API data sets can exist simultaneously, improving system consistency.
 - Test Updates: Added unit tests in DataSetValidatorTests.cs to verify new draft API data set validation behavior.
 - New Validation Message: Introduced a localized error message in ValidationMessages.cs to notify users about the restriction.
 - Frontend Update: Added a new error identifier CannotCreateMultipleDraftApiDataSet to the DataFileUploadForm for error handling on the frontend.