### PR TITLE
EES-7036 - Set expires to end of day 7 days from activates when expires is not provided by user

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
@@ -71,7 +71,7 @@ public abstract class PreviewTokenControllerTests(PreviewTokenControllerTestsFix
         [Fact]
         public async Task Success()
         {
-            var sevenDaysFromNow = DateTimeOffset.UtcNow.AddDays(7);
+            var sevenDaysFromNow = DateTimeOffset.UtcNow.AddDays(7).GetUkEndOfDayUtc();
             var dataSetVersion = await SetUpDataSetVersionTestData();
 
             var label = new string('A', count: 100);
@@ -154,8 +154,8 @@ public abstract class PreviewTokenControllerTests(PreviewTokenControllerTestsFix
 
             var expectedExpires =
                 suppliedExpires // The supplied expires value
-                ?? suppliedActivates?.AddDays(7) // otherwise 7 days after activates if that has a supplied value
-                ?? DateTimeOffset.UtcNow.AddDays(7); // otherwise 7 days from now
+                ?? suppliedActivates?.AddDays(7).GetUkEndOfDayUtc() // otherwise 7 days after activates if that has a supplied value
+                ?? DateTimeOffset.UtcNow.AddDays(7).GetUkEndOfDayUtc(); // otherwise 7 days from now
 
             Assert.Multiple(
                 () => Assert.Equal(previewTokenId, viewModel.Id),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
@@ -71,7 +71,7 @@ public abstract class PreviewTokenControllerTests(PreviewTokenControllerTestsFix
         [Fact]
         public async Task Success()
         {
-            var sevenDaysFromNow = DateTimeOffset.UtcNow.AddDays(7).GetUkEndOfDayUtc();
+            var expectedExpires = DateTimeOffset.UtcNow.AddDays(7).GetUkEndOfDayUtc(includeFractionalSeconds: false);
             var dataSetVersion = await SetUpDataSetVersionTestData();
 
             var label = new string('A', count: 100);
@@ -93,7 +93,7 @@ public abstract class PreviewTokenControllerTests(PreviewTokenControllerTestsFix
                 () => Assert.Equal(fixture.BauUser.Email, viewModel.CreatedByEmail),
                 () => viewModel.Created.AssertUtcNow(),
                 () => viewModel.Activates.AssertUtcNow(),
-                () => viewModel.Expires.AssertEqual(sevenDaysFromNow),
+                () => viewModel.Expires.AssertEqual(expectedExpires),
                 () => Assert.Null(viewModel.Updated)
             );
 
@@ -111,7 +111,7 @@ public abstract class PreviewTokenControllerTests(PreviewTokenControllerTestsFix
                 () => Assert.Equal(fixture.BauUser.Id, actualPreviewToken.CreatedByUserId),
                 () => actualPreviewToken.Created.AssertUtcNow(),
                 () => actualPreviewToken.Activates.AssertUtcNow(),
-                () => actualPreviewToken.Expires.AssertEqual(sevenDaysFromNow),
+                () => actualPreviewToken.Expires.AssertEqual(expectedExpires),
                 () => Assert.Null(actualPreviewToken.Updated)
             );
         }
@@ -154,8 +154,8 @@ public abstract class PreviewTokenControllerTests(PreviewTokenControllerTestsFix
 
             var expectedExpires =
                 suppliedExpires // The supplied expires value
-                ?? suppliedActivates?.AddDays(7).GetUkEndOfDayUtc() // otherwise 7 days after activates if that has a supplied value
-                ?? DateTimeOffset.UtcNow.AddDays(7).GetUkEndOfDayUtc(); // otherwise 7 days from now
+                ?? suppliedActivates?.AddDays(7).GetUkEndOfDayUtc(includeFractionalSeconds: false) // otherwise 7 days after activates if that has a supplied value
+                ?? DateTimeOffset.UtcNow.AddDays(7).GetUkEndOfDayUtc(includeFractionalSeconds: false); // otherwise 7 days from now
 
             Assert.Multiple(
                 () => Assert.Equal(previewTokenId, viewModel.Id),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
@@ -344,7 +344,7 @@ public abstract class PreviewTokenControllerTests(PreviewTokenControllerTestsFix
         private static DateTimeOffset GetUkEndOfDayUtcAfterDays(DateTimeOffset date, int daysToAdd) =>
             // The request validation expects the expiry value to be at the end of the day,
             // without fractional seconds.
-            date.ToUkDateOnly().AddDays(daysToAdd).GetUkEndOfDayUtc(includeFractionalSeconds: false);
+            date.ToUkDateOnly().AddDays(daysToAdd).GetUkEndOfDayUtc();
 
         private async Task<HttpResponseMessage> CreatePreviewToken(
             Guid dataSetVersionId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/PreviewTokenControllerTests.cs
@@ -71,7 +71,7 @@ public abstract class PreviewTokenControllerTests(PreviewTokenControllerTestsFix
         [Fact]
         public async Task Success()
         {
-            var expectedExpires = DateTimeOffset.UtcNow.AddDays(7).GetUkEndOfDayUtc(includeFractionalSeconds: false);
+            var expectedExpires = DateTimeOffset.UtcNow.AddDays(7).GetUkEndOfDayUtc();
             var dataSetVersion = await SetUpDataSetVersionTestData();
 
             var label = new string('A', count: 100);
@@ -154,8 +154,8 @@ public abstract class PreviewTokenControllerTests(PreviewTokenControllerTestsFix
 
             var expectedExpires =
                 suppliedExpires // The supplied expires value
-                ?? suppliedActivates?.AddDays(7).GetUkEndOfDayUtc(includeFractionalSeconds: false) // otherwise 7 days after activates if that has a supplied value
-                ?? DateTimeOffset.UtcNow.AddDays(7).GetUkEndOfDayUtc(includeFractionalSeconds: false); // otherwise 7 days from now
+                ?? suppliedActivates?.AddDays(7).GetUkEndOfDayUtc() // otherwise 7 days after activates if that has a supplied value
+                ?? DateTimeOffset.UtcNow.AddDays(7).GetUkEndOfDayUtc(); // otherwise 7 days from now
 
             Assert.Multiple(
                 () => Assert.Equal(previewTokenId, viewModel.Id),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/PreviewTokenCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/Public.Data/PreviewTokenCreateRequest.cs
@@ -90,13 +90,17 @@ public record PreviewTokenCreateRequest
                                 .WithMessage("Expires date must be no more than 7 days from today.");
                         });
                     RuleFor(r => r.Expires)
-                        .Must(expires => expires!.Value.ConvertToUkTimeZone().TimeOfDay == _timeAtEndOfDay)
+                        .Must(expires =>
+                            TruncateMilliSeconds(expires!.Value.ConvertToUkTimeZone().TimeOfDay) == _timeAtEndOfDay
+                        )
                         .WithMessage("Expires time must always be at 23:59:59 UK local time.");
                 }
             );
 
             RuleFor(r => r.DataSetVersionId).NotEmpty();
             RuleFor(r => r.Label).NotEmpty().MaximumLength(100);
+            TimeSpan TruncateMilliSeconds(TimeSpan timeSpan) =>
+                new(timeSpan.Days, timeSpan.Hours, timeSpan.Minutes, timeSpan.Seconds);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PreviewTokenService.cs
@@ -39,7 +39,9 @@ public class PreviewTokenService(
             .OnSuccess(async () =>
             {
                 var activatesUtc = activates?.ToUniversalTime() ?? DateTimeOffset.UtcNow;
-                var expiresUtc = expires?.ToUniversalTime() ?? activatesUtc.AddDays(7).GetUkEndOfDayUtc();
+                var expiresUtc =
+                    expires?.ToUniversalTime()
+                    ?? activatesUtc.AddDays(7).GetUkEndOfDayUtc(includeFractionalSeconds: false);
 
                 var previewToken = publicDataDbContext.PreviewTokens.Add(
                     new PreviewToken

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PreviewTokenService.cs
@@ -39,9 +39,7 @@ public class PreviewTokenService(
             .OnSuccess(async () =>
             {
                 var activatesUtc = activates?.ToUniversalTime() ?? DateTimeOffset.UtcNow;
-                var expiresUtc =
-                    expires?.ToUniversalTime()
-                    ?? activatesUtc.AddDays(7).GetUkEndOfDayUtc(includeFractionalSeconds: false);
+                var expiresUtc = expires?.ToUniversalTime() ?? activatesUtc.AddDays(7).GetUkEndOfDayUtc();
 
                 var previewToken = publicDataDbContext.PreviewTokens.Add(
                     new PreviewToken

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PreviewTokenService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Public.Data/PreviewTokenService.cs
@@ -39,7 +39,8 @@ public class PreviewTokenService(
             .OnSuccess(async () =>
             {
                 var activatesUtc = activates?.ToUniversalTime() ?? DateTimeOffset.UtcNow;
-                var expiresUtc = expires?.ToUniversalTime() ?? activatesUtc.AddDays(7);
+                var expiresUtc = expires?.ToUniversalTime() ?? activatesUtc.AddDays(7).GetUkEndOfDayUtc();
+
                 var previewToken = publicDataDbContext.PreviewTokens.Add(
                     new PreviewToken
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateOnlyExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateOnlyExtensionsTests.cs
@@ -53,14 +53,14 @@ public abstract class DateOnlyExtensionsTests
         }
 
         [Theory]
-        [InlineData("2025-01-01", "2025-01-01T23:59:59 +00:00")] // Day within GMT
-        [InlineData("2025-06-01", "2025-06-01T22:59:59 +00:00")] // Day within BST
-        [InlineData("2025-03-29", "2025-03-29T23:59:59 +00:00")] // Day before BST starts (end of day is within GMT)
-        [InlineData("2025-03-30", "2025-03-30T22:59:59 +00:00")] // BST starts on this day (end of day is within BST)
-        [InlineData("2025-03-31", "2025-03-31T22:59:59 +00:00")] // Day after BST starts (end of day is within BST)
-        [InlineData("2025-10-25", "2025-10-25T22:59:59 +00:00")] // Day before BST ends (end of day is within BST)
-        [InlineData("2025-10-26", "2025-10-26T23:59:59 +00:00")] // BST ends on this day (end of day is within GMT)
-        [InlineData("2025-10-27", "2025-10-27T23:59:59 +00:00")] // Day after BST ends (end of day is within GMT)
+        [InlineData("2025-01-01", "2025-01-01T23:59:59.9999999 +00:00")] // Day within GMT
+        [InlineData("2025-06-01", "2025-06-01T22:59:59.9999999 +00:00")] // Day within BST
+        [InlineData("2025-03-29", "2025-03-29T23:59:59.9999999 +00:00")] // Day before BST starts (end of day is within GMT)
+        [InlineData("2025-03-30", "2025-03-30T22:59:59.9999999 +00:00")] // BST starts on this day (end of day is within BST)
+        [InlineData("2025-03-31", "2025-03-31T22:59:59.9999999 +00:00")] // Day after BST starts (end of day is within BST)
+        [InlineData("2025-10-25", "2025-10-25T22:59:59.9999999 +00:00")] // Day before BST ends (end of day is within BST)
+        [InlineData("2025-10-26", "2025-10-26T23:59:59.9999999 +00:00")] // BST ends on this day (end of day is within GMT)
+        [InlineData("2025-10-27", "2025-10-27T23:59:59.9999999 +00:00")] // Day after BST ends (end of day is within GMT)
         public void WhenIncludeMillisecondsIsFalse_ReturnsTimeAtEndOfUkDayWithoutMilliseconds(
             string dateOnlyString,
             string expectedDateTimeOffsetString
@@ -69,7 +69,7 @@ public abstract class DateOnlyExtensionsTests
             var dateOnly = DateOnly.Parse(dateOnlyString);
             var expectedDateTimeOffset = DateTimeOffset.Parse(expectedDateTimeOffsetString);
 
-            var actual = dateOnly.GetUkEndOfDayUtc(includeFractionalSeconds: false);
+            var actual = dateOnly.GetUkEndOfDayUtc();
 
             Assert.Equal(TimeSpan.Zero, actual.Offset);
             Assert.Equal(expectedDateTimeOffset, actual);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTests.cs
@@ -50,7 +50,7 @@ public abstract class DateTimeOffsetExtensionsTests
             string description
         )
         {
-            var actual = dateTimeOffset.GetUkEndOfDayUtc(includeFractionalSeconds: false);
+            var actual = dateTimeOffset.GetUkEndOfDayUtc(includeFractionalSeconds: true);
 
             Assert.Equal(TimeSpan.Zero, actual.Offset);
             Assert.True(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTests.cs
@@ -33,6 +33,33 @@ public abstract class DateTimeOffsetExtensionsTests
         }
     }
 
+    public class GetUkEndOfDayUtcTests : DateTimeOffsetExtensionsTests
+    {
+        [Theory]
+        [MemberData(
+            nameof(DateTimeOffsetExtensionsTestsTheoryData.GetUkEndOfDayUtcUTheoryData.UtcZoneData),
+            MemberType = typeof(DateTimeOffsetExtensionsTestsTheoryData.GetUkEndOfDayUtcUTheoryData)
+        )]
+        [MemberData(
+            nameof(DateTimeOffsetExtensionsTestsTheoryData.GetUkEndOfDayUtcUTheoryData.UkZoneData),
+            MemberType = typeof(DateTimeOffsetExtensionsTestsTheoryData.GetUkEndOfDayUtcUTheoryData)
+        )]
+        public void GetUkEndOfDayUtc_ReturnsExpectedResult(
+            DateTimeOffset dateTimeOffset,
+            DateTimeOffset expectedDateTimeOffset,
+            string description
+        )
+        {
+            var actual = dateTimeOffset.GetUkEndOfDayUtc();
+
+            Assert.Equal(TimeSpan.Zero, actual.Offset);
+            Assert.True(
+                expectedDateTimeOffset.Equals(actual),
+                $"Expected: {expectedDateTimeOffset:o}\nActual:   {actual:o}\nDescription: {description}"
+            );
+        }
+    }
+
     public class ToUkDateOnlyTests : DateTimeOffsetExtensionsTests
     {
         [Theory]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTests.cs
@@ -50,7 +50,7 @@ public abstract class DateTimeOffsetExtensionsTests
             string description
         )
         {
-            var actual = dateTimeOffset.GetUkEndOfDayUtc();
+            var actual = dateTimeOffset.GetUkEndOfDayUtc(includeFractionalSeconds: false);
 
             Assert.Equal(TimeSpan.Zero, actual.Offset);
             Assert.True(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTests.cs
@@ -50,7 +50,7 @@ public abstract class DateTimeOffsetExtensionsTests
             string description
         )
         {
-            var actual = dateTimeOffset.GetUkEndOfDayUtc(includeFractionalSeconds: true);
+            var actual = dateTimeOffset.GetUkEndOfDayUtc();
 
             Assert.Equal(TimeSpan.Zero, actual.Offset);
             Assert.True(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTestsTheoryData.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTestsTheoryData.cs
@@ -108,6 +108,61 @@ public class DateTimeOffsetExtensionsTestsTheoryData
         };
     }
 
+    public class GetUkEndOfDayUtcUTheoryData
+    {
+        /// <summary>
+        /// Test data of UTC <see cref="DateTimeOffset"/> values used to verify end-of-day calculation.
+        /// </summary>
+        public static readonly TheoryData<DateTimeOffset, DateTimeOffset, string> UtcZoneData = new()
+        {
+            // csharpier-ignore-start
+            // Winter (GMT) - End of day is 23:59:59 UTC
+            { Dt("2025-01-01T00:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Start of UK local day (Result: 23:59:59 GMT)" },
+            { Dt("2025-01-01T12:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Noon UK local time (Result: 23:59:59 GMT)" },
+            { Dt("2025-01-01T23:59:59 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "End of UK local day (Result: 23:59:59 GMT)" },
+
+            // Summer (BST) - End of day is 23:59:59 BST (which is 22:59:59 UTC)
+            { Dt("2025-05-31T23:00:00 +00:00"), Dt("2025-06-01T22:59:59 +00:00"), "Start of UK local day (Result: 22:59:59 UTC)" },
+            { Dt("2025-06-01T11:00:00 +00:00"), Dt("2025-06-01T22:59:59 +00:00"), "Noon UK local time (Result: 22:59:59 UTC)" },
+            { Dt("2025-06-01T22:59:59 +00:00"), Dt("2025-06-01T22:59:59 +00:00"), "End of UK local day (Result: 22:59:59 UTC)" },
+
+            // --- SPRING TRANSITION (GMT to BST) ---
+            { Dt("2025-03-29T12:00:00 +00:00"), Dt("2025-03-29T23:59:59 +00:00"), "Day before Spring transition (Result: 23:59:59 GMT)" },
+            { Dt("2025-03-30T00:00:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "Midnight GMT before spring forward" },
+            { Dt("2025-03-30T12:00:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "Noon BST (11:00 UTC) on transition day" },
+            { Dt("2025-03-31T12:00:00 +00:00"), Dt("2025-03-31T22:59:59 +00:00"), "Day after Spring transition (Result: 22:59:59 UTC / 23:59:59 BST)" },
+
+            // --- AUTUMN TRANSITION (BST to GMT) ---
+            { Dt("2025-10-25T12:00:00 +00:00"), Dt("2025-10-25T22:59:59 +00:00"), "Day before Autumn transition (Result: 22:59:59 UTC / 23:59:59 BST)" },
+            { Dt("2025-10-26T00:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "Midnight BST before fall back" },
+            { Dt("2025-10-26T12:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "Noon GMT on transition day" },
+            { Dt("2025-10-27T12:00:00 +00:00"), Dt("2025-10-27T23:59:59 +00:00"), "Day after Autumn transition (Result: 23:59:59 GMT)" }
+            // csharpier-ignore-end
+        };
+
+        /// <summary>
+        /// Test data of UK time zone <see cref="DateTimeOffset"/> values used to verify end-of-day calculation.
+        /// </summary>
+        public static readonly TheoryData<DateTimeOffset, DateTimeOffset, string> UkZoneData = new()
+        {
+            // csharpier-ignore-start
+            // Winter (GMT)
+            { Dt("2025-01-01T12:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Noon GMT" },
+
+            // Summer (BST)
+            { Dt("2025-06-01T12:00:00 +01:00"), Dt("2025-06-01T22:59:59 +00:00"), "Noon BST (22:59 UTC)" },
+
+            // Complex Transition: Spring Forward (Clocks skip 01:00 to 02:00)
+            { Dt("2025-03-30T00:30:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "Inside the last GMT hour of spring transition day" },
+            { Dt("2025-03-30T02:30:00 +01:00"), Dt("2025-03-30T22:59:59 +00:00"), "Inside the first BST hour of spring transition day" },
+
+            // Complex Transition: Fall Back (01:00 to 02:00 happens twice)
+            { Dt("2025-10-26T01:30:00 +01:00"), Dt("2025-10-26T23:59:59 +00:00"), "The first 01:30 (BST) on fall back day" },
+            { Dt("2025-10-26T01:30:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "The second 01:30 (GMT) on fall back day" }
+            // csharpier-ignore-end
+        };
+    }
+
     public class ToUkDateOnlyTheoryData
     {
         /// <summary>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTestsTheoryData.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTestsTheoryData.cs
@@ -116,27 +116,27 @@ public class DateTimeOffsetExtensionsTestsTheoryData
         public static readonly TheoryData<DateTimeOffset, DateTimeOffset, string> UtcZoneData = new()
         {
             // csharpier-ignore-start
-            // Winter (GMT) - End of day is 23:59:59 UTC
-            { Dt("2025-01-01T00:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Start of UK local day (Result: 23:59:59 GMT)" },
-            { Dt("2025-01-01T12:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Noon UK local time (Result: 23:59:59 GMT)" },
-            { Dt("2025-01-01T23:59:59 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "End of UK local day (Result: 23:59:59 GMT)" },
+            { Dt("2025-01-01T00:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Start of UK local day (00:00:00 GMT, 00:00:00 UTC)" },
+            { Dt("2025-01-01T12:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Noon UK local time (12:00:00 GMT, 12:00:00 UTC)" },
+            { Dt("2025-01-01T23:59:59 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "End of UK local day (23:59:59 GMT, 23:59:59 UTC)" },
 
-            // Summer (BST) - End of day is 23:59:59 BST (which is 22:59:59 UTC)
-            { Dt("2025-05-31T23:00:00 +00:00"), Dt("2025-06-01T22:59:59 +00:00"), "Start of UK local day (Result: 22:59:59 UTC)" },
-            { Dt("2025-06-01T11:00:00 +00:00"), Dt("2025-06-01T22:59:59 +00:00"), "Noon UK local time (Result: 22:59:59 UTC)" },
-            { Dt("2025-06-01T22:59:59 +00:00"), Dt("2025-06-01T22:59:59 +00:00"), "End of UK local day (Result: 22:59:59 UTC)" },
+            { Dt("2025-05-31T23:00:00 +00:00"), Dt("2025-06-01T22:59:59 +00:00"), "Start of UK local day (00:00:00 BST, 23:00:00 UTC previous day)" },
+            { Dt("2025-06-01T11:00:00 +00:00"), Dt("2025-06-01T22:59:59 +00:00"), "Noon UK local time (12:00:00 BST, 11:00:00 UTC)" },
+            { Dt("2025-06-01T22:59:59 +00:00"), Dt("2025-06-01T22:59:59 +00:00"), "End of UK local day (23:59:59 BST, 22:59:59 UTC)" },
 
-            // --- SPRING TRANSITION (GMT to BST) ---
-            { Dt("2025-03-29T12:00:00 +00:00"), Dt("2025-03-29T23:59:59 +00:00"), "Day before Spring transition (Result: 23:59:59 GMT)" },
-            { Dt("2025-03-30T00:00:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "Midnight GMT before spring forward" },
-            { Dt("2025-03-30T12:00:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "Noon BST (11:00 UTC) on transition day" },
-            { Dt("2025-03-31T12:00:00 +00:00"), Dt("2025-03-31T22:59:59 +00:00"), "Day after Spring transition (Result: 22:59:59 UTC / 23:59:59 BST)" },
+            { Dt("2025-03-30T00:00:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "One hour before BST starts (01:00:00 GMT, 00:00:00 UTC)" },
+            { Dt("2025-03-30T00:59:59 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "One second before BST starts (01:59:59 GMT, 00:59:59 UTC)" },
+            { Dt("2025-03-30T01:00:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "BST starts at this instant (01:00:00 GMT -> 02:00:00 BST, 01:00:00 UTC)" },
+            { Dt("2025-03-30T01:00:01 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "One second after BST started (02:00:01 BST, 01:00:01 UTC)" },
+            { Dt("2025-03-30T02:00:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "One hour after BST started (03:00:00 BST, 02:00:00 UTC)" },
 
-            // --- AUTUMN TRANSITION (BST to GMT) ---
-            { Dt("2025-10-25T12:00:00 +00:00"), Dt("2025-10-25T22:59:59 +00:00"), "Day before Autumn transition (Result: 22:59:59 UTC / 23:59:59 BST)" },
-            { Dt("2025-10-26T00:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "Midnight BST before fall back" },
-            { Dt("2025-10-26T12:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "Noon GMT on transition day" },
-            { Dt("2025-10-27T12:00:00 +00:00"), Dt("2025-10-27T23:59:59 +00:00"), "Day after Autumn transition (Result: 23:59:59 GMT)" }
+            { Dt("2025-10-26T00:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "One hour before BST ends (01:00:00 BST, 00:00:00 UTC)" },
+            { Dt("2025-10-26T00:30:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "01:30:00 local time before BST ends (01:30:00 BST, 00:30:00 UTC)" },
+            { Dt("2025-10-26T00:59:59 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "One second before BST ends (01:59:59 BST, 00:59:59 UTC)" },
+            { Dt("2025-10-26T01:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "BST ends at this instant (02:00:00 BST -> 01:00:00 GMT, 01:00:00 UTC)" },
+            { Dt("2025-10-26T01:00:01 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "One second after BST ended (01:00:01 GMT, 01:00:01 UTC)" },
+            { Dt("2025-10-26T01:30:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "01:30:00 local time after BST ended (01:30:00 GMT, 01:30:00 UTC)" },
+            { Dt("2025-10-26T02:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "One hour after BST ended (02:00:00 GMT, 02:00:00 UTC)" }
             // csharpier-ignore-end
         };
 
@@ -147,18 +147,27 @@ public class DateTimeOffsetExtensionsTestsTheoryData
         {
             // csharpier-ignore-start
             // Winter (GMT)
-            { Dt("2025-01-01T12:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Noon GMT" },
+            { Dt("2025-01-01T00:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Start of UK local day (00:00:00 GMT, 00:00:00 UTC)" },
+            { Dt("2025-01-01T12:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Noon UK local time (12:00:00 GMT, 12:00:00 UTC)" },
+            { Dt("2025-01-01T23:59:59 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "End of UK local day (23:59:59 GMT, 23:59:59 UTC)" },
 
-            // Summer (BST)
-            { Dt("2025-06-01T12:00:00 +01:00"), Dt("2025-06-01T22:59:59 +00:00"), "Noon BST (22:59 UTC)" },
+            { Dt("2025-06-01T00:00:00 +01:00"), Dt("2025-06-01T22:59:59 +00:00"), "Start of UK local day (00:00:00 BST, 23:00:00 UTC previous day)" },
+            { Dt("2025-06-01T12:00:00 +01:00"), Dt("2025-06-01T22:59:59 +00:00"), "Noon UK local time (12:00:00 BST, 11:00:00 UTC)" },
+            { Dt("2025-06-01T23:59:59 +01:00"), Dt("2025-06-01T22:59:59 +00:00"), "End of UK local day (23:59:59 BST, 22:59:59 UTC)" },
 
-            // Complex Transition: Spring Forward (Clocks skip 01:00 to 02:00)
-            { Dt("2025-03-30T00:30:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "Inside the last GMT hour of spring transition day" },
-            { Dt("2025-03-30T02:30:00 +01:00"), Dt("2025-03-30T22:59:59 +00:00"), "Inside the first BST hour of spring transition day" },
+            { Dt("2025-03-30T00:00:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "One hour before BST starts (01:00:00 GMT, 00:00:00 UTC)" },
+            { Dt("2025-03-30T00:59:59 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "One second before BST starts (01:59:59 GMT, 00:59:59 UTC)" },
+            { Dt("2025-03-30T02:00:00 +01:00"), Dt("2025-03-30T22:59:59 +00:00"), "BST starts at this instant (01:00:00 GMT -> 02:00:00 BST, 01:00:00 UTC)" },
+            { Dt("2025-03-30T02:00:01 +01:00"), Dt("2025-03-30T22:59:59 +00:00"), "One second after BST started (02:00:01 BST, 01:00:01 UTC)" },
+            { Dt("2025-03-30T03:00:00 +01:00"), Dt("2025-03-30T22:59:59 +00:00"), "One hour after BST started (03:00:00 BST, 02:00:00 UTC)" },
 
-            // Complex Transition: Fall Back (01:00 to 02:00 happens twice)
-            { Dt("2025-10-26T01:30:00 +01:00"), Dt("2025-10-26T23:59:59 +00:00"), "The first 01:30 (BST) on fall back day" },
-            { Dt("2025-10-26T01:30:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "The second 01:30 (GMT) on fall back day" }
+            { Dt("2025-10-26T01:00:00 +01:00"), Dt("2025-10-26T23:59:59 +00:00"), "One hour before BST ends (01:00:00 BST, 00:00:00 UTC)" },
+            { Dt("2025-10-26T01:30:00 +01:00"), Dt("2025-10-26T23:59:59 +00:00"), "01:30:00 local time before BST ends (01:30:00 BST, 00:30:00 UTC)" },
+            { Dt("2025-10-26T01:59:59 +01:00"), Dt("2025-10-26T23:59:59 +00:00"), "One second before BST ends (01:59:59 BST, 00:59:59 UTC)" },
+            { Dt("2025-10-26T01:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "BST ends at this instant (02:00:00 BST -> 01:00:00 GMT, 01:00:00 UTC)" },
+            { Dt("2025-10-26T01:00:01 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "One second after BST ended (01:00:01 GMT, 01:00:01 UTC)" },
+            { Dt("2025-10-26T01:30:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "01:30:00 local time after BST ended (01:30:00 GMT, 01:30:00 UTC)" },
+            { Dt("2025-10-26T02:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "One hour after BST ended (02:00:00 GMT, 02:00:00 UTC)" }
             // csharpier-ignore-end
         };
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTestsTheoryData.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/DateTimeOffsetExtensionsTestsTheoryData.cs
@@ -113,61 +113,100 @@ public class DateTimeOffsetExtensionsTestsTheoryData
         /// <summary>
         /// Test data of UTC <see cref="DateTimeOffset"/> values used to verify end-of-day calculation.
         /// </summary>
+        /// <remarks>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>parameter</term>
+        /// <description>description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>dateTimeOffset</term>
+        /// <description>The input <see cref="DateTimeOffset"/> with offset for UK time zone.</description>
+        /// </item>
+        /// <item>
+        /// <term>expectedDateTimeOffset</term>
+        /// <description>The expected <see cref="DateTimeOffset"/> result in UTC.</description>
+        /// </item>
+        /// <item>
+        /// <term>description</term>
+        /// <description>A description of the test case printed on failure.</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
         public static readonly TheoryData<DateTimeOffset, DateTimeOffset, string> UtcZoneData = new()
         {
             // csharpier-ignore-start
-            { Dt("2025-01-01T00:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Start of UK local day (00:00:00 GMT, 00:00:00 UTC)" },
-            { Dt("2025-01-01T12:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Noon UK local time (12:00:00 GMT, 12:00:00 UTC)" },
-            { Dt("2025-01-01T23:59:59 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "End of UK local day (23:59:59 GMT, 23:59:59 UTC)" },
+            { Dt("2025-01-01T00:00:00 +00:00"), Dt("2025-01-01T23:59:59.9999999 +00:00"), "Start of UK local day (00:00:00 GMT, 00:00:00 UTC)" },
+            { Dt("2025-01-01T12:00:00 +00:00"), Dt("2025-01-01T23:59:59.9999999 +00:00"), "Noon UK local time (12:00:00 GMT, 12:00:00 UTC)" },
+            { Dt("2025-01-01T23:59:59 +00:00"), Dt("2025-01-01T23:59:59.9999999 +00:00"), "End of UK local day (23:59:59 GMT, 23:59:59 UTC)" },
 
-            { Dt("2025-05-31T23:00:00 +00:00"), Dt("2025-06-01T22:59:59 +00:00"), "Start of UK local day (00:00:00 BST, 23:00:00 UTC previous day)" },
-            { Dt("2025-06-01T11:00:00 +00:00"), Dt("2025-06-01T22:59:59 +00:00"), "Noon UK local time (12:00:00 BST, 11:00:00 UTC)" },
-            { Dt("2025-06-01T22:59:59 +00:00"), Dt("2025-06-01T22:59:59 +00:00"), "End of UK local day (23:59:59 BST, 22:59:59 UTC)" },
+            { Dt("2025-05-31T23:00:00 +00:00"), Dt("2025-06-01T22:59:59.9999999 +00:00"), "Start of UK local day (00:00:00 BST, 23:00:00 UTC previous day)" },
+            { Dt("2025-06-01T11:00:00 +00:00"), Dt("2025-06-01T22:59:59.9999999 +00:00"), "Noon UK local time (12:00:00 BST, 11:00:00 UTC)" },
+            { Dt("2025-06-01T22:59:59 +00:00"), Dt("2025-06-01T22:59:59.9999999 +00:00"), "End of UK local day (23:59:59 BST, 22:59:59 UTC)" },
 
-            { Dt("2025-03-30T00:00:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "One hour before BST starts (01:00:00 GMT, 00:00:00 UTC)" },
-            { Dt("2025-03-30T00:59:59 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "One second before BST starts (01:59:59 GMT, 00:59:59 UTC)" },
-            { Dt("2025-03-30T01:00:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "BST starts at this instant (01:00:00 GMT -> 02:00:00 BST, 01:00:00 UTC)" },
-            { Dt("2025-03-30T01:00:01 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "One second after BST started (02:00:01 BST, 01:00:01 UTC)" },
-            { Dt("2025-03-30T02:00:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "One hour after BST started (03:00:00 BST, 02:00:00 UTC)" },
+            { Dt("2025-03-30T00:00:00 +00:00"), Dt("2025-03-30T22:59:59.9999999 +00:00"), "One hour before BST starts (01:00:00 GMT, 00:00:00 UTC)" },
+            { Dt("2025-03-30T00:59:59 +00:00"), Dt("2025-03-30T22:59:59.9999999 +00:00"), "One second before BST starts (01:59:59 GMT, 00:59:59 UTC)" },
+            { Dt("2025-03-30T01:00:00 +00:00"), Dt("2025-03-30T22:59:59.9999999 +00:00"), "BST starts at this instant (01:00:00 GMT -> 02:00:00 BST, 01:00:00 UTC)" },
+            { Dt("2025-03-30T01:00:01 +00:00"), Dt("2025-03-30T22:59:59.9999999 +00:00"), "One second after BST started (02:00:01 BST, 01:00:01 UTC)" },
+            { Dt("2025-03-30T02:00:00 +00:00"), Dt("2025-03-30T22:59:59.9999999 +00:00"), "One hour after BST started (03:00:00 BST, 02:00:00 UTC)" },
 
-            { Dt("2025-10-26T00:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "One hour before BST ends (01:00:00 BST, 00:00:00 UTC)" },
-            { Dt("2025-10-26T00:30:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "01:30:00 local time before BST ends (01:30:00 BST, 00:30:00 UTC)" },
-            { Dt("2025-10-26T00:59:59 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "One second before BST ends (01:59:59 BST, 00:59:59 UTC)" },
-            { Dt("2025-10-26T01:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "BST ends at this instant (02:00:00 BST -> 01:00:00 GMT, 01:00:00 UTC)" },
-            { Dt("2025-10-26T01:00:01 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "One second after BST ended (01:00:01 GMT, 01:00:01 UTC)" },
-            { Dt("2025-10-26T01:30:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "01:30:00 local time after BST ended (01:30:00 GMT, 01:30:00 UTC)" },
-            { Dt("2025-10-26T02:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "One hour after BST ended (02:00:00 GMT, 02:00:00 UTC)" }
+            { Dt("2025-10-26T00:00:00 +00:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "One hour before BST ends (01:00:00 BST, 00:00:00 UTC)" },
+            { Dt("2025-10-26T00:30:00 +00:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "01:30:00 local time before BST ends (01:30:00 BST, 00:30:00 UTC)" },
+            { Dt("2025-10-26T00:59:59 +00:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "One second before BST ends (01:59:59 BST, 00:59:59 UTC)" },
+            { Dt("2025-10-26T01:00:00 +00:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "BST ends at this instant (02:00:00 BST -> 01:00:00 GMT, 01:00:00 UTC)" },
+            { Dt("2025-10-26T01:00:01 +00:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "One second after BST ended (01:00:01 GMT, 01:00:01 UTC)" },
+            { Dt("2025-10-26T01:30:00 +00:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "01:30:00 local time after BST ended (01:30:00 GMT, 01:30:00 UTC)" },
+            { Dt("2025-10-26T02:00:00 +00:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "One hour after BST ended (02:00:00 GMT, 02:00:00 UTC)" }
             // csharpier-ignore-end
         };
 
         /// <summary>
         /// Test data of UK time zone <see cref="DateTimeOffset"/> values used to verify end-of-day calculation.
         /// </summary>
+        /// <remarks>
+        /// <list type="table">
+        /// <listheader>
+        /// <term>parameter</term>
+        /// <description>description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>dateTimeOffset</term>
+        /// <description>The input <see cref="DateTimeOffset"/> with offset for UK time zone.</description>
+        /// </item>
+        /// <item>
+        /// <term>expectedDateTimeOffset</term>
+        /// <description>The expected <see cref="DateTimeOffset"/> result in UTC.</description>
+        /// </item>
+        /// <item>
+        /// <term>description</term>
+        /// <description>A description of the test case printed on failure.</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
         public static readonly TheoryData<DateTimeOffset, DateTimeOffset, string> UkZoneData = new()
         {
             // csharpier-ignore-start
-            // Winter (GMT)
-            { Dt("2025-01-01T00:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Start of UK local day (00:00:00 GMT, 00:00:00 UTC)" },
-            { Dt("2025-01-01T12:00:00 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "Noon UK local time (12:00:00 GMT, 12:00:00 UTC)" },
-            { Dt("2025-01-01T23:59:59 +00:00"), Dt("2025-01-01T23:59:59 +00:00"), "End of UK local day (23:59:59 GMT, 23:59:59 UTC)" },
+            { Dt("2025-01-01T00:00:00 +00:00"), Dt("2025-01-01T23:59:59.9999999 +00:00"), "Start of UK local day (00:00:00 GMT, 00:00:00 UTC)" },
+            { Dt("2025-01-01T12:00:00 +00:00"), Dt("2025-01-01T23:59:59.9999999 +00:00"), "Noon UK local time (12:00:00 GMT, 12:00:00 UTC)" },
+            { Dt("2025-01-01T23:59:59 +00:00"), Dt("2025-01-01T23:59:59.9999999 +00:00"), "End of UK local day (23:59:59 GMT, 23:59:59 UTC)" },
 
-            { Dt("2025-06-01T00:00:00 +01:00"), Dt("2025-06-01T22:59:59 +00:00"), "Start of UK local day (00:00:00 BST, 23:00:00 UTC previous day)" },
-            { Dt("2025-06-01T12:00:00 +01:00"), Dt("2025-06-01T22:59:59 +00:00"), "Noon UK local time (12:00:00 BST, 11:00:00 UTC)" },
-            { Dt("2025-06-01T23:59:59 +01:00"), Dt("2025-06-01T22:59:59 +00:00"), "End of UK local day (23:59:59 BST, 22:59:59 UTC)" },
+            { Dt("2025-06-01T00:00:00 +01:00"), Dt("2025-06-01T22:59:59.9999999 +00:00"), "Start of UK local day (00:00:00 BST, 23:00:00 UTC previous day)" },
+            { Dt("2025-06-01T12:00:00 +01:00"), Dt("2025-06-01T22:59:59.9999999 +00:00"), "Noon UK local time (12:00:00 BST, 11:00:00 UTC)" },
+            { Dt("2025-06-01T23:59:59 +01:00"), Dt("2025-06-01T22:59:59.9999999 +00:00"), "End of UK local day (23:59:59 BST, 22:59:59 UTC)" },
 
-            { Dt("2025-03-30T00:00:00 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "One hour before BST starts (01:00:00 GMT, 00:00:00 UTC)" },
-            { Dt("2025-03-30T00:59:59 +00:00"), Dt("2025-03-30T22:59:59 +00:00"), "One second before BST starts (01:59:59 GMT, 00:59:59 UTC)" },
-            { Dt("2025-03-30T02:00:00 +01:00"), Dt("2025-03-30T22:59:59 +00:00"), "BST starts at this instant (01:00:00 GMT -> 02:00:00 BST, 01:00:00 UTC)" },
-            { Dt("2025-03-30T02:00:01 +01:00"), Dt("2025-03-30T22:59:59 +00:00"), "One second after BST started (02:00:01 BST, 01:00:01 UTC)" },
-            { Dt("2025-03-30T03:00:00 +01:00"), Dt("2025-03-30T22:59:59 +00:00"), "One hour after BST started (03:00:00 BST, 02:00:00 UTC)" },
+            { Dt("2025-03-30T00:00:00 +00:00"), Dt("2025-03-30T22:59:59.9999999 +00:00"), "One hour before BST starts (01:00:00 GMT, 00:00:00 UTC)" },
+            { Dt("2025-03-30T00:59:59 +00:00"), Dt("2025-03-30T22:59:59.9999999 +00:00"), "One second before BST starts (01:59:59 GMT, 00:59:59 UTC)" },
+            { Dt("2025-03-30T02:00:00 +01:00"), Dt("2025-03-30T22:59:59.9999999 +00:00"), "BST starts at this instant (01:00:00 GMT -> 02:00:00 BST, 01:00:00 UTC)" },
+            { Dt("2025-03-30T02:00:01 +01:00"), Dt("2025-03-30T22:59:59.9999999 +00:00"), "One second after BST started (02:00:01 BST, 01:00:01 UTC)" },
+            { Dt("2025-03-30T03:00:00 +01:00"), Dt("2025-03-30T22:59:59.9999999 +00:00"), "One hour after BST started (03:00:00 BST, 02:00:00 UTC)" },
 
-            { Dt("2025-10-26T01:00:00 +01:00"), Dt("2025-10-26T23:59:59 +00:00"), "One hour before BST ends (01:00:00 BST, 00:00:00 UTC)" },
-            { Dt("2025-10-26T01:30:00 +01:00"), Dt("2025-10-26T23:59:59 +00:00"), "01:30:00 local time before BST ends (01:30:00 BST, 00:30:00 UTC)" },
-            { Dt("2025-10-26T01:59:59 +01:00"), Dt("2025-10-26T23:59:59 +00:00"), "One second before BST ends (01:59:59 BST, 00:59:59 UTC)" },
-            { Dt("2025-10-26T01:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "BST ends at this instant (02:00:00 BST -> 01:00:00 GMT, 01:00:00 UTC)" },
-            { Dt("2025-10-26T01:00:01 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "One second after BST ended (01:00:01 GMT, 01:00:01 UTC)" },
-            { Dt("2025-10-26T01:30:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "01:30:00 local time after BST ended (01:30:00 GMT, 01:30:00 UTC)" },
-            { Dt("2025-10-26T02:00:00 +00:00"), Dt("2025-10-26T23:59:59 +00:00"), "One hour after BST ended (02:00:00 GMT, 02:00:00 UTC)" }
+            { Dt("2025-10-26T01:00:00 +01:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "One hour before BST ends (01:00:00 BST, 00:00:00 UTC)" },
+            { Dt("2025-10-26T01:30:00 +01:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "01:30:00 local time before BST ends (01:30:00 BST, 00:30:00 UTC)" },
+            { Dt("2025-10-26T01:59:59 +01:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "One second before BST ends (01:59:59 BST, 00:59:59 UTC)" },
+            { Dt("2025-10-26T01:00:00 +00:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "BST ends at this instant (02:00:00 BST -> 01:00:00 GMT, 01:00:00 UTC)" },
+            { Dt("2025-10-26T01:00:01 +00:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "One second after BST ended (01:00:01 GMT, 01:00:01 UTC)" },
+            { Dt("2025-10-26T01:30:00 +00:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "01:30:00 local time after BST ended (01:30:00 GMT, 01:30:00 UTC)" },
+            { Dt("2025-10-26T02:00:00 +00:00"), Dt("2025-10-26T23:59:59.9999999 +00:00"), "One hour after BST ended (02:00:00 GMT, 02:00:00 UTC)" }
             // csharpier-ignore-end
         };
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateOnlyExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateOnlyExtensions.cs
@@ -18,11 +18,10 @@ public static class DateOnlyExtensions
         return new DateTimeOffset(ukMidnightDateTimeInUtc, TimeSpan.Zero);
     }
 
-    public static DateTimeOffset GetUkEndOfDayUtc(this DateOnly date, bool includeFractionalSeconds = true)
+    public static DateTimeOffset GetUkEndOfDayUtc(this DateOnly date)
     {
         // Get a TimeOnly value set to the end of the day.
-        // This is either 23:59:59.9999999 or 23:59:59 depending on whether fractional seconds should be included.
-        var timeAtEndOfDay = includeFractionalSeconds ? TimeOnly.MaxValue : new TimeOnly(23, 59, 59);
+        var timeAtEndOfDay = TimeOnly.MaxValue;
 
         // Get a DateTime set to the date of this DateOnly instance and the time at the end of the day
         var endOfDayDateTime = date.ToDateTime(timeAtEndOfDay, DateTimeKind.Unspecified);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeOffsetExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeOffsetExtensions.cs
@@ -34,7 +34,7 @@ public static class DateTimeOffsetExtensions
         // Convert the date and time to the UK time zone
         var inUkZone = dateTimeOffset.ConvertToUkTimeZone();
 
-        // Get the date component of that date in the UK time zone (DateTime at midnight)
+        // Get the date component of that date in the UK time zone (DateTime at midnight) (This sets time to 00:00)
         var ukMidnightDateTime = inUkZone.Date;
 
         // Get the correct UTC offset for midnight on that date in the UK time zone
@@ -45,6 +45,37 @@ public static class DateTimeOffsetExtensions
 
         // Convert the DateTimeOffset to UTC
         return ukMidnightDateTimeOffset.ToUniversalTime();
+    }
+
+    /// <summary>
+    /// <para>
+    /// Adjusts the provided <paramref name="dateTimeOffset"/> to the UK time zone and returns a
+    /// <see cref="DateTimeOffset"/> representing the end of that UK day (23:59:59.000),
+    /// accounting for daylight saving time.
+    /// </para>
+    /// </summary>
+    /// <param name="dateTimeOffset">The input <see cref="DateTimeOffset"/> to convert.</param>
+    /// <returns>A <see cref="DateTimeOffset"/> in UTC corresponding to the start of the UK day for the provided input.</returns>
+    public static DateTimeOffset GetUkEndOfDayUtc(this DateTimeOffset dateTimeOffset)
+    {
+        // 1. Convert to UK time
+        var inUkZone = dateTimeOffset.ConvertToUkTimeZone();
+
+        // 2. Get the date at midnight, then add 1 day to get the start of the next day
+        var ukNextDayMidnight = inUkZone.Date.AddDays(1);
+
+        // 3. Subtract the smallest possible unit (1 tick) to get the end of the current day
+        // This results in 23:59:59.00
+        var ukEndOfDayDateTime = ukNextDayMidnight.AddSeconds(-1);
+
+        // 4. Get the offset for that specific moment
+        // (Crucial for days when the clocks change at midnight!)
+        var ukZoneOffset = UkTimeZone.GetUtcOffset(ukEndOfDayDateTime);
+
+        // 5. Create the DateTimeOffset and convert back to UTC
+        var ukEndOfDayDateTimeOffset = new DateTimeOffset(ukEndOfDayDateTime, ukZoneOffset);
+
+        return ukEndOfDayDateTimeOffset.ToUniversalTime();
     }
 
     /// <summary>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeOffsetExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeOffsetExtensions.cs
@@ -34,7 +34,7 @@ public static class DateTimeOffsetExtensions
         // Convert the date and time to the UK time zone
         var inUkZone = dateTimeOffset.ConvertToUkTimeZone();
 
-        // Get the date component of that date in the UK time zone (DateTime at midnight) (This sets time to 00:00)
+        // Get the date component in the UK time zone, which sets the time to midnight (00:00)
         var ukMidnightDateTime = inUkZone.Date;
 
         // Get the correct UTC offset for midnight on that date in the UK time zone
@@ -55,28 +55,12 @@ public static class DateTimeOffsetExtensions
     /// </para>
     /// </summary>
     /// <param name="dateTimeOffset">The input <see cref="DateTimeOffset"/> to convert.</param>
+    /// <param name="includeFractionalSeconds">Sets the milliseconds component to .999 if true and .0 if false.</param>
     /// <returns>A <see cref="DateTimeOffset"/> in UTC corresponding to the start of the UK day for the provided input.</returns>
-    public static DateTimeOffset GetUkEndOfDayUtc(this DateTimeOffset dateTimeOffset)
-    {
-        // 1. Convert to UK time
-        var inUkZone = dateTimeOffset.ConvertToUkTimeZone();
-
-        // 2. Get the date at midnight, then add 1 day to get the start of the next day
-        var ukNextDayMidnight = inUkZone.Date.AddDays(1);
-
-        // 3. Subtract the smallest possible unit (1 tick) to get the end of the current day
-        // This results in 23:59:59.00
-        var ukEndOfDayDateTime = ukNextDayMidnight.AddSeconds(-1);
-
-        // 4. Get the offset for that specific moment
-        // (Crucial for days when the clocks change at midnight!)
-        var ukZoneOffset = UkTimeZone.GetUtcOffset(ukEndOfDayDateTime);
-
-        // 5. Create the DateTimeOffset and convert back to UTC
-        var ukEndOfDayDateTimeOffset = new DateTimeOffset(ukEndOfDayDateTime, ukZoneOffset);
-
-        return ukEndOfDayDateTimeOffset.ToUniversalTime();
-    }
+    public static DateTimeOffset GetUkEndOfDayUtc(
+        this DateTimeOffset dateTimeOffset,
+        bool includeFractionalSeconds = true
+    ) => dateTimeOffset.ToUkDateOnly().GetUkEndOfDayUtc(includeFractionalSeconds);
 
     /// <summary>
     /// <para>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeOffsetExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeOffsetExtensions.cs
@@ -50,13 +50,12 @@ public static class DateTimeOffsetExtensions
     /// <summary>
     /// <para>
     /// Adjusts the provided <paramref name="dateTimeOffset"/> to the UK time zone and returns a
-    /// <see cref="DateTimeOffset"/> representing the end of that UK day (23:59:59.000),
-    /// accounting for daylight saving time.
+    /// <see cref="DateTimeOffset"/> in UTC representing the end of that UK day, accounting for daylight saving time.
     /// </para>
     /// </summary>
     /// <param name="dateTimeOffset">The input <see cref="DateTimeOffset"/> to convert.</param>
-    /// <param name="includeFractionalSeconds">Sets the milliseconds component to .999 if true and .0 if false.</param>
-    /// <returns>A <see cref="DateTimeOffset"/> in UTC corresponding to the start of the UK day for the provided input.</returns>
+    /// <param name="includeFractionalSeconds">Sets the milliseconds component to .9999999 if true and .0 if false.</param>
+    /// <returns>A <see cref="DateTimeOffset"/> in UTC corresponding to the end of the UK day for the provided input.</returns>
     public static DateTimeOffset GetUkEndOfDayUtc(
         this DateTimeOffset dateTimeOffset,
         bool includeFractionalSeconds = true

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeOffsetExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeOffsetExtensions.cs
@@ -54,12 +54,9 @@ public static class DateTimeOffsetExtensions
     /// </para>
     /// </summary>
     /// <param name="dateTimeOffset">The input <see cref="DateTimeOffset"/> to convert.</param>
-    /// <param name="includeFractionalSeconds">Sets the milliseconds component to .9999999 if true and .0 if false.</param>
     /// <returns>A <see cref="DateTimeOffset"/> in UTC corresponding to the end of the UK day for the provided input.</returns>
-    public static DateTimeOffset GetUkEndOfDayUtc(
-        this DateTimeOffset dateTimeOffset,
-        bool includeFractionalSeconds = true
-    ) => dateTimeOffset.ToUkDateOnly().GetUkEndOfDayUtc(includeFractionalSeconds);
+    public static DateTimeOffset GetUkEndOfDayUtc(this DateTimeOffset dateTimeOffset) =>
+        dateTimeOffset.ToUkDateOnly().GetUkEndOfDayUtc();
 
     /// <summary>
     /// <para>


### PR DESCRIPTION
This is a very small change for something that was spotted recently to have been overlooked. 

We defined rules around the value preview token expiry dates get set when the user doesn’t provide an expiry date themselves. This rule is that it should be set 7 days from the activation date. This ticket tweaks this so that the expiry date is set 7 days from the activation date at the end of the day on that 7th day. 

This change is related to the way the backend processes the data. The frontend has validation that stops this from being submitted. 

A way to test this change, use chrome web dev tools in order to re-send a customized request, by 

 - manually triggering generation of preview token using UI with F12 console open
 - finding the network POST (/preview-tokens) network event that creates a preview token 
 - modifying the ‘Body’ to exclude the expires date and then pressing button ‘SEND’ on chrome’s 


Behaviour before the change: 
<img width="1235" height="439" alt="image" src="https://github.com/user-attachments/assets/60f3a418-37ed-4457-b02e-1b23cd5b15ac" />
Behaviour after change:
<img width="1297" height="473" alt="image" src="https://github.com/user-attachments/assets/03a52cec-2608-411a-97d4-35014be30413" />
