### PR TITLE
EES-7051 - Tweak migration AddOrganisationLogos in order to add/edit …

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260323175045_EES6981_AddOrganisationLogos.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260323175045_EES6981_AddOrganisationLogos.cs
@@ -94,14 +94,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                 END"
             );
 
-            // Add Department for Health and Social Care
+            // Add Department of Health and Social Care
             // or update it to use 'govuk-crest.svg' as LogoFileName and `UseGISLogo` = true
             migrationBuilder.Sql(
                 $@"
-                IF NOT EXISTS (SELECT 1 FROM dbo.Organisations WHERE Title = N'Department for Health and Social Care')
+                IF NOT EXISTS (SELECT 1 FROM dbo.Organisations WHERE Title = N'Department of Health and Social Care')
                 BEGIN   
                     INSERT INTO dbo.Organisations (Id, Title, Url, Created, Updated, UseGISLogo, GISLogoHexCode, LogoFileName) 
-                    VALUES (NEWID(), N'Department for Health and Social Care', N'https://www.gov.uk/government/organisations/department-of-health-and-social-care', SYSDATETIMEOFFSET(), null, 'True', '#00ad93', 'govuk-crest.svg');
+                    VALUES (NEWID(), N'Department of Health and Social Care', N'https://www.gov.uk/government/organisations/department-of-health-and-social-care', SYSDATETIMEOFFSET(), null, 'True', '#00ad93', 'govuk-crest.svg');
                 END
                 ELSE
                 BEGIN
@@ -110,7 +110,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         UseGISLogo = 'True', 
                         GISLogoHexCode = '#00ad93', 
                         LogoFileName = 'govuk-crest.svg' 
-                    WHERE Title = 'Department for Health and Social Care';
+                    WHERE Title = 'Department of Health and Social Care';
                 END"
             );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260323175045_EES6981_AddOrganisationLogos.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260323175045_EES6981_AddOrganisationLogos.cs
@@ -7,9 +7,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
     /// <inheritdoc />
     public partial class EES6981_AddOrganisationLogos : Migration
     {
-        /// <inheritdoc />
         private const string TableName = "Organisations";
 
+        /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<string>(
@@ -45,55 +45,77 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
             // Update Department for Education
             migrationBuilder.Sql(
-                $"UPDATE dbo.Organisations SET Updated = '{DateTimeOffset.UtcNow:O}', UseGISLogo = 'True', GISLogoHexCode = '#003764', LogoFileName = 'govuk-crest.svg' WHERE Id = '5e089801-cf1a-b375-acd3-88e9d8aece66';"
+                $"UPDATE dbo.Organisations SET Updated = SYSDATETIMEOFFSET(), UseGISLogo = 'True', GISLogoHexCode = '#003764', LogoFileName = 'govuk-crest.svg' WHERE Title = 'Department for Education';"
             );
 
             // Update Skills England
             migrationBuilder.Sql(
-                $"UPDATE dbo.Organisations SET Updated = '{DateTimeOffset.UtcNow:O}', UseGISLogo = 'True', GISLogoHexCode = '#00bcb5', LogoFileName = 'govuk-crest.svg' WHERE Id = '5e089801-ce1a-e274-9915-e83f3e978699';"
+                $"UPDATE dbo.Organisations SET Updated = SYSDATETIMEOFFSET(), UseGISLogo = 'True', GISLogoHexCode = '#00bcb5', LogoFileName = 'govuk-crest.svg' WHERE Title = 'Skills England';"
             );
 
-            // Add Department for Work & Pensions
+            // Add Department for Work and Pensions
+            // or update it to use 'govuk-crest.svg' as LogoFileName and `UseGISLogo` = truu
+            // if it already exists.
             migrationBuilder.Sql(
-                $"INSERT INTO dbo.Organisations (Id, Title, Url, Created, Updated, UseGISLogo, GISLogoHexCode, LogoFileName) VALUES (N'ECCFF2B6-7F81-4AF3-917E-7BB7D5650975', N'Department for Work & Pensions', N'https://www.gov.uk/government/organisations/department-for-work-pensions', '{DateTimeOffset.UtcNow:O}', null, 'True', '#00bcb5', 'govuk-crest.svg');"
+                $@"
+                IF NOT EXISTS (SELECT 1 FROM dbo.Organisations WHERE Title = N'Department for Work and Pensions')
+                BEGIN
+                    INSERT INTO dbo.Organisations (Id, Title, Url, Created, Updated, UseGISLogo, GISLogoHexCode, LogoFileName) 
+                    VALUES (NEWID(), N'Department for Work and Pensions', N'https://www.gov.uk/government/organisations/department-for-work-pensions', SYSDATETIMEOFFSET(), null, 'True', '#00bcb5', 'govuk-crest.svg');
+                END
+                ELSE
+                BEGIN
+                    UPDATE dbo.Organisations 
+                    SET Updated = SYSDATETIMEOFFSET(), 
+                        UseGISLogo = 'True', 
+                        GISLogoHexCode = '#00bcb5', 
+                        LogoFileName = 'govuk-crest.svg' 
+                    WHERE Title = 'Department for Work and Pensions';
+                END"
             );
 
             // Add Ofsted
             migrationBuilder.Sql(
-                $"INSERT INTO dbo.Organisations (Id, Title, Url, Created, Updated, UseGISLogo, GISLogoHexCode, LogoFileName) VALUES (N'DCDA7BE0-FCDB-4671-960E-3AD49BD47097', N'Ofsted', N'https://www.gov.uk/government/organisations/ofsted', '{DateTimeOffset.UtcNow:O}', null, 'False', null, 'ofsted-logo.png');"
+                $@"
+                IF NOT EXISTS (SELECT 1 FROM dbo.Organisations WHERE Title = N'Ofsted')
+                BEGIN
+                    INSERT INTO dbo.Organisations (Id, Title, Url, Created, Updated, UseGISLogo, GISLogoHexCode, LogoFileName) 
+                    VALUES (NEWID(), N'Ofsted', N'https://www.gov.uk/government/organisations/ofsted', SYSDATETIMEOFFSET(), null, 'False', null, 'ofsted-logo.png');
+                END"
             );
 
             // Add Ofqual
             migrationBuilder.Sql(
-                $"INSERT INTO dbo.Organisations (Id, Title, Url, Created, Updated, UseGISLogo, GISLogoHexCode, LogoFileName) VALUES (N'FFF076EF-C9FD-45F7-A0A5-1266755BD168', N'Ofqual', N'https://www.gov.uk/government/organisations/ofqual', '{DateTimeOffset.UtcNow:O}', null, 'False', null, 'ofqual-logo.png');"
+                $@"
+                IF NOT EXISTS (SELECT 1 FROM dbo.Organisations WHERE Title = N'Ofqual')
+                BEGIN
+                    INSERT INTO dbo.Organisations (Id, Title, Url, Created, Updated, UseGISLogo, GISLogoHexCode, LogoFileName) 
+                    VALUES (NEWID(), N'Ofqual', N'https://www.gov.uk/government/organisations/ofqual', SYSDATETIMEOFFSET(), null, 'False', null, 'ofqual-logo.png');
+                END"
+            );
+
+            // Add Department for Health and Social Care
+            // or update it to use 'govuk-crest.svg' as LogoFileName and `UseGISLogo` = true
+            migrationBuilder.Sql(
+                $@"
+                IF NOT EXISTS (SELECT 1 FROM dbo.Organisations WHERE Title = N'Department for Health and Social Care')
+                BEGIN   
+                    INSERT INTO dbo.Organisations (Id, Title, Url, Created, Updated, UseGISLogo, GISLogoHexCode, LogoFileName) 
+                    VALUES (NEWID(), N'Department for Health and Social Care', N'https://www.gov.uk/government/organisations/department-of-health-and-social-care', SYSDATETIMEOFFSET(), null, 'True', '#00ad93', 'govuk-crest.svg');
+                END
+                ELSE
+                BEGIN
+                    UPDATE dbo.Organisations 
+                    SET Updated = SYSDATETIMEOFFSET(), 
+                        UseGISLogo = 'True', 
+                        GISLogoHexCode = '#00ad93', 
+                        LogoFileName = 'govuk-crest.svg' 
+                    WHERE Title = 'Department for Health and Social Care';
+                END"
             );
         }
 
         /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropCheckConstraint(name: "CK_Organisations_GISLogoHexCode", table: "Organisations");
-
-            migrationBuilder.DropColumn(name: "GISLogoHexCode", table: TableName);
-
-            migrationBuilder.DropColumn(name: "LogoFileName", table: TableName);
-
-            migrationBuilder.DropColumn(name: "UseGISLogo", table: TableName);
-
-            // Revert Department for Education
-            migrationBuilder.Sql(
-                $"UPDATE dbo.Organisations SET Updated = null, WHERE Id = '5e089801-cf1a-b375-acd3-88e9d8aece66';"
-            );
-
-            // Revert Skills England
-            migrationBuilder.Sql(
-                $"UPDATE dbo.Organisations SET Updated = null, WHERE Id = '5e089801-ce1a-e274-9915-e83f3e978699';"
-            );
-
-            // Delete Department for Work & Pensions, Ofsted and Ofqual
-            migrationBuilder.Sql(
-                $"DELETE FROM dbo.Organisations WHERE Id IN ('ECCFF2B6-7F81-4AF3-917E-7BB7D5650975', 'DCDA7BE0-FCDB-4671-960E-3AD49BD47097', 'FFF076EF-C9FD-45F7-A0A5-1266755BD168');"
-            );
-        }
+        protected override void Down(MigrationBuilder migrationBuilder) { }
     }
 }


### PR DESCRIPTION
…rows (#6884)

* EES-7051 - Tweak migration AddOrganisationLogos in order to add/edit row for department of health and social care, set department of work and pensions to use 'and' in it's title and insert data only if doesn't exist.

* EES-7051 - Update AddOrganisationLogos migration: use `Title` instead of `Id` for updates, replace `now` with `SYSDATETIMEOFFSET()`, generate IDs with `NEWID()`, and ensure upserts handle existing organisation rows correctly.