### PR TITLE
EES-6997: Add "Last published" column to release table

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -2199,7 +2199,8 @@ public class PublicationServiceTests
             Assert.Equal(releaseVersion.Release.YearTitle, summaryViewModel.YearTitle);
             Assert.Equal(releaseVersion.Release.TimePeriodCoverage, summaryViewModel.TimePeriodCoverage);
             Assert.Equal(releaseVersion.Release.Label, summaryViewModel.Label);
-            Assert.Equal(releaseVersion.PublishedDisplayDate, summaryViewModel.Published);
+            Assert.Equal(releaseVersion.PublishedDisplayDate, summaryViewModel.PublishedDisplayDate);
+            Assert.Equal(releaseVersion.Published, summaryViewModel.LastPublished);
             Assert.Equal(releaseVersion.Live, summaryViewModel.Live);
             Assert.Equal(releaseVersion.PublishScheduled?.ToUkDateOnly(), summaryViewModel.PublishScheduled);
             Assert.Equal(releaseVersion.NextReleaseDate, summaryViewModel.NextReleaseDate);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -159,9 +159,11 @@ public record ReleaseVersionSummaryViewModel
     [JsonConverter(typeof(StringEnumConverter))]
     public ReleaseApprovalStatus ApprovalStatus { get; init; }
 
-    public DateTimeOffset? Published { get; init; }
+    public DateTimeOffset? PublishedDisplayDate { get; init; }
 
-    public bool Live => Published != null;
+    public DateTimeOffset? LastPublished { get; init; }
+
+    public bool Live => PublishedDisplayDate != null;
 
     public DateOnly? PublishScheduled { get; init; }
 
@@ -194,7 +196,8 @@ public record ReleaseVersionSummaryViewModel
             YearTitle = releaseVersion.Release.YearTitle,
             TimePeriodCoverage = releaseVersion.Release.TimePeriodCoverage,
             ApprovalStatus = releaseVersion.ApprovalStatus,
-            Published = releaseVersion.PublishedDisplayDate,
+            PublishedDisplayDate = releaseVersion.PublishedDisplayDate,
+            LastPublished = releaseVersion.Published,
             PublishScheduled = releaseVersion.PublishScheduled?.ToUkDateOnly(),
             NextReleaseDate = releaseVersion.NextReleaseDate,
             Type = releaseVersion.Type,

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleasesTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationPublishedReleasesTable.tsx
@@ -64,6 +64,7 @@ export default function PublicationPublishedReleasesTable({
                 Status
               </th>
               <th>Published date</th>
+              <th>Last published</th>
               <th className="govuk-!-width-one-quarter">Actions</th>
             </tr>
           </thead>
@@ -83,8 +84,15 @@ export default function PublicationPublishedReleasesTable({
                     <Tag colour="green">Published</Tag>
                   </td>
                   <td>
-                    {release.published && (
-                      <FormattedDate>{release.published}</FormattedDate>
+                    {release.publishedDisplayDate && (
+                      <FormattedDate>
+                        {release.publishedDisplayDate}
+                      </FormattedDate>
+                    )}
+                  </td>
+                  <td>
+                    {release.lastPublished && (
+                      <FormattedDate>{release.lastPublished}</FormattedDate>
                     )}
                   </td>
                   <td>

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationScheduledReleases.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationScheduledReleases.tsx
@@ -40,7 +40,7 @@ const PublicationScheduledReleases = ({
             <th className="govuk-!-width-one-quarter dfe-white-space--nowrap">
               Stages checklist
             </th>
-            <th>Publish date</th>
+            <th>Scheduled publication date</th>
             <th>Actions</th>
           </tr>
         </thead>

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationDraftReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationDraftReleases.test.tsx
@@ -46,7 +46,7 @@ describe('PublicationDraftReleases', () => {
     ...testRelease1,
     approvalStatus: 'HigherLevelReview',
     id: 'release-2',
-    published: '2022-01-02T00:00:00',
+    publishedDisplayDate: '2022-01-02T00:00:00+00:00',
     slug: 'release-2-slug',
     title: 'Release 2',
   };
@@ -64,7 +64,7 @@ describe('PublicationDraftReleases', () => {
       canViewReleaseVersion: false,
     },
     previousVersionId: 'release-previous-id',
-    published: '2022-01-03T00:00:00',
+    publishedDisplayDate: '2022-01-03T00:00:00+00:00',
     slug: 'release-3-slug',
     title: 'Release 3',
   };

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationPublishedReleases.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationPublishedReleases.test.tsx
@@ -51,7 +51,8 @@ describe('PublicationPublishedReleases', () => {
       canMakeAmendmentOfReleaseVersion: true,
       canViewReleaseVersion: true,
     },
-    published: '2022-01-01T00:00:00',
+    publishedDisplayDate: '2022-01-01T00:00:00+00:00',
+    lastPublished: '2022-07-01T00:00:00+00:00',
     slug: 'release-1-slug',
     title: 'Release 1',
     timePeriodCoverage: {
@@ -67,7 +68,8 @@ describe('PublicationPublishedReleases', () => {
     ...testRelease1,
     id: 'release-2-version-1',
     releaseId: 'release-2',
-    published: '2022-01-02T00:00:00',
+    publishedDisplayDate: '2022-01-02T00:00:00+00:00',
+    lastPublished: '2022-07-02T00:00:00+00:00',
     slug: 'release-2-slug',
     title: 'Release 2',
     year: 2020,
@@ -78,7 +80,8 @@ describe('PublicationPublishedReleases', () => {
     ...testRelease1,
     id: 'release-3-version-1',
     releaseId: 'release-3',
-    published: '2022-01-03T00:00:00',
+    publishedDisplayDate: '2022-01-03T00:00:00+00:00',
+    lastPublished: '2022-07-03T00:00:00+00:00',
     slug: 'release-3-slug',
     title: 'Release 3',
     year: 2019,
@@ -89,7 +92,8 @@ describe('PublicationPublishedReleases', () => {
     ...testRelease1,
     id: 'release-4-version-1',
     releaseId: 'release-4',
-    published: '2022-01-04T00:00:00',
+    publishedDisplayDate: '2022-01-04T00:00:00+00:00',
+    lastPublished: '2022-07-04T00:00:00+00:00',
     slug: 'release-4-slug',
     title: 'Release 4',
     year: 2018,
@@ -100,7 +104,8 @@ describe('PublicationPublishedReleases', () => {
     ...testRelease1,
     id: 'release-5-version-1',
     releaseId: 'release-5',
-    published: '2022-01-05T00:00:00',
+    publishedDisplayDate: '2022-01-05T00:00:00+00:00',
+    lastPublished: '2022-07-05T00:00:00+00:00',
     slug: 'release-5-slug',
     title: 'Release 5',
     year: 2017,
@@ -111,7 +116,8 @@ describe('PublicationPublishedReleases', () => {
     ...testRelease1,
     id: 'release-6-version-1',
     releaseId: 'release-6',
-    published: '2022-01-06T00:00:00',
+    publishedDisplayDate: '2022-01-06T00:00:00+00:00',
+    lastPublished: '2022-07-06T00:00:00+00:00',
     slug: 'release-6-slug',
     title: 'Release 6',
     year: 2016,
@@ -122,7 +128,8 @@ describe('PublicationPublishedReleases', () => {
     ...testRelease1,
     id: 'release-7-version-1',
     releaseId: 'release-7',
-    published: '2022-01-07T00:00:00',
+    publishedDisplayDate: '2022-01-07T00:00:00+00:00',
+    lastPublished: '2022-07-07T00:00:00+00:00',
     slug: 'release-7-slug',
     title: 'Release 7',
     year: 2015,
@@ -196,17 +203,18 @@ describe('PublicationPublishedReleases', () => {
     expect(
       within(row1Cells[2]).getByText('1 January 2022'),
     ).toBeInTheDocument();
+    expect(within(row1Cells[3]).getByText('1 July 2022')).toBeInTheDocument();
     expect(
-      within(row1Cells[3]).getByRole('button', { name: 'Amend Release 1' }),
+      within(row1Cells[4]).getByRole('button', { name: 'Amend Release 1' }),
     ).toBeInTheDocument();
     expect(
-      within(row1Cells[3]).getByRole('link', { name: 'View Release 1' }),
+      within(row1Cells[4]).getByRole('link', { name: 'View Release 1' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-1-version-1/summary',
     );
     expect(
-      within(row1Cells[3]).getByRole('button', {
+      within(row1Cells[4]).getByRole('button', {
         name: 'Edit release label for Release 1',
       }),
     ).toBeInTheDocument();
@@ -217,17 +225,18 @@ describe('PublicationPublishedReleases', () => {
     expect(
       within(row2Cells[2]).getByText('2 January 2022'),
     ).toBeInTheDocument();
+    expect(within(row2Cells[3]).getByText('2 July 2022')).toBeInTheDocument();
     expect(
-      within(row2Cells[3]).getByRole('button', { name: 'Amend Release 2' }),
+      within(row2Cells[4]).getByRole('button', { name: 'Amend Release 2' }),
     ).toBeInTheDocument();
     expect(
-      within(row2Cells[3]).getByRole('link', { name: 'View Release 2' }),
+      within(row2Cells[4]).getByRole('link', { name: 'View Release 2' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-2-version-1/summary',
     );
     expect(
-      within(row2Cells[3]).getByRole('button', {
+      within(row2Cells[4]).getByRole('button', {
         name: 'Edit release label for Release 2',
       }),
     ).toBeInTheDocument();
@@ -238,17 +247,18 @@ describe('PublicationPublishedReleases', () => {
     expect(
       within(row3Cells[2]).getByText('3 January 2022'),
     ).toBeInTheDocument();
+    expect(within(row3Cells[3]).getByText('3 July 2022')).toBeInTheDocument();
     expect(
-      within(row3Cells[3]).getByRole('button', { name: 'Amend Release 3' }),
+      within(row3Cells[4]).getByRole('button', { name: 'Amend Release 3' }),
     ).toBeInTheDocument();
     expect(
-      within(row3Cells[3]).getByRole('link', { name: 'View Release 3' }),
+      within(row3Cells[4]).getByRole('link', { name: 'View Release 3' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-3-version-1/summary',
     );
     expect(
-      within(row3Cells[3]).getByRole('button', {
+      within(row3Cells[4]).getByRole('button', {
         name: 'Edit release label for Release 3',
       }),
     ).toBeInTheDocument();
@@ -259,17 +269,18 @@ describe('PublicationPublishedReleases', () => {
     expect(
       within(row4Cells[2]).getByText('4 January 2022'),
     ).toBeInTheDocument();
+    expect(within(row4Cells[3]).getByText('4 July 2022')).toBeInTheDocument();
     expect(
-      within(row4Cells[3]).getByRole('button', { name: 'Amend Release 4' }),
+      within(row4Cells[4]).getByRole('button', { name: 'Amend Release 4' }),
     ).toBeInTheDocument();
     expect(
-      within(row4Cells[3]).getByRole('link', { name: 'View Release 4' }),
+      within(row4Cells[4]).getByRole('link', { name: 'View Release 4' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-4-version-1/summary',
     );
     expect(
-      within(row4Cells[3]).getByRole('button', {
+      within(row4Cells[4]).getByRole('button', {
         name: 'Edit release label for Release 4',
       }),
     ).toBeInTheDocument();
@@ -280,17 +291,18 @@ describe('PublicationPublishedReleases', () => {
     expect(
       within(row5Cells[2]).getByText('5 January 2022'),
     ).toBeInTheDocument();
+    expect(within(row5Cells[3]).getByText('5 July 2022')).toBeInTheDocument();
     expect(
-      within(row5Cells[3]).getByRole('button', { name: 'Amend Release 5' }),
+      within(row5Cells[4]).getByRole('button', { name: 'Amend Release 5' }),
     ).toBeInTheDocument();
     expect(
-      within(row5Cells[3]).getByRole('link', { name: 'View Release 5' }),
+      within(row5Cells[4]).getByRole('link', { name: 'View Release 5' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-5-version-1/summary',
     );
     expect(
-      within(row5Cells[3]).getByRole('button', {
+      within(row5Cells[4]).getByRole('button', {
         name: 'Edit release label for Release 5',
       }),
     ).toBeInTheDocument();
@@ -338,13 +350,13 @@ describe('PublicationPublishedReleases', () => {
 
       if (canUpdateRelease) {
         expect(
-          within(rowCells[3]).getByRole('button', {
+          within(rowCells[4]).getByRole('button', {
             name: 'Edit release label for Release 1',
           }),
         ).toBeInTheDocument();
       } else {
         expect(
-          within(rowCells[3]).queryByRole('button', {
+          within(rowCells[4]).queryByRole('button', {
             name: 'Edit release label for Release 1',
           }),
         ).not.toBeInTheDocument();
@@ -423,11 +435,12 @@ describe('PublicationPublishedReleases', () => {
     expect(
       within(row6Cells[2]).getByText('6 January 2022'),
     ).toBeInTheDocument();
+    expect(within(row6Cells[3]).getByText('6 July 2022')).toBeInTheDocument();
     expect(
-      within(row6Cells[3]).getByRole('button', { name: 'Amend Release 6' }),
+      within(row6Cells[4]).getByRole('button', { name: 'Amend Release 6' }),
     ).toBeInTheDocument();
     expect(
-      within(row6Cells[3]).getByRole('link', { name: 'View Release 6' }),
+      within(row6Cells[4]).getByRole('link', { name: 'View Release 6' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-6-version-1/summary',
@@ -439,11 +452,12 @@ describe('PublicationPublishedReleases', () => {
     expect(
       within(row7Cells[2]).getByText('7 January 2022'),
     ).toBeInTheDocument();
+    expect(within(row7Cells[3]).getByText('7 July 2022')).toBeInTheDocument();
     expect(
-      within(row7Cells[3]).getByRole('button', { name: 'Amend Release 7' }),
+      within(row7Cells[4]).getByRole('button', { name: 'Amend Release 7' }),
     ).toBeInTheDocument();
     expect(
-      within(row7Cells[3]).getByRole('link', { name: 'View Release 7' }),
+      within(row7Cells[4]).getByRole('link', { name: 'View Release 7' }),
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-7-version-1/summary',

--- a/src/explore-education-statistics-admin/src/services/releaseVersionService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseVersionService.ts
@@ -62,7 +62,8 @@ export interface ReleaseVersionSummary {
   timePeriodCoverage: ValueLabelPair;
   approvalStatus: ReleaseApprovalStatus;
   publishScheduled?: string;
-  published?: string;
+  publishedDisplayDate?: string;
+  lastPublished?: string;
   live: boolean;
   nextReleaseDate?: PartialDate;
   type: ReleaseType;


### PR DESCRIPTION
This PR adds a 'Last published' date to tables listing releases in Admin, to help analysts clearly see when a release was last published.