### PR TITLE
EES-7046 Fix Robot Test that was expecting removed release page element

### DIFF
--- a/tests/robot-tests/tests/admin_and_public_2/bau/publishing_organisations.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publishing_organisations.robot
@@ -100,6 +100,7 @@ Verify "Published by" shows default organisation
     user checks published by in admin    ${DEFAULT_ORGANISATION_TEXT}
 
 Publish amendment
+    user clicks link    Content
     user clicks button    Add note
     user enters text into element    id:create-release-note-form-reason    Test release note one
     user clicks button    Save note
@@ -148,8 +149,6 @@ user checks published by in admin
     ...    Accredited official statistics
     ...
     ...    ${published_by}
-    user clicks link    Content
-    user checks testid element contains    Produced by-value    ${published_by}
 
 user checks published by on public release page
     [Arguments]    ${published_by}


### PR DESCRIPTION
We recently merged a change that removed lots of elements from the release page edit screen.

When doing the work I missed a robot test that was expecting to see the 'produced by' values on that screen, which were removed. This PR amends the robot test so it is no longer checking for this element. It still verifies the publishing organisations on other screens.
