### PR TITLE
EES-2991 - Moving Admin's email template id params to appsettings.json

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -348,43 +348,6 @@
         "description": "Disables response compression for the public app. This is required to prevent double compression in conjunction with the CDN. WARN: Also used in next config!"
       }
     },
-    "notifyInviteWithRolesTemplateId": {
-      "type": "securestring",
-      "defaultValue": "change-me",
-      "metadata": {
-        "description": "Gov UK Notify service template Id for new user invites"
-      }
-    },
-    "notifyPublicationRoleTemplateId": {
-      "type": "securestring",
-      "defaultValue": "change-me"
-    },
-    "notifyReleaseRoleTemplateId": {
-      "type": "securestring",
-      "defaultValue": "change-me"
-    },
-    "notifyPreReleaseTemplateId": {
-      "type": "securestring",
-      "defaultValue": "change-me"
-    },
-    "notifyContributorTemplateId": {
-      "type": "securestring",
-      "defaultValue": "change-me"
-    },
-    "notifyReleaseHigherReviewersTemplateId": {
-      "type": "securestring",
-      "defaultValue": "change-me",
-      "metadata": {
-        "description": "Gov UK Notify service template ID for release higher review approver notifications"
-      }
-    },
-    "notifyMethodologyHigherReviewersTemplateId": {
-      "type": "securestring",
-      "defaultValue": "change-me",
-      "metadata": {
-        "description": "Gov UK Notify service template ID for methodology higher review approver notifications"
-      }
-    },
     "immediatePublicationOfScheduledReleaseVersionsEnabled": {
       "type": "bool",
       "defaultValue": false,
@@ -1992,13 +1955,6 @@
         "IdentityServer__IssuerUri": "[concat('urn=', parameters('adminUri'))]",
         "IdentityServer__Key__Name": "[concat('CN=', parameters('adminUri'))]",
         "Notify__ApiKey": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-admin-govuknotify-api-key'), '2018-02-14').secretUriWithVersion, ')')]",
-        "Notify__InviteWithRolesTemplateId": "[parameters('notifyInviteWithRolesTemplateId')]",
-        "Notify__PublicationRoleTemplateId": "[parameters('notifyPublicationRoleTemplateId')]",
-        "Notify__ReleaseRoleTemplateId": "[parameters('notifyReleaseRoleTemplateId')]",
-        "Notify__PreReleaseTemplateId": "[parameters('notifyPreReleaseTemplateId')]",
-        "Notify__ContributorTemplateId": "[parameters('notifyContributorTemplateId')]",
-        "Notify__ReleaseHigherReviewersTemplateId": "[parameters('notifyReleaseHigherReviewersTemplateId')]",
-        "Notify__MethodologyHigherReviewersTemplateId": "[parameters('notifyMethodologyHigherReviewersTemplateId')]",
         "OpenIdConnectIdentityFramework__ClientId": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-openidconnect-clientid'), '2018-02-14').secretUriWithVersion, ')')]",
         "OpenIdConnectIdentityFramework__Authority": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-openidconnect-authority'), '2018-02-14').secretUriWithVersion, ')')]",
         "OpenIdConnectIdentityFramework__TokenValidationParameters__ValidAudience": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-openidconnect-valid-audience'), '2018-02-14').secretUriWithVersion, ')')]",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -366,7 +366,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
 
         services.Configure<AppOptions>(configuration.GetRequiredSection(AppOptions.Section));
         services.Configure<AppInsightsOptions>(configuration.GetSection(AppInsightsOptions.Section));
-        services.Configure<NotifyOptions>(configuration.GetSection(NotifyOptions.Section));
+        services.Configure<NotifyOptions>(configuration.GetRequiredSection(NotifyOptions.Section));
         services.Configure<PublicAppOptions>(configuration.GetRequiredSection(PublicAppOptions.Section));
         services.Configure<PublicDataProcessorOptions>(
             configuration.GetRequiredSection(PublicDataProcessorOptions.Section)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -25,14 +25,7 @@
     }
   },
   "Notify": {
-    "ApiKey": "",
-    "InviteWithRolesTemplateId": "",
-    "PublicationRoleTemplateId": "",
-    "ReleaseRoleTemplateId": "",
-    "PreReleaseTemplateId": "",
-    "ContributorTemplateId": "",
-    "ReleaseHigherReviewersTemplateId": "",
-    "MethodologyHigherReviewersTemplateId": ""
+    "ApiKey": ""
   },
   "PreReleaseAccess": {
     "AccessWindow": {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
@@ -21,5 +21,14 @@
         "LocalAuthority"
       ]
     }
+  },
+  "Notify": {
+    "InviteWithRolesTemplateId": "9da83e64-f159-498e-b87e-7f3bc3ad67e4",
+    "PublicationRoleTemplateId": "e7220f13-8a8a-40ae-92f2-b1fcc972d8fa",
+    "ReleaseRoleTemplateId": "4aed5a3f-d633-466d-91b8-bd3721cafd45",
+    "PreReleaseTemplateId": "b756db8d-4d68-4aaa-8b9a-5e04170dbef3",
+    "ContributorTemplateId": "4759aae3-6e06-4238-aebe-157d4c4ff549",
+    "ReleaseHigherReviewersTemplateId": "3ebce00e-ce78-47b5-9377-3c75ab3842f2",
+    "MethodologyHigherReviewersTemplateId": "b2d0406e-3555-4322-b6e8-5c9ca3f51060"
   }
 }


### PR DESCRIPTION
Currently the email template ID environment variable values for the Admin app are supplied to the ARM template as arguments of DevOps infrastructure deploy in the release pipeline.

This process involves quite a few steps when creating or amending Admin email template id’s and is prone to error especially around the two different DevOps tasks which need updating and the ‘Override template parameters’ config which is a long string value of all the concatenated variable names and values.

Changes cannot be made early in advance of the infrastructure code changes being present, so this process has always required a faffy deploy step to remember to update the DevOps config as the code is progressed to each environment.


The purpose of this work is to move these email template IDs into the Admin project's `appsettings.json`. We have already done this elsewhere **(see the Notifier project)**.

This means, in the future, that we can easily update/change these IDs and deploy them sequentially through the environments via a simple Admin app deploy.

After this ticket is merged, there is a task to:

- go into the `EES - Infrastructure release` pipeline and change the Override template parameters string to remove all references to the email template ID variables. Do this in both:
  - The Validate step
  - The Deploy step
- Then re-run the release for the dev environment and ensure it passes.

We will then repeat this for all environments sequentially. Whenever the admin app is progressed through to a new environment, apply the fixes to the `EES - Infrastructure release` pipeline and deploy it

Once done for ALL environments, we will go back to the Variables tab of the `EES - Infrastructure release` pipeline and remove all of the now unused email template variables