### PR TITLE
EES-6488 - replacing az upgrade request with apt update

### DIFF
--- a/infrastructure/common/ci/tasks/update-azure-cli-and-extensions.yml
+++ b/infrastructure/common/ci/tasks/update-azure-cli-and-extensions.yml
@@ -1,0 +1,14 @@
+steps:
+- task: Bash@3
+  displayName: Upgrade Azure CLI and extensions
+  inputs:
+    targetType: inline
+    script: |
+      set -e
+      sudo apt-get update && \
+        sudo apt-get install --only-upgrade -y azure-cli
+      
+      # Grab the list of installed Azure CLI extensions and
+      # for each, call "az extension update" on it.
+      az extension list --query '[].name' --output tsv \
+        | xargs -i az extension update --name {}

--- a/infrastructure/templates/analytics/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/analytics/ci/jobs/deploy-infrastructure.yml
@@ -21,8 +21,7 @@ jobs:
           steps:
             - checkout: self
 
-            - script: az upgrade --yes
-              displayName: Upgrade Azure CLI and extensions
+            - template: ../../../../common/ci/tasks/update-azure-cli-and-extensions.yml
 
             - template: ../tasks/deploy-bicep.yml
               parameters:

--- a/infrastructure/templates/public-api/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/public-api/ci/jobs/deploy-infrastructure.yml
@@ -21,8 +21,7 @@ jobs:
           steps:
             - checkout: self
 
-            - script: az upgrade --yes
-              displayName: Upgrade Azure CLI and extensions
+            - template: ../../../../common/ci/tasks/update-azure-cli-and-extensions.yml
 
             - template: ../tasks/deploy-bicep.yml
               parameters:

--- a/infrastructure/templates/screener/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/screener/ci/jobs/deploy-infrastructure.yml
@@ -21,8 +21,7 @@ jobs:
           steps:
             - checkout: self
 
-            - script: az upgrade --yes
-              displayName: Upgrade Azure CLI and extensions
+            - template: ../../../../common/ci/tasks/update-azure-cli-and-extensions.yml
 
             - template: ../tasks/deploy-bicep.yml
               parameters:

--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -31,8 +31,7 @@ jobs:
             - checkout: self
             - download: none
 
-            - script: az upgrade --yes
-              displayName: Upgrade Azure CLI and extensions
+            - template: ../../../../common/ci/tasks/update-azure-cli-and-extensions.yml
 
             - template: ../tasks/deploy-bicep.yml
               parameters:


### PR DESCRIPTION
This PR:
- fixes the "Upgrade Azure CLI and extensions" step used in various deploy pipelines, by switching from unsupported `az upgrade` to apt-based upgrade.

The problem that we're solving is that since version 2.76 of Azure CLI, performing an `az upgrade` in DevOps is failing with a Python error about missing packages.  DevOps also states that `az upgrade` is not supported yet.

This PR replaces that with an apt update and a focused upgrade of az-cli, followed by invoking `az extension update` on every installed extension.

This fixes:
- Public API pipeline
- Screener pipeline
- Search pipeline
- Analytics pipeline