### PR TITLE
EES-7047 Remove 'old' design of key stats

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatPreview.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/EditableKeyStatPreview.tsx
@@ -28,7 +28,10 @@ export default function EditableKeyStatPreview({
 
   return (
     <KeyStat {...keyStatProps} includeWrapper={false}>
-      <ButtonGroup className="govuk-!-margin-top-2">
+      <ButtonGroup
+        className="govuk-!-margin-top-1 govuk-!-margin-bottom-1"
+        alignment="start"
+      >
         <Button onClick={onEdit}>
           Edit <VisuallyHidden> key statistic: {title}</VisuallyHidden>
         </Button>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlinesPreview.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlinesPreview.tsx
@@ -37,7 +37,6 @@ const ReleaseHeadlinesRedesign = ({
                 trend={keyStat.trend}
                 guidanceTitle={keyStat.guidanceTitle}
                 guidanceText={keyStat.guidanceText}
-                isRedesignStyle
               />
             );
           }
@@ -50,7 +49,6 @@ const ReleaseHeadlinesRedesign = ({
               trend={keyStat.trend}
               guidanceTitle={keyStat.guidanceTitle}
               guidanceText={keyStat.guidanceText}
-              isRedesignStyle
             />
           );
         })}

--- a/src/explore-education-statistics-common/src/components/ButtonGroup.module.scss
+++ b/src/explore-education-statistics-common/src/components/ButtonGroup.module.scss
@@ -3,8 +3,9 @@
 .group {
   --horizontalSpacing: #{govuk-spacing(2)};
   --verticalSpacing: #{govuk-spacing(2)};
+  --alignment: center;
 
-  align-items: center;
+  align-items: var(--alignment);
   display: flex;
   flex-direction: column;
   margin-bottom: govuk-spacing(6);
@@ -23,7 +24,11 @@
 td > .group {
   // Avoid centering within a table cell as this
   // is likely to be an 'Actions' column.
-  align-items: flex-start;
+  --alignment: flex-start;
+}
+
+.alignStart {
+  --alignment: flex-start;
 }
 
 .horizontalSpacing--m {

--- a/src/explore-education-statistics-common/src/components/ButtonGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/ButtonGroup.tsx
@@ -5,11 +5,13 @@ import styles from './ButtonGroup.module.scss';
 interface Props {
   children: ReactNode;
   className?: string;
+  alignment?: 'start';
   horizontalSpacing?: 'l' | 'm' | 's';
   verticalSpacing?: 'l' | 'm' | 's';
 }
 
 export default function ButtonGroup({
+  alignment,
   children,
   className,
   horizontalSpacing = 's',
@@ -21,6 +23,9 @@ export default function ButtonGroup({
         styles.group,
         styles[`horizontalSpacing--${horizontalSpacing}`],
         styles[`verticalSpacing--${verticalSpacing}`],
+        {
+          [styles.alignStart]: alignment === 'start',
+        },
         className,
       )}
     >

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.module.scss
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.module.scss
@@ -29,44 +29,8 @@
   white-space: pre-wrap;
 }
 
-.guidanceTitle {
-  background: govuk-colour('white');
-  font-size: 16px !important;
-  margin: 0;
-  padding: 0.2rem 0 0.2rem 0.5rem;
-  position: relative;
-  text-align: left;
-  width: 100%;
-
-  &[open] {
-    box-shadow: 3px govuk-colour('black');
-  }
-
-  :global(.govuk-details__summary) {
-    margin-bottom: 0;
-    max-width: calc(100% - 1rem);
-    overflow: hidden;
-    padding-left: 16px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  :global(.govuk-details__text) {
-    background: govuk-colour('white');
-    border: 2px solid govuk-colour('black');
-    border-top: 0;
-    box-sizing: border-box;
-    max-height: 40vh;
-    overflow: auto;
-    position: absolute;
-    text-align: left;
-    width: 100%;
-    z-index: 2;
-  }
-}
-
 /* stylelint-disable max-nesting-depth */
-.guidanceTitleRedesign {
+.guidanceTitle {
   background: $_govuk-rebrand-light-blue-background-colour;
   margin: 0;
   padding: 0;
@@ -144,7 +108,9 @@
 
 .wrapper {
   box-sizing: border-box;
-  display: flex;
+  display: grid;
+  grid-template-rows: subgrid;
+  grid-row: span 3;
   flex: 1 0 100%;
   flex-direction: column;
   margin-bottom: govuk-spacing(2);
@@ -154,10 +120,4 @@
   &:only-child {
     text-align: center;
   }
-}
-
-.wrapperRedesign {
-  display: grid;
-  grid-template-rows: subgrid;
-  grid-row: span 2;
 }

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
@@ -2,7 +2,6 @@ import Details from '@common/components/Details';
 import KeyStatTile from '@common/modules/find-statistics/components/KeyStatTile';
 import React, { ReactNode } from 'react';
 import styles from '@common/modules/find-statistics/components/KeyStat.module.scss';
-import classNames from 'classnames';
 
 interface KeyStatContainerProps {
   children: ReactNode;
@@ -14,22 +13,12 @@ export const KeyStatContainer = ({ children }: KeyStatContainerProps) => {
 
 interface KeyStatWrapperProps {
   children: ReactNode;
-  isRedesignStyle?: boolean;
   testId?: string;
 }
 
-export const KeyStatWrapper = ({
-  children,
-  isRedesignStyle = false,
-  testId,
-}: KeyStatWrapperProps) => {
+export const KeyStatWrapper = ({ children, testId }: KeyStatWrapperProps) => {
   return (
-    <div
-      className={classNames(styles.wrapper, {
-        [styles.wrapperRedesign]: isRedesignStyle,
-      })}
-      data-testid={testId}
-    >
+    <div className={styles.wrapper} data-testid={testId}>
       {children}
     </div>
   );
@@ -40,7 +29,6 @@ export interface KeyStatProps {
   guidanceTitle?: string;
   guidanceText?: string;
   includeWrapper?: boolean;
-  isRedesignStyle?: boolean;
   statistic: string;
   testId?: string;
   title: string;
@@ -52,7 +40,6 @@ const KeyStat = ({
   guidanceTitle = 'Help',
   guidanceText,
   includeWrapper = true,
-  isRedesignStyle = false,
   statistic,
   testId = 'keyStat',
   title,
@@ -71,12 +58,8 @@ const KeyStat = ({
       {guidanceText && (
         <Details
           summary={guidanceTitle}
-          className={
-            isRedesignStyle
-              ? styles.guidanceTitleRedesign
-              : styles.guidanceTitle
-          }
-          showCloseButton={isRedesignStyle}
+          className={styles.guidanceTitle}
+          showCloseButton
           hiddenText={guidanceTitle === 'Help' ? `for ${title}` : undefined}
         >
           <div data-testid={`${testId}-guidanceText`}>
@@ -90,9 +73,7 @@ const KeyStat = ({
   );
 
   return includeWrapper ? (
-    <KeyStatWrapper testId={testId} isRedesignStyle={isRedesignStyle}>
-      {body}
-    </KeyStatWrapper>
+    <KeyStatWrapper testId={testId}>{body}</KeyStatWrapper>
   ) : (
     body
   );

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatDataBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatDataBlock.tsx
@@ -11,7 +11,6 @@ export interface KeyStatDataBlockProps {
   trend?: string;
   guidanceTitle?: string;
   guidanceText?: string;
-  isRedesignStyle?: boolean;
   testId?: string;
 }
 
@@ -22,7 +21,6 @@ export default function KeyStatDataBlock({
   trend,
   guidanceTitle = 'Help',
   guidanceText,
-  isRedesignStyle = false,
   testId = 'keyStat',
 }: KeyStatDataBlockProps) {
   const {
@@ -48,7 +46,6 @@ export default function KeyStatDataBlock({
         trend={trend}
         guidanceTitle={guidanceTitle}
         guidanceText={guidanceText}
-        isRedesignStyle={isRedesignStyle}
         testId={testId}
       >
         {children}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationReleaseHeadlinesSection.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationReleaseHeadlinesSection.tsx
@@ -40,7 +40,6 @@ const PublicationReleaseHeadlinesSection = ({
                 trend={keyStat.trend}
                 guidanceTitle={keyStat.guidanceTitle}
                 guidanceText={keyStat.guidanceText}
-                isRedesignStyle
               />
             );
           }
@@ -53,7 +52,6 @@ const PublicationReleaseHeadlinesSection = ({
               trend={keyStat.trend}
               guidanceTitle={keyStat.guidanceTitle}
               guidanceText={keyStat.guidanceText}
-              isRedesignStyle
             />
           );
         })}


### PR DESCRIPTION
Update the key stats in the admin content edit screen to match the new style of key stats introduced with the release redesign

I had to tweak the button container to make it look ok using the subgrid layout. 
If there is a guidance title key stat on the same row as a non-guidance title key stat, there will be a tiny bit of extra space above the button container (as the height of the grid row that the guidance sits in will be determined by the height of the button container). But I think it's acceptable as it's so minor, and couldn't think of a better way of handling it that didn't change it all back to a flex-based layout (which would cause other issues).

**Before**:

<img width="973" height="683" alt="image" src="https://github.com/user-attachments/assets/606ea4fd-575a-4987-82e1-8caae633827c" />


**After**:

<img width="980" height="863" alt="image" src="https://github.com/user-attachments/assets/5e95e010-355f-484c-9837-c8533e4905f7" />
