### PR TITLE
Ees 7003 handle completion of background screening processes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,5 +67,6 @@ services:
       - LOG_DIR=/tmp
       - DD_CHECKS=FALSE
       - LOG_SCREENING_RESULTS=TRUE
+      - CONCURRENT_R_WORKERS=4
 volumes:
   data-storage-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,5 +66,6 @@ services:
       - AzureWebJobs_StartScreening=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;QueueEndpoint=http://data-storage:10001/devstoreaccount1;
       - LOG_DIR=/tmp
       - DD_CHECKS=FALSE
+      - LOG_SCREENING_RESULTS=TRUE
 volumes:
   data-storage-data:

--- a/infrastructure/templates/screener/application/screenerContainerisedFunctionApp.bicep
+++ b/infrastructure/templates/screener/application/screenerContainerisedFunctionApp.bicep
@@ -48,6 +48,9 @@ param screenerDockerImageTag string
 @description('Whether or not to include Data Dictionary checks in the Screener.')
 param includeDataDictionaryChecks bool = false
 
+@description('Whether or not to log screening results in the Screener API logs.')
+param logScreeningResults = false
+
 @description('Whether to create or update Azure Monitor alerts during this deploy.')
 param deployAlerts bool
 
@@ -115,6 +118,10 @@ module containerisedFunctionAppModule '../../common/components/containerisedFunc
       {
         name: 'DD_CHECKS'
         value: includeDataDictionaryChecks ? 'TRUE' : 'FALSE'
+      }
+      {
+        name: 'LOG_SCREENING_RESULTS'
+        value: logScreeningResults ? 'TRUE' : 'FALSE'
       }
       {
         name: 'AzureWebJobs_StartScreening__queueServiceUri'

--- a/infrastructure/templates/screener/application/screenerContainerisedFunctionApp.bicep
+++ b/infrastructure/templates/screener/application/screenerContainerisedFunctionApp.bicep
@@ -46,10 +46,13 @@ param functionAppImageName string
 param screenerDockerImageTag string
 
 @description('Whether or not to include Data Dictionary checks in the Screener.')
-param includeDataDictionaryChecks bool = false
+param includeDataDictionaryChecks bool
 
 @description('Whether or not to log screening results in the Screener API logs.')
-param logScreeningResults = false
+param logScreeningResults bool
+
+@description('Number of concurrent threads that can be used by Plumber to process background jobs.')
+param concurrentRWorkers int
 
 @description('Whether to create or update Azure Monitor alerts during this deploy.')
 param deployAlerts bool
@@ -122,6 +125,10 @@ module containerisedFunctionAppModule '../../common/components/containerisedFunc
       {
         name: 'LOG_SCREENING_RESULTS'
         value: logScreeningResults ? 'TRUE' : 'FALSE'
+      }
+      {
+          name: 'CONCURRENT_R_WORKERS'
+          value: '${concurrentRWorkers}'
       }
       {
         name: 'AzureWebJobs_StartScreening__queueServiceUri'

--- a/infrastructure/templates/screener/main.bicep
+++ b/infrastructure/templates/screener/main.bicep
@@ -34,6 +34,9 @@ param devopsServicePrincipalId string = ''
 @description('Whether or not to include Data Dictionary checks in the Screener.')
 param includeDataDictionaryChecks bool = false
 
+@description('Whether or not to log screening results in the Screener API logs.')
+param logScreeningResults = false
+
 @description('Tagging : Date Provisioned. Used for tagging resources created by this infrastructure pipeline.')
 param dateProvisioned string = utcNow('u')
 
@@ -94,6 +97,7 @@ module screenerFunctionAppModule 'application/screenerContainerisedFunctionApp.b
     screenerAppRegistrationClientId: screenerAppRegistrationClientId
     devopsServicePrincipalId: devopsServicePrincipalId
     includeDataDictionaryChecks: includeDataDictionaryChecks
+    logScreeningResults: logScreeningResults
     screenerDockerImageTag: screenerDockerImageTag
     resourceNames: resourceNames
     functionAppExists: screenerFunctionAppExists

--- a/infrastructure/templates/screener/main.bicep
+++ b/infrastructure/templates/screener/main.bicep
@@ -35,7 +35,10 @@ param devopsServicePrincipalId string = ''
 param includeDataDictionaryChecks bool = false
 
 @description('Whether or not to log screening results in the Screener API logs.')
-param logScreeningResults = false
+param logScreeningResults bool = false
+
+@description('Number of concurrent threads that can be used by Plumber to process background jobs.')
+param concurrentRWorkers int = 4
 
 @description('Tagging : Date Provisioned. Used for tagging resources created by this infrastructure pipeline.')
 param dateProvisioned string = utcNow('u')
@@ -98,6 +101,7 @@ module screenerFunctionAppModule 'application/screenerContainerisedFunctionApp.b
     devopsServicePrincipalId: devopsServicePrincipalId
     includeDataDictionaryChecks: includeDataDictionaryChecks
     logScreeningResults: logScreeningResults
+    concurrentRWorkers: concurrentRWorkers
     screenerDockerImageTag: screenerDockerImageTag
     resourceNames: resourceNames
     functionAppExists: screenerFunctionAppExists

--- a/infrastructure/templates/screener/parameters/main-dev.bicepparam
+++ b/infrastructure/templates/screener/parameters/main-dev.bicepparam
@@ -2,3 +2,6 @@ using '../main.bicep'
 
 // Environment Params
 param environmentName = 'Development'
+
+// Allow screening results to be logged in the Screener API log stream on Dev.
+param logScreeningResults = true

--- a/infrastructure/templates/screener/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/screener/parameters/main-preprod.bicepparam
@@ -2,3 +2,6 @@ using '../main.bicep'
 
 // Environment Params
 param environmentName = 'Pre-Production'
+
+// Allow screening results to be logged in the Screener API log stream on Pre-Prod.
+param logScreeningResults = true

--- a/infrastructure/templates/screener/parameters/main-preprod.bicepparam
+++ b/infrastructure/templates/screener/parameters/main-preprod.bicepparam
@@ -5,3 +5,6 @@ param environmentName = 'Pre-Production'
 
 // Allow screening results to be logged in the Screener API log stream on Pre-Prod.
 param logScreeningResults = true
+
+// Don't include any worker pool in Plumber yet for Pre-Prod.
+param concurrentRWorkers = 0

--- a/infrastructure/templates/screener/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/screener/parameters/main-prod.bicepparam
@@ -15,3 +15,6 @@ param screenerFunctionAppSku = {
 // In the future, this can be switched back to true to allow Prod to properly enforce this
 // quality check.
 param includeDataDictionaryChecks = false
+
+// Don't include any worker pool in Plumber yet for Prod.
+param concurrentRWorkers = 0

--- a/infrastructure/templates/screener/parameters/main-test.bicepparam
+++ b/infrastructure/templates/screener/parameters/main-test.bicepparam
@@ -2,3 +2,6 @@ using '../main.bicep'
 
 // Environment Params
 param environmentName = 'Test'
+
+// Allow screening results to be logged in the Screener API log stream on Test.
+param logScreeningResults = true

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetUploadMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetUploadMockBuilder.cs
@@ -101,6 +101,7 @@ public class DataSetUploadMockBuilder(TimeProvider? timeProvider = null)
             Created = DateTime.UtcNow,
             ScreenerResult = new()
             {
+                Passed = true,
                 OverallResult = "Passed",
                 TestResults =
                 [

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetUploadMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetUploadMockBuilder.cs
@@ -85,6 +85,25 @@ public class DataSetUploadMockBuilder(TimeProvider? timeProvider = null)
         };
     }
 
+    public DataSetUpload BuildScreenerErrorEntity()
+    {
+        return new DataSetUpload
+        {
+            ReleaseVersionId = _releaseVersionId ?? Guid.NewGuid(),
+            DataSetTitle = "Test Data Set",
+            DataFileId = Guid.NewGuid(),
+            DataFileName = "data.csv",
+            DataFileSizeInBytes = 434,
+            MetaFileId = Guid.NewGuid(),
+            MetaFileName = "meta.data.csv",
+            MetaFileSizeInBytes = 157,
+            Status = DataSetUploadStatus.SCREENER_ERROR,
+            UploadedBy = "test@test.com",
+            Created = _timeProvider.GetUtcNow().AddDays(-1).Date,
+            ReplacingFileId = null,
+        };
+    }
+
     public static DataSetUploadViewModel BuildViewModel()
     {
         return new DataSetUploadViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetUploadRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetUploadRepositoryTests.cs
@@ -31,12 +31,13 @@ public class DataSetUploadRepositoryTests
         var upload1 = builder.WithReleaseVersionId(releaseVersionId).BuildInitialEntity();
         var upload2 = builder.WithReleaseVersionId(releaseVersionId).WithFailingTests().BuildScreenedEntity();
         var upload3 = builder.WithReleaseVersionId(releaseVersionId).WithWarningTests().BuildScreenedEntity();
+        var upload4 = builder.WithReleaseVersionId(releaseVersionId).BuildScreenerErrorEntity();
         var unrelatedUpload = builder.WithReleaseVersionId(Guid.NewGuid()).BuildScreenedEntity();
 
         var contextId = Guid.NewGuid().ToString();
         await using (var contentDbContext = InMemoryApplicationDbContext(contextId))
         {
-            contentDbContext.DataSetUploads.AddRange(upload1, upload2, upload3, unrelatedUpload);
+            contentDbContext.DataSetUploads.AddRange(upload1, upload2, upload3, upload4, unrelatedUpload);
             await contentDbContext.SaveChangesAsync();
         }
 
@@ -50,18 +51,16 @@ public class DataSetUploadRepositoryTests
             // Assert
             var uploadViewModels = result.AssertRight();
 
-            Assert.Equal(3, uploadViewModels.Count);
+            Assert.Equal(4, uploadViewModels.Count);
 
             // Assert the basic details are mapped correctly.
             AssertBasicViewModelDetailsCorrect(uploadViewModels[0], upload1);
             AssertBasicViewModelDetailsCorrect(uploadViewModels[1], upload2);
             AssertBasicViewModelDetailsCorrect(uploadViewModels[2], upload3);
+            AssertBasicViewModelDetailsCorrect(uploadViewModels[3], upload4);
 
-            // Assert that a DataSetUpload with no screening is mapped correctly.
-            // TODO EES-7003 - we're currently asserting that status is SCREENER_ERROR at the moment without
-            // a screening result present. This needs to be updated so that initially after upload, it's OK for
-            // there to be no screener result.
-            Assert.Equal(nameof(DataSetUploadStatus.SCREENER_ERROR), uploadViewModels[0].Status);
+            // Assert that a DataSetUpload that is undergoing screening is mapped correctly.
+            Assert.Equal(nameof(DataSetUploadStatus.SCREENING), uploadViewModels[0].Status);
 
             // Assert it has no screener results or progress yet.
             Assert.False(uploadViewModels[0].PublicApiCompatible);
@@ -93,6 +92,14 @@ public class DataSetUploadRepositoryTests
                 uploadViewModels[2].ScreenerProgress!.PercentageComplete
             );
             Assert.Equal(upload3.ScreenerProgress!.Stage, uploadViewModels[2].ScreenerProgress!.Stage);
+
+            // Assert that a DataSetUpload that has received a Screener error is mapped correctly.
+            Assert.Equal(nameof(DataSetUploadStatus.SCREENER_ERROR), uploadViewModels[3].Status);
+
+            // Assert it has no screener results or progress yet.
+            Assert.False(uploadViewModels[3].PublicApiCompatible);
+            Assert.Null(uploadViewModels[3].ScreenerResult);
+            Assert.Null(uploadViewModels[3].ScreenerProgress);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerClientTests.cs
@@ -226,7 +226,7 @@ public class DataSetScreenerClientTests
             Guid[] dataSetIds = [Guid.NewGuid(), Guid.NewGuid()];
 
             _mockHttp
-                .Expect(HttpMethod.Delete, $"{BaseUri.AbsoluteUri}/progress")
+                .Expect(HttpMethod.Delete, $"{BaseUri.AbsoluteUri}/progress-and-completion-files")
                 .WithQueryString($"data_set_id={dataSetIds[0]}&data_set_id={dataSetIds[1]}")
                 .Respond(HttpStatusCode.NoContent);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerClientTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerClientTests.cs
@@ -104,7 +104,7 @@ public class DataSetScreenerClientTests
             _mockHttp
                 .Expect(HttpMethod.Post, $"{BaseUri.AbsoluteUri}/screen")
                 .WithJsonContent(request, _requestSerializerOptions)
-                .Respond(HttpStatusCode.Accepted, "application/json", JsonSerializer.Serialize(responseBody));
+                .Respond(HttpStatusCode.OK, "application/json", JsonSerializer.Serialize(responseBody));
 
             var dataSetScreenerClient = BuildService();
 
@@ -128,25 +128,31 @@ public class DataSetScreenerClientTests
                 new()
                 {
                     DataSetId = dataSetIds[0],
-                    PercentageComplete = 50.12,
-                    Completed = false,
-                    Passed = false,
-                    Stage = "Validation",
+                    ProgressReport = new DataSetScreenerProgressReport
+                    {
+                        PercentageComplete = 50.12,
+                        Completed = false,
+                        Passed = false,
+                        Stage = "Validation",
+                    },
                 },
                 new()
                 {
                     DataSetId = dataSetIds[1],
-                    PercentageComplete = 100.00,
-                    Completed = true,
-                    Passed = true,
-                    Stage = "Screening",
+                    ProgressReport = new DataSetScreenerProgressReport
+                    {
+                        PercentageComplete = 100.00,
+                        Completed = true,
+                        Passed = true,
+                        Stage = "Screening",
+                    },
                 },
             ];
 
             _mockHttp
                 .Expect(HttpMethod.Get, $"{BaseUri.AbsoluteUri}/progress")
                 .WithQueryString($"data_set_id={dataSetIds[0]}&data_set_id={dataSetIds[1]}")
-                .Respond(HttpStatusCode.Accepted, "application/json", JsonSerializer.Serialize(responseBody));
+                .Respond(HttpStatusCode.OK, "application/json", JsonSerializer.Serialize(responseBody));
 
             var dataSetScreenerClient = BuildService();
 
@@ -158,6 +164,80 @@ public class DataSetScreenerClientTests
             _mockHttp.VerifyNoOutstandingExpectation();
 
             Assert.Equivalent(responseBody, response);
+        }
+    }
+
+    public class GetScreeningCompletionReportsTests : DataSetScreenerClientTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            Guid[] dataSetIds = [Guid.NewGuid(), Guid.NewGuid()];
+
+            DataSetScreenerCompletionReportResponse[] responseBody =
+            [
+                new()
+                {
+                    DataSetId = dataSetIds[0],
+                    CompletionReport = new DataSetScreenerResponse
+                    {
+                        OverallResult = "passed",
+                        Passed = true,
+                        PublicApiCompatible = true,
+                        TestResults = [],
+                    },
+                },
+                new()
+                {
+                    DataSetId = dataSetIds[1],
+                    CompletionReport = new DataSetScreenerResponse
+                    {
+                        OverallResult = "passed",
+                        Passed = true,
+                        PublicApiCompatible = true,
+                        TestResults = [new DataScreenerTestResult { Stage = "stage 1", TestFunctionName = "test 1" }],
+                    },
+                },
+            ];
+
+            _mockHttp
+                .Expect(HttpMethod.Get, $"{BaseUri.AbsoluteUri}/completion-reports")
+                .WithQueryString($"data_set_id={dataSetIds[0]}&data_set_id={dataSetIds[1]}")
+                .Respond(HttpStatusCode.OK, "application/json", JsonSerializer.Serialize(responseBody));
+
+            var dataSetScreenerClient = BuildService();
+
+            var response = await dataSetScreenerClient.GetScreenerCompletionReports(
+                dataSetIds: dataSetIds,
+                CancellationToken.None
+            );
+
+            _mockHttp.VerifyNoOutstandingExpectation();
+
+            Assert.Equivalent(responseBody, response);
+        }
+    }
+
+    public class DeleteScreenerProgressAndCompletionFiles : DataSetScreenerClientTests
+    {
+        [Fact]
+        public async Task Success()
+        {
+            Guid[] dataSetIds = [Guid.NewGuid(), Guid.NewGuid()];
+
+            _mockHttp
+                .Expect(HttpMethod.Delete, $"{BaseUri.AbsoluteUri}/progress")
+                .WithQueryString($"data_set_id={dataSetIds[0]}&data_set_id={dataSetIds[1]}")
+                .Respond(HttpStatusCode.NoContent);
+
+            var dataSetScreenerClient = BuildService();
+
+            await dataSetScreenerClient.DeleteScreenerProgressAndCompletionFiles(
+                dataSetIds: dataSetIds,
+                CancellationToken.None
+            );
+
+            _mockHttp.VerifyNoOutstandingExpectation();
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerProgressUpdaterJobTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerProgressUpdaterJobTests.cs
@@ -9,7 +9,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
-using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Screener;
 
@@ -42,6 +41,10 @@ public class DataSetScreenerProgressUpdaterJobTests
             .Setup(s => s.MarkDataSetsWithoutProgressAsFailed(It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
+        dataSetScreenerService
+            .Setup(s => s.CompleteDataSetScreeningForFinishedDataSets(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
         var job = BuildService(
             dataSetScreenerService: dataSetScreenerService.Object,
             periodicTimer: periodicTimer.Object
@@ -53,12 +56,17 @@ public class DataSetScreenerProgressUpdaterJobTests
 
         periodicTimer.Verify(p => p.WaitForNextTickAsync(It.IsAny<CancellationToken>()), Times.Exactly(1));
 
+        dataSetScreenerService.Verify(s => s.UpdateScreeningProgress(It.IsAny<CancellationToken>()), Times.Exactly(1));
+
         dataSetScreenerService.Verify(
             s => s.MarkDataSetsWithoutProgressAsFailed(It.IsAny<CancellationToken>()),
             Times.Exactly(1)
         );
 
-        dataSetScreenerService.Verify(s => s.UpdateScreeningProgress(It.IsAny<CancellationToken>()), Times.Exactly(1));
+        dataSetScreenerService.Verify(
+            s => s.CompleteDataSetScreeningForFinishedDataSets(It.IsAny<CancellationToken>()),
+            Times.Exactly(1)
+        );
     }
 
     [Fact]
@@ -94,6 +102,10 @@ public class DataSetScreenerProgressUpdaterJobTests
             .Setup(s => s.MarkDataSetsWithoutProgressAsFailed(It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
+        dataSetScreenerService
+            .Setup(s => s.CompleteDataSetScreeningForFinishedDataSets(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
         var job = BuildService(
             dataSetScreenerService: dataSetScreenerService.Object,
             periodicTimer: periodicTimer.Object
@@ -105,12 +117,17 @@ public class DataSetScreenerProgressUpdaterJobTests
 
         periodicTimer.Verify(p => p.WaitForNextTickAsync(It.IsAny<CancellationToken>()), Times.Exactly(3));
 
+        dataSetScreenerService.Verify(s => s.UpdateScreeningProgress(It.IsAny<CancellationToken>()), Times.Exactly(3));
+
         dataSetScreenerService.Verify(
             s => s.MarkDataSetsWithoutProgressAsFailed(It.IsAny<CancellationToken>()),
             Times.Exactly(3)
         );
 
-        dataSetScreenerService.Verify(s => s.UpdateScreeningProgress(It.IsAny<CancellationToken>()), Times.Exactly(3));
+        dataSetScreenerService.Verify(
+            s => s.CompleteDataSetScreeningForFinishedDataSets(It.IsAny<CancellationToken>()),
+            Times.Exactly(3)
+        );
     }
 
     private DataSetScreenerProgressUpdaterJob BuildService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServicePermissionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServicePermissionsTests.cs
@@ -11,6 +11,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Content.Security;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Screener;
@@ -47,7 +48,8 @@ public class DataSetScreenerServicePermissionsTests
             contentDbContext: contentDbContext,
             timeProvider: TimeProvider.System,
             mapper: MapperUtils.AdminMapper(),
-            options: new DataScreenerOptions().ToOptionsWrapper()
+            options: new DataScreenerOptions().ToOptionsWrapper(),
+            logger: Mock.Of<ILogger<DataSetScreenerService>>()
         );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
@@ -14,6 +14,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Fixtures;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Utils.ContentDbUtils;
@@ -1315,7 +1316,8 @@ public abstract class DataSetScreenerServiceTests
             {
                 ScreenerProgressUpdateIntervalSeconds = ScreenerProgressUpdateIntervalSeconds,
                 ScreenerProgressUpdateFailureIntervalMinutes = ScreenerProgressUpdateFailureIntervalMinutes,
-            }.ToOptionsWrapper()
+            }.ToOptionsWrapper(),
+            logger: Mock.Of<ILogger<DataSetScreenerService>>()
         );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
@@ -163,18 +163,24 @@ public abstract class DataSetScreenerServiceTests
                 new()
                 {
                     DataSetId = dataSetIds[1],
-                    PercentageComplete = 100.00,
-                    Completed = true,
-                    Passed = true,
-                    Stage = "complete",
+                    ProgressReport = new DataSetScreenerProgressReport
+                    {
+                        PercentageComplete = 100.00,
+                        Completed = true,
+                        Passed = true,
+                        Stage = "complete",
+                    },
                 },
                 new()
                 {
                     DataSetId = dataSetIds[0],
-                    PercentageComplete = 80.99,
-                    Completed = false,
-                    Passed = false,
-                    Stage = "screening",
+                    ProgressReport = new DataSetScreenerProgressReport
+                    {
+                        PercentageComplete = 80.99,
+                        Completed = false,
+                        Passed = false,
+                        Stage = "screening",
+                    },
                 },
             ];
 
@@ -389,10 +395,13 @@ public abstract class DataSetScreenerServiceTests
                 new()
                 {
                     DataSetId = dataSetIds[1],
-                    PercentageComplete = 100.00,
-                    Completed = true,
-                    Passed = true,
-                    Stage = "Complete",
+                    ProgressReport = new DataSetScreenerProgressReport
+                    {
+                        PercentageComplete = 100.00,
+                        Completed = true,
+                        Passed = true,
+                        Stage = "Complete",
+                    },
                 },
             ];
 
@@ -505,10 +514,13 @@ public abstract class DataSetScreenerServiceTests
                 new()
                 {
                     DataSetId = dataSetUndergoingScreening.Id,
-                    PercentageComplete = dataSetUndergoingScreening.ScreenerProgress!.PercentageComplete,
-                    Completed = dataSetUndergoingScreening.ScreenerProgress!.Completed,
-                    Passed = dataSetUndergoingScreening.ScreenerProgress!.Passed,
-                    Stage = dataSetUndergoingScreening.ScreenerProgress!.Stage,
+                    ProgressReport = new DataSetScreenerProgressReport
+                    {
+                        PercentageComplete = dataSetUndergoingScreening.ScreenerProgress!.PercentageComplete,
+                        Completed = dataSetUndergoingScreening.ScreenerProgress!.Completed,
+                        Passed = dataSetUndergoingScreening.ScreenerProgress!.Passed,
+                        Stage = dataSetUndergoingScreening.ScreenerProgress!.Stage,
+                    },
                 },
             ];
 
@@ -832,12 +844,22 @@ public abstract class DataSetScreenerServiceTests
                 await context.SaveChangesAsync();
             }
 
+            var dataSetIds = dataSetsUndergoingScreening.Select(upload => upload.Id).ToList();
+
+            var screenerClient = new Mock<IDataSetScreenerClient>(MockBehavior.Strict);
+
+            screenerClient
+                .Setup(s => s.DeleteScreenerProgressAndCompletionFiles(dataSetIds, CancellationToken.None))
+                .Returns(Task.CompletedTask);
+
             await using (var context = InMemoryContentDbContext(contextId))
             {
-                var service = BuildService(contentDbContext: context);
+                var service = BuildService(contentDbContext: context, screenerClient: screenerClient.Object);
 
                 // Act
                 var results = await service.MarkDataSetsWithoutProgressAsFailed(CancellationToken.None);
+
+                screenerClient.VerifyAll();
 
                 Assert.Equal(2, results.Count);
 
@@ -973,6 +995,300 @@ public abstract class DataSetScreenerServiceTests
 
                 // Expect it to be in its original state.
                 Assert.Equal(DataSetUploadStatus.PENDING_REVIEW, upload.Status);
+
+                // Expect it not to have had any ScreenerResult applied.
+                Assert.Null(upload.ScreenerResult);
+            }
+        }
+    }
+
+    public class CompleteDataSetScreeningForFinishedDataSetsTests : DataSetScreenerServiceTests
+    {
+        [Fact]
+        public async Task DataSetsWithCompletedScreeningProgress_MarkedAsComplete()
+        {
+            // Arrange
+            var dataSetsUndergoingScreening = _dataFixture
+                .DefaultDataSetUpload()
+                .WithStatus(DataSetUploadStatus.SCREENING)
+                // The first data set has had a progress update that shows it has completed successfully.
+                .ForIndex(
+                    0,
+                    s =>
+                        s.SetScreenerProgress(
+                            new DataSetScreenerProgress
+                            {
+                                Completed = true,
+                                Passed = false,
+                                PercentageComplete = 100,
+                                Stage = "Completed",
+                            }
+                        )
+                )
+                // The second data set has had a progress update that shows it has not yet completed.
+                .ForIndex(
+                    1,
+                    s =>
+                        s.SetScreenerProgress(
+                            new DataSetScreenerProgress
+                            {
+                                Completed = false,
+                                Passed = false,
+                                PercentageComplete = 70,
+                                Stage = "screening",
+                            }
+                        )
+                )
+                // The third data set has had a progress update that shows it has not completed, but not successfully.
+                .ForIndex(
+                    2,
+                    s =>
+                        s.SetScreenerProgress(
+                            new DataSetScreenerProgress
+                            {
+                                Completed = true,
+                                Passed = false,
+                                PercentageComplete = 70,
+                                Stage = "failed",
+                            }
+                        )
+                )
+                .GenerateList();
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                await context.DataSetUploads.AddRangeAsync(dataSetsUndergoingScreening);
+                await context.SaveChangesAsync();
+            }
+
+            // Return the completion reports out of order, to ensure they're matched up correctly with the
+            // correct data sets by id.
+            List<DataSetScreenerCompletionReportResponse> completionReportsResponse =
+            [
+                new()
+                {
+                    DataSetId = dataSetsUndergoingScreening[2].Id,
+                    CompletionReport = new DataSetScreenerResponse
+                    {
+                        OverallResult = "Failed screening at stage 2",
+                        Passed = false,
+                        PublicApiCompatible = false,
+                        TestResults =
+                        [
+                            new DataScreenerTestResult
+                            {
+                                Stage = "stage 2",
+                                TestFunctionName = "a test",
+                                Notes = "Some notes",
+                                GuidanceUrl = "https://example.com",
+                                Result = TestResult.FAIL,
+                            },
+                        ],
+                    },
+                },
+                new()
+                {
+                    DataSetId = dataSetsUndergoingScreening[0].Id,
+                    CompletionReport = new DataSetScreenerResponse
+                    {
+                        OverallResult = "Passed all tests",
+                        Passed = true,
+                        PublicApiCompatible = true,
+                        TestResults =
+                        [
+                            new DataScreenerTestResult
+                            {
+                                Stage = "stage 2",
+                                TestFunctionName = "a test",
+                                Notes = "Some notes",
+                                GuidanceUrl = "https://example.com",
+                                Result = TestResult.PASS,
+                            },
+                            new DataScreenerTestResult
+                            {
+                                Stage = "stage 3",
+                                TestFunctionName = "another test",
+                                Notes = "Some notes",
+                                GuidanceUrl = "https://example.com",
+                                Result = TestResult.PASS,
+                            },
+                        ],
+                    },
+                },
+            ];
+
+            var screenerClient = new Mock<IDataSetScreenerClient>(MockBehavior.Strict);
+
+            screenerClient
+                .Setup(s =>
+                    s.GetScreenerCompletionReports(
+                        new[] { dataSetsUndergoingScreening[0].Id, dataSetsUndergoingScreening[2].Id },
+                        CancellationToken.None
+                    )
+                )
+                .ReturnsAsync(completionReportsResponse);
+
+            screenerClient
+                .Setup(s =>
+                    s.DeleteScreenerProgressAndCompletionFiles(
+                        new[] { dataSetsUndergoingScreening[2].Id, dataSetsUndergoingScreening[0].Id },
+                        CancellationToken.None
+                    )
+                )
+                .Returns(Task.CompletedTask);
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var service = BuildService(screenerClient: screenerClient.Object, contentDbContext: context);
+
+                // Act
+                var results = await service.CompleteDataSetScreeningForFinishedDataSets(CancellationToken.None);
+
+                // Assert
+                screenerClient.VerifyAll();
+
+                Assert.Equal(2, results.Count);
+
+                Assert.Equal(dataSetsUndergoingScreening[0].Id, results[0].Id);
+                var expectedDataSet1CompletionReport = completionReportsResponse[1].CompletionReport;
+                Assert.Equal(expectedDataSet1CompletionReport.OverallResult, results[0].ScreenerResult!.OverallResult);
+                Assert.Equal(
+                    expectedDataSet1CompletionReport.TestResults.Count,
+                    results[0].ScreenerResult!.TestResults.Count
+                );
+
+                Assert.Equal(dataSetsUndergoingScreening[2].Id, results[1].Id);
+                var expectedDataSet3CompletionReport = completionReportsResponse[0].CompletionReport;
+                Assert.Equal(expectedDataSet3CompletionReport.OverallResult, results[1].ScreenerResult!.OverallResult);
+                Assert.Equal(
+                    expectedDataSet3CompletionReport.TestResults.Count,
+                    results[1].ScreenerResult!.TestResults.Count
+                );
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var updatedDataSetUploads = context.DataSetUploads.ToList();
+
+                // Expect that data set 1 had its completion report applied and status updated to
+                // show that it passed screening successfully.
+                var dataSetUpload1 = updatedDataSetUploads[0];
+                var expectedDataSet1CompletionReport = completionReportsResponse[1].CompletionReport;
+                expectedDataSet1CompletionReport.AssertDeepEqualTo(dataSetUpload1.ScreenerResult);
+                Assert.Equal(DataSetUploadStatus.PENDING_REVIEW, dataSetUpload1.Status);
+
+                // Expect that data set 2 has no updates as it has not yet completed.
+                var dataSetUpload2 = updatedDataSetUploads[1];
+                Assert.Null(dataSetUpload2.ScreenerResult);
+                Assert.Equal(DataSetUploadStatus.SCREENING, dataSetUpload2.Status);
+
+                // Expect that data set 3 had its completion report applied and status updated to
+                // show that it failed screening.
+                var dataSetUpload3 = updatedDataSetUploads[2];
+                var expectedDataSet3CompletionReport = completionReportsResponse[0].CompletionReport;
+                expectedDataSet3CompletionReport.AssertDeepEqualTo(dataSetUpload3.ScreenerResult);
+                Assert.Equal(DataSetUploadStatus.FAILED_SCREENING, dataSetUpload3.Status);
+            }
+        }
+
+        [Fact]
+        public async Task DataSetWithoutCompletionReport_Ignored_NotUpdated()
+        {
+            // Arrange
+            DataSetUpload dataSetUndergoingScreening = _dataFixture
+                .DefaultDataSetUpload()
+                .WithStatus(DataSetUploadStatus.SCREENING)
+                .WithScreenerProgress(
+                    new DataSetScreenerProgress
+                    {
+                        Completed = true,
+                        Passed = false,
+                        PercentageComplete = 100,
+                        Stage = "Completed",
+                    }
+                );
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                await context.DataSetUploads.AddRangeAsync(dataSetUndergoingScreening);
+                await context.SaveChangesAsync();
+            }
+
+            var screenerClient = new Mock<IDataSetScreenerClient>(MockBehavior.Strict);
+
+            // Return no completion reports, to simulate an issue getting it successfully
+            // from the Screener API.
+            screenerClient
+                .Setup(s =>
+                    s.GetScreenerCompletionReports(new[] { dataSetUndergoingScreening.Id }, CancellationToken.None)
+                )
+                .ReturnsAsync([]);
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var service = BuildService(screenerClient: screenerClient.Object, contentDbContext: context);
+
+                // Act
+                var results = await service.CompleteDataSetScreeningForFinishedDataSets(CancellationToken.None);
+
+                // Assert
+                screenerClient.VerifyAll();
+
+                Assert.Empty(results);
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var dataSetUpload = context.DataSetUploads.Single();
+
+                // Expect that the data set has been ignored.
+                dataSetUpload.AssertDeepEqualTo(dataSetUndergoingScreening);
+            }
+        }
+
+        [Fact]
+        public async Task DataSetNotUndergoingScreening_Ignored_NotMarkedAsComplete()
+        {
+            // Arrange
+            DataSetUpload dataSetUndergoingScreening = _dataFixture
+                .DefaultDataSetUpload()
+                .WithStatus(DataSetUploadStatus.PENDING_IMPORT)
+                .WithScreenerProgress(
+                    new DataSetScreenerProgress
+                    {
+                        Completed = true,
+                        Passed = true,
+                        PercentageComplete = 100,
+                        Stage = "complete",
+                    }
+                );
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                await context.DataSetUploads.AddRangeAsync(dataSetUndergoingScreening);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var service = BuildService(contentDbContext: context);
+
+                // Act
+                var results = await service.CompleteDataSetScreeningForFinishedDataSets(CancellationToken.None);
+
+                Assert.Empty(results);
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                // ReSharper disable once EntityFramework.NPlusOne.IncompleteDataQuery
+                var upload = context.DataSetUploads.Single();
+
+                // Expect it to be in its original state.
+                Assert.Equal(DataSetUploadStatus.PENDING_IMPORT, upload.Status);
 
                 // Expect it not to have had any ScreenerResult applied.
                 Assert.Null(upload.ScreenerResult);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
@@ -1039,7 +1039,7 @@ public abstract class DataSetScreenerServiceTests
                             }
                         )
                 )
-                // The third data set has had a progress update that shows it has not completed, but not successfully.
+                // The third data set has had a progress update that shows it has completed, but not successfully.
                 .ForIndex(
                     2,
                     s =>
@@ -1132,7 +1132,7 @@ public abstract class DataSetScreenerServiceTests
             screenerClient
                 .Setup(s =>
                     s.DeleteScreenerProgressAndCompletionFiles(
-                        new[] { dataSetsUndergoingScreening[2].Id, dataSetsUndergoingScreening[0].Id },
+                        new[] { dataSetsUndergoingScreening[0].Id, dataSetsUndergoingScreening[2].Id },
                         CancellationToken.None
                     )
                 )

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
@@ -209,7 +209,7 @@ public abstract class DataSetScreenerServiceTests
 
                 var expectedDataSet1ScreenerProgress = dataSetsUndergoingScreening[0].ScreenerProgress! with
                 {
-                    PercentageComplete = 80,
+                    PercentageComplete = 80.99,
                     Stage = "screening",
                 };
 
@@ -470,6 +470,92 @@ public abstract class DataSetScreenerServiceTests
                 Assert.Equal(utcNow, dataSetUpload2.ScreenerProgressLastUpdated);
             }
         }
+
+        [Fact]
+        public async Task DataSetsBeingScreened_NeedProgressUpdate_NoProgressChanged_OnlyCheckedDateUpdated()
+        {
+            var utcNow = DateTimeOffset.UtcNow;
+
+            // Arrange
+            DataSetUpload dataSetUndergoingScreening = _dataFixture
+                .DefaultDataSetUpload()
+                .WithStatus(DataSetUploadStatus.SCREENING)
+                .WithScreenerProgress(
+                    new DataSetScreenerProgress
+                    {
+                        Completed = false,
+                        Passed = false,
+                        PercentageComplete = 50,
+                        Stage = "validation",
+                    }
+                )
+                .WithScreenerProgressLastChecked(utcNow.AddSeconds(-ScreenerProgressUpdateIntervalSeconds))
+                .WithScreenerProgressLastUpdated(utcNow.AddSeconds(-ScreenerProgressUpdateIntervalSeconds));
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                await context.DataSetUploads.AddRangeAsync(dataSetUndergoingScreening);
+                await context.SaveChangesAsync();
+            }
+
+            // Return a progress response with no updates since the last time it was checked.
+            List<DataSetScreenerProgressResponse> progressResponse =
+            [
+                new()
+                {
+                    DataSetId = dataSetUndergoingScreening.Id,
+                    PercentageComplete = dataSetUndergoingScreening.ScreenerProgress!.PercentageComplete,
+                    Completed = dataSetUndergoingScreening.ScreenerProgress!.Completed,
+                    Passed = dataSetUndergoingScreening.ScreenerProgress!.Passed,
+                    Stage = dataSetUndergoingScreening.ScreenerProgress!.Stage,
+                },
+            ];
+
+            var screenerClient = new Mock<IDataSetScreenerClient>(MockBehavior.Strict);
+
+            screenerClient
+                .Setup(s => s.GetScreenerProgress(new[] { dataSetUndergoingScreening.Id }, CancellationToken.None))
+                .ReturnsAsync(progressResponse);
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var service = BuildService(
+                    screenerClient: screenerClient.Object,
+                    contentDbContext: context,
+                    timeProvider: new FakeTimeProvider(utcNow)
+                );
+
+                // Act
+                var result = await service.UpdateScreeningProgress(CancellationToken.None);
+
+                // Assert
+                screenerClient.VerifyAll();
+
+                Assert.Equal(progressResponse, result);
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var updatedDataSetUploads = context.DataSetUploads.ToList();
+
+                var dataSetUpload = updatedDataSetUploads.Single();
+
+                // Assert that no progress fields have been updated because nothing changed since the last check.
+                Assert.Equal(dataSetUndergoingScreening.ScreenerProgress, dataSetUpload.ScreenerProgress);
+
+                // Expect the "last checked" date to be updated to show that Admin requested
+                // a progress update for this data set.
+                Assert.Equal(utcNow, dataSetUpload.ScreenerProgressLastChecked);
+
+                // Expect the "last updated" date to be left unchanged, as no progress changes occurred since last
+                // time it was updated.
+                Assert.Equal(
+                    dataSetUndergoingScreening.ScreenerProgressLastUpdated,
+                    dataSetUpload.ScreenerProgressLastUpdated
+                );
+            }
+        }
     }
 
     public class GetScreenerProgressTests : DataSetScreenerServiceTests
@@ -536,13 +622,13 @@ public abstract class DataSetScreenerServiceTests
                     new()
                     {
                         DataSetUploadId = dataSetsUndergoingScreening[0].Id,
-                        PercentageComplete = dataSetsUndergoingScreening[0].ScreenerProgress!.PercentageComplete,
+                        PercentageComplete = (int)dataSetsUndergoingScreening[0].ScreenerProgress!.PercentageComplete,
                         Stage = dataSetsUndergoingScreening[0].ScreenerProgress!.Stage,
                     },
                     new()
                     {
                         DataSetUploadId = dataSetsUndergoingScreening[1].Id,
-                        PercentageComplete = dataSetsUndergoingScreening[1].ScreenerProgress!.PercentageComplete,
+                        PercentageComplete = (int)dataSetsUndergoingScreening[1].ScreenerProgress!.PercentageComplete,
                         Stage = dataSetsUndergoingScreening[1].ScreenerProgress!.Stage,
                     },
                 ];

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -126,7 +126,7 @@ public class MappingProfiles : CommonMappingProfile
             .ForMember(dest => dest.Type, m => m.MapFrom(dataSetVersion => dataSetVersion.VersionType));
 
         CreateMap<DataSetUpload, DataSetUploadViewModel>()
-            .ForMember(dest => dest.Status, m => m.MapFrom(upload => GetDataSetUploadStatus(upload.ScreenerResult)))
+            .ForMember(dest => dest.Status, m => m.MapFrom(upload => GetDataSetUploadStatus(upload)))
             .ForMember(
                 dest => dest.PublicApiCompatible,
                 m => m.MapFrom(upload => upload.ScreenerResult != null && upload.ScreenerResult.PublicApiCompatible)
@@ -155,8 +155,15 @@ public class MappingProfiles : CommonMappingProfile
             .ForMember(d => d.DataSetId, m => m.MapFrom(upload => upload.Id));
     }
 
-    private static string GetDataSetUploadStatus(DataSetScreenerResponse? screenerResult)
+    private static string GetDataSetUploadStatus(DataSetUpload dataSetUpload)
     {
+        if (dataSetUpload.Status == DataSetUploadStatus.SCREENING)
+        {
+            return nameof(DataSetUploadStatus.SCREENING);
+        }
+
+        var screenerResult = dataSetUpload.ScreenerResult;
+
         if (screenerResult is null)
         {
             return nameof(DataSetUploadStatus.SCREENER_ERROR);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Responses/Screener/DataSetScreenerCompletionReportResponse.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Responses/Screener/DataSetScreenerCompletionReportResponse.cs
@@ -1,0 +1,14 @@
+#nullable enable
+using System.Text.Json.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Screener;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Responses.Screener;
+
+public record DataSetScreenerCompletionReportResponse
+{
+    [JsonPropertyName("data_set_id")]
+    public required Guid DataSetId { get; init; }
+
+    [JsonPropertyName("completion_report")]
+    public required DataSetScreenerResponse CompletionReport { get; init; }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Responses/Screener/DataSetScreenerProgressResponse.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Responses/Screener/DataSetScreenerProgressResponse.cs
@@ -8,6 +8,12 @@ public record DataSetScreenerProgressResponse
     [JsonPropertyName("data_set_id")]
     public required Guid DataSetId { get; init; }
 
+    [JsonPropertyName("progress_report")]
+    public required DataSetScreenerProgressReport ProgressReport { get; init; }
+}
+
+public record DataSetScreenerProgressReport
+{
     [JsonPropertyName("percentage_complete")]
     public required double PercentageComplete { get; init; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Screener/IDataSetScreenerClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Screener/IDataSetScreenerClient.cs
@@ -16,4 +16,11 @@ public interface IDataSetScreenerClient
         IList<Guid> dataSetIds,
         CancellationToken cancellationToken
     );
+
+    Task<List<DataSetScreenerCompletionReportResponse>> GetScreenerCompletionReports(
+        IList<Guid> dataSetIds,
+        CancellationToken cancellationToken
+    );
+
+    Task DeleteScreenerProgressAndCompletionFiles(IList<Guid> dataSetIds, CancellationToken cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Screener/IDataSetScreenerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Screener/IDataSetScreenerService.cs
@@ -45,4 +45,10 @@ public interface IDataSetScreenerService
         Guid releaseVersionId,
         CancellationToken cancellationToken
     );
+
+    /// <summary>
+    /// This method will find any data sets that have received a progress update that is flagged as "completed" and
+    /// complete the screening process from both the Admin and Screener API sides.
+    /// </summary>
+    Task<List<DataSetUploadViewModel>> CompleteDataSetScreeningForFinishedDataSets(CancellationToken cancellationToken);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerClient.cs
@@ -62,4 +62,49 @@ public class DataSetScreenerClient(
                 $"Failed to get screener progress for data set ids {dataSetIds.JoinToString(",")} - status code {response.StatusCode}."
             );
     }
+
+    public async Task<List<DataSetScreenerCompletionReportResponse>> GetScreenerCompletionReports(
+        IList<Guid> dataSetIds,
+        CancellationToken cancellationToken
+    )
+    {
+        await authenticationManager.AddAuthentication(httpClient, cancellationToken);
+
+        var query = HttpUtility.ParseQueryString(string.Empty);
+        dataSetIds.ForEach(dataSetId => query.Add("data_set_id", dataSetId.ToString()));
+
+        var url = $"{httpClient.BaseAddress}/completion-reports?{query}";
+        var response = await httpClient.GetAsync(url, cancellationToken);
+
+        return response.IsSuccessStatusCode
+            ? (
+                await response.Content.ReadFromJsonAsync<List<DataSetScreenerCompletionReportResponse>>(
+                    cancellationToken
+                )
+            )!
+            : throw new DataScreenerException(
+                $"Failed to get screener completion reports for data set ids {dataSetIds.JoinToString(",")} - status code {response.StatusCode}."
+            );
+    }
+
+    public async Task DeleteScreenerProgressAndCompletionFiles(
+        IList<Guid> dataSetIds,
+        CancellationToken cancellationToken
+    )
+    {
+        await authenticationManager.AddAuthentication(httpClient, cancellationToken);
+
+        var query = HttpUtility.ParseQueryString(string.Empty);
+        dataSetIds.ForEach(dataSetId => query.Add("data_set_id", dataSetId.ToString()));
+
+        var url = $"{httpClient.BaseAddress}/progress?{query}";
+        var response = await httpClient.DeleteAsync(url, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new DataScreenerException(
+                $"Failed to delete screener progress and completion files for data set ids {dataSetIds.JoinToString(",")} - status code {response.StatusCode}."
+            );
+        }
+    }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerClient.cs
@@ -97,7 +97,7 @@ public class DataSetScreenerClient(
         var query = HttpUtility.ParseQueryString(string.Empty);
         dataSetIds.ForEach(dataSetId => query.Add("data_set_id", dataSetId.ToString()));
 
-        var url = $"{httpClient.BaseAddress}/progress?{query}";
+        var url = $"{httpClient.BaseAddress}/progress-and-completion-files?{query}";
         var response = await httpClient.DeleteAsync(url, cancellationToken);
 
         if (!response.IsSuccessStatusCode)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerProgressUpdaterJob.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerProgressUpdaterJob.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Options;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Screener;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.Extensions.Options;
 
@@ -71,6 +72,36 @@ public class DataSetScreenerProgressUpdaterJob(
                         + "as failed screening at {Time} (UTC)",
                     failures.Count,
                     options.Value.ScreenerProgressUpdateFailureIntervalMinutes,
+                    DateTimeOffset.UtcNow.ToString("dd/MM/yyyy HH:mm:ss")
+                );
+            }
+
+            var completions = await dataSetScreenerService.CompleteDataSetScreeningForFinishedDataSets(
+                cancellationToken: cancellationToken
+            );
+
+            var successfulCompletions = completions
+                .Where(c => c.Status == nameof(DataSetUploadStatus.PENDING_REVIEW))
+                .ToList();
+
+            var failedCompletions = completions
+                .Where(c => c.Status == nameof(DataSetUploadStatus.FAILED_SCREENING))
+                .ToList();
+
+            if (successfulCompletions.Count > 0)
+            {
+                logger.LogInformation(
+                    "{Count} data sets completed screening successfully at {Time} (UTC)",
+                    successfulCompletions.Count,
+                    DateTimeOffset.UtcNow.ToString("dd/MM/yyyy HH:mm:ss")
+                );
+            }
+
+            if (failedCompletions.Count > 0)
+            {
+                logger.LogInformation(
+                    "{Count} data sets completed screening with failures at {Time} (UTC)",
+                    successfulCompletions.Count,
                     DateTimeOffset.UtcNow.ToString("dd/MM/yyyy HH:mm:ss")
                 );
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
@@ -89,12 +89,12 @@ public class DataSetScreenerService(
                 result.DataSetId == dataSetToUpdate.Id
             );
 
+            var progressReport = progressUpdateForDataSet?.ProgressReport;
+
             // If a progress response was returned from the Screener API for this
             // data set, apply it.
-            if (progressUpdateForDataSet != null)
+            if (progressReport != null && ScreenerProgressHasChanged(dataSetToUpdate.ScreenerProgress, progressReport))
             {
-                var progressReport = progressUpdateForDataSet.ProgressReport;
-
                 // Only update Screener progress details if some actual progress has been made since the
                 // last time the progress was updated. This helps to identify and clean up any stalled
                 // screening attempts.
@@ -211,22 +211,14 @@ public class DataSetScreenerService(
         CancellationToken cancellationToken
     )
     {
-        // Find all data sets currently undergoing screening.
-        var screeningDataSets = await contentDbContext
-            .DataSetUploads.Where(upload => upload.Status == DataSetUploadStatus.SCREENING)
-            .ToListAsync(cancellationToken: cancellationToken);
+        var dataSetsCompletedScreening = await GetDataSetsThatHaveCompletedScreening(cancellationToken);
 
-        // Find only those whose latest progress reports show as having been completed.
-        var dataSetsFinishedScreening = screeningDataSets
-            .Where(upload => upload.ScreenerProgress is { Completed: true })
-            .ToList();
-
-        if (dataSetsFinishedScreening.Count == 0)
+        if (dataSetsCompletedScreening.Count == 0)
         {
             return [];
         }
 
-        var dataSetIds = dataSetsFinishedScreening.Select(upload => upload.Id).ToList();
+        var dataSetIds = dataSetsCompletedScreening.Select(upload => upload.Id).ToList();
 
         // Get the full report on their completion statuses.
         var completionReports = await dataSetScreenerClient.GetScreenerCompletionReports(
@@ -238,9 +230,15 @@ public class DataSetScreenerService(
         // to be a post-screening status. This way, successful ones will no longer be polled for progress updates,
         // and stalled ones will eventually be cleaned up by MarkDataSetsWithoutProgressAsFailed() if we cannot get
         // a completion report successfully for them within a time limit.
-        var dataSetsToComplete = dataSetsFinishedScreening
+        var dataSetsToComplete = dataSetsCompletedScreening
             .Where(upload => completionReports.Any(report => report.DataSetId == upload.Id))
             .ToList();
+
+        // If we don't have any completion reports for our completed data sets yet, return early.
+        if (dataSetsToComplete.Count == 0)
+        {
+            return [];
+        }
 
         dataSetsToComplete.ForEach(uploadToComplete =>
         {
@@ -255,21 +253,27 @@ public class DataSetScreenerService(
 
         await contentDbContext.SaveChangesAsync(cancellationToken: cancellationToken);
 
-        if (completionReports.Count > 0)
-        {
-            // For all uploads that were successfully marked as having completed screening, call the Screener API to clean
-            // up its progress and completion report files.
-            var dataSetIdsWithSuccessfulCompletionReports = completionReports
-                .Select(report => report.DataSetId)
-                .ToList();
+        // For all uploads that were successfully marked as having completed screening, call the Screener API to clean
+        // up its progress and completion report files.
+        var dataSetIdsWithSuccessfulCompletionReports = dataSetsToComplete.Select(upload => upload.Id).ToList();
 
-            await dataSetScreenerClient.DeleteScreenerProgressAndCompletionFiles(
-                dataSetIds: dataSetIdsWithSuccessfulCompletionReports,
-                cancellationToken: cancellationToken
-            );
-        }
+        await dataSetScreenerClient.DeleteScreenerProgressAndCompletionFiles(
+            dataSetIds: dataSetIdsWithSuccessfulCompletionReports,
+            cancellationToken: cancellationToken
+        );
 
         return [.. dataSetsToComplete.Select(mapper.Map<DataSetUploadViewModel>)];
+    }
+
+    private async Task<List<DataSetUpload>> GetDataSetsThatHaveCompletedScreening(CancellationToken cancellationToken)
+    {
+        // Find all data sets currently undergoing screening.
+        var screeningDataSets = await contentDbContext
+            .DataSetUploads.Where(upload => upload.Status == DataSetUploadStatus.SCREENING)
+            .ToListAsync(cancellationToken: cancellationToken);
+
+        // Find only those whose latest progress reports show as having been completed.
+        return [.. screeningDataSets.Where(upload => upload.ScreenerProgress is { Completed: true })];
     }
 
     private bool ScreenerProgressHasChanged(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
@@ -93,14 +93,19 @@ public class DataSetScreenerService(
             // data set, apply it.
             if (progressUpdateForDataSet != null)
             {
-                dataSetToUpdate.ScreenerProgress!.PercentageComplete = (int)
-                    Math.Round(progressUpdateForDataSet.PercentageComplete, MidpointRounding.ToZero);
-                dataSetToUpdate.ScreenerProgress.Stage = progressUpdateForDataSet.Stage;
-                dataSetToUpdate.ScreenerProgress.Completed = progressUpdateForDataSet.Completed;
-                dataSetToUpdate.ScreenerProgress.Passed = progressUpdateForDataSet.Passed;
+                // Only update Screener progress details if some actual progress has been made since the
+                // last time the progress was updated. This helps to identify and clean up any stalled
+                // screening attempts.
+                if (ScreenerProgressHasChanged(dataSetToUpdate.ScreenerProgress, progressUpdateForDataSet))
+                {
+                    dataSetToUpdate.ScreenerProgress!.PercentageComplete = progressUpdateForDataSet.PercentageComplete;
+                    dataSetToUpdate.ScreenerProgress.Stage = progressUpdateForDataSet.Stage;
+                    dataSetToUpdate.ScreenerProgress.Completed = progressUpdateForDataSet.Completed;
+                    dataSetToUpdate.ScreenerProgress.Passed = progressUpdateForDataSet.Passed;
 
-                // Mark the data set as having received a successful progress update.
-                dataSetToUpdate.ScreenerProgressLastUpdated = utcNow;
+                    // Mark the data set as having received a successful progress update.
+                    dataSetToUpdate.ScreenerProgressLastUpdated = utcNow;
+                }
             }
 
             // Update the "last checked" date to mark the last time that progress was checked
@@ -177,10 +182,27 @@ public class DataSetScreenerService(
                     .Select(upload => new ScreenerProgressWithDataSetUploadIdViewModel
                     {
                         DataSetUploadId = upload.Id,
-                        PercentageComplete = upload.ScreenerProgress?.PercentageComplete ?? 0,
+                        PercentageComplete = (int)
+                            Math.Round(upload.ScreenerProgress?.PercentageComplete ?? 0, MidpointRounding.ToZero),
                         Stage = upload.ScreenerProgress?.Stage,
                     })
                     .ToList();
             });
+    }
+
+    private bool ScreenerProgressHasChanged(
+        DataSetScreenerProgress? currentScreenerProgress,
+        DataSetScreenerProgressResponse progressUpdate
+    )
+    {
+        if (currentScreenerProgress == null)
+        {
+            return true;
+        }
+
+        return Math.Abs(currentScreenerProgress.PercentageComplete - progressUpdate.PercentageComplete) > 0.001
+            || currentScreenerProgress.Stage != progressUpdate.Stage
+            || currentScreenerProgress.Passed != progressUpdate.Passed
+            || currentScreenerProgress.Completed != progressUpdate.Completed;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
@@ -93,15 +93,17 @@ public class DataSetScreenerService(
             // data set, apply it.
             if (progressUpdateForDataSet != null)
             {
+                var progressReport = progressUpdateForDataSet.ProgressReport;
+
                 // Only update Screener progress details if some actual progress has been made since the
                 // last time the progress was updated. This helps to identify and clean up any stalled
                 // screening attempts.
-                if (ScreenerProgressHasChanged(dataSetToUpdate.ScreenerProgress, progressUpdateForDataSet))
+                if (ScreenerProgressHasChanged(dataSetToUpdate.ScreenerProgress, progressReport))
                 {
-                    dataSetToUpdate.ScreenerProgress!.PercentageComplete = progressUpdateForDataSet.PercentageComplete;
-                    dataSetToUpdate.ScreenerProgress.Stage = progressUpdateForDataSet.Stage;
-                    dataSetToUpdate.ScreenerProgress.Completed = progressUpdateForDataSet.Completed;
-                    dataSetToUpdate.ScreenerProgress.Passed = progressUpdateForDataSet.Passed;
+                    dataSetToUpdate.ScreenerProgress!.PercentageComplete = progressReport.PercentageComplete;
+                    dataSetToUpdate.ScreenerProgress.Stage = progressReport.Stage;
+                    dataSetToUpdate.ScreenerProgress.Completed = progressReport.Completed;
+                    dataSetToUpdate.ScreenerProgress.Passed = progressReport.Passed;
 
                     // Mark the data set as having received a successful progress update.
                     dataSetToUpdate.ScreenerProgressLastUpdated = utcNow;
@@ -133,7 +135,6 @@ public class DataSetScreenerService(
         // Find any data sets where the gap between their last successful progress update
         // (or the very first attempt to get a progress update), and the last time that Admin checked
         // for a progress update, has become too large.
-
         var screeningDataSetsWithoutRecentProgressUpdates = screeningDataSets
             .Where(upload =>
                 upload is { ScreenerProgressLastChecked: not null, ScreenerProgressLastUpdated: not null }
@@ -141,6 +142,11 @@ public class DataSetScreenerService(
                     >= progressUpdatesFailureIntervalMins
             )
             .ToList();
+
+        if (screeningDataSetsWithoutRecentProgressUpdates.Count == 0)
+        {
+            return [];
+        }
 
         // For each affected data set, mark it as having failed screening due to not receiving
         // a successful progress update for too long.
@@ -154,10 +160,21 @@ public class DataSetScreenerService(
                 PublicApiCompatible = false,
             };
             upload.Status = DataSetUploadStatus.SCREENER_ERROR;
+            contentDbContext.DataSetUploads.Update(upload);
         });
 
-        contentDbContext.DataSetUploads.UpdateRange(screeningDataSetsWithoutRecentProgressUpdates);
         await contentDbContext.SaveChangesAsync(cancellationToken: cancellationToken);
+
+        // Ask the Screener API to delete any progress files that it may have for any of the data sets
+        // that we marked as failed, if any exist for them.
+        var dataSetIdsMarkedAsFailed = screeningDataSetsWithoutRecentProgressUpdates
+            .Select(upload => upload.Id)
+            .ToList();
+
+        await dataSetScreenerClient.DeleteScreenerProgressAndCompletionFiles(
+            dataSetIds: dataSetIdsMarkedAsFailed,
+            cancellationToken: cancellationToken
+        );
 
         return [.. screeningDataSetsWithoutRecentProgressUpdates.Select(mapper.Map<DataSetUploadViewModel>)];
     }
@@ -190,9 +207,74 @@ public class DataSetScreenerService(
             });
     }
 
+    public async Task<List<DataSetUploadViewModel>> CompleteDataSetScreeningForFinishedDataSets(
+        CancellationToken cancellationToken
+    )
+    {
+        // Find all data sets currently undergoing screening.
+        var screeningDataSets = await contentDbContext
+            .DataSetUploads.Where(upload => upload.Status == DataSetUploadStatus.SCREENING)
+            .ToListAsync(cancellationToken: cancellationToken);
+
+        // Find only those whose latest progress reports show as having been completed.
+        var dataSetsFinishedScreening = screeningDataSets
+            .Where(upload => upload.ScreenerProgress is { Completed: true })
+            .ToList();
+
+        if (dataSetsFinishedScreening.Count == 0)
+        {
+            return [];
+        }
+
+        var dataSetIds = dataSetsFinishedScreening.Select(upload => upload.Id).ToList();
+
+        // Get the full report on their completion statuses.
+        var completionReports = await dataSetScreenerClient.GetScreenerCompletionReports(
+            dataSetIds: dataSetIds,
+            cancellationToken: cancellationToken
+        );
+
+        // For every completion report in the response, attach it to the appropriate upload, and update its status
+        // to be a post-screening status. This way, successful ones will no longer be polled for progress updates,
+        // and stalled ones will eventually be cleaned up by MarkDataSetsWithoutProgressAsFailed() if we cannot get
+        // a completion report successfully for them within a time limit.
+        var dataSetsToComplete = dataSetsFinishedScreening
+            .Where(upload => completionReports.Any(report => report.DataSetId == upload.Id))
+            .ToList();
+
+        dataSetsToComplete.ForEach(uploadToComplete =>
+        {
+            var report = completionReports.Single(u => u.DataSetId == uploadToComplete.Id);
+
+            uploadToComplete.ScreenerResult = report.CompletionReport;
+            uploadToComplete.Status = report.CompletionReport.Passed
+                ? DataSetUploadStatus.PENDING_REVIEW
+                : DataSetUploadStatus.FAILED_SCREENING;
+            contentDbContext.DataSetUploads.Update(uploadToComplete);
+        });
+
+        await contentDbContext.SaveChangesAsync(cancellationToken: cancellationToken);
+
+        if (completionReports.Count > 0)
+        {
+            // For all uploads that were successfully marked as having completed screening, call the Screener API to clean
+            // up its progress and completion report files.
+            var dataSetIdsWithSuccessfulCompletionReports = completionReports
+                .Select(report => report.DataSetId)
+                .ToList();
+
+            await dataSetScreenerClient.DeleteScreenerProgressAndCompletionFiles(
+                dataSetIds: dataSetIdsWithSuccessfulCompletionReports,
+                cancellationToken: cancellationToken
+            );
+        }
+
+        return [.. dataSetsToComplete.Select(mapper.Map<DataSetUploadViewModel>)];
+    }
+
     private bool ScreenerProgressHasChanged(
         DataSetScreenerProgress? currentScreenerProgress,
-        DataSetScreenerProgressResponse progressUpdate
+        DataSetScreenerProgressReport progressReport
     )
     {
         if (currentScreenerProgress == null)
@@ -200,9 +282,9 @@ public class DataSetScreenerService(
             return true;
         }
 
-        return Math.Abs(currentScreenerProgress.PercentageComplete - progressUpdate.PercentageComplete) > 0.001
-            || currentScreenerProgress.Stage != progressUpdate.Stage
-            || currentScreenerProgress.Passed != progressUpdate.Passed
-            || currentScreenerProgress.Completed != progressUpdate.Completed;
+        return Math.Abs(currentScreenerProgress.PercentageComplete - progressReport.PercentageComplete) > 0.001
+            || currentScreenerProgress.Stage != progressReport.Stage
+            || currentScreenerProgress.Passed != progressReport.Passed
+            || currentScreenerProgress.Completed != progressReport.Completed;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
@@ -27,7 +27,8 @@ public class DataSetScreenerService(
     ContentDbContext contentDbContext,
     TimeProvider timeProvider,
     IMapper mapper,
-    IOptions<DataScreenerOptions> options
+    IOptions<DataScreenerOptions> options,
+    ILogger<DataSetScreenerService> logger
 ) : IDataSetScreenerService
 {
     public const string StartScreeningQueue = "start-screening";
@@ -80,6 +81,21 @@ public class DataSetScreenerService(
             dataSetIdsUndergoingScreening,
             cancellationToken
         );
+
+        var dataSetIdsWithoutProgressUpdates = dataSetIdsUndergoingScreening
+            .Except(progressResults.Select(result => result.DataSetId))
+            .ToList();
+
+        if (dataSetIdsWithoutProgressUpdates.Count > 0)
+        {
+            logger.LogWarning(
+                message: "Expected to receive {ExpectedUpdatesCount} progress updates but received "
+                    + "{ActualUpdatesCount}. Missing progress updates for data sets {DataSetIds}.",
+                dataSetIdsUndergoingScreening.Count,
+                progressResults.Count,
+                string.Join(", ", dataSetIdsWithoutProgressUpdates)
+            );
+        }
 
         // For each data set that required a progress update, attempt to update its progress
         // based on the responses received from the Screener API.
@@ -233,6 +249,19 @@ public class DataSetScreenerService(
         var dataSetsToComplete = dataSetsCompletedScreening
             .Where(upload => completionReports.Any(report => report.DataSetId == upload.Id))
             .ToList();
+
+        var dataSetsWithoutReports = dataSetsCompletedScreening.Except(dataSetsToComplete).ToList();
+
+        if (dataSetsWithoutReports.Count > 0)
+        {
+            logger.LogWarning(
+                message: "Expected to receive {ExpectedReportCount} completion reports but received "
+                    + "{ActualReportCount}. Missing reports for data sets {DataSetIds}.",
+                dataSetsCompletedScreening.Count,
+                completionReports.Count,
+                string.Join(", ", dataSetsWithoutReports.Select(upload => upload.Id))
+            );
+        }
 
         // If we don't have any completion reports for our completed data sets yet, return early.
         if (dataSetsToComplete.Count == 0)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Screener/ScreenerResultViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Screener/ScreenerResultViewModel.cs
@@ -3,6 +3,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Screener;
 
 public record ScreenerResultViewModel
 {
+    public required bool Passed { get; set; }
+
     public required string OverallResult { get; set; }
 
     public List<ScreenerTestResultViewModel> TestResults { get; set; } = [];

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Screener/DataSetScreenerProgress.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Screener/DataSetScreenerProgress.cs
@@ -6,7 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Screener;
 /// </summary>
 public record DataSetScreenerProgress
 {
-    public int PercentageComplete { get; set; }
+    public double PercentageComplete { get; set; }
 
     public string Stage { get; set; } = null!;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Screener/DataSetScreenerResponse.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Screener/DataSetScreenerResponse.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Screener;
 
+// TODO EES-7003 - rename to "DataSetScreenerCompletionReport" in a follow-up PR.
 public record DataSetScreenerResponse
 {
     [JsonPropertyName("overall_stage")]

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableUploadsRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableUploadsRow.tsx
@@ -65,7 +65,7 @@ export default function DataFilesTableUploadRow({
     hasFailures;
 
   const importUnavailable = !Object.values(warningAcknowledgements).every(
-    acknowledgement => acknowledgement === true,
+    acknowledgement => acknowledgement,
   );
 
   useEffect(() => {


### PR DESCRIPTION
:warning: This PR needs https://github.com/dfe-analytical-services/ees-screener-api/pull/26 to be merged in and deployed to support it :warning: 

This PR:
- adds completion handling to background screening processes, including marking screening as successful or failed in Admin and cleanup of Screener API files.
- makes a small tweak for the front end's benefit, to show "Screening" in the Data and Files page directly after an upload has completed.
- enhances the "stalled screening" cleanup code to include data sets where their progress updates don't update for a certain period of time (e.g. staying at 56.43% for a day or more despite getting regular updates).
- adds support to log screening results locally and in all Azure environments but Prod.

Note that this all still happens *only when the feature flag is enabled*.

## The completion process

From previous PRs, we now have files being screened in the background and have given Admin a scheduled job to get screening progress and update in the Content DB.  We had not yet had a way of dealing with a completed screening process however.

This PR looks to see if any screening progress update results have come back from the Screener API saying "Complete: true" and will initiate the process of marking them as complete and then cleaning up the Screener API files.

It:
* Asks the Screener API for a "completion report" for all completed data sets (basically the final eesyscreener output reports, as we've previously retrieved with the current Screener journey).
* Attaches it as the ScreenerResult to the appropriate DataSetUpload record.
* Updates the DataSetUpload.Status to mark it as either having passed or failed screening, depending on the outcome of the report.
* Calls the Screener API to clear up any old progress / completion report files for the completed data sets.

To support this, it has 2 new methods added to the Screener HTTP client that's used by Admin, which will allow it to request completion reports from the Screener API, and to ask the Screener API to clear up its old progress and completion files.

## Front end

Upon the file successfully uploading, the user will immediately see the file go into Screening:

<img width="1854" height="961" alt="image" src="https://github.com/user-attachments/assets/6454634a-3cbe-4fc1-ae43-afc3c9bc1d3f" />

Via a manual page refresh later on, the file will have ended up in "Pending review" or "Failed screening":

<img width="1854" height="961" alt="image" src="https://github.com/user-attachments/assets/2eb50870-85d3-417b-aa96-2fe2ca0c0623" />

There is still front end work to do here to get frequent progress updates and update a screening progress bar.  