### PR TITLE
EES-6472 Enable nullable reference types in `Content.Api.Tests` project

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/ContentSectionViewModelBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/ContentSectionViewModelBuilder.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Builders;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/ThemeViewModelBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/ThemeViewModelBuilder.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Builders;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerAnalyticsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerAnalyticsTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerCachingTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net;
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/GlossaryControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/GlossaryControllerTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/MethodologyControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/MethodologyControllerTests.cs
@@ -29,9 +29,9 @@ public class MethodologyControllerTests
         var controller = new MethodologyController(methodologyService.Object);
 
         var result = await controller.GetLatestMethodologyBySlug("test-slug");
-        var methodologyViewModel = result.Value;
+        var methodologyVersionViewModel = result.AssertOkResult();
 
-        Assert.Equal(methodologyId, methodologyViewModel.Id);
+        Assert.Equal(methodologyId, methodologyVersionViewModel.Id);
 
         MockUtils.VerifyAllMocks(methodologyService);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/PageFeedbackControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/PageFeedbackControllerTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net.Http.Json;
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/PublicationControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/PublicationControllerTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/RedirectsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/RedirectsControllerTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Fixtures;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerCachingTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseControllerTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleaseFileControllerTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net.Http.Json;
 using System.Net.Mime;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleasePublishingFeedbackControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ReleasePublishingFeedbackControllerTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net.Http.Json;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerCachingTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Fixtures/IntegrationTestFixture.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Fixtures/IntegrationTestFixture.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using DotNet.Testcontainers.Containers;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Fixtures/TestApplicationFactory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Fixtures/TestApplicationFactory.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Reflection;
 using GovUk.Education.ExploreEducationStatistics.Analytics.Common.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     </PropertyGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/MockBuilders/PublicationsSearchServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/MockBuilders/PublicationsSearchServiceMockBuilder.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Requests;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/MockBuilders/PublicationsSitemapServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/MockBuilders/PublicationsSitemapServiceMockBuilder.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Content.Services.Publications;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Services.Publications;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Publications.Dtos;
 using Moq;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/MockBuilders/RelatedInformationServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/MockBuilders/RelatedInformationServiceMockBuilder.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Content.Services.RelatedInformation;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Services.RelatedInformation;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.RelatedInformation.Dtos;
 using Moq;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Publications/PublicationsSearchControllerCachingTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Publications/PublicationsSearchControllerCachingTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Publications/PublicationsSearchControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Publications/PublicationsSearchControllerTests.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers.Publications;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.MockBuilders;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Publications/PublicationsSitemapControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Publications/PublicationsSitemapControllerTests.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers.Publications;
+﻿using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers.Publications;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Publications.Dtos;
 using Xunit;


### PR DESCRIPTION
This change enables nullable reference types in the `Content.Api.Tests` project.

This work is being done as part of EES-6401 so that no newly created or edited controller tests have to be checked for the `#nullable enable` pragma.

`Content.Api.Tests` has 26 .cs files.

`#nullable enable` enable was already added on a file-by-file basis to all files of `Content.Api.Tests`, except for  

* `RelatedInformationControllerTests.cs`
* `MethodologyControllerTests.cs`
* `SecurityHeadersTests.cs`

`RelatedInformationControllerTests` and `SecurityHeadersTests` have been checked to make sure no new warnings are introduced after nullable reference types are enabled with this change.

This PR has 25 files changed:
* 23 .cs files changed removing `#nullable enable`
* `MethodologyControllerTests` changed to fix a nullable warning
* 1 .csproj file changed