### PR TITLE
Fix a couple of broken robot tests

### DIFF
--- a/tests/robot-tests/tests/general_public/no_javascript.robot
+++ b/tests/robot-tests/tests/general_public/no_javascript.robot
@@ -1,7 +1,6 @@
 *** Settings ***
 Resource        ../libs/public-common.robot
 Library         ../libs/no_javascript.py
-Resource        ../seed_data/seed_data_theme_1_constants.robot
 
 Test Setup      fail test fast if required
 
@@ -16,8 +15,6 @@ Parse Find Statistics page HTML
     ...    %{PUBLIC_URL}/find-statistics?sortBy=relevance&search=Pupil+absence+in+schools+in+England
     set suite variable    ${parsed_page}
 
-Validate Seed Data Theme 1 Publication 1 publication on page
+Validate publications list is on page
+    [Tags]    NotAgainstDev    NotAgainstTest    NotAgainstPreProd
     ${list}=    user_gets_publications_list    ${parsed_page}
-
-    Skip    Skipping as not compatible with azure search
-    user_checks_list_contains_publication    ${list}    ${PUPIL_ABSENCE_PUBLICATION_TITLE}

--- a/tests/robot-tests/tests/general_public/prod_only/no_javascript.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/no_javascript.robot
@@ -15,8 +15,5 @@ Parse Find Statistics page HTML
     ...    %{PUBLIC_URL}/find-statistics?sortBy=relevance&search=Pupil+absence+in+schools+in+England
     set suite variable    ${parsed_page}
 
-Validate Seed Data Theme 1 Publication 1 publication on page
+Validate publications list is on page
     ${list}=    user_gets_publications_list    ${parsed_page}
-
-    Skip    Skipping as not compatible with azure search
-    user_checks_list_contains_publication    ${list}    Pupil absence in schools in England

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -12,25 +12,13 @@ Force Tags          GeneralPublic    Local    Dev    Preprod
 
 *** Test Cases ***
 Navigate to Absence publication
-    user navigates to public site homepage
-    user waits until page contains    Explore our statistics and data
-
-    user clicks link    Explore
-    user waits until page contains
-    ...    Find statistics and data
-    ...    %{WAIT_MEDIUM}
-
-    user clicks radio    Oldest
-    user waits until page contains link    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
-    user clicks link    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
+    environment variable should be set    PUBLIC_URL
+    user navigates to    %{PUBLIC_URL}${PUPIL_ABSENCE_PUBLICATION_RELATIVE_URL}
     user waits until h1 is visible    ${PUPIL_ABSENCE_PUBLICATION_TITLE}    %{WAIT_MEDIUM}
 
 Validate title
     user waits until h1 is visible    ${PUPIL_ABSENCE_PUBLICATION_TITLE}    %{WAIT_MEDIUM}
     user waits until page contains title caption    Academic year 2016/17
-
-Validate URL
-    user checks url contains    %{PUBLIC_URL}${PUPIL_ABSENCE_PUBLICATION_RELATIVE_URL}
 
 Validate Published date
     [Tags]    NotAgainstPreProd


### PR DESCRIPTION
This PR addresses a couple of UI test failures that have appeared after making azure search the default search on the find statistics page.
- We now navigate directly to a release rather than via the find stats page
- Remove tests looking for specific publications
- Don't run the no_javascript test on dev, test or preprod as (for now) the publications list doesn't load without JS.
  - We are investigating why it does load on prod but not preprod/dev, but for now we will skip the test
