### PR TITLE
EES-7128 Ensure all DataSetMapping entries have a unique OriginalData…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518075724_Ees7128PreventDuplicateDataSetMappings.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518075724_Ees7128PreventDuplicateDataSetMappings.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518075724_Ees7128PreventDuplicateDataSetMappings")]
+    partial class Ees7128PreventDuplicateDataSetMappings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518075724_Ees7128PreventDuplicateDataSetMappings.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518075724_Ees7128PreventDuplicateDataSetMappings.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees7128PreventDuplicateDataSetMappings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_DataSetMappings_OriginalDataSetId",
+                table: "DataSetMappings",
+                column: "OriginalDataSetId",
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataSetMappings_ReplacementDataSetId",
+                table: "DataSetMappings",
+                column: "ReplacementDataSetId",
+                unique: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(name: "IX_DataSetMappings_OriginalDataSetId", table: "DataSetMappings");
+
+            migrationBuilder.DropIndex(name: "IX_DataSetMappings_ReplacementDataSetId", table: "DataSetMappings");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -27,7 +27,8 @@ public record DataSetMapping
     {
         public void Configure(EntityTypeBuilder<DataSetMapping> builder)
         {
-            builder.HasKey(x => x.Id);
+            builder.HasIndex(x => x.OriginalDataSetId).IsUnique();
+            builder.HasIndex(x => x.ReplacementDataSetId).IsUnique();
 
             builder
                 .Property(x => x.IndicatorMappings)


### PR DESCRIPTION
…SetId

This PR turns DataSetMappings.OriginalDataSetId into an index. This ensures that we cannot have duplicate DataSetMappings generated for the same data set. This happened almost immediately after deploying the initial Data set mapping work.

I haven't put a joint uniqueness constraints with `ReplacementDataSetId` as there should only be one mapping per original data set. Mappings are removed if a replacement is cancelled, so this *shouldn't* caused a problem.