### PR TITLE
EES-6605 Amend style of tile buttons, add modal confirm for deleting

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/education-in-numbers/content/__tests__/EditableTileGroupBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/education-in-numbers/content/__tests__/EditableTileGroupBlock.test.tsx
@@ -1,4 +1,6 @@
 import { EditingContextProvider } from '@admin/contexts/EditingContext';
+import EditableTileGroupBlock from '@admin/pages/education-in-numbers/content/components/EditableTileGroupBlock';
+import { EducationInNumbersPageContentProvider } from '@admin/pages/education-in-numbers/content/context/EducationInNumbersPageContentContext';
 import render from '@common-test/render';
 import { screen, waitFor, within } from '@testing-library/react';
 import noop from 'lodash/noop';
@@ -6,8 +8,6 @@ import React from 'react';
 import testEinPageVersion, {
   testEinPageContent,
 } from '../../__tests__/__data__/testEducationInNumbersPageAndContent';
-import EditableTileGroupBlock from '../components/EditableTileGroupBlock';
-import { EducationInNumbersPageContentProvider } from '../context/EducationInNumbersPageContentContext';
 import testBlock from './__data__/testBlock';
 
 const renderWithContext = (component: React.ReactNode) =>
@@ -159,5 +159,28 @@ describe('EditableTileGroupBlock', () => {
         screen.queryByTestId('freeTextStatTile-editForm'),
       ).not.toBeInTheDocument(),
     );
+  });
+
+  test('when the remove tile button is clicked a confirm modal is shown', async () => {
+    const { user } = renderWithContext(
+      <EditableTileGroupBlock
+        block={testBlock}
+        editable
+        sectionId="test-section"
+        onDelete={noop}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Delete tile - Test Tile Group Block Title',
+      }),
+    );
+
+    const modal = within(screen.getByRole('dialog'));
+
+    await waitFor(() => {
+      expect(modal.getByText('Remove tile')).toBeInTheDocument();
+    });
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/education-in-numbers/content/components/EditableTileGroupBlock.tsx
+++ b/src/explore-education-statistics-admin/src/pages/education-in-numbers/content/components/EditableTileGroupBlock.tsx
@@ -4,8 +4,10 @@ import { useEducationInNumbersPageContentState } from '@admin/pages/education-in
 import useEducationInNumbersPageContentActions from '@admin/pages/education-in-numbers/content/context/useEducationInNumbersPageContentActions';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
+import ButtonText from '@common/components/ButtonText';
 import { FormTextInput } from '@common/components/form';
 import InsetText from '@common/components/InsetText';
+import ModalConfirm from '@common/components/ModalConfirm';
 import ReorderableList from '@common/components/ReorderableList';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import useToggle from '@common/hooks/useToggle';
@@ -207,12 +209,21 @@ const EditableTileGroupBlock = ({
                       <FreeTextStatTile key={tile.id} tile={tile} />
                       {!isEditingStatTile && (
                         <ButtonGroup className="govuk-!-margin-top-2">
-                          <Button onClick={() => setIsEditingStatTile(tile.id)}>
+                          <Button
+                            onClick={() => setIsEditingStatTile(tile.id)}
+                            variant="secondary"
+                          >
                             Edit <VisuallyHidden> tile: {title}</VisuallyHidden>
                           </Button>
-                          <Button
-                            variant="warning"
-                            onClick={async () => {
+                          <ModalConfirm
+                            title="Remove tile"
+                            triggerButton={
+                              <ButtonText variant="warning">
+                                Delete tile
+                                <VisuallyHidden>- {title}</VisuallyHidden>
+                              </ButtonText>
+                            }
+                            onConfirm={async () => {
                               await deleteFreeTextStatTile({
                                 educationInNumbersPageId,
                                 blockId: block.id,
@@ -221,9 +232,8 @@ const EditableTileGroupBlock = ({
                               });
                             }}
                           >
-                            Delete tile
-                            <VisuallyHidden>- {title}</VisuallyHidden>
-                          </Button>
+                            <p>Are you sure you want to remove this tile?</p>
+                          </ModalConfirm>
                         </ButtonGroup>
                       )}
                     </>


### PR DESCRIPTION
Small PR to tweak the style of buttons when editing tile group blocks on Education in Numbers pages. 
- No longer green and red buttons for each tile
- Now grey edit button and red button text for delete

As the delete button is less prominent, I've also added a modal confirmation before actually deleting the tile.

Before:
<img width="1294" height="717" alt="image" src="https://github.com/user-attachments/assets/3e14cf92-54c0-4bb6-9f6a-b39201c258e9" />

After:
<img width="1342" height="701" alt="image" src="https://github.com/user-attachments/assets/1078ac87-8858-4958-aba9-96c8d74f450b" />

<img width="799" height="437" alt="image" src="https://github.com/user-attachments/assets/a6a03d25-d5fc-479d-a129-a86b216b25ed" />
