### PR TITLE
EES-6602 Test UI test speed up (and hope doesn't increase flakiness)

### DIFF
--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -187,9 +187,12 @@ user waits until page finishes loading
     # waiting for user interaction prior to loading their content.
     user waits until page does not contain element    //*[@class!="lazyload-wrapper"]/*[@data-testid="loadingSpinner"]
     ...    ${spinner_timeout}
-    # Wait to ensure network activity attribute is updated in DOM
+
     sleep    0.5
-    user waits until page does not contain element    css:body[data-network-activity="active"]    ${network_timeout}
+
+    # Wait to ensure network activity attribute is updated in DOM
+    # EES-6602 Temporarily disable this check to see how it effects run speed and reliability
+    #user waits until page does not contain element    css:body[data-network-activity="active"]    ${network_timeout}
 
 user waits until parent contains element
     [Arguments]


### PR DESCRIPTION
I noticed that the UI tests were pausing for a long time in certain places.

I found the the culprit was the one line commented out in this PR. This line was added (along with some frontend code) because we previously had UI tests that failed and we had no DOM elements we could wait for, as it was javascript loading in the background. This meant that we had to have arbitrary sleeps which is imprecise.

This PR is a temporary test for a week or two to see if removing this check will speed up tests and see how much we rely on this `data-network-activity` body attribute for test reliability. Depending on how it plays out will determine how we move forward.