### PR TITLE
EES-6478 restore the replace data button

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -1,3 +1,4 @@
+import releaseDataFileService from '@admin/services/releaseDataFileService';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
@@ -7,13 +8,15 @@ import FormFieldFileInput from '@common/components/form/FormFieldFileInput';
 import FormProvider from '@common/components/form/FormProvider';
 import Form from '@common/components/form/Form';
 import LoadingSpinner from '@common/components/LoadingSpinner';
+import WarningMessage from '@common/components/WarningMessage';
+import useToggle from '@common/hooks/useToggle';
 import {
   FieldMessageMapper,
   FieldName,
   mapFieldErrors,
 } from '@common/validation/serverValidations';
 import Yup from '@common/validation/yup';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { ObjectSchema } from 'yup';
 
 type FileType = 'csv' | 'zip' | 'bulkZip';
@@ -44,6 +47,7 @@ const subjectErrorMappings = [
 // Error messages are returned by the backend so don't need to
 // define them here, but can't leave them blank in the mapping.
 const fileErrorMappings = {
+  DataReplacementAlreadyInProgress: 'Data replacement already in progress',
   DataSetTitleCannotBeEmpty: 'DataSetTitleCannotBeEmpty',
   DataSetTitleShouldNotContainSpecialCharacters:
     'DataSetTitleShouldNotContainSpecialCharacters',
@@ -87,8 +91,6 @@ function baseErrorMappings(
             'DataSetNamesCsvFileNamesShouldBeUnique',
           FileNotFoundInZip: 'FileNotFoundInZip',
           ZipContainsUnusedFiles: 'ZipContainsUnusedFiles',
-          DataReplacementAlreadyInProgress:
-            'Data replacement already in progress',
           DataSetTitleTooLong: 'DataSetTitleTooLong',
         },
       }),
@@ -121,23 +123,75 @@ function baseErrorMappings(
 }
 
 interface Props {
+  dataSetFileTitles?: string[];
   isDataReplacement?: boolean;
-  onSubmit: (values: DataFileUploadFormValues) => void | Promise<void>;
+  releaseVersionId: string;
+  dataFileTitle?: string;
+  onSubmit: () => void;
   onCancel?: () => void;
 }
 
 export default function DataFileUploadForm({
+  dataSetFileTitles = [],
   isDataReplacement = false,
+  releaseVersionId,
+  dataFileTitle,
   onSubmit,
   onCancel,
 }: Props) {
   const [selectedFileType, setSelectedFileType] = useState<FileType>('csv');
+  const [showReplacementWarning, toggleReplacementWarning] = useToggle(false);
 
   const getErrorMappings = () => {
     return isDataReplacement
       ? baseErrorMappings(selectedFileType)
       : [...baseErrorMappings(selectedFileType), ...subjectErrorMappings];
   };
+
+  const handleSubmit = useCallback(
+    async (values: DataFileUploadFormValues) => {
+      switch (values.uploadType) {
+        case 'csv': {
+          if (!values.title) {
+            return;
+          }
+
+          await releaseDataFileService.uploadDataSetFilePair(releaseVersionId, {
+            title: values.title,
+            dataFile: values.dataFile as File,
+            metadataFile: values.metadataFile as File,
+          });
+          break;
+        }
+        case 'zip': {
+          if (!values.title) {
+            return;
+          }
+          await releaseDataFileService.uploadZippedDataSetFilePair(
+            releaseVersionId,
+            {
+              title: values.title,
+              zipFile: values.zipFile as File,
+            },
+          );
+          break;
+        }
+        case 'bulkZip': {
+          await releaseDataFileService.uploadBulkZipDataSetFile(
+            releaseVersionId,
+            values.bulkZipFile!,
+          );
+          break;
+        }
+        default:
+          break;
+      }
+
+      onSubmit();
+      toggleReplacementWarning.off();
+    },
+    [onSubmit, releaseVersionId, toggleReplacementWarning],
+  );
 
   const validationSchema = useMemo<
     ObjectSchema<DataFileUploadFormValues>
@@ -196,36 +250,54 @@ export default function DataFileUploadForm({
     uploadType: 'csv',
     dataFile: null,
     metadataFile: null,
+    title: dataFileTitle ?? '',
     zipFile: null,
   };
 
   return (
     <FormProvider
       errorMappings={getErrorMappings()}
-      initialValues={
-        isDataReplacement
-          ? defaultInitialValues
-          : { ...defaultInitialValues, title: '' }
-      }
+      initialValues={defaultInitialValues}
       resetAfterSubmit
       validationSchema={validationSchema}
     >
-      {({ formState, reset, getValues }) => {
+      {({ formState, reset, getValues, watch }) => {
         const uploadType = getValues('uploadType');
+        const title = watch('title');
 
         return (
-          <Form id="dataFileUploadForm" onSubmit={onSubmit}>
+          <Form
+            id={
+              isDataReplacement
+                ? 'dataFileReplacementUploadForm'
+                : 'dataFileUploadForm'
+            }
+            onSubmit={handleSubmit}
+          >
             <div style={{ position: 'relative' }}>
               {formState.isSubmitting && (
                 <LoadingSpinner text="Uploading files" overlay />
               )}
               {!isDataReplacement && uploadType !== 'bulkZip' && (
-                <FormFieldTextInput<DataFileUploadFormValues>
-                  name="title"
-                  label="Title"
-                  className="govuk-!-width-two-thirds"
-                  maxLength={titleMaxLength}
-                />
+                <>
+                  <FormFieldTextInput<DataFileUploadFormValues>
+                    name="title"
+                    label="Title"
+                    className="govuk-!-width-two-thirds"
+                    maxLength={titleMaxLength}
+                    onBlur={() => {
+                      toggleReplacementWarning(
+                        dataSetFileTitles.includes(title),
+                      );
+                    }}
+                  />
+                  {showReplacementWarning && (
+                    <WarningMessage>
+                      Using this title will trigger a data replacement on the
+                      matching file.
+                    </WarningMessage>
+                  )}
+                </>
               )}
 
               <FormFieldRadioGroup<DataFileUploadFormValues>
@@ -290,7 +362,15 @@ export default function DataFileUploadForm({
               />
 
               <ButtonGroup>
-                <Button type="submit" disabled={formState.isSubmitting}>
+                <Button
+                  type="submit"
+                  disabled={formState.isSubmitting}
+                  testId={
+                    isDataReplacement
+                      ? 'upload-replacement-files-button'
+                      : 'upload-files-button'
+                  }
+                >
                   Upload data files
                 </Button>
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTable.tsx
@@ -19,6 +19,7 @@ interface Props {
   onDeleteFile: (deletedFileId: string) => void;
   onDeleteUpload: (deletedUploadId: string) => void;
   onDataSetImport: (dataSetImportIds: string[]) => void;
+  onReplaceFile: () => void;
   onStatusChange: (
     dataFile: DataFile,
     importStatus: DataFileImportStatus,
@@ -36,6 +37,7 @@ export default function DataFilesTable({
   onDeleteFile,
   onDeleteUpload,
   onDataSetImport,
+  onReplaceFile,
   onStatusChange,
 }: Props) {
   return (
@@ -62,6 +64,7 @@ export default function DataFilesTable({
             publicationId={publicationId}
             releaseVersionId={releaseVersionId}
             onConfirmDelete={onDeleteFile}
+            onReplaceFile={onReplaceFile}
             onStatusChange={onStatusChange}
           />
         ))}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableRow.tsx
@@ -17,10 +17,12 @@ import {
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
 import Modal from '@common/components/Modal';
+import useToggle from '@common/hooks/useToggle';
 import React from 'react';
 import { generatePath } from 'react-router';
 import styles from './DataFilesTable.module.scss';
 import DeleteDataFileModal from './DeleteDataFileModal';
+import DataFileUploadForm from './DataFileUploadForm';
 
 interface Props {
   canUpdateRelease?: boolean;
@@ -28,6 +30,7 @@ interface Props {
   publicationId: string;
   releaseVersionId: string;
   onConfirmDelete: (deletedFileId: string) => void;
+  onReplaceFile: () => void;
   onStatusChange: (
     dataFile: DataFile,
     importStatus: DataFileImportStatus,
@@ -39,9 +42,11 @@ export default function DataFilesTableRow({
   dataFile,
   publicationId,
   releaseVersionId,
+  onReplaceFile,
   onConfirmDelete,
   onStatusChange,
 }: Props) {
+  const [showReplacementModal, toggleReplacementModal] = useToggle(false);
   return (
     <tr key={dataFile.title}>
       <td data-testid="Title" className={styles.title}>
@@ -76,18 +81,40 @@ export default function DataFilesTableRow({
             terminalImportStatuses.includes(dataFile.status) && (
               <>
                 {dataFile.status === 'COMPLETE' && (
-                  <Link
-                    to={generatePath<ReleaseDataFileRouteParams>(
-                      releaseDataFileRoute.path,
-                      {
-                        publicationId,
-                        releaseVersionId,
-                        fileId: dataFile.id,
-                      },
-                    )}
-                  >
-                    Edit title
-                  </Link>
+                  <>
+                    <Link
+                      to={generatePath<ReleaseDataFileRouteParams>(
+                        releaseDataFileRoute.path,
+                        {
+                          publicationId,
+                          releaseVersionId,
+                          fileId: dataFile.id,
+                        },
+                      )}
+                    >
+                      Edit title
+                    </Link>
+                    <Modal
+                      open={showReplacementModal}
+                      title="Replace data"
+                      triggerButton={
+                        <ButtonText onClick={toggleReplacementModal.on}>
+                          Replace data
+                        </ButtonText>
+                      }
+                    >
+                      <DataFileUploadForm
+                        isDataReplacement
+                        releaseVersionId={releaseVersionId}
+                        dataFileTitle={dataFile.title}
+                        onCancel={toggleReplacementModal.off}
+                        onSubmit={() => {
+                          toggleReplacementModal.off();
+                          onReplaceFile();
+                        }}
+                      />
+                    </Modal>
+                  </>
                 )}
                 {dataFile.publicApiDataSetId ? (
                   <Modal

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -176,50 +176,10 @@ export default function ReleaseDataUploadsSection({
     );
   }, []);
 
-  const handleSubmit = useCallback(
-    async (values: DataFileUploadFormValues) => {
-      switch (values.uploadType) {
-        case 'csv': {
-          if (!values.title) {
-            return;
-          }
-
-          await releaseDataFileService.uploadDataSetFilePair(releaseVersionId, {
-            title: values.title,
-            dataFile: values.dataFile as File,
-            metadataFile: values.metadataFile as File,
-          });
-          break;
-        }
-        case 'zip': {
-          if (!values.title) {
-            return;
-          }
-          await releaseDataFileService.uploadZippedDataSetFilePair(
-            releaseVersionId,
-            {
-              title: values.title,
-              zipFile: values.zipFile as File,
-            },
-          );
-          break;
-        }
-        case 'bulkZip': {
-          await releaseDataFileService.uploadBulkZipDataSetFile(
-            releaseVersionId,
-            values.bulkZipFile!,
-          );
-          break;
-        }
-        default:
-          break;
-      }
-
-      await refetchDataFiles();
-      await refetchDataSetUploads();
-    },
-    [releaseVersionId, refetchDataFiles, refetchDataSetUploads],
-  );
+  const handleSubmit = async () => {
+    await refetchDataFiles();
+    await refetchDataSetUploads();
+  };
 
   const handleConfirmReordering = useCallback(
     async (nextDataFiles: DataFile[]) => {
@@ -273,16 +233,21 @@ export default function ReleaseDataUploadsSection({
             </a>
           </li>
         </ul>
-
+        <h4>Data replacement</h4>
         <p>
-          Files are expected to have a unique "Title", any files that are
-          uploaded with a "Title" that matches an existing "Title" will provide
-          an option to start a data replacement instead of importing as a
-          separate file.
+          Files are expected to have a unique title, any files that are uploaded
+          with a title that matches an existing file will start a data
+          replacement instead of importing as a separate file.
         </p>
       </InsetText>
       {canUpdateRelease ? (
-        <DataFileUploadForm onSubmit={handleSubmit} />
+        <DataFileUploadForm
+          dataSetFileTitles={dataFilesExcludingReplacements.map(
+            file => file.title,
+          )}
+          releaseVersionId={releaseVersionId}
+          onSubmit={handleSubmit}
+        />
       ) : (
         <WarningMessage>
           This release has been approved, and can no longer be updated.
@@ -347,6 +312,7 @@ export default function ReleaseDataUploadsSection({
                     onDeleteFile={handleDeleteConfirm}
                     onDeleteUpload={handleDeleteUploadConfirm}
                     onDataSetImport={handleDataSetImport}
+                    onReplaceFile={handleSubmit}
                     onStatusChange={handleStatusChange}
                   />
                 )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileUploadForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileUploadForm.test.tsx
@@ -1,12 +1,24 @@
 import DataFileUploadForm from '@admin/pages/release/data/components/DataFileUploadForm';
+import _releaseDataFileService from '@admin/services/releaseDataFileService';
 import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import noop from 'lodash/noop';
 import render from '@common-test/render';
 
+jest.mock('@admin/services/releaseDataFileService');
+
+const releaseDataFileService = _releaseDataFileService as jest.Mocked<
+  typeof _releaseDataFileService
+>;
+
 describe('DataFileUploadForm', () => {
   test('shows validation message when no data file selected', async () => {
-    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={noop}
+      />,
+    );
 
     await user.click(
       screen.getByRole('button', {
@@ -24,7 +36,12 @@ describe('DataFileUploadForm', () => {
   });
 
   test('shows validation message when data file is not empty', async () => {
-    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={noop}
+      />,
+    );
 
     const file = new File([], 'test.csv', {
       type: 'text/csv',
@@ -47,7 +64,12 @@ describe('DataFileUploadForm', () => {
   });
 
   test('shows validation message when no meta data file selected', async () => {
-    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={noop}
+      />,
+    );
 
     await user.click(
       screen.getByRole('button', {
@@ -65,7 +87,12 @@ describe('DataFileUploadForm', () => {
   });
 
   test('shows validation message when metadata file is not empty', async () => {
-    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={noop}
+      />,
+    );
 
     const file = new File([], 'test.csv', {
       type: 'text/csv',
@@ -88,7 +115,12 @@ describe('DataFileUploadForm', () => {
   });
 
   test('shows validation message when no ZIP file selected', async () => {
-    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={noop}
+      />,
+    );
 
     await user.click(screen.getByLabelText('ZIP file'));
     await user.click(
@@ -107,7 +139,12 @@ describe('DataFileUploadForm', () => {
   });
 
   test('shows validation message when ZIP file is empty', async () => {
-    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={noop}
+      />,
+    );
 
     const file = new File([], 'test.zip', {
       type: 'application/zip',
@@ -131,7 +168,12 @@ describe('DataFileUploadForm', () => {
   });
 
   test('shows validation message when no bulk ZIP file selected', async () => {
-    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={noop}
+      />,
+    );
 
     await user.click(screen.getByLabelText('Bulk ZIP upload'));
     await user.click(
@@ -149,9 +191,100 @@ describe('DataFileUploadForm', () => {
     });
   });
 
-  test('form submits without error when suitable file is used', async () => {
+  test('form submits and calls the correct endpoint csv files are used', async () => {
     const onSubmit = jest.fn();
-    const { user } = render(<DataFileUploadForm onSubmit={onSubmit} />);
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const file = new File(['hello, world!'], 'test.csv', {
+      type: 'application/csv',
+    });
+    const metaFile = new File(['hello, world!'], 'test.meta.csv', {
+      type: 'application/csv',
+    });
+
+    await user.type(screen.getByLabelText('Title'), 'Test title');
+    await user.click(screen.getByLabelText('CSV files'));
+    await user.upload(screen.getByLabelText('Upload data file'), file);
+    await user.upload(screen.getByLabelText('Upload metadata file'), metaFile);
+
+    expect(releaseDataFileService.uploadDataSetFilePair).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Upload data files',
+      }),
+    );
+
+    expect(releaseDataFileService.uploadDataSetFilePair).toHaveBeenCalledTimes(
+      1,
+    );
+
+    expect(releaseDataFileService.uploadDataSetFilePair).toHaveBeenCalledWith(
+      'release-version-id',
+      {
+        title: 'Test title',
+        dataFile: file,
+        metadataFile: metaFile,
+      },
+    );
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  test('form submits and calls the correct endpoint when a zip file is used', async () => {
+    const onSubmit = jest.fn();
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const file = new File(['hello, world!'], 'test.zip', {
+      type: 'application/zip',
+    });
+
+    await user.type(screen.getByLabelText('Title'), 'Test title');
+    await user.click(screen.getByLabelText('ZIP file'));
+    await user.upload(screen.getByLabelText('Upload ZIP file'), file);
+
+    expect(
+      releaseDataFileService.uploadZippedDataSetFilePair,
+    ).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Upload data files',
+      }),
+    );
+
+    expect(
+      releaseDataFileService.uploadZippedDataSetFilePair,
+    ).toHaveBeenCalledTimes(1);
+
+    expect(
+      releaseDataFileService.uploadZippedDataSetFilePair,
+    ).toHaveBeenCalledWith('release-version-id', {
+      title: 'Test title',
+      zipFile: file,
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  test('form submits and calls the correct endpoint when a bulk zip file is used', async () => {
+    const onSubmit = jest.fn();
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={onSubmit}
+      />,
+    );
 
     const file = new File(['hello, world!'], 'test.zip', {
       type: 'application/zip',
@@ -159,17 +292,35 @@ describe('DataFileUploadForm', () => {
 
     await user.click(screen.getByLabelText('Bulk ZIP upload'));
     await user.upload(screen.getByLabelText('Upload bulk ZIP file'), file);
+
+    expect(
+      releaseDataFileService.uploadBulkZipDataSetFile,
+    ).not.toHaveBeenCalled();
+
     await user.click(
       screen.getByRole('button', {
         name: 'Upload data files',
       }),
     );
 
+    expect(
+      releaseDataFileService.uploadBulkZipDataSetFile,
+    ).toHaveBeenCalledTimes(1);
+
+    expect(
+      releaseDataFileService.uploadBulkZipDataSetFile,
+    ).toHaveBeenCalledWith('release-version-id', file);
+
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
   test('shows validation message when bulk ZIP file is empty', async () => {
-    const { user } = render(<DataFileUploadForm onSubmit={noop} />);
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={noop}
+      />,
+    );
 
     const file = new File([], 'test.zip', {
       type: 'application/zip',
@@ -195,7 +346,12 @@ describe('DataFileUploadForm', () => {
   test('cannot submit with invalid values when trying to upload CSV files', async () => {
     const handleSubmit = jest.fn();
 
-    const { user } = render(<DataFileUploadForm onSubmit={handleSubmit} />);
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={handleSubmit}
+      />,
+    );
 
     await user.click(
       screen.getByRole('button', {
@@ -227,7 +383,12 @@ describe('DataFileUploadForm', () => {
   test('cannot submit with invalid values when trying to upload ZIP file', async () => {
     const handleSubmit = jest.fn();
 
-    const { user } = render(<DataFileUploadForm onSubmit={handleSubmit} />);
+    const { user } = render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={handleSubmit}
+      />,
+    );
 
     await user.click(screen.getByLabelText('ZIP file'));
     await user.click(
@@ -256,5 +417,86 @@ describe('DataFileUploadForm', () => {
         }),
       ).toBeInTheDocument();
     });
+  });
+
+  test('shows the title field when not a data replacement', () => {
+    render(
+      <DataFileUploadForm
+        releaseVersionId="release-version-id"
+        onSubmit={noop}
+      />,
+    );
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
+  });
+
+  test('does not show title field for data replacement', () => {
+    render(
+      <DataFileUploadForm
+        isDataReplacement
+        releaseVersionId="release-version-id"
+        dataFileTitle="Test title"
+        onSubmit={noop}
+      />,
+    );
+    expect(screen.queryByLabelText('Title')).not.toBeInTheDocument();
+  });
+
+  test('submits data replacement correctly', async () => {
+    const onSubmit = jest.fn();
+    const { user } = render(
+      <DataFileUploadForm
+        isDataReplacement
+        releaseVersionId="release-version-id"
+        dataFileTitle="Test title"
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const file = new File(['hello, world!'], 'test.zip', {
+      type: 'application/zip',
+    });
+
+    await user.click(screen.getByLabelText('ZIP file'));
+    await user.upload(screen.getByLabelText('Upload ZIP file'), file);
+
+    expect(
+      releaseDataFileService.uploadZippedDataSetFilePair,
+    ).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Upload data files',
+      }),
+    );
+
+    expect(
+      releaseDataFileService.uploadZippedDataSetFilePair,
+    ).toHaveBeenCalledTimes(1);
+
+    expect(
+      releaseDataFileService.uploadZippedDataSetFilePair,
+    ).toHaveBeenCalledWith('release-version-id', {
+      title: 'Test title',
+      zipFile: file,
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows a warning if uploading a data replacement when using the main form', async () => {
+    const { user } = render(
+      <DataFileUploadForm
+        dataSetFileTitles={['Test title']}
+        releaseVersionId="release-version-id"
+        onSubmit={noop}
+      />,
+    );
+    await user.type(screen.getByLabelText('Title'), 'Test title');
+    await user.tab();
+    expect(
+      screen.getByText(
+        /Using this title will trigger a data replacement on the matching file/,
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/PendingDataReplacementSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/PendingDataReplacementSection.test.tsx
@@ -98,10 +98,13 @@ describe('PendingDataReplacementSection', () => {
   test('cancelling as an analyst when there is a public API linked to the data file is not possible', async () => {
     renderWithAuth({ ...defaultProps }, analyst);
     await waitFor(async () => {
-      await userEvent.click(
+      expect(
         screen.getByRole('button', { name: /cancel data replacement/i }),
-      );
+      ).toBeInTheDocument();
     });
+    await userEvent.click(
+      screen.getByRole('button', { name: /cancel data replacement/i }),
+    );
     expect(
       screen.getByText(
         /You do not have permission to cancel this data replacement. This is because it is linked to an API data set version which can only be modified by BAU users./i,
@@ -124,10 +127,13 @@ describe('PendingDataReplacementSection', () => {
   test('cancelling as an bau when there is a public API linked to the data file is not possible', async () => {
     renderWithAuth({ ...defaultProps }, bau);
     await waitFor(async () => {
-      await userEvent.click(
+      expect(
         screen.getByRole('button', { name: /cancel data replacement/i }),
-      );
+      ).toBeInTheDocument();
     });
+    await userEvent.click(
+      screen.getByRole('button', { name: /cancel data replacement/i }),
+    );
 
     expect(
       screen.queryByText(/explore.statistics@education.gov.uk/i),

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -216,8 +216,26 @@ Change the Release type
 Upload a replacement data set
     user clicks link    Data and files
     user waits until page contains data uploads table
-    user uploads subject and waits until complete    Dates test subject    dates-replacement.csv
+    user uploads subject replacement    Dates test subject    dates-replacement.csv
     ...    dates-replacement.meta.csv
+
+Confirm data replacement via quick action
+    user waits until page contains element    testid:Data file replacements table
+    user checks table cell contains    1    1    Dates test subject    testid:Data file replacements table
+    user checks table cell contains    1    2    17 Kb    testid:Data file replacements table
+    user checks table cell contains    1    3    Ready    testid:Data file replacements table
+
+    user clicks button    Confirm replacement
+    user waits until page contains data uploads table
+    user checks table cell contains    1    1    Dates test subject    testid:Data files table
+    user checks table cell contains    1    2    17 Kb    testid:Data files table
+    user checks table cell contains    1    3    Complete    testid:Data files table
+
+Upload a replacement data set using the button
+    user clicks button    Replace data
+    user chooses file    id:dataFileReplacementUploadForm-dataFile    ${FILES_DIR}dates-replacement.csv
+    user chooses file    id:dataFileReplacementUploadForm-metadataFile    ${FILES_DIR}dates-replacement.meta.csv
+    user clicks element    testid:upload-replacement-files-button
 
 Confirm data replacement via quick action
     user waits until page contains element    testid:Data file replacements table


### PR DESCRIPTION
- Restored the 'replace data' button for data files, when clicked it opens a modal with the file upload form in.

<img width="1454" height="975" alt="Screenshot 2025-09-04 102241" src="https://github.com/user-attachments/assets/8e155b74-fac6-48a1-a1b4-ccc67c6ac19d" />


- Using the main form, if you use an existing file title you get a warning that it will replace the data. I initially used a modal on submit for this, which was a bit nicer, but it didn't play nicely with the server side error messages so changed to showing a warning instead.

<img width="884" height="204" alt="Screenshot 2025-09-04 160742" src="https://github.com/user-attachments/assets/b9923df5-c437-475a-bc7e-a1d25cec8630" />


- If you try to upload a data replacement, using the main form, for a file that the replacement is already in progress for it shows the correct error message (it was a generic one before)

- Updated the guidance text for data replacements.

- I've copied Dunc's fix for a jest test to this PR as it's not on master yet https://github.com/dfe-analytical-services/explore-education-statistics/commit/da8c1986247480684707ed96c4d800318a39f1fa 
