### PR TITLE
EES-6602 Reenable NetworkActivityContext UI test check

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
@@ -550,8 +550,7 @@ public class ReleaseVersionService(
             })
             .OnSuccess(releaseVersions => releaseVersions.Where(rv => !rv.Live))
             .OnSuccess(async releaseVersions =>
-            {
-                var approvedReleases = await releaseVersions
+                await releaseVersions
                     .ToAsyncEnumerable()
                     .SelectAwait(async releaseVersion =>
                     {
@@ -562,10 +561,8 @@ public class ReleaseVersionService(
                         );
                         return releaseViewModel;
                     })
-                    .ToListAsync();
-
-                return approvedReleases.ToList();
-            });
+                    .ToListAsync()
+            );
     }
 
     public async Task<Either<ActionResult, DeleteDataFilePlanViewModel>> GetDeleteDataFilePlan(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
@@ -548,6 +548,7 @@ public class ReleaseVersionService(
                         )
                     );
             })
+            .OnSuccess(releaseVersions => releaseVersions.Where(rv => !rv.Live))
             .OnSuccess(async releaseVersions =>
             {
                 var approvedReleases = await releaseVersions
@@ -563,7 +564,7 @@ public class ReleaseVersionService(
                     })
                     .ToListAsync();
 
-                return approvedReleases.Where(release => !release.Live).ToList();
+                return approvedReleases.ToList();
             });
     }
 

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -194,8 +194,7 @@ user waits until page finishes loading
     sleep    0.5
 
     # Wait to ensure network activity attribute is updated in DOM
-    # EES-6602 Temporarily disable this check to see how it effects run speed and reliability
-    #user waits until page does not contain element    css:body[data-network-activity="active"]    ${network_timeout}
+    user waits until page does not contain element    css:body[data-network-activity="active"]    ${network_timeout}
 
 user waits until parent contains element
     [Arguments]


### PR DESCRIPTION
This PR does two things:
- reenable the NetworkActivityContext UI test check
- and attempt to improve the performance of `ReleaseVersionService#ListScheduledReleases`.

Previous this PR was intending to remove NetworkActivityContext, but after a chat with Dunc, we're now going to keep it.

I had intended to remove this I noticed that the UI test check on the network activity attribute in pages' `Body` was remaining active for a long time, slowing down UI tests by 30-60 seconds unnecessarily. I assumed this would happen anywhere the `user waits until page finishes loading` keyword was called, but Dunc pointed out that it will be specific to the Dashboard, and specifically the `api/releases/scheduled` endpoint that still hasn't returned.

It's also possible that while we saw no flaky test failures after removing the UI test check, it's possible flakiness was being hidden by UI test reruns. So we're readding the UI test check.

