### PR TITLE
EES-6409 - phasing out StreamBlob in favour of GetDownloadStream

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
@@ -33,40 +33,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services;
 /// changes that make it difficult to upgrade when relying on lower-level
 /// details e.g. Azure SDK v12 is an entirely new package compared to v11.
 /// </summary>
-public abstract class BlobStorageService : IBlobStorageService
+public abstract class BlobStorageService(
+    string s,
+    BlobServiceClient client,
+    ILogger<IBlobStorageService> logger,
+    IStorageInstanceCreationUtil storageInstanceCreationUtil,
+    IBlobSasService blobSasService)
+    : IBlobStorageService
 {
     private static readonly TimeSpan DownloadTokenExpiryDuration = TimeSpan.FromMinutes(5);
-    
-    private readonly string _connectionString;
-    private readonly BlobServiceClient _client;
-    private readonly ILogger<IBlobStorageService> _logger;
-    private readonly IStorageInstanceCreationUtil _storageInstanceCreationUtil;
-    private readonly IBlobSasService _blobSasService;
 
     protected BlobStorageService(
         string connectionString,
         ILogger<IBlobStorageService> logger,
         IBlobSasService blobSasService)
+        : this(
+            connectionString,
+            new BlobServiceClient(connectionString),
+            logger,
+            new StorageInstanceCreationUtil(),
+            blobSasService)
     {
-        _connectionString = connectionString;
-        _client = new BlobServiceClient(connectionString);
-        _logger = logger;
-        _blobSasService = blobSasService;
-        _storageInstanceCreationUtil = new StorageInstanceCreationUtil();
-    }
-
-    protected BlobStorageService(
-        string connectionString,
-        BlobServiceClient client,
-        ILogger<IBlobStorageService> logger,
-        IStorageInstanceCreationUtil storageInstanceCreationUtil,
-        IBlobSasService blobSasService)
-    {
-        _connectionString = connectionString;
-        _client = client;
-        _logger = logger;
-        _storageInstanceCreationUtil = storageInstanceCreationUtil;
-        _blobSasService = blobSasService;
     }
 
     public async Task<bool> CheckBlobExists(IBlobContainer containerName, string path)
@@ -100,7 +87,7 @@ public abstract class BlobStorageService : IBlobStorageService
 
         var blobContainer = await GetBlobContainer(containerName);
 
-        _logger.LogInformation("Deleting blobs from {containerName}/{path}", blobContainer.Name, directoryPath);
+        logger.LogInformation("Deleting blobs from {containerName}/{path}", blobContainer.Name, directoryPath);
 
         string? continuationToken = null;
 
@@ -125,11 +112,11 @@ public abstract class BlobStorageService : IBlobStorageService
 
                     if (excluded || !included)
                     {
-                        _logger.LogInformation("Ignoring blob {containerName}/{path}", blobContainer.Name, blob.Name);
+                        logger.LogInformation("Ignoring blob {containerName}/{path}", blobContainer.Name, blob.Name);
                         continue;
                     }
 
-                    _logger.LogInformation("Deleting blob {containerName}/{path}", blobContainer.Name, blob.Name);
+                    logger.LogInformation("Deleting blob {containerName}/{path}", blobContainer.Name, blob.Name);
 
                     deleteTasks.Add(blobContainer.DeleteBlobIfExistsAsync(blob.Name));
                 }
@@ -145,7 +132,7 @@ public abstract class BlobStorageService : IBlobStorageService
     {
         var blob = await GetBlobClient(containerName, path);
 
-        _logger.LogInformation("Deleting blob {containerName}/{path}", containerName, path);
+        logger.LogInformation("Deleting blob {containerName}/{path}", containerName, path);
 
         await blob.DeleteIfExistsAsync();
     }
@@ -159,7 +146,7 @@ public abstract class BlobStorageService : IBlobStorageService
 
         var tempFilePath = await UploadToTemporaryFile(file);
 
-        _logger.LogInformation("Uploading file to blob {containerName}/{path}", containerName, path);
+        logger.LogInformation("Uploading file to blob {containerName}/{path}", containerName, path);
 
         await blob.UploadAsync(
             path: tempFilePath,
@@ -184,7 +171,7 @@ public abstract class BlobStorageService : IBlobStorageService
         var sourceBlob = sourceContainerClient.GetBlobClient(sourcePath);
         if (!await sourceBlob.ExistsAsync())
         {
-            _logger.LogWarning(
+            logger.LogWarning(
                 "Source blob not found while moving blob. Source: '{Source}' Destination: '{Destination}'",
                 sourcePath,
                 destinationPath);
@@ -194,7 +181,7 @@ public abstract class BlobStorageService : IBlobStorageService
         var destinationBlob = destinationContainerClient.GetBlobClient(destinationPath);
         if (await destinationBlob.ExistsAsync())
         {
-            _logger.LogWarning(
+            logger.LogWarning(
                 "Destination already exists while moving blob. Source: '{Source}' Destination: '{Destination}'",
                 sourcePath,
                 destinationPath);
@@ -217,7 +204,7 @@ public abstract class BlobStorageService : IBlobStorageService
             while (destinationProperties.CopyStatus == CopyStatus.Pending)
             {
                 await Task.Delay(1000);
-                _logger.LogInformation("Copy progress: {Progress}", destinationProperties.CopyProgress);
+                logger.LogInformation("Copy progress: {Progress}", destinationProperties.CopyProgress);
                 destinationProperties = await destinationBlob.GetPropertiesAsync();
             }
 
@@ -258,7 +245,7 @@ public abstract class BlobStorageService : IBlobStorageService
     {
         var blob = await GetBlobClient(containerName, path);
 
-        _logger.LogInformation("Uploading text to blob {containerName}/{path}", containerName, path);
+        logger.LogInformation("Uploading text to blob {containerName}/{path}", containerName, path);
 
         sourceStream.SeekToBeginning();
 
@@ -421,49 +408,12 @@ public abstract class BlobStorageService : IBlobStorageService
         BlobDownloadToken token,
         CancellationToken cancellationToken)
     {
-        return _blobSasService
-            .CreateSecureBlobClient(blobServiceClient: _client, token: token)
+        return blobSasService
+            .CreateSecureBlobClient(blobServiceClient: client, token: token)
             .OnSuccess(blobClient => GetDownloadStream(blob: blobClient, decompress: true, cancellationToken))
             .OnSuccess(stream => new FileStreamResult(
                 fileStream: stream,
                 contentType: token.ContentType) { FileDownloadName = token.Filename });
-    }
-
-    public async Task<Stream> StreamBlob(
-        IBlobContainer containerName,
-        string path,
-        CancellationToken cancellationToken = default)
-    {
-        var blob = await GetBlobClient(containerName, path);
-
-        try
-        {
-            var blobStream = await blob.OpenReadAsync(cancellationToken: cancellationToken);
-
-            BlobProperties blobProperties =
-                await blob.GetPropertiesAsync(cancellationToken: cancellationToken);
-
-            // Check the ContentEncoding property to determine if the blob
-            // is compressed and only decompress if necessary.
-            if (blobProperties.ContentEncoding.IsNullOrEmpty())
-            {
-                return blobStream;
-            }
-
-            return CompressionUtils.GetCompressionStream(
-                targetStream: blobStream,
-                contentEncoding: blobProperties.ContentEncoding!,
-                compressionMode: CompressionMode.Decompress);
-        }
-        catch (RequestFailedException exception)
-        {
-            if (exception.Status == 404)
-            {
-                ThrowFileNotFoundException(containerName, path);
-            }
-
-            throw;
-        }
     }
 
     public async Task<Either<ActionResult, BlobDownloadToken>> GetBlobDownloadToken(
@@ -472,9 +422,9 @@ public abstract class BlobStorageService : IBlobStorageService
         string path,
         CancellationToken cancellationToken)
     {
-        return await _blobSasService
+        return await blobSasService
             .CreateBlobDownloadToken(
-                blobServiceClient: _client,
+                blobServiceClient: client,
                 container: container,
                 filename: filename,
                 path: path,
@@ -555,7 +505,7 @@ public abstract class BlobStorageService : IBlobStorageService
         string destinationDirectoryPath,
         IBlobStorageService.CopyDirectoryOptions? options = null)
     {
-        _logger.LogInformation(
+        logger.LogInformation(
             "Copying directory from {sourceContainer}/{sourcePath} to {destinationContainer}/{destinationPath}",
             sourceContainerName,
             sourceDirectoryPath,
@@ -641,7 +591,7 @@ public abstract class BlobStorageService : IBlobStorageService
             )
         );
 
-        _logger.LogInformation(
+        logger.LogInformation(
             "Transferred {sourceContainer}/{sourcePath} -> {destinationContainer}/{destinationPath}",
             source.Container.Name,
             source.Name,
@@ -655,7 +605,7 @@ public abstract class BlobStorageService : IBlobStorageService
         var source = (CloudBlockBlob)e.Source;
         var destination = (CloudBlockBlob)e.Destination;
 
-        _logger.LogInformation(
+        logger.LogInformation(
             "Failed to transfer {sourceContainer}/{sourcePath} -> {destinationContainer}/{destinationPath}. Error message: {errorMessage}",
             source.Container.Name,
             source.Name,
@@ -670,7 +620,7 @@ public abstract class BlobStorageService : IBlobStorageService
         var source = (CloudBlockBlob)e.Source;
         var destination = (CloudBlockBlob)e.Destination;
 
-        _logger.LogInformation(
+        logger.LogInformation(
             "Skipped transfer {sourceContainer}/{sourcePath} -> {destinationContainer}/{destinationPath}",
             source.Container.Name,
             source.Name,
@@ -695,7 +645,7 @@ public abstract class BlobStorageService : IBlobStorageService
             return blobClient;
         }
 
-        _logger.LogWarning("Could not find blob {containerName}/{path}", containerName, path);
+        logger.LogWarning("Could not find blob {containerName}/{path}", containerName, path);
         return new NotFoundResult();
     }
 
@@ -709,15 +659,15 @@ public abstract class BlobStorageService : IBlobStorageService
         IBlobContainer container,
         string? connectionString = null)
     {
-        var storageAccount = CloudStorageAccount.Parse(connectionString ?? _connectionString);
+        var storageAccount = CloudStorageAccount.Parse(connectionString ?? s);
         var blobClient = storageAccount.CreateCloudBlobClient();
 
         var containerName = IsDevelopmentStorageAccount(blobClient) ? container.EmulatedName : container.Name;
 
         var containerClient = blobClient.GetContainerReference(containerName);
 
-        await _storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(
-            _connectionString,
+        await storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(
+            s,
             AzureStorageType.Blob,
             containerName,
             () => containerClient.CreateIfNotExistsAsync());
@@ -727,12 +677,12 @@ public abstract class BlobStorageService : IBlobStorageService
 
     private async Task<BlobContainerClient> GetBlobContainer(IBlobContainer container)
     {
-        var containerName = IsDevelopmentStorageAccount(_client) ? container.EmulatedName : container.Name;
+        var containerName = IsDevelopmentStorageAccount(client) ? container.EmulatedName : container.Name;
 
-        var containerClient = _client.GetBlobContainerClient(containerName);
+        var containerClient = client.GetBlobContainerClient(containerName);
 
-        await _storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(
-            _connectionString,
+        await storageInstanceCreationUtil.CreateInstanceIfNotExistsAsync(
+            s,
             AzureStorageType.Blob,
             containerName,
             () => containerClient.CreateIfNotExistsAsync());

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
@@ -67,25 +67,6 @@ public interface IBlobStorageService
         string path,
         bool decompress = true,
         CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Stream a blob in chunks.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This differs from <see cref="DownloadToStream">DownloadToStream</see> in
-    /// that it does not download the entirety of the blob beforehand. This causes
-    /// differences in how the outputted stream behaves that you may or may not want.
-    /// </para>
-    /// </remarks>
-    /// <param name="containerName">Name of the blob container</param>
-    /// <param name="path">Path to the blob within the container</param>
-    /// <param name="cancellationToken">Token to cancel the request</param>
-    /// <returns>The chunked blob stream</returns>
-    Task<Stream> StreamBlob(
-        IBlobContainer containerName,
-        string path,
-        CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Obtain a secure,short-lived download token for use with <see cref="StreamWithToken"/>.

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/DataSetFilesController.cs
@@ -49,10 +49,11 @@ public class DataSetFilesController : ControllerBase
 
     [HttpGet("data-set-files/{dataSetFileId:guid}")]
     public async Task<ActionResult<DataSetFileViewModel>> GetDataSetFile(
-        Guid dataSetFileId)
+        Guid dataSetFileId,
+        CancellationToken cancellationToken)
     {
         return await _dataSetFileService
-            .GetDataSetFile(dataSetFileId)
+            .GetDataSetFile(dataSetFileId, cancellationToken)
             .HandleFailuresOrOk();
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/Interfaces/IReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/Interfaces/IReleaseFileBlobService.cs
@@ -1,14 +1,12 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
 
 public interface IReleaseFileBlobService
 {
-    Task<Stream> StreamBlob(
+    Task<Either<ActionResult, Stream>> GetDownloadStream(
         ReleaseFile releaseFile,
         CancellationToken cancellationToken = default);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PrivateReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PrivateReleaseFileBlobService.cs
@@ -1,7 +1,9 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Services;
@@ -9,14 +11,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Services;
 public class PrivateReleaseFileBlobService(
     IPrivateBlobStorageService privateBlobStorageService) : IReleaseFileBlobService
 {
-    public Task<Stream> StreamBlob(
+    public Task<Either<ActionResult, Stream>> GetDownloadStream(
         ReleaseFile releaseFile,
         CancellationToken cancellationToken = default)
     {
-        return privateBlobStorageService.StreamBlob(
+        return privateBlobStorageService.GetDownloadStream(
             containerName: PrivateReleaseFiles,
             path: releaseFile.Path(),
-            cancellationToken: cancellationToken
-        );
+            cancellationToken: cancellationToken);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PublicReleaseFileBlobService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Services/PublicReleaseFileBlobService.cs
@@ -1,7 +1,9 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Services;
@@ -9,14 +11,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Services;
 public class PublicReleaseFileBlobService(
     IPublicBlobStorageService publicBlobStorageService) : IReleaseFileBlobService
 {
-    public Task<Stream> StreamBlob(
+    public Task<Either<ActionResult, Stream>> GetDownloadStream(
         ReleaseFile releaseFile,
         CancellationToken cancellationToken = default)
     {
-        return publicBlobStorageService.StreamBlob(
+        return publicBlobStorageService.GetDownloadStream(
             containerName: PublicReleaseFiles,
             path: releaseFile.PublicPath(),
-            cancellationToken: cancellationToken
-        );
+            cancellationToken: cancellationToken);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IDataSetFileService.cs
@@ -23,7 +23,9 @@ public interface IDataSetFileService
         int pageSize,
         CancellationToken cancellationToken = default);
 
-    Task<Either<ActionResult, DataSetFileViewModel>> GetDataSetFile(Guid dataSetFileId);
+    Task<Either<ActionResult, DataSetFileViewModel>> GetDataSetFile(
+        Guid dataSetFileId,
+        CancellationToken cancellationToken);
 
     Task<ActionResult> DownloadDataSetFile(
         Guid dataSetFileId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkCsvMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkCsvMetaServiceTests.cs
@@ -467,7 +467,7 @@ public class PermalinkCsvMetaServiceTests
             var releaseFileBlobService = new Mock<IReleaseFileBlobService>(Strict);
 
             releaseFileBlobService
-                .Setup(s => s.StreamBlob(
+                .Setup(s => s.GetDownloadStream(
                     It.Is<ReleaseFile>(rf =>
                         rf.FileId == releaseFile.FileId && rf.ReleaseVersionId == releaseFile.ReleaseVersionId),
                     default
@@ -673,7 +673,7 @@ public class PermalinkCsvMetaServiceTests
             var releaseFileBlobService = new Mock<IReleaseFileBlobService>(Strict);
 
             releaseFileBlobService
-                .Setup(s => s.StreamBlob(
+                .Setup(s => s.GetDownloadStream(
                     It.Is<ReleaseFile>(rf =>
                         rf.FileId == releaseDataFile.FileId && rf.ReleaseVersionId == releaseDataFile.ReleaseVersionId),
                     default
@@ -903,7 +903,7 @@ public class PermalinkCsvMetaServiceTests
             var releaseFileBlobService = new Mock<IReleaseFileBlobService>(Strict);
 
             releaseFileBlobService
-                .Setup(s => s.StreamBlob(
+                .Setup(s => s.GetDownloadStream(
                     It.Is<ReleaseFile>(rf =>
                         rf.FileId == releaseFile.FileId && rf.ReleaseVersionId == releaseFile.ReleaseVersionId),
                     default

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkCsvMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkCsvMetaService.cs
@@ -94,7 +94,9 @@ public class PermalinkCsvMetaService : IPermalinkCsvMetaService
                     cancellationToken: cancellationToken
                 );
 
-            return await _releaseFileBlobService.StreamBlob(releaseFile, cancellationToken: cancellationToken);
+            return (await _releaseFileBlobService
+                .GetDownloadStream(releaseFile, cancellationToken: cancellationToken))
+                .Right;
         }
         catch (Exception exception)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage1Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage1Tests.cs
@@ -83,12 +83,12 @@ public class ProcessorStage1Tests
         var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
             "Resources", metaFileUnderTest);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.File.Path(),
             dataFilePath);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.MetaFile.Path(),
             metaFilePath);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage2Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage2Tests.cs
@@ -204,12 +204,12 @@ public class ProcessorStage2Tests
         var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
             "Resources", metaFileUnderTest);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.File.Path(),
             dataFilePath);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.MetaFile.Path(),
             metaFilePath);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorStage3Tests.cs
@@ -125,12 +125,12 @@ public class ProcessorStage3Tests
         var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
             "Resources", import.MetaFile.Filename);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.File.Path(),
             dataFilePath);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.MetaFile.Path(),
             metaFilePath);
@@ -352,12 +352,12 @@ public class ProcessorStage3Tests
         var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
             "Resources", import.MetaFile.Filename);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.File.Path(),
             dataFilePath);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.MetaFile.Path(),
             metaFilePath);
@@ -483,12 +483,12 @@ public class ProcessorStage3Tests
         var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
             "Resources", import.MetaFile.Filename);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.File.Path(),
             dataFilePath);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.MetaFile.Path(),
             metaFilePath);
@@ -632,12 +632,12 @@ public class ProcessorStage3Tests
         var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
             "Resources", import.MetaFile.Filename);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.File.Path(),
             dataFilePath);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.MetaFile.Path(),
             metaFilePath);
@@ -767,12 +767,12 @@ public class ProcessorStage3Tests
         var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
             "Resources", import.MetaFile.Filename);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.File.Path(),
             dataFilePath);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.MetaFile.Path(),
             metaFilePath);
@@ -928,12 +928,12 @@ public class ProcessorStage3Tests
         var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
             "Resources", import.MetaFile.Filename);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.File.Path(),
             dataFilePath);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.MetaFile.Path(),
             metaFilePath);
@@ -1069,12 +1069,12 @@ public class ProcessorStage3Tests
         var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
             "Resources", import.MetaFile.Filename);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.File.Path(),
             dataFilePath);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.MetaFile.Path(),
             metaFilePath);
@@ -1339,12 +1339,12 @@ public class ProcessorStage3Tests
         var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
             "Resources", import.MetaFile.Filename);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.File.Path(),
             dataFilePath);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.MetaFile.Path(),
             metaFilePath);
@@ -1506,12 +1506,12 @@ public class ProcessorStage3Tests
         var metaFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
             "Resources", import.MetaFile.Filename);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.File.Path(),
             dataFilePath);
 
-        privateBlobStorageService.SetupStreamBlob(
+        privateBlobStorageService.SetupGetDownloadStreamWithFilePath(
             PrivateReleaseFiles,
             import.MetaFile.Path(),
             metaFilePath);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Extensions/PrivateBlobStorageServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Extensions/PrivateBlobStorageServiceExtensions.cs
@@ -1,0 +1,27 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Extensions;
+
+public static class PrivateBlobStorageServiceExtensions
+{
+    public static Func<Task<Stream>> GetDataFileStreamProvider(
+        this IPrivateBlobStorageService service,
+        DataImport import)
+    {
+        return async () => (await service
+            .GetDownloadStream(PrivateReleaseFiles, import.File.Path()))
+            .Right;
+    }
+    
+    public static Func<Task<Stream>> GetMetadataFileStreamProvider(
+        this IPrivateBlobStorageService service,
+        DataImport import)
+    {
+        return async () => (await service
+            .GetDownloadStream(PrivateReleaseFiles, import.MetaFile.Path()))
+            .Right;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -1,13 +1,12 @@
 # nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Models;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.DataImportStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services;
@@ -60,8 +59,8 @@ public class FileImportService : IFileImportService
 
         var subject = await context.Subject.SingleAsync(s => s.Id.Equals(import.SubjectId));
 
-        var datafileStreamProvider = () => _privateBlobStorageService.StreamBlob(PrivateReleaseFiles, import.File.Path());
-        var metaFileStreamProvider = () => _privateBlobStorageService.StreamBlob(PrivateReleaseFiles, import.MetaFile.Path());
+        var datafileStreamProvider = _privateBlobStorageService.GetDataFileStreamProvider(import);
+        var metaFileStreamProvider = _privateBlobStorageService.GetMetadataFileStreamProvider(import);
 
         await _importerService.ImportObservations(
             import,
@@ -82,7 +81,7 @@ public class FileImportService : IFileImportService
     {
         var import = await _dataImportService.GetImport(importId);
 
-        var datafileStreamProvider = () => _privateBlobStorageService.StreamBlob(PrivateReleaseFiles, import.File.Path());
+        var datafileStreamProvider = _privateBlobStorageService.GetDataFileStreamProvider(import);
 
         await _importerService.ImportFiltersAndLocations(
             import,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
@@ -2,13 +2,12 @@
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services;
 
@@ -67,7 +66,7 @@ public class ProcessorService : IProcessorService
 
         var subject = await statisticsDbContext.Subject.SingleAsync(subject => subject.Id == import.SubjectId);
 
-        var metaFileStreamProvider = () => _privateBlobStorageService.StreamBlob(PrivateReleaseFiles, import.MetaFile.Path());
+        var metaFileStreamProvider = _privateBlobStorageService.GetMetadataFileStreamProvider(import);
 
         var metaFileCsvHeaders = await CsvUtils.GetCsvHeaders(metaFileStreamProvider);
         var metaFileCsvRows = await CsvUtils.GetCsvRows(metaFileStreamProvider);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
@@ -6,11 +6,10 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Models;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
 using Microsoft.Extensions.Logging;
-using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.ValidationErrorMessages;
 using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
@@ -83,11 +82,8 @@ public class ValidatorService : IValidatorService
 
         await _dataImportService.UpdateStatus(import.Id, DataImportStatus.STAGE_1, 0);
 
-        var dataFileStreamProvider = () => _privateBlobStorageService.StreamBlob(PrivateReleaseFiles,
-            import.File.Path());
-
-        var metaFileStreamProvider = () => _privateBlobStorageService.StreamBlob(PrivateReleaseFiles,
-            import.MetaFile.Path());
+        var dataFileStreamProvider = _privateBlobStorageService.GetDataFileStreamProvider(import);
+        var metaFileStreamProvider = _privateBlobStorageService.GetMetadataFileStreamProvider(import);
 
         return await
             ValidateCsvFileType(metaFileStreamProvider, isMetaFile: true)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectCsvMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/SubjectCsvMetaServiceTests.cs
@@ -150,7 +150,7 @@ public class SubjectCsvMetaServiceTests
             // Stubbing this out as testing headers in other methods
             releaseFileBlobService
                 .Setup(s =>
-                    s.StreamBlob(It.IsAny<ReleaseFile>(), default))
+                    s.GetDownloadStream(It.IsAny<ReleaseFile>(), default))
                 .ReturnsAsync("csv_header".ToStream());
 
             var service = BuildService(
@@ -299,7 +299,7 @@ public class SubjectCsvMetaServiceTests
             // Stubbing this out as testing headers in other methods
             releaseFileBlobService
                 .Setup(s =>
-                    s.StreamBlob(It.IsAny<ReleaseFile>(), default))
+                    s.GetDownloadStream(It.IsAny<ReleaseFile>(), default))
                 .ReturnsAsync("csv_header".ToStream());
 
             var service = BuildService(
@@ -415,7 +415,7 @@ public class SubjectCsvMetaServiceTests
             // Stubbing this out as testing headers in other methods
             releaseFileBlobService
                 .Setup(s =>
-                    s.StreamBlob(It.IsAny<ReleaseFile>(), default))
+                    s.GetDownloadStream(It.IsAny<ReleaseFile>(), default))
                 .ReturnsAsync("csv_header".ToStream());
 
             var service = BuildService(
@@ -513,7 +513,7 @@ public class SubjectCsvMetaServiceTests
             releaseFileBlobService
                 .Setup(
                     s =>
-                        s.StreamBlob(It.IsAny<ReleaseFile>(), default)
+                        s.GetDownloadStream(It.IsAny<ReleaseFile>(), default)
                 )
                 .ReturnsAsync("csv_header".ToStream());
 
@@ -620,7 +620,7 @@ public class SubjectCsvMetaServiceTests
             // Stubbing this out as testing headers in other methods
             releaseFileBlobService
                 .Setup(s =>
-                    s.StreamBlob(It.IsAny<ReleaseFile>(), default))
+                    s.GetDownloadStream(It.IsAny<ReleaseFile>(), default))
                 .ReturnsAsync("csv_header".ToStream());
 
             var service = BuildService(
@@ -707,7 +707,7 @@ public class SubjectCsvMetaServiceTests
             // Stubbing this out as testing headers in other methods
             releaseFileBlobService
                 .Setup(s =>
-                    s.StreamBlob(It.IsAny<ReleaseFile>(), default))
+                    s.GetDownloadStream(It.IsAny<ReleaseFile>(), default))
                 .ReturnsAsync("csv_header".ToStream());
 
             var service = BuildService(
@@ -828,7 +828,7 @@ public class SubjectCsvMetaServiceTests
 
             releaseFileBlobService
                 .Setup(
-                    s => s.StreamBlob(
+                    s => s.GetDownloadStream(
                         It.Is<ReleaseFile>(
                             rf => rf.FileId == releaseFile.FileId && rf.ReleaseVersionId == releaseFile.ReleaseVersionId
                         ),
@@ -1006,7 +1006,7 @@ public class SubjectCsvMetaServiceTests
 
             releaseFileBlobService
                 .Setup(
-                    s => s.StreamBlob(
+                    s => s.GetDownloadStream(
                         It.Is<ReleaseFile>(
                             rf => rf.FileId == releaseFile.FileId && rf.ReleaseVersionId == releaseFile.ReleaseVersionId
                         ),
@@ -1141,7 +1141,7 @@ public class SubjectCsvMetaServiceTests
 
             releaseFileBlobService
                 .Setup(
-                    s => s.StreamBlob(
+                    s => s.GetDownloadStream(
                         It.Is<ReleaseFile>(
                             rf => rf.FileId == releaseFile.FileId && rf.ReleaseVersionId == releaseFile.ReleaseVersionId
                         ),
@@ -1264,7 +1264,7 @@ public class SubjectCsvMetaServiceTests
 
             releaseFileBlobService
                 .Setup(
-                    s => s.StreamBlob(
+                    s => s.GetDownloadStream(
                         It.Is<ReleaseFile>(
                             rf => rf.FileId == releaseFile.FileId && rf.ReleaseVersionId == releaseFile.ReleaseVersionId
                         ),
@@ -1388,7 +1388,7 @@ public class SubjectCsvMetaServiceTests
 
             releaseFileBlobService
                 .Setup(
-                    s => s.StreamBlob(
+                    s => s.GetDownloadStream(
                         It.Is<ReleaseFile>(
                             rf => rf.FileId == releaseFile.FileId && rf.ReleaseVersionId == releaseFile.ReleaseVersionId
                         ),
@@ -1556,7 +1556,7 @@ public class SubjectCsvMetaServiceTests
 
             releaseFileBlobService
                 .Setup(
-                    s => s.StreamBlob(
+                    s => s.GetDownloadStream(
                         It.Is<ReleaseFile>(
                             rf => rf.FileId == releaseDataFile.FileId && rf.ReleaseVersionId == releaseDataFile.ReleaseVersionId
                         ),
@@ -1773,7 +1773,7 @@ public class SubjectCsvMetaServiceTests
             // Blob for release file does not exist in storage
             releaseFileBlobService
                 .Setup(
-                    s => s.StreamBlob(
+                    s => s.GetDownloadStream(
                         It.Is<ReleaseFile>(
                             rf => rf.FileId == releaseFile.FileId && rf.ReleaseVersionId == releaseFile.ReleaseVersionId
                         ),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectCsvMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectCsvMetaService.cs
@@ -90,7 +90,9 @@ public class SubjectCsvMetaService : ISubjectCsvMetaService
                     cancellationToken: cancellationToken
                 );
 
-            return await _releaseFileBlobService.StreamBlob(releaseFile, cancellationToken: cancellationToken);
+            return (await _releaseFileBlobService
+                .GetDownloadStream(releaseFile, cancellationToken: cancellationToken))
+                .Right;
         }
         catch (Exception exception)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CopyCsvFilesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Processor/Functions/CopyCsvFilesFunction.cs
@@ -71,11 +71,18 @@ public class CopyCsvFilesFunction(
                 destinationPath);
         }
 
-        var blobStream = await privateBlobStorageService.StreamBlob(
+        var blobStreamResult = await privateBlobStorageService.GetDownloadStream(
             BlobContainers.PrivateReleaseFiles,
             csvFile.Path(),
             cancellationToken: cancellationToken);
 
+        if (blobStreamResult.IsLeft)
+        {
+            throw new Exception($"Error getting blob stream for csv file '{csvFile.Path()}'. " +
+                                $"Got {blobStreamResult.Left.GetType().Name}");
+        }
+
+        await using var blobStream = blobStreamResult.Right;
         await using var fileStream = new FileStream(destinationPath, FileMode.Create, FileAccess.Write, FileShare.None);
 
         if (compress)


### PR DESCRIPTION
This PR:
- replaces usages of StreamBlob with GetDownloadStream, which is identical in function but offers the optional ability to disable decompression, and handles errors with Eithers rather than Exceptions.