### PR TITLE
EES-7119 Set 95% trigger for AFD origin health alert

### DIFF
--- a/infrastructure/templates/common/components/front-door/frontDoor.bicep
+++ b/infrastructure/templates/common/components/front-door/frontDoor.bicep
@@ -1,5 +1,5 @@
 import { abbreviations } from '../../abbreviations.bicep'
-import { staticAverageLessThanHundred, staticAverageGreaterThanZero } from '../../../public-api/components/alerts/staticAlertConfig.bicep'
+import { staticAverageLessThan95, staticAverageGreaterThanZero } from '../../../public-api/components/alerts/staticAlertConfig.bicep'
 import { dynamicAverageGreaterThan, dynamicAverageLessThan } from '../../../public-api/components/alerts/dynamicAlertConfig.bicep'
 import { FrontDoorCertificateType } from 'types.bicep'
 
@@ -317,7 +317,7 @@ module originHealthPercentageAlert '../../../public-api/components/alerts/static
       metric: 'OriginHealthPercentage'
     }
     config: {
-      ...staticAverageLessThanHundred
+      ...staticAverageLessThan95
       nameSuffix: 'origin-health-percentage'
     }
     alertsGroupName: alerts!.alertsGroupName

--- a/infrastructure/templates/public-api/components/alerts/staticAlertConfig.bicep
+++ b/infrastructure/templates/public-api/components/alerts/staticAlertConfig.bicep
@@ -55,6 +55,14 @@ var staticAverageLessThanHundred = {
 }
 
 @export()
+var staticAverageLessThan95 = {
+  ...defaultStaticAlertConfig
+  aggregation: 'Average'
+  operator: 'LessThan'
+  threshold: '95'
+}
+
+@export()
 var staticMaxGreaterThanZero = {
   ...defaultStaticAlertConfig
   aggregation: 'Maximum'


### PR DESCRIPTION
We are currently seeing a lot of alerts across all environments for `ees-afd-origin-health-percentage`.  This seems to not be an issue with our origin server, but with the AFD edge locations. Looking at logs for our health endpoint, we didn't see any responses that weren't 200.

This PR lowers the Average OriginHealthPercentage required to trigger the alert to less than 95.