### PR TITLE
EES-7124 - Add support to UI tests for creating summary text blocks via API. Test summery text blocks are editable in old releases that already contain them.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ContentService.cs
@@ -358,7 +358,7 @@ public class ContentService : IContentService
             return order.Value;
         }
 
-        if (!section.Content.Any())
+        if (section.Content.Any())
         {
             return section.Content.Max(contentBlock => contentBlock.Order) + 1;
         }

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -23,14 +23,14 @@ ${DATABLOCK_NAME}=                  Dates data block name
 ${SUBJECT_NAME}=                    Dates test subject
 ${ANCILLARY_FILE_NAME}=             Test ancillary file 1
 ${ANCILLARY_FILE_NAME_2}=           Test ancillary file 2
-${legacy_summary_text_box_body}=    Test summary text for ${PUBLICATION_NAME}
+${LEGACY_SUMMARY_TEXT_BLOCK}=       Test summary text for ${PUBLICATION_NAME}
 
 
 *** Test Cases ***
 Create new publication for "UI tests theme" theme
     ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
     user creates test release with legacy summary text block via api    ${PUBLICATION_ID}    FY    3000
-    ...    label=${RELEASE_LABEL}    summary_text_block=${legacy_summary_text_box_body}
+    ...    label=${RELEASE_LABEL}    summary_text_block=${LEGACY_SUMMARY_TEXT_BLOCK}
 
 Go to "Release summary" page
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
@@ -133,7 +133,7 @@ Navigate to 'Content' page
     user waits until page contains button    Add a warning text block    %{WAIT_SMALL}
 
 Verify legacy summary text block content is correct
-    user waits until element contains    id:releaseSummary    ${legacy_summary_text_box_body}    %{WAIT_SMALL}
+    user waits until element contains    id:releaseSummary    ${LEGACY_SUMMARY_TEXT_BLOCK}    %{WAIT_SMALL}
 
 Add free text key stat
     user adds free text key stat    Free text key stat title    9001%    Trend    Guidance title    Guidance text
@@ -296,7 +296,7 @@ Verify release page meta
     ...    ${PUBLICATION_NAME} summary
 
 Verify release page background information
-    user waits until element contains    id:background-information    ${legacy_summary_text_box_body}
+    user waits until element contains    id:background-information    ${LEGACY_SUMMARY_TEXT_BLOCK}
     ...    %{WAIT_SMALL}
 
 Verify release URL
@@ -635,10 +635,10 @@ Navigate to 'Content' page for amendment
     user waits until page contains button    Add a warning text block
 
 Verify legacy summary text block content is correct for amendment
-    user waits until element contains    id:releaseSummary    ${legacy_summary_text_box_body}    %{WAIT_SMALL}
+    user waits until element contains    id:releaseSummary    ${LEGACY_SUMMARY_TEXT_BLOCK}    %{WAIT_SMALL}
 
 Update legacy summary text block for amendment
-    user adds content to autosaving text block    id:releaseSummary    Amended ${legacy_summary_text_box_body}
+    user adds content to autosaving text block    id:releaseSummary    Amended ${LEGACY_SUMMARY_TEXT_BLOCK}
 
 Update free text key stat
     user updates free text key stat    1    Updated title    New stat    Updated trend
@@ -750,7 +750,7 @@ Navigate to amendment release page
     user checks nth breadcrumb contains    3    ${PUBLICATION_NAME}
 
 Verify amended background information
-    user waits until element contains    id:background-information    Amended ${legacy_summary_text_box_body}
+    user waits until element contains    id:background-information    Amended ${LEGACY_SUMMARY_TEXT_BLOCK}
     ...    %{WAIT_SMALL}
 
 Verify amendment is displayed as the latest release and the 'All releases in this series' page only displays the latest release

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -16,19 +16,21 @@ Force Tags          Admin    Local    Dev    AltersData
 
 
 *** Variables ***
-${PUBLICATION_NAME}=            Publish release and amend %{RUN_IDENTIFIER}
-${RELEASE_LABEL}=               provisional
-${RELEASE_NAME}=                Financial year 3000-01 ${RELEASE_LABEL}
-${DATABLOCK_NAME}=              Dates data block name
-${SUBJECT_NAME}=                Dates test subject
-${ANCILLARY_FILE_NAME}=         Test ancillary file 1
-${ANCILLARY_FILE_NAME_2}=       Test ancillary file 2
+${PUBLICATION_NAME}=                Publish release and amend %{RUN_IDENTIFIER}
+${RELEASE_LABEL}=                   provisional
+${RELEASE_NAME}=                    Financial year 3000-01 ${RELEASE_LABEL}
+${DATABLOCK_NAME}=                  Dates data block name
+${SUBJECT_NAME}=                    Dates test subject
+${ANCILLARY_FILE_NAME}=             Test ancillary file 1
+${ANCILLARY_FILE_NAME_2}=           Test ancillary file 2
+${legacy_summary_text_box_body}=    Test summary text for ${PUBLICATION_NAME}
 
 
 *** Test Cases ***
 Create new publication for "UI tests theme" theme
     ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
-    user creates test release via api    ${PUBLICATION_ID}    FY    3000    label=${RELEASE_LABEL}
+    user creates test release with legacy summary text block via api    ${PUBLICATION_ID}    FY    3000
+    ...    label=${RELEASE_LABEL}    summary_text_block=${legacy_summary_text_box_body}
 
 Go to "Release summary" page
     user navigates to draft release page from dashboard    ${PUBLICATION_NAME}
@@ -129,6 +131,9 @@ Navigate to 'Content' page
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user waits until page contains button    Add a warning text block    %{WAIT_SMALL}
+
+Verify legacy summary text block content is correct
+    user waits until element contains    id:releaseSummary    ${legacy_summary_text_box_body}    %{WAIT_SMALL}
 
 Add free text key stat
     user adds free text key stat    Free text key stat title    9001%    Trend    Guidance title    Guidance text
@@ -289,6 +294,10 @@ Verify release page meta
     user checks meta title should be    Release home - ${PUBLICATION_NAME}
     user checks meta description should be
     ...    ${PUBLICATION_NAME} summary
+
+Verify release page background information
+    user waits until element contains    id:background-information    ${legacy_summary_text_box_body}
+    ...    %{WAIT_SMALL}
 
 Verify release URL
     user checks url contains    %{PUBLIC_URL}/find-statistics/publish-release-and-amend-%{RUN_IDENTIFIER}
@@ -625,6 +634,12 @@ Navigate to 'Content' page for amendment
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user waits until page contains button    Add a warning text block
 
+Verify legacy summary text block content is correct for amendment
+    user waits until element contains    id:releaseSummary    ${legacy_summary_text_box_body}    %{WAIT_SMALL}
+
+Update legacy summary text block for amendment
+    user adds content to autosaving text block    id:releaseSummary    Amended ${legacy_summary_text_box_body}
+
 Update free text key stat
     user updates free text key stat    1    Updated title    New stat    Updated trend
     ...    Updated guidance title    Updated guidance text
@@ -733,6 +748,10 @@ Navigate to amendment release page
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Find statistics and data
     user checks nth breadcrumb contains    3    ${PUBLICATION_NAME}
+
+Verify amended background information
+    user waits until element contains    id:background-information    Amended ${legacy_summary_text_box_body}
+    ...    %{WAIT_SMALL}
 
 Verify amendment is displayed as the latest release and the 'All releases in this series' page only displays the latest release
     user checks page contains    Latest release

--- a/tests/robot-tests/tests/general_public/prod_only/permalink_prod_1.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/permalink_prod_1.robot
@@ -15,7 +15,7 @@ Go to Table Tool page
 Go to permalink
     user navigates to    %{PUBLIC_URL}/data-tables/permalink/30999037-fcd4-409f-9ff4-d3680da7402d
     user waits until h1 is visible
-    ...    'Total days missed due to fixed period exclusions' from 'Permanent and fixed-period exclusions in England'
+    ...    'Total days missed due to fixed period exclusions' from 'Permanent & fixed-period exclusions in England'
 
 Validate breadcrumbs
     user checks breadcrumb count should be    4
@@ -23,7 +23,7 @@ Validate breadcrumbs
     user checks nth breadcrumb contains    2    Data tables
     user checks nth breadcrumb contains    3    Permanent link
     user checks nth breadcrumb contains    4
-    ...    'Total days missed due to fixed period exclusions' from 'Permanent and fixed-period exclusions in England'
+    ...    'Total days missed due to fixed period exclusions' from 'Permanent & fixed-period exclusions in England'
 
 Validate miscellaneous
     user checks summary list contains    Created    7 April 2020

--- a/tests/robot-tests/tests/general_public/prod_only/permalink_prod_2.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/permalink_prod_2.robot
@@ -15,7 +15,7 @@ Go to Table Tool page
 Go to permalink
     user navigates to    %{PUBLIC_URL}/data-tables/permalink/edfe9f83-d1f0-40fc-8dce-9467a250c61b
     user waits until h1 is visible
-    ...    'Exclusions by characteristic' from 'Permanent and fixed-period exclusions in England'
+    ...    'Exclusions by characteristic' from 'Permanent & fixed-period exclusions in England'
 
 Validate breadcrumbs
     user checks breadcrumb count should be    4
@@ -23,7 +23,7 @@ Validate breadcrumbs
     user checks nth breadcrumb contains    2    Data tables
     user checks nth breadcrumb contains    3    Permanent link
     user checks nth breadcrumb contains    4
-    ...    'Exclusions by characteristic' from 'Permanent and fixed-period exclusions in England'
+    ...    'Exclusions by characteristic' from 'Permanent & fixed-period exclusions in England'
 
 Validate miscellaneous
     user checks summary list contains    Created    7 April 2020

--- a/tests/robot-tests/tests/general_public/prod_only/permalink_prod_3.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/permalink_prod_3.robot
@@ -15,7 +15,7 @@ Go to Table Tool page
 Go to permalink
     user navigates to    %{PUBLIC_URL}/data-tables/permalink/c5688b39-2630-4de0-a143-725df9e48690
     user waits until h1 is visible
-    ...    'Exclusions by geographic level' from 'Permanent and fixed-period exclusions in England'
+    ...    'Exclusions by geographic level' from 'Permanent & fixed-period exclusions in England'
 
 Validate breadcrumbs
     user checks breadcrumb count should be    4
@@ -23,7 +23,7 @@ Validate breadcrumbs
     user checks nth breadcrumb contains    2    Data tables
     user checks nth breadcrumb contains    3    Permanent link
     user checks nth breadcrumb contains    4
-    ...    'Exclusions by geographic level' from 'Permanent and fixed-period exclusions in England'
+    ...    'Exclusions by geographic level' from 'Permanent & fixed-period exclusions in England'
 
 Validate miscellaneous
     user checks summary list contains    Created    7 April 2020

--- a/tests/robot-tests/tests/libs/admin_api.py
+++ b/tests/robot-tests/tests/libs/admin_api.py
@@ -191,6 +191,61 @@ def user_creates_test_release_via_api(
     return response.json()["id"]
 
 
+def user_creates_test_release_with_legacy_summary_text_block_via_api(
+    publication_id: str,
+    time_period: str,
+    year: str,
+    summary_text_block: str,
+    type: str = "AccreditedOfficialStatistics",
+    label: str = None,
+):
+    response = admin_client.post(
+        f"/api/releases",
+        {
+            "publicationId": publication_id,
+            "timePeriodCoverage": {
+                "value": time_period,
+            },
+            "year": int(year),
+            "type": type,
+            "label": label,
+            "templateReleaseId": "",
+        },
+    )
+    assert (
+        response.status_code < 300
+    ), f"Creating release API request failed with {response.status_code} and {response.text}"
+
+    response_json = response.json()
+
+    release_content_response = admin_client.get(
+        f"/api/releaseVersions/{response_json['id']}/content?isPrerelease=false"
+    )
+    summary_section_id = release_content_response.json()["release"]["summarySection"]["id"]
+
+    post_summary_block_response = admin_client.post(
+        f"/api/release/{response_json['id']}/content/section/{summary_section_id}/blocks/add",
+        {"type": "HtmlBlock"},
+    )
+
+    assert (
+        post_summary_block_response.status_code < 300
+    ), f"Creating summary block API request failed with {post_summary_block_response.status_code} and {post_summary_block_response.text}"
+
+    put_summary_block_response = admin_client.put(
+        f"/api/release/{response_json['id']}/content/section/{summary_section_id}/block/{post_summary_block_response.json()['id']}",
+        {
+            "body": summary_text_block,
+        },
+    )
+
+    assert (
+        put_summary_block_response.status_code < 300
+    ), f"Updating summary block API request failed with {put_summary_block_response.status_code} and {put_summary_block_response.text}"
+
+    return response_json["id"]
+
+
 def user_updates_release_published_date_via_api(release_id: str, published: datetime) -> None:
     response = admin_client.patch(
         f"/api/releaseVersions/{release_id}/published-display-date", {"publishedDisplayDate": published.isoformat()}

--- a/tests/robot-tests/tests/libs/table_tool.robot
+++ b/tests/robot-tests/tests/libs/table_tool.robot
@@ -113,7 +113,7 @@ user creates data block
     user waits until table tool wizard step is available    2    Choose locations    %{WAIT_MEDIUM}
 
     # Select locations.
-    @{location_details_sections}=    Get WebElements    //*[starts-with(@data-testid, 'Expand Details Section')]
+    @{location_details_sections}=    Get WebElements    //*[starts-with(@data-testid, 'filter-accordion-button')]
     FOR    ${location_details_section}    IN    @{location_details_sections}
         user clicks element    ${location_details_section}
     END

--- a/tests/robot-tests/tests/seed_data/generate_seed_data_theme_1.robot
+++ b/tests/robot-tests/tests/seed_data/generate_seed_data_theme_1.robot
@@ -65,11 +65,12 @@ Add legacy releases to ${PUPIL_ABSENCE_PUBLICATION_TITLE}
     ...    https://www.gov.uk/government/statistics/pupil-absence-in-schools-in-england-2014-to-2015
 
 Create ${RELEASE_1_NAME} release
-    user creates test release via api
+    user creates test release with legacy summary text block via api
     ...    ${PUBLICATION_ID}
     ...    ${PUPIL_ABSENCE_RELEASE_TIME}
     ...    ${PUPIL_ABSENCE_RELEASE_YEAR}
     ...    OfficialStatistics
+    ...    summary_text_block=Read national statistical summaries, view charts and tables and download data files.
 
     user navigates to draft release page from dashboard
     ...    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
@@ -237,12 +238,6 @@ Add map chart to ${RELEASE_1_NAME}
 Add release content to ${RELEASE_1_NAME}
     user clicks link    Content
     user waits until page finishes loading
-
-Add release summary to ${RELEASE_1_NAME}
-    # TODO: WIP for EES-7124 - this needs to be done via an API as we no longer should add 'background/summary' text blocks to publications
-    # user adds summary text block
-    # user adds content to summary text block
-    # ...    Read national statistical summaries, view charts and tables and download data files.
 
 Add key statistics to ${RELEASE_1_NAME}
     user adds key statistic from data block
@@ -536,11 +531,12 @@ Add legacy releases to ${EXCLUSIONS_PUBLICATION_TITLE}
     ...    https://www.gov.uk/government/statistics/permanent-and-fixed-period-exclusions-in-england-2015-to-2016
 
 Create ${RELEASE_2_NAME} release
-    user creates test release via api
+    user creates test release with legacy summary text block via api
     ...    ${PUBLICATION_ID}
     ...    ${EXCLUSIONS_PUBLICATION_RELEASE_TIME}
     ...    ${EXCLUSIONS_PUBLICATION_RELEASE_YEAR}
     ...    OfficialStatistics
+    ...    summary_text_block=Read national statistical summaries, view charts and tables and download data files.
 
     user navigates to draft release page from dashboard
     ...    ${EXCLUSIONS_PUBLICATION_TITLE}
@@ -692,12 +688,6 @@ Add line chart 3 to ${RELEASE_2_NAME}
 Add release content to ${RELEASE_2_NAME}
     user clicks link    Content
     user waits until page finishes loading
-
-Add release summary to ${RELEASE_2_NAME}
-    # TODO: WIP for EES-7124 - this needs to be done via an API as we no longer should add 'background/summary' text blocks to publications
-    # user adds summary text block
-    # user adds content to summary text block
-    # ...    Read national statistical summaries, view charts and tables and download data files.
 
 Add key statistics to ${RELEASE_2_NAME}
     user adds key statistic from data block

--- a/tests/robot-tests/tests/seed_data/generate_seed_data_theme_1.robot
+++ b/tests/robot-tests/tests/seed_data/generate_seed_data_theme_1.robot
@@ -208,7 +208,7 @@ Create data block 7 for ${RELEASE_1_NAME}
 
 Add line chart to ${RELEASE_1_NAME}
     # This test may fail intermittently due to StaleElementReferenceException exception.
-    # If it does, run this script from this point on after manually setting suite variable ${ThEME_ID}
+    # If it does, run this script from this point on after manually setting suite variable ${THEME_ID}
     # to the theme id of the newly created `Seed theme - Pupils and schools` theme.
     user clicks link    Data blocks
     user waits until h2 is visible    Data blocks    %{WAIT_SMALL}

--- a/tests/robot-tests/tests/seed_data/generate_seed_data_theme_1.robot
+++ b/tests/robot-tests/tests/seed_data/generate_seed_data_theme_1.robot
@@ -69,7 +69,7 @@ Create ${RELEASE_1_NAME} release
     ...    ${PUBLICATION_ID}
     ...    ${PUPIL_ABSENCE_RELEASE_TIME}
     ...    ${PUPIL_ABSENCE_RELEASE_YEAR}
-    ...    OfficialStatistics
+    ...    type=OfficialStatistics
     ...    summary_text_block=Read national statistical summaries, view charts and tables and download data files.
 
     user navigates to draft release page from dashboard
@@ -207,6 +207,9 @@ Create data block 7 for ${RELEASE_1_NAME}
     ...    ${EMPTY}
 
 Add line chart to ${RELEASE_1_NAME}
+    # This test may fail intermittently due to StaleElementReferenceException exception.
+    # If it does, run this script from this point on after manually setting suite variable ${ThEME_ID}
+    # to the theme id of the newly created `Seed theme - Pupils and schools` theme.
     user clicks link    Data blocks
     user waits until h2 is visible    Data blocks    %{WAIT_SMALL}
     user waits until table is visible
@@ -232,7 +235,7 @@ Add map chart to ${RELEASE_1_NAME}
     user selects all data sets for chart
     user clicks link    Boundary levels
     user waits until h3 is visible    Boundary levels
-    user chooses select option    name:boundaryLevel    Local Authority Districts (December 2021) UK BUC
+    user chooses select option    name:boundaryLevel    Local Authority Districts UK BUC 2023/12
     user saves chart configuration
 
 Add release content to ${RELEASE_1_NAME}
@@ -535,7 +538,7 @@ Create ${RELEASE_2_NAME} release
     ...    ${PUBLICATION_ID}
     ...    ${EXCLUSIONS_PUBLICATION_RELEASE_TIME}
     ...    ${EXCLUSIONS_PUBLICATION_RELEASE_YEAR}
-    ...    OfficialStatistics
+    ...    type=OfficialStatistics
     ...    summary_text_block=Read national statistical summaries, view charts and tables and download data files.
 
     user navigates to draft release page from dashboard
@@ -644,6 +647,8 @@ Create data block 6 for ${RELEASE_2_NAME}
     ...    ${EMPTY}
 
 Add line chart 1 to ${RELEASE_2_NAME}
+    # This test may fail intermittently due to StaleElementReferenceException exception.
+    # If it does, run this script from this point on and it should complete on the second try.
     user clicks link    Data blocks
     user waits until h2 is visible    Data blocks    %{WAIT_SMALL}
     user waits until table is visible

--- a/tests/robot-tests/tests/seed_data/seed_data_theme_1_constants.robot
+++ b/tests/robot-tests/tests/seed_data/seed_data_theme_1_constants.robot
@@ -15,7 +15,7 @@ ${PUPIL_ABSENCE_RELEASE_TIME}                   AY
 ${PUPIL_ABSENCE_RELEASE_YEAR}                   2016
 ${PUPIL_ABSENCE_RELEASE_NAME}                   Academic year 2016/17
 
-${EXCLUSIONS_PUBLICATION_TITLE}                 ${PUBLICATION_TITLE_PREFIX}Permanent and fixed-period exclusions in England
+${EXCLUSIONS_PUBLICATION_TITLE}                 ${PUBLICATION_TITLE_PREFIX}Permanent & fixed-period exclusions in England
 ${EXCLUSIONS_PUBLICATION_RELEASE_TIME}          AY
 ${EXCLUSIONS_PUBLICATION_RELEASE_YEAR}          2016
 ${EXCLUSIONS_PUBLICATION_RELEASE_NAME}          Academic year 2016/17


### PR DESCRIPTION
# Summary

#6970 deprecated summary/background text block to new releases so these can not be added to new releases. Old releases however retain their background text block and be editable. This PR focuses on robot tests and adds a way to create a release which contains deprecated 'summary'/'background' text blocks via API as this can not be done via UI any more. 

This PR tweaks `publish_release_and_amend.robot ` to test that we can still edit old releases which contain a summary text box and that they work as expected when going through an amendment. 

It also tweaks `generate_seed_data_theme_1.robot` to maintain that the seeded releases contain this deprecated background/summary text block. 

## Main Changes:
- Added new test cases in publish_release_and_amend.robot to verify legacy summary text block creation, updates, and content correctness.
- Implemented a new API helper function `user_creates_test_release_with_legacy_summary_text_block_via_api` in admin_api.py for creating releases with legacy summary text blocks.
- Updated seed data script `generate_seed_data_theme_1.robot` to add deprecated summary text blocks directly through APIs, replacing deprecated UI manual steps. 
- Fixed seed data script `generate_seed_data_theme_1.robot` to be able to run locally successfully
- Fixed a logic flaw in ContentService.cs regarding handling empty content sections.
- The publication `Seed publication - Permanent and fixed-period exclusions in England` had been renamed to `Seed publication - Permanent & fixed-period exclusions in England` in order to by pass a validation error when publications are created via API which limits the maximum characters of a publication's title to be 65 characters.