### PR TITLE
EES-7024 - reverting Dev to use its original public URL

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -51,8 +51,7 @@
       "value": 3
     },
     "domain": {
-      // TODO EES-7024 - revert public URL after testing.
-      "value": "devafd.explore-education-statistics.service.gov.uk"
+      "value": "dev.explore-education-statistics.service.gov.uk"
     },
     "contentApiUrl": {
       "value": "content.dev.explore-education-statistics.service.gov.uk"

--- a/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
@@ -43,15 +43,18 @@ var frontDoorProfileName = '${resourcePrefix}-${abbreviations.frontDoorProfiles}
 // over to Azure Front Door properly.  In the meantime, we will host the site through AFD on a temporary
 // https://<env name>afd.explore-education-statistics.service.gov.uk with an associated certificate so as
 // not to break the use of the environment for others.
+//
+// Note that this only applies to Prod and Pre-Prod now, as Dev and Test can now use their proper public site
+// URLs to reach AFD.
 var publicSiteHostName = replaceMultiple(publicSiteUrl, {
   
   // Handle the case for Prod to allow access via "https://afd.explore-education-statistics.service.gov.uk" during
   // testing.
   'https://explore-education': 'afd.explore-education'
   
-  // Handle the case for all other environments to allow access via
-  // "https://<env>afd.explore-education-statistics.service.gov.uk" during testing.
-  '.explore-education': 'afd.explore-education'
+  // Handle the case for Pre-Production to allow access via
+  // "https://pre-productionafd.explore-education-statistics.service.gov.uk" during testing.
+  'pre-production.explore-education': 'pre-productionafd.explore-education'
   
   // Finally, remove the "https://" from the URL to leave just the domain name.
   'https://': ''
@@ -63,7 +66,13 @@ var publicSiteHostName = replaceMultiple(publicSiteUrl, {
 // a temporary https://<env name>afd.explore-education-statistics.service.gov.uk
 // URL with an associated certificate so as not to break the use of the environment
 // for others.
-var certificateName = '${legacyResourcePrefix}as-ees-public-site-afd-certificate'
+//
+// Note that Dev and Test now have the original public site URLs pointing towards
+// their AFD instances now rather than the original App Service, so they can serve
+// up the real certificate rather than the temporary testing one.  
+var certificateName = subscription == 's101d01' || subscription == 's101t01'
+    ? '${legacyResourcePrefix}as-ees-public-site-certificate'
+    : '${legacyResourcePrefix}as-ees-public-site-afd-certificate'
 
 var nextJsRuleSetName = 'nextjsruleset'
 

--- a/infrastructure/templates/public-api/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/public-api/parameters/main-dev.bicepparam
@@ -5,8 +5,7 @@ param environmentName = 'Development'
 
 param publicUrls = {
   contentApi: 'https://content.dev.explore-education-statistics.service.gov.uk'
-  // TODO EES-7024 - revert public URL after testing.
-  publicSite: 'https://devafd.explore-education-statistics.service.gov.uk'
+  publicSite: 'https://dev.explore-education-statistics.service.gov.uk'
   publicApi: 'https://pp-api.education.gov.uk/statistics-dev'
   publicApiAppGateway: 'https://dev.statistics.api.education.gov.uk'
 }

--- a/src/explore-education-statistics-common/src/utils/url/allowedHosts.ts
+++ b/src/explore-education-statistics-common/src/utils/url/allowedHosts.ts
@@ -1,8 +1,6 @@
 export const internalHosts = [
   'localhost:3000',
   'dev.explore-education-statistics.service.gov.uk',
-  // TODO EES-7024 - revert public URL after testing.
-  'devafd.explore-education-statistics.service.gov.uk',
   'test.explore-education-statistics.service.gov.uk',
   'pre-production.explore-education-statistics.service.gov.uk',
   'explore-education-statistics.service.gov.uk',

--- a/src/explore-education-statistics-frontend/web.config
+++ b/src/explore-education-statistics-frontend/web.config
@@ -25,8 +25,7 @@
           <conditions>
             <add input="{HTTP_HOST}" pattern="s101d01-as-ees-public.azurewebsites.net" />
           </conditions>
-          <!-- TODO EES-7024 - revert public URL after testing. -->
-          <action type="Redirect" url="https://devafd.explore-education-statistics.service.gov.uk/{R:0}" />
+          <action type="Redirect" url="https://dev.explore-education-statistics.service.gov.uk/{R:0}" />
         </rule>
         <rule name="Redirect azure to govuk test" patternSyntax="Wildcard" stopProcessing="true">
           <match url="*" />

--- a/tests/robot-tests/tests/general_public/redirects_www.robot
+++ b/tests/robot-tests/tests/general_public/redirects_www.robot
@@ -10,7 +10,6 @@ Force Tags          GeneralPublic    Local    Dev
 
 *** Test Cases ***
 Verify that routes with www are redirected without them
-    Skip    EES-7024 - skipping whilst testing on Azure Front Door temporary URL
     user navigates to www    %{PUBLIC_URL}/
     user waits until page contains    Explore education statistics
     user checks url equals    %{PUBLIC_URL}/


### PR DESCRIPTION
This PR:
- reverts Dev (and Test) to use their normal URLs to access the public site through Azure Front Door.
- reverts the UI test pipeline to use the original URL again for testing.

Now that `dev.explore...` and `test.explore...` DNS records are pointing towards Azure Front Door instances in those environments, we can switch configuration to expect the site to be accessed on those URLs.

This involves making sure that the AFD Domains (that link the URL being used to hit AFD with the public site App Service backend) use a certificate that match the real URL rather than our temporary `devafd.explore...` and `testafd.explore...` testing URLs.

## Correct URL

<img width="883" height="763" alt="image" src="https://github.com/user-attachments/assets/deeaeda7-e2df-473e-8f54-6b6376dcda7d" />

## Correct Azure Front Door domain config

<img width="1357" height="1026" alt="image" src="https://github.com/user-attachments/assets/8a519dd7-5d6e-4851-a4d8-a7323dc56497" />

This image shows the URL that links AFD with the public site App Service backend.

<img width="2256" height="1251" alt="image" src="https://github.com/user-attachments/assets/a8a468ab-42ee-40d7-b45b-38469d573d32" />

This image shows the correct certificate linked to the Domain.

## UI test config

UI tests are now configured to use the original URL in the pipeline.

<img width="654" height="293" alt="image" src="https://github.com/user-attachments/assets/1fe1940f-7d8c-4abc-9e15-17901f73c4e1" />
