### PR TITLE
EES-6441 Add release updates page

### DIFF
--- a/src/explore-education-statistics-common/src/services/releaseUpdatesService.ts
+++ b/src/explore-education-statistics-common/src/services/releaseUpdatesService.ts
@@ -1,0 +1,22 @@
+import { contentApi } from '@common/services/api';
+import { PaginatedList, PaginationRequestParams } from './types/pagination';
+
+export interface ReleaseUpdate {
+  date: string;
+  summary: string;
+}
+
+const releaseDataGuidanceService = {
+  getReleaseUpdates(
+    publicationSlug: string,
+    releaseSlug: string,
+    params?: PaginationRequestParams,
+  ): Promise<PaginatedList<ReleaseUpdate>> {
+    return contentApi.get(
+      `/publications/${publicationSlug}/releases/${releaseSlug}/updates`,
+      { params },
+    );
+  },
+};
+
+export default releaseDataGuidanceService;

--- a/src/explore-education-statistics-common/src/services/types/pagination.ts
+++ b/src/explore-education-statistics-common/src/services/types/pagination.ts
@@ -9,3 +9,8 @@ export interface Paging {
   totalResults: number;
   totalPages: number;
 }
+
+export interface PaginationRequestParams {
+  page?: number;
+  pageSize?: number;
+}

--- a/src/explore-education-statistics-frontend/src/components/Page.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Page.tsx
@@ -4,6 +4,7 @@ import UserTestingBanner from '@frontend/components/UserTestingBanner';
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
 import Breadcrumbs, { BreadcrumbsProps } from './Breadcrumbs';
+import Link from './Link';
 import PageFooter from './PageFooter';
 import PageHeader from './PageHeader';
 import PageMeta, { PageMetaProps } from './PageMeta';
@@ -26,6 +27,7 @@ type Props = {
   customBannerContent?: ReactNode;
   width?: PageWidth;
   isHomepage?: boolean;
+  backLinkDestination?: string; // Back link overrides breadcrumbs if provided
 } & BreadcrumbsProps;
 
 const Page = ({
@@ -43,6 +45,7 @@ const Page = ({
   width,
   isHomepage = false,
   breadcrumbs = [],
+  backLinkDestination,
 }: Props) => {
   return (
     <>
@@ -67,13 +70,19 @@ const Page = ({
 
         {customBannerContent}
 
-        <Breadcrumbs
-          breadcrumbs={
-            isHomepage
-              ? undefined
-              : breadcrumbs.concat([{ name: breadcrumbLabel || title }])
-          }
-        />
+        {backLinkDestination ? (
+          <Link className="govuk-back-link" to={backLinkDestination}>
+            Back
+          </Link>
+        ) : (
+          <Breadcrumbs
+            breadcrumbs={
+              isHomepage
+                ? undefined
+                : breadcrumbs.concat([{ name: breadcrumbLabel || title }])
+            }
+          />
+        )}
 
         <main
           className="govuk-main-wrapper app-main-class"

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/ReleaseUpdatesPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/ReleaseUpdatesPage.tsx
@@ -1,0 +1,134 @@
+import FormattedDate from '@common/components/FormattedDate';
+import publicationService, {
+  PublicationSummaryRedesign,
+  ReleaseVersionSummary,
+} from '@common/services/publicationService';
+import releaseUpdatesService, {
+  ReleaseUpdate,
+} from '@common/services/releaseUpdatesService';
+import { PaginatedList } from '@common/services/types/pagination';
+import Link from '@frontend/components/Link';
+import Page from '@frontend/components/Page';
+import Pagination from '@frontend/components/Pagination';
+import { logEvent } from '@frontend/services/googleAnalyticsService';
+import { Dictionary } from '@frontend/types';
+import { GetServerSideProps } from 'next';
+import React from 'react';
+
+interface Props {
+  publicationSummary: PublicationSummaryRedesign;
+  releaseUpdates: PaginatedList<ReleaseUpdate>;
+  releaseVersionSummary: ReleaseVersionSummary;
+}
+
+const ReleaseUpdatesPage = ({
+  publicationSummary,
+  releaseUpdates,
+  releaseVersionSummary,
+}: Props) => {
+  const { paging, results } = releaseUpdates ?? {};
+  const { page, totalPages } = paging ?? {};
+
+  return (
+    <Page
+      title={publicationSummary.title}
+      metaTitle={`${publicationSummary.title} - ${
+        releaseVersionSummary.title
+      } - updates ${page ? `- page ${page}` : ''}`}
+      description={`Table showing updates to ${publicationSummary.title.toLocaleLowerCase()} ${releaseVersionSummary.title.toLocaleLowerCase()}.`}
+      caption={releaseVersionSummary.title}
+      backLinkDestination={`/find-statistics/${publicationSummary.slug}/${releaseVersionSummary.slug}?redesign=true`} // TODO EES-6449 remove redesign query param
+      width="wide"
+    >
+      <Link
+        to={`/find-statistics/${publicationSummary.slug}/releases`}
+        className="govuk-!-margin-bottom-6 govuk-!-display-inline-block"
+      >
+        All releases in this series
+      </Link>
+
+      <table className="govuk-table" data-testid="release-updates-table">
+        <caption className="govuk-table__caption--m">
+          Table showing updates to this release
+        </caption>
+
+        <thead className="govuk-table__head">
+          <tr className="govuk-table__row">
+            <th scope="col" className="govuk-table__header">
+              Date updated
+            </th>
+            <th scope="col" className="govuk-table__header">
+              Summary of update
+            </th>
+          </tr>
+        </thead>
+
+        <tbody className="govuk-table__body">
+          {results.map(update => (
+            <tr className="govuk-table__row" key={update.date}>
+              <td className="govuk-table__cell">
+                <FormattedDate>{update.date}</FormattedDate>
+              </td>
+              <td className="govuk-table__cell">{update.summary}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {page && !!totalPages && (
+        <Pagination
+          currentPage={page}
+          totalPages={totalPages}
+          onClick={pageNumber => {
+            logEvent({
+              category: 'Publication updates',
+              action: `Pagination clicked`,
+              label: `Page ${pageNumber}`,
+            });
+          }}
+        />
+      )}
+    </Page>
+  );
+};
+
+export default ReleaseUpdatesPage;
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({
+  query,
+}) => {
+  const {
+    publication: publicationSlug,
+    release: releaseSlug,
+    page,
+    pageSize,
+  } = query as Dictionary<string>;
+
+  if (process.env.APP_ENV === 'Production') {
+    return {
+      redirect: {
+        destination: `/find-statistics/${publicationSlug}/${releaseSlug}`,
+        permanent: true,
+      },
+    };
+  }
+
+  const publicationSummary =
+    await publicationService.getPublicationSummaryRedesign(publicationSlug);
+
+  const [releaseVersionSummary, releaseUpdates] = await Promise.all([
+    publicationService.getReleaseVersionSummary(publicationSlug, releaseSlug),
+    releaseUpdatesService.getReleaseUpdates(publicationSlug, releaseSlug, {
+      page: page ? Number(page) : undefined,
+      pageSize: pageSize ? Number(pageSize) : undefined,
+    }),
+  ]);
+
+  return {
+    props: {
+      publicationSummary,
+      releaseVersionSummary,
+      releaseUpdates,
+    },
+  };
+};

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/ReleaseUpdatesPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/ReleaseUpdatesPage.test.tsx
@@ -1,0 +1,88 @@
+import { ReleaseUpdate } from '@common/services/releaseUpdatesService';
+import { PaginatedList } from '@common/services/types/pagination';
+import { render, screen, within } from '@testing-library/react';
+import React from 'react';
+import ReleaseUpdatesPage from '../ReleaseUpdatesPage';
+import {
+  testPublicationSummary,
+  testReleaseVersionSummary,
+} from './__data__/testReleaseData';
+
+describe('Release updates page', () => {
+  const testReleaseUpdates: PaginatedList<ReleaseUpdate> = {
+    results: [
+      {
+        date: '2025-09-04T16:42:37',
+        summary: `Update 3`,
+      },
+      {
+        date: '2025-07-09T11:30:12',
+        summary: 'Update 2',
+      },
+      {
+        date: '2024-12-30T09:11:59',
+        summary: 'Update 1',
+      },
+    ],
+    paging: {
+      page: 1,
+      pageSize: 10,
+      totalResults: 3,
+      totalPages: 1,
+    },
+  };
+  test('renders link to all releases', () => {
+    render(
+      <ReleaseUpdatesPage
+        releaseVersionSummary={testReleaseVersionSummary}
+        publicationSummary={testPublicationSummary}
+        releaseUpdates={testReleaseUpdates}
+      />,
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'All releases in this series',
+      }),
+    ).toHaveAttribute('href', '/find-statistics/publication-slug/releases');
+  });
+
+  test('renders correct back link', () => {
+    render(
+      <ReleaseUpdatesPage
+        releaseVersionSummary={testReleaseVersionSummary}
+        publicationSummary={testPublicationSummary}
+        releaseUpdates={testReleaseUpdates}
+      />,
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Back',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/find-statistics/publication-slug/release-slug?redesign=true',
+    ); // TODO EES-6449 remove redesign query param
+  });
+
+  test('renders table data correctly', () => {
+    render(
+      <ReleaseUpdatesPage
+        releaseVersionSummary={testReleaseVersionSummary}
+        publicationSummary={testPublicationSummary}
+        releaseUpdates={testReleaseUpdates}
+      />,
+    );
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+
+    const rows = within(screen.getByRole('table')).getAllByRole('row');
+    expect(rows).toHaveLength(4); // including header row
+    const row1Cells = within(rows[1]).getAllByRole('cell');
+    expect(
+      within(row1Cells[0]).getByText('4 September 2025'),
+    ).toBeInTheDocument();
+    expect(within(row1Cells[1]).getByText('Update 3')).toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-frontend/src/pages/find-statistics/[publication]/[release]/updates.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/find-statistics/[publication]/[release]/updates.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  getServerSideProps,
+} from '@frontend/modules/find-statistics/ReleaseUpdatesPage';


### PR DESCRIPTION
This PR adds a new page for the release page redesign - release updates - viewable at `/find-statistics/publication-slug/release-slug/updates`. Jira ticket - https://dfedigital.atlassian.net/browse/EES-6441

Just to note, there will always be at least one update to show, as work is happening to return the 'first published' as an update. So if a release has been published, it will have an update to show and the table should never be empty.

We are showing a paginated list of updates with a default pagination window of 10. If there are fewer updates and you want to test pagination, you can manually control the pagination with query params at the end of the url for **pageSize** and **page** e.g.  `/find-statistics/publication-slug/release-slug/updates?pageSize=1&page=2` will show 1 update per page.

The **back link** didn't exist on the site prior to this design - we currently show breadcrumbs on every page. I have made it so that if you supply a `backLinkDestination` to the page component, it will show _instead of_ the breadcrumbs, [in line with GDS guidance](https://design-system.service.gov.uk/components/back-link/#when-not-to-use-this-component).