### PR TITLE
EES-7007 - simplified progress response Admin endpoint 

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Releases/ReleaseVersionsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Releases/ReleaseVersionsControllerTests.cs
@@ -652,27 +652,29 @@ public class ReleaseVersionsControllerUnitTests
     {
         // Arrange
         var releaseVersionId = Guid.NewGuid();
+        var uploadId = Guid.NewGuid();
 
-        List<ScreenerProgressWithDataSetUploadIdViewModel> response =
-        [
-            new()
-            {
-                DataSetUploadId = Guid.NewGuid(),
-                PercentageComplete = 100,
-                Stage = "completed",
-            },
-        ];
+        var response = new ScreenerProgressViewModel
+        {
+            PercentageComplete = 100,
+            Stage = "completed",
+            Completed = true,
+        };
 
         var dataSetScreenerService = new Mock<IDataSetScreenerService>(Strict);
 
         dataSetScreenerService
-            .Setup(s => s.GetScreenerProgress(releaseVersionId, CancellationToken.None))
+            .Setup(s => s.GetScreenerProgress(releaseVersionId, uploadId, CancellationToken.None))
             .ReturnsAsync(response);
 
         var controller = BuildController(dataSetScreenerService: dataSetScreenerService.Object);
 
         // Act
-        var result = await controller.GetDataSetUploadScreenerProgress(releaseVersionId, CancellationToken.None);
+        var result = await controller.GetDataSetUploadScreenerProgress(
+            releaseVersionId,
+            uploadId,
+            CancellationToken.None
+        );
 
         // Assert
         VerifyAllMocks(dataSetScreenerService);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServicePermissionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServicePermissionsTests.cs
@@ -24,9 +24,11 @@ public class DataSetScreenerServicePermissionsTests
     public async Task GetScreenerProgress()
     {
         ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
+        DataSetUpload upload = _dataFixture.DefaultDataSetUpload().WithReleaseVersionId(releaseVersion.Id);
 
         await using var contentDbContext = DbUtils.InMemoryApplicationDbContext();
         contentDbContext.ReleaseVersions.Add(releaseVersion);
+        contentDbContext.DataSetUploads.Add(upload);
         await contentDbContext.SaveChangesAsync();
 
         await PermissionTestUtils
@@ -35,7 +37,7 @@ public class DataSetScreenerServicePermissionsTests
             .AssertForbidden(userService =>
             {
                 var service = BuildService(userService: userService.Object, contentDbContext: contentDbContext);
-                return service.GetScreenerProgress(releaseVersion.Id, CancellationToken.None);
+                return service.GetScreenerProgress(releaseVersion.Id, upload.Id, CancellationToken.None);
             });
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
@@ -574,7 +574,7 @@ public abstract class DataSetScreenerServiceTests
     public class GetScreenerProgressTests : DataSetScreenerServiceTests
     {
         [Fact]
-        public async Task DataSetsBeingScreened_ProgressUpdatesReturned()
+        public async Task DataSetWithScreenerProgress_ProgressUpdatesReturned()
         {
             // Arrange
             ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
@@ -582,7 +582,6 @@ public abstract class DataSetScreenerServiceTests
             var dataSetsUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
                 .WithReleaseVersionId(releaseVersion.Id)
-                .WithStatus(DataSetUploadStatus.SCREENING)
                 .ForIndex(
                     0,
                     s =>
@@ -596,6 +595,7 @@ public abstract class DataSetScreenerServiceTests
                             }
                         )
                 )
+                // Add an unrelated DataSetUpload.
                 .ForIndex(
                     1,
                     s =>
@@ -626,32 +626,61 @@ public abstract class DataSetScreenerServiceTests
                 // Act
                 var result = await service.GetScreenerProgress(
                     releaseVersionId: releaseVersion.Id,
+                    dataSetUploadId: dataSetsUndergoingScreening[0].Id,
                     cancellationToken: CancellationToken.None
                 );
 
                 // Assert
-                List<ScreenerProgressWithDataSetUploadIdViewModel> expectedProgressUpdates =
-                [
-                    new()
-                    {
-                        DataSetUploadId = dataSetsUndergoingScreening[0].Id,
-                        PercentageComplete = (int)dataSetsUndergoingScreening[0].ScreenerProgress!.PercentageComplete,
-                        Stage = dataSetsUndergoingScreening[0].ScreenerProgress!.Stage,
-                    },
-                    new()
-                    {
-                        DataSetUploadId = dataSetsUndergoingScreening[1].Id,
-                        PercentageComplete = (int)dataSetsUndergoingScreening[1].ScreenerProgress!.PercentageComplete,
-                        Stage = dataSetsUndergoingScreening[1].ScreenerProgress!.Stage,
-                    },
-                ];
+                var expectedProgressUpdate = new ScreenerProgressViewModel
+                {
+                    PercentageComplete = (int)dataSetsUndergoingScreening[0].ScreenerProgress!.PercentageComplete,
+                    Stage = dataSetsUndergoingScreening[0].ScreenerProgress!.Stage,
+                    Completed = dataSetsUndergoingScreening[0].ScreenerProgress!.Completed,
+                };
 
-                result.AssertRight(expectedProgressUpdates);
+                result.AssertRight(expectedProgressUpdate);
             }
         }
 
         [Fact]
-        public async Task DataSetBeingScreened_DifferentReleaseVersion_ProgressUpdatesNotReturned()
+        public async Task DataSetBeingScreened_NoProgressUpdatesYet_NullProgressUpdateReturned()
+        {
+            // Arrange
+            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
+
+            DataSetUpload dataSetUndergoingScreening = _dataFixture
+                .DefaultDataSetUpload()
+                .WithReleaseVersionId(releaseVersion.Id)
+                // No progress update has yet been fetched for this data set.
+                .WithScreenerProgress(null);
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                await context.DataSetUploads.AddRangeAsync(dataSetUndergoingScreening);
+                await context.ReleaseVersions.AddRangeAsync(releaseVersion);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var service = BuildService(contentDbContext: context);
+
+                // Act
+                var result = await service.GetScreenerProgress(
+                    releaseVersionId: releaseVersion.Id,
+                    dataSetUploadId: dataSetUndergoingScreening.Id,
+                    cancellationToken: CancellationToken.None
+                );
+
+                // Assert
+                var response = result.AssertRight();
+                Assert.Null(response);
+            }
+        }
+
+        [Fact]
+        public async Task DataSetBeingScreened_ReleaseVersionAndDataSetUploadMismatch_NotFound()
         {
             // Arrange
             ReleaseVersion unrelatedReleaseVersion = _dataFixture.DefaultReleaseVersion();
@@ -660,7 +689,6 @@ public abstract class DataSetScreenerServiceTests
                 .DefaultDataSetUpload()
                 // Assign these DataSetUploads to a different ReleaseVersion.
                 .WithReleaseVersionId(Guid.NewGuid())
-                .WithStatus(DataSetUploadStatus.SCREENING)
                 .WithScreenerProgress(
                     new DataSetScreenerProgress
                     {
@@ -686,32 +714,37 @@ public abstract class DataSetScreenerServiceTests
                 // Act
                 var result = await service.GetScreenerProgress(
                     releaseVersionId: unrelatedReleaseVersion.Id,
+                    dataSetUploadId: dataSetUndergoingScreening.Id,
                     cancellationToken: CancellationToken.None
                 );
 
                 // Assert
-                result.AssertRight([]);
+                result.AssertNotFound();
             }
         }
 
         [Fact]
-        public async Task DataSetBeingScreened_NoProgressUpdatesYet_DefaultProgressUpdateReturned()
+        public async Task DataSetBeingScreened_ReleaseVersionNotFound_NotFound()
         {
             // Arrange
-            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
-
             DataSetUpload dataSetUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
-                .WithReleaseVersionId(releaseVersion.Id)
-                .WithStatus(DataSetUploadStatus.SCREENING)
-                // No progress update has yet been fetched for this data set.
-                .WithScreenerProgress(null);
+                // Assign these DataSetUploads to a different ReleaseVersion.
+                .WithReleaseVersionId(Guid.NewGuid())
+                .WithScreenerProgress(
+                    new DataSetScreenerProgress
+                    {
+                        Completed = false,
+                        Passed = false,
+                        PercentageComplete = 50,
+                        Stage = "validation",
+                    }
+                );
 
             var contextId = Guid.NewGuid().ToString();
             await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.DataSetUploads.AddRangeAsync(dataSetUndergoingScreening);
-                await context.ReleaseVersions.AddRangeAsync(releaseVersion);
                 await context.SaveChangesAsync();
             }
 
@@ -721,74 +754,14 @@ public abstract class DataSetScreenerServiceTests
 
                 // Act
                 var result = await service.GetScreenerProgress(
-                    releaseVersionId: releaseVersion.Id,
-                    cancellationToken: CancellationToken.None
-                );
-
-                List<ScreenerProgressWithDataSetUploadIdViewModel> expectedProgressUpdates =
-                [
-                    new()
-                    {
-                        DataSetUploadId = dataSetUndergoingScreening.Id,
-                        PercentageComplete = 0,
-                        Stage = null,
-                    },
-                ];
-
-                // Assert
-                result.AssertRight(expectedProgressUpdates);
-            }
-        }
-
-        [Fact]
-        public async Task DataSetNotCurrentlyUndergoingScreening_NoProgressUpdateReturned()
-        {
-            // Arrange
-            ReleaseVersion releaseVersion = _dataFixture.DefaultReleaseVersion();
-
-            DataSetUpload dataSetNotUndergoingScreening = _dataFixture
-                .DefaultDataSetUpload()
-                .WithReleaseVersionId(releaseVersion.Id)
-                // Not currently undergoing screening.
-                .WithStatus(DataSetUploadStatus.PENDING_REVIEW);
-
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryContentDbContext(contextId))
-            {
-                await context.DataSetUploads.AddRangeAsync(dataSetNotUndergoingScreening);
-                await context.ReleaseVersions.AddRangeAsync(releaseVersion);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryContentDbContext(contextId))
-            {
-                var service = BuildService(contentDbContext: context);
-
-                // Act
-                var result = await service.GetScreenerProgress(
-                    releaseVersionId: releaseVersion.Id,
+                    releaseVersionId: Guid.NewGuid(), // Non-existent ReleaseVersion id.
+                    dataSetUploadId: dataSetUndergoingScreening.Id,
                     cancellationToken: CancellationToken.None
                 );
 
                 // Assert
-                result.AssertRight([]);
+                result.AssertNotFound();
             }
-        }
-
-        [Fact]
-        public async Task ReleaseVersionDoesNotExist_ReturnsNotFound()
-        {
-            await using var context = InMemoryContentDbContext();
-            var service = BuildService(contentDbContext: context);
-
-            // Act
-            var result = await service.GetScreenerProgress(
-                releaseVersionId: Guid.NewGuid(),
-                cancellationToken: CancellationToken.None
-            );
-
-            // Assert
-            result.AssertNotFound();
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Releases/ReleaseVersionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Releases/ReleaseVersionsController.cs
@@ -108,13 +108,15 @@ public class ReleaseVersionsController(
             .HandleFailuresOrNoContent();
     }
 
-    [HttpGet("releaseVersions/{releaseVersionId:guid}/uploads/screener/progress")]
-    public async Task<
-        ActionResult<List<ScreenerProgressWithDataSetUploadIdViewModel>>
-    > GetDataSetUploadScreenerProgress(Guid releaseVersionId, CancellationToken cancellationToken)
+    [HttpGet("releaseVersions/{releaseVersionId:guid}/uploads/{dataSetUploadId:guid}/screener/progress")]
+    public async Task<ActionResult<ScreenerProgressViewModel>> GetDataSetUploadScreenerProgress(
+        Guid releaseVersionId,
+        Guid dataSetUploadId,
+        CancellationToken cancellationToken
+    )
     {
         return await dataSetScreenerService
-            .GetScreenerProgress(releaseVersionId, cancellationToken)
+            .GetScreenerProgress(releaseVersionId, dataSetUploadId, cancellationToken)
             .HandleFailuresOrOk();
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Screener/IDataSetScreenerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Screener/IDataSetScreenerService.cs
@@ -39,10 +39,11 @@ public interface IDataSetScreenerService
     Task<List<DataSetUploadViewModel>> MarkDataSetsWithoutProgressAsFailed(CancellationToken cancellationToken);
 
     /// <summary>
-    /// Get the progress of all data sets undergoing screening for a given ReleaseVersion.
+    /// Get the progress of a data set undergoing screening for a given ReleaseVersion and dataSetUploadId.
     /// </summary>
-    Task<Either<ActionResult, List<ScreenerProgressWithDataSetUploadIdViewModel>>> GetScreenerProgress(
+    Task<Either<ActionResult, ScreenerProgressViewModel?>> GetScreenerProgress(
         Guid releaseVersionId,
+        Guid dataSetUploadId,
         CancellationToken cancellationToken
     );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
@@ -195,32 +195,32 @@ public class DataSetScreenerService(
         return [.. screeningDataSetsWithoutRecentProgressUpdates.Select(mapper.Map<DataSetUploadViewModel>)];
     }
 
-    public Task<Either<ActionResult, List<ScreenerProgressWithDataSetUploadIdViewModel>>> GetScreenerProgress(
+    public Task<Either<ActionResult, ScreenerProgressViewModel?>> GetScreenerProgress(
         Guid releaseVersionId,
+        Guid dataSetUploadId,
         CancellationToken cancellationToken
     )
     {
         return contentDbContext
             .ReleaseVersions.SingleOrNotFound(rv => rv.Id == releaseVersionId)
             .OnSuccess(userService.CheckCanViewReleaseVersion)
-            .OnSuccess(async () =>
-            {
-                var dataSetsUndergoingScreening = await contentDbContext
-                    .DataSetUploads.Where(upload =>
-                        upload.ReleaseVersionId == releaseVersionId && upload.Status == DataSetUploadStatus.SCREENING
-                    )
-                    .ToListAsync(cancellationToken: cancellationToken);
-
-                return dataSetsUndergoingScreening
-                    .Select(upload => new ScreenerProgressWithDataSetUploadIdViewModel
+            .OnSuccess(() =>
+                contentDbContext.DataSetUploads.SingleOrNotFoundAsync(
+                    upload => upload.Id == dataSetUploadId && upload.ReleaseVersionId == releaseVersionId,
+                    cancellationToken: cancellationToken
+                )
+            )
+            .OnSuccess(upload =>
+                upload.ScreenerProgress != null
+                    ? new ScreenerProgressViewModel
                     {
-                        DataSetUploadId = upload.Id,
                         PercentageComplete = (int)
                             Math.Round(upload.ScreenerProgress?.PercentageComplete ?? 0, MidpointRounding.ToZero),
                         Stage = upload.ScreenerProgress?.Stage,
-                    })
-                    .ToList();
-            });
+                        Completed = upload.ScreenerProgress?.Completed ?? false,
+                    }
+                    : null
+            );
     }
 
     public async Task<List<DataSetUploadViewModel>> CompleteDataSetScreeningForFinishedDataSets(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Screener/ScreenerProgressViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Screener/ScreenerProgressViewModel.cs
@@ -5,9 +5,6 @@ public record ScreenerProgressViewModel
     public int PercentageComplete { get; set; }
 
     public string Stage { get; set; } = null!;
-}
 
-public record ScreenerProgressWithDataSetUploadIdViewModel : ScreenerProgressViewModel
-{
-    public Guid DataSetUploadId { get; set; }
+    public bool Completed { get; set; }
 }


### PR DESCRIPTION
This PR:
- simplifies the "screener progress" Admin endpoint o only return responses for a single DataSetUpload at a time, in line with how we get importer progress updates in the current frontend codebase.