### PR TITLE
EES-6991: Stack organisation logos on smaller devices

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/PublishingOrganisations.module.scss
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/PublishingOrganisations.module.scss
@@ -1,7 +1,18 @@
+@import '@common/styles/breakpoints';
 @import '~govuk-frontend/dist/govuk/base';
 
 .container {
   display: flex;
-  gap: 2rem;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+
+  @include govuk-media-query($from: 'mobile-lg') {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  @include govuk-media-query($from: 'tablet') {
+    gap: 2rem;
+  }
 }

--- a/src/explore-education-statistics-common/src/styles/_breakpoints.scss
+++ b/src/explore-education-statistics-common/src/styles/_breakpoints.scss
@@ -1,6 +1,7 @@
-// Adding desktop-lg and desktop-xl to the default govuk breakpoints.
+// Adding mobile-lg, desktop-lg and desktop-xl to the default govuk breakpoints.
 $govuk-breakpoints: (
   mobile: 320px,
+  mobile-lg: 400px,
   tablet: 641px,
   desktop: 769px,
   desktop-lg: 1024px,


### PR DESCRIPTION
The Figma designs for organisation logo alignment/spacing were based on a minimum width of 393px, however we support devices from 320px. Device widths lower than 393px caused the logos to overflow the container. This PR adds a media query to stack the logos on smaller devices.