### PR TITLE
EES-6456 Informative error message when replacing an ongoing replacement that has not been confirmed

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -64,6 +64,7 @@ const fileErrorMappings = {
   DataSetIsNotInAnImportableState: 'DataSetIsNotInAnImportableState',
   AnalystCannotReplaceApiDataSet: 'AnalystCannotReplaceApiDataSet',
   CannotCreateMultipleDraftApiDataSet: 'CannotCreateMultipleDraftApiDataSet',
+  DataReplacementAlreadyInProgress: 'DataReplacementAlreadyInProgress',
 };
 
 function baseErrorMappings(
@@ -87,8 +88,6 @@ function baseErrorMappings(
             'DataSetNamesCsvFileNamesShouldBeUnique',
           FileNotFoundInZip: 'FileNotFoundInZip',
           ZipContainsUnusedFiles: 'ZipContainsUnusedFiles',
-          DataReplacementAlreadyInProgress:
-            'Data replacement already in progress',
           DataSetTitleTooLong: 'DataSetTitleTooLong',
         },
       }),


### PR DESCRIPTION
This PR Fixes frontend code so that when on going replacement has not been confirmed, and another replacement is attempted, the error message is more instructive based on the original error message intended.

Current error message:
<img width="778" height="787" alt="image" src="https://github.com/user-attachments/assets/3e39afb5-0b3a-4580-bdfa-985a42632b57" />

Intended error message after small tweak:
<img width="1010" height="585" alt="image" src="https://github.com/user-attachments/assets/f61380a8-3f26-4b33-af48-9b9065efafc4" />

There are tests in place already for the backend which produces this error message. 