### PR TITLE
EES-6502 - Resetting `User.DeletedById` back to `Null` when signing-in with a soft deleted user

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/SignInServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/SignInServiceTests.cs
@@ -439,6 +439,7 @@ public class SignInServiceTests
                 .WithFirstName(firstName)
                 .WithLastName(lastName)
                 .WithSoftDeleted(DateTime.UtcNow.AddDays(-1))
+                .WithDeletedBy(createdByInternalUser)
                 .WithActive(false)
                 .WithCreated(DateTime.UtcNow.AddDays(-2))
                 .Generate();
@@ -569,6 +570,7 @@ public class SignInServiceTests
                 Assert.Equal(updatedFirstName, newUser.FirstName); // Updated to the new FirstName from the invite
                 Assert.Equal(updatedLastName, newUser.LastName); // Updated to the new LastName from the invite
                 Assert.Null(newUser.SoftDeleted); // Reset back to active state
+                Assert.Null(newUser.DeletedById); // Reset back to active state
                 Assert.True(newUser.Active); // Reset back to active state
                 Assert.Equal(userInvite.RoleId, newUser.RoleId); // Updated to the new Role from the invite
                 newUser.Created.AssertUtcNow(); // Updated to now

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/SignInService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/SignInService.cs
@@ -115,6 +115,7 @@ public class SignInService(
             existingInternalUser.FirstName = newAspNetUser.FirstName;
             existingInternalUser.LastName = newAspNetUser.LastName;
             existingInternalUser.SoftDeleted = null;
+            existingInternalUser.DeletedById = null;
             existingInternalUser.Active = true;
             existingInternalUser.RoleId = inviteToSystem.RoleId;
             existingInternalUser.Created = DateTimeOffset.UtcNow;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/UserGeneratorExtensions.cs
@@ -9,108 +9,126 @@ public static class UserGeneratorExtensions
         => fixture.Generator<User>().WithDefaults();
 
     public static Generator<User> WithDefaults(this Generator<User> generator)
-        => generator.ForInstance(d => d.SetDefaults());
+        => generator.ForInstance(i => i.SetDefaults());
 
     public static Generator<User> WithId(this Generator<User> generator, Guid id)
-        => generator.ForInstance(d => d.SetId(id));
+        => generator.ForInstance(i => i.SetId(id));
 
     public static Generator<User> WithFirstName(this Generator<User> generator, string firstName)
-        => generator.ForInstance(d => d.SetFirstName(firstName));
+        => generator.ForInstance(i => i.SetFirstName(firstName));
 
     public static Generator<User> WithLastName(this Generator<User> generator, string lastName)
-        => generator.ForInstance(d => d.SetLastName(lastName));
+        => generator.ForInstance(i => i.SetLastName(lastName));
 
     public static Generator<User> WithEmail(this Generator<User> generator, string email)
-        => generator.ForInstance(d => d.SetEmail(email));
+        => generator.ForInstance(i => i.SetEmail(email));
 
     public static Generator<User> WithSoftDeleted(this Generator<User> generator, DateTime? softDeletedDate)
-        => generator.ForInstance(d => d.SetSoftDeleted(softDeletedDate));
+        => generator.ForInstance(i => i.SetSoftDeleted(softDeletedDate));
+
+    public static Generator<User> WithDeletedById(this Generator<User> generator, Guid? deletedById)
+        => generator.ForInstance(i => i.SetDeletedById(deletedById));
+
+    public static Generator<User> WithDeletedBy(this Generator<User> generator, User? deletedBy)
+        => generator.ForInstance(i => i.SetDeletedBy(deletedBy));
 
     public static Generator<User> WithActive(this Generator<User> generator, bool active)
-        => generator.ForInstance(d => d.SetActive(active));
+        => generator.ForInstance(i => i.SetActive(active));
 
     public static Generator<User> WithRoleId(this Generator<User> generator, string roleId)
-        => generator.ForInstance(d => d.SetRoleId(roleId));
+        => generator.ForInstance(i => i.SetRoleId(roleId));
 
     public static Generator<User> WithRole(this Generator<User> generator, IdentityRole role)
-        => generator.ForInstance(d => d.SetRole(role));
+        => generator.ForInstance(i => i.SetRole(role));
 
     public static Generator<User> WithCreated(this Generator<User> generator, DateTimeOffset created)
-        => generator.ForInstance(d => d.SetCreated(created));
+        => generator.ForInstance(i => i.SetCreated(created));
 
     public static Generator<User> WithCreatedById(this Generator<User> generator, Guid createdById)
-        => generator.ForInstance(d => d.SetCreatedById(createdById));
+        => generator.ForInstance(i => i.SetCreatedById(createdById));
 
     public static Generator<User> WithCreatedBy(this Generator<User> generator, User createdBy)
-        => generator.ForInstance(d => d.SetCreatedBy(createdBy));
+        => generator.ForInstance(i => i.SetCreatedBy(createdBy));
 
     public static InstanceSetters<User> SetDefaults(this InstanceSetters<User> setters)
         => setters
-            .SetDefault(p => p.Id)
-            .SetDefault(p => p.FirstName)
-            .SetDefault(p => p.LastName)
-            .Set(p => p.Email, f => f.Internet.Email())
-            .Set(p => p.Active, true)
-            .SetDefault(p => p.RoleId)
+            .SetDefault(u => u.Id)
+            .SetDefault(u => u.FirstName)
+            .SetDefault(u => u.LastName)
+            .Set(u => u.Email, f => f.Internet.Email())
+            .Set(u => u.Active, true)
+            .SetDefault(u => u.RoleId)
             .Set(u => u.Created, f => f.Date.Past())
-            .SetDefault(p => p.CreatedById);
+            .SetDefault(u => u.CreatedById);
 
     public static InstanceSetters<User> SetId(
         this InstanceSetters<User> setters,
         Guid id)
-        => setters.Set(d => d.Id, id);
+        => setters.Set(u => u.Id, id);
 
     public static InstanceSetters<User> SetFirstName(
         this InstanceSetters<User> setters,
         string firstName)
-        => setters.Set(d => d.FirstName, firstName);
+        => setters.Set(u => u.FirstName, firstName);
 
     public static InstanceSetters<User> SetLastName(
         this InstanceSetters<User> setters,
         string lastName)
-        => setters.Set(d => d.LastName, lastName);
+        => setters.Set(u => u.LastName, lastName);
 
     public static InstanceSetters<User> SetEmail(
         this InstanceSetters<User> setters,
         string email)
-        => setters.Set(d => d.Email, email);
+        => setters.Set(u => u.Email, email);
 
     public static InstanceSetters<User> SetSoftDeleted(
         this InstanceSetters<User> setters,
         DateTime? softDeletedDate)
-        => setters.Set(d => d.SoftDeleted, softDeletedDate);
+        => setters.Set(u => u.SoftDeleted, softDeletedDate);
+
+    public static InstanceSetters<User> SetDeletedById(
+        this InstanceSetters<User> setters,
+        Guid? deletedById)
+        => setters.Set(u => u.DeletedById, deletedById);
+
+    public static InstanceSetters<User> SetDeletedBy(
+        this InstanceSetters<User> setters,
+        User? deletedBy)
+        => setters
+            .Set(u => u.DeletedBy, deletedBy)
+            .Set(u => u.DeletedById, deletedBy?.Id);
 
     public static InstanceSetters<User> SetActive(
         this InstanceSetters<User> setters,
         bool active)
-        => setters.Set(d => d.Active, active);
+        => setters.Set(u => u.Active, active);
 
     public static InstanceSetters<User> SetRoleId(
         this InstanceSetters<User> setters,
         string roleId)
-        => setters.Set(d => d.RoleId, roleId);
+        => setters.Set(u => u.RoleId, roleId);
 
     public static InstanceSetters<User> SetRole(
         this InstanceSetters<User> setters,
         IdentityRole role)
         => setters
-            .Set(d => d.Role, role)
-            .Set(uri => uri.RoleId, role.Id);
+            .Set(u => u.Role, role)
+            .Set(u => u.RoleId, role.Id);
 
     public static InstanceSetters<User> SetCreated(
         this InstanceSetters<User> setters,
         DateTimeOffset created)
-        => setters.Set(d => d.Created, created);
+        => setters.Set(u => u.Created, created);
 
     public static InstanceSetters<User> SetCreatedById(
         this InstanceSetters<User> setters,
         Guid createdById)
-        => setters.Set(d => d.CreatedById, createdById);
+        => setters.Set(u => u.CreatedById, createdById);
 
     public static InstanceSetters<User> SetCreatedBy(
         this InstanceSetters<User> setters,
         User createdBy)
         => setters
-            .Set(d => d.CreatedBy, createdBy)
-            .Set(uri => uri.CreatedById, createdBy.Id);
+            .Set(u => u.CreatedBy, createdBy)
+            .Set(u => u.CreatedById, createdBy.Id);
 }


### PR DESCRIPTION
This 1-liner was missed on the [previous PR for EES-6502](https://github.com/dfe-analytical-services/explore-education-statistics/pull/6305).

It makes sense to reset the `User.DeletedById` field to `Null` when signing in with a previously soft-deleted user.