### PR TITLE
EES-7088 - switching Pre-Prod and Prod Azure Front Door instances to use BYO certificates

### DIFF
--- a/infrastructure/templates/core/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-preprod.bicepparam
@@ -2,5 +2,3 @@ using '../main.bicep'
 
 // Environment Params
 param environmentName = 'Pre-Production'
-
-param certificateType = 'Provisioned'

--- a/infrastructure/templates/core/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-prod.bicepparam
@@ -3,6 +3,4 @@ using '../main.bicep'
 // Environment Params
 param environmentName = 'Production'
 
-param certificateType = 'Provisioned'
-
 param averagePublicSiteResponseTimeAlertThresholdMillis = 250


### PR DESCRIPTION
This PR:
- switches Pre-Prod and Prod Azure Front Door instances to use BYO certificates use BYO certificates so that we can test them using the temporary AFD testing URLs ahead of switching over DNS entirely.

An infra rollout of these changes will cause Pre-Prod and Prod AFD instances to look for BYO certificates.  Certificates named "s101p01-as-ees-public-site-afd-certificate" and "s101p02-as-ees-public-site-afd-certificate" have been created manually ahead of time for this infra deploy process to pick up.

The switching over to BYO certificates allows us to supply certificates in Key Vault that cover our testing URLs.