### PR TITLE
EES-6422 Remove background/summary text block in edit release content

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/__tests__/ReleaseContentPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/__tests__/ReleaseContentPage.test.tsx
@@ -557,10 +557,6 @@ describe('ReleaseContentPage', () => {
           name: 'Add new section',
         }),
       ).toBeInTheDocument();
-
-      expect(
-        screen.getByTestId('release-summary-deprecated-warning'),
-      ).toBeInTheDocument();
     });
   });
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentEdit.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentEdit.tsx
@@ -217,75 +217,64 @@ const ReleaseContentEdit = ({
           </div>
 
           <div id="releaseSummary" data-testid="release-summary">
-            <WarningMessage testId="release-summary-deprecated-warning">
-              <p className="govuk-!-font-weight-bold">
-                Warning: As part of the redesign of the EES release pages, the
-                summary text block functionality will be removed.
-              </p>
-              <p>
-                Existing pages released with a summary text block will retain
-                the information as legacy support, but new releases will cease
-                to offer this as an option.
-              </p>
-              <p>
-                We recommend any draft publications avoid using the summary text
-                block and instead add any summary content in a standard text
-                block below headlines and key stats.
-              </p>
-              <p>
-                Note that important warnings and messages will be accommodated
-                via a dedicated warnings text block in future. As always, we
-                welcome feedback on this change via the feedback form linked
-                above.
-              </p>
-            </WarningMessage>
-            {release.summarySection && (
-              <>
-                <EditableSectionBlocks
-                  blocks={release.summarySection.content}
-                  renderBlock={block => (
-                    <ReleaseBlock
-                      block={block}
-                      releaseVersionId={release.id}
-                      transformFeaturedTableLinks={transformFeaturedTableLinks}
-                    />
+            {release.summarySection &&
+              release.summarySection.content?.length > 0 && (
+                <>
+                  <WarningMessage testId="release-summary-deprecated-warning">
+                    <p className="govuk-!-font-weight-bold">
+                      Warning: Summary text blocks are now only retained for
+                      legacy purposes in existing releases and are no longer
+                      offered on new statistics releases.
+                    </p>
+                  </WarningMessage>
+                  <EditableSectionBlocks
+                    blocks={release.summarySection.content}
+                    renderBlock={block => (
+                      <ReleaseBlock
+                        block={block}
+                        releaseVersionId={release.id}
+                        transformFeaturedTableLinks={
+                          transformFeaturedTableLinks
+                        }
+                      />
+                    )}
+                    renderEditableBlock={block => (
+                      <ReleaseEditableBlock
+                        allowComments
+                        block={block}
+                        editButtonLabel={
+                          <>
+                            Edit<VisuallyHidden> summary</VisuallyHidden> block
+                          </>
+                        }
+                        publicationId={release.publication.id}
+                        releaseVersionId={release.id}
+                        removeButtonLabel={
+                          <>
+                            Remove<VisuallyHidden> summary</VisuallyHidden>{' '}
+                            block
+                          </>
+                        }
+                        sectionId={release.summarySection.id}
+                        sectionKey="summarySection"
+                        label="Summary block"
+                        onAfterDeleteBlock={onAfterDeleteSummaryBlock}
+                      />
+                    )}
+                  />
+                  {release.summarySection.content?.length === 0 && (
+                    <div className="govuk-!-margin-bottom-8 govuk-!-text-align-centre">
+                      <Button
+                        variant="secondary"
+                        onClick={addSummaryBlock}
+                        ref={addSummaryBlockButton}
+                      >
+                        Add a summary text block
+                      </Button>
+                    </div>
                   )}
-                  renderEditableBlock={block => (
-                    <ReleaseEditableBlock
-                      allowComments
-                      block={block}
-                      editButtonLabel={
-                        <>
-                          Edit<VisuallyHidden> summary</VisuallyHidden> block
-                        </>
-                      }
-                      publicationId={release.publication.id}
-                      releaseVersionId={release.id}
-                      removeButtonLabel={
-                        <>
-                          Remove<VisuallyHidden> summary</VisuallyHidden> block
-                        </>
-                      }
-                      sectionId={release.summarySection.id}
-                      sectionKey="summarySection"
-                      label="Summary block"
-                      onAfterDeleteBlock={onAfterDeleteSummaryBlock}
-                    />
-                  )}
-                />
-                {release.summarySection.content?.length === 0 && (
-                  <div className="govuk-!-margin-bottom-8 govuk-!-text-align-centre">
-                    <Button
-                      variant="secondary"
-                      onClick={addSummaryBlock}
-                      ref={addSummaryBlockButton}
-                    >
-                      Add a summary text block
-                    </Button>
-                  </div>
-                )}
-              </>
-            )}
+                </>
+              )}
           </div>
         </div>
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentEdit.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentEdit.tsx
@@ -39,7 +39,6 @@ const ReleaseContentEdit = ({
   const { release } = useReleaseContentState();
   const { addContentSectionBlock } = useReleaseContentActions();
 
-  const addSummaryBlockButton = useRef<HTMLButtonElement>(null);
   const addWarningBlockButton = useRef<HTMLButtonElement>(null);
 
   const blockRouteChange = useMemo(() => {
@@ -72,21 +71,6 @@ const ReleaseContentEdit = ({
 
     focusAddedSectionBlockButton(newBlock.id);
   }, [addContentSectionBlock, release.id, release.warningSection]);
-
-  const addSummaryBlock = useCallback(async () => {
-    const newBlock = await addContentSectionBlock({
-      releaseVersionId: release.id,
-      sectionId: release.summarySection.id,
-      sectionKey: 'summarySection',
-      block: {
-        type: 'HtmlBlock',
-        order: 0,
-        body: '',
-      },
-    });
-
-    focusAddedSectionBlockButton(newBlock.id);
-  }, [addContentSectionBlock, release.id, release.summarySection.id]);
 
   const addRelatedDashboardsBlock = useCallback(async () => {
     if (release.relatedDashboardsSection) {
@@ -136,12 +120,6 @@ const ReleaseContentEdit = ({
       window.removeEventListener('scroll', handleScroll);
     };
   }, [handleScroll]);
-
-  const onAfterDeleteSummaryBlock = () => {
-    setTimeout(() => {
-      addSummaryBlockButton.current?.focus();
-    }, 100);
-  };
 
   const onAfterDeleteWarningBlock = () => {
     setTimeout(() => {
@@ -216,66 +194,49 @@ const ReleaseContentEdit = ({
             )}
           </div>
 
-          <div id="releaseSummary" data-testid="release-summary">
-            {release.summarySection &&
-              release.summarySection.content?.length > 0 && (
-                <>
-                  <WarningMessage testId="release-summary-deprecated-warning">
-                    <p className="govuk-!-font-weight-bold">
-                      Warning: Summary text blocks are now only retained for
-                      legacy purposes in existing releases and are no longer
-                      offered on new statistics releases.
-                    </p>
-                  </WarningMessage>
-                  <EditableSectionBlocks
-                    blocks={release.summarySection.content}
-                    renderBlock={block => (
-                      <ReleaseBlock
-                        block={block}
-                        releaseVersionId={release.id}
-                        transformFeaturedTableLinks={
-                          transformFeaturedTableLinks
-                        }
-                      />
-                    )}
-                    renderEditableBlock={block => (
-                      <ReleaseEditableBlock
-                        allowComments
-                        block={block}
-                        editButtonLabel={
-                          <>
-                            Edit<VisuallyHidden> summary</VisuallyHidden> block
-                          </>
-                        }
-                        publicationId={release.publication.id}
-                        releaseVersionId={release.id}
-                        removeButtonLabel={
-                          <>
-                            Remove<VisuallyHidden> summary</VisuallyHidden>{' '}
-                            block
-                          </>
-                        }
-                        sectionId={release.summarySection.id}
-                        sectionKey="summarySection"
-                        label="Summary block"
-                        onAfterDeleteBlock={onAfterDeleteSummaryBlock}
-                      />
-                    )}
-                  />
-                  {release.summarySection.content?.length === 0 && (
-                    <div className="govuk-!-margin-bottom-8 govuk-!-text-align-centre">
-                      <Button
-                        variant="secondary"
-                        onClick={addSummaryBlock}
-                        ref={addSummaryBlockButton}
-                      >
-                        Add a summary text block
-                      </Button>
-                    </div>
+          {release.summarySection &&
+            release.summarySection.content?.length > 0 && (
+              <div id="releaseSummary" data-testid="release-summary">
+                <WarningMessage testId="release-summary-deprecated-warning">
+                  <p className="govuk-!-font-weight-bold">
+                    Warning: Summary text blocks are now only retained for
+                    legacy purposes in existing releases and are no longer
+                    offered on new statistics releases.
+                  </p>
+                </WarningMessage>
+                <EditableSectionBlocks
+                  blocks={release.summarySection.content}
+                  renderBlock={block => (
+                    <ReleaseBlock
+                      block={block}
+                      releaseVersionId={release.id}
+                      transformFeaturedTableLinks={transformFeaturedTableLinks}
+                    />
                   )}
-                </>
-              )}
-          </div>
+                  renderEditableBlock={block => (
+                    <ReleaseEditableBlock
+                      allowComments
+                      block={block}
+                      editButtonLabel={
+                        <>
+                          Edit<VisuallyHidden> summary</VisuallyHidden> block
+                        </>
+                      }
+                      publicationId={release.publication.id}
+                      releaseVersionId={release.id}
+                      removeButtonLabel={
+                        <>
+                          Remove<VisuallyHidden> summary</VisuallyHidden> block
+                        </>
+                      }
+                      sectionId={release.summarySection.id}
+                      sectionKey="summarySection"
+                      label="Summary block"
+                    />
+                  )}
+                />
+              </div>
+            )}
         </div>
 
         <div className="govuk-grid-column-one-third">

--- a/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
@@ -93,7 +93,7 @@ Create chart for data block
 Create some release content
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
-    user waits until page contains button    Add a summary text block    %{WAIT_SMALL}
+    user waits until page contains button    Add a warning text block    %{WAIT_SMALL}
 
     user adds headlines text block
     user adds content to headlines text block    Headline text block text

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -285,8 +285,6 @@ Validate prerelease has started
     user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
     user waits until h2 is visible    ${PUBLICATION_NAME}
 
-    user waits until element contains    id:background-information    Test summary text for ${PUBLICATION_NAME}
-    ...    %{WAIT_SMALL}
     user waits until element contains    id:headlines-section    Test headlines summary text for ${PUBLICATION_NAME}
     ...    %{WAIT_SMALL}
 
@@ -422,7 +420,6 @@ Validate prerelease has started for Analyst user
     user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
     user waits until h2 is visible    ${PUBLICATION_NAME}
 
-    user waits until element contains    id:background-information    Test summary text for ${PUBLICATION_NAME}
     user waits until element contains    id:headlines-section    Test headlines summary text for ${PUBLICATION_NAME}
 
 Validate public metdata guidance for Analyst user

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -279,7 +279,6 @@ Validate prerelease has started for Analyst user after amendment
     user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
     user waits until h2 is visible    ${PUBLICATION_NAME}
 
-    user waits until element contains    id:background-information    Test summary text for ${PUBLICATION_NAME}
     user waits until element contains    id:headlines-section    Test headlines summary text for ${PUBLICATION_NAME}
 
 Validate contact banner is shown

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -56,10 +56,6 @@ Navigate to 'Content' page
     user waits until h1 is visible    ${PUBLICATION_NAME}
     user waits until h2 is visible    ${PUBLICATION_NAME}
 
-Add summary content to release
-    user adds summary text block
-    user adds content to summary text block    Test intro text for ${PUBLICATION_NAME}
-
 Add release note to release
     user adds a release note    Test release note one
     ${date}=    get london date

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -65,12 +65,8 @@ Validate checklist errors and warnings after adding headline text block
     user waits until page does not contain testid    releaseChecklist-errors
     user waits until page does not contain testid    releaseChecklist-success
 
-Add empty Summary section text block to the page
-    user navigates to content page    ${PUBLICATION_NAME}
-    user clicks button    Add a summary text block    id:releaseSummary
-    user waits until element contains    id:releaseSummary    This section is empty    %{WAIT_SMALL}
-
 Add content section with empty content block to the page
+    user navigates to content page    ${PUBLICATION_NAME}
     user creates new content section    1    Test section one
     user adds text block to editable accordion section    Test section one    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
 
@@ -96,9 +92,7 @@ Validate checklist errors and warnings after adding empty content sections
     user checks checklist warnings contains link    A public pre-release access list has not been created
 
     user checks checklist errors contains
-    ...    5 issues that must be resolved before this release can be published.
-    user checks checklist errors contains link
-    ...    Release content should not contain an empty summary section
+    ...    4 issues that must be resolved before this release can be published.
     user checks checklist errors contains link
     ...    Release content should not contain any empty sections
     user checks checklist errors contains link
@@ -108,12 +102,8 @@ Validate checklist errors and warnings after adding empty content sections
     user checks checklist errors contains link
     ...    Release content should not contain an empty warning section. Please either add the required warning text or remove the warning block entirely
 
-Add content to text block in Summary section
-    user navigates to content page    ${PUBLICATION_NAME}
-    user adds content to summary text block
-    ...    Summary test text
-
 Add content to text block in Test section one
+    user navigates to content page    ${PUBLICATION_NAME}
     user opens accordion section    Test section one    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
     user adds content to autosaving accordion section text block    Test section one    1
     ...    Test section one text    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
@@ -149,14 +139,12 @@ Validate checklist errors and warnings after adding content to text blocks
     user clicks link    Publishing checklist
 
     user checks checklist warnings contains
-    ...    6 things you may have forgotten, but do not need to resolve to publish this release.
+    ...    5 things you may have forgotten, but do not need to resolve to publish this release.
     user checks checklist warnings contains link    An in-EES methodology page has not been linked to this publication
     user checks checklist warnings contains link    No next expected release date has been added
     user checks checklist warnings contains link    No data files uploaded
     user checks checklist warnings contains link    A public pre-release access list has not been created
     user checks checklist warnings contains link    The content has unresolved comments
-    user checks checklist warnings contains link
-    ...    A summary text block has been added, note that this functionality will be removed as part of the release page redesign (although legacy support for published releases will be in place)
 
     user waits until page does not contain testid    releaseChecklist-errors
     user waits until page does not contain testid    releaseChecklist-success
@@ -194,12 +182,10 @@ Verify release checklist has not been updated by status
     user clicks link    Publishing checklist
 
     user checks checklist warnings contains
-    ...    4 things you may have forgotten, but do not need to resolve to publish this release.
+    ...    3 things you may have forgotten, but do not need to resolve to publish this release.
     user checks checklist warnings contains link    An in-EES methodology page has not been linked to this publication
     user checks checklist warnings contains link    No data files uploaded
     user checks checklist warnings contains link    A public pre-release access list has not been created
-    user checks checklist warnings contains link
-    ...    A summary text block has been added, note that this functionality will be removed as part of the release page redesign (although legacy support for published releases will be in place)
     user checks checklist warnings does not contain link    The content has unresolved comments
 
     user waits until page does not contain testid    releaseChecklist-errors
@@ -213,9 +199,7 @@ Verify release checklist has been updated
     user clicks link    Publishing checklist
 
     user checks checklist warnings contains
-    ...    3 things you may have forgotten, but do not need to resolve to publish this release.
-    user checks checklist warnings contains link
-    ...    A summary text block has been added, note that this functionality will be removed as part of the release page redesign (although legacy support for published releases will be in place)
+    ...    2 things you may have forgotten, but do not need to resolve to publish this release.
     user checks checklist warnings contains link    An in-EES methodology page has not been linked to this publication
     user checks checklist warnings contains link    No data files uploaded
 
@@ -259,9 +243,7 @@ Check that having a Draft owned Methodology attached to this Release's Publicati
     user clicks link    Publishing checklist
     user waits until element is visible    testid:releaseChecklist-warnings    %{WAIT_SMALL}
     user checks checklist warnings contains
-    ...    3 things you may have forgotten, but do not need to resolve to publish this release.
-    user checks checklist warnings contains link
-    ...    A summary text block has been added, note that this functionality will be removed as part of the release page redesign (although legacy support for published releases will be in place)
+    ...    2 things you may have forgotten, but do not need to resolve to publish this release.
     user checks checklist warnings contains link    A methodology for this publication is not yet approved
 
 Approve the owned methodology and verify the warning disappears
@@ -271,9 +253,7 @@ Approve the owned methodology and verify the warning disappears
     user clicks link    Publishing checklist
     user waits until element is visible    testid:releaseChecklist-warnings    %{WAIT_SMALL}
     user checks checklist warnings contains
-    ...    2 things you may have forgotten, but do not need to resolve to publish this release.
-    user checks checklist warnings contains link
-    ...    A summary text block has been added, note that this functionality will be removed as part of the release page redesign (although legacy support for published releases will be in place)
+    ...    1 thing you may have forgotten, but do not need to resolve to publish this release.
     user checks checklist warnings does not contain link    A methodology for this publication is not yet approved
 
 Create published methodology for adopted publication
@@ -305,9 +285,7 @@ Check that having a draft methodology amendment adopted by this Release's Public
     ...    Financial year 2100-01
     user clicks link    Publishing checklist
     user checks checklist warnings contains
-    ...    3 things you may have forgotten, but do not need to resolve to publish this release.
-    user checks checklist warnings contains link
-    ...    A summary text block has been added, note that this functionality will be removed as part of the release page redesign (although legacy support for published releases will be in place)
+    ...    2 things you may have forgotten, but do not need to resolve to publish this release.
     user checks checklist warnings contains link    A methodology for this publication is not yet approved
 
 Approve the adopted methodology amendment and verify the warning disappears
@@ -316,9 +294,7 @@ Approve the adopted methodology amendment and verify the warning disappears
     ...    Financial year 2100-01
     user clicks link    Publishing checklist
     user checks checklist warnings contains
-    ...    2 things you may have forgotten, but do not need to resolve to publish this release.
-    user checks checklist warnings contains link
-    ...    A summary text block has been added, note that this functionality will be removed as part of the release page redesign (although legacy support for published releases will be in place)
+    ...    1 thing you may have forgotten, but do not need to resolve to publish this release.
     user checks checklist warnings does not contain link    A methodology for this publication is not yet approved
 
 Publish new release from adopted publication and make an amendment
@@ -346,7 +322,7 @@ Verify the checklist errors and warnings for amendment
 Navigate to contents page and add a release note
     user clicks link    Content
     user waits until h2 is visible    ${ADOPTED_PUBLICATION_NAME}
-    user waits until page contains button    Add a summary text block
+    user waits until page contains button    Add a warning text block
     user clicks button    Add note
     user enters text into element    id:create-release-note-form-reason    Test release note one
     user clicks button    Save note

--- a/tests/robot-tests/tests/admin_and_public_2/bau/edit_data_block_from_replacement.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/edit_data_block_from_replacement.robot
@@ -83,11 +83,9 @@ Create data block table
 Navigate to 'Content' page
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
-    user waits until page contains button    Add a summary text block    %{WAIT_SMALL}
+    user waits until page contains button    Add a warning text block    %{WAIT_SMALL}
 
-Add summary text block and key free text key statistic
-    user adds summary text block
-    user adds content to summary text block    Test intro text for ${PUBLICATION_NAME}
+Add key free text key statistic
     user adds free text key stat    Free text key stat title    9001%    Trend    Guidance title    Guidance text
 
     user checks element count is x    testid:keyStat    1

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -91,7 +91,7 @@ Create chart for data block
 Navigate to 'Content' page
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
-    user waits until page contains button    Add a summary text block    %{WAIT_SMALL}
+    user waits until page contains button    Add a warning text block    %{WAIT_SMALL}
 
     user waits until page finishes loading
     user waits until page finishes loading
@@ -328,7 +328,7 @@ Save data block for amendment
 Navigate to 'Content' page for amendment
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
-    user waits until page contains button    Add a summary text block
+    user waits until page contains button    Add a warning text block
 
 Verify amended Dates data block table has footnotes
     ${accordion}=    user opens accordion section    Dates data block    ${RELEASE_CONTENT_EDITABLE_ACCORDION}

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -128,7 +128,7 @@ Create chart for data block
 Navigate to 'Content' page
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
-    user waits until page contains button    Add a summary text block    %{WAIT_SMALL}
+    user waits until page contains button    Add a warning text block    %{WAIT_SMALL}
 
 Add free text key stat
     user adds free text key stat    Free text key stat title    9001%    Trend    Guidance title    Guidance text
@@ -231,7 +231,7 @@ Edit data block
 Navigate to the 'Content' page
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
-    user waits until page contains button    Add a summary text block    %{WAIT_SMALL}
+    user waits until page contains button    Add a warning text block    %{WAIT_SMALL}
 
 Verify data block is updated correctly
     # checking if data block cache has been invalidated by verifying the updates on the block
@@ -623,7 +623,7 @@ Update data block chart for amendment
 Navigate to 'Content' page for amendment
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
-    user waits until page contains button    Add a summary text block
+    user waits until page contains button    Add a warning text block
 
 Update free text key stat
     user updates free text key stat    1    Updated title    New stat    Updated trend

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend_2.robot
@@ -280,7 +280,7 @@ Delete second subject file
 Navigate to 'Content' page for release amendment
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
-    user waits until page contains button    Add a summary text block
+    user waits until page contains button    Add a warning text block
 
 Add release note to release amendment
     user clicks button    Add note

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publishing_organisations.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publishing_organisations.robot
@@ -49,7 +49,7 @@ Verify "Published by" shows updated organisations
 Navigate to 'Content' page
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
-    user waits until page contains button    Add a summary text block    %{WAIT_SMALL}
+    user waits until page contains button    Add a warning text block    %{WAIT_SMALL}
 
 Add free text key stat
     user adds free text key stat    Free text key stat title    9001%    Trend    Guidance title    Guidance text

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -28,9 +28,6 @@ user navigates to content page
 
 user adds basic release content
     [Arguments]    ${publication}    ${add_headlines_block}=${True}
-    user adds summary text block
-    user adds content to summary text block    Test summary text for ${publication}
-
     IF    ${add_headlines_block}
         user adds headlines text block
         user adds content to headlines text block    Test headlines summary text for ${publication}
@@ -234,10 +231,6 @@ user checks accordion section contains x blocks
     ${blocks}=    get child elements    ${section}    css:[data-testid="editableSectionBlock"]
     length should be    ${blocks}    ${num_blocks}
 
-user adds summary text block
-    user clicks button    Add a summary text block    id:releaseSummary
-    user waits until element contains    id:releaseSummary    This section is empty    %{WAIT_SMALL}
-
 user adds headlines text block
     user clicks button    Add a headlines text block    id:releaseHeadlines
     user waits until element contains    id:releaseHeadlines    This section is empty    %{WAIT_SMALL}
@@ -332,10 +325,6 @@ user adds content to autosaving text block
         user saves autosaving text block    ${parent}
     END
     user waits until element contains    ${parent}    ${content}    %{WAIT_SMALL}
-
-user adds content to summary text block
-    [Arguments]    ${content}
-    user adds content to autosaving text block    id:releaseSummary    ${content}
 
 user adds content to headlines text block
     [Arguments]    ${content}

--- a/tests/robot-tests/tests/seed_data/generate_seed_data_theme_1.robot
+++ b/tests/robot-tests/tests/seed_data/generate_seed_data_theme_1.robot
@@ -239,9 +239,10 @@ Add release content to ${RELEASE_1_NAME}
     user waits until page finishes loading
 
 Add release summary to ${RELEASE_1_NAME}
-    user adds summary text block
-    user adds content to summary text block
-    ...    Read national statistical summaries, view charts and tables and download data files.
+    # TODO: WIP for EES-7124 - this needs to be done via an API as we no longer should add 'background/summary' text blocks to publications
+    # user adds summary text block
+    # user adds content to summary text block
+    # ...    Read national statistical summaries, view charts and tables and download data files.
 
 Add key statistics to ${RELEASE_1_NAME}
     user adds key statistic from data block
@@ -693,9 +694,10 @@ Add release content to ${RELEASE_2_NAME}
     user waits until page finishes loading
 
 Add release summary to ${RELEASE_2_NAME}
-    user adds summary text block
-    user adds content to summary text block
-    ...    Read national statistical summaries, view charts and tables and download data files.
+    # TODO: WIP for EES-7124 - this needs to be done via an API as we no longer should add 'background/summary' text blocks to publications
+    # user adds summary text block
+    # user adds content to summary text block
+    # ...    Read national statistical summaries, view charts and tables and download data files.
 
 Add key statistics to ${RELEASE_2_NAME}
     user adds key statistic from data block


### PR DESCRIPTION
This is the first PR for EES-6422. It removes the summary text block from being able to be added to releases that don't currently contain a summary text block. It also fixes UI tests that break as a result. 

Second PR is going to focus on fixing the TODOs in `generate_seed_data_theme_1.robot` so that it can be used to generate the seeded publications with a background/summary text block. 
This allows that we test that an existing "legacy" release with a summary section has that section still editable and that the summary section is still visible.