### PR TITLE
EES-7055 - Fix shared step `user chooses file` in order to upload file into govuk-frontend's FileUpload component

### DIFF
--- a/tests/robot-tests/tests/admin/bau/delete_subject.robot
+++ b/tests/robot-tests/tests/admin/bau/delete_subject.robot
@@ -140,7 +140,7 @@ Navigate to Create chart tab
     user waits until page finishes loading
     user clicks link    Chart
     user clicks button    Choose an infographic as alternative
-    choose file    id:chartConfigurationForm-file    ${FILES_DIR}dfe-logo.jpg
+    user chooses file    id:chartConfigurationForm-file    ${FILES_DIR}dfe-logo.jpg
     user checks radio is checked    Use table title
     user clicks radio    Set an alternative title
     user enters text into element    id:chartConfigurationForm-title    Sample title

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -189,7 +189,7 @@ Change ancillary file
     user waits until h2 is visible    Edit ancillary file
     user enters text into element    label:Title    Test 2 updated
     user enters text into element    label:Summary    Test 2 summary updated
-    user chooses file    label:Upload new file    ${FILES_DIR}test-file-3.txt
+    user chooses file    ancillaryFileForm-file    ${FILES_DIR}test-file-3.txt
 
     user clicks button    Save file
 

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -599,10 +599,8 @@ user uploads subject
     user clicks link    Data and files
     user waits until page contains element    id:dataFileUploadForm-title    %{WAIT_SMALL}
     user enters text into element    id:dataFileUploadForm-title    ${SUBJECT_NAME}
-    user waits until element is visible    id:dataFileUploadForm-dataFile
-    choose file    id:dataFileUploadForm-dataFile-input    ${FOLDER}${SUBJECT_FILE}
-    user waits until element is visible    id:dataFileUploadForm-metadataFile
-    choose file    id:dataFileUploadForm-metadataFile-input    ${FOLDER}${META_FILE}
+    user chooses file    id:dataFileUploadForm-dataFile    ${FOLDER}${SUBJECT_FILE}
+    user chooses file    id:dataFileUploadForm-metadataFile    ${FOLDER}${META_FILE}
     user clicks button    Upload data files
     user waits until page contains element    testid:Data files table
 

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -829,7 +829,7 @@ user chooses select option at index
 user chooses file
     [Arguments]    ${locator}    ${file_path}
     user waits until element is visible    ${locator}
-    choose file    ${locator}    ${file_path}
+    choose file    ${locator}-input    ${file_path}
 
 user clears element text
     [Arguments]    ${selector}


### PR DESCRIPTION
This PR fixes a shared step called `user chooses file` which is used to upload files across the app.

The file upload component had recently been updated by govuk-frontend. This requires our robot tests to identify this component slightly differently. This PR contains this tweak to get these tests passing again. The tests that should be passing now are: 
```
\tests\admin\bau\release_status.robot
\tests\admin\bau\create_data_block_with_chart.robot
\tests\admin\bau\screener_errors.robot
\tests\admin\bau\upload_files.robot
\tests\admin\bau\delete_subject.robot
\tests\admin\analyst\edit_and_approve_release_as_publication_approver.robot
\tests\admin_and_public\bau\subject_reordering.robot
\tests\admin_and_public\bau\data_reordering.robot
\tests\admin_and_public_2\bau\publish_release_and_amend_2.robot
\tests\admin_and_public_2\bau\edit_data_block_from_replacement.robot
\tests\admin_and_public_2\bau\publish_release_and_amend.robot
\tests\admin_and_public_2\bau\publish_amend_and_cancel.robot
\tests\public_api\public_api_patch_replacement_public.robot
\tests\public_api\public_api_patch_replacement.robot
```
This PR undoes changes made in #6892 as this wasn't being applied in the shared step that is used in other places.