### PR TITLE
EES-6524 Add logicApp slackwebhook diagnostic setting IaC

### DIFF
--- a/infrastructure/templates/logic-app-template.json
+++ b/infrastructure/templates/logic-app-template.json
@@ -16,12 +16,15 @@
     },
     "resourceGroup": {
       "type": "string"
+    },
+    "workspaceResourceId": {
+      "type": "string"
     }
   },
   "resources": [
     {
       "type": "Microsoft.Logic/workflows",
-      "apiVersion": "2017-07-01",
+      "apiVersion": "2019-05-01",
       "name": "[parameters('logicAppName')]",
       "location": "[resourceGroup().location]",
       "properties": {
@@ -408,6 +411,31 @@
           },
           "outputs": {}
         }
+      }
+    },
+    {
+      "type": "Microsoft.Insights/diagnosticSettings",
+      "apiVersion": "2021-05-01-preview",
+      "name": "[concat(parameters('logicAppName'), '-diagnostic')]",
+      "scope": "[resourceId('Microsoft.Logic/workflows', parameters('logicAppName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Logic/workflows', parameters('logicAppName'))]"
+      ],
+      "properties": {
+          "logs": [
+              {
+                  "categoryGroup": "allLogs",
+                  "enabled": true
+              }
+          ],
+          "metrics": [
+              {
+                  "category": "AllMetrics",
+                  "enabled": true
+              }
+          ],
+          "workspaceId": "[parameters('workspaceResourceId')]",
+          "logAnalyticsDestinationType": null
       }
     }
   ]

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -4311,7 +4311,8 @@
           },
           "resourceGroup": {
             "value": "[resourceGroup().name]"
-          }
+          },
+          "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('appInsightsWorkspace'))]"
         }
       },
       "dependsOn": [


### PR DESCRIPTION
This PR adds a diagnostic setting to our Azure Logic App slackwebhook across all environments. This adds logging for the logic app to our Log Analytics workspace.