### PR TITLE
EES-6485 Fix failing comparison of Update 'On' DateTime values in unit test CreateReleaseAmendment

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseAmendmentServiceTests.cs
@@ -93,23 +93,26 @@ public class ReleaseAmendmentServiceTests
                     Description = "Link 2",
                     Url = "URL 2"
                 }))
-            .WithUpdates(ListOf<Update>(
-                new()
+            .WithUpdates([
+                // 'On' is deliberately set in local time with DateTime.Now to match how ReleaseNoteService creates Updates.
+                // TODO EES-6490 Convert 'On' from DateTime to DateTimeOffset
+                new Update
                 {
                     Id = Guid.NewGuid(),
-                    On = DateTime.UtcNow.AddDays(-4),
+                    On = DateTime.Now.AddDays(-4),
                     Reason = "Reason 1",
                     Created = DateTime.UtcNow.AddDays(-6),
                     CreatedById = Guid.NewGuid(),
                 },
-                new()
+                new Update
                 {
                     Id = Guid.NewGuid(),
-                    On = DateTime.UtcNow.AddDays(-5),
+                    On = DateTime.Now.AddDays(-5),
                     Reason = "Reason 2",
                     Created = DateTime.UtcNow.AddDays(-2),
                     CreatedById = Guid.NewGuid(),
-                }))
+                }
+            ])
             .WithKeyStatistics(ListOf<KeyStatistic>(
                 new KeyStatisticText
                 {


### PR DESCRIPTION
This PR fixes the failing unit test `ReleaseAmendmentServiceTests.CreateReleaseAmendment` which was failing

```
Types [DateTime,DateTime], Item Expected.On != Actual.On, Values (08/09/2025 12:59:46,08/09/2025 12:59:46)
```

The comparison was failing because the value of `On` in original updates was being set up with `DateTime.UtcNow` with kind 'DateTimeKind.Utc', rather than the kind of `On` in the amended update which is `DateTime.Local`. That was a change made by https://github.com/dfe-analytical-services/explore-education-statistics/pull/6280.

EES-6490 has already been raised to tidy this up.