### PR TITLE
EES-6523 Add searchService diagnostic setting IaC

### DIFF
--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -28,6 +28,9 @@ param semanticRankerAvailability string
 @description('A list of IP network rules to allow access to the Search storage account from specific public internet IP address ranges.')
 param storageIpRules IpRange[]
 
+@description('The id of the Log Analytics workspace which logs and metrics will be sent to.')
+param logAnalyticsWorkspaceId string
+
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
@@ -62,6 +65,7 @@ module searchServiceModule '../components/searchService.bicep' = {
       throttledSearchQueriesPercentage: true
       alertsGroupName: resourceNames.existingResources.alertsGroup
     }
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
     tagValues: tagValues
   }
 }

--- a/infrastructure/templates/search/components/searchService.bicep
+++ b/infrastructure/templates/search/components/searchService.bicep
@@ -78,6 +78,9 @@ param alerts {
   alertsGroupName: string
 }?
 
+@description('The id of the Log Analytics workspace which logs and metrics will be sent to.')
+param logAnalyticsWorkspaceId string
+
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object
 
@@ -120,6 +123,26 @@ resource searchService 'Microsoft.Search/searchServices@2025-02-01-preview' = {
     hostingMode: hostingMode
   }
   tags: tagValues
+}
+
+resource searchDiagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: '${name}-diagnostic'
+  properties: {
+    logAnalyticsDestinationType: null
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+    workspaceId: logAnalyticsWorkspaceId
+  }
 }
 
 module searchLatencyAlert '../../public-api/components/alerts/dynamicMetricAlert.bicep' = if (alerts != null) {

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -161,6 +161,7 @@ module searchServiceModule 'application/searchService.bicep' = {
     searchServiceIpRules: [] // No restrictions applied as the resource is intended to be publicly accessible.
     semanticRankerAvailability: searchServiceSemanticRankerAvailability
     storageIpRules: maintenanceIpRanges
+    logAnalyticsWorkspaceId: monitoringModule.outputs.logAnalyticsWorkspaceId
     tagValues: tagValues
   }
 }


### PR DESCRIPTION
This PR adds a diagnostic setting to azure search services across all environments. This adds logging for search services to our Log Analytics workspace.