### PR TITLE
Skip `no_javascript.robot` UI test failing in local environment

### DIFF
--- a/tests/robot-tests/tests/general_public/no_javascript.robot
+++ b/tests/robot-tests/tests/general_public/no_javascript.robot
@@ -16,5 +16,5 @@ Parse Find Statistics page HTML
     set suite variable    ${parsed_page}
 
 Validate publications list is on page
-    [Tags]    NotAgainstDev    NotAgainstTest    NotAgainstPreProd
+    Skip    msg=Requires frontend Azure Search configuration in Local; Fails in Dev/Test/PreProd due to auth issue.
     ${list}=    user_gets_publications_list    ${parsed_page}


### PR DESCRIPTION
This PR skips the `Validate publications list is on page` test case in the `no_javascript.robot` file.

It is skipped with a message explaining that it requires frontend Azure Search configuration in the local environment and fails in Dev, Test, and PreProd. The failures in those environments is suspected to be due to Basic Authentication.

<img width="1078" height="59" alt="image" src="https://github.com/user-attachments/assets/f42aed36-ca4f-447e-b043-d861105d376a" />
