### PR TITLE
EES-6612 - added special-case siteHostname value for Prod, as order o…

### DIFF
--- a/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
@@ -46,17 +46,19 @@ var frontDoorProfileName = '${resourcePrefix}-${abbreviations.frontDoorProfiles}
 //
 // Note that this only applies to Prod and Pre-Prod now, as Dev and Test can now use their proper public site
 // URLs to reach AFD.
-var publicSiteHostName = replaceMultiple(publicSiteUrl, {
+var publicSiteHostName = subscription == 's101p01'
   
   // Handle the case for Prod to allow access via "https://afd.explore-education-statistics.service.gov.uk" during
   // testing.
-  'https://explore-education': 'afd.explore-education'
+  ? 'afd.explore-education-statistics.service.gov.uk'
+  
+  : replaceMultiple(publicSiteUrl, {
   
   // Handle the case for Pre-Production to allow access via
   // "https://pre-productionafd.explore-education-statistics.service.gov.uk" during testing.
   'pre-production.explore-education': 'pre-productionafd.explore-education'
   
-  // Finally, remove the "https://" from the URL to leave just the domain name.
+  // Remove the "https://" from the URL to leave just the domain name.
   'https://': ''
 })
 


### PR DESCRIPTION
This PR:
- fixes a failing search-and-replace for swapping the real public site URL for Prod for a testing AFD hostname.

It was failing to perform the search-and-replace because the order of search-and-replaces used by `replaceMultiple` is operating in reverse order, causing the "https://" to be stripped off the string before testing for "https://explore-education". 