### PR TITLE
EES-7002 - add admin controller endpoint to allow front end to request progress updates

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Releases/ReleaseVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Releases/ReleaseVersionsControllerTests.cs
@@ -10,10 +10,12 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Screener;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Fixture.Optimised;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.IntegrationTests;
 using GovUk.Education.ExploreEducationStatistics.Common.IntegrationTests.WebApp;
@@ -645,6 +647,39 @@ public class ReleaseVersionsControllerUnitTests
         result.AssertOkResult(amendmentCreatedResponse);
     }
 
+    [Fact]
+    public async Task GetDataSetUploadScreenerProgress()
+    {
+        // Arrange
+        var releaseVersionId = Guid.NewGuid();
+
+        List<ScreenerProgressWithDataSetUploadIdViewModel> response =
+        [
+            new()
+            {
+                DataSetUploadId = Guid.NewGuid(),
+                PercentageComplete = 100,
+                Stage = "completed",
+            },
+        ];
+
+        var dataSetScreenerService = new Mock<IDataSetScreenerService>(Strict);
+
+        dataSetScreenerService
+            .Setup(s => s.GetScreenerProgress(releaseVersionId, CancellationToken.None))
+            .ReturnsAsync(response);
+
+        var controller = BuildController(dataSetScreenerService: dataSetScreenerService.Object);
+
+        // Act
+        var result = await controller.GetDataSetUploadScreenerProgress(releaseVersionId, CancellationToken.None);
+
+        // Assert
+        VerifyAllMocks(dataSetScreenerService);
+
+        result.AssertOkResult(response);
+    }
+
     private static IFormFile MockFile(string fileName, bool isZip = false)
     {
         var fileMock = new Mock<IFormFile>(Strict);
@@ -682,7 +717,8 @@ public class ReleaseVersionsControllerUnitTests
         IReleaseChecklistService? releaseChecklistService = null,
         IDataImportService? importService = null,
         IDataSetUploadRepository? dataSetUploadRepository = null,
-        IDataSetFileStorage? dataSetFileStorage = null
+        IDataSetFileStorage? dataSetFileStorage = null,
+        IDataSetScreenerService? dataSetScreenerService = null
     )
     {
         return new ReleaseVersionsController(
@@ -694,7 +730,8 @@ public class ReleaseVersionsControllerUnitTests
             releaseChecklistService ?? Mock.Of<IReleaseChecklistService>(Strict),
             importService ?? Mock.Of<IDataImportService>(Strict),
             dataSetUploadRepository ?? Mock.Of<IDataSetUploadRepository>(Strict),
-            dataSetFileStorage ?? Mock.Of<IDataSetFileStorage>(Strict)
+            dataSetFileStorage ?? Mock.Of<IDataSetFileStorage>(Strict),
+            dataSetScreenerService ?? Mock.Of<IDataSetScreenerService>(Strict)
         );
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetUploadMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetUploadMockBuilder.cs
@@ -1,9 +1,7 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Screener;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using Org.BouncyCastle.Asn1.X509;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetUploadMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetUploadMockBuilder.cs
@@ -1,17 +1,18 @@
 #nullable enable
-using GovUk.Education.ExploreEducationStatistics.Admin.Responses.Screener;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Screener;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Org.BouncyCastle.Asn1.X509;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 
-public class DataSetUploadMockBuilder
+public class DataSetUploadMockBuilder(TimeProvider? timeProvider = null)
 {
     private Guid? _releaseVersionId;
     private string? _screenerResult;
     private List<DataScreenerTestResult>? _testResults;
+    private TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
 
     public DataSetUpload BuildInitialEntity()
     {
@@ -27,7 +28,7 @@ public class DataSetUploadMockBuilder
             MetaFileSizeInBytes = 157,
             Status = DataSetUploadStatus.SCREENING,
             UploadedBy = "test@test.com",
-            Created = DateTime.UtcNow,
+            Created = _timeProvider.GetUtcNow().AddDays(-1).Date,
             ReplacingFileId = null,
         };
     }
@@ -50,6 +51,7 @@ public class DataSetUploadMockBuilder
             Created = DateTime.UtcNow,
             ScreenerResult = new DataSetScreenerResponse
             {
+                Passed = _screenerResult == "Passed",
                 OverallResult = _screenerResult ?? "Passed",
                 TestResults =
                     _testResults
@@ -73,6 +75,14 @@ public class DataSetUploadMockBuilder
                         },
                     ],
             },
+            ScreenerProgress = new DataSetScreenerProgress
+            {
+                PercentageComplete = 100,
+                Stage = "Stage 1",
+                Completed = true,
+                Passed = _screenerResult == "Passed",
+                LastUpdated = _timeProvider.GetUtcNow(),
+            },
             ReplacingFileId = null,
         };
     }
@@ -85,7 +95,7 @@ public class DataSetUploadMockBuilder
             DataSetTitle = "Data set title",
             DataFileSize = "123 Kb",
             DataFileName = "data.csv",
-            Status = DataSetUploadStatus.PENDING_IMPORT.ToString(),
+            Status = nameof(DataSetUploadStatus.PENDING_IMPORT),
             UploadedBy = "test.user",
             MetaFileName = "data.meta.csv",
             MetaFileSize = "123 B",
@@ -93,7 +103,6 @@ public class DataSetUploadMockBuilder
             Created = DateTime.UtcNow,
             ScreenerResult = new()
             {
-                Message = "Screener result message",
                 OverallResult = "Passed",
                 TestResults =
                 [
@@ -102,14 +111,14 @@ public class DataSetUploadMockBuilder
                         TestFunctionName = "TestFunction1",
                         Notes = "Test 1 passed",
                         Stage = "1",
-                        Result = TestResult.PASS.ToString(),
+                        Result = nameof(TestResult.PASS),
                     },
                     new()
                     {
                         TestFunctionName = "TestFunction2",
                         Notes = "Test 2 passed",
                         Stage = "2",
-                        Result = TestResult.PASS.ToString(),
+                        Result = nameof(TestResult.PASS),
                     },
                 ],
             },

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetUploadMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetUploadMockBuilder.cs
@@ -12,7 +12,7 @@ public class DataSetUploadMockBuilder(TimeProvider? timeProvider = null)
     private Guid? _releaseVersionId;
     private string? _screenerResult;
     private List<DataScreenerTestResult>? _testResults;
-    private TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
 
     public DataSetUpload BuildInitialEntity()
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetUploadRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetUploadRepositoryTests.cs
@@ -1,10 +1,16 @@
 #nullable enable
-using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Screener;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
@@ -19,16 +25,18 @@ public class DataSetUploadRepositoryTests
     {
         // Arrange
         var releaseVersionId = Guid.NewGuid();
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
 
-        var builder = new DataSetUploadMockBuilder();
-        var upload1 = builder.WithReleaseVersionId(releaseVersionId).BuildScreenedEntity();
-        var upload2 = builder.WithReleaseVersionId(releaseVersionId).BuildScreenedEntity();
-        var upload3 = builder.WithReleaseVersionId(releaseVersionId).BuildScreenedEntity();
+        var builder = new DataSetUploadMockBuilder(timeProvider: timeProvider);
+        var upload1 = builder.WithReleaseVersionId(releaseVersionId).BuildInitialEntity();
+        var upload2 = builder.WithReleaseVersionId(releaseVersionId).WithFailingTests().BuildScreenedEntity();
+        var upload3 = builder.WithReleaseVersionId(releaseVersionId).WithWarningTests().BuildScreenedEntity();
+        var unrelatedUpload = builder.WithReleaseVersionId(Guid.NewGuid()).BuildScreenedEntity();
 
         var contextId = Guid.NewGuid().ToString();
         await using (var contentDbContext = InMemoryApplicationDbContext(contextId))
         {
-            contentDbContext.DataSetUploads.AddRange(upload1, upload2, upload3);
+            contentDbContext.DataSetUploads.AddRange(upload1, upload2, upload3, unrelatedUpload);
             await contentDbContext.SaveChangesAsync();
         }
 
@@ -37,12 +45,54 @@ public class DataSetUploadRepositoryTests
             var service = BuildService(contentDbContext);
 
             // Act
-            var result = await service.ListAll(releaseVersionId, default);
+            var result = await service.ListAll(releaseVersionId, CancellationToken.None);
 
             // Assert
-            var uploads = result.AssertRight();
+            var uploadViewModels = result.AssertRight();
 
-            Assert.Equal(3, uploads.Count);
+            Assert.Equal(3, uploadViewModels.Count);
+
+            // Assert the basic details are mapped correctly.
+            AssertBasicViewModelDetailsCorrect(uploadViewModels[0], upload1);
+            AssertBasicViewModelDetailsCorrect(uploadViewModels[1], upload2);
+            AssertBasicViewModelDetailsCorrect(uploadViewModels[2], upload3);
+
+            // Assert that a DataSetUpload with no screening is mapped correctly.
+            // TODO EES-7003 - we're currently asserting that status is SCREENER_ERROR at the moment without
+            // a screening result present. This needs to be updated so that initially after upload, it's OK for
+            // there to be no screener result.
+            Assert.Equal(nameof(DataSetUploadStatus.SCREENER_ERROR), uploadViewModels[0].Status);
+
+            // Assert it has no screener results or progress yet.
+            Assert.False(uploadViewModels[0].PublicApiCompatible);
+            Assert.Null(uploadViewModels[0].ScreenerResult);
+            Assert.Null(uploadViewModels[0].ScreenerProgress);
+
+            // Assert that a DataSetUpload with a failed screening result is mapped correctly.
+            Assert.Equal(nameof(DataSetUploadStatus.FAILED_SCREENING), uploadViewModels[1].Status);
+
+            // Assert its screening progress is mapped correctly.
+            Assert.Equal(
+                upload2.ScreenerProgress!.PercentageComplete,
+                uploadViewModels[1].ScreenerProgress!.PercentageComplete
+            );
+            Assert.Equal(upload2.ScreenerProgress!.Stage, uploadViewModels[1].ScreenerProgress!.Stage);
+
+            // Assert that a DataSetUpload with a warning screening result is mapped correctly.
+            Assert.Equal(nameof(DataSetUploadStatus.PENDING_REVIEW), uploadViewModels[2].Status);
+            Assert.Equal(upload3.ScreenerResult!.PublicApiCompatible, uploadViewModels[2].PublicApiCompatible);
+            Assert.Equal(upload3.ScreenerResult!.OverallResult, uploadViewModels[2].ScreenerResult!.OverallResult);
+            AssertScreenerTestsCorrect(
+                upload3.ScreenerResult!.TestResults,
+                uploadViewModels[2].ScreenerResult!.TestResults
+            );
+
+            // Assert its screening progress is mapped correctly.
+            Assert.Equal(
+                upload3.ScreenerProgress!.PercentageComplete,
+                uploadViewModels[2].ScreenerProgress!.PercentageComplete
+            );
+            Assert.Equal(upload3.ScreenerProgress!.Stage, uploadViewModels[2].ScreenerProgress!.Stage);
         }
     }
 
@@ -75,7 +125,7 @@ public class DataSetUploadRepositoryTests
             var service = BuildService(contentDbContext, privateBlobStorageService.Object);
 
             // Act
-            var result = await service.Delete(releaseVersionId, upload2.Id, default);
+            var result = await service.Delete(releaseVersionId, upload2.Id, CancellationToken.None);
 
             // Assert
             privateBlobStorageService.Verify(
@@ -118,7 +168,7 @@ public class DataSetUploadRepositoryTests
             var service = BuildService(contentDbContext, privateBlobStorageService.Object);
 
             // Act
-            var result = await service.DeleteAll(releaseVersionId, default);
+            var result = await service.DeleteAll(releaseVersionId, CancellationToken.None);
 
             // Assert
             privateBlobStorageService.Verify(
@@ -131,16 +181,47 @@ public class DataSetUploadRepositoryTests
         }
     }
 
+    private void AssertBasicViewModelDetailsCorrect(DataSetUploadViewModel uploadViewModel, DataSetUpload upload)
+    {
+        Assert.Equal(upload.Id, uploadViewModel.Id);
+        Assert.Equal(upload.Created, uploadViewModel.Created);
+        Assert.Equal(upload.DataFileName, uploadViewModel.DataFileName);
+        Assert.Equal(upload.DataFileSizeInBytes.DisplaySize(), uploadViewModel.DataFileSize);
+        Assert.Equal(upload.DataSetTitle, uploadViewModel.DataSetTitle);
+        Assert.Equal(upload.MetaFileName, uploadViewModel.MetaFileName);
+        Assert.Equal(upload.MetaFileSizeInBytes.DisplaySize(), uploadViewModel.MetaFileSize);
+        Assert.Equal(upload.ReplacingFileId, uploadViewModel.ReplacingFileId);
+        Assert.Equal(upload.UploadedBy, uploadViewModel.UploadedBy);
+    }
+
+    private void AssertScreenerTestsCorrect(
+        List<DataScreenerTestResult> testResults,
+        List<ScreenerTestResultViewModel> viewModels
+    )
+    {
+        Assert.Equal(testResults.Count, viewModels.Count);
+
+        testResults.ForEach(
+            (testResult, index) =>
+            {
+                var viewModel = viewModels[index];
+                Assert.Equal(testResult.Stage, viewModel.Stage);
+                Assert.Equal(testResult.Notes, viewModel.Notes);
+                Assert.Equal(testResult.Result.ToString(), viewModel.Result);
+                Assert.Equal(testResult.TestFunctionName, viewModel.TestFunctionName);
+            }
+        );
+    }
+
     private static DataSetUploadRepository BuildService(
         ContentDbContext context,
-        IPrivateBlobStorageService? privateBlobStorageService = null,
-        IMapper? mapper = null
+        IPrivateBlobStorageService? privateBlobStorageService = null
     )
     {
         return new DataSetUploadRepository(
             context,
             privateBlobStorageService ?? Mock.Of<IPrivateBlobStorageService>(),
-            mapper ?? Mock.Of<IMapper>()
+            mapper: MapperUtils.AdminMapper()
         );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServicePermissionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServicePermissionsTests.cs
@@ -1,0 +1,52 @@
+using GovUk.Education.ExploreEducationStatistics.Admin.Options;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Screener;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Screener;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
+using Moq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Screener;
+
+public class DataSetScreenerServicePermissionsTests
+{
+    private readonly DataFixture _dataFixture = new();
+
+    [Fact]
+    public async Task GetScreenerProgress()
+    {
+        ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
+
+        await using var contentDbContext = DbUtils.InMemoryApplicationDbContext();
+        contentDbContext.ReleaseVersions.Add(releaseVersion);
+        await contentDbContext.SaveChangesAsync();
+
+        await PermissionTestUtils
+            .PolicyCheckBuilder<ContentSecurityPolicies>()
+            .SetupResourceCheckToFail(releaseVersion, ContentSecurityPolicies.CanViewSpecificReleaseVersion)
+            .AssertForbidden(userService =>
+            {
+                var service = BuildService(userService: userService.Object, contentDbContext: contentDbContext);
+                return service.GetScreenerProgress(releaseVersion.Id, CancellationToken.None);
+            });
+    }
+
+    private IDataSetScreenerService BuildService(IUserService userService, ContentDbContext contentDbContext)
+    {
+        return new DataSetScreenerService(
+            dataSetScreenerClient: Mock.Of<IDataSetScreenerClient>(MockBehavior.Strict),
+            queueServiceClient: Mock.Of<IQueueServiceClient>(MockBehavior.Strict),
+            userService: userService,
+            contentDbContext: contentDbContext,
+            timeProvider: TimeProvider.System,
+            new DataScreenerOptions().ToOptionsWrapper()
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
@@ -3,11 +3,15 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Options;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Responses.Screener;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Screener;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Screener;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Screener;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
@@ -480,9 +484,231 @@ public abstract class DataSetScreenerServiceTests
         }
     }
 
+    public class GetScreenerProgressTests : DataSetScreenerServiceTests
+    {
+        [Fact]
+        public async Task DataSetsBeingScreened_ProgressUpdatesReturned()
+        {
+            // Arrange
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
+
+            var dataSetsUndergoingScreening = _dataFixture
+                .DefaultDataSetUpload()
+                .WithReleaseVersionId(releaseVersion.Id)
+                .WithStatus(DataSetUploadStatus.SCREENING)
+                .ForIndex(
+                    0,
+                    s =>
+                        s.SetScreenerProgress(
+                            new DataSetScreenerProgress
+                            {
+                                Completed = false,
+                                Passed = false,
+                                PercentageComplete = 50,
+                                Stage = "validation",
+                            }
+                        )
+                )
+                .ForIndex(
+                    1,
+                    s =>
+                        s.SetScreenerProgress(
+                            new DataSetScreenerProgress
+                            {
+                                Completed = false,
+                                Passed = false,
+                                PercentageComplete = 70,
+                                Stage = "screening",
+                            }
+                        )
+                )
+                .GenerateList();
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                await context.DataSetUploads.AddRangeAsync(dataSetsUndergoingScreening);
+                await context.ReleaseVersions.AddRangeAsync(releaseVersion);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var service = BuildService(contentDbContext: context);
+
+                // Act
+                var result = await service.GetScreenerProgress(
+                    releaseVersionId: releaseVersion.Id,
+                    cancellationToken: CancellationToken.None
+                );
+
+                // Assert
+                List<ScreenerProgressWithDataSetUploadIdViewModel> expectedProgressUpdates =
+                [
+                    new()
+                    {
+                        DataSetUploadId = dataSetsUndergoingScreening[0].Id,
+                        PercentageComplete = dataSetsUndergoingScreening[0].ScreenerProgress!.PercentageComplete,
+                        Stage = dataSetsUndergoingScreening[0].ScreenerProgress!.Stage,
+                    },
+                    new()
+                    {
+                        DataSetUploadId = dataSetsUndergoingScreening[1].Id,
+                        PercentageComplete = dataSetsUndergoingScreening[1].ScreenerProgress!.PercentageComplete,
+                        Stage = dataSetsUndergoingScreening[1].ScreenerProgress!.Stage,
+                    },
+                ];
+
+                result.AssertRight(expectedProgressUpdates);
+            }
+        }
+
+        [Fact]
+        public async Task DataSetBeingScreened_DifferentReleaseVersion_ProgressUpdatesNotReturned()
+        {
+            // Arrange
+            ReleaseVersion unrelatedReleaseVersion = _dataFixture.DefaultReleaseVersion();
+
+            DataSetUpload dataSetUndergoingScreening = _dataFixture
+                .DefaultDataSetUpload()
+                // Assign these DataSetUploads to a different ReleaseVersion.
+                .WithReleaseVersionId(Guid.NewGuid())
+                .WithStatus(DataSetUploadStatus.SCREENING)
+                .WithScreenerProgress(
+                    new DataSetScreenerProgress
+                    {
+                        Completed = false,
+                        Passed = false,
+                        PercentageComplete = 50,
+                        Stage = "validation",
+                    }
+                );
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                await context.DataSetUploads.AddRangeAsync(dataSetUndergoingScreening);
+                await context.ReleaseVersions.AddRangeAsync(unrelatedReleaseVersion);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var service = BuildService(contentDbContext: context);
+
+                // Act
+                var result = await service.GetScreenerProgress(
+                    releaseVersionId: unrelatedReleaseVersion.Id,
+                    cancellationToken: CancellationToken.None
+                );
+
+                // Assert
+                result.AssertRight([]);
+            }
+        }
+
+        [Fact]
+        public async Task DataSetBeingScreened_NoProgressUpdatesYet_DefaultProgressUpdateReturned()
+        {
+            // Arrange
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
+
+            DataSetUpload dataSetUndergoingScreening = _dataFixture
+                .DefaultDataSetUpload()
+                .WithReleaseVersionId(releaseVersion.Id)
+                .WithStatus(DataSetUploadStatus.SCREENING)
+                // No progress update has yet been fetched for this data set.
+                .WithScreenerProgress(null);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                await context.DataSetUploads.AddRangeAsync(dataSetUndergoingScreening);
+                await context.ReleaseVersions.AddRangeAsync(releaseVersion);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var service = BuildService(contentDbContext: context);
+
+                // Act
+                var result = await service.GetScreenerProgress(
+                    releaseVersionId: releaseVersion.Id,
+                    cancellationToken: CancellationToken.None
+                );
+
+                List<ScreenerProgressWithDataSetUploadIdViewModel> expectedProgressUpdates =
+                [
+                    new()
+                    {
+                        DataSetUploadId = dataSetUndergoingScreening.Id,
+                        PercentageComplete = 0,
+                        Stage = null,
+                    },
+                ];
+
+                // Assert
+                result.AssertRight(expectedProgressUpdates);
+            }
+        }
+
+        [Fact]
+        public async Task DataSetNotCurrentlyUndergoingScreening_NoProgressUpdateReturned()
+        {
+            // Arrange
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
+
+            DataSetUpload dataSetNotUndergoingScreening = _dataFixture
+                .DefaultDataSetUpload()
+                .WithReleaseVersionId(releaseVersion.Id)
+                // Not currently undergoing screening.
+                .WithStatus(DataSetUploadStatus.PENDING_REVIEW);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                await context.DataSetUploads.AddRangeAsync(dataSetNotUndergoingScreening);
+                await context.ReleaseVersions.AddRangeAsync(releaseVersion);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var service = BuildService(contentDbContext: context);
+
+                // Act
+                var result = await service.GetScreenerProgress(
+                    releaseVersionId: releaseVersion.Id,
+                    cancellationToken: CancellationToken.None
+                );
+
+                // Assert
+                result.AssertRight([]);
+            }
+        }
+
+        [Fact]
+        public async Task ReleaseVersionDoesNotExist_ReturnsNotFound()
+        {
+            await using var context = InMemoryContentDbContext();
+            var service = BuildService(contentDbContext: context);
+
+            // Act
+            var result = await service.GetScreenerProgress(
+                releaseVersionId: Guid.NewGuid(),
+                cancellationToken: CancellationToken.None
+            );
+
+            // Assert
+            result.AssertNotFound();
+        }
+    }
+
     private DataSetScreenerService BuildService(
         IDataSetScreenerClient? screenerClient = null,
         IQueueServiceClient? queueServiceClient = null,
+        IUserService? userService = null,
         ContentDbContext? contentDbContext = null,
         TimeProvider? timeProvider = null
     )
@@ -490,6 +716,7 @@ public abstract class DataSetScreenerServiceTests
         return new DataSetScreenerService(
             dataSetScreenerClient: screenerClient ?? Mock.Of<IDataSetScreenerClient>(MockBehavior.Strict),
             queueServiceClient: queueServiceClient ?? Mock.Of<IQueueServiceClient>(MockBehavior.Strict),
+            userService: userService ?? MockUtils.AlwaysTrueUserService().Object,
             contentDbContext: contentDbContext ?? Mock.Of<ContentDbContext>(),
             timeProvider: timeProvider ?? TimeProvider.System,
             options: new DataScreenerOptions { ScreenerProgressUpdateIntervalSeconds = 5 }.ToOptionsWrapper()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Releases/ReleaseVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Releases/ReleaseVersionsController.cs
@@ -3,7 +3,9 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Screener;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
@@ -16,46 +18,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Relea
 [Route("api")]
 [ApiController]
 [Authorize]
-public class ReleaseVersionsController : ControllerBase
+public class ReleaseVersionsController(
+    IReleaseVersionService releaseVersionService,
+    IReleaseAmendmentService releaseAmendmentService,
+    IReleaseApprovalService releaseApprovalService,
+    IReleaseDataFileService releaseDataFileService,
+    IReleasePublishingStatusService releasePublishingStatusService,
+    IReleaseChecklistService releaseChecklistService,
+    IDataImportService dataImportService,
+    IDataSetUploadRepository dataSetUploadRepository,
+    IDataSetFileStorage dataSetFileStorage,
+    IDataSetScreenerService dataSetScreenerService
+) : ControllerBase
 {
-    private readonly IReleaseVersionService _releaseVersionService;
-    private readonly IReleaseAmendmentService _releaseAmendmentService;
-    private readonly IReleaseApprovalService _releaseApprovalService;
-    private readonly IReleaseDataFileService _releaseDataFileService;
-    private readonly IReleasePublishingStatusService _releasePublishingStatusService;
-    private readonly IReleaseChecklistService _releaseChecklistService;
-    private readonly IDataImportService _dataImportService;
-    private readonly IDataSetUploadRepository _dataSetUploadRepository;
-    private readonly IDataSetFileStorage _dataSetFileStorage;
-
-    public ReleaseVersionsController(
-        IReleaseVersionService releaseVersionService,
-        IReleaseAmendmentService releaseAmendmentService,
-        IReleaseApprovalService releaseApprovalService,
-        IReleaseDataFileService releaseDataFileService,
-        IReleasePublishingStatusService releasePublishingStatusService,
-        IReleaseChecklistService releaseChecklistService,
-        IDataImportService dataImportService,
-        IDataSetUploadRepository dataSetUploadRepository,
-        IDataSetFileStorage dataSetFileStorage
-    )
-    {
-        _releaseVersionService = releaseVersionService;
-        _releaseAmendmentService = releaseAmendmentService;
-        _releaseApprovalService = releaseApprovalService;
-        _releaseDataFileService = releaseDataFileService;
-        _releasePublishingStatusService = releasePublishingStatusService;
-        _releaseChecklistService = releaseChecklistService;
-        _dataImportService = dataImportService;
-        _dataSetUploadRepository = dataSetUploadRepository;
-        _dataSetFileStorage = dataSetFileStorage;
-    }
-
     // We intend to change this route, to make these endpoints more consistent, as per EES-5895
     [HttpDelete("release/{releaseVersionId:guid}")]
     public async Task<ActionResult> DeleteReleaseVersion(Guid releaseVersionId, CancellationToken cancellationToken)
     {
-        return await _releaseVersionService
+        return await releaseVersionService
             .DeleteReleaseVersion(releaseVersionId, cancellationToken)
             .HandleFailuresOrNoContent(convertNotFoundToNoContent: false);
     }
@@ -64,13 +44,13 @@ public class ReleaseVersionsController : ControllerBase
     [HttpPost("release/{releaseVersionId:guid}/amendment")]
     public async Task<ActionResult<IdViewModel>> CreateReleaseAmendment(Guid releaseVersionId)
     {
-        return await _releaseAmendmentService.CreateReleaseAmendment(releaseVersionId).HandleFailuresOrOk();
+        return await releaseAmendmentService.CreateReleaseAmendment(releaseVersionId).HandleFailuresOrOk();
     }
 
     [HttpGet("releaseVersions/{releaseVersionId:guid}/data/{fileId:guid}")]
     public async Task<ActionResult<DataFileInfo>> GetDataFileInfo(Guid releaseVersionId, Guid fileId)
     {
-        return await _releaseDataFileService.GetInfo(releaseVersionId, fileId).HandleFailuresOrOk();
+        return await releaseDataFileService.GetInfo(releaseVersionId, fileId).HandleFailuresOrOk();
     }
 
     [HttpGet(
@@ -83,7 +63,7 @@ public class ReleaseVersionsController : ControllerBase
         CancellationToken cancellationToken
     )
     {
-        return await _dataSetFileStorage
+        return await dataSetFileStorage
             .GetTemporaryFileDownloadToken(releaseVersionId, dataSetUploadId, fileType, cancellationToken)
             .OnSuccess(token => token.ToBase64JsonString())
             .HandleFailuresOrOk();
@@ -96,7 +76,7 @@ public class ReleaseVersionsController : ControllerBase
         Guid fileId
     )
     {
-        return await _releaseDataFileService
+        return await releaseDataFileService
             .GetAccoutrementsSummary(releaseVersionId: releaseVersionId, fileId: fileId)
             .HandleFailuresOrOk();
     }
@@ -104,7 +84,7 @@ public class ReleaseVersionsController : ControllerBase
     [HttpGet("releaseVersions/{releaseVersionId:guid}/data")]
     public async Task<ActionResult<List<DataFileInfo>>> GetDataFileInfo(Guid releaseVersionId)
     {
-        return await _releaseDataFileService.ListAll(releaseVersionId).HandleFailuresOrOk();
+        return await releaseDataFileService.ListAll(releaseVersionId).HandleFailuresOrOk();
     }
 
     [HttpGet("releaseVersions/{releaseVersionId:guid}/uploads")]
@@ -113,7 +93,7 @@ public class ReleaseVersionsController : ControllerBase
         CancellationToken cancellationToken
     )
     {
-        return await _dataSetUploadRepository.ListAll(releaseVersionId, cancellationToken).HandleFailuresOrOk();
+        return await dataSetUploadRepository.ListAll(releaseVersionId, cancellationToken).HandleFailuresOrOk();
     }
 
     [HttpDelete("releaseVersions/{releaseVersionId:guid}/upload/{dataSetUploadId:guid}")]
@@ -123,16 +103,26 @@ public class ReleaseVersionsController : ControllerBase
         CancellationToken cancellationToken
     )
     {
-        return await _dataSetUploadRepository
+        return await dataSetUploadRepository
             .Delete(releaseVersionId, dataSetUploadId, cancellationToken)
             .HandleFailuresOrNoContent();
+    }
+
+    [HttpGet("releaseVersions/{releaseVersionId:guid}/uploads/screener/progress")]
+    public async Task<
+        ActionResult<List<ScreenerProgressWithDataSetUploadIdViewModel>>
+    > GetDataSetUploadScreenerProgress(Guid releaseVersionId, CancellationToken cancellationToken)
+    {
+        return await dataSetScreenerService
+            .GetScreenerProgress(releaseVersionId, cancellationToken)
+            .HandleFailuresOrOk();
     }
 
     // We intend to change this route, to make these endpoints more consistent, as per EES-5895
     [HttpPut("release/{releaseVersionId:guid}/data/order")]
     public async Task<ActionResult<List<DataFileInfo>>> ReorderDataFiles(Guid releaseVersionId, List<Guid> fileIds)
     {
-        return await _releaseDataFileService.ReorderDataFiles(releaseVersionId, fileIds).HandleFailuresOrOk();
+        return await releaseDataFileService.ReorderDataFiles(releaseVersionId, fileIds).HandleFailuresOrOk();
     }
 
     [HttpPost("releaseVersions/data")]
@@ -146,7 +136,7 @@ public class ReleaseVersionsController : ControllerBase
         await using var dataFile = new ManagedStreamFormFile(request.DataFile);
         await using var metaFile = new ManagedStreamFormFile(request.MetaFile);
 
-        return await _releaseDataFileService
+        return await releaseDataFileService
             .Upload(request.ReleaseVersionId, dataFile, metaFile, request.Title, cancellationToken)
             .HandleFailuresOrOk();
     }
@@ -161,7 +151,7 @@ public class ReleaseVersionsController : ControllerBase
     {
         await using var zipFile = new ManagedStreamZipFormFile(request.ZipFile);
 
-        return await _releaseDataFileService
+        return await releaseDataFileService
             .UploadFromZip(request.ReleaseVersionId, zipFile, request.Title, cancellationToken)
             .HandleFailuresOrOk();
     }
@@ -176,7 +166,7 @@ public class ReleaseVersionsController : ControllerBase
     {
         await using var zipFile = new ManagedStreamZipFormFile(request.ZipFile);
 
-        return await _releaseDataFileService
+        return await releaseDataFileService
             .UploadFromBulkZip(request.ReleaseVersionId, zipFile, cancellationToken)
             .HandleFailuresOrOk();
     }
@@ -188,7 +178,7 @@ public class ReleaseVersionsController : ControllerBase
         CancellationToken cancellationToken
     )
     {
-        return await _releaseDataFileService
+        return await releaseDataFileService
             .SaveDataSetsFromTemporaryBlobStorage(releaseVersionId, dataSetUploadIds, cancellationToken)
             .HandleFailuresOrNoContent(convertNotFoundToNoContent: false);
     }
@@ -197,14 +187,14 @@ public class ReleaseVersionsController : ControllerBase
     [HttpGet("releases/{releaseVersionId:guid}")]
     public async Task<ActionResult<ReleaseVersionViewModel>> GetReleaseVersion(Guid releaseVersionId)
     {
-        return await _releaseVersionService.GetRelease(releaseVersionId).HandleFailuresOrOk();
+        return await releaseVersionService.GetRelease(releaseVersionId).HandleFailuresOrOk();
     }
 
     // We intend to change this route, to make these endpoints more consistent, as per EES-5895
     [HttpGet("releases/{releaseVersionId:guid}/status")]
     public async Task<ActionResult<List<ReleaseStatusViewModel>>> ListReleaseStatuses(Guid releaseVersionId)
     {
-        return await _releaseApprovalService.ListReleaseStatuses(releaseVersionId).HandleFailuresOrOk();
+        return await releaseApprovalService.ListReleaseStatuses(releaseVersionId).HandleFailuresOrOk();
     }
 
     // We intend to change this route, to make these endpoints more consistent, as per EES-5895
@@ -213,7 +203,7 @@ public class ReleaseVersionsController : ControllerBase
         Guid releaseVersionId
     )
     {
-        return await _releaseVersionService.GetReleasePublicationStatus(releaseVersionId).HandleFailuresOrOk();
+        return await releaseVersionService.GetReleasePublicationStatus(releaseVersionId).HandleFailuresOrOk();
     }
 
     [HttpPatch("releaseVersions/{releaseVersionId:guid}")]
@@ -222,7 +212,7 @@ public class ReleaseVersionsController : ControllerBase
         Guid releaseVersionId
     )
     {
-        return await _releaseVersionService.UpdateReleaseVersion(releaseVersionId, request).HandleFailuresOrOk();
+        return await releaseVersionService.UpdateReleaseVersion(releaseVersionId, request).HandleFailuresOrOk();
     }
 
     // We intend to change this route, to make these endpoints more consistent, as per EES-5895
@@ -232,9 +222,9 @@ public class ReleaseVersionsController : ControllerBase
         Guid releaseVersionId
     )
     {
-        return await _releaseApprovalService
+        return await releaseApprovalService
             .CreateReleaseStatus(releaseVersionId, request)
-            .OnSuccess(_ => _releaseVersionService.GetRelease(releaseVersionId))
+            .OnSuccess(_ => releaseVersionService.GetRelease(releaseVersionId))
             .HandleFailuresOrOk();
     }
 
@@ -242,14 +232,14 @@ public class ReleaseVersionsController : ControllerBase
     [HttpGet("publications/{publicationId:guid}/releases/template")]
     public async Task<ActionResult<IdTitleViewModel>> GetTemplateRelease([Required] Guid publicationId)
     {
-        return await _releaseVersionService.GetLatestPublishedRelease(publicationId).HandleFailuresOrOk();
+        return await releaseVersionService.GetLatestPublishedRelease(publicationId).HandleFailuresOrOk();
     }
 
     // We intend to change this route, to make these endpoints more consistent, as per EES-5895
     [HttpGet("releases/draft")]
     public async Task<ActionResult<List<ReleaseVersionSummaryViewModel>>> ListDraftReleases()
     {
-        return await _releaseVersionService
+        return await releaseVersionService
             .ListReleasesWithStatuses(ReleaseApprovalStatus.Draft, ReleaseApprovalStatus.HigherLevelReview)
             .HandleFailuresOrOk();
     }
@@ -258,21 +248,21 @@ public class ReleaseVersionsController : ControllerBase
     [HttpGet("releases/approvals")]
     public async Task<ActionResult<List<ReleaseVersionSummaryViewModel>>> ListUsersReleasesForApproval()
     {
-        return await _releaseVersionService.ListUsersReleasesForApproval().HandleFailuresOrOk();
+        return await releaseVersionService.ListUsersReleasesForApproval().HandleFailuresOrOk();
     }
 
     // We intend to change this route, to make these endpoints more consistent, as per EES-5895
     [HttpGet("releases/scheduled")]
     public async Task<ActionResult<List<ReleaseVersionSummaryViewModel>>> ListScheduledReleases()
     {
-        return await _releaseVersionService.ListScheduledReleases().HandleFailuresOrOk();
+        return await releaseVersionService.ListScheduledReleases().HandleFailuresOrOk();
     }
 
     // We intend to change this route, to make these endpoints more consistent, as per EES-5895
     [HttpGet("release/{releaseVersionId:guid}/data/{fileId:guid}/import/status")]
     public Task<ActionResult<DataImportStatusViewModel>> GetDataUploadStatus(Guid releaseVersionId, Guid fileId)
     {
-        return _releaseVersionService
+        return releaseVersionService
             .GetDataFileImportStatus(releaseVersionId: releaseVersionId, fileId: fileId)
             .HandleFailuresOrOk();
     }
@@ -284,7 +274,7 @@ public class ReleaseVersionsController : ControllerBase
         CancellationToken cancellationToken
     )
     {
-        return await _releaseVersionService
+        return await releaseVersionService
             .GetDeleteReleaseVersionPlan(releaseVersionId, cancellationToken)
             .HandleFailuresOrOk();
     }
@@ -297,7 +287,7 @@ public class ReleaseVersionsController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
-        return await _releaseVersionService
+        return await releaseVersionService
             .GetDeleteDataFilePlan(
                 releaseVersionId: releaseVersionId,
                 fileId: fileId,
@@ -310,7 +300,7 @@ public class ReleaseVersionsController : ControllerBase
     [HttpDelete("release/{releaseVersionId:guid}/data/{fileId:guid}")]
     public async Task<ActionResult> DeleteDataFiles(Guid releaseVersionId, Guid fileId)
     {
-        return await _releaseVersionService
+        return await releaseVersionService
             .RemoveDataFiles(releaseVersionId: releaseVersionId, fileId: fileId)
             .HandleFailuresOrNoContent();
     }
@@ -319,7 +309,7 @@ public class ReleaseVersionsController : ControllerBase
     [HttpPost("release/{releaseVersionId:guid}/data/{fileId:guid}/import/cancel")]
     public async Task<ActionResult> CancelFileImport(Guid releaseVersionId, Guid fileId)
     {
-        return await _dataImportService
+        return await dataImportService
             .CancelImport(releaseVersionId: releaseVersionId, fileId: fileId)
             .HandleFailuresOr(_ => new AcceptedResult());
     }
@@ -328,13 +318,13 @@ public class ReleaseVersionsController : ControllerBase
     [HttpGet("releases/{releaseVersionId:guid}/stage-status")]
     public async Task<ActionResult<ReleasePublishingStatusViewModel>> GetReleaseStatusesAsync(Guid releaseVersionId)
     {
-        return await _releasePublishingStatusService.GetReleaseStatusAsync(releaseVersionId).HandleFailuresOrOk();
+        return await releasePublishingStatusService.GetReleaseStatusAsync(releaseVersionId).HandleFailuresOrOk();
     }
 
     [HttpGet("releaseVersions/{releaseVersionId:guid}/checklist")]
     public async Task<ActionResult<ReleaseChecklistViewModel>> GetChecklist(Guid releaseVersionId)
     {
-        return await _releaseChecklistService.GetChecklist(releaseVersionId).HandleFailuresOrOk();
+        return await releaseChecklistService.GetChecklist(releaseVersionId).HandleFailuresOrOk();
     }
 
     [HttpPatch("releaseVersions/{releaseVersionId:guid}/prerelease-access-list")]
@@ -343,9 +333,9 @@ public class ReleaseVersionsController : ControllerBase
         ReleaseVersionPreReleaseAccessListUpdateRequest request,
         CancellationToken cancellationToken = default
     ) =>
-        await _releaseVersionService
+        await releaseVersionService
             .UpdatePreReleaseAccessList(releaseVersionId, request, cancellationToken)
-            .OnSuccess(_ => _releaseVersionService.GetRelease(releaseVersionId))
+            .OnSuccess(_ => releaseVersionService.GetRelease(releaseVersionId))
             .HandleFailuresOrOk();
 
     [HttpPatch("releaseVersions/{releaseVersionId:guid}/published-display-date")]
@@ -354,7 +344,7 @@ public class ReleaseVersionsController : ControllerBase
         ReleaseVersionPublishedDisplayDateUpdateRequest request
     )
     {
-        return await _releaseVersionService
+        return await releaseVersionService
             .UpdatePublishedDisplayDate(releaseVersionId, request)
             .HandleFailuresOrNoContent();
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -1,12 +1,11 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
-using GovUk.Education.ExploreEducationStatistics.Admin.Responses.Screener;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Public.Data;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Mappings;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Screener;
 using GovUk.Education.ExploreEducationStatistics.Common.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -130,7 +129,7 @@ public class MappingProfiles : CommonMappingProfile
             .ForMember(dest => dest.Status, m => m.MapFrom(upload => GetDataSetUploadStatus(upload.ScreenerResult)))
             .ForMember(
                 dest => dest.PublicApiCompatible,
-                m => m.MapFrom(upload => upload.ScreenerResult.PublicApiCompatible)
+                m => m.MapFrom(upload => upload.ScreenerResult != null && upload.ScreenerResult.PublicApiCompatible)
             )
             .ForMember(
                 dest => dest.DataFileSize,
@@ -143,6 +142,8 @@ public class MappingProfiles : CommonMappingProfile
 
         CreateMap<DataSetScreenerResponse, ScreenerResultViewModel>();
 
+        CreateMap<DataSetScreenerProgress, ScreenerProgressViewModel>();
+
         CreateMap<DataScreenerTestResult, ScreenerTestResultViewModel>()
             .ForMember(dest => dest.Result, m => m.MapFrom(upload => upload.Result.ToString()));
 
@@ -154,7 +155,7 @@ public class MappingProfiles : CommonMappingProfile
             .ForMember(d => d.DataSetId, m => m.MapFrom(upload => upload.Id));
     }
 
-    private static string GetDataSetUploadStatus(DataSetScreenerResponse screenerResult)
+    private static string GetDataSetUploadStatus(DataSetScreenerResponse? screenerResult)
     {
         if (screenerResult is null)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Screener/IDataSetScreenerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Screener/IDataSetScreenerService.cs
@@ -1,7 +1,9 @@
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Responses.Screener;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Screener;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Screener;
 
@@ -26,4 +28,12 @@ public interface IDataSetScreenerService
     /// this method will also exclude any data sets that had their progress updated very recently.
     /// </summary>
     Task<List<DataSetScreenerProgressResponse>> UpdateScreeningProgress(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get the progress of all data sets undergoing screening for a given ReleaseVersion.
+    /// </summary>
+    Task<Either<ActionResult, List<ScreenerProgressWithDataSetUploadIdViewModel>>> GetScreenerProgress(
+        Guid releaseVersionId,
+        CancellationToken cancellationToken
+    );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
@@ -2,10 +2,16 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Options;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Responses.Screener;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Screener;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Screener;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -14,6 +20,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Screener;
 public class DataSetScreenerService(
     IDataSetScreenerClient dataSetScreenerClient,
     [FromKeyedServices(nameof(DataSetScreenerService))] IQueueServiceClient queueServiceClient,
+    IUserService userService,
     ContentDbContext contentDbContext,
     TimeProvider timeProvider,
     IOptions<DataScreenerOptions> options
@@ -99,5 +106,32 @@ public class DataSetScreenerService(
         await contentDbContext.SaveChangesAsync(cancellationToken: cancellationToken);
 
         return progressResults;
+    }
+
+    public Task<Either<ActionResult, List<ScreenerProgressWithDataSetUploadIdViewModel>>> GetScreenerProgress(
+        Guid releaseVersionId,
+        CancellationToken cancellationToken
+    )
+    {
+        return contentDbContext
+            .ReleaseVersions.SingleOrNotFound(rv => rv.Id == releaseVersionId)
+            .OnSuccess(userService.CheckCanViewReleaseVersion)
+            .OnSuccess(async () =>
+            {
+                var dataSetsUndergoingScreening = await contentDbContext
+                    .DataSetUploads.Where(upload =>
+                        upload.ReleaseVersionId == releaseVersionId && upload.Status == DataSetUploadStatus.SCREENING
+                    )
+                    .ToListAsync(cancellationToken: cancellationToken);
+
+                return dataSetsUndergoingScreening
+                    .Select(upload => new ScreenerProgressWithDataSetUploadIdViewModel
+                    {
+                        DataSetUploadId = upload.Id,
+                        PercentageComplete = upload.ScreenerProgress?.PercentageComplete ?? 0,
+                        Stage = upload.ScreenerProgress?.Stage,
+                    })
+                    .ToList();
+            });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataSetUploadViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataSetUploadViewModel.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
+
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 
 public record DataSetUploadViewModel
@@ -18,6 +20,8 @@ public record DataSetUploadViewModel
     public required string Status { get; set; }
 
     public ScreenerResultViewModel? ScreenerResult { get; set; }
+
+    public ScreenerProgressViewModel? ScreenerProgress { get; set; }
 
     public required DateTime Created { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Screener/ScreenerProgressViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Screener/ScreenerProgressViewModel.cs
@@ -1,8 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
 
-public class ScreenerProgressViewModel
+public record ScreenerProgressViewModel
 {
     public int PercentageComplete { get; set; }
 
     public string Stage { get; set; } = null!;
+}
+
+public record ScreenerProgressWithDataSetUploadIdViewModel : ScreenerProgressViewModel
+{
+    public Guid DataSetUploadId { get; set; }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Screener/ScreenerProgressViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Screener/ScreenerProgressViewModel.cs
@@ -1,0 +1,8 @@
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
+
+public class ScreenerProgressViewModel
+{
+    public int PercentageComplete { get; set; }
+
+    public string Stage { get; set; } = null!;
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Screener/ScreenerResultViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Screener/ScreenerResultViewModel.cs
@@ -1,11 +1,9 @@
 #nullable enable
-namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
 
 public record ScreenerResultViewModel
 {
     public required string OverallResult { get; set; }
-
-    public required string Message { get; set; }
 
     public List<ScreenerTestResultViewModel> TestResults { get; set; } = [];
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Screener/ScreenerTestResultViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Screener/ScreenerTestResultViewModel.cs
@@ -1,5 +1,5 @@
 #nullable enable
-namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
 
 public record ScreenerTestResultViewModel
 {


### PR DESCRIPTION
This PR:
- adds more support for the enhanced Screener user journey.
- adds an Admin controller endpoint to allow the front end to request progress updates for all of the data sets currently undergoing screening under a given ReleaseVersion.
- adds a service method to get the  progress updates for all of the data sets currently undergoing screening under a given ReleaseVersion.

This will let the user see periodic Screener progress updates via the "Data and files" tab when the front end is hooked up.

The next piece of work to be carried out to support the enhanced user journey will be a scheduled job that will allow Admin to periodically update the Screener progress in the Content DB by querying the Screener API (via a mechanism that is already built but not currently being periodically called).

This PR also contains a bit of reorganisation, moving some classes into "Screener" subfolders in the codebase, and moving some Admin-only Screener-related records out of Common and into Admin. 