### PR TITLE
EES-6612 - fixed default certificate type to be Bring Your Own

### DIFF
--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -13,7 +13,7 @@ param environmentName string
 param publicSiteUrl string = ''
 
 @description('Certificate type for Azure Front Door.')
-param certificateType FrontDoorCertificateType = 'Provisioned'
+param certificateType FrontDoorCertificateType = 'BringYourOwn'
 
 @description('Whether or not to create role assignments necessary for performing certain backup actions.')
 param deployBackupVaultReaderRoleAssignment bool = true


### PR DESCRIPTION
This PR:
- changes the certificate type for all AFD instances to be Bring Your Own, now that we're testing on all environments.