### PR TITLE
EES-6930 - Add feedback link to glossary page and update UI test

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/glossary/GlossaryPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/glossary/GlossaryPage.tsx
@@ -51,7 +51,7 @@ const GlossaryPage: NextPage<Props> = ({ categories = [] }) => {
               rel="noreferrer"
               target="_blank"
             >
-              sign-up for a research session using our online form.
+              sign up for a research session using our online form.
             </a>
           </p>
 

--- a/src/explore-education-statistics-frontend/src/modules/glossary/GlossaryPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/glossary/GlossaryPage.tsx
@@ -39,6 +39,21 @@ const GlossaryPage: NextPage<Props> = ({ categories = [] }) => {
             The glossary is intended to grow over time as the service is
             populated.
           </p>
+          <p>Did you find what you were looking for in the glossary?</p>
+          <p>
+            We’d be interested in hearing your thoughts on how well it’s helping
+            you understand the terms used across the site.
+          </p>
+          <p>
+            Send us feedback or{' '}
+            <a
+              href="https://forms.office.com/e/brCmzrQfXU"
+              rel="noreferrer"
+              target="_blank"
+            >
+              sign-up for a research session using our online form.
+            </a>
+          </p>
 
           <PageSearchFormWithAnalytics
             inputLabel="Search our A to Z list of definitions for terms used across

--- a/tests/robot-tests/tests/general_public/glossary_page.robot
+++ b/tests/robot-tests/tests/general_public/glossary_page.robot
@@ -9,7 +9,7 @@ Force Tags          GeneralPublic    Local    Dev    Test    Preprod    Prod
 
 
 *** Variables ***
-${FEEDBACK_LINK}    sign-up for a research session using our online form.
+${FEEDBACK_LINK}    sign up for a research session using our online form.
 
 
 *** Test Cases ***

--- a/tests/robot-tests/tests/general_public/glossary_page.robot
+++ b/tests/robot-tests/tests/general_public/glossary_page.robot
@@ -8,6 +8,10 @@ Test Setup          fail test fast if required
 Force Tags          GeneralPublic    Local    Dev    Test    Preprod    Prod
 
 
+*** Variables ***
+${FEEDBACK_LINK}    sign-up for a research session using our online form.
+
+
 *** Test Cases ***
 Navigate to glossary page
     user navigates to public site homepage
@@ -24,6 +28,13 @@ Validate glossary accordion sections
     user checks accordion is in position    C    3
     user checks accordion is in position    D    4
     user checks accordion is in position    Z    26
+
+Check feedback link is present
+    user waits until page contains link    ${FEEDBACK_LINK}
+    user checks element attribute value should be    link:${FEEDBACK_LINK}    href
+    ...    https://forms.office.com/e/brCmzrQfXU
+    user checks element attribute value should be    link:${FEEDBACK_LINK}    target    _blank
+    user checks element attribute value should be    link:${FEEDBACK_LINK}    rel    noreferrer
 
 Search for Voluntary repayment
     user verifies accordion is closed    V


### PR DESCRIPTION
This updates the glossary page and adds a link to a form to collect feedback from users. This updates UI tests to verify this link is there.
This is how it looks visually:
<img width="995" height="531" alt="image" src="https://github.com/user-attachments/assets/51444c30-f3e5-480c-853f-b50cb1bc314c" />

