### PR TITLE
EES-7002 - fixed Screener API base URL by removing "/screen" suffix.

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -2027,7 +2027,7 @@
         "PublicDataApi__AppRegistrationClientId": "[parameters('apiAppRegistrationClientId')]",
         "PublicDataProcessor__Url": "[concat('https://', variables('publicDataProcessorName'), '.azurewebsites.net')]",
         "PublicDataProcessor__AppRegistrationClientId": "[parameters('publicDataProcessorAppRegistrationClientId')]",
-        "DataScreener__Url": "[concat('https://', variables('dataScreenerName'), '.azurewebsites.net', '/api/screen')]",
+        "DataScreener__Url": "[concat('https://', variables('dataScreenerName'), '.azurewebsites.net', '/api')]",
         "DataScreener__AppRegistrationClientId": "[parameters('screenerAppRegistrationClientId')]",
         "DataScreener__ScreenerStorage": "",
         "DataScreener__EnhancedScreenerJourney": false


### PR DESCRIPTION
This PR:
- fixes a bug with the Screener API URL as used by Admin when deployed to Azure.

The ARM template still had the `/screen` suffix on the base URL, thus causing Admin to make requests to `/api/screen/screen`.