### PR TITLE
EES-6946 Tidy up

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Releases/ReleaseDataContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Releases/ReleaseDataContentServiceTests.cs
@@ -40,20 +40,26 @@ public abstract class ReleaseDataContentServiceTests
                 .DefaultContentSection(ContentSectionType.RelatedDashboards)
                 .WithContentBlocks([_dataFixture.DefaultHtmlBlock().WithBody("<p>Data dashboards</p>")]);
 
+            var publicApiDataSetId = Guid.NewGuid();
+
             var dataSets = _dataFixture
                 .DefaultReleaseFile()
                 .ForIndex(
                     0,
                     s =>
                         s.SetFile(
-                            _dataFixture
-                                .DefaultFile(FileType.Data)
-                                .WithDataSetFileMeta(_dataFixture.DefaultDataSetFileMeta().WithNumDataFileRows(1000))
-                                .WithDataSetFileVersionGeographicLevels([
-                                    GeographicLevel.Country,
-                                    GeographicLevel.LocalAuthority,
-                                ])
-                        )
+                                _dataFixture
+                                    .DefaultFile(FileType.Data)
+                                    .WithDataSetFileMeta(
+                                        _dataFixture.DefaultDataSetFileMeta().WithNumDataFileRows(1000)
+                                    )
+                                    .WithDataSetFileVersionGeographicLevels([
+                                        GeographicLevel.Country,
+                                        GeographicLevel.LocalAuthority,
+                                    ])
+                            )
+                            // Set this data set to be available by API
+                            .SetPublicApiDataSetId(publicApiDataSetId)
                 )
                 .ForIndex(
                     1,
@@ -570,6 +576,97 @@ public abstract class ReleaseDataContentServiceTests
             }
         }
 
+        [Fact]
+        public async Task WhenDataSetHasPublicApiDataSetId_IsApiEnabledIsTrueAndPublicApiDataSetIdIsSet()
+        {
+            // Arrange
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var release = publication.Releases[0];
+            var releaseVersion = release.Versions[0];
+
+            var publicApiDataSetId = Guid.NewGuid();
+
+            ReleaseFile dataSet = _dataFixture
+                .DefaultReleaseFile()
+                .WithFile(() => _dataFixture.DefaultFile(FileType.Data))
+                .WithReleaseVersion(releaseVersion)
+                .WithPublicApiDataSetId(publicApiDataSetId);
+
+            DataImport dataImport = _dataFixture
+                .DefaultDataImport()
+                .WithFile(dataSet.File)
+                .WithStatus(DataImportStatus.COMPLETE);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.DataImports.Add(dataImport);
+                context.Publications.Add(publication);
+                context.ReleaseFiles.Add(dataSet);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetReleaseDataContent(releaseVersion.Id);
+
+                // Assert
+                var result = outcome.AssertRight();
+
+                Assert.True(result.DataSets[0].IsApiEnabled);
+                Assert.Equal(publicApiDataSetId, result.DataSets[0].PublicApiDataSetId);
+            }
+        }
+
+        [Fact]
+        public async Task WhenDataSetHasNoPublicApiDataSetId_IsApiEnabledIsFalse()
+        {
+            // Arrange
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var release = publication.Releases[0];
+            var releaseVersion = release.Versions[0];
+
+            ReleaseFile dataSet = _dataFixture
+                .DefaultReleaseFile()
+                .WithFile(() => _dataFixture.DefaultFile(FileType.Data))
+                .WithReleaseVersion(releaseVersion);
+
+            DataImport dataImport = _dataFixture
+                .DefaultDataImport()
+                .WithFile(dataSet.File)
+                .WithStatus(DataImportStatus.COMPLETE);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.DataImports.Add(dataImport);
+                context.Publications.Add(publication);
+                context.ReleaseFiles.Add(dataSet);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetReleaseDataContent(releaseVersion.Id);
+
+                // Assert
+                var result = outcome.AssertRight();
+
+                Assert.False(result.DataSets[0].IsApiEnabled);
+                Assert.Null(result.DataSets[0].PublicApiDataSetId);
+            }
+        }
+
         [Theory]
         [MemberData(nameof(IncompleteDataImportStatuses))]
         public async Task WhenDataSetImportIsIncomplete_DataSetIsNotReturned(DataImportStatus importStatus)
@@ -770,6 +867,8 @@ public abstract class ReleaseDataContentServiceTests
             AssertDataSetFileMetaEqual(expected, actual.Meta);
             Assert.Equal(expected.Summary, actual.Summary);
             Assert.Equal(expected.Name, actual.Title);
+            Assert.Equal(expected.PublicApiDataSetId != null, actual.IsApiEnabled);
+            Assert.Equal(expected.PublicApiDataSetId, actual.PublicApiDataSetId);
         }
 
         private static void AssertDataSetFileMetaEqual(ReleaseFile expected, ReleaseDataContentDataSetMetaDto actual)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Releases/Dtos/ReleaseDataContentDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Releases/Dtos/ReleaseDataContentDto.cs
@@ -43,7 +43,7 @@ public record ReleaseDataContentDataSetDto
     public required ReleaseDataContentDataSetMetaDto Meta { get; init; }
     public required string Title { get; init; }
     public required string? Summary { get; init; }
-    public Guid? PublicApiDataSetId { get; init; }
+    public required Guid? PublicApiDataSetId { get; init; }
     public bool IsApiEnabled => PublicApiDataSetId != null;
 
     public static ReleaseDataContentDataSetDto FromReleaseFile(ReleaseFile releaseFile) =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/Releases/ReleaseDataContentDtoBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Builders/Releases/ReleaseDataContentDtoBuilder.cs
@@ -79,6 +79,7 @@ public class ReleaseDataContentDataSetDtoBuilder
     private Guid _fileId = Guid.NewGuid();
     private Guid _subjectId = Guid.NewGuid();
     private ReleaseDataContentDataSetMetaDto _meta = new ReleaseDataContentDataSetMetaDtoBuilder().Build();
+    private Guid _publicApiDataSetId = Guid.NewGuid();
     private string _summary = "Summary";
     private string _title = "Title";
 
@@ -89,6 +90,7 @@ public class ReleaseDataContentDataSetDtoBuilder
             FileId = _fileId,
             SubjectId = _subjectId,
             Meta = _meta,
+            PublicApiDataSetId = _publicApiDataSetId,
             Summary = _summary,
             Title = _title,
         };
@@ -114,6 +116,12 @@ public class ReleaseDataContentDataSetDtoBuilder
     public ReleaseDataContentDataSetDtoBuilder WithMeta(ReleaseDataContentDataSetMetaDto meta)
     {
         _meta = meta;
+        return this;
+    }
+
+    public ReleaseDataContentDataSetDtoBuilder WithPublicApiDataSetId(Guid publicApiDataSetId)
+    {
+        _publicApiDataSetId = publicApiDataSetId;
         return this;
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseDataContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseDataContentServiceTests.cs
@@ -35,21 +35,27 @@ public abstract class ReleaseDataContentServiceTests
             releaseVersion.RelatedDashboardsSection = _dataFixture
                 .DefaultContentSection(ContentSectionType.RelatedDashboards)
                 .WithContentBlocks([_dataFixture.DefaultHtmlBlock().WithBody("<p>Data dashboards</p>")]);
+
             var publicApiDataSetId = Guid.NewGuid();
+
             var dataSets = _dataFixture
                 .DefaultReleaseFile()
                 .ForIndex(
                     0,
                     s =>
                         s.SetFile(
-                            _dataFixture
-                                .DefaultFile(FileType.Data)
-                                .WithDataSetFileMeta(_dataFixture.DefaultDataSetFileMeta().WithNumDataFileRows(1000))
-                                .WithDataSetFileVersionGeographicLevels([
-                                    GeographicLevel.Country,
-                                    GeographicLevel.LocalAuthority,
-                                ])
-                        )
+                                _dataFixture
+                                    .DefaultFile(FileType.Data)
+                                    .WithDataSetFileMeta(
+                                        _dataFixture.DefaultDataSetFileMeta().WithNumDataFileRows(1000)
+                                    )
+                                    .WithDataSetFileVersionGeographicLevels([
+                                        GeographicLevel.Country,
+                                        GeographicLevel.LocalAuthority,
+                                    ])
+                            )
+                            // Set this data set to be available by API
+                            .SetPublicApiDataSetId(publicApiDataSetId)
                 )
                 .ForIndex(
                     1,
@@ -66,9 +72,6 @@ public abstract class ReleaseDataContentServiceTests
                 )
                 .WithReleaseVersion(releaseVersion)
                 .GenerateArray(2);
-
-            // Set one of the dataSets to be
-            dataSets[0].PublicApiDataSetId = publicApiDataSetId;
 
             var supportingFiles = _dataFixture
                 .DefaultReleaseFile()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseDataContentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Releases/ReleaseDataContentServiceTests.cs
@@ -548,6 +548,91 @@ public abstract class ReleaseDataContentServiceTests
         }
 
         [Fact]
+        public async Task WhenDataSetHasPublicApiDataSetId_IsApiEnabledIsTrueAndPublicApiDataSetIdIsSet()
+        {
+            // Arrange
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var release = publication.Releases[0];
+            var releaseVersion = release.Versions[0];
+
+            var publicApiDataSetId = Guid.NewGuid();
+
+            ReleaseFile dataSet = _dataFixture
+                .DefaultReleaseFile()
+                .WithFile(() => _dataFixture.DefaultFile(FileType.Data))
+                .WithReleaseVersion(releaseVersion)
+                .WithPublicApiDataSetId(publicApiDataSetId);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                context.ReleaseFiles.Add(dataSet);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetReleaseDataContent(
+                    publicationSlug: publication.Slug,
+                    releaseSlug: release.Slug
+                );
+
+                // Assert
+                var result = outcome.AssertRight();
+
+                Assert.True(result.DataSets[0].IsApiEnabled);
+                Assert.Equal(publicApiDataSetId, result.DataSets[0].PublicApiDataSetId);
+            }
+        }
+
+        [Fact]
+        public async Task WhenDataSetHasNoPublicApiDataSetId_IsApiEnabledIsFalse()
+        {
+            // Arrange
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => [_dataFixture.DefaultRelease(publishedVersions: 1)]);
+            var release = publication.Releases[0];
+            var releaseVersion = release.Versions[0];
+
+            ReleaseFile dataSet = _dataFixture
+                .DefaultReleaseFile()
+                .WithFile(() => _dataFixture.DefaultFile(FileType.Data))
+                .WithReleaseVersion(releaseVersion);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                context.ReleaseFiles.Add(dataSet);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetReleaseDataContent(
+                    publicationSlug: publication.Slug,
+                    releaseSlug: release.Slug
+                );
+
+                // Assert
+                var result = outcome.AssertRight();
+
+                Assert.False(result.DataSets[0].IsApiEnabled);
+                Assert.Null(result.DataSets[0].PublicApiDataSetId);
+            }
+        }
+
+        [Fact]
         public async Task WhenSupportingFileHasNoSummary_ReturnsEmptySummary()
         {
             // Arrange

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/Dtos/ReleaseDataContentDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Releases/Dtos/ReleaseDataContentDto.cs
@@ -42,7 +42,7 @@ public record ReleaseDataContentDataSetDto
     public required ReleaseDataContentDataSetMetaDto Meta { get; init; }
     public required string Title { get; init; }
     public required string Summary { get; init; }
-    public Guid? PublicApiDataSetId { get; init; }
+    public required Guid? PublicApiDataSetId { get; init; }
     public bool IsApiEnabled => PublicApiDataSetId != null;
 
     public static ReleaseDataContentDataSetDto FromReleaseFile(ReleaseFile releaseFile) =>


### PR DESCRIPTION
This PR makes a tiny bit of tidy-up spotted after #6893 was merged in.

- Adds the `required` keyword to `Content.Services.Releases.Dtos.ReleaseDataContentDataSetDto.PublicApiDataSetId` and `Admin.Services.Releases.Dtos.ReleaseDataContentDataSetDto.PublicApiDataSetId`  to ensure they are always initialised (even if set to null). This prevents accidently initialising the object without remembering to set the property, and follows the pattern used for all the other properties.
- Tidies up the incomplete comment `// Set one of the dataSets to be` around setting one of the data sets to be available by API in  test `ReleaseDataContentServiceTests.GetReleaseDataContentTests.WhenPublicationAndReleaseExist_ReturnsExpectedDataContent`. That method of setting the ID is also removed in favour of using the test data generator setter.
- Add two new dedicated tests to verify the API enabled status in `Content.Services.Tests.Releases.ReleaseDataContentServiceTests.GetReleaseDataContentTests`. The test  `WhenPublicationAndReleaseExist_ReturnsExpectedDataContent` is at risk of doing too much and is a more general test, although I thought it was fine to leave this rather than removing the changes already made to it.
- Make all the corresponding change to verify API enabled status to the tests for `Admin.Services.Releases.ReleaseDataContentService` which previously had no test coverage.