### PR TITLE
EEES-6625 - temporarily fixing Bicep version while bug in 0.38.3+

### DIFF
--- a/infrastructure/templates/public-api/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/public-api/ci/tasks/deploy-bicep.yml
@@ -43,7 +43,14 @@ steps:
 
         # Workaround for AZ CLI 2.71.x breaks bicep deployments when using Azure Devops Agent
         # See https://github.com/Azure/azure-cli/issues/31189
-        az config set bicep.use_binary_from_path=false
+        # az config set bicep.use_binary_from_path=true
+        
+        # Another workaround for Azure CLI and its bundled version of Bicep, which introduces
+        # a bug. See https://github.com/Azure/bicep/pull/18167.
+        # Once this one is sorted, we can look to see if the workaround mentioned above this
+        # one can be removed too.
+        az bicep install --version v0.38.2
+        az config set bicep.use_binary_from_path=true
 
         az deployment group ${{ parameters.action }} \
           --name $(infraDeployName) \

--- a/infrastructure/templates/screener/ci/tasks/deploy-bicep.yml
+++ b/infrastructure/templates/screener/ci/tasks/deploy-bicep.yml
@@ -25,7 +25,14 @@ steps:
 
         # Workaround for AZ CLI 2.71.x breaks bicep deployments when using Azure Devops Agent
         # See https://github.com/Azure/azure-cli/issues/31189
-        az config set bicep.use_binary_from_path=false
+        # az config set bicep.use_binary_from_path=true
+        
+        # Another workaround for Azure CLI and its bundled version of Bicep, which introduces
+        # a bug. See https://github.com/Azure/bicep/pull/18167.
+        # Once this one is sorted, we can look to see if the workaround mentioned above this
+        # one can be removed too.
+        az bicep install --version v0.38.2
+        az config set bicep.use_binary_from_path=true
 
         az deployment group ${{ parameters.action }} \
           --name $(infraDeployName) \


### PR DESCRIPTION
This PR:
- fixes the version of Bicep that is used in the pipeline at 0.38.2, prior to the bug introduced in https://github.com/Azure/bicep/pull/18167. 