### PR TITLE
EES-6520 Remove ARM template DDOS protection config

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1198,7 +1198,6 @@
     ],
     "vNetName": "[concat(parameters('subscription'), '-vnet-', parameters('environment'))]",
     "vNetRef": "[resourceId('Microsoft.Network/virtualNetworks', variables('vNetName'))]",
-    "vNetDdosPlanName": "[concat(parameters('subscription'), '-vnet-', parameters('environment'), '-ddos-plan')]",
     "adminSubnetName": "[concat(parameters('subscription'), '-snet-', parameters('environment'), '-admin')]",
     "adminSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('adminSubnetName'))]",
     "analyticsFunctionAppSubnetName": "[concat(parameters('subscription'), '-', parameters('environment'), '-snet-fa-analytics')]",
@@ -3574,26 +3573,6 @@
     },
     {
       "condition": "[parameters('deploySubnets')]",
-      "type": "Microsoft.Network/ddosProtectionPlans",
-      "apiVersion": "2024-07-01",
-      "name": "[variables('vNetDdosPlanName')]",
-      "location": "[resourceGroup().location]",
-      "tags": {
-        "Department": "[parameters('departmentName')]",
-        "Solution": "[parameters('solutionName')]",
-        "ServiceType": "Ddos protection plan",
-        "Environment": "[parameters('environmentName')]",
-        "Subscription": "[parameters('subscriptionName')]",
-        "CostCentre": "[parameters('costCentre')]",
-        "ServiceOwner": "[parameters('serviceOwnerName')]",
-        "DateProvisioned": "[parameters('dateProvisioned')]",
-        "CreatedBy": "[parameters('createdBy')]",
-        "DeploymentRepo": "[parameters('deploymentRepo')]",
-        "DeploymentScript": "[parameters('deploymentScript')]"
-      }
-    },
-    {
-      "condition": "[parameters('deploySubnets')]",
       "apiVersion": "2020-05-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('vNetName')]",
@@ -3611,16 +3590,11 @@
         "DeploymentRepo": "[parameters('deploymentRepo')]",
         "DeploymentScript": "[parameters('deploymentScript')]"
       },
-      "dependsOn": ["[resourceId('Microsoft.Network/ddosProtectionPlans', variables('vNetDdosPlanName'))]"],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
             "10.0.0.0/16"
           ]
-        },
-        "enableDdosProtection": true,
-        "ddosProtectionPlan": {
-          "id": "[resourceId('Microsoft.Network/ddosProtectionPlans', variables('vNetDdosPlanName'))]"
         },
         "subnets": [
           {


### PR DESCRIPTION
This PR removes DDoS protection config from our ARM template. We're doing as a temporary measure until it can be readded. Currently there is a restriction of one DdosProtectionPlan per subscription that is preventing us from deploying this to production.