### PR TITLE
EES-6442 releases in this series page

### DIFF
--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -13,6 +13,7 @@ import { Organisation } from '@common/services/types/organisation';
 import { SortDirection } from '@common/services/types/sort';
 import { PartialDate } from '@common/utils/date/partialDate';
 import { contentApi } from './api';
+import { PaginatedList, PaginationRequestParams } from './types/pagination';
 
 export type ReleaseApprovalStatus = 'Draft' | 'HigherLevelReview' | 'Approved';
 
@@ -209,6 +210,27 @@ export interface ReleaseVersionSummary {
   yearTitle: string;
 }
 
+export interface PublicationLegacyReleaseListItem {
+  title: string;
+  url: string;
+}
+
+export interface PublicationReleaseListItem {
+  coverageTitle: string;
+  isLatestRelease?: boolean;
+  label?: string;
+  lastUpdated: string;
+  published: string;
+  releaseId: string;
+  slug: string;
+  title: string;
+  yearTitle: string;
+}
+
+export type PublicationReleaseSeriesItem =
+  | PublicationLegacyReleaseListItem
+  | PublicationReleaseListItem;
+
 export interface ReleaseSummary {
   id: string;
   title: string;
@@ -271,50 +293,7 @@ const publicationService = {
   getPublicationSummaryRedesign(
     publicationSlug: string,
   ): Promise<PublicationSummaryRedesign> {
-    // TODO EES-6404 - remove dummy data and reinstate API call
-    // return contentApi.get(`/publications/${publicationSlug}`);
-    const basePublicationSummary = {
-      id: 'publication-summary-1',
-      title: 'Pupil attendance in schools',
-      slug: 'publication-slug',
-      summary:
-        'Pupil attendance and absence data including termly national statistics and fortnightly statistics in development derived from DfE’s regular attendance data',
-      latestRelease: {
-        slug: 'release-slug',
-        title: 'Calendar year 2024 - Final',
-        id: 'release-version-summary-1',
-      },
-      nextReleaseDate: { year: 2026, month: 3 },
-      theme: {
-        id: '323e4567-e89b-12d3-a456-426614174000',
-        title: 'Pupils and schools',
-        summary:
-          'Including absence, application and offers, capacity, exclusion and special educational needs (SEN) statistics',
-      },
-      contact: {
-        teamName: 'Test team',
-        teamEmail: 'test@test.com',
-        contactName: 'Joe Bloggs',
-        contactTelNo: '01234 567890',
-        id: 'contact-id',
-      },
-    };
-    return new Promise(resolve => {
-      setTimeout(() => {
-        resolve(
-          publicationSlug === 'superseded-publication'
-            ? {
-                ...basePublicationSummary,
-                supersededByPublication: {
-                  id: '223e4567-e89b-12d3-a456-426614174000',
-                  title: 'Superseding publication',
-                  slug: 'superseding-publication',
-                },
-              }
-            : basePublicationSummary,
-        );
-      }, 500);
-    });
+    return contentApi.get(`/publications/${publicationSlug}`);
   },
   getPublicationTitle(publicationSlug: string): Promise<PublicationTitle> {
     return contentApi.get(`/publications/${publicationSlug}/title`);
@@ -342,42 +321,61 @@ const publicationService = {
       `/publications/${publicationSlug}/releases/${releaseSlug}`,
     );
   },
-  // TODO EES-6404 - remove dummy data and reinstate API call
   getReleaseVersionSummary(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     publicationSlug: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     releaseSlug: string,
   ): Promise<ReleaseVersionSummary> {
-    return new Promise(resolve => {
-      setTimeout(() => {
-        resolve({
-          id: 'release-version-summary-1',
-          slug: 'release-slug',
-          type: 'AccreditedOfficialStatistics',
-          title: 'Calendar year 2024 - Final',
-          yearTitle: '2024',
-          coverageTitle: 'Calendar year',
-          label: 'Final',
-          published: '2025-08-10T09:30:00+01:00',
-          lastUpdated: '2025-08-11T14:30:00+01:00',
-          publishingOrganisations: [
-            {
-              id: '5e089801-cf1a-b375-acd3-88e9d8aece66',
-              title: 'Department for Education',
-              url: 'https://www.gov.uk/government/organisations/department-for-education',
-            },
-            {
-              id: '5e089801-ce1a-e274-9915-e83f3e978699',
-              title: 'Skills England',
-              url: 'https://www.gov.uk/government/organisations/skills-england',
-            },
-          ],
-          isLatestRelease: true,
-          updateCount: 5,
+    return contentApi.get(
+      `/publications/${publicationSlug}/releases/${releaseSlug}/version-summary`,
+    );
+  },
+  getPublicationReleaseList(
+    publicationSlug: string,
+    params?: PaginationRequestParams,
+  ): Promise<PaginatedList<PublicationReleaseSeriesItem>> {
+    return publicationSlug === 'test'
+      ? contentApi.get(`/publications/${publicationSlug}/release-entries`, {
+          params,
+        })
+      : new Promise(resolve => {
+          setTimeout(() => {
+            resolve({
+              paging: {
+                page: 1,
+                pageSize: 2,
+                totalResults: 5,
+                totalPages: 3,
+              },
+              results: [
+                {
+                  releaseId: '550e8400-e29b-41d4-a716-446655440000',
+                  slug: publicationSlug,
+                  title: 'Calendar year 2024 - Final',
+                  yearTitle: '2021/22',
+                  coverageTitle: 'Academic Year',
+                  label: 'Final',
+                  published: '2025-08-10T09:30:00+01:00',
+                  lastUpdated: '2025-08-11T14:30:00+01:00',
+                  isLatestRelease: true,
+                },
+                {
+                  releaseId: '550e8400-e29a-41d4-a716-446655440000',
+                  slug: publicationSlug,
+                  title: 'Calendar year 2024',
+                  yearTitle: '2021/22',
+                  coverageTitle: 'Academic Year',
+                  published: '2025-07-01T09:30:00+01:00',
+                  lastUpdated: '2025-07-11T14:30:00+01:00',
+                  isLatestRelease: false,
+                },
+                {
+                  title: '2020/21',
+                  url: 'https://example.com/legacy/2021-22',
+                },
+              ],
+            });
+          }, 500);
         });
-      }, 500);
-    });
   },
   getPublicationReleaseSummary(
     publicationSlug: string,

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -333,49 +333,9 @@ const publicationService = {
     publicationSlug: string,
     params?: PaginationRequestParams,
   ): Promise<PaginatedList<PublicationReleaseSeriesItem>> {
-    return publicationSlug === 'test'
-      ? contentApi.get(`/publications/${publicationSlug}/release-entries`, {
-          params,
-        })
-      : new Promise(resolve => {
-          setTimeout(() => {
-            resolve({
-              paging: {
-                page: 1,
-                pageSize: 2,
-                totalResults: 5,
-                totalPages: 3,
-              },
-              results: [
-                {
-                  releaseId: '550e8400-e29b-41d4-a716-446655440000',
-                  slug: publicationSlug,
-                  title: 'Calendar year 2024 - Final',
-                  yearTitle: '2021/22',
-                  coverageTitle: 'Academic Year',
-                  label: 'Final',
-                  published: '2025-08-10T09:30:00+01:00',
-                  lastUpdated: '2025-08-11T14:30:00+01:00',
-                  isLatestRelease: true,
-                },
-                {
-                  releaseId: '550e8400-e29a-41d4-a716-446655440000',
-                  slug: publicationSlug,
-                  title: 'Calendar year 2024',
-                  yearTitle: '2021/22',
-                  coverageTitle: 'Academic Year',
-                  published: '2025-07-01T09:30:00+01:00',
-                  lastUpdated: '2025-07-11T14:30:00+01:00',
-                  isLatestRelease: false,
-                },
-                {
-                  title: '2020/21',
-                  url: 'https://example.com/legacy/2021-22',
-                },
-              ],
-            });
-          }, 500);
-        });
+    return contentApi.get(`/publications/${publicationSlug}/release-entries`, {
+      params,
+    });
   },
   getPublicationReleaseSummary(
     publicationSlug: string,

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
@@ -43,12 +43,15 @@ const PublicationReleaseListPage = ({
           link: `/find-statistics/${publicationSummary.slug}/${publicationSummary.latestRelease.slug}`,
         },
       ]}
-      breadcrumbLabel="Updates"
+      breadcrumbLabel="Releases"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           {publicationSummary.nextReleaseDate && (
-            <div className="govuk-!-margin-bottom-2">
+            <div
+              className="govuk-!-margin-bottom-2"
+              data-testid="next-release-date"
+            >
               <h3 className="govuk-heading-m govuk-!-margin-bottom-2">
                 Next release date
               </h3>
@@ -75,20 +78,19 @@ const PublicationReleaseListPage = ({
                 <th scope="col">Last update</th>
               </tr>
             </thead>
-
             <tbody>
               {results.map(release =>
                 'releaseId' in release ? (
                   <tr key={release.releaseId}>
                     <td>
                       <Link
-                        to={`/find-statistics/${publicationSummary.slug}/${release.slug}`}
+                        to={`/find-statistics/${publicationSummary.slug}/${release.slug}?redesign=true`} // TODO EES-6449 remove query param when live
                       >
                         {release.title}
                       </Link>
                     </td>
                     <td>
-                      <div className="dfe-flex dfe-gap-2">
+                      <div className="dfe-flex dfe-flex-wrap dfe-gap-2">
                         <FormattedDate>{release.published}</FormattedDate>
                         {release.isLatestRelease === true && (
                           <Tag>Latest release</Tag>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
@@ -46,7 +46,7 @@ const PublicationReleaseListPage = ({
       breadcrumbLabel="Releases"
     >
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-two-thirds">
+        <div className="govuk-grid-column-three-quarters">
           {publicationSummary.nextReleaseDate && (
             <div
               className="govuk-!-margin-bottom-2"

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
@@ -1,0 +1,167 @@
+import FormattedDate from '@common/components/FormattedDate';
+import Tag from '@common/components/Tag';
+import publicationService, {
+  PublicationReleaseSeriesItem,
+  PublicationSummaryRedesign,
+} from '@common/services/publicationService';
+import { PaginatedList } from '@common/services/types/pagination';
+import { formatPartialDate } from '@common/utils/date/partialDate';
+import Link from '@frontend/components/Link';
+import Page from '@frontend/components/Page';
+import Pagination from '@frontend/components/Pagination';
+import { logEvent } from '@frontend/services/googleAnalyticsService';
+import { Dictionary } from '@frontend/types';
+import { GetServerSideProps } from 'next';
+import React from 'react';
+
+interface Props {
+  publicationSummary: PublicationSummaryRedesign;
+  releases: PaginatedList<PublicationReleaseSeriesItem>;
+}
+
+const PublicationReleaseListPage = ({
+  publicationSummary,
+  releases,
+}: Props) => {
+  const { paging, results } = releases ?? {};
+  const { page, totalPages } = paging ?? {};
+
+  return (
+    <Page
+      title={publicationSummary.title}
+      metaTitle={`Releases - ${publicationSummary.title} ${
+        page ? `- page ${page}` : ''
+      }`}
+      description={`Releases in ${publicationSummary.title.toLocaleLowerCase()}.`}
+      caption="Releases in this series"
+      captionInsideTitle
+      width="wide"
+      breadcrumbs={[
+        { name: 'Find statistics and data', link: '/find-statistics' },
+        {
+          name: publicationSummary.title,
+          link: `/find-statistics/${publicationSummary.slug}/${publicationSummary.latestRelease.slug}`,
+        },
+      ]}
+      breadcrumbLabel="Updates"
+    >
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          {publicationSummary.nextReleaseDate && (
+            <div className="govuk-!-margin-bottom-2">
+              <h3 className="govuk-heading-m govuk-!-margin-bottom-2">
+                Next release date
+              </h3>
+              <time>
+                {formatPartialDate(publicationSummary.nextReleaseDate)}
+              </time>
+            </div>
+          )}
+          <Link
+            to={`/find-statistics/${publicationSummary.slug}/${publicationSummary.latestRelease.slug}`}
+            className="govuk-!-margin-bottom-8 govuk-!-display-inline-block"
+          >
+            Release home (latest release)
+          </Link>
+          <table data-testid="release-updates-table">
+            <caption className="govuk-table__caption--m">
+              Table showing all published releases in this series
+            </caption>
+
+            <thead>
+              <tr>
+                <th scope="col">Release period</th>
+                <th scope="col">Published date</th>
+                <th scope="col">Last update</th>
+              </tr>
+            </thead>
+
+            <tbody>
+              {results.map(release =>
+                'releaseId' in release ? (
+                  <tr key={release.releaseId}>
+                    <td>
+                      <Link
+                        to={`/find-statistics/${publicationSummary.slug}/${release.slug}`}
+                      >
+                        {release.title}
+                      </Link>
+                    </td>
+                    <td>
+                      <div className="dfe-flex dfe-gap-2">
+                        <FormattedDate>{release.published}</FormattedDate>
+                        {release.isLatestRelease === true && (
+                          <Tag>Latest release</Tag>
+                        )}
+                      </div>
+                    </td>
+                    <td>
+                      <FormattedDate>{release.lastUpdated}</FormattedDate>
+                    </td>
+                  </tr>
+                ) : (
+                  <tr key={release.title}>
+                    <td>
+                      <Link to={release.url}>{release.title}</Link>
+                    </td>
+                    <td>Not available</td>
+                    <td>Not available</td>
+                  </tr>
+                ),
+              )}
+            </tbody>
+          </table>
+          {page && !!totalPages && (
+            <Pagination
+              currentPage={page}
+              totalPages={totalPages}
+              onClick={pageNumber => {
+                logEvent({
+                  category: 'Publication releases',
+                  action: `Pagination clicked`,
+                  label: `Page ${pageNumber}`,
+                });
+              }}
+            />
+          )}
+        </div>
+      </div>
+    </Page>
+  );
+};
+
+export default PublicationReleaseListPage;
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({
+  query,
+}) => {
+  const {
+    publication: publicationSlug,
+    page,
+    pageSize,
+  } = query as Dictionary<string>;
+
+  if (process.env.APP_ENV === 'Production') {
+    return {
+      notFound: true,
+    };
+  }
+
+  const publicationSummary =
+    await publicationService.getPublicationSummaryRedesign(publicationSlug);
+
+  const releases = await publicationService.getPublicationReleaseList(
+    publicationSlug,
+    {
+      page: page ? Number(page) : undefined,
+      pageSize: pageSize ? Number(pageSize) : undefined,
+    },
+  );
+
+  return {
+    props: {
+      publicationSummary,
+      releases,
+    },
+  };
+};

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleaseListPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleaseListPage.test.tsx
@@ -1,0 +1,147 @@
+import { PublicationReleaseSeriesItem } from '@common/services/publicationService';
+import { PaginatedList } from '@common/services/types/pagination';
+import { render, screen, within } from '@testing-library/react';
+import React from 'react';
+import PublicationReleaseListPage from '../PublicationReleaseListPage';
+import { testPublicationSummary } from './__data__/testReleaseData';
+
+describe('Publication release list page', () => {
+  const testReleases: PaginatedList<PublicationReleaseSeriesItem> = {
+    results: [
+      {
+        releaseId: 'test-release-id-3',
+        slug: 'test-release-slug-3',
+        title: 'Test Release Title 3 - Final',
+        yearTitle: '2021/22',
+        coverageTitle: 'Academic Year',
+        label: 'Final',
+        published: '2025-08-10T09:30:00+01:00',
+        lastUpdated: '2025-08-11T14:30:00+01:00',
+        isLatestRelease: true,
+      },
+      {
+        releaseId: 'test-release-id-2',
+        slug: 'test-release-slug-2',
+        title: 'Test Release Title 2',
+        yearTitle: '2021/22',
+        coverageTitle: 'Academic Year',
+        published: '2025-07-01T09:30:00+01:00',
+        lastUpdated: '2025-07-11T14:30:00+01:00',
+        isLatestRelease: false,
+      },
+      {
+        title: 'Legacy title',
+        url: 'https://example.com/legacy-title',
+      },
+    ],
+    paging: {
+      page: 1,
+      pageSize: 10,
+      totalResults: 3,
+      totalPages: 1,
+    },
+  };
+  test('renders next publish date', () => {
+    render(
+      <PublicationReleaseListPage
+        publicationSummary={testPublicationSummary}
+        releases={testReleases}
+      />,
+    );
+
+    const nextReleaseDate = screen.getByTestId('next-release-date');
+    expect(nextReleaseDate).toBeInTheDocument();
+    expect(within(nextReleaseDate).getByText('March 2026')).toBeInTheDocument();
+  });
+
+  test('renders table data correctly', () => {
+    render(
+      <PublicationReleaseListPage
+        publicationSummary={testPublicationSummary}
+        releases={testReleases}
+      />,
+    );
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+
+    const rows = within(screen.getByRole('table')).getAllByRole('row');
+    expect(rows).toHaveLength(4); // including header row
+    const row1Cells = within(rows[1]).getAllByRole('cell');
+    const row1Link = within(row1Cells[0]).getByRole('link', {
+      name: 'Test Release Title 3 - Final',
+    });
+    expect(row1Link).toBeInTheDocument();
+    expect(row1Link).toHaveAttribute(
+      'href',
+      '/find-statistics/publication-slug/test-release-slug-3?redesign=true', // TODO EES-6449 remove query param when live
+    );
+    expect(
+      within(row1Cells[1]).getByText('10 August 2025'),
+    ).toBeInTheDocument();
+    expect(
+      within(row1Cells[1]).getByText('Latest release'),
+    ).toBeInTheDocument();
+    expect(
+      within(row1Cells[2]).getByText('11 August 2025'),
+    ).toBeInTheDocument();
+    const row2Cells = within(rows[2]).getAllByRole('cell');
+    const row2link = within(row2Cells[0]).getByRole('link', {
+      name: 'Test Release Title 2',
+    });
+    expect(row2link).toBeInTheDocument();
+    expect(row2link).toHaveAttribute(
+      'href',
+      '/find-statistics/publication-slug/test-release-slug-2?redesign=true', // TODO EES-6449 remove query param when live
+    );
+    expect(within(row2Cells[1]).getByText('1 July 2025')).toBeInTheDocument();
+    expect(
+      within(row2Cells[1]).queryByText('Latest release'),
+    ).not.toBeInTheDocument();
+    expect(within(row2Cells[2]).getByText('11 July 2025')).toBeInTheDocument();
+    const row3Cells = within(rows[3]).getAllByRole('cell');
+    const row3link = within(row3Cells[0]).getByRole('link', {
+      name: 'Legacy title',
+    });
+    expect(row3link).toBeInTheDocument();
+    expect(row3link).toHaveAttribute(
+      'href',
+      'https://example.com/legacy-title',
+    );
+    expect(within(row3Cells[1]).getByText('Not available')).toBeInTheDocument();
+    expect(within(row3Cells[2]).getByText('Not available')).toBeInTheDocument();
+  });
+
+  test('renders pagination when multiple pages', () => {
+    const testReleasesMultiPage: PaginatedList<PublicationReleaseSeriesItem> = {
+      ...testReleases,
+      paging: {
+        page: 2,
+        pageSize: 1,
+        totalResults: 3,
+        totalPages: 3,
+      },
+    };
+    render(
+      <PublicationReleaseListPage
+        publicationSummary={testPublicationSummary}
+        releases={testReleasesMultiPage}
+      />,
+    );
+
+    expect(
+      screen.getByRole('navigation', { name: 'Pagination' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Page 1' })).toHaveAttribute(
+      'href',
+      '?page=1',
+    );
+    expect(screen.getByRole('link', { name: 'Page 2' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('link', { name: 'Page 3' })).toHaveAttribute(
+      'href',
+      '?page=3',
+    );
+  });
+});

--- a/src/explore-education-statistics-frontend/src/pages/find-statistics/[publication]/releases.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/find-statistics/[publication]/releases.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  getServerSideProps,
+} from '@frontend/modules/find-statistics/PublicationReleaseListPage';


### PR DESCRIPTION
This PR adds a new page to a publication (at `/find-statistics/publication-slug/releases`) which shows a list of releases belonging to the publication (legacy and standard releases)

The results are paginated like the 'updates' page.

There is an optional display of 'next release' if the publication has one.

<img width="1396" height="1220" alt="image" src="https://github.com/user-attachments/assets/3778a34f-aeac-4068-b399-a5e29bad8e53" />
