### PR TITLE
EES-7028 Refactor table tool to remove `PublicationReleaseSummary` after release page redesign

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseController.cs
@@ -24,12 +24,19 @@ public class ReleaseController(
     TimeProvider timeProvider
 ) : ControllerBase
 {
+    /// <summary>
+    /// Returns a list of releases for a given publication, used by the Public site frontend Data Catalogue page
+    /// when a publication is selected.
+    /// </summary>
     [HttpGet("publications/{publicationSlug}/releases")]
     public async Task<ActionResult<List<ReleaseSummaryViewModel>>> ListReleases(string publicationSlug)
     {
         return await releaseService.List(publicationSlug).HandleFailuresOrOk();
     }
 
+    /// <summary>
+    /// TODO This is pending removal by EES-7022 (PR #6939) but depends on EES-7102 removing usages of it first
+    /// </summary>
     [HttpGet("publications/{publicationSlug}/releases/latest")]
     public Task<ActionResult<ReleaseViewModel>> GetLatestRelease(string publicationSlug)
     {
@@ -43,12 +50,18 @@ public class ReleaseController(
         );
     }
 
+    /// <summary>
+    /// TODO This is unused after EES-7028 (PR #6947) and pending removal by EES-7022 (PR #6939)
+    /// </summary>
     [HttpGet("publications/{publicationSlug}/releases/latest/summary")]
     public async Task<ActionResult<ReleaseSummaryViewModel>> GetLatestReleaseSummary(string publicationSlug)
     {
         return await GetReleaseSummaryViewModel(publicationSlug).HandleFailuresOrOk();
     }
 
+    /// <summary>
+    /// TODO This is unused after EES-7028 (PR #6940) and pending removal by EES-7022 (PR #6939)
+    /// </summary>
     [HttpGet("publications/{publicationSlug}/releases/{releaseSlug}")]
     public Task<ActionResult<ReleaseViewModel>> GetRelease(string publicationSlug, string releaseSlug)
     {
@@ -62,6 +75,9 @@ public class ReleaseController(
         );
     }
 
+    /// <summary>
+    /// TODO This is unused after EES-7028 (PR #6947) and pending removal by EES-7022 (PR #6939)
+    /// </summary>
     [HttpGet("publications/{publicationSlug}/releases/{releaseSlug}/summary")]
     public async Task<ActionResult<ReleaseSummaryViewModel>> GetReleaseSummary(
         string publicationSlug,

--- a/src/explore-education-statistics-admin/src/prototypes/components/PrototypeTableToolWizard.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/components/PrototypeTableToolWizard.tsx
@@ -39,7 +39,8 @@ import {
   timePeriodSubjectMeta,
   subjectMeta,
   subjects,
-  summary,
+  publicationSummary,
+  releaseVersionSummary,
 } from '@admin/prototypes/data/tableToolData';
 
 export interface InitialTableToolState {
@@ -141,10 +142,19 @@ const PrototypeTableToolWizard = ({
 
     const featuredTables: FeaturedTable[] = [];
 
-    // const latestRelease = await publicationService.getLatestPublicationReleaseSummary(
+    // const publicationSummary = await publicationService.getPublicationSummary(
     //   publication.slug,
     // );
-    const latestRelease = summary;
+
+    const { latestRelease } = publicationSummary;
+
+    // const selectedReleaseVersion =
+    //   await publicationService.getReleaseVersionSummary(
+    //     publication.slug,
+    //     latestRelease.slug,
+    //   );
+
+    const selectedReleaseVersion = releaseVersionSummary;
 
     updateState(draft => {
       draft.subjects = subjects;
@@ -156,11 +166,11 @@ const PrototypeTableToolWizard = ({
         slug: publication.slug,
         title: publication.title,
         selectedRelease: {
-          id: latestRelease.id,
-          latestData: latestRelease.latestRelease,
-          slug: latestRelease.slug,
-          title: latestRelease.title,
-          type: latestRelease.type,
+          id: selectedReleaseVersion.id,
+          latestData: selectedReleaseVersion.isLatestRelease,
+          slug: selectedReleaseVersion.slug,
+          title: selectedReleaseVersion.title,
+          type: selectedReleaseVersion.type,
         },
         latestRelease: {
           title: latestRelease.title,

--- a/src/explore-education-statistics-admin/src/prototypes/data/tableToolData.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/data/tableToolData.tsx
@@ -3,7 +3,10 @@ import {
   SubjectMeta,
   TableDataResponse,
 } from '@common/services/tableBuilderService';
-import { PublicationReleaseSummary } from '@common/services/publicationService';
+import {
+  ReleaseVersionSummary,
+  PublicationSummary,
+} from '@common/services/publicationService';
 
 // eslint-disable-next-line import/prefer-default-export
 export const subjects: Subject[] = [
@@ -673,32 +676,41 @@ export const subjects: Subject[] = [
   },
 ];
 
-export const summary: PublicationReleaseSummary = {
-  id: 'dc190008-a8f7-41a4-faa6-08d973655eae',
-  title: 'Reporting Year 2021',
-  slug: '2021',
-  yearTitle: '2021',
-  coverageTitle: 'Reporting Year',
+export const publicationSummary: PublicationSummary = {
+  id: '89869bba-0c00-40f7-b7d6-e28cb904ad37',
+  title: 'Characteristics of children in need',
+  slug: "Statistics on children in need in England, including child protection plans and referrals to and assessments completed by children's social care services.",
+  summary: 'Publication summary',
+  latestRelease: {
+    id: 'dc190008-a8f7-41a4-faa6-08d973655eae',
+    slug: '2021',
+    title: 'Reporting Year 2021',
+  },
+  contact: {
+    teamName: 'Contact Team Name',
+    teamEmail: 'Contact Team Email',
+    contactName: 'Contact Name',
+  },
+  theme: {
+    id: 'a05c8110-9f6e-49c3-a715-dfcee76aaa9a',
+    title: "Children's social care",
+    summary:
+      'Including children in need and child protection, children looked after and social work workforce statistics.',
+  },
+};
+
+export const releaseVersionSummary: ReleaseVersionSummary = {
+  id: '7bfe9a51-ec89-486e-aa6d-09fb45ae1a43',
+  isLatestRelease: true,
+  lastUpdated: '2021-10-28T08:30:02.6926703',
   published: '2021-10-28T08:30:02.6926703',
-  nextReleaseDate: {
-    year: '2022',
-    month: '10',
-    day: '',
-  },
+  slug: '2021',
+  title: 'Reporting Year 2021',
+  coverageTitle: 'Reporting Year',
+  yearTitle: '2021',
   type: 'AccreditedOfficialStatistics',
-  latestRelease: true,
-  publication: {
-    id: '89869bba-0c00-40f7-b7d6-e28cb904ad37',
-    title: 'Characteristics of children in need',
-    slug: 'characteristics-of-children-in-need',
-    latestReleaseSlug: 'latest-release-slug',
-    owner: true,
-    contact: {
-      teamName: 'Contact Team Name',
-      teamEmail: 'Contact Team Email',
-      contactName: 'Contact Name',
-    },
-  },
+  updateCount: 1,
+  preReleaseAccessList: '',
 };
 
 export const subjectMeta: SubjectMeta = {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -200,9 +200,14 @@ export default function TableToolWizard({
       tableBuilderService.listLatestReleaseFeaturedTables(publication.id),
     ]);
 
-    const latestRelease =
-      await publicationService.getLatestPublicationReleaseSummary(
+    const publicationSummary = await publicationService.getPublicationSummary(
+      publication.slug,
+    );
+    const { latestRelease } = publicationSummary;
+    const selectedReleaseVersion =
+      await publicationService.getReleaseVersionSummary(
         publication.slug,
+        latestRelease.slug,
       );
 
     const updatedDataSetTitle =
@@ -218,11 +223,11 @@ export default function TableToolWizard({
       draft.selectedPublication = {
         ...publication,
         selectedRelease: {
-          id: latestRelease.id,
-          latestData: latestRelease.latestRelease,
-          slug: latestRelease.slug,
-          title: latestRelease.title,
-          type: latestRelease.type,
+          id: selectedReleaseVersion.id,
+          latestData: selectedReleaseVersion.isLatestRelease,
+          slug: selectedReleaseVersion.slug,
+          title: selectedReleaseVersion.title,
+          type: selectedReleaseVersion.type,
         },
         latestRelease: {
           title: latestRelease.title,

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -367,10 +367,6 @@ export interface ReleaseSummary {
   latestRelease: boolean;
 }
 
-export interface PublicationReleaseSummary extends ReleaseSummary {
-  publication: PublicationSummaryPreview;
-}
-
 export interface PublicationTreeSummary {
   id: string;
   title: string;
@@ -428,23 +424,6 @@ const publicationService = {
     publicationSlug: string,
   ): Promise<ReleaseVersion> {
     return contentApi.get(`/publications/${publicationSlug}/releases/latest`);
-  },
-  // Currently used within table tool
-  getPublicationReleaseSummary(
-    publicationSlug: string,
-    releaseSlug: string,
-  ): Promise<PublicationReleaseSummary> {
-    return contentApi.get(
-      `/publications/${publicationSlug}/releases/${releaseSlug}/summary`,
-    );
-  },
-  // Currently used within table tool
-  getLatestPublicationReleaseSummary(
-    publicationSlug: string,
-  ): Promise<PublicationReleaseSummary> {
-    return contentApi.get(
-      `/publications/${publicationSlug}/releases/latest/summary`,
-    );
   },
   getReleaseVersionSummary(
     publicationSlug: string,

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -209,7 +209,7 @@ export interface ReleaseVersion<
 export interface ReleaseVersionSummary {
   coverageTitle: string;
   id: string;
-  isLatestRelease?: boolean;
+  isLatestRelease: boolean;
   label?: string;
   lastUpdated: string;
   published: string;

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -336,29 +336,26 @@ export const getServerSideProps: GetServerSideProps<
     };
   }
 
-  const latestRelease =
-    await publicationService.getLatestPublicationReleaseSummary(
+  const publicationSummary = await publicationService.getPublicationSummary(
+    publicationSlug,
+  );
+  const { latestRelease } = publicationSummary;
+  const selectedReleaseVersion =
+    await publicationService.getReleaseVersionSummary(
       publicationSlug,
+      releaseSlug ?? latestRelease.slug,
     );
 
-  const selectedRelease =
-    !releaseSlug || latestRelease.slug === releaseSlug
-      ? latestRelease
-      : await publicationService.getPublicationReleaseSummary(
-          publicationSlug,
-          releaseSlug,
-        );
-
   const [subjects, featuredTables, fullPublication] = await Promise.all([
-    tableBuilderService.listReleaseSubjects(selectedRelease.id),
-    tableBuilderService.listReleaseFeaturedTables(selectedRelease.id),
+    tableBuilderService.listReleaseSubjects(selectedReleaseVersion.id),
+    tableBuilderService.listReleaseFeaturedTables(selectedReleaseVersion.id),
     publicationService.getLatestPublicationRelease(publicationSlug),
   ]);
 
   if (subjectId && subjects.some(subject => subject.id === subjectId)) {
     const subjectMeta = await tableBuilderService.getSubjectMeta(
       subjectId,
-      selectedRelease.id,
+      selectedReleaseVersion.id,
     );
 
     return {
@@ -368,11 +365,11 @@ export const getServerSideProps: GetServerSideProps<
         selectedPublication: {
           ...selectedPublication,
           selectedRelease: {
-            id: selectedRelease.id,
-            latestData: selectedRelease.latestRelease,
-            slug: selectedRelease.slug,
-            title: selectedRelease.title,
-            type: selectedRelease.type,
+            id: selectedReleaseVersion.id,
+            latestData: selectedReleaseVersion.isLatestRelease,
+            slug: selectedReleaseVersion.slug,
+            title: selectedReleaseVersion.title,
+            type: selectedReleaseVersion.type,
           },
           latestRelease: {
             title: latestRelease.title,
@@ -394,11 +391,11 @@ export const getServerSideProps: GetServerSideProps<
       selectedPublication: {
         ...selectedPublication,
         selectedRelease: {
-          id: selectedRelease.id,
-          latestData: selectedRelease.latestRelease,
-          slug: selectedRelease.slug,
-          title: selectedRelease.title,
-          type: selectedRelease.type,
+          id: selectedReleaseVersion.id,
+          latestData: selectedReleaseVersion.isLatestRelease,
+          slug: selectedReleaseVersion.slug,
+          title: selectedReleaseVersion.title,
+          type: selectedReleaseVersion.type,
         },
         latestRelease: {
           title: latestRelease.title,

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -343,7 +343,7 @@ export const getServerSideProps: GetServerSideProps<
   const selectedReleaseVersion =
     await publicationService.getReleaseVersionSummary(
       publicationSlug,
-      releaseSlug ?? latestRelease.slug,
+      releaseSlug || latestRelease.slug,
     );
 
   const [subjects, featuredTables, fullPublication] = await Promise.all([


### PR DESCRIPTION
This PR is a frontend change which removes usages of `getPublicationReleaseSummary` and `getLatestPublicationReleaseSummary ` from `publicationService.ts`, and removes the `PublicationReleaseSummary` type. This work is part of the tidy-up after the redesigned release page has gone live.

These methods were used by the table tool and correspond with the Content API's endpoints as follows:

- `publicationService.getPublicationReleaseSummary` -> `Content.Api.Controllers.ReleaseController.GetReleaseSummary`
- `publicationService.getLatestPublicationReleaseSummary` -> `Content.Api.Controllers.ReleaseController.GetLatestReleaseSummary`

Both of these involved retrieving the full publication and release version in the backend, including all of the release version summary content in order to produce a narrowed release summary response model.

These Content API endpoints are intended to be removed from the backend by #6939.

The solution in the PR to allow for removing these, at least for now, has been to switch to using `publicationService.getReleaseVersionSummary` which contains all the required information for the selected release (release version id, release version type etc).

Unfortunately this has required adding an additional API call via `publicationService.getPublicationSummary` to get the latest release slug (in the case where a specific release slug hasn't been requested) before getting the version summary which requires the release slug, but the page is already making multiple calls so I didn't really see this as a big concern.

### Changes to prototypes

To enable the removal of the `PublicationReleaseSummary` type completely, the `PrototypeTableToolWizard.tsx` and the prototypes table tool data in `tableToolData.tsx` are also updated.

These changes are in a separate commit.

ℹ️ Protoypes are about to be removed by EES-7068 so these changes can probably be ignored during a review.

### Other changes

- Correct the nullability of `ReleaseVersionSummary.isLatestRelease` in `publicationService.ts` which will always be present. This change is in the first commit.

### UI test report

<img width="1076" height="118" alt="image" src="https://github.com/user-attachments/assets/1ef48c2e-e889-453e-bc89-4396a3358ca0" />
