### PR TITLE
EES-7060 Hotfix: Fix main-prod.bicepparam syntax error

### DIFF
--- a/infrastructure/templates/screener/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/screener/parameters/main-prod.bicepparam
@@ -14,4 +14,4 @@ param screenerFunctionAppSku = {
 //
 // In the future, this can be switched back to true to allow Prod to properly enforce this
 // quality check.
-param includeDataDictionaryChecks bool = false
+param includeDataDictionaryChecks = false


### PR DESCRIPTION
This fixes a syntax error in main-prod.bicepparam which is preventing us from deploying the latest Data screener