### PR TITLE
EES-6970: Table tool hierarchy quick link to select everything in single tier

### DIFF
--- a/src/explore-education-statistics-common/src/components/ButtonText.tsx
+++ b/src/explore-education-statistics-common/src/components/ButtonText.tsx
@@ -7,12 +7,14 @@ export interface ButtonTextProps extends ButtonOptions {
   ref?: Ref<HTMLButtonElement>;
   underline?: boolean;
   variant?: 'secondary' | 'warning';
+  title?: string;
 }
 
 const ButtonText = ({
   ref,
   underline = true,
   variant,
+  title,
   ...props
 }: ButtonTextProps) => {
   const { className, ...button } = useButton(props);
@@ -32,6 +34,7 @@ const ButtonText = ({
         className,
       )}
       ref={ref}
+      title={title}
     />
   );
 };

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
@@ -4,6 +4,7 @@ import { useFormIdContext } from '@common/components/form/contexts/FormIdContext
 import FormCheckboxSelectedCount from '@common/components/form/FormCheckboxSelectedCount';
 import FormSearchBar from '@common/components/form/FormSearchBar';
 import Modal from '@common/components/Modal';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 import FilterAccordion from '@common/modules/table-tool/components/FilterAccordion';
 import getFilterOptionIdsRecursively from '@common/modules/table-tool/utils/getFilterOptionIdsRecursively';
 import { SubjectMetaFilterHierarchy } from '@common/services/tableBuilderService';
@@ -41,6 +42,7 @@ export interface FilterHierarchyProps {
 export interface TierSelectionState {
   tier: number;
   selected: boolean;
+  disabled: boolean;
 }
 
 function FilterHierarchy({
@@ -67,7 +69,7 @@ function FilterHierarchy({
   const tiersInitialState = () => {
     const tierState: TierSelectionState[] = [];
     for (let i = 0; i < tiersTotal; i += 1) {
-      tierState.push({ tier: i, selected: false });
+      tierState.push({ tier: i, selected: false, disabled: false });
     }
 
     return tierState;
@@ -112,7 +114,7 @@ function FilterHierarchy({
       tierSelectedValues.includes(filterOptionId),
     );
 
-    setTierSelectionState(prev =>
+    updateTierSelectionState(prev =>
       prev.map((item, index) =>
         index === tier ? { ...item, selected: allTierOptionsSelected } : item,
       ),
@@ -120,6 +122,20 @@ function FilterHierarchy({
   };
 
   const [expandedOptionsList, setExpandedOptionsList] = useState<string[]>([]);
+  const [tierSelectionLoading, setTierSelectionLoading] = useState(false);
+
+  const updateTierSelectionState = (
+    updater: (prev: TierSelectionState[]) => TierSelectionState[],
+  ) => {
+    setTierSelectionLoading(true);
+    setTierSelectionState(updater);
+  };
+
+  useEffect(() => {
+    if (tierSelectionLoading) {
+      setTierSelectionLoading(false);
+    }
+  }, [tierSelectionState, tierSelectionLoading]);
 
   const filterLabels: string[] = [
     ...filterHierarchy.map(({ filterId }) => optionLabelsMap[filterId ?? '']),
@@ -196,6 +212,25 @@ function FilterHierarchy({
     expandAllOptions,
   ]);
 
+  const watchedValues: string[] = useWatch({ name });
+  const selectedValues = useMemo(() => watchedValues ?? [], [watchedValues]);
+
+  useEffect(() => {
+    updateTierSelectionState(prev =>
+      prev.map((item, index) => ({
+        ...item,
+        disabled:
+          hierarchySearchTerm !== '' &&
+          (!tierOptions[index] || tierOptions[index].length === 0),
+        selected:
+          tierOptions[index]?.length > 0 &&
+          tierOptions[index].every(filterOptionId =>
+            selectedValues.includes(filterOptionId),
+          ),
+      })),
+    );
+  }, [tierOptions, hierarchySearchTerm, selectedValues]);
+
   const getOptionUniqueValue = useCallback(
     (optionValue: string): string => {
       return hierarchyOptionsToString(
@@ -209,7 +244,6 @@ function FilterHierarchy({
     [filterHierarchy, name, optionLabelsMap],
   );
 
-  const selectedValues: string[] = useWatch({ name }) ?? [];
   const optionsWithSelectedChildren: SelectedChildren = useMemo(() => {
     if (!selectedValues?.length) {
       return {
@@ -375,7 +409,7 @@ function FilterHierarchy({
         error={errorMessage?.toString()}
       >
         <div data-testid="filter-hierarchy-options">
-          <div className="dfe-flex dfe-gap-4">
+          <div className="dfe-flex dfe-gap-4 dfe-align-items--baseline">
             {filterLabels.map((filterLabel, index) => {
               const isLast = index + 1 === filterLabels.length;
 
@@ -385,10 +419,13 @@ function FilterHierarchy({
                   className={
                     !isLast
                       ? 'dfe-border-right govuk-!-padding-right-5 govuk-!-margin-bottom-3'
-                      : undefined
+                      : 'govuk-!-margin-bottom-3'
                   }
                 >
-                  <ButtonText onClick={() => toggleTierSelection(index)}>
+                  <ButtonText
+                    onClick={() => toggleTierSelection(index)}
+                    disabled={tierSelectionState[index].disabled}
+                  >
                     {tierSelectionState[index].selected ? 'Unselect' : 'Select'}{' '}
                     {hierarchySearchTerm ? '' : 'all'} {filterLabel} (tier{' '}
                     {index + 1})
@@ -396,6 +433,7 @@ function FilterHierarchy({
                 </div>
               );
             })}
+            <LoadingSpinner loading={tierSelectionLoading} inline size="sm" />
           </div>
           {rootOptionTrees.map(optionTree => {
             return (

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
@@ -54,6 +54,8 @@ function FilterHierarchy({
 }: FilterHierarchyProps) {
   const {
     formState: { errors },
+    setValue,
+    getValues,
   } = useFormContext();
 
   const { fieldId } = useFormIdContext();
@@ -75,13 +77,46 @@ function FilterHierarchy({
     useState<TierSelectionState[]>(tiersInitialState);
 
   const toggleTierSelection = (tier: number) => {
-    setTierSelectionState(prev => ({
-      ...prev,
-      [tier]: {
-        ...prev[tier],
-        selected: !prev[tier].selected,
-      },
-    }));
+    toggleCheckboxSelectionsForTier(tier);
+    toggleSelectionStateForTier(tier);
+  };
+
+  const toggleCheckboxSelectionsForTier = (tier: number) => {
+    if (tierSelectionState[tier].selected) {
+      deselectAllFiltersForTier(tier);
+    } else {
+      selectAllFiltersForTier(tier);
+    }
+  };
+
+  const deselectAllFiltersForTier = (tier: number) => {
+    setValue(
+      name,
+      selectedValues.filter(sv => !tierOptions[tier].includes(sv)),
+    );
+  };
+
+  const selectAllFiltersForTier = (tier: number) => {
+    const combinedSelections = [...selectedValues, ...tierOptions[tier]];
+    const distinctSelections = combinedSelections.reduce(
+      (acc: string[], item) => (acc.includes(item) ? acc : [...acc, item]),
+      [],
+    );
+
+    setValue(name, distinctSelections);
+  };
+
+  const toggleSelectionStateForTier = (tier: number) => {
+    const tierSelectedValues: string[] = getValues(name);
+    const allTierOptionsSelected = tierOptions[tier].every(filterOptionId =>
+      tierSelectedValues.includes(filterOptionId),
+    );
+
+    setTierSelectionState(prev =>
+      prev.map((item, index) =>
+        index === tier ? { ...item, selected: allTierOptionsSelected } : item,
+      ),
+    );
   };
 
   const [expandedOptionsList, setExpandedOptionsList] = useState<string[]>([]);
@@ -115,7 +150,15 @@ function FilterHierarchy({
     [setExpandedOptionsList],
   );
 
-  const { rootOptionTrees, searchLegend } = useMemo(() => {
+  const {
+    rootOptionTrees,
+    tierOptions,
+    searchLegend,
+  }: {
+    rootOptionTrees: FilterHierarchyOption[];
+    tierOptions: string[][];
+    searchLegend: string;
+  } = useMemo(() => {
     const optionTrees = getRootOptionTrees(
       filterHierarchy,
       optionLabelsMap,
@@ -124,9 +167,11 @@ function FilterHierarchy({
     if (optionTrees.length === 0) {
       return {
         rootOptionTrees: [],
+        tierOptions: [],
         searchLegend: `No options found, searching '${hierarchySearchTerm}' in all tiers of ${legend.toLowerCase()}, please expand your search`,
       };
     }
+    const optionsByTier = buildTierArray(optionTrees);
 
     if (hierarchySearchTerm) {
       expandAllOptions(optionTrees);
@@ -138,7 +183,11 @@ function FilterHierarchy({
       ? `Searching '${hierarchySearchTerm}' in all tiers of ${legend.toLowerCase()}`
       : `Browse all tiers of ${legend.toLowerCase()}`;
 
-    return { rootOptionTrees: optionTrees, searchLegend: searchHint };
+    return {
+      rootOptionTrees: optionTrees,
+      tierOptions: optionsByTier,
+      searchLegend: searchHint,
+    };
   }, [
     filterHierarchy,
     optionLabelsMap,
@@ -160,7 +209,7 @@ function FilterHierarchy({
     [filterHierarchy, name, optionLabelsMap],
   );
 
-  const selectedValues = useWatch({ name }) as string[];
+  const selectedValues: string[] = useWatch({ name }) ?? [];
   const optionsWithSelectedChildren: SelectedChildren = useMemo(() => {
     if (!selectedValues?.length) {
       return {
@@ -335,13 +384,14 @@ function FilterHierarchy({
                   key={filterLabel}
                   className={
                     !isLast
-                      ? 'dfe-border-right govuk-!-padding-right-5'
+                      ? 'dfe-border-right govuk-!-padding-right-5 govuk-!-margin-bottom-3'
                       : undefined
                   }
                 >
                   <ButtonText onClick={() => toggleTierSelection(index)}>
-                    {tierSelectionState[index].selected ? 'Deselect' : 'Select'}{' '}
-                    all {filterLabel} (tier {index + 1})
+                    {tierSelectionState[index].selected ? 'Unselect' : 'Select'}{' '}
+                    {hierarchySearchTerm ? '' : 'all'} {filterLabel} (tier{' '}
+                    {index + 1})
                   </ButtonText>
                 </div>
               );
@@ -357,8 +407,8 @@ function FilterHierarchy({
                 selectedValues={selectedValues}
                 level={0}
                 expandedOptionsList={expandedOptionsList}
-                tierSelectionState={tierSelectionState}
                 hierarchySearchTerm={hierarchySearchTerm}
+                toggleSelectionStateForTier={toggleSelectionStateForTier}
                 selectedChildren={optionsWithSelectedChildren}
                 onToggleOptions={handleToggleOptions}
               />
@@ -461,6 +511,21 @@ function mapOptionTreesRecursively({
       .includes(hierarchySearchTerm.trim().toLowerCase());
     return hasOptions || hasSearchTerm;
   });
+}
+
+/**
+ * Traverses filter hierarchy option trees using a breadth-first search to sort option by tier.
+ */
+function buildTierArray(nodes: FilterHierarchyOption[]): string[][] {
+  const result: string[][] = [];
+  let queue = nodes;
+
+  while (queue.length) {
+    result.push(queue.map(n => n.value));
+    queue = queue.flatMap(n => n.options ?? []);
+  }
+
+  return result;
 }
 
 export default memo(FilterHierarchy);

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
@@ -38,6 +38,11 @@ export interface FilterHierarchyProps {
   onToggle?: (isOpen: boolean) => void;
 }
 
+interface TierSelectionState {
+  tier: number;
+  selected: boolean;
+}
+
 function FilterHierarchy({
   optionLabelsMap,
   filterHierarchy,
@@ -56,6 +61,29 @@ function FilterHierarchy({
   const errorMessage = get(errors, name)?.message;
 
   const tiersTotal = filterHierarchy.length + 1;
+
+  const tiersInitialState = () => {
+    const tierState: TierSelectionState[] = [];
+    for (let i = 0; i < tiersTotal; i += 1) {
+      tierState.push({ tier: i, selected: false });
+    }
+
+    return tierState;
+  };
+
+  const [tierSelectionState, setTierSelectionState] =
+    useState<TierSelectionState[]>(tiersInitialState);
+
+  const toggleTierSelection = (tier: number) => {
+    setTierSelectionState(prev => ({
+      ...prev,
+      [tier]: {
+        ...prev[tier],
+        selected: !prev[tier].selected,
+      },
+    }));
+  };
+
   const [expandedOptionsList, setExpandedOptionsList] = useState<string[]>([]);
 
   const filterLabels: string[] = [
@@ -311,8 +339,9 @@ function FilterHierarchy({
                       : undefined
                   }
                 >
-                  <ButtonText>
-                    Select all {filterLabel} (tier {index + 1})
+                  <ButtonText onClick={() => toggleTierSelection(index)}>
+                    {tierSelectionState[index].selected ? 'Deselect' : 'Select'}{' '}
+                    all {filterLabel} (tier {index + 1})
                   </ButtonText>
                 </div>
               );
@@ -395,6 +424,7 @@ function mapOptionTreesRecursively({
     ]);
 
     return {
+      tier,
       value: optionValue,
       label: optionLabelsMap[optionId]?.trim(),
       filterLabel: optionLabelsMap[filterHierarchy[tier]?.filterId] ?? '',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
@@ -38,7 +38,7 @@ export interface FilterHierarchyProps {
   onToggle?: (isOpen: boolean) => void;
 }
 
-interface TierSelectionState {
+export interface TierSelectionState {
   tier: number;
   selected: boolean;
 }
@@ -357,6 +357,7 @@ function FilterHierarchy({
                 selectedValues={selectedValues}
                 level={0}
                 expandedOptionsList={expandedOptionsList}
+                tierSelectionState={tierSelectionState}
                 hierarchySearchTerm={hierarchySearchTerm}
                 selectedChildren={optionsWithSelectedChildren}
                 onToggleOptions={handleToggleOptions}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
@@ -425,6 +425,11 @@ function FilterHierarchy({
                   <ButtonText
                     onClick={() => toggleTierSelection(index)}
                     disabled={tierSelectionState[index].disabled}
+                    title={
+                      tierSelectionState[index].disabled
+                        ? 'This element is not clickable as there are no options available in this tier'
+                        : undefined
+                    }
                   >
                     {tierSelectionState[index].selected ? 'Unselect' : 'Select'}{' '}
                     {hierarchySearchTerm ? '' : 'all'} {filterLabel} (tier{' '}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
@@ -298,6 +298,26 @@ function FilterHierarchy({
         error={errorMessage?.toString()}
       >
         <div data-testid="filter-hierarchy-options">
+          <div className="dfe-flex dfe-gap-4">
+            {filterLabels.map((filterLabel, index) => {
+              const isLast = index + 1 === filterLabels.length;
+
+              return (
+                <div
+                  key={filterLabel}
+                  className={
+                    !isLast
+                      ? 'dfe-border-right govuk-!-padding-right-5'
+                      : undefined
+                  }
+                >
+                  <ButtonText>
+                    Select all {filterLabel} (tier {index + 1})
+                  </ButtonText>
+                </div>
+              );
+            })}
+          </div>
           {rootOptionTrees.map(optionTree => {
             return (
               <FilterHierarchyOptions

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
@@ -57,7 +57,6 @@ function FilterHierarchy({
   const {
     formState: { errors },
     setValue,
-    getValues,
   } = useFormContext();
 
   const { fieldId } = useFormIdContext();
@@ -66,17 +65,16 @@ function FilterHierarchy({
 
   const tiersTotal = filterHierarchy.length + 1;
 
-  const tiersInitialState = () => {
+  const [tierSelectionState, setTierSelectionState] = useState<
+    TierSelectionState[]
+  >(() => {
     const tierState: TierSelectionState[] = [];
     for (let i = 0; i < tiersTotal; i += 1) {
       tierState.push({ tier: i, selected: false, disabled: false });
     }
 
     return tierState;
-  };
-
-  const [tierSelectionState, setTierSelectionState] =
-    useState<TierSelectionState[]>(tiersInitialState);
+  });
 
   const toggleTierSelection = (tier: number) => {
     toggleCheckboxSelectionsForTier(tier);
@@ -91,45 +89,16 @@ function FilterHierarchy({
     }
   };
 
-  const deselectAllFiltersForTier = (tier: number) => {
-    setValue(
-      name,
-      selectedValues.filter(sv => !tierOptions[tier].includes(sv)),
-    );
-  };
-
-  const selectAllFiltersForTier = (tier: number) => {
-    const combinedSelections = [...selectedValues, ...tierOptions[tier]];
-    const distinctSelections = combinedSelections.reduce(
-      (acc: string[], item) => (acc.includes(item) ? acc : [...acc, item]),
-      [],
-    );
-
-    setValue(name, distinctSelections);
-  };
-
-  const toggleSelectionStateForTier = (tier: number) => {
-    const tierSelectedValues: string[] = getValues(name);
-    const allTierOptionsSelected = tierOptions[tier].every(filterOptionId =>
-      tierSelectedValues.includes(filterOptionId),
-    );
-
-    updateTierSelectionState(prev =>
-      prev.map((item, index) =>
-        index === tier ? { ...item, selected: allTierOptionsSelected } : item,
-      ),
-    );
-  };
-
   const [expandedOptionsList, setExpandedOptionsList] = useState<string[]>([]);
   const [tierSelectionLoading, setTierSelectionLoading] = useState(false);
 
-  const updateTierSelectionState = (
-    updater: (prev: TierSelectionState[]) => TierSelectionState[],
-  ) => {
-    setTierSelectionLoading(true);
-    setTierSelectionState(updater);
-  };
+  const updateTierSelectionState = useCallback(
+    (updater: (prev: TierSelectionState[]) => TierSelectionState[]) => {
+      setTierSelectionLoading(true);
+      setTierSelectionState(updater);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (tierSelectionLoading) {
@@ -215,6 +184,49 @@ function FilterHierarchy({
   const watchedValues: string[] = useWatch({ name });
   const selectedValues = useMemo(() => watchedValues ?? [], [watchedValues]);
 
+  const toggleSelectionStateForTier = useCallback(
+    (tier: number) => {
+      const totalSelectionAboveMinimumForTier =
+        selectedValues.length < tierOptions[tier].length;
+
+      const allTierOptionsSelected =
+        totalSelectionAboveMinimumForTier &&
+        tierOptions[tier].every(filterOptionId =>
+          selectedValues.includes(filterOptionId),
+        );
+
+      updateTierSelectionState(prev =>
+        prev.map((item, index) =>
+          index === tier ? { ...item, selected: allTierOptionsSelected } : item,
+        ),
+      );
+    },
+    [tierOptions, selectedValues, updateTierSelectionState],
+  );
+
+  const deselectAllFiltersForTier = useCallback(
+    (tier: number) => {
+      setValue(
+        name,
+        selectedValues.filter(sv => !tierOptions[tier].includes(sv)),
+      );
+    },
+    [name, selectedValues, setValue, tierOptions],
+  );
+
+  const selectAllFiltersForTier = useCallback(
+    (tier: number) => {
+      const combinedSelections = [...selectedValues, ...tierOptions[tier]];
+      const distinctSelections = combinedSelections.reduce(
+        (acc: string[], item) => (acc.includes(item) ? acc : [...acc, item]),
+        [],
+      );
+
+      setValue(name, distinctSelections);
+    },
+    [name, selectedValues, setValue, tierOptions],
+  );
+
   useEffect(() => {
     updateTierSelectionState(prev =>
       prev.map((item, index) => ({
@@ -229,7 +241,12 @@ function FilterHierarchy({
           ),
       })),
     );
-  }, [tierOptions, hierarchySearchTerm, selectedValues]);
+  }, [
+    tierOptions,
+    hierarchySearchTerm,
+    selectedValues,
+    updateTierSelectionState,
+  ]);
 
   const getOptionUniqueValue = useCallback(
     (optionValue: string): string => {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
@@ -76,19 +76,6 @@ function FilterHierarchy({
     return tierState;
   });
 
-  const toggleTierSelection = (tier: number) => {
-    toggleCheckboxSelectionsForTier(tier);
-    toggleSelectionStateForTier(tier);
-  };
-
-  const toggleCheckboxSelectionsForTier = (tier: number) => {
-    if (tierSelectionState[tier].selected) {
-      deselectAllFiltersForTier(tier);
-    } else {
-      selectAllFiltersForTier(tier);
-    }
-  };
-
   const [expandedOptionsList, setExpandedOptionsList] = useState<string[]>([]);
   const [tierSelectionLoading, setTierSelectionLoading] = useState(false);
 
@@ -184,7 +171,7 @@ function FilterHierarchy({
   const watchedValues: string[] = useWatch({ name });
   const selectedValues = useMemo(() => watchedValues ?? [], [watchedValues]);
 
-  const toggleSelectionStateForTier = useCallback(
+  const handleTierOptionChange = useCallback(
     (tier: number) => {
       const totalSelectionAboveMinimumForTier =
         selectedValues.length < tierOptions[tier].length;
@@ -204,27 +191,41 @@ function FilterHierarchy({
     [tierOptions, selectedValues, updateTierSelectionState],
   );
 
-  const deselectAllFiltersForTier = useCallback(
+  const toggleTierSelection = useCallback(
     (tier: number) => {
-      setValue(
-        name,
-        selectedValues.filter(sv => !tierOptions[tier].includes(sv)),
-      );
-    },
-    [name, selectedValues, setValue, tierOptions],
-  );
+      const deselectAllFiltersForTier = () => {
+        setValue(
+          name,
+          selectedValues.filter(sv => !tierOptions[tier].includes(sv)),
+        );
+      };
 
-  const selectAllFiltersForTier = useCallback(
-    (tier: number) => {
-      const combinedSelections = [...selectedValues, ...tierOptions[tier]];
-      const distinctSelections = combinedSelections.reduce(
-        (acc: string[], item) => (acc.includes(item) ? acc : [...acc, item]),
-        [],
-      );
+      const selectAllFiltersForTier = () => {
+        const combinedSelections = [...selectedValues, ...tierOptions[tier]];
+        const distinctSelections = combinedSelections.reduce(
+          (acc: string[], item) => (acc.includes(item) ? acc : [...acc, item]),
+          [],
+        );
 
-      setValue(name, distinctSelections);
+        setValue(name, distinctSelections);
+      };
+
+      if (tierSelectionState[tier].selected) {
+        deselectAllFiltersForTier();
+      } else {
+        selectAllFiltersForTier();
+      }
+
+      handleTierOptionChange(tier);
     },
-    [name, selectedValues, setValue, tierOptions],
+    [
+      name,
+      selectedValues,
+      setValue,
+      tierOptions,
+      tierSelectionState,
+      handleTierOptionChange,
+    ],
   );
 
   useEffect(() => {
@@ -468,7 +469,7 @@ function FilterHierarchy({
                 level={0}
                 expandedOptionsList={expandedOptionsList}
                 hierarchySearchTerm={hierarchySearchTerm}
-                toggleSelectionStateForTier={toggleSelectionStateForTier}
+                handleTierOptionChange={handleTierOptionChange}
                 selectedChildren={optionsWithSelectedChildren}
                 onToggleOptions={handleToggleOptions}
               />

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.tsx
@@ -10,6 +10,7 @@ import { Dictionary } from '@common/types';
 import classNames from 'classnames';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { TierSelectionState } from './FilterHierarchy';
 
 export type FilterHierarchyOption = {
   /** Zero-based */
@@ -29,7 +30,9 @@ export type SelectedChildren = {
 interface FilterHierarchyOptionsProps {
   disabled?: boolean;
   expandedOptionsList?: string[];
+  tierSelectionState: TierSelectionState[];
   hierarchySearchTerm?: string;
+  /** Tier number, zero-based */
   level: number;
   name: string;
   optionTree: FilterHierarchyOption;
@@ -45,6 +48,7 @@ function FilterHierarchyOptions({
   level,
   selectedValues = [],
   expandedOptionsList = [],
+  tierSelectionState,
   hierarchySearchTerm = '',
   selectedChildren,
   onToggleOptions,
@@ -185,7 +189,10 @@ function FilterHierarchyOptions({
           value={optionTree.value}
           hint={optionTree.filterLabel}
           disabled={disabled}
-          checked={selectedValues.includes(optionTree.value)}
+          checked={
+            selectedValues.includes(optionTree.value) ||
+            tierSelectionState[level].selected
+          }
         />
       </div>
       {!!optionTree.options?.length && (
@@ -259,6 +266,7 @@ function FilterHierarchyOptions({
                 disabled={disabled}
                 selectedValues={selectedValues}
                 level={level + 1}
+                tierSelectionState={tierSelectionState}
                 hierarchySearchTerm={hierarchySearchTerm}
                 selectedChildren={selectedChildren}
                 onToggleOptions={onToggleOptions}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.tsx
@@ -12,6 +12,8 @@ import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 export type FilterHierarchyOption = {
+  /** Zero-based */
+  tier: number;
   value: string;
   label: string;
   filterLabel: string;
@@ -162,6 +164,7 @@ function FilterHierarchyOptions({
   return (
     <div
       data-testid={`filter-hierarchy-options-${optionTree.value}`}
+      data-tier={level}
       className={classNames(
         'govuk-checkboxes',
         'govuk-checkboxes--small',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.tsx
@@ -10,7 +10,6 @@ import { Dictionary } from '@common/types';
 import classNames from 'classnames';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { TierSelectionState } from './FilterHierarchy';
 
 export type FilterHierarchyOption = {
   /** Zero-based */
@@ -30,7 +29,7 @@ export type SelectedChildren = {
 interface FilterHierarchyOptionsProps {
   disabled?: boolean;
   expandedOptionsList?: string[];
-  tierSelectionState: TierSelectionState[];
+  toggleSelectionStateForTier: (tier: number) => void;
   hierarchySearchTerm?: string;
   /** Tier number, zero-based */
   level: number;
@@ -48,7 +47,7 @@ function FilterHierarchyOptions({
   level,
   selectedValues = [],
   expandedOptionsList = [],
-  tierSelectionState,
+  toggleSelectionStateForTier,
   hierarchySearchTerm = '',
   selectedChildren,
   onToggleOptions,
@@ -189,10 +188,11 @@ function FilterHierarchyOptions({
           value={optionTree.value}
           hint={optionTree.filterLabel}
           disabled={disabled}
-          checked={
-            selectedValues.includes(optionTree.value) ||
-            tierSelectionState[level].selected
-          }
+          checked={selectedValues.includes(optionTree.value)}
+          onChange={e => {
+            field.onChange(e);
+            toggleSelectionStateForTier(optionTree.tier);
+          }}
         />
       </div>
       {!!optionTree.options?.length && (
@@ -266,7 +266,7 @@ function FilterHierarchyOptions({
                 disabled={disabled}
                 selectedValues={selectedValues}
                 level={level + 1}
-                tierSelectionState={tierSelectionState}
+                toggleSelectionStateForTier={toggleSelectionStateForTier}
                 hierarchySearchTerm={hierarchySearchTerm}
                 selectedChildren={selectedChildren}
                 onToggleOptions={onToggleOptions}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchyOptions.tsx
@@ -29,7 +29,7 @@ export type SelectedChildren = {
 interface FilterHierarchyOptionsProps {
   disabled?: boolean;
   expandedOptionsList?: string[];
-  toggleSelectionStateForTier: (tier: number) => void;
+  handleTierOptionChange: (tier: number) => void;
   hierarchySearchTerm?: string;
   /** Tier number, zero-based */
   level: number;
@@ -47,7 +47,7 @@ function FilterHierarchyOptions({
   level,
   selectedValues = [],
   expandedOptionsList = [],
-  toggleSelectionStateForTier,
+  handleTierOptionChange,
   hierarchySearchTerm = '',
   selectedChildren,
   onToggleOptions,
@@ -191,7 +191,7 @@ function FilterHierarchyOptions({
           checked={selectedValues.includes(optionTree.value)}
           onChange={e => {
             field.onChange(e);
-            toggleSelectionStateForTier(optionTree.tier);
+            handleTierOptionChange(optionTree.tier);
           }}
         />
       </div>
@@ -266,7 +266,7 @@ function FilterHierarchyOptions({
                 disabled={disabled}
                 selectedValues={selectedValues}
                 level={level + 1}
-                toggleSelectionStateForTier={toggleSelectionStateForTier}
+                handleTierOptionChange={handleTierOptionChange}
                 hierarchySearchTerm={hierarchySearchTerm}
                 selectedChildren={selectedChildren}
                 onToggleOptions={onToggleOptions}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FilterHierarchy.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FilterHierarchy.test.tsx
@@ -409,4 +409,208 @@ describe('FilterHierarchy', () => {
       '7 selected',
     );
   });
+
+  test('tier selection buttons (de)select all options in that tier and update button text', async () => {
+    const { user } = render(
+      <FormProvider>
+        <FilterHierarchy
+          filterHierarchy={testFilterHierarchy}
+          name="test-filter"
+          optionLabelsMap={testOptionsLabelsMap}
+        />
+      </FormProvider>,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Name of course being studied (3 tiers) - show options',
+      }),
+    );
+
+    const tier2Button = screen.getByRole('button', {
+      name: 'Select all Sector subject area (tier 2)',
+    });
+    await user.click(tier2Button);
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Unselect all Sector subject area (tier 2)',
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show sub categories for entry level',
+      }),
+    );
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show sub categories for higher',
+      }),
+    );
+
+    expect(screen.getByRole('checkbox', { name: 'Engineering' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Science' })).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: 'Construction' }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: 'Horticulture' }),
+    ).toBeChecked();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Unselect all Sector subject area (tier 2)',
+      }),
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Select all Sector subject area (tier 2)',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'Engineering' }),
+    ).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Science' })).not.toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: 'Construction' }),
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: 'Horticulture' }),
+    ).not.toBeChecked();
+  });
+
+  test('tier button text updates only after all visible tier options are selected', async () => {
+    const { user } = render(
+      <FormProvider>
+        <FilterHierarchy
+          filterHierarchy={testFilterHierarchy}
+          name="test-filter"
+          optionLabelsMap={testOptionsLabelsMap}
+        />
+      </FormProvider>,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Name of course being studied (3 tiers) - show options',
+      }),
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show sub categories for entry level',
+      }),
+    );
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show sub categories for higher',
+      }),
+    );
+
+    const tier2Button = screen.getByRole('button', {
+      name: 'Select all Sector subject area (tier 2)',
+    });
+
+    await user.click(screen.getByRole('checkbox', { name: 'Engineering' }));
+    expect(tier2Button).toHaveTextContent(
+      'Select all Sector subject area (tier 2)',
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'Science' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Construction' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Horticulture' }));
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Unselect all Sector subject area (tier 2)',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('tier selection with active search only affects visible tier options', async () => {
+    const { user } = render(
+      <FormProvider>
+        <FilterHierarchy
+          filterHierarchy={testFilterHierarchy}
+          name="test-filter"
+          optionLabelsMap={testOptionsLabelsMap}
+        />
+      </FormProvider>,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Name of course being studied (3 tiers) - show options',
+      }),
+    );
+
+    await user.type(
+      screen.getByLabelText(
+        'Search all tiers and name of course being studied',
+      ),
+      'engineering',
+    );
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    const tier2Button = screen.getByRole('button', {
+      name: 'Select Sector subject area (tier 2)',
+    });
+    await user.click(tier2Button);
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Unselect Sector subject area (tier 2)',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Engineering' })).toBeChecked();
+    expect(screen.getByTestId('test-filter-count')).toHaveTextContent(
+      '1 selected',
+    );
+
+    const clearSearchButton = screen.getByRole('button', {
+      name: 'Clear search',
+    });
+    await user.click(clearSearchButton);
+
+    expect(screen.getByRole('checkbox', { name: 'Science' })).not.toBeChecked();
+  });
+
+  test('tier selection button is disabled when no options are available in that tier after search', async () => {
+    const { user } = render(
+      <FormProvider>
+        <FilterHierarchy
+          filterHierarchy={testFilterHierarchy}
+          name="test-filter"
+          optionLabelsMap={testOptionsLabelsMap}
+        />
+      </FormProvider>,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Name of course being studied (3 tiers) - show options',
+      }),
+    );
+
+    await user.type(
+      screen.getByLabelText(
+        'Search all tiers and name of course being studied',
+      ),
+      'entry level',
+    );
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Select Sector subject area (tier 2)',
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('button', {
+        name: 'Select Name of course being studied (tier 3)',
+      }),
+    ).toBeDisabled();
+  });
 });

--- a/src/explore-education-statistics-common/src/styles/utils/_border.scss
+++ b/src/explore-education-statistics-common/src/styles/utils/_border.scss
@@ -11,3 +11,7 @@
 .dfe-border-top {
   border-top: 1px solid govuk-colour('mid-grey');
 }
+
+.dfe-border-right {
+  border-right: 1px solid govuk-colour('mid-grey');
+}


### PR DESCRIPTION
This PR adds non-recursive selection options to table tool hierarchy filters to allow users to (de)select all items within a specific tier - sub-tier selection would just be the totals for each filter unless explicitly selected manually.

A loading spinner has been included to account for more complex hierarchies where toggle (de)selection may take longer to complete and may appear to users like the system has stopped responding.
<img width="618" height="883" alt="image" src="https://github.com/user-attachments/assets/8162d6d3-bdef-4f2e-8052-e1f973e7f66a" />


When a search term is present, the button text changes slightly to indicate that tier selection only applies to the visible filters (i.e. not "all"), and the selection counts update accordingly. If no filters for the given search term are present, the (de)selection option button is disabled.
<img width="624" height="741" alt="image" src="https://github.com/user-attachments/assets/f7ddac9a-ecb1-4113-bf8f-dd7b82f4847a" />
