### PR TITLE
EES-6401 Enable nullable reference types in `Content.Services` project

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/AnalyticsOptions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services;
 
 public class AnalyticsOptions

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/AllMethodologiesCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/AllMethodologiesCacheKey.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common;
+﻿using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/GlossaryCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/GlossaryCacheKey.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/GlossaryCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/GlossaryCacheService.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.Cache;
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/MethodologyCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/MethodologyCacheService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheKey.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationCacheService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Text.RegularExpressions;
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationTreeCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationTreeCacheKey.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/RedirectsCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/RedirectsCacheKey.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/RedirectsCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/RedirectsCacheService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/ReleaseCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/ReleaseCacheKey.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common;
+﻿using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/ReleaseCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/ReleaseCacheService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/ReleaseStagedCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/ReleaseStagedCacheKey.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common;
+﻿using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataSetFileService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Globalization;
 using System.Linq.Expressions;
 using CsvHelper;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Extensions/OrderedQueryableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Extensions/OrderedQueryableExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GlossaryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GlossaryService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GovUk.Education.ExploreEducationStatistics.Content.Services.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GovUk.Education.ExploreEducationStatistics.Content.Services.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     </PropertyGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IGlossaryCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IGlossaryCacheService.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
+﻿using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IMethodologyCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IMethodologyCacheService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IPublicationCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IPublicationCacheService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IRedirectsCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IRedirectsCacheService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IReleaseCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/Cache/IReleaseCacheService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataGuidanceFileWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataGuidanceFileWriter.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataGuidanceService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IGlossaryService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IGlossaryService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using Microsoft.AspNetCore.Mvc;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IMethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IMethodologyImageService.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IMethodologyService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IPublicationService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IRedirectsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IRedirectsService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IReleaseFileService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Requests;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IReleaseService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 using Microsoft.AspNetCore.Mvc;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IThemeService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Mappings/MappingProfiles.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Mappings;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyImageService.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/PublicationService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/RedirectsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/RedirectsService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/RelatedInformation/Dtos/RelatedInformationDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/RelatedInformation/Dtos/RelatedInformationDto.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.RelatedInformation.Dtos;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/RelatedInformation/IRelatedInformationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/RelatedInformation/IRelatedInformationService.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.RelatedInformation.Dtos;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/RelatedInformation/RelatedInformationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/RelatedInformation/RelatedInformationService.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseFileService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.IO.Compression;
 using System.Net.Mime;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ReleaseService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Text.RegularExpressions;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/AnalyticsCaptureRequests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/AnalyticsCaptureRequests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/PublicationTreeFilter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Requests/PublicationTreeFilter.cs
@@ -1,4 +1,3 @@
-#nullable enable
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWritePublicCsvDownloadStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWritePublicCsvDownloadStrategy.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Strategies;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWritePublicZipDownloadStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Strategies/AnalyticsWritePublicZipDownloadStrategy.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Strategies;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ThemeService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;


### PR DESCRIPTION
This change enables nullable reference types in the `Content.Services` project.

This work is being done as part of EES-6401 so that no newly created or edited services have to be checked for the `#nullable enable' pragma.

`Content.Services` has 50 .cs files.

This PR has:
* 49 .cs files changed
* 1 .csproj files changed

`#nullable enable` enable was already added on a file-by-file basis to all files of `Content.Services`, except for  `DataBlockViewModelPostMappingAction.cs` which did not have it. This has been checked to make sure it has no new warnings after nullable reference types are enabled with this change.