### PR TITLE
EES-6599 improve accordions for screen reader users

### DIFF
--- a/src/explore-education-statistics-common/src/components/AccordionSection.tsx
+++ b/src/explore-education-statistics-common/src/components/AccordionSection.tsx
@@ -95,6 +95,9 @@ const AccordionSection = ({
               <button
                 aria-controls={contentId}
                 aria-expanded={open}
+                aria-label={`${heading}, ${
+                  open ? 'hide' : 'show'
+                } this section`}
                 className={classes.sectionButton}
                 data-scroll={trackScroll ? true : undefined}
                 id={headingId}
@@ -104,6 +107,9 @@ const AccordionSection = ({
                 }}
               >
                 <HeadingContent caption={caption} heading={heading} />
+                <span className="govuk-visually-hidden govuk-accordion__section-heading-divider">
+                  ,{' '}
+                </span>
                 <span className="govuk-accordion__section-toggle">
                   <span className="govuk-accordion__section-toggle-focus">
                     <span

--- a/src/explore-education-statistics-common/src/components/__tests__/Accordion.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Accordion.test.tsx
@@ -1,5 +1,5 @@
-import { render, waitFor, screen, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import render from '@common-test/render';
+import { waitFor, screen, within } from '@testing-library/react';
 import React from 'react';
 import Accordion from '../Accordion';
 import AccordionSection from '../AccordionSection';
@@ -44,7 +44,7 @@ describe('Accordion', () => {
   });
 
   test('clicking heading makes the section content expanded', async () => {
-    render(
+    const { user } = render(
       <Accordion id="test-sections">
         <AccordionSection heading="Test heading">Test content</AccordionSection>
       </Accordion>,
@@ -54,7 +54,7 @@ describe('Accordion', () => {
 
     expect(heading).toHaveAttribute('aria-expanded', 'false');
 
-    await userEvent.click(heading);
+    await user.click(heading);
 
     expect(heading).toHaveAttribute('aria-expanded', 'true');
   });
@@ -185,7 +185,7 @@ describe('Accordion', () => {
   test('accordion sections that were opened when the location hash matches an element in the section content can be closed', async () => {
     window.location.hash = '#test-sections-1-content';
 
-    render(
+    const { user } = render(
       <Accordion id="test-sections">
         <AccordionSection heading="Test heading 1">
           Test content 1
@@ -205,7 +205,7 @@ describe('Accordion', () => {
 
     expect(heading).toHaveAttribute('aria-expanded', 'true');
 
-    await userEvent.click(heading);
+    await user.click(heading);
 
     expect(
       await within(accordionSections[0]).findByText('Show'),
@@ -235,7 +235,7 @@ describe('Accordion', () => {
   });
 
   test('clicking on `Show all sections` reveals all sections', async () => {
-    render(
+    const { user } = render(
       <Accordion id="test-sections">
         <AccordionSection heading="Test heading 1">
           Test content 1
@@ -255,7 +255,7 @@ describe('Accordion', () => {
     expect(sections[0]).toHaveAttribute('aria-expanded', 'false');
     expect(sections[1]).toHaveAttribute('aria-expanded', 'true');
 
-    await userEvent.click(button);
+    await user.click(button);
 
     expect(button).toHaveAttribute('aria-expanded', 'true');
     expect(sections[0]).toHaveAttribute('aria-expanded', 'true');
@@ -265,7 +265,7 @@ describe('Accordion', () => {
   test('clicking on `Show all sections` causes `onToggleAll` handler to be called with new state', async () => {
     const toggleAll = jest.fn();
 
-    render(
+    const { user } = render(
       <Accordion id="test-sections" onToggleAll={toggleAll}>
         <AccordionSection heading="Test heading">Test content</AccordionSection>
       </Accordion>,
@@ -273,15 +273,13 @@ describe('Accordion', () => {
 
     expect(toggleAll).not.toHaveBeenCalled();
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Show all sections' }),
-    );
+    await user.click(screen.getByRole('button', { name: 'Show all sections' }));
 
     expect(toggleAll).toHaveBeenCalledWith(true);
   });
 
   test('clicking on `Hide all sections` closes all sections', async () => {
-    render(
+    const { user } = render(
       <Accordion id="test-sections">
         <AccordionSection heading="Test heading 1" open>
           Test content 1
@@ -301,7 +299,7 @@ describe('Accordion', () => {
     expect(sections[0]).toHaveAttribute('aria-expanded', 'true');
     expect(sections[1]).toHaveAttribute('aria-expanded', 'true');
 
-    await userEvent.click(closeAllButton);
+    await user.click(closeAllButton);
 
     expect(closeAllButton).toHaveAttribute('aria-expanded', 'false');
     expect(sections[0]).toHaveAttribute('aria-expanded', 'false');
@@ -311,7 +309,7 @@ describe('Accordion', () => {
   test('clicking on `Hide all sections` causes `onToggleAll` handler to be called with new state', async () => {
     const toggleAll = jest.fn();
 
-    render(
+    const { user } = render(
       <Accordion id="test-sections" onToggleAll={toggleAll}>
         <AccordionSection heading="Test heading" open>
           Test content
@@ -321,9 +319,7 @@ describe('Accordion', () => {
 
     expect(toggleAll).not.toHaveBeenCalled();
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Hide all sections' }),
-    );
+    await user.click(screen.getByRole('button', { name: 'Hide all sections' }));
 
     expect(toggleAll).toHaveBeenCalledWith(false);
   });
@@ -338,11 +334,31 @@ describe('Accordion', () => {
       </Accordion>,
     );
 
-    expect(container.querySelectorAll('.govuk-visually-hidden')).toHaveLength(
-      1,
+    const hiddenText = container.querySelectorAll('.govuk-visually-hidden');
+
+    expect(hiddenText).toHaveLength(2);
+    expect(hiddenText[0]).toHaveTextContent('Academic year 2016/17 sections');
+    expect(hiddenText[1]).toHaveTextContent(',');
+  });
+
+  test('it renders the correct aria-label', async () => {
+    const { user } = render(
+      <Accordion
+        id="test-sections"
+        toggleAllHiddenText="Academic year 2016/17 sections"
+      >
+        <AccordionSection heading="Test heading">Test content</AccordionSection>
+      </Accordion>,
     );
-    expect(container.querySelector('.govuk-visually-hidden')).toHaveTextContent(
-      'Academic year 2016/17 sections',
-    );
+
+    expect(
+      screen.getByRole('button', { name: /Test heading/ }),
+    ).toHaveAttribute('aria-label', 'Test heading, show this section');
+
+    await user.click(screen.getByRole('button', { name: /Test heading/ }));
+
+    expect(
+      screen.getByRole('button', { name: /Test heading/ }),
+    ).toHaveAttribute('aria-label', 'Test heading, hide this section');
   });
 });

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`AccordionSection renders correctly with required props 1`] = `
     >
       <button aria-controls="accordionSection-content"
               aria-expanded="false"
+              aria-label="Test heading, show this section"
               class="govuk-accordion__section-button"
               id="accordionSection-heading"
               type="button"
@@ -21,6 +22,9 @@ exports[`AccordionSection renders correctly with required props 1`] = `
           >
             Test heading
           </span>
+        </span>
+        <span class="govuk-visually-hidden govuk-accordion__section-heading-divider">
+          ,
         </span>
         <span class="govuk-accordion__section-toggle">
           <span class="govuk-accordion__section-toggle-focus">
@@ -62,6 +66,7 @@ exports[`AccordionSection renders with caption 1`] = `
     >
       <button aria-controls="accordionSection-content"
               aria-expanded="false"
+              aria-label="Test heading, show this section"
               class="govuk-accordion__section-button"
               id="accordionSection-heading"
               type="button"
@@ -77,6 +82,9 @@ exports[`AccordionSection renders with caption 1`] = `
           <span class="govuk-accordion__section-summary-focus">
             Some caption text
           </span>
+        </span>
+        <span class="govuk-visually-hidden govuk-accordion__section-heading-divider">
+          ,
         </span>
         <span class="govuk-accordion__section-toggle">
           <span class="govuk-accordion__section-toggle-focus">
@@ -118,6 +126,7 @@ exports[`AccordionSection renders with different heading size 1`] = `
     >
       <button aria-controls="accordionSection-content"
               aria-expanded="false"
+              aria-label="Test heading, show this section"
               class="govuk-accordion__section-button"
               id="accordionSection-heading"
               type="button"
@@ -128,6 +137,9 @@ exports[`AccordionSection renders with different heading size 1`] = `
           >
             Test heading
           </span>
+        </span>
+        <span class="govuk-visually-hidden govuk-accordion__section-heading-divider">
+          ,
         </span>
         <span class="govuk-accordion__section-toggle">
           <span class="govuk-accordion__section-toggle-focus">


### PR DESCRIPTION
Fixes an accessibility issue raised by DAC where when screen reader users are navigating using the arrow keys, accordion headings are read as two separate elements (the actual heading and 'show'). Comparing our html with the design system I noticed we were missing two things, adding them has fixed the issue:
- an `aria-label` containing the the heading and 'show / hide this section'
- a hidden span containing `, ` between the heading and 'show /hide'