### PR TITLE
EES-6620 Add csharpier check to CI pipeline

### DIFF
--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -57,35 +57,22 @@ jobs:
           version: $(DotNetVersion)
           performMultiLevelLookup: true
 
-      # TODO: Uncomment this step once formatter has been run globally.
-      # This is because whitespace rules cannot be warnings or suggestions; they will always be errors
-      # - task: DotNetCoreCLI@2
-      #   displayName: Verify formatting
-      #   inputs:
-      #     command: custom
-      #     custom: format whitespace src/GovUk.Education.ExploreEducationStatistics.sln --verify-no-changes --severity error
-      #     arguments: --verify-no-changes --verbosity diagnostic
-
+      # Check code formatting
       - task: DotNetCoreCLI@2
-        displayName: Verify style
+        displayName: Restore .NET tools
         inputs:
           command: custom
-          custom: format
-          ## TODO: Remove "--severity error" once style formatter has been run across project
-          arguments: style --verify-no-changes --verbosity diagnostic --severity error
-          projects: src/GovUk.Education.ExploreEducationStatistics.sln
+          custom: tool
+          arguments: restore
 
       - task: DotNetCoreCLI@2
-        displayName: Verify analyzers
+        displayName: CSharpier check formatting
         inputs:
           command: custom
-          custom: format
-          ## TODO: Remove "--severity error" once work has been done to resolve build warnings (https://dfedigital.atlassian.net/browse/EES-4594).
-          arguments: analyzers --verify-no-changes --verbosity diagnostic --severity error
-          projects: src/GovUk.Education.ExploreEducationStatistics.sln
+          custom: csharpier
+          arguments: check .
 
-      # TODO: Wrap the above three tasks up into a single `dotnet format` task once all TODOs are done
-
+      # Check Public API OpenAPI docs
       - task: DotNetCoreCLI@2
         displayName: Build Public API
         inputs:

--- a/infrastructure/templates/search/ci/azure-pipelines-build.yml
+++ b/infrastructure/templates/search/ci/azure-pipelines-build.yml
@@ -39,6 +39,16 @@ jobs:
           version: $(dotNetVersion)
 
       - task: DotNetCoreCLI@2
+        displayName: Restore .NET tools
+        inputs:
+          command: custom
+          custom: tool
+          arguments: restore
+
+      - script: dotnet csharpier check $(System.DefaultWorkingDirectory)/src/GovUk.Education.ExploreEducationStatistics.Content.Search*
+        displayName: CSharpier check formatting
+
+      - task: DotNetCoreCLI@2
         displayName: 'Build the solution'
         inputs:
           command: 'build'

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
       "python3 -m pipenv run black",
       "python3 -m pipenv run isort"
     ],
-    "*.cs": [
+    "*.{cs,csproj}": [
       "dotnet csharpier check"
     ]
   }


### PR DESCRIPTION
This PR adds `dotnet csharpier check .`  to the CI pipeline and fails if the cs/csproj/nuget.config files aren't formatted correctly.

Tested by building the EES-6620 branch:
<img width="720" height="322" alt="image_720" src="https://github.com/user-attachments/assets/d4d536ff-a0a6-415e-bf5f-8349d153f115" />

Edit: Updated to add a format check for the search build. There is no need to add checks for Analytics/Public API processor as they use artifacts from the main build.

I've also updated the githook so that csharpier also checks csproj files are formatted correctly.
