### PR TITLE
EES-7028 Remove unused `getPublicationRelease` method from frontend

### DIFF
--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -424,15 +424,6 @@ const publicationService = {
     return contentApi.get(`/publications/${publicationSlug}/releases`);
   },
   // Currently used within table tool
-  getPublicationRelease(
-    publicationSlug: string,
-    releaseSlug: string,
-  ): Promise<ReleaseVersion> {
-    return contentApi.get(
-      `/publications/${publicationSlug}/releases/${releaseSlug}`,
-    );
-  },
-  // Currently used within table tool
   getLatestPublicationRelease(
     publicationSlug: string,
   ): Promise<ReleaseVersion> {


### PR DESCRIPTION
This PR is a quick tidy-up following up from #6870 to remove an unused method `getPublicationRelease` from publicationService.ts`.

It was spotted during a further review of the table tool and data catalogues interaction with the backend API's.