### PR TITLE
EES-7101 - temporarily exclude subscription verification URLs from lowercase redirects

### DIFF
--- a/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/__tests__/redirectPages.test.ts
@@ -753,5 +753,49 @@ describe('redirectPages', () => {
         expect(nextSpy).toHaveBeenCalledTimes(2);
       },
     );
+
+    test('excludes subscription verification urls from uppercase-to-lowercase redirects', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      await runMiddleware(
+        redirectPages,
+        'https://my-env/subscriptions/release-name/confirm-subscription/AbC',
+      );
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalled();
+    });
+
+    test('excludes unsubscription verification urls from uppercase-to-lowercase redirects', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      await runMiddleware(
+        redirectPages,
+        'https://my-env/subscriptions/release-name/confirm-unsubscription/AbC',
+      );
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalled();
+    });
+
+    test('excludes API subscription verification urls from uppercase-to-lowercase redirects', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      await runMiddleware(
+        redirectPages,
+        'https://my-env/api-subscriptions/release-name/confirm-subscription/AbC',
+      );
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalled();
+    });
+
+    test('excludes API unsubscription verification urls from uppercase-to-lowercase redirects', async () => {
+      redirectService.list.mockResolvedValue(testRedirects);
+      await runMiddleware(
+        redirectPages,
+        'https://my-env/api-subscriptions/release-name/confirm-unsubscription/AbC',
+      );
+
+      expect(redirectSpy).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
+++ b/src/explore-education-statistics-frontend/src/middleware/pages/redirectPages.ts
@@ -34,6 +34,21 @@ const redirectPatterns: URLPattern[] = [
   }),
 ];
 
+const lowercaseRedirectsExclusionPatterns: URLPattern[] = [
+  new URLPattern({
+    pathname: `/subscriptions/:${publicationSlugKey}/confirm-subscription/.*`,
+  }),
+  new URLPattern({
+    pathname: `/subscriptions/:${publicationSlugKey}/confirm-unsubscription/.*`,
+  }),
+  new URLPattern({
+    pathname: `/api-subscriptions/:${publicationSlugKey}/confirm-subscription/.*`,
+  }),
+  new URLPattern({
+    pathname: `/api-subscriptions/:${publicationSlugKey}/confirm-unsubscription/.*`,
+  }),
+];
+
 export default async function redirectPages(
   request: NextRequest,
   event: NextFetchEvent,
@@ -61,14 +76,25 @@ export default async function redirectPages(
     }
   }
 
-  // Redirect any URLs with uppercase characters to lowercase.
-  if (decodedPathname !== lowerCasedPathname) {
+  // Redirect any URLs with uppercase characters to lowercase, unless explicitly excluded.
+  if (
+    !requestExcludedFromLowercaseRedirects(decodedPathname) &&
+    decodedPathname !== lowerCasedPathname
+  ) {
     const url = nextUrl.clone();
     url.pathname = lowerCasedPathname;
     return NextResponse.redirect(url, 301);
   }
 
   return middleware(request, event);
+}
+
+function requestExcludedFromLowercaseRedirects(lowerCasedPathname: string) {
+  return lowercaseRedirectsExclusionPatterns.some(exclusionPattern =>
+    exclusionPattern.exec({
+      pathname: lowerCasedPathname,
+    }),
+  );
 }
 
 function findRouteSlugsBySlugKey(


### PR DESCRIPTION
This PR:
- fixes excludes subscription verification requests by excluding subscription verification requests from lowercase redirecting.

We have some middleware which redirects any URLs with uppercase characters in them to their lowercase equivalents.  Request params aren't tested as a part of this, so uppercase query params won't be changed or cause a redirect by themself. 

The problem we had was:
1. The subscription verification URL contains a JWT *as part of the path, not as a request parameter*.
2. Middleware that previously didn't run against this URL pattern now does.

The ideal fix will be to make the verification token a request parameter instead of part of the URL path, but if we change this immediately this may break any existing not-yet-confirmed URLs sent out in emails, so we will need a "zero downtime" fix for this.

In the meantime, this tweak will fix the immediate issue.