### PR TITLE
🐛 EES-7078 Correct the name of property used by the Search Doc Function App's Content API Client

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/Dtos/ReleaseVersionSummaryDto.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Clients/ContentApi/Dtos/ReleaseVersionSummaryDto.cs
@@ -13,7 +13,7 @@ public record ReleaseVersionSummaryDto
     public string? CoverageTitle { get; init; }
     public DateTimeOffset? Published { get; init; }
     public string? Type { get; init; }
-    public bool? LatestRelease { get; init; }
+    public bool? IsLatestRelease { get; init; }
     public ReleaseVersionSummaryPublicationDto? Publication { get; init; }
 
     public ReleaseVersionSummary ToModel() =>
@@ -27,7 +27,7 @@ public record ReleaseVersionSummaryDto
             CoverageTitle = CoverageTitle,
             Published = Published,
             Type = Type,
-            IsLatestRelease = LatestRelease,
+            IsLatestRelease = IsLatestRelease,
             PublicationId = Publication?.Id,
             PublicationTitle = Publication?.Title,
             PublicationSlug = Publication?.Slug,


### PR DESCRIPTION
This PR is a tiny bugfix after #6924 because when testing the Search Doc Function App's `SearchableDocumentCheck` with @N-moh we noticed an unexpected `null` value in the report that's returned in the function's response.

The response returned for the Dev environment looked like this:

```json
{
    "okBlobCount": 286,
    "totalBlobCount": 286,
    "totalPublicationCount": 287,
    "missingBlobs": [
        "04508005-0bf0-4704-93da-08de8b243341"
    ],
    "extraneousBlobs": [],
    "missingBlobSummaries": [
        {
            "id": "5688c012-be00-4eb9-fc9a-08de8b243331",
            "releaseId": "04508005-0bf0-4704-93da-08de8b243341",
            "title": "Academic year Q1 2020/21",
            "slug": "2020-21-q1",
            "yearTitle": "2020/21",
            "coverageTitle": "Academic year Q1",
            "published": "2026-03-26T11:22:05.5780701+00:00",
            "type": "AccreditedOfficialStatistics",
            "isLatestRelease": null,
            "publicationId": "dca2d01e-4056-4d1d-c96b-08de8b2432ea",
            "publicationTitle": "Data catalogue 04q8fk-3",
            "publicationSlug": "data-catalogue-04q8fk-3"
        }
    ]
}
```
But we don't expect this because it should be either `true` or `false`:

```
"isLatestRelease": null,
```

The issue was in the DTO used by the function app's Content API client which it expects to be able to deserialize the response by, because the property returned in the Content API's response is `IsLatestRelease`, NOT `LatestRelease`.