### PR TITLE
EES-7123 Fix EIN full page deletion + EIN UI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,6 @@ lerna-debug.log
 
 admin-start.sh
 remote-profile
-queries
 
 .DS_Store
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/EducationInNumbersService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/EducationInNumbersService.cs
@@ -308,15 +308,21 @@ public class EducationInNumbersService(
             throw new Exception("Full delete not enabled");
         }
 
-        var pagesToRemove = contentDbContext
-            .EinPages.Include(page => page.PageVersions)
-            .Single(page => page.Slug == slug);
+        await contentDbContext.RequireTransaction(async () =>
+        {
+            var pageToRemove = contentDbContext.EinPages.Single(page => page.Slug == slug);
 
-        contentDbContext.EinPages.Remove(pagesToRemove);
+            pageToRemove.LatestPublishedVersionId = null;
+            pageToRemove.LatestVersionId = null;
 
-        // NOTE: Page versions, content sections and blocks are cascade deleted by the database
+            await contentDbContext.SaveChangesAsync();
 
-        await contentDbContext.SaveChangesAsync();
+            contentDbContext.EinPages.Remove(pageToRemove);
+
+            // NOTE: Page versions, content sections and blocks are cascade deleted by the database
+
+            await contentDbContext.SaveChangesAsync();
+        });
 
         return Unit.Instance;
     }

--- a/tests/robot-tests/tests/admin_and_public_2/bau/education_in_numbers.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/education_in_numbers.robot
@@ -139,7 +139,6 @@ Check page appears on public site
 
     user waits until h1 is visible    UI test page
 
-    user checks page contains link with text and url    Education in numbers    /education-in-numbers
     user checks page contains link with text and url    UI test page    /education-in-numbers/ui-test-page
 
     user checks page contains    Content section title
@@ -202,7 +201,6 @@ Check amendment on public site
 
     user waits until h1 is visible    UI test page
 
-    user checks page contains link with text and url    Education in numbers    /education-in-numbers
     user checks page contains link with text and url    UI test page    /education-in-numbers/ui-test-page
 
     user checks page contains    Content section title


### PR DESCRIPTION
This fixes an error where the EIN full delete endpoint would fail. This endpoint is only used by the UI tests.

### Other changes

- I removed the UI test check that an Education in numbers page link also exists - this relies on it being published, which currently isn't the case in both our test data zip or on the dev environment.
- I added `queries` to the gitignore file, and that unintentionally meant directories with code were now gitignored. This didn't cause any problem so far, but would if someone tried to update those files. It should have been `/queries`, but I'll instead just add it to gitignore.