### PR TITLE
EES-6471 Reduce statistics database scale after temporarily scaling up

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -90,7 +90,7 @@
       "value": "GeneralPurpose"
     },
     "capacityStatisticsDb": {
-      "value": 12
+      "value": 10
     },
     "tableBuilderMaxTableCellsAllowed": {
       "value": 1000000


### PR DESCRIPTION
This PR reverts the change made in https://github.com/dfe-analytical-services/explore-education-statistics/pull/6260.

It reduces the scale of the statistics primary and replica databases in the Prod environment, from provisioned 12 to 10 vCores.

The update in code reflects the manual adjustment that has already applied to the databases on 10/09/25.