### PR TITLE
EES-6485 Add 'First published' entry to Release updates

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ReleaseNoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ReleaseNoteService.cs
@@ -43,6 +43,7 @@ public class ReleaseNoteService : IReleaseNoteService
             {
                 _context.Update.Add(new Update
                 {
+                    // TODO EES-6490 Convert 'On' from DateTime to DateTimeOffset
                     On = saveRequest.On ?? DateTime.Now,
                     Reason = saveRequest.Reason,
                     ReleaseVersionId = releaseVersion.Id,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -912,7 +912,8 @@ internal class NoOpDataSetVersionService : IDataSetVersionService
         int pageSize,
         CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>.Paginate([], 1, 10));
+        return Task.FromResult(new Either<ActionResult, PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>>(
+            PaginatedListViewModel<DataSetLiveVersionSummaryViewModel>.Paginate([], 1, 10)));
     }
 
     public Task<Either<ActionResult, DataSetVersionInfoViewModel>> GetDataSetVersion(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ViewModels/PaginatedListViewModelTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/ViewModels/PaginatedListViewModelTests.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using Xunit;
 
@@ -12,53 +11,53 @@ public class PaginatedListViewModelTests
     {
         var allResults = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
 
-        Assert.Throws<ArgumentException>(() => 
+        Assert.Throws<ArgumentException>(() =>
             new PaginatedListViewModel<int>(allResults, allResults.Count, -1, 5));
     }
-    
+
     [Fact]
     public void InvalidPageSizeThrows()
     {
         var allResults = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
 
-        Assert.Throws<ArgumentException>(() => 
+        Assert.Throws<ArgumentException>(() =>
             new PaginatedListViewModel<int>(allResults, allResults.Count, 1, -1));
     }
-    
+
     [Fact]
     public void Paginate()
     {
         var allResults = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
 
-        var page = 2;
-        var pageSize = 3;
+        const int page = 2;
+        const int pageSize = 3;
 
-        var result = PaginatedListViewModel<int>.Paginate(
-            allResults, page, pageSize);
+        var paginatedViewModel = PaginatedListViewModel<int>.Paginate(
+            allResults,
+            page,
+            pageSize);
 
-        var paginatedViewModel = result.AssertRight();
-
-        Assert.Equal(new List<int> { 4, 5, 6 },  paginatedViewModel.Results);
+        Assert.Equal([4, 5, 6], paginatedViewModel.Results);
         Assert.Equal(page, paginatedViewModel.Paging.Page);
         Assert.Equal(pageSize, paginatedViewModel.Paging.PageSize);
         Assert.Equal(allResults.Count, paginatedViewModel.Paging.TotalResults);
         Assert.Equal(4, paginatedViewModel.Paging.TotalPages);
     }
-    
+
     [Fact]
     public void Paginate_LastPage()
     {
         var allResults = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
 
-        var page = 4;
-        var pageSize = 3;
+        const int page = 4;
+        const int pageSize = 3;
 
-        var result = PaginatedListViewModel<int>.Paginate(
-            allResults, page, pageSize);
+        var paginatedViewModel = PaginatedListViewModel<int>.Paginate(
+            allResults,
+            page,
+            pageSize);
 
-        var paginatedViewModel = result.AssertRight();
-
-        Assert.Equal(new List<int> { 10 },  paginatedViewModel.Results);
+        Assert.Equal([10], paginatedViewModel.Results);
         Assert.Equal(page, paginatedViewModel.Paging.Page);
         Assert.Equal(pageSize, paginatedViewModel.Paging.PageSize);
         Assert.Equal(allResults.Count, paginatedViewModel.Paging.TotalResults);
@@ -70,15 +69,15 @@ public class PaginatedListViewModelTests
     {
         var allResults = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
 
-        var page = 1;
-        var pageSize = 100;
+        const int page = 1;
+        const int pageSize = 100;
 
-        var result = PaginatedListViewModel<int>.Paginate(
-            allResults, page, pageSize);
+        var paginatedViewModel = PaginatedListViewModel<int>.Paginate(
+            allResults,
+            page,
+            pageSize);
 
-        var paginatedViewModel = result.AssertRight();
-
-        Assert.Equal(allResults,  paginatedViewModel.Results);
+        Assert.Equal(allResults, paginatedViewModel.Results);
         Assert.Equal(page, paginatedViewModel.Paging.Page);
         Assert.Equal(pageSize, paginatedViewModel.Paging.PageSize);
         Assert.Equal(allResults.Count, paginatedViewModel.Paging.TotalResults);
@@ -90,15 +89,15 @@ public class PaginatedListViewModelTests
     {
         var allResults = new List<int> { 1 };
 
-        var page = 1;
-        var pageSize = 10;
+        const int page = 1;
+        const int pageSize = 10;
 
-        var result = PaginatedListViewModel<int>.Paginate(
-            allResults, page, pageSize);
+        var paginatedViewModel = PaginatedListViewModel<int>.Paginate(
+            allResults,
+            page,
+            pageSize);
 
-        var paginatedViewModel = result.AssertRight();
-
-        Assert.Equal(allResults,  paginatedViewModel.Results);
+        Assert.Equal(allResults, paginatedViewModel.Results);
         Assert.Equal(page, paginatedViewModel.Paging.Page);
         Assert.Equal(pageSize, paginatedViewModel.Paging.PageSize);
         Assert.Equal(allResults.Count, paginatedViewModel.Paging.TotalResults);
@@ -108,20 +107,20 @@ public class PaginatedListViewModelTests
     [Fact]
     public void Paginate_NoResults()
     {
-        var noResults = new List<int>();
+        var allResults = new List<int>();
 
-        var page = 1;
-        var pageSize = 10;
+        const int page = 1;
+        const int pageSize = 10;
 
-        var result = PaginatedListViewModel<int>.Paginate(
-            noResults, page, pageSize);
+        var paginatedViewModel = PaginatedListViewModel<int>.Paginate(
+            allResults,
+            page,
+            pageSize);
 
-        var paginatedViewModel = result.AssertRight();
-
-        Assert.Equal(noResults,  paginatedViewModel.Results);
+        Assert.Equal(allResults, paginatedViewModel.Results);
         Assert.Equal(page, paginatedViewModel.Paging.Page);
         Assert.Equal(pageSize, paginatedViewModel.Paging.PageSize);
-        Assert.Equal(noResults.Count, paginatedViewModel.Paging.TotalResults);
+        Assert.Equal(allResults.Count, paginatedViewModel.Paging.TotalResults);
         Assert.Equal(1, paginatedViewModel.Paging.TotalPages);
     }
 
@@ -130,12 +129,18 @@ public class PaginatedListViewModelTests
     {
         var allResults = new List<int>{ 1, 2, 3 };
 
-        var page = 2;
-        var pageSize = 10;
+        const int page = 2;
+        const int pageSize = 10;
 
-        var result = PaginatedListViewModel<int>.Paginate(
-            allResults, page, pageSize);
+        var paginatedViewModel = PaginatedListViewModel<int>.Paginate(
+            allResults,
+            page,
+            pageSize);
 
-        result.AssertNotFound();
+        Assert.Empty(paginatedViewModel.Results);
+        Assert.Equal(page, paginatedViewModel.Paging.Page);
+        Assert.Equal(pageSize, paginatedViewModel.Paging.PageSize);
+        Assert.Equal(allResults.Count, paginatedViewModel.Paging.TotalResults);
+        Assert.Equal(1, paginatedViewModel.Paging.TotalPages);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/PaginatedListViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/ViewModels/PaginatedListViewModel.cs
@@ -1,7 +1,5 @@
 #nullable enable
 using System.Text.Json.Serialization;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 
@@ -37,7 +35,7 @@ public record PaginatedListViewModel<T>
     /// <param name="allResults">All of the un-paginated results</param>
     /// <param name="page">The current page</param>
     /// <param name="pageSize">The size of each page</param>
-    public static Either<ActionResult, PaginatedListViewModel<T>> Paginate(
+    public static PaginatedListViewModel<T> Paginate(
         List<T> allResults,
         int page,
         int pageSize)
@@ -47,19 +45,12 @@ public record PaginatedListViewModel<T>
             .Take(pageSize)
             .ToList();
 
-        var paginatedViewModel = new PaginatedListViewModel<T>(
+        return new PaginatedListViewModel<T>(
             results: pagedResults,
             totalResults: allResults.Count,
             page: page,
             pageSize: pageSize
         );
-
-        if (paginatedViewModel.Paging.Page > paginatedViewModel.Paging.TotalPages)
-        {
-            return new NotFoundResult();
-        }
-
-        return paginatedViewModel;
     }
 }
 
@@ -84,7 +75,7 @@ public record PagingViewModel
         {
             throw new ArgumentException("Page size cannot be less than 1");
         }
-        
+
         Page = page;
         PageSize = pageSize;
         TotalResults = totalResults;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Update.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Update.cs
@@ -1,5 +1,7 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
@@ -20,7 +22,28 @@ public class Update : ICreatedTimestamp<DateTime?>
     // Nullable to support older records missing CreatedBy references
     public Guid? CreatedById { get; set; }
 
+    // TODO EES-6490 Convert 'On' from DateTime to DateTimeOffset
     public DateTime On { get; set; }
 
     public string Reason { get; set; } = null!;
+
+    internal class Config : IEntityTypeConfiguration<Update>
+    {
+        public void Configure(EntityTypeBuilder<Update> builder)
+        {
+            // Values of 'On' are stored in the db in a datetime2 column - a raw value without timezone offset or kind.
+            // Reapply a DateTimeKind when reading from database results to avoid values with DateTimeKind.Unspecified,
+            // which are ambiguous in API responses due to being serialised to JSON without an offset.
+            // TODO EES-6490 Convert 'On' from DateTime to DateTimeOffset
+            builder.Property(u => u.On)
+                .HasConversion(
+                    v => v,
+                    v => DateTime.SpecifyKind(v,
+                        // Updates are created by ReleaseNoteService in local time using DateTime.Now,
+                        // so reapply DateTimeKind.Local here rather than DateTimeKind.Utc.
+                        // It's different to the rest of the service where new date values use DateTime.UtcNow,
+                        // where the kind would be reapplied with DateTimeKind.Utc here.
+                        DateTimeKind.Local));
+        }
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseUpdatesServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseUpdatesServiceTests.cs
@@ -15,8 +15,305 @@ public abstract class ReleaseUpdatesServiceTests
 
     public class GetPaginatedUpdatesForReleaseTests : ReleaseUpdatesServiceTests
     {
+        [Theory]
+        [InlineData(0, 1, 10)]
+        [InlineData(1, 1, 10)]
+        [InlineData(5, 1, 10)]
+        [InlineData(15, 1, 10)]
+        [InlineData(15, 2, 5)]
+        public async Task WhenPublicationAndReleaseExist_ReturnsPaginatedUpdates(
+            int numUpdates,
+            int page,
+            int pageSize)
+        {
+            // Arrange
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var release = publication.Releases[0];
+            var releaseVersion = release.Versions[0];
+
+            releaseVersion.Updates = _dataFixture.DefaultUpdate()
+                .WithReleaseVersionId(releaseVersion.Id)
+                .GenerateList(numUpdates);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetPaginatedUpdatesForRelease(
+                    publicationSlug: publication.Slug,
+                    releaseSlug: release.Slug,
+                    page: page,
+                    pageSize: pageSize);
+
+                // Assert
+                var pagedResult = outcome.AssertRight();
+
+                // Total results should include an extra update for the 'First published' entry
+                var expectedTotalResults = numUpdates + 1;
+
+                pagedResult.AssertHasExpectedPagingAndResultCount(
+                    expectedTotalResults: expectedTotalResults,
+                    expectedPage: page,
+                    expectedPageSize: pageSize);
+            }
+        }
+
         [Fact]
-        public async Task GetPaginatedUpdatesForRelease_WhenPublicationDoesNotExist_ReturnsNotFound()
+        public async Task WhenUpdatesExist_MapsUpdatesCorrectly()
+        {
+            // Arrange
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var release = publication.Releases[0];
+            var releaseVersion = release.Versions[0];
+
+            releaseVersion.Updates = _dataFixture.DefaultUpdate()
+                .WithReleaseVersionId(releaseVersion.Id)
+                .WithOn(releaseVersion.Published!.Value.AddDays(1))
+                .GenerateList(1);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetPaginatedUpdatesForRelease(
+                    publicationSlug: publication.Slug,
+                    releaseSlug: release.Slug);
+
+                // Assert
+                var pagedResult = outcome.AssertRight();
+
+                // Total results should include an extra update for the 'First published' entry
+                var expectedTotalResults = releaseVersion.Updates.Count + 1;
+
+                pagedResult.AssertHasExpectedPagingAndResultCount(
+                    expectedTotalResults: expectedTotalResults,
+                    expectedPage: 1,
+                    expectedPageSize: 10);
+
+                var results = pagedResult.Results;
+
+                Assert.Equal(releaseVersion.Updates[0].On, results[0].Date);
+                Assert.Equal(releaseVersion.Updates[0].Reason, results[0].Summary);
+
+                // Check that the last item is the 'First published' entry
+                Assert.Equal(releaseVersion.Published, results[^1].Date);
+                Assert.Equal("First published", results[^1].Summary);
+            }
+        }
+
+        [Fact]
+        public async Task WhenMultipleUpdatesExist_ReturnsUpdatesInDescendingDateOrder()
+        {
+            // Arrange
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var release = publication.Releases[0];
+            var releaseVersion = release.Versions[0];
+
+            // Set a shuffled list of updates dated after the release version published date
+            releaseVersion.Updates =
+            [
+                .. Enumerable.Range(0, 9)
+                    .Select(i => _dataFixture.DefaultUpdate()
+                        .WithReleaseVersionId(releaseVersion.Id)
+                        .WithOn(releaseVersion.Published!.Value.AddDays(i + 1))
+                        .Generate()
+                    )
+                    .ToArray()
+                    .Shuffle()
+            ];
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetPaginatedUpdatesForRelease(
+                    publicationSlug: publication.Slug,
+                    releaseSlug: release.Slug);
+
+                // Assert
+                var pagedResult = outcome.AssertRight();
+
+                // Total results should include an extra update for the 'First published' entry
+                var expectedTotalResults = releaseVersion.Updates.Count + 1;
+
+                pagedResult.AssertHasExpectedPagingAndResultCount(
+                    expectedTotalResults: expectedTotalResults,
+                    expectedPage: 1,
+                    expectedPageSize: 10);
+
+                // Check that the results are in descending date order
+                var results = pagedResult.Results;
+                for (var i = 0; i < results.Count - 1; i++)
+                {
+                    Assert.True(results[i].Date > results[i + 1].Date);
+                }
+
+                // Check that the last item is the 'First published' entry
+                Assert.Equal(releaseVersion.Published, results[^1].Date);
+                Assert.Equal("First published", results[^1].Summary);
+            }
+        }
+
+        [Fact]
+        public async Task WhenUpdatesExistBeforeReleasePublishedDate_ReturnsUpdatesInDescendingDateOrder()
+        {
+            // Arrange
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var release = publication.Releases[0];
+            var releaseVersion = release.Versions[0];
+
+            // There are usually no updates before the first published date, but if they do exist,
+            // ensure all updates including the 'First published' entry are correctly ordered.
+            var (updateBeforeFirstPublished, updateAfterFirstPublished) = _dataFixture.DefaultUpdate()
+                .WithReleaseVersionId(releaseVersion.Id)
+                .ForIndex(0, setters => setters.SetOn(releaseVersion.Published!.Value.AddDays(-1)))
+                .ForIndex(1, setters => setters.SetOn(releaseVersion.Published!.Value.AddDays(1)))
+                .GenerateTuple2();
+            releaseVersion.Updates = [updateBeforeFirstPublished, updateAfterFirstPublished];
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetPaginatedUpdatesForRelease(
+                    publicationSlug: publication.Slug,
+                    releaseSlug: release.Slug);
+
+                // Assert
+                var pagedResult = outcome.AssertRight();
+
+                pagedResult.AssertHasExpectedPagingAndResultCount(
+                    expectedTotalResults: 3,
+                    expectedPage: 1,
+                    expectedPageSize: 10);
+
+                var results = pagedResult.Results;
+
+                Assert.Equal(updateAfterFirstPublished.On, results[0].Date);
+                Assert.Equal(updateAfterFirstPublished.Reason, results[0].Summary);
+                Assert.Equal(releaseVersion.Published!.Value, results[1].Date);
+                Assert.Equal("First published", results[1].Summary);
+                Assert.Equal(updateBeforeFirstPublished.On, results[2].Date);
+                Assert.Equal(updateBeforeFirstPublished.Reason, results[2].Summary);
+            }
+        }
+
+        [Fact]
+        public async Task WhenNoUpdatesExist_ReturnsOnlyFirstPublishedEntry()
+        {
+            // Arrange
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var release = publication.Releases[0];
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetPaginatedUpdatesForRelease(
+                    publicationSlug: publication.Slug,
+                    releaseSlug: release.Slug);
+
+                // Assert
+                var pagedResult = outcome.AssertRight();
+
+                pagedResult.AssertHasExpectedPagingAndResultCount(
+                    expectedTotalResults: 1,
+                    expectedPage: 1,
+                    expectedPageSize: 10);
+
+                Assert.Equal(release.Versions[0].Published, pagedResult.Results[0].Date);
+                Assert.Equal("First published", pagedResult.Results[0].Summary);
+            }
+        }
+
+        [Fact]
+        public async Task WhenReleaseHasMultiplePublishedVersions_ReturnsFirstPublishedEntryUsingFirstPublishedVersion()
+        {
+            // Arrange
+            Publication publication = _dataFixture.DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 2)]);
+            var release = publication.Releases[0];
+
+            // Ensure the generated release versions have different published dates
+            Assert.True(release.Versions[0].Published < release.Versions[1].Published,
+                "The first version should have an earlier published date than the second version");
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetPaginatedUpdatesForRelease(
+                    publicationSlug: publication.Slug,
+                    releaseSlug: release.Slug);
+
+                // Assert
+                var pagedResult = outcome.AssertRight();
+
+                pagedResult.AssertHasExpectedPagingAndResultCount(
+                    expectedTotalResults: 1,
+                    expectedPage: 1,
+                    expectedPageSize: 10);
+
+                Assert.Equal(release.Versions[0].Published, pagedResult.Results[0].Date);
+                Assert.Equal("First published", pagedResult.Results[0].Summary);
+            }
+        }
+
+        [Fact]
+        public async Task WhenPublicationDoesNotExist_ReturnsNotFound()
         {
             // Arrange
             const string publicationSlug = "publication-that-does-not-exist";
@@ -35,7 +332,7 @@ public abstract class ReleaseUpdatesServiceTests
         }
 
         [Fact]
-        public async Task GetPaginatedUpdatesForRelease_WhenReleaseDoesNotExist_ReturnsNotFound()
+        public async Task WhenReleaseDoesNotExist_ReturnsNotFound()
         {
             // Arrange
             Publication publication = _dataFixture.DefaultPublication();
@@ -63,7 +360,7 @@ public abstract class ReleaseUpdatesServiceTests
         }
 
         [Fact]
-        public async Task GetPaginatedUpdatesForRelease_WhenReleaseHasNoPublishedVersion_ReturnsNotFound()
+        public async Task WhenReleaseHasNoPublishedVersion_ReturnsNotFound()
         {
             // Arrange
             Publication publication = _dataFixture.DefaultPublication()


### PR DESCRIPTION
This PR makes an update to the new Content API endpoint to get release updates added by https://github.com/dfe-analytical-services/explore-education-statistics/pull/6274.

It appends an update entry with the summary 'First published' and the date that the first version of the release was published.

Request:

```http
GET https://content-api.url/api/publications/{publicationSlug}/releases/{releaseSlug}/updates?page=1&pageSize=10
```

Updated response, now including the 'First published' entry:

```http
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8

{
  "results": [
    {
      "date": "2025-09-09T14:32:33.44189+01:00",
      "summary": "Update 3"
    },
    {
      "date": "2025-09-09T14:32:04.5317757+01:00",
      "summary": "Update 2"
    },
    {
      "date": "2025-09-09T14:31:42.1236855+01:00",
      "summary": "Update 1"
    },
    {
      "date": "2025-09-09T13:31:07.2132124Z",
      "summary": "First published"
    }
  ],
  "paging": {
    "page": 1,
    "pageSize": 10,
    "totalResults": 4,
    "totalPages": 1
  }
}
```

### Observations

- **All** entries including 'First published' are sorted in descending date order. It's possible in the Admin to add updates to the **first** release version before the release is first published, and it's possible to edit the date of updates in any version, which allows setting them to dates in the past. This means it's theoretically possible that the 'First published' entry is not the last (oldest) entry in the result.

- Due to combining an extra entry with the database results, pagination is now done in-memory rather than in the database. Unfortunately this is less optimal due to always needing to select all rows in the database query, but we don't expect there to be a large number of updates.

- The method `PaginatedListViewModel.Paginate` returned the Mvc `NotFound` type if the page was greater than the number of pages. It's more common to return empty results or a validation error rather than return a not found status, so I removed this check meaning it now returns a `PaginatedListViewModel` with empty results.

- I spotted there's an inconsistency in the Admin's `ReleaseNoteService` when creating updates which sets the date in local time using `DateTime.Now` rather than `DateTimeKind.Utc`. It's different to the rest of the service where new date values use `DateTime.UtcNow`. No 'kind' was being set when reading from database results, so values of `Update.On` and values mapped to DTO's and view models all had `DateTimeKind.Unspecified`. This was being serialised to JSON in API responses as a timestamp with no offset. To remove ambiguity I've added database context entity type configuration to reapply `DateTimeKind.Local`. I've also added ticket references to EES-6490, suggesting that we change updates to use `DateTimeOffset`.

However, at least for now, the difference between the updates which have kind DateTimeKind.Local, and the synthetic 'First published' update which copies the published date from the first release version, which has DateTimeKind.Utc, means there can be an inconsistency in the dates in the response.

**Example of inconsistent timezone offsets (`Z` suffix and `+00:00`)**:

```json
    {
      "date": "2025-01-01T09:36:43.365+00:00",
      "summary": "Update"
    },
    {
      "date": "2025-01-01T09:30:00.7549251Z",
      "summary": "First published"
    }
```

- Unrelated to this change, but I noticed that when updates are edited in the Admin using the 'Update note' feature after creating them to set new values of day/month/year, the time precision of the updated note is being deliberately cleared.

**Note updated to 2025-06-01 (falls within BST)**:

```json
    {
      "date": "2025-06-01T00:00:00+01:00",
      "summary": "Update edited after creation"
    }
```

**Note updated to 2025-01-01 (falls within GMT)**:

```json
    {
      "date": "2025-01-01T00:00:00+00:00",
      "summary": "Update edited after creation"
    }
```