### PR TITLE
EES-7055 - Fix UI tests failng on file upload steps after using `FileUpload` from govuk-frontend.

### DIFF
--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -599,8 +599,10 @@ user uploads subject
     user clicks link    Data and files
     user waits until page contains element    id:dataFileUploadForm-title    %{WAIT_SMALL}
     user enters text into element    id:dataFileUploadForm-title    ${SUBJECT_NAME}
-    user chooses file    id:dataFileUploadForm-dataFile    ${FOLDER}${SUBJECT_FILE}
-    user chooses file    id:dataFileUploadForm-metadataFile    ${FOLDER}${META_FILE}
+    user waits until element is visible    id:dataFileUploadForm-dataFile
+    choose file    id:dataFileUploadForm-dataFile-input    ${FOLDER}${SUBJECT_FILE}
+    user waits until element is visible    id:dataFileUploadForm-metadataFile
+    choose file    id:dataFileUploadForm-metadataFile-input    ${FOLDER}${META_FILE}
     user clicks button    Upload data files
     user waits until page contains element    testid:Data files table
 


### PR DESCRIPTION
Following DAC_Dragon_Usability_01 which contained UI design changes to the file upload section for releases, UI tests started failing as they couldn't find the old HTML elements. This PR tweaks the step which uploads a data set and a meta file in order to successfully upload data sets.