### PR TITLE
EES-7048 Add ability to update data set indicator mappings

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.Utils;
+using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
@@ -266,9 +267,12 @@ public class DataSetMappingServiceTests
 
     private static DataSetMappingService SetupDataSetMappingService(
         ContentDbContext contentDbContext,
-        StatisticsDbContext statisticsDbContext
+        StatisticsDbContext? statisticsDbContext = null
     )
     {
-        return new DataSetMappingService(contentDbContext, statisticsDbContext);
+        return new DataSetMappingService(
+            contentDbContext,
+            statisticsDbContext ?? Mock.Of<StatisticsDbContext>(MockBehavior.Strict)
+        );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
@@ -1,6 +1,8 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
@@ -262,6 +264,389 @@ public class DataSetMappingServiceTests
             };
 
             result.AssertDeepEqualTo(expectedMapping, ignoreProperties: [mapping => mapping.Id]);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateIndicatorMapping_Success()
+    {
+        var originalDataSetId = Guid.NewGuid();
+        var replacementDataSetId = Guid.NewGuid();
+
+        var originalIndicator1Id = Guid.NewGuid();
+        var originalIndicator2Id = Guid.NewGuid();
+        var originalIndicator3Id = Guid.NewGuid();
+        var originalIndicator4Id = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataSetId = originalDataSetId,
+            ReplacementDataSetId = replacementDataSetId,
+            IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
+            {
+                {
+                    originalIndicator1Id,
+                    new IndicatorMapping
+                    {
+                        OriginalId = originalIndicator1Id,
+                        OriginalLabel = "Original indicator 1 label",
+                        OriginalColumnName = "original_indicator_1",
+                        OriginalGroupId = Guid.NewGuid(),
+                        OriginalGroupLabel = "Original indicator 1 group label",
+                        Status = MapStatus.Unset,
+                    }
+                },
+                {
+                    originalIndicator2Id,
+                    new IndicatorMapping
+                    {
+                        OriginalId = originalIndicator2Id,
+                        OriginalLabel = "Original indicator 2 label",
+                        OriginalColumnName = "original_indicator_2",
+                        OriginalGroupId = Guid.NewGuid(),
+                        OriginalGroupLabel = "Original indicator 2 group label",
+                        ReplacementId = Guid.NewGuid(),
+                        ReplacementLabel = "Replacement indicator 1 - that will be unset",
+                        ReplacementColumnName = "replacement_indicator_1",
+                        ReplacementGroupId = Guid.NewGuid(),
+                        ReplacementGroupLabel = "Replacement indicator 1 group label",
+                        Status = MapStatus.AutoSet,
+                    }
+                },
+                {
+                    originalIndicator3Id,
+                    new IndicatorMapping
+                    {
+                        OriginalId = originalIndicator3Id,
+                        OriginalLabel = "Original indicator 3 label",
+                        OriginalColumnName = "original_indicator_3",
+                        OriginalGroupId = Guid.NewGuid(),
+                        OriginalGroupLabel = "Original indicator 3 group label",
+                        ReplacementId = Guid.NewGuid(),
+                        ReplacementLabel = "Replacement indicator 2 - that will be unset",
+                        ReplacementColumnName = "replacement_indicator_2",
+                        ReplacementGroupId = Guid.NewGuid(),
+                        ReplacementGroupLabel = "Replacement indicator 2 group label",
+                        Status = MapStatus.ManuallySet,
+                    }
+                },
+                {
+                    originalIndicator4Id,
+                    new IndicatorMapping
+                    {
+                        OriginalId = originalIndicator4Id,
+                        OriginalLabel = "Original indicator 4 label - to not change",
+                        OriginalColumnName = "original_indicator_4",
+                        OriginalGroupId = Guid.NewGuid(),
+                        OriginalGroupLabel = "Original indicator 4 group label",
+                        ReplacementId = Guid.NewGuid(),
+                        ReplacementLabel = "Replacement indicator 3 - that will remain",
+                        ReplacementColumnName = "replacement_indicator_3",
+                        ReplacementGroupId = Guid.NewGuid(),
+                        ReplacementGroupLabel = "Replacement indicator 3 group label",
+                        Status = MapStatus.AutoSet,
+                    }
+                },
+            },
+            UnmappedReplacementIndicators =
+            [
+                new UnmappedIndicator
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Replacement indicator 4 - that will be mapped to Original indicator 1",
+                    ColumnName = "replacement_indicator_4",
+                    GroupId = Guid.NewGuid(),
+                    GroupLabel = "Replacement indicator 4 group label",
+                },
+                new UnmappedIndicator
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Replacement indicator 5 - that will be mapped to Original indicator 2",
+                    ColumnName = "replacement_indicator_5",
+                    GroupId = Guid.NewGuid(),
+                    GroupLabel = "Replacement indicator 5 group label",
+                },
+                new UnmappedIndicator
+                {
+                    Id = Guid.NewGuid(),
+                    Label = "Replacement indicator 6 - that will be remain unmapped",
+                    ColumnName = "replacement_indicator_6",
+                    GroupId = Guid.NewGuid(),
+                    GroupLabel = "Replacement indicator 6 group label",
+                },
+            ],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateIndicatorMappings(
+                new IndicatorMappingUpdatesRequest
+                {
+                    OriginalDataSetId = originalDataSetId,
+                    ReplacementDataSetId = replacementDataSetId,
+                    Updates =
+                    [
+                        new()
+                        {
+                            OriginalColumnName = "original_indicator_1",
+                            NewReplacementColumnName = "replacement_indicator_4",
+                        },
+                        new()
+                        {
+                            OriginalColumnName = "original_indicator_2",
+                            NewReplacementColumnName = "replacement_indicator_5",
+                        },
+                        new() { OriginalColumnName = "original_indicator_3", NewReplacementColumnName = null },
+                    ],
+                }
+            );
+
+            var indicatorMappingList = result.AssertRight();
+
+            Assert.Equal(4, indicatorMappingList.Count);
+
+            var originalIndicator1Mapping = indicatorMappingList.Single(indMap =>
+                indMap.OriginalColumnName == "original_indicator_1"
+            );
+            var originalIndicator2Mapping = indicatorMappingList.Single(indMap =>
+                indMap.OriginalColumnName == "original_indicator_2"
+            );
+            var originalIndicator3Mapping = indicatorMappingList.Single(indMap =>
+                indMap.OriginalColumnName == "original_indicator_3"
+            );
+            var originalIndicator4Mapping = indicatorMappingList.Single(indMap =>
+                indMap.OriginalColumnName == "original_indicator_4"
+            );
+
+            Assert.Multiple(
+                () => Assert.Equal("replacement_indicator_4", originalIndicator1Mapping.ReplacementColumnName),
+                () => Assert.Equal(nameof(MapStatus.ManuallySet), originalIndicator1Mapping.Status),
+                () => Assert.Equal("replacement_indicator_5", originalIndicator2Mapping.ReplacementColumnName),
+                () => Assert.Equal(nameof(MapStatus.ManuallySet), originalIndicator2Mapping.Status),
+                () => Assert.Null(originalIndicator3Mapping.ReplacementColumnName),
+                () => Assert.Equal(nameof(MapStatus.ManuallySet), originalIndicator3Mapping.Status),
+                () => Assert.Equal("replacement_indicator_3", originalIndicator4Mapping.ReplacementColumnName),
+                () => Assert.Equal(nameof(MapStatus.AutoSet), originalIndicator4Mapping.Status)
+            );
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var dbMapping = Assert.Single(contentDbContext.DataSetMappings.ToList());
+
+            var indicatorMappingList = dbMapping.IndicatorMappings.Values.ToList();
+            var originalIndicator1Mapping = indicatorMappingList.Single(indMap =>
+                indMap.OriginalColumnName == "original_indicator_1"
+            );
+            var originalIndicator2Mapping = indicatorMappingList.Single(indMap =>
+                indMap.OriginalColumnName == "original_indicator_2"
+            );
+            var originalIndicator3Mapping = indicatorMappingList.Single(indMap =>
+                indMap.OriginalColumnName == "original_indicator_3"
+            );
+            var originalIndicator4Mapping = indicatorMappingList.Single(indMap =>
+                indMap.OriginalColumnName == "original_indicator_4"
+            );
+
+            Assert.Multiple(
+                () => Assert.Equal("replacement_indicator_4", originalIndicator1Mapping.ReplacementColumnName),
+                () => Assert.Equal(MapStatus.ManuallySet, originalIndicator1Mapping.Status),
+                () => Assert.Equal("replacement_indicator_5", originalIndicator2Mapping.ReplacementColumnName),
+                () => Assert.Equal(MapStatus.ManuallySet, originalIndicator2Mapping.Status),
+                () => Assert.Null(originalIndicator3Mapping.ReplacementColumnName),
+                () => Assert.Equal(MapStatus.ManuallySet, originalIndicator3Mapping.Status),
+                () => Assert.Equal("replacement_indicator_3", originalIndicator4Mapping.ReplacementColumnName),
+                () => Assert.Equal(MapStatus.AutoSet, originalIndicator4Mapping.Status)
+            );
+
+            var unmappedReplacementIndicators = dbMapping.UnmappedReplacementIndicators.ToList();
+            Assert.Multiple(
+                () => Assert.Equal(3, unmappedReplacementIndicators.Count),
+                () =>
+                    Assert.NotNull(
+                        unmappedReplacementIndicators.FirstOrDefault(x => x.ColumnName == "replacement_indicator_1")
+                    ),
+                () =>
+                    Assert.NotNull(
+                        unmappedReplacementIndicators.FirstOrDefault(x => x.ColumnName == "replacement_indicator_2")
+                    ),
+                () =>
+                    Assert.NotNull(
+                        unmappedReplacementIndicators.FirstOrDefault(x => x.ColumnName == "replacement_indicator_6")
+                    )
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateIndicatorMapping_NoDataSetMapping_NotFound()
+    {
+        var originalDataSetId = Guid.NewGuid();
+        var replacementDataSetId = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataSetId = originalDataSetId,
+            ReplacementDataSetId = replacementDataSetId,
+            IndicatorMappings = new Dictionary<Guid, IndicatorMapping>(),
+            UnmappedReplacementIndicators = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateIndicatorMappings(
+                new IndicatorMappingUpdatesRequest
+                {
+                    OriginalDataSetId = originalDataSetId,
+                    ReplacementDataSetId = Guid.NewGuid(),
+                    Updates = [],
+                }
+            );
+
+            result.AssertNotFound();
+        }
+    }
+
+    [Fact]
+    public async Task UpdateIndicatorMapping_OriginalIndicatorNotFound_Fail()
+    {
+        var originalDataSetId = Guid.NewGuid();
+        var replacementDataSetId = Guid.NewGuid();
+
+        var originalIndicator1Id = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataSetId = originalDataSetId,
+            ReplacementDataSetId = replacementDataSetId,
+            IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
+            {
+                {
+                    originalIndicator1Id,
+                    new IndicatorMapping
+                    {
+                        OriginalId = originalIndicator1Id,
+                        OriginalColumnName = "original_indicator_1",
+                        ReplacementColumnName = "replacement_indicator_already_mapped",
+                    }
+                },
+            },
+            UnmappedReplacementIndicators = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateIndicatorMappings(
+                new IndicatorMappingUpdatesRequest
+                {
+                    OriginalDataSetId = originalDataSetId,
+                    ReplacementDataSetId = replacementDataSetId,
+                    Updates = [new() { OriginalColumnName = "does_not_exist", NewReplacementColumnName = null }],
+                }
+            );
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasError(
+                expectedPath: "Updates.OriginalColumnName",
+                expectedCode: "IndicatorMatchingOriginalColumnNameNotFound",
+                expectedMessage: $"Could not find indicator mapping matching original column name \"does_not_exist\""
+            );
+        }
+    }
+
+    [Fact]
+    public async Task UpdateIndicatorMapping_UnmappedReplacementIndicatorNotFound_Fail()
+    {
+        var originalDataSetId = Guid.NewGuid();
+        var replacementDataSetId = Guid.NewGuid();
+
+        var originalIndicator1Id = Guid.NewGuid();
+
+        var mapping = new DataSetMapping
+        {
+            OriginalDataSetId = originalDataSetId,
+            ReplacementDataSetId = replacementDataSetId,
+            IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
+            {
+                {
+                    originalIndicator1Id,
+                    new IndicatorMapping
+                    {
+                        OriginalId = originalIndicator1Id,
+                        OriginalColumnName = "original_indicator_1",
+                        ReplacementColumnName = "replacement_indicator_already_mapped",
+                    }
+                },
+            },
+            UnmappedReplacementIndicators = [],
+        };
+
+        var contentDbContextId = Guid.NewGuid().ToString();
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            contentDbContext.DataSetMappings.Add(mapping);
+            await contentDbContext.SaveChangesAsync();
+        }
+
+        await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+        {
+            var service = SetupDataSetMappingService(contentDbContext);
+
+            var result = await service.UpdateIndicatorMappings(
+                new IndicatorMappingUpdatesRequest
+                {
+                    OriginalDataSetId = originalDataSetId,
+                    ReplacementDataSetId = replacementDataSetId,
+                    Updates =
+                    [
+                        new()
+                        {
+                            OriginalColumnName = "original_indicator_1",
+                            NewReplacementColumnName = "replacement_indicator_already_mapped",
+                        },
+                    ],
+                }
+            );
+
+            var validationProblem = result.AssertBadRequestWithValidationProblem();
+
+            Assert.Single(validationProblem.Errors);
+
+            validationProblem.AssertHasError(
+                expectedPath: "Updates.NewReplacementColumnName",
+                expectedCode: "UnmappedIndicatorMatchingReplacementColumnNameNotFound",
+                expectedMessage: $"No available unmapped indicator matching replacement column name \"replacement_indicator_already_mapped\""
+            );
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataSetMappingController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataSetMappingController.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
@@ -12,7 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
 [ApiController]
 public class DataSetMappingController(IDataSetMappingService dataSetMappingService) : ControllerBase
 {
-    [HttpPatch("releases/{releaseVersionId:guid}/data/replacements/mapping/indicator")]
+    [HttpPatch("releases/{releaseVersionId:guid}/data/replacements/mapping/indicators")]
     public async Task<ActionResult<List<IndicatorMappingDto>>> UpdateIndicatorMappings(
         [FromRoute] Guid releaseVersionId,
         [FromBody] IndicatorMappingUpdatesRequest request,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataSetMappingController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataSetMappingController.cs
@@ -1,0 +1,24 @@
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
+
+[Route("api")]
+[Authorize]
+[ApiController]
+public class DataSetMappingController(IDataSetMappingService dataSetMappingService) : ControllerBase
+{
+    [HttpPatch("releases/{releaseVersionId:guid}/data/replacements/mapping/indicator")]
+    public async Task<ActionResult<List<IndicatorMappingDto>>> UpdateIndicatorMappings(
+        [FromRoute] Guid releaseVersionId,
+        [FromBody] IndicatorMappingUpdatesRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return await dataSetMappingService.UpdateIndicatorMappings(request).HandleFailuresOrOk();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/IndicatorMappingUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/IndicatorMappingUpdateRequest.cs
@@ -1,0 +1,66 @@
+#nullable enable
+using FluentValidation;
+using LinqToDB.Internal.Common;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+
+public class IndicatorMappingUpdatesRequest
+{
+    public Guid OriginalDataSetId { get; init; }
+    public Guid ReplacementDataSetId { get; init; }
+
+    public List<IndicatorMappingUpdateRequest> Updates { get; init; } = [];
+
+    public class Validator : AbstractValidator<IndicatorMappingUpdatesRequest>
+    {
+        public Validator()
+        {
+            RuleForEach(x => x.Updates).SetValidator(new IndicatorMappingUpdateRequest.Validator());
+
+            RuleFor(x => x.Updates)
+                .Must(HaveUniqueOriginalNames)
+                .WithMessage("Each OriginalColumnName must be unique.")
+                .Must(HaveUniqueReplacementNames)
+                .WithMessage("Each NewReplacementColumnName must be unique (if provided).");
+        }
+
+        private bool HaveUniqueOriginalNames(List<IndicatorMappingUpdateRequest> updates)
+        {
+            if (updates.IsNullOrEmpty())
+            {
+                return true;
+            }
+
+            return updates.Select(u => u.OriginalColumnName).Distinct().Count() == updates.Count;
+        }
+
+        private bool HaveUniqueReplacementNames(List<IndicatorMappingUpdateRequest> updates)
+        {
+            if (updates.IsNullOrEmpty())
+            {
+                return true;
+            }
+
+            var nonNullReplacements = updates
+                .Where(u => !string.IsNullOrEmpty(u.NewReplacementColumnName))
+                .Select(u => u.NewReplacementColumnName)
+                .ToList();
+
+            return nonNullReplacements.Distinct().Count() == nonNullReplacements.Count;
+        }
+    }
+}
+
+public record IndicatorMappingUpdateRequest
+{
+    public string OriginalColumnName { get; init; } = "";
+    public string? NewReplacementColumnName { get; init; }
+
+    public class Validator : AbstractValidator<IndicatorMappingUpdateRequest>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.OriginalColumnName).NotEmpty().WithMessage("OriginalColumnName cannot be an empty.");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/IndicatorMappingUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/IndicatorMappingUpdateRequest.cs
@@ -15,6 +15,10 @@ public class IndicatorMappingUpdatesRequest
     {
         public Validator()
         {
+            RuleFor(x => x.OriginalDataSetId).NotEmpty();
+
+            RuleFor(x => x.ReplacementDataSetId).NotEmpty();
+
             RuleForEach(x => x.Updates).SetValidator(new IndicatorMappingUpdateRequest.Validator());
 
             RuleFor(x => x.Updates)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -134,23 +134,18 @@ public class DataSetMappingService(ContentDbContext contentDbContext, Statistics
             .SingleOrNotFoundAsync()
             .OnSuccess(async mapping =>
             {
-                var results = new List<Either<ActionResult, IndicatorMapping>>();
-                foreach (var update in request.Updates) // UpdateIndicatorMapping updates `mapping`, so cannot use async
-                {
-                    var result = UpdateIndicatorMapping(
-                        mapping,
-                        update.OriginalColumnName,
-                        update.NewReplacementColumnName
-                    );
-                    results.Add(result);
-                }
+                var updatedMappings = request
+                    .Updates.Select(update =>
+                        UpdateIndicatorMapping(mapping, update.OriginalColumnName, update.NewReplacementColumnName)
+                    )
+                    .ToList(); // cannot be async!
 
                 // we still save changes from the Updates that succeeded, even if some failed
                 await contentDbContext.SaveChangesAsync();
 
-                return results
+                return updatedMappings
                     .OnSuccessAll()
-                    .OnSuccess(mappings => mappings.Select(IndicatorMappingDto.FromModel).ToList());
+                    .OnSuccess(_ => mapping.IndicatorMappings.Values.Select(IndicatorMappingDto.FromModel).ToList());
             });
     }
 
@@ -168,6 +163,9 @@ public class DataSetMappingService(ContentDbContext contentDbContext, Statistics
             return Common.Validators.ValidationUtils.ValidationResult(
                 new ErrorViewModel
                 {
+                    Path =
+                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(IndicatorMappingUpdateRequest.OriginalColumnName)}",
+                    Code = "IndicatorMatchingOriginalColumnNameNotFound",
                     Message =
                         $"Could not find indicator mapping matching original column name \"{originalColumnName}\"",
                 }
@@ -191,6 +189,9 @@ public class DataSetMappingService(ContentDbContext contentDbContext, Statistics
             return Common.Validators.ValidationUtils.ValidationResult(
                 new ErrorViewModel
                 {
+                    Path =
+                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(IndicatorMappingUpdateRequest.NewReplacementColumnName)}",
+                    Code = "UnmappedIndicatorMatchingReplacementColumnNameNotFound",
                     Message =
                         $"No available unmapped indicator matching replacement column name \"{newReplacementColumnName}\"",
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -1,8 +1,14 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services;
@@ -114,5 +120,118 @@ public class DataSetMappingService(ContentDbContext contentDbContext, Statistics
             .ToList();
 
         return (initialMappingDictionary, unmappedReplacementIds);
+    }
+
+    public async Task<Either<ActionResult, List<IndicatorMappingDto>>> UpdateIndicatorMappings(
+        IndicatorMappingUpdatesRequest request
+    )
+    {
+        return await contentDbContext
+            .DataSetMappings.Where(map =>
+                map.OriginalDataSetId == request.OriginalDataSetId
+                && map.ReplacementDataSetId == request.ReplacementDataSetId
+            )
+            .SingleOrNotFoundAsync()
+            .OnSuccess(async mapping =>
+            {
+                var results = new List<Either<ActionResult, IndicatorMapping>>();
+                foreach (var update in request.Updates) // UpdateIndicatorMapping updates `mapping`, so cannot use async
+                {
+                    var result = UpdateIndicatorMapping(
+                        mapping,
+                        update.OriginalColumnName,
+                        update.NewReplacementColumnName
+                    );
+                    results.Add(result);
+                }
+
+                // we still save changes from the Updates that succeeded, even if some failed
+                await contentDbContext.SaveChangesAsync();
+
+                return results
+                    .OnSuccessAll()
+                    .OnSuccess(mappings => mappings.Select(IndicatorMappingDto.FromModel).ToList());
+            });
+    }
+
+    private Either<ActionResult, IndicatorMapping> UpdateIndicatorMapping(
+        DataSetMapping dataSetMapping,
+        string originalColumnName,
+        string? newReplacementColumnName = null
+    )
+    {
+        var indicatorMapping = dataSetMapping.IndicatorMappings.Values.SingleOrDefault(map =>
+            map.OriginalColumnName == originalColumnName
+        );
+        if (indicatorMapping == null)
+        {
+            return Common.Validators.ValidationUtils.ValidationResult(
+                new ErrorViewModel
+                {
+                    Message =
+                        $"Could not find indicator mapping matching original column name \"{originalColumnName}\"",
+                }
+            );
+        }
+
+        if (
+            indicatorMapping.ReplacementColumnName == newReplacementColumnName
+            && indicatorMapping.Status == MapStatus.ManuallySet
+        )
+        {
+            return indicatorMapping; // it is already mapped, so can skip
+        }
+
+        var availableUnmappedIndicator = dataSetMapping.UnmappedReplacementIndicators.SingleOrDefault(
+            unmappedIndicator => unmappedIndicator.ColumnName == newReplacementColumnName
+        );
+
+        if (newReplacementColumnName != null && availableUnmappedIndicator == null)
+        {
+            return Common.Validators.ValidationUtils.ValidationResult(
+                new ErrorViewModel
+                {
+                    Message =
+                        $"No available unmapped indicator matching replacement column name \"{newReplacementColumnName}\"",
+                }
+            );
+        }
+
+        if (availableUnmappedIndicator != null)
+        {
+            // remove availableUnmappedIndicator from UnmappedReplacementIndicators as it's about to become mapped
+            dataSetMapping.UnmappedReplacementIndicators.Remove(availableUnmappedIndicator);
+            contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementIndicators).IsModified = true;
+        }
+
+        if (
+            indicatorMapping.ReplacementId != null
+            && indicatorMapping.ReplacementColumnName != newReplacementColumnName
+        )
+        {
+            // We need to move the preexisting mapped indicator into UnmappedReplacementIndicators, as it will be overwritten
+            var newlyUnmappedIndicator = new UnmappedIndicator
+            {
+                Id = indicatorMapping.ReplacementId.Value,
+                ColumnName = indicatorMapping.ReplacementColumnName!,
+                Label = indicatorMapping.ReplacementLabel!,
+                GroupId = indicatorMapping.ReplacementGroupId!.Value,
+                GroupLabel = indicatorMapping.ReplacementGroupLabel!,
+            };
+            dataSetMapping.UnmappedReplacementIndicators.Add(newlyUnmappedIndicator);
+            contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementIndicators).IsModified = true;
+        }
+
+        // mapping.Original* properties should never change
+        indicatorMapping.ReplacementId = availableUnmappedIndicator?.Id;
+        indicatorMapping.ReplacementColumnName = availableUnmappedIndicator?.ColumnName;
+        indicatorMapping.ReplacementLabel = availableUnmappedIndicator?.Label;
+        indicatorMapping.ReplacementGroupId = availableUnmappedIndicator?.GroupId;
+        indicatorMapping.ReplacementGroupLabel = availableUnmappedIndicator?.GroupLabel;
+        indicatorMapping.Status = MapStatus.ManuallySet;
+
+        contentDbContext.Entry(dataSetMapping).Property(x => x.IndicatorMappings).IsModified = true;
+
+        return indicatorMapping;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataSetMappingService.cs
@@ -1,5 +1,9 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 
@@ -9,5 +13,9 @@ public interface IDataSetMappingService
         Guid originalSubjectId,
         Guid replacementSubjectId,
         CancellationToken cancellationToken = default
+    );
+
+    Task<Either<ActionResult, List<IndicatorMappingDto>>> UpdateIndicatorMappings(
+        IndicatorMappingUpdatesRequest request
     );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
@@ -151,6 +151,25 @@ public class ReplacementPlanService(
                     ? null
                     : await GetApiVersionPlanViewModel(replacementApiDataSetVersion, cancellationToken);
 
+                var mappingPlan = new ReplacementPlanMappingViewModel
+                {
+                    Indicators = new ReplacementPlanIndicatorsMappingViewModel
+                    {
+                        Mappings = mapping.IndicatorMappings.Values.ToDictionary(
+                            map => map.OriginalColumnName,
+                            map => new ReplacementPlanIndicatorMappingViewModel
+                            {
+                                Source = new ReplacementPlanIndicatorViewModel { Label = map.OriginalLabel },
+                                Type = map.Status,
+                                CandidateKey = map.ReplacementColumnName,
+                            }
+                        ),
+                        Candidates = statisticsDbContext
+                            .Indicator.Where(i => i.IndicatorGroup.SubjectId == replacementSubjectId)
+                            .ToDictionary(i => i.Name, i => new ReplacementPlanIndicatorViewModel { Label = i.Label }),
+                    },
+                };
+
                 return new DataReplacementPlanViewModel
                 {
                     DataBlocks = dataBlocks,
@@ -158,6 +177,7 @@ public class ReplacementPlanService(
                     ApiDataSetVersionPlan = apiDataSetVersionPlan,
                     OriginalSubjectId = originalSubjectId,
                     ReplacementSubjectId = replacementSubjectId,
+                    Mapping = mappingPlan,
                 };
             });
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
@@ -160,7 +160,7 @@ public class ReplacementPlanService(
                             map => new ReplacementPlanIndicatorMappingViewModel
                             {
                                 Source = new ReplacementPlanIndicatorViewModel { Label = map.OriginalLabel },
-                                Type = map.Status,
+                                Type = map.Status.ToString(),
                                 CandidateKey = map.ReplacementColumnName,
                             }
                         ),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
@@ -12,6 +13,7 @@ public class DataReplacementPlanViewModel
     public IEnumerable<DataBlockReplacementPlanViewModel> DataBlocks { get; init; } = [];
     public IEnumerable<FootnoteReplacementPlanViewModel> Footnotes { get; init; } = [];
     public ReplaceApiDataSetVersionPlanViewModel? ApiDataSetVersionPlan { get; init; }
+    public ReplacementPlanMappingViewModel? Mapping { get; init; }
     public Guid OriginalSubjectId { get; init; }
     public Guid ReplacementSubjectId { get; init; }
 
@@ -33,6 +35,7 @@ public class DataReplacementPlanViewModel
             ApiDataSetVersionPlan = ApiDataSetVersionPlan,
             OriginalSubjectId = OriginalSubjectId,
             ReplacementSubjectId = ReplacementSubjectId,
+            Mapping = Mapping, // @MarkFix we want this? If so Mapping shouldn't be nullable
         };
     }
 }
@@ -331,4 +334,30 @@ public abstract class ReplacementViewModel
     {
         Valid = valid;
     }
+}
+
+public record ReplacementPlanMappingViewModel
+{
+    public ReplacementPlanIndicatorsMappingViewModel Indicators { get; init; } = new();
+}
+
+public record ReplacementPlanIndicatorsMappingViewModel
+{
+    // Key is original indicator csv column name
+    public Dictionary<string, ReplacementPlanIndicatorMappingViewModel> Mappings { get; init; } = new();
+
+    // Key is replacement indicator csv column name
+    public Dictionary<string, ReplacementPlanIndicatorViewModel> Candidates { get; init; } = new();
+}
+
+public record ReplacementPlanIndicatorMappingViewModel
+{
+    public ReplacementPlanIndicatorViewModel Source { get; init; } = new();
+    public MapStatus Type { get; init; }
+    public string? CandidateKey { get; init; } // replacement indicator csv column name
+}
+
+public record ReplacementPlanIndicatorViewModel
+{
+    public string Label { get; init; } = "";
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -3,7 +3,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
@@ -13,7 +12,7 @@ public class DataReplacementPlanViewModel
     public IEnumerable<DataBlockReplacementPlanViewModel> DataBlocks { get; init; } = [];
     public IEnumerable<FootnoteReplacementPlanViewModel> Footnotes { get; init; } = [];
     public ReplaceApiDataSetVersionPlanViewModel? ApiDataSetVersionPlan { get; init; }
-    public ReplacementPlanMappingViewModel? Mapping { get; init; }
+    public ReplacementPlanMappingViewModel Mapping { get; init; } = new();
     public Guid OriginalSubjectId { get; init; }
     public Guid ReplacementSubjectId { get; init; }
 
@@ -35,7 +34,7 @@ public class DataReplacementPlanViewModel
             ApiDataSetVersionPlan = ApiDataSetVersionPlan,
             OriginalSubjectId = OriginalSubjectId,
             ReplacementSubjectId = ReplacementSubjectId,
-            Mapping = Mapping, // @MarkFix we want this? If so Mapping shouldn't be nullable
+            Mapping = Mapping,
         };
     }
 }
@@ -353,7 +352,7 @@ public record ReplacementPlanIndicatorsMappingViewModel
 public record ReplacementPlanIndicatorMappingViewModel
 {
     public ReplacementPlanIndicatorViewModel Source { get; init; } = new();
-    public MapStatus Type { get; init; }
+    public string Type { get; init; } = "";
     public string? CandidateKey { get; init; } // replacement indicator csv column name
 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/IndicatorMappingDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/IndicatorMappingDto.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+
+public class IndicatorMappingDto
+{
+    public Guid OriginalId { get; set; }
+    public string OriginalLabel { get; set; } = "";
+    public string OriginalColumnName { get; set; } = "";
+    public Guid OriginalGroupId { get; set; }
+    public string OriginalGroupLabel { get; set; } = "";
+
+    public Guid? ReplacementId { get; set; }
+    public string? ReplacementLabel { get; set; }
+    public string? ReplacementColumnName { get; set; }
+    public Guid? ReplacementGroupId { get; set; }
+    public string? ReplacementGroupLabel { get; set; }
+
+    public string Status { get; set; } = "";
+
+    public static IndicatorMappingDto FromModel(IndicatorMapping indicatorMapping)
+    {
+        return new IndicatorMappingDto
+        {
+            OriginalId = indicatorMapping.OriginalId,
+            OriginalLabel = indicatorMapping.OriginalLabel,
+            OriginalColumnName = indicatorMapping.OriginalColumnName,
+            OriginalGroupId = indicatorMapping.OriginalGroupId,
+            OriginalGroupLabel = indicatorMapping.OriginalGroupLabel,
+            ReplacementId = indicatorMapping.ReplacementId,
+            ReplacementLabel = indicatorMapping.ReplacementLabel,
+            ReplacementColumnName = indicatorMapping.ReplacementColumnName,
+            ReplacementGroupId = indicatorMapping.ReplacementGroupId,
+            ReplacementGroupLabel = indicatorMapping.ReplacementGroupLabel,
+            Status = indicatorMapping.Status.ToString(),
+        };
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -16,15 +16,15 @@ public record DataSetMapping
     public Dictionary<Guid, IndicatorMapping> IndicatorMappings { get; set; } = new();
     public List<UnmappedIndicator> UnmappedReplacementIndicators { get; set; } = [];
 
+    public static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() }, // so we save MapStatus as a string
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false,
+    };
+
     internal class Config : IEntityTypeConfiguration<DataSetMapping>
     {
-        private static readonly JsonSerializerOptions JsonOptions = new()
-        {
-            Converters = { new JsonStringEnumConverter() }, // so we save MapStatus as a string
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            WriteIndented = false,
-        };
-
         public void Configure(EntityTypeBuilder<DataSetMapping> builder)
         {
             builder.HasKey(x => x.Id);

--- a/tests/test-data/files/small-files/replace-data/one_2indicatorsrenamed.csv
+++ b/tests/test-data/files/small-files/replace-data/one_2indicatorsrenamed.csv
@@ -1,0 +1,8 @@
+time_identifier,time_period,geographic_level,country_code,country_name,old_la_code,new_la_code,la_name,ind_one_renamed,ind_two_renamed
+Academic year,202021,Local authority,E92000001,England,330,E08000025,Birmingham,1,2
+Academic year,202122,Local authority,E92000001,England,370,E08000016,Barnsley,1,2
+Academic year,202223,Local authority,E92000001,England,203,E09000011,Greenwich,1,2
+Academic year,202223,Local authority,E92000001,England,202,E09000007,Camden,2,2
+Academic year,202324,Local authority,E92000001,England,202,E09000007,Camden,2,2
+Academic year,202324,Local authority,E92000001,England,330,E08000025,Birmingham,2,2
+Academic year,202425,Local authority,E92000001,England,330,E08000025,Birmingham,2,2

--- a/tests/test-data/files/small-files/replace-data/one_2indicatorsrenamed.meta.csv
+++ b/tests/test-data/files/small-files/replace-data/one_2indicatorsrenamed.meta.csv
@@ -1,0 +1,3 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+ind_one_renamed,Indicator,Indicator one renamed,Indicator group,,,,
+ind_two_renamed,Indicator,Indicator two renamed,Indicator group,,,,


### PR DESCRIPTION
:rotating_light: This merges into EES-6913 - if EES-6913 this will need to be redirected to merge into dev :rotating_light: 

This PR adds an endpoint that gives the frontend the ability to update indicator mappings. This means that during a replacement, if an original indicator hasn't been automatically mapped to a replacement indicator (due to having matching label), the user can manually map a original indicator to a replacement indicator.

This PR also returns mapping data as part of `DataReplacementPlanViewModel`. This gives the frontend the data it needs to make indicator mapping update requests.

Previously, if that original indicator was included in data blocks or charts, and wasn't automapped to a replacement indicator, then the user would have been forced to edit data blocks/footnotes, removing that indicator to complete the replacement. Now, via the new endpoint, a user can manually map the original indicator to an available replacement indicator, avoiding the need to edit data blocks/footnotes to complete the replacement.

This work also allows users to mark a particular original indicator as intentionally not having a replacement. Currently, this doesn't affect the validity of a replacement, but we will explore removing indicators from data blocks/footnotes if a user as manually marked them not to be mapped in EES-7071.

### Notes of Point (sic)
- There are currently no tests for `DataSetMappingService.UpdateIndicatorMappings`. I did try, but due to DataSetMappings using JSON columns, and the in-memory DB we use in tests not supporting them, the tests I did write didn't seem to have much value, so I decided to go without. But happy to accept suggestions from my dear reviewer.
- Admin defaults to using Newtonsoft.Json, but I've intentionally used System.Text.Json. We intend to switch to System.Text.Json overtime, hence why I've used that in this work.
- When updating `DataSetMapping.IndicatorMappings`, I initially intended to use a custom query to inspect/replace the json in IndicatorMappings for performance, but I ended up not. I figured the way I've done it is easier to follow and I only pull the `DataSetMapping` once and write it once per request. If performance is revealed to be a problem, I think we can cross that bridge when we come to it.