### PR TITLE
EES-7110 search data filters

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
@@ -69,7 +69,14 @@ const FormFieldset = ({
             },
           )}
         >
-          {legend}
+          {/* Extra span to avoid browser rendering quirk with hidden legend */}
+          <span
+            className={classNames({
+              'govuk-visually-hidden': legendHidden,
+            })}
+          >
+            {legend}
+          </span>
         </legend>
 
         {hint && (

--- a/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
@@ -69,14 +69,7 @@ const FormFieldset = ({
             },
           )}
         >
-          {/* Extra span to avoid browser rendering quirk with hidden legend */}
-          <span
-            className={classNames({
-              'govuk-visually-hidden': legendHidden,
-            })}
-          >
-            {legend}
-          </span>
+          {legend}
         </legend>
 
         {hint && (

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FilterAccordion.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FilterAccordion.test.tsx
@@ -1,0 +1,80 @@
+import FilterAccordion from '@common/modules/table-tool/components/FilterAccordion';
+import render from '@common-test/render';
+import { screen } from '@testing-library/react';
+import React from 'react';
+
+describe('FilterAccordion', () => {
+  test('renders correctly', () => {
+    render(
+      <FilterAccordion label="Test label" id="test-id">
+        content
+      </FilterAccordion>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Test label - show options' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('content')).toBeInTheDocument();
+  });
+
+  test('is closed by default and expands when clicked', async () => {
+    const { user } = render(
+      <FilterAccordion label="Test label" id="test-id">
+        <h2>content</h2>
+      </FilterAccordion>,
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'Test label - show options',
+    });
+
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(button);
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Test label - hide options',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('is expanded when open is set to true', async () => {
+    const { user } = render(
+      <FilterAccordion label="Test label" id="test-id" open>
+        <h2>content</h2>
+      </FilterAccordion>,
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'Test label - hide options',
+    });
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(button);
+
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('cannot be opened or closed when preventToggle is set', async () => {
+    const { user } = render(
+      <FilterAccordion label="Test label" id="test-id" open preventToggle>
+        <h2>content</h2>
+      </FilterAccordion>,
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'Test label - hide options',
+    });
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(button);
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/src/explore-education-statistics-common/src/utils/getAsArray.ts
+++ b/src/explore-education-statistics-common/src/utils/getAsArray.ts
@@ -1,0 +1,6 @@
+export default function getAsArray(
+  val: string | string[] | undefined,
+): string[] | undefined {
+  if (!val) return undefined;
+  return Array.isArray(val) ? val : [val];
+}

--- a/src/explore-education-statistics-frontend/src/components/FiltersMobile.module.scss
+++ b/src/explore-education-statistics-frontend/src/components/FiltersMobile.module.scss
@@ -15,7 +15,7 @@
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: 1;
+  z-index: 2;
 
   :focus & {
     border: $govuk-focus-width solid $govuk-focus-colour;

--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.module.scss
@@ -33,3 +33,10 @@
     border-color: govuk-colour('blue');
   }
 }
+
+.stickyFilters {
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+  overflow: auto;
+}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.module.scss
@@ -38,5 +38,6 @@
   position: sticky;
   top: 0;
   max-height: 100vh;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
 }

--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
@@ -9,6 +9,7 @@ import VisuallyHidden from '@common/components/VisuallyHidden';
 import WarningMessage from '@common/components/WarningMessage';
 import { useMobileMedia } from '@common/hooks/useMedia';
 import { ReleaseType, releaseTypes } from '@common/services/types/releaseType';
+import getAsArray from '@common/utils/getAsArray';
 import FilterResetButton from '@frontend/components/FilterResetButton';
 import FiltersMobile from '@frontend/components/FiltersMobile';
 import Link from '@frontend/components/Link';
@@ -50,7 +51,7 @@ export interface SearchDataPageQuery {
   releaseType?: ReleaseType;
   search?: string;
   sortBy?: PublicationSortOption;
-  themeId?: string;
+  themeId?: string | string[];
 }
 
 const SearchDataPage: NextPage = () => {
@@ -131,12 +132,12 @@ const SearchDataPage: NextPage = () => {
     isFilteredByDataSetType ||
     isFilteredAllReleases;
 
-  const selectedTheme = themes.find(theme => theme.id === themeId);
+  const selectedThemes = themes.filter(theme => themeId?.includes(theme.id));
   const selectedReleaseType = releaseTypes[releaseType as ReleaseType];
 
   const filteredByString = compact([
     search,
-    selectedTheme?.title,
+    ...selectedThemes.map(t => t.title),
     selectedReleaseType,
     isFilteredByDataSetType ? 'API data sets only' : undefined,
     isFilteredAllReleases ? 'All releases' : undefined,
@@ -187,6 +188,13 @@ const SearchDataPage: NextPage = () => {
     });
   };
 
+  const multiValueFilters: string[] = [
+    'themeId',
+    'releaseType',
+    'geographicLevel',
+    'publicationId',
+  ];
+
   const handleChangeFilter = async ({
     filterType,
     nextValue,
@@ -194,20 +202,50 @@ const SearchDataPage: NextPage = () => {
     filterType: SearchDataFilter;
     nextValue: string;
   }) => {
-    // If performing a search (by search term), reset sortBy to relevance
+    // 1. If performing a search (by search term), reset sortBy to relevance
     const nextSortBy =
       filterType === 'search' && nextValue.length > 0 ? 'relevance' : sortBy;
 
-    const newParams =
-      nextValue === 'all' && filterType !== 'dataSetType'
-        ? omit(router.query, 'page', filterType)
-        : {
-            ...omit(router.query, 'page'),
-            [filterType]: nextValue,
-            sortBy: nextSortBy,
-          };
+    // 2. Start building the new query.
+    // We use a Record here so TypeScript allows dynamic key assignments.
+    let newQuery: Record<string, string | string[] | undefined> = {
+      ...omit(router.query, 'page'),
+      sortBy: nextSortBy,
+    };
 
-    await updateQueryParams(newParams);
+    // 3. Determine if this filter should be handled as an array (checkboxes) or a single string (radios/selects)
+    if (multiValueFilters.includes(filterType)) {
+      // Safely grab the current query param and ensure it's an array.
+      const currentParam = router.query[filterType] as
+        | string
+        | string[]
+        | undefined;
+      const currentValues = getAsArray(currentParam) ?? [];
+
+      let updatedValues: string[];
+      if (currentValues.includes(nextValue)) {
+        // Remove it if already selected
+        updatedValues = currentValues.filter(v => v !== nextValue);
+      } else {
+        // Add it if not selected
+        updatedValues = [...currentValues, nextValue];
+      }
+
+      // If the array is empty, wipe it from the URL entirely. Otherwise, set it.
+      if (updatedValues.length === 0) {
+        newQuery = omit(newQuery, filterType);
+      } else {
+        newQuery[filterType] = updatedValues;
+      }
+    } else if (nextValue === 'all' && filterType !== 'dataSetType') {
+      // Wipe the parameter from the URL if 'all' is selected
+      newQuery = omit(newQuery, filterType);
+    } else {
+      // Set the specific single string value
+      newQuery[filterType] = nextValue;
+    }
+
+    await updateQueryParams(newQuery as SearchDataPageQuery);
 
     logEvent({
       category: 'Find statistics and data',
@@ -384,7 +422,7 @@ const SearchDataPage: NextPage = () => {
               releaseTypeOptions={releaseTypeOptions}
               sortBy={sortBy}
               sortOptions={sortOptions}
-              themeId={themeId}
+              themeIds={themeId}
               themes={themes}
               themeOptions={themeOptions}
               onChange={handleChangeFilter}
@@ -403,7 +441,7 @@ const SearchDataPage: NextPage = () => {
                 releaseType={releaseType}
                 sortBy={sortBy}
                 sortOptions={sortOptions}
-                themeId={themeId}
+                themeIds={themeId}
                 themes={themes}
                 themeOptions={themeOptions}
                 onChange={handleChangeFilter}
@@ -436,13 +474,19 @@ const SearchDataPage: NextPage = () => {
                 />
               )}
 
-              {selectedTheme && (
+              {selectedThemes.map(theme => (
                 <FilterResetButton
+                  key={theme.id}
                   filterType="Theme"
-                  name={selectedTheme.title}
-                  onClick={() => handleResetFilter({ filterType: 'themeId' })}
+                  name={theme.title}
+                  onClick={() =>
+                    handleChangeFilter({
+                      filterType: 'themeId',
+                      nextValue: theme.id,
+                    })
+                  }
                 />
-              )}
+              ))}
               {selectedReleaseType && (
                 <FilterResetButton
                   filterType="Release type"

--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
@@ -32,6 +32,7 @@ import themeQueries from '@frontend/queries/themeQueries';
 import { DataSetType } from '@frontend/services/dataSetFileService';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
 import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
+import classNames from 'classnames';
 import compact from 'lodash/compact';
 import omit from 'lodash/omit';
 import { GetServerSideProps, NextPage } from 'next';
@@ -368,7 +369,12 @@ const SearchDataPage: NextPage = () => {
         </div>
       </div>
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-one-third">
+        <div
+          className={classNames([
+            'govuk-grid-column-one-third',
+            styles.stickyFilters,
+          ])}
+        >
           {!isMobileMedia && (
             <SearchDataFilters
               dataSetType={dataSetType as DataSetType}
@@ -376,7 +382,6 @@ const SearchDataPage: NextPage = () => {
               latestDataOnly={latestDataOnly}
               releaseType={releaseType}
               releaseTypeOptions={releaseTypeOptions}
-              showResetFiltersButton={!isMobileMedia && isFiltered}
               sortBy={sortBy}
               sortOptions={sortOptions}
               themeId={themeId}
@@ -384,7 +389,6 @@ const SearchDataPage: NextPage = () => {
               themeOptions={themeOptions}
               onChange={handleChangeFilter}
               onSortChange={handleSortBy}
-              onResetFilters={() => handleResetFilter({ filterType: 'all' })}
             />
           )}
         </div>
@@ -467,6 +471,16 @@ const SearchDataPage: NextPage = () => {
                 />
               )}
             </div>
+
+            {isFiltered && (
+              <div className="govuk-!-width-full">
+                <ButtonText
+                  onClick={() => handleResetFilter({ filterType: 'all' })}
+                >
+                  Clear all filters
+                </ButtonText>
+              </div>
+            )}
           </div>
 
           <LoadingSpinner

--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
@@ -48,7 +48,7 @@ export interface SearchDataPageQuery {
   dataSetType?: DataSetType;
   latestDataOnly?: string;
   page?: number;
-  releaseType?: ReleaseType;
+  releaseType?: ReleaseType | ReleaseType[];
   search?: string;
   sortBy?: PublicationSortOption;
   themeId?: string | string[];
@@ -125,20 +125,25 @@ const SearchDataPage: NextPage = () => {
     !isPublicationsSearch && dataSetType === 'api';
   const isFilteredAllReleases = !isPublicationsSearch && !latestDataOnly;
 
+  const selectedThemes = themes.filter(theme => themeId?.includes(theme.id));
+  const selectedReleaseTypes = releaseType
+    ? getAsArray(releaseType)!.map(type => ({
+        id: type,
+        title: releaseTypes[type as ReleaseType],
+      }))
+    : [];
+
   const isFiltered =
     !!search ||
-    !!releaseType ||
-    !!themeId ||
+    selectedReleaseTypes.length > 0 ||
+    selectedThemes.length > 0 ||
     isFilteredByDataSetType ||
     isFilteredAllReleases;
-
-  const selectedThemes = themes.filter(theme => themeId?.includes(theme.id));
-  const selectedReleaseType = releaseTypes[releaseType as ReleaseType];
 
   const filteredByString = compact([
     search,
     ...selectedThemes.map(t => t.title),
-    selectedReleaseType,
+    ...selectedReleaseTypes.map(rt => rt.title),
     isFilteredByDataSetType ? 'API data sets only' : undefined,
     isFilteredAllReleases ? 'All releases' : undefined,
   ]).join(', ');
@@ -418,7 +423,7 @@ const SearchDataPage: NextPage = () => {
               dataSetType={dataSetType as DataSetType}
               includeDataFilters={!isPublicationsSearch}
               latestDataOnly={latestDataOnly}
-              releaseType={releaseType}
+              releaseTypes={releaseType}
               releaseTypeOptions={releaseTypeOptions}
               sortBy={sortBy}
               sortOptions={sortOptions}
@@ -438,7 +443,7 @@ const SearchDataPage: NextPage = () => {
                 includeDataFilters={!isPublicationsSearch}
                 latestDataOnly={latestDataOnly}
                 releaseTypeOptions={releaseTypeOptions}
-                releaseType={releaseType}
+                releaseTypes={releaseType}
                 sortBy={sortBy}
                 sortOptions={sortOptions}
                 themeIds={themeId}
@@ -487,15 +492,21 @@ const SearchDataPage: NextPage = () => {
                   }
                 />
               ))}
-              {selectedReleaseType && (
+
+              {selectedReleaseTypes.map(rt => (
                 <FilterResetButton
+                  key={rt.id}
                   filterType="Release type"
-                  name={selectedReleaseType}
+                  name={rt.title}
                   onClick={() =>
-                    handleResetFilter({ filterType: 'releaseType' })
+                    handleChangeFilter({
+                      filterType: 'releaseType',
+                      nextValue: rt.id,
+                    })
                   }
                 />
-              )}
+              ))}
+
               {isFilteredByDataSetType && (
                 <FilterResetButton
                   filterType="Data set type"

--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
@@ -8,7 +8,10 @@ import ScreenReaderMessage from '@common/components/ScreenReaderMessage';
 import VisuallyHidden from '@common/components/VisuallyHidden';
 import WarningMessage from '@common/components/WarningMessage';
 import { useMobileMedia } from '@common/hooks/useMedia';
-import { ReleaseType, releaseTypes } from '@common/services/types/releaseType';
+import {
+  ReleaseType,
+  releaseTypes as statisticsReleaseTypes,
+} from '@common/services/types/releaseType';
 import getAsArray from '@common/utils/getAsArray';
 import locationLevelsMap, {
   GeographicLevelCode,
@@ -122,11 +125,11 @@ const SearchDataPage: NextPage = () => {
     dataSetType,
     geographicLevels,
     latestDataOnly,
-    publicationId,
-    releaseType,
+    publicationIds,
+    releaseTypes,
     search,
     sortBy,
-    themeId,
+    themeIds,
   } = getParamsFromQuery(router.query);
 
   const themeOptions = themes.map(theme => {
@@ -136,9 +139,9 @@ const SearchDataPage: NextPage = () => {
     };
   });
 
-  const releaseTypeOptions = Object.keys(releaseTypes).map(type => {
+  const releaseTypeOptions = Object.keys(statisticsReleaseTypes).map(type => {
     return {
-      label: releaseTypes[type as ReleaseType],
+      label: statisticsReleaseTypes[type as ReleaseType],
       value: type,
     };
   });
@@ -152,11 +155,11 @@ const SearchDataPage: NextPage = () => {
     },
   );
 
-  const selectedThemes = themes.filter(theme => themeId?.includes(theme.id));
-  const selectedReleaseTypes = releaseType
-    ? getAsArray(releaseType)!.map(type => ({
+  const selectedThemes = themes.filter(theme => themeIds?.includes(theme.id));
+  const selectedReleaseTypes = releaseTypes
+    ? getAsArray(releaseTypes)!.map(type => ({
         id: type,
-        title: releaseTypes[type as ReleaseType],
+        title: statisticsReleaseTypes[type as ReleaseType],
       }))
     : [];
 
@@ -168,7 +171,7 @@ const SearchDataPage: NextPage = () => {
 
   const allPublications = publicationTree.flatMap(theme => theme.publications);
   const selectedPublications = allPublications.filter(
-    publication => publicationId?.includes(publication.id),
+    publication => publicationIds?.includes(publication.id),
   );
 
   const isFilteredByDataSetType =
@@ -506,13 +509,13 @@ const SearchDataPage: NextPage = () => {
               geographicLevelOptions={geographicLevelOptions}
               includeDataFilters={!isPublicationsSearch}
               latestDataOnly={latestDataOnly}
-              publicationIds={publicationId}
+              publicationIds={publicationIds}
               publicationTree={publicationTree}
-              releaseTypes={releaseType}
+              releaseTypes={releaseTypes}
               releaseTypeOptions={releaseTypeOptions}
               sortBy={sortBy}
               sortOptions={sortOptions}
-              themeIds={themeId}
+              themeIds={themeIds}
               themes={themes}
               themeOptions={themeOptions}
               onChange={handleChangeFilter}
@@ -530,13 +533,13 @@ const SearchDataPage: NextPage = () => {
                 geographicLevelOptions={geographicLevelOptions}
                 includeDataFilters={!isPublicationsSearch}
                 latestDataOnly={latestDataOnly}
-                publicationIds={publicationId}
+                publicationIds={publicationIds}
                 publicationTree={publicationTree}
                 releaseTypeOptions={releaseTypeOptions}
-                releaseTypes={releaseType}
+                releaseTypes={releaseTypes}
                 sortBy={sortBy}
                 sortOptions={sortOptions}
-                themeIds={themeId}
+                themeIds={themeIds}
                 themes={themes}
                 themeOptions={themeOptions}
                 onChange={handleChangeFilter}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
@@ -86,7 +86,7 @@ const SearchDataPage: NextPage = () => {
     isFetching: isPublicationsFetching,
     isLoading: isPublicationsLoading,
   } = useQuery({
-    ...azurePublicationQueries.list(router.query),
+    ...azurePublicationQueries.listStatisticalReleases(router.query),
     keepPreviousData: true,
     refetchOnWindowFocus: false,
     staleTime: 60000,
@@ -697,7 +697,9 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   await Promise.all([
     isPublicationsSearch
-      ? queryClient.prefetchQuery(azurePublicationQueries.list(query))
+      ? queryClient.prefetchQuery(
+          azurePublicationQueries.listStatisticalReleases(query),
+        )
       : queryClient.prefetchQuery(azureDataSetQueries.list(query)),
     queryClient.prefetchQuery(themeQueries.listProdThemes()),
   ]);

--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
@@ -10,6 +10,10 @@ import WarningMessage from '@common/components/WarningMessage';
 import { useMobileMedia } from '@common/hooks/useMedia';
 import { ReleaseType, releaseTypes } from '@common/services/types/releaseType';
 import getAsArray from '@common/utils/getAsArray';
+import locationLevelsMap, {
+  GeographicLevelCode,
+  geographicLevelCodesMap,
+} from '@common/utils/locationLevelsMap';
 import FilterResetButton from '@frontend/components/FilterResetButton';
 import FiltersMobile from '@frontend/components/FiltersMobile';
 import Link from '@frontend/components/Link';
@@ -46,6 +50,7 @@ type RoutePath = 'search-releases' | 'search-data';
 
 export interface SearchDataPageQuery {
   dataSetType?: DataSetType;
+  geographicLevel?: GeographicLevelCode | GeographicLevelCode[];
   latestDataOnly?: string;
   page?: number;
   releaseType?: ReleaseType | ReleaseType[];
@@ -104,8 +109,15 @@ const SearchDataPage: NextPage = () => {
     totalResults = 0,
   } = (isPublicationsSearch ? publicationsPaging : dataSetsPaging) ?? {};
 
-  const { dataSetType, latestDataOnly, releaseType, search, sortBy, themeId } =
-    getParamsFromQuery(router.query);
+  const {
+    dataSetType,
+    geographicLevels,
+    latestDataOnly,
+    releaseType,
+    search,
+    sortBy,
+    themeId,
+  } = getParamsFromQuery(router.query);
 
   const themeOptions = themes.map(theme => {
     return {
@@ -121,9 +133,14 @@ const SearchDataPage: NextPage = () => {
     };
   });
 
-  const isFilteredByDataSetType =
-    !isPublicationsSearch && dataSetType === 'api';
-  const isFilteredAllReleases = !isPublicationsSearch && !latestDataOnly;
+  const geographicLevelOptions = Object.values(locationLevelsMap).map(
+    location => {
+      return {
+        label: location.filterLabel,
+        value: location.code,
+      };
+    },
+  );
 
   const selectedThemes = themes.filter(theme => themeId?.includes(theme.id));
   const selectedReleaseTypes = releaseType
@@ -133,20 +150,38 @@ const SearchDataPage: NextPage = () => {
       }))
     : [];
 
+  const selectedGeographicLevels = geographicLevels
+    ? getAsArray(geographicLevels)!
+        .map(code => geographicLevelCodesMap[code as GeographicLevelCode])
+        .filter(Boolean)
+    : [];
+
+  const isFilteredByDataSetType =
+    !isPublicationsSearch && dataSetType === 'api';
+  const isFilteredAllReleases = !isPublicationsSearch && !latestDataOnly;
+  const isFilteredByGeographicLevel =
+    !isPublicationsSearch && selectedGeographicLevels.length > 0;
+
   const isFiltered =
     !!search ||
     selectedReleaseTypes.length > 0 ||
     selectedThemes.length > 0 ||
     isFilteredByDataSetType ||
-    isFilteredAllReleases;
+    isFilteredAllReleases ||
+    isFilteredByGeographicLevel;
 
-  const filteredByString = compact([
-    search,
-    ...selectedThemes.map(t => t.title),
-    ...selectedReleaseTypes.map(rt => rt.title),
-    isFilteredByDataSetType ? 'API data sets only' : undefined,
-    isFilteredAllReleases ? 'All releases' : undefined,
-  ]).join(', ');
+  const filteredByString = compact(
+    [
+      search,
+      ...selectedThemes.map(t => t.title),
+      ...selectedReleaseTypes.map(rt => rt.title),
+      isFilteredByGeographicLevel
+        ? [...selectedGeographicLevels.map(gl => gl.filterLabel)]
+        : undefined,
+      isFilteredByDataSetType ? 'API data sets only' : undefined,
+      isFilteredAllReleases ? 'All releases' : undefined,
+    ].flat(),
+  ).join(', ');
 
   const sortOptions: SortOption[] = [
     { label: 'Newest', value: 'newest' },
@@ -197,7 +232,6 @@ const SearchDataPage: NextPage = () => {
     'themeId',
     'releaseType',
     'geographicLevel',
-    'publicationId',
   ];
 
   const handleChangeFilter = async ({
@@ -420,7 +454,9 @@ const SearchDataPage: NextPage = () => {
         >
           {!isMobileMedia && (
             <SearchDataFilters
-              dataSetType={dataSetType as DataSetType}
+              dataSetType={dataSetType}
+              geographicLevels={geographicLevels}
+              geographicLevelOptions={geographicLevelOptions}
               includeDataFilters={!isPublicationsSearch}
               latestDataOnly={latestDataOnly}
               releaseTypes={releaseType}
@@ -439,7 +475,9 @@ const SearchDataPage: NextPage = () => {
           {isMobileMedia && (
             <FiltersMobile title="Filter and sort" totalResults={totalResults}>
               <SearchDataFilters
-                dataSetType={dataSetType as DataSetType}
+                dataSetType={dataSetType}
+                geographicLevels={geographicLevels}
+                geographicLevelOptions={geographicLevelOptions}
                 includeDataFilters={!isPublicationsSearch}
                 latestDataOnly={latestDataOnly}
                 releaseTypeOptions={releaseTypeOptions}
@@ -493,6 +531,20 @@ const SearchDataPage: NextPage = () => {
                 />
               ))}
 
+              {isFilteredByGeographicLevel &&
+                selectedGeographicLevels.map(gl => (
+                  <FilterResetButton
+                    key={gl.code}
+                    filterType="Geographic level"
+                    name={gl.filterLabel}
+                    onClick={() =>
+                      handleChangeFilter({
+                        filterType: 'geographicLevel',
+                        nextValue: gl.code,
+                      })
+                    }
+                  />
+                ))}
               {selectedReleaseTypes.map(rt => (
                 <FilterResetButton
                   key={rt.id}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
@@ -33,6 +33,7 @@ import {
 } from '@frontend/modules/search-data/utils/searchDataFilters';
 import azureDataSetQueries from '@frontend/queries/azureDataSetQueries';
 import azurePublicationQueries from '@frontend/queries/azurePublicationQueries';
+import publicationQueries from '@frontend/queries/publicationQueries';
 import themeQueries from '@frontend/queries/themeQueries';
 import { DataSetType } from '@frontend/services/dataSetFileService';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
@@ -53,6 +54,7 @@ export interface SearchDataPageQuery {
   geographicLevel?: GeographicLevelCode | GeographicLevelCode[];
   latestDataOnly?: string;
   page?: number;
+  publicationId?: string | string[];
   releaseType?: ReleaseType | ReleaseType[];
   search?: string;
   sortBy?: PublicationSortOption;
@@ -98,6 +100,13 @@ const SearchDataPage: NextPage = () => {
     staleTime: Infinity,
   });
 
+  const { data: publicationTree = [] } = useQuery({
+    ...publicationQueries.getPrototypePublicationTree({
+      filter: 'DataCatalogue',
+    }),
+    staleTime: Infinity,
+  });
+
   const { paging: dataSetsPaging, results: dataSets = [] } = dataSetsData ?? {};
 
   const { paging: publicationsPaging, results: publications = [] } =
@@ -113,6 +122,7 @@ const SearchDataPage: NextPage = () => {
     dataSetType,
     geographicLevels,
     latestDataOnly,
+    publicationId,
     releaseType,
     search,
     sortBy,
@@ -156,11 +166,18 @@ const SearchDataPage: NextPage = () => {
         .filter(Boolean)
     : [];
 
+  const allPublications = publicationTree.flatMap(theme => theme.publications);
+  const selectedPublications = allPublications.filter(
+    publication => publicationId?.includes(publication.id),
+  );
+
   const isFilteredByDataSetType =
     !isPublicationsSearch && dataSetType === 'api';
   const isFilteredAllReleases = !isPublicationsSearch && !latestDataOnly;
   const isFilteredByGeographicLevel =
     !isPublicationsSearch && selectedGeographicLevels.length > 0;
+  const isFilteredByPublicationId =
+    !isPublicationsSearch && selectedPublications.length > 0;
 
   const isFiltered =
     !!search ||
@@ -168,7 +185,8 @@ const SearchDataPage: NextPage = () => {
     selectedThemes.length > 0 ||
     isFilteredByDataSetType ||
     isFilteredAllReleases ||
-    isFilteredByGeographicLevel;
+    isFilteredByGeographicLevel ||
+    isFilteredByPublicationId;
 
   const filteredByString = compact(
     [
@@ -177,6 +195,9 @@ const SearchDataPage: NextPage = () => {
       ...selectedReleaseTypes.map(rt => rt.title),
       isFilteredByGeographicLevel
         ? [...selectedGeographicLevels.map(gl => gl.filterLabel)]
+        : undefined,
+      isFilteredByPublicationId
+        ? [...selectedPublications.map(p => p.title)]
         : undefined,
       isFilteredByDataSetType ? 'API data sets only' : undefined,
       isFilteredAllReleases ? 'All releases' : undefined,
@@ -232,7 +253,32 @@ const SearchDataPage: NextPage = () => {
     'themeId',
     'releaseType',
     'geographicLevel',
+    'publicationId',
   ];
+
+  const handleBatchChangeFilters = async (
+    updates: Record<string, string[]>,
+  ) => {
+    let newQuery: Record<string, string | string[] | undefined> = {
+      ...omit(router.query, 'page'),
+    };
+
+    // Apply batch updates
+    Object.entries(updates).forEach(([key, values]) => {
+      if (values.length === 0) {
+        newQuery = omit(newQuery, key);
+      } else {
+        newQuery[key] = values;
+      }
+    });
+
+    await updateQueryParams(newQuery as SearchDataPageQuery);
+
+    logEvent({
+      category: 'Find statistics and data',
+      action: `Data filtered by themes or release`,
+    });
+  };
 
   const handleChangeFilter = async ({
     filterType,
@@ -277,7 +323,7 @@ const SearchDataPage: NextPage = () => {
         newQuery[filterType] = updatedValues;
       }
     } else if (nextValue === 'all' && filterType !== 'dataSetType') {
-      // Wipe the parameter from the URL if 'all' is selected
+      // Wipe the parameter from the URL if 'all' is selected (and it's not the dataSetType value of 'all')
       newQuery = omit(newQuery, filterType);
     } else {
       // Set the specific single string value
@@ -339,6 +385,7 @@ const SearchDataPage: NextPage = () => {
       // Don't include the default meta title when filtered to prevent too much screen reader noise.
       includeDefaultMetaTitle={pageTitle === defaultPageTitle}
       metaTitle={pageTitle}
+      width="wide"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
@@ -459,6 +506,8 @@ const SearchDataPage: NextPage = () => {
               geographicLevelOptions={geographicLevelOptions}
               includeDataFilters={!isPublicationsSearch}
               latestDataOnly={latestDataOnly}
+              publicationIds={publicationId}
+              publicationTree={publicationTree}
               releaseTypes={releaseType}
               releaseTypeOptions={releaseTypeOptions}
               sortBy={sortBy}
@@ -467,6 +516,7 @@ const SearchDataPage: NextPage = () => {
               themes={themes}
               themeOptions={themeOptions}
               onChange={handleChangeFilter}
+              onChangeBatch={handleBatchChangeFilters}
               onSortChange={handleSortBy}
             />
           )}
@@ -480,6 +530,8 @@ const SearchDataPage: NextPage = () => {
                 geographicLevelOptions={geographicLevelOptions}
                 includeDataFilters={!isPublicationsSearch}
                 latestDataOnly={latestDataOnly}
+                publicationIds={publicationId}
+                publicationTree={publicationTree}
                 releaseTypeOptions={releaseTypeOptions}
                 releaseTypes={releaseType}
                 sortBy={sortBy}
@@ -488,6 +540,7 @@ const SearchDataPage: NextPage = () => {
                 themes={themes}
                 themeOptions={themeOptions}
                 onChange={handleChangeFilter}
+                onChangeBatch={handleBatchChangeFilters}
                 onSortChange={handleSortBy}
               />
             </FiltersMobile>
@@ -545,6 +598,22 @@ const SearchDataPage: NextPage = () => {
                     }
                   />
                 ))}
+
+              {isFilteredByPublicationId &&
+                selectedPublications.map(pub => (
+                  <FilterResetButton
+                    key={pub.id}
+                    filterType="Publication"
+                    name={pub.title}
+                    onClick={() =>
+                      handleChangeFilter({
+                        filterType: 'publicationId',
+                        nextValue: pub.id,
+                      })
+                    }
+                  />
+                ))}
+
               {selectedReleaseTypes.map(rt => (
                 <FilterResetButton
                   key={rt.id}
@@ -701,7 +770,13 @@ export const getServerSideProps: GetServerSideProps = async ({
           azurePublicationQueries.listStatisticalReleases(query),
         )
       : queryClient.prefetchQuery(azureDataSetQueries.list(query)),
-    queryClient.prefetchQuery(themeQueries.listProdThemes()),
+    isPublicationsSearch
+      ? queryClient.prefetchQuery(themeQueries.listProdThemes())
+      : queryClient.prefetchQuery(
+          publicationQueries.getPrototypePublicationTree({
+            filter: 'DataCatalogue',
+          }),
+        ),
   ]);
 
   return {

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/ExpandableFilterGroup.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/ExpandableFilterGroup.module.scss
@@ -1,7 +1,7 @@
 @import '~govuk-frontend/dist/govuk/base';
 
 .inner {
-  margin: 0 0 govuk-spacing(2);
+  margin: 0 0 govuk-spacing(1);
 }
 
 .sectionContent {

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/ExpandableFilterGroup.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/ExpandableFilterGroup.module.scss
@@ -1,0 +1,27 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.inner {
+  margin: 0 0 govuk-spacing(2);
+}
+
+.sectionContent {
+  display: none;
+  padding: 0 0 govuk-spacing(3) govuk-spacing(4);
+
+  .sectionContent {
+    background: govuk-colour('white');
+    border: 0;
+    box-shadow: inset 0 -3px 1px -1px #ccc;
+    padding: govuk-spacing(2) govuk-spacing(1) !important;
+
+    @include govuk-media-query($from: tablet) {
+      box-shadow: none;
+      padding: govuk-spacing(4) govuk-spacing(2) govuk-spacing(4)
+        govuk-spacing(8) !important;
+    }
+  }
+}
+
+.expanded > .sectionContent {
+  display: block;
+}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/ExpandableFilterGroup.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/ExpandableFilterGroup.module.scss
@@ -22,6 +22,16 @@
   }
 }
 
+.toggleButton {
+  display: flex;
+  align-items: center;
+  text-align: left;
+
+  :global(.govuk-accordion-nav__chevron) {
+    flex-shrink: 0;
+  }
+}
+
 .expanded > .sectionContent {
   display: block;
 }

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/ExpandableFilterGroup.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/ExpandableFilterGroup.tsx
@@ -38,7 +38,7 @@ export default function ExpandableFilterGroup({
 
   return (
     <div
-      className={classNames('govuk-!-margin-bottom-2 dfe-border-bottom', {
+      className={classNames('govuk-!-margin-bottom-1 dfe-border-bottom', {
         [styles.expanded]: open,
       })}
       data-testid={testId}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/ExpandableFilterGroup.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/ExpandableFilterGroup.tsx
@@ -1,0 +1,79 @@
+import { ToggleHandler } from '@common/components/AccordionSection';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import useToggle from '@common/hooks/useToggle';
+import styles from '@frontend/modules/search-data/components/ExpandableFilterGroup.module.scss';
+import classNames from 'classnames';
+import React, { ReactNode, useEffect } from 'react';
+
+interface Props {
+  children: ReactNode;
+  label: string;
+  labelHiddenText?: string;
+  labelAfter?: ReactNode;
+  id: string;
+  open?: boolean;
+  testId?: string;
+  onToggle?: ToggleHandler;
+}
+
+export default function ExpandableFilterGroup({
+  children,
+  label,
+  labelAfter,
+  labelHiddenText,
+  id,
+  open: initialOpen = false,
+  testId = 'expandable-filter-group',
+  onToggle,
+}: Props) {
+  const contentId = `${id}-content`;
+
+  const [open, toggleOpen] = useToggle(initialOpen);
+
+  useEffect(() => {
+    toggleOpen(initialOpen);
+  }, [initialOpen, toggleOpen]);
+
+  return (
+    <div
+      className={classNames('govuk-!-margin-bottom-2 dfe-border-bottom', {
+        [styles.expanded]: open,
+      })}
+      data-testid={testId}
+      id={id}
+    >
+      <div className={styles.inner}>
+        <button
+          aria-controls={contentId}
+          aria-expanded={open}
+          className="govuk-accordion__show-all govuk-!-margin-bottom-0"
+          data-testid="expandable-filter-group-button"
+          type="button"
+          onClick={() => {
+            toggleOpen();
+            onToggle?.(!open, id);
+          }}
+        >
+          <span
+            className={classNames('govuk-accordion-nav__chevron', {
+              'govuk-accordion-nav__chevron--down': !open,
+            })}
+          />
+          <span className="govuk-accordion__show-all-text">
+            {label}
+            <VisuallyHidden>
+              {labelHiddenText ??
+                ` - ${open ? 'hide options' : 'show options'}`}
+            </VisuallyHidden>
+          </span>
+        </button>
+
+        {labelAfter}
+      </div>
+
+      <div className={styles.sectionContent} id={contentId}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/ExpandableFilterGroup.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/ExpandableFilterGroup.tsx
@@ -10,6 +10,7 @@ interface Props {
   label: string;
   labelHiddenText?: string;
   labelAfter?: ReactNode;
+  labelSub?: string;
   id: string;
   open?: boolean;
   testId?: string;
@@ -21,6 +22,7 @@ export default function ExpandableFilterGroup({
   label,
   labelAfter,
   labelHiddenText,
+  labelSub,
   id,
   open: initialOpen = false,
   testId = 'expandable-filter-group',
@@ -46,7 +48,10 @@ export default function ExpandableFilterGroup({
         <button
           aria-controls={contentId}
           aria-expanded={open}
-          className="govuk-accordion__show-all govuk-!-margin-bottom-0"
+          className={classNames(
+            'govuk-accordion__show-all govuk-!-margin-bottom-0',
+            styles.toggleButton,
+          )}
           data-testid="expandable-filter-group-button"
           type="button"
           onClick={() => {
@@ -61,6 +66,11 @@ export default function ExpandableFilterGroup({
           />
           <span className="govuk-accordion__show-all-text">
             {label}
+            {labelSub && (
+              <span className="govuk-!-font-size-16 govuk-!-display-block">
+                {labelSub}
+              </span>
+            )}
             <VisuallyHidden>
               {labelHiddenText ??
                 ` - ${open ? 'hide options' : 'show options'}`}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.module.scss
@@ -1,0 +1,19 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.form {
+  margin-top: govuk-spacing(5);
+
+  :global(.govuk-form-group) {
+    margin-top: govuk-spacing(2);
+  }
+
+  :global(.govuk-select) {
+    min-width: auto;
+  }
+}
+
+.modalButtonContainer {
+  display: flex;
+  justify-content: flex-end;
+  margin: govuk-spacing(2) 0;
+}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
@@ -163,7 +163,7 @@ export default function Filters({
       >
         <FormCheckboxGroup
           id={`${formId}-release-type`}
-          legend="Filter by Release Type"
+          legend="Filter by Release type"
           legendHidden
           name="releaseType"
           options={releaseTypeOptions}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
@@ -2,6 +2,7 @@ import Button from '@common/components/Button';
 import { FormCheckboxGroup, FormRadioGroup } from '@common/components/form';
 import { CheckboxOption } from '@common/components/form/FormCheckboxGroup';
 import ReleaseTypesModal from '@common/modules/release/components/ReleaseTypesModal';
+import { Theme } from '@common/services/publicationService';
 import { ThemeSummary } from '@common/services/themeService';
 import { ReleaseType } from '@common/services/types/releaseType';
 import { GeographicLevelCode } from '@common/utils/locationLevelsMap';
@@ -10,6 +11,7 @@ import ThemesModal from '@frontend/modules/find-statistics/components/ThemesModa
 import { PublicationSortOption } from '@frontend/modules/find-statistics/utils/publicationSortOptions';
 import ExpandableFilterGroup from '@frontend/modules/search-data/components/ExpandableFilterGroup';
 import styles from '@frontend/modules/search-data/components/SearchDataFilters.module.scss';
+import ThemesAndReleasesFilterGroup from '@frontend/modules/search-data/components/ThemesAndReleasesFilterGroup';
 import { SearchDataFilter } from '@frontend/modules/search-data/utils/searchDataFilters';
 import { DataSetType } from '@frontend/services/dataSetFileService';
 import React from 'react';
@@ -32,6 +34,8 @@ interface Props {
   geographicLevelOptions: CheckboxOption[];
   includeDataFilters: boolean;
   latestDataOnly?: boolean;
+  publicationIds?: string[];
+  publicationTree: Theme[];
   releaseTypes?: ReleaseType[];
   releaseTypeOptions: CheckboxOption[];
   sortBy: SortOptionType;
@@ -40,6 +44,7 @@ interface Props {
   themes: ThemeSummary[];
   themeOptions: CheckboxOption[];
   onChange: FilterChangeHandler;
+  onChangeBatch: (updates: Record<string, string[]>) => void;
   onSortChange: (nextSortBy: SortOptionType) => void;
 }
 
@@ -49,6 +54,8 @@ export default function Filters({
   geographicLevelOptions,
   includeDataFilters,
   latestDataOnly,
+  publicationIds,
+  publicationTree,
   releaseTypes,
   releaseTypeOptions,
   sortBy,
@@ -57,24 +64,39 @@ export default function Filters({
   themes,
   themeOptions,
   onChange,
+  onChangeBatch,
   onSortChange,
 }: Props) {
   return (
     <form className={styles.form} id={formId}>
       <h2 className="govuk-heading-m">Filter and sort</h2>
       <ExpandableFilterGroup id={`${formId}-theme-group`} label="Theme">
-        <FormCheckboxGroup
-          id={`${formId}-theme`}
-          legend="Filter by Theme"
-          legendHidden
-          name="themeId"
-          options={themeOptions}
-          small
-          value={themeIds || []}
-          onChange={e => {
-            onChange({ filterType: 'themeId', nextValue: e.target.value });
-          }}
-        />
+        {includeDataFilters ? (
+          <ThemesAndReleasesFilterGroup
+            publicationTree={publicationTree}
+            themeIds={themeIds}
+            publicationIds={publicationIds}
+            onChangeBatch={(nextThemes, nextPubs) => {
+              onChangeBatch({
+                themeId: nextThemes,
+                publicationId: nextPubs,
+              });
+            }}
+          />
+        ) : (
+          <FormCheckboxGroup
+            id={`${formId}-theme`}
+            legend="Filter by Theme"
+            legendHidden
+            name="themeId"
+            options={themeOptions}
+            small
+            value={themeIds || []}
+            onChange={e => {
+              onChange({ filterType: 'themeId', nextValue: e.target.value });
+            }}
+          />
+        )}
         <div className={styles.modalButtonContainer}>
           <ThemesModal themes={themes} />
         </div>

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
@@ -1,18 +1,18 @@
 import { SelectOption } from '@common/components/form/FormSelect';
 import VisuallyHidden from '@common/components/VisuallyHidden';
-import { FormGroup, FormRadioGroup, FormSelect } from '@common/components/form';
+import { FormRadioGroup, FormSelect } from '@common/components/form';
 import { ThemeSummary } from '@common/services/themeService';
 import { ReleaseType } from '@common/services/types/releaseType';
 import Button from '@common/components/Button';
-import ButtonText from '@common/components/ButtonText';
 import ReleaseTypesModal from '@common/modules/release/components/ReleaseTypesModal';
-import ThemesModal from '@frontend/modules/find-statistics/components/ThemesModal';
-import styles from '@frontend/modules/data-catalogue/components/Filters.module.scss';
 import { SortOption } from '@frontend/components/SortControls';
-import React from 'react';
+import ThemesModal from '@frontend/modules/find-statistics/components/ThemesModal';
 import { PublicationSortOption } from '@frontend/modules/find-statistics/utils/publicationSortOptions';
+import ExpandableFilterGroup from '@frontend/modules/search-data/components/ExpandableFilterGroup';
+import styles from '@frontend/modules/search-data/components/SearchDataFilters.module.scss';
 import { SearchDataFilter } from '@frontend/modules/search-data/utils/searchDataFilters';
 import { DataSetType } from '@frontend/services/dataSetFileService';
+import React from 'react';
 
 const formId = 'filters-form';
 
@@ -32,14 +32,12 @@ interface Props {
   latestDataOnly?: boolean;
   releaseType?: ReleaseType;
   releaseTypeOptions: SelectOption[];
-  showResetFiltersButton?: boolean;
   sortBy: SortOptionType;
   sortOptions: SortOption[];
   themeId?: string;
   themes: ThemeSummary[];
   themeOptions: SelectOption[];
   onChange: FilterChangeHandler;
-  onResetFilters?: () => void;
   onSortChange: (nextSortBy: SortOptionType) => void;
 }
 
@@ -49,20 +47,18 @@ export default function Filters({
   latestDataOnly,
   releaseType,
   releaseTypeOptions,
-  showResetFiltersButton,
   sortBy,
   sortOptions,
   themeId,
   themes,
   themeOptions,
   onChange,
-  onResetFilters,
   onSortChange,
 }: Props) {
   return (
     <form className={styles.form} id={formId}>
       <h2 className="govuk-heading-m">Filter and sort</h2>
-      <FormGroup>
+      <ExpandableFilterGroup id={`${formId}-theme-group`} label="Theme">
         <FormSelect
           className="govuk-!-width-full govuk-!-margin-bottom-1"
           id={`${formId}-theme`}
@@ -79,10 +75,46 @@ export default function Filters({
             onChange({ filterType: 'themeId', nextValue: e.target.value });
           }}
         />
-        <ThemesModal themes={themes} />
-      </FormGroup>
+        <div className={styles.modalButtonContainer}>
+          <ThemesModal themes={themes} />
+        </div>
+      </ExpandableFilterGroup>
 
-      <FormGroup>
+      {includeDataFilters && (
+        <ExpandableFilterGroup
+          id={`${formId}-showLatest-group`}
+          label="Show latest or all releases"
+        >
+          <FormRadioGroup<'true' | 'false'>
+            formGroupClass="govuk-!-margin-top-0"
+            id={`${formId}-showLatest`}
+            legend="Show latest or all releases"
+            legendHidden
+            name="latestDataOnly"
+            options={[
+              { label: 'Show latest releases only', value: 'true' },
+              {
+                label: 'Show all releases',
+                value: 'false',
+              },
+            ]}
+            small
+            order={[]}
+            value={latestDataOnly ? 'true' : 'false'}
+            onChange={e => {
+              onChange({
+                filterType: 'latestDataOnly',
+                nextValue: e.target.value,
+              });
+            }}
+          />
+        </ExpandableFilterGroup>
+      )}
+
+      <ExpandableFilterGroup
+        id={`${formId}-release-type-group`}
+        label="Release types"
+      >
         <FormSelect
           className="govuk-!-width-full govuk-!-margin-bottom-1"
           id={`${formId}-release-type`}
@@ -105,16 +137,21 @@ export default function Filters({
             });
           }}
         />
-        <ReleaseTypesModal />
-      </FormGroup>
+        <div className={styles.modalButtonContainer}>
+          <ReleaseTypesModal />
+        </div>
+      </ExpandableFilterGroup>
 
       {includeDataFilters && (
-        <>
+        <ExpandableFilterGroup
+          id={`${formId}-dataSetType-group`}
+          label="API data sets"
+        >
           <FormRadioGroup<DataSetType>
-            formGroupClass="dfe-border-top govuk-!-padding-top-4 govuk-!-margin-top-2"
+            formGroupClass="govuk-!-margin-top-0"
             id={`${formId}-dataSetType`}
             legend="Type of data"
-            legendSize="s"
+            legendHidden
             name="dataSetType"
             options={[
               { label: 'All data', value: 'all' },
@@ -132,50 +169,21 @@ export default function Filters({
               });
             }}
           />
-          <FormGroup>
-            <FormRadioGroup<'true' | 'false'>
-              formGroupClass="dfe-border-top govuk-!-padding-top-4 govuk-!-margin-top-2"
-              id={`${formId}-showLatest`}
-              legend="Show latest or all releases"
-              legendSize="s"
-              name="latestDataOnly"
-              options={[
-                { label: 'Show latest releases only', value: 'true' },
-                {
-                  label: 'Show all releases',
-                  value: 'false',
-                },
-              ]}
-              small
-              order={[]}
-              value={latestDataOnly ? 'true' : 'false'}
-              onChange={e => {
-                onChange({
-                  filterType: 'latestDataOnly',
-                  nextValue: e.target.value,
-                });
-              }}
-            />
-          </FormGroup>
-        </>
+        </ExpandableFilterGroup>
       )}
-
-      <FormGroup>
-        <FormSelect
-          className="govuk-!-width-full govuk-!-margin-bottom-1"
+      <ExpandableFilterGroup id={`${formId}-sortBy-group`} label="Sort by">
+        <FormRadioGroup<SortOptionType>
+          formGroupClass="govuk-!-margin-top-0"
           id={`${formId}-sortBy`}
-          label="Sort by"
+          legend="Sort by"
+          legendHidden
           name="sortBy"
           options={sortOptions}
+          small
           value={sortBy}
-          order={[]}
           onChange={event => onSortChange(event.target.value as SortOptionType)}
         />
-      </FormGroup>
-
-      {showResetFiltersButton && (
-        <ButtonText onClick={onResetFilters}>Reset filters</ButtonText>
-      )}
+      </ExpandableFilterGroup>
 
       <Button className="dfe-js-hidden" type="submit">
         Submit

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
@@ -4,6 +4,7 @@ import { CheckboxOption } from '@common/components/form/FormCheckboxGroup';
 import ReleaseTypesModal from '@common/modules/release/components/ReleaseTypesModal';
 import { ThemeSummary } from '@common/services/themeService';
 import { ReleaseType } from '@common/services/types/releaseType';
+import { GeographicLevelCode } from '@common/utils/locationLevelsMap';
 import { SortOption } from '@frontend/components/SortControls';
 import ThemesModal from '@frontend/modules/find-statistics/components/ThemesModal';
 import { PublicationSortOption } from '@frontend/modules/find-statistics/utils/publicationSortOptions';
@@ -27,6 +28,8 @@ type SortOptionType = PublicationSortOption;
 
 interface Props {
   dataSetType?: DataSetType;
+  geographicLevels?: GeographicLevelCode[];
+  geographicLevelOptions: CheckboxOption[];
   includeDataFilters: boolean;
   latestDataOnly?: boolean;
   releaseTypes?: ReleaseType[];
@@ -42,6 +45,8 @@ interface Props {
 
 export default function Filters({
   dataSetType,
+  geographicLevels,
+  geographicLevelOptions,
   includeDataFilters,
   latestDataOnly,
   releaseTypes,
@@ -57,7 +62,11 @@ export default function Filters({
   return (
     <form className={styles.form} id={formId}>
       <h2 className="govuk-heading-m">Filter and sort</h2>
-      <ExpandableFilterGroup id={`${formId}-theme-group`} label="Theme">
+      <ExpandableFilterGroup
+        id={`${formId}-theme-group`}
+        label="Theme"
+        open={!!themeIds}
+      >
         <FormCheckboxGroup
           id={`${formId}-theme`}
           legend="Filter by Theme"
@@ -77,8 +86,33 @@ export default function Filters({
 
       {includeDataFilters && (
         <ExpandableFilterGroup
+          id={`${formId}-geographicLevel-group`}
+          label="Geographic level"
+          open={!!geographicLevels}
+        >
+          <FormCheckboxGroup
+            id={`${formId}-geographicLevel`}
+            legend="Filter by Geographic Level"
+            legendHidden
+            name="geographicLevel"
+            options={geographicLevelOptions}
+            small
+            value={geographicLevels || []}
+            onChange={e => {
+              onChange({
+                filterType: 'geographicLevel',
+                nextValue: e.target.value,
+              });
+            }}
+          />
+        </ExpandableFilterGroup>
+      )}
+
+      {includeDataFilters && (
+        <ExpandableFilterGroup
           id={`${formId}-showLatest-group`}
           label="Show latest or all releases"
+          open={latestDataOnly !== undefined}
         >
           <FormRadioGroup<'true' | 'false'>
             formGroupClass="govuk-!-margin-top-0"
@@ -109,6 +143,7 @@ export default function Filters({
       <ExpandableFilterGroup
         id={`${formId}-release-type-group`}
         label="Release types"
+        open={!!releaseTypes}
       >
         <FormCheckboxGroup
           id={`${formId}-release-type`}
@@ -131,6 +166,7 @@ export default function Filters({
         <ExpandableFilterGroup
           id={`${formId}-dataSetType-group`}
           label="API data sets"
+          open={dataSetType !== undefined}
         >
           <FormRadioGroup<DataSetType>
             formGroupClass="govuk-!-margin-top-0"
@@ -156,7 +192,12 @@ export default function Filters({
           />
         </ExpandableFilterGroup>
       )}
-      <ExpandableFilterGroup id={`${formId}-sortBy-group`} label="Sort by">
+
+      <ExpandableFilterGroup
+        id={`${formId}-sortBy-group`}
+        label="Sort by"
+        open={sortBy !== undefined}
+      >
         <FormRadioGroup<SortOptionType>
           formGroupClass="govuk-!-margin-top-0"
           id={`${formId}-sortBy`}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
@@ -84,6 +84,7 @@ export default function Filters({
         <ExpandableFilterGroup
           id={`${formId}-geographicLevel-group`}
           label="Geographic level"
+          labelSub="(includes schools and providers)"
         >
           <FormCheckboxGroup
             id={`${formId}-geographicLevel`}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
@@ -62,11 +62,7 @@ export default function Filters({
   return (
     <form className={styles.form} id={formId}>
       <h2 className="govuk-heading-m">Filter and sort</h2>
-      <ExpandableFilterGroup
-        id={`${formId}-theme-group`}
-        label="Theme"
-        open={!!themeIds}
-      >
+      <ExpandableFilterGroup id={`${formId}-theme-group`} label="Theme">
         <FormCheckboxGroup
           id={`${formId}-theme`}
           legend="Filter by Theme"
@@ -88,7 +84,6 @@ export default function Filters({
         <ExpandableFilterGroup
           id={`${formId}-geographicLevel-group`}
           label="Geographic level"
-          open={!!geographicLevels}
         >
           <FormCheckboxGroup
             id={`${formId}-geographicLevel`}
@@ -112,7 +107,6 @@ export default function Filters({
         <ExpandableFilterGroup
           id={`${formId}-showLatest-group`}
           label="Show latest or all releases"
-          open={latestDataOnly !== undefined}
         >
           <FormRadioGroup<'true' | 'false'>
             formGroupClass="govuk-!-margin-top-0"
@@ -143,7 +137,6 @@ export default function Filters({
       <ExpandableFilterGroup
         id={`${formId}-release-type-group`}
         label="Release types"
-        open={!!releaseTypes}
       >
         <FormCheckboxGroup
           id={`${formId}-release-type`}
@@ -166,7 +159,6 @@ export default function Filters({
         <ExpandableFilterGroup
           id={`${formId}-dataSetType-group`}
           label="API data sets"
-          open={dataSetType !== undefined}
         >
           <FormRadioGroup<DataSetType>
             formGroupClass="govuk-!-margin-top-0"
@@ -193,11 +185,7 @@ export default function Filters({
         </ExpandableFilterGroup>
       )}
 
-      <ExpandableFilterGroup
-        id={`${formId}-sortBy-group`}
-        label="Sort by"
-        open={sortBy !== undefined}
-      >
+      <ExpandableFilterGroup id={`${formId}-sortBy-group`} label="Sort by">
         <FormRadioGroup<SortOptionType>
           formGroupClass="govuk-!-margin-top-0"
           id={`${formId}-sortBy`}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
@@ -1,6 +1,10 @@
 import { SelectOption } from '@common/components/form/FormSelect';
 import VisuallyHidden from '@common/components/VisuallyHidden';
-import { FormRadioGroup, FormSelect } from '@common/components/form';
+import {
+  FormCheckboxGroup,
+  FormRadioGroup,
+  FormSelect,
+} from '@common/components/form';
 import { ThemeSummary } from '@common/services/themeService';
 import { ReleaseType } from '@common/services/types/releaseType';
 import Button from '@common/components/Button';
@@ -13,6 +17,7 @@ import styles from '@frontend/modules/search-data/components/SearchDataFilters.m
 import { SearchDataFilter } from '@frontend/modules/search-data/utils/searchDataFilters';
 import { DataSetType } from '@frontend/services/dataSetFileService';
 import React from 'react';
+import { CheckboxOption } from '@common/components/form/FormCheckboxGroup';
 
 const formId = 'filters-form';
 
@@ -34,9 +39,9 @@ interface Props {
   releaseTypeOptions: SelectOption[];
   sortBy: SortOptionType;
   sortOptions: SortOption[];
-  themeId?: string;
+  themeIds?: string[];
   themes: ThemeSummary[];
-  themeOptions: SelectOption[];
+  themeOptions: CheckboxOption[];
   onChange: FilterChangeHandler;
   onSortChange: (nextSortBy: SortOptionType) => void;
 }
@@ -49,7 +54,7 @@ export default function Filters({
   releaseTypeOptions,
   sortBy,
   sortOptions,
-  themeId,
+  themeIds,
   themes,
   themeOptions,
   onChange,
@@ -59,18 +64,14 @@ export default function Filters({
     <form className={styles.form} id={formId}>
       <h2 className="govuk-heading-m">Filter and sort</h2>
       <ExpandableFilterGroup id={`${formId}-theme-group`} label="Theme">
-        <FormSelect
-          className="govuk-!-width-full govuk-!-margin-bottom-1"
+        <FormCheckboxGroup
           id={`${formId}-theme`}
-          label={
-            <>
-              <VisuallyHidden>Filter by </VisuallyHidden>Theme
-            </>
-          }
+          legend="Filter by Theme"
+          legendHidden
           name="themeId"
-          options={[{ label: 'All themes', value: 'all' }, ...themeOptions]}
-          value={themeId ?? 'all'}
-          order={[]}
+          options={themeOptions}
+          small
+          value={themeIds || []}
           onChange={e => {
             onChange({ filterType: 'themeId', nextValue: e.target.value });
           }}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataFilters.tsx
@@ -1,14 +1,9 @@
-import { SelectOption } from '@common/components/form/FormSelect';
-import VisuallyHidden from '@common/components/VisuallyHidden';
-import {
-  FormCheckboxGroup,
-  FormRadioGroup,
-  FormSelect,
-} from '@common/components/form';
+import Button from '@common/components/Button';
+import { FormCheckboxGroup, FormRadioGroup } from '@common/components/form';
+import { CheckboxOption } from '@common/components/form/FormCheckboxGroup';
+import ReleaseTypesModal from '@common/modules/release/components/ReleaseTypesModal';
 import { ThemeSummary } from '@common/services/themeService';
 import { ReleaseType } from '@common/services/types/releaseType';
-import Button from '@common/components/Button';
-import ReleaseTypesModal from '@common/modules/release/components/ReleaseTypesModal';
 import { SortOption } from '@frontend/components/SortControls';
 import ThemesModal from '@frontend/modules/find-statistics/components/ThemesModal';
 import { PublicationSortOption } from '@frontend/modules/find-statistics/utils/publicationSortOptions';
@@ -17,7 +12,6 @@ import styles from '@frontend/modules/search-data/components/SearchDataFilters.m
 import { SearchDataFilter } from '@frontend/modules/search-data/utils/searchDataFilters';
 import { DataSetType } from '@frontend/services/dataSetFileService';
 import React from 'react';
-import { CheckboxOption } from '@common/components/form/FormCheckboxGroup';
 
 const formId = 'filters-form';
 
@@ -35,8 +29,8 @@ interface Props {
   dataSetType?: DataSetType;
   includeDataFilters: boolean;
   latestDataOnly?: boolean;
-  releaseType?: ReleaseType;
-  releaseTypeOptions: SelectOption[];
+  releaseTypes?: ReleaseType[];
+  releaseTypeOptions: CheckboxOption[];
   sortBy: SortOptionType;
   sortOptions: SortOption[];
   themeIds?: string[];
@@ -50,7 +44,7 @@ export default function Filters({
   dataSetType,
   includeDataFilters,
   latestDataOnly,
-  releaseType,
+  releaseTypes,
   releaseTypeOptions,
   sortBy,
   sortOptions,
@@ -116,26 +110,16 @@ export default function Filters({
         id={`${formId}-release-type-group`}
         label="Release types"
       >
-        <FormSelect
-          className="govuk-!-width-full govuk-!-margin-bottom-1"
+        <FormCheckboxGroup
           id={`${formId}-release-type`}
-          label={
-            <>
-              <VisuallyHidden>Filter by </VisuallyHidden>Release type
-            </>
-          }
+          legend="Filter by Release Type"
+          legendHidden
           name="releaseType"
-          options={[
-            { label: 'All release types', value: 'all' },
-            ...releaseTypeOptions,
-          ]}
-          value={releaseType ?? 'all'}
-          order={[]}
+          options={releaseTypeOptions}
+          small
+          value={releaseTypes || []}
           onChange={e => {
-            onChange({
-              filterType: 'releaseType',
-              nextValue: e.target.value,
-            });
+            onChange({ filterType: 'releaseType', nextValue: e.target.value });
           }}
         />
         <div className={styles.modalButtonContainer}>

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/ThemesAndReleasesFilterGroup.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/ThemesAndReleasesFilterGroup.module.scss
@@ -1,0 +1,8 @@
+@import '~govuk-frontend/dist/govuk/base';
+
+.expandedThemeContainer {
+  border-left: 4px solid govuk-colour('mid-grey');
+  padding: 0 0 govuk-spacing(0) govuk-spacing(4);
+  margin-bottom: govuk-spacing(2);
+  margin-top: govuk-spacing(1);
+}

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/ThemesAndReleasesFilterGroup.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/ThemesAndReleasesFilterGroup.tsx
@@ -1,0 +1,166 @@
+import { FormTextSearchInput } from '@common/components/form';
+import FormCheckbox from '@common/components/form/FormCheckbox';
+import { Theme } from '@common/services/publicationService';
+import React, { memo, useMemo, useState } from 'react';
+import ThemesAndReleasesFilterGroupReleases from './ThemesAndReleasesFilterGroupReleases';
+
+export interface ThemesAndReleasesFilterGroupProps {
+  publicationIds?: string[];
+  publicationTree: Theme[];
+  themeIds?: string[];
+  onChangeBatch: (nextThemeIds: string[], nextPublicationIds: string[]) => void;
+}
+
+const ThemesAndReleasesFilterGroup = ({
+  publicationIds = [],
+  publicationTree,
+  themeIds = [],
+  onChangeBatch,
+}: ThemesAndReleasesFilterGroupProps) => {
+  const [searchTerm, setSearchTerm] = useState('');
+
+  // Filter the tree based on the search term
+  const filteredTree = useMemo(() => {
+    if (!searchTerm) {
+      return publicationTree;
+    }
+
+    const lowercaseSearchTerm = searchTerm.toLowerCase();
+
+    return publicationTree.reduce<Theme[]>((acc, theme) => {
+      const matchesTheme = theme.title
+        .toLowerCase()
+        .includes(lowercaseSearchTerm);
+      const matchingPubs = theme.publications.filter(pub =>
+        pub.title.toLowerCase().includes(lowercaseSearchTerm),
+      );
+
+      if (matchesTheme || matchingPubs.length > 0) {
+        acc.push({
+          ...theme,
+          publications: matchingPubs,
+        });
+      }
+
+      return acc;
+    }, []);
+  }, [publicationTree, searchTerm]);
+
+  // Calculate total matching checkboxes (themes + publications)
+  const matchCount = useMemo(() => {
+    return filteredTree.reduce(
+      (total, theme) => total + 1 + (theme.publications?.length || 0),
+      0,
+    );
+  }, [filteredTree]);
+
+  const handleThemeChange = (themeId: string, isChecked: boolean) => {
+    let nextThemeIds = [...themeIds];
+    let nextPublicationIds = [...publicationIds];
+
+    if (isChecked) {
+      nextThemeIds.push(themeId);
+      // Uncheck all publications contained under this theme to avoid logical overlap
+      const themePubIds =
+        publicationTree
+          .find(t => t.id === themeId)
+          ?.publications.map(p => p.id) || [];
+      nextPublicationIds = nextPublicationIds.filter(
+        id => !themePubIds.includes(id),
+      );
+    } else {
+      nextThemeIds = nextThemeIds.filter(id => id !== themeId);
+    }
+
+    onChangeBatch(nextThemeIds, nextPublicationIds);
+  };
+
+  const handlePublicationChange = (
+    themeId: string,
+    pubId: string,
+    isChecked: boolean,
+  ) => {
+    let nextThemeIds = [...themeIds];
+    let nextPublicationIds = [...publicationIds];
+
+    if (isChecked) {
+      nextPublicationIds.push(pubId);
+      // Uncheck the parent theme if a nested publication is specifically selected
+      nextThemeIds = nextThemeIds.filter(id => id !== themeId);
+    } else {
+      nextPublicationIds = nextPublicationIds.filter(id => id !== pubId);
+    }
+
+    onChangeBatch(nextThemeIds, nextPublicationIds);
+  };
+
+  return (
+    <div className="govuk-form-group">
+      <FormTextSearchInput
+        id="theme-publication-search"
+        name="theme-publication-search"
+        label="Find themes and releases"
+        width={20}
+        onChange={event => setSearchTerm(event.target.value)}
+        onKeyPress={event => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+          }
+        }}
+      />
+
+      {searchTerm && (
+        <span aria-live="polite" aria-atomic className="govuk-visually-hidden">
+          {`${matchCount} option${matchCount === 1 ? '' : 's'} found`}
+        </span>
+      )}
+
+      <fieldset className="govuk-fieldset govuk-!-margin-top-4">
+        <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
+          Themes
+        </legend>
+
+        {filteredTree.length === 0 ? (
+          <p className="govuk-body">No options available.</p>
+        ) : (
+          <div className="govuk-checkboxes govuk-checkboxes--small">
+            {filteredTree.map(theme => {
+              const isThemeChecked = themeIds.includes(theme.id);
+              const publications = theme.publications || [];
+              const hasPublications = publications.length > 0;
+
+              return (
+                <div key={theme.id} className="govuk-!-margin-bottom-1">
+                  <FormCheckbox
+                    id={`theme-${theme.id}`}
+                    name="themeId"
+                    value={theme.id}
+                    label={theme.title}
+                    checked={isThemeChecked}
+                    onChange={e =>
+                      handleThemeChange(theme.id, e.target.checked)
+                    }
+                  />
+
+                  {hasPublications && (
+                    <div className="govuk-!-margin-left-4">
+                      <ThemesAndReleasesFilterGroupReleases
+                        publicationIds={publicationIds}
+                        publications={publications}
+                        themeId={theme.id}
+                        themeTitle={theme.title}
+                        onChange={handlePublicationChange}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </fieldset>
+    </div>
+  );
+};
+
+export default memo(ThemesAndReleasesFilterGroup);

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/ThemesAndReleasesFilterGroup.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/ThemesAndReleasesFilterGroup.tsx
@@ -49,6 +49,7 @@ const ThemesAndReleasesFilterGroup = ({
   // Calculate total matching checkboxes (themes + publications)
   const matchCount = useMemo(() => {
     return filteredTree.reduce(
+      // add together total, 1 for the theme itself, and the number of publications
       (total, theme) => total + 1 + (theme.publications?.length || 0),
       0,
     );
@@ -61,12 +62,12 @@ const ThemesAndReleasesFilterGroup = ({
     if (isChecked) {
       nextThemeIds.push(themeId);
       // Uncheck all publications contained under this theme to avoid logical overlap
-      const themePubIds =
+      const themePublicationIds =
         publicationTree
           .find(t => t.id === themeId)
           ?.publications.map(p => p.id) || [];
       nextPublicationIds = nextPublicationIds.filter(
-        id => !themePubIds.includes(id),
+        id => !themePublicationIds.includes(id),
       );
     } else {
       nextThemeIds = nextThemeIds.filter(id => id !== themeId);
@@ -77,18 +78,20 @@ const ThemesAndReleasesFilterGroup = ({
 
   const handlePublicationChange = (
     themeId: string,
-    pubId: string,
+    publicationId: string,
     isChecked: boolean,
   ) => {
     let nextThemeIds = [...themeIds];
     let nextPublicationIds = [...publicationIds];
 
     if (isChecked) {
-      nextPublicationIds.push(pubId);
+      nextPublicationIds.push(publicationId);
       // Uncheck the parent theme if a nested publication is specifically selected
       nextThemeIds = nextThemeIds.filter(id => id !== themeId);
     } else {
-      nextPublicationIds = nextPublicationIds.filter(id => id !== pubId);
+      nextPublicationIds = nextPublicationIds.filter(
+        id => id !== publicationId,
+      );
     }
 
     onChangeBatch(nextThemeIds, nextPublicationIds);

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/ThemesAndReleasesFilterGroupReleases.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/ThemesAndReleasesFilterGroupReleases.tsx
@@ -1,0 +1,74 @@
+import ButtonText from '@common/components/ButtonText';
+import FormCheckbox from '@common/components/form/FormCheckbox';
+import VisuallyHidden from '@common/components/VisuallyHidden';
+import useToggle from '@common/hooks/useToggle';
+import { PublicationTreeSummary } from '@common/services/publicationService';
+import styles from '@frontend/modules/search-data/components/ThemesAndReleasesFilterGroup.module.scss';
+import classNames from 'classnames';
+import React from 'react';
+
+interface ThemesAndReleasesFilterGroupReleasesProps {
+  publicationIds: string[];
+  publications: PublicationTreeSummary[];
+  themeId: string;
+  themeTitle: string;
+  onChange: (themeId: string, pubId: string, isChecked: boolean) => void;
+}
+
+const ThemesAndReleasesFilterGroupReleases = ({
+  publicationIds,
+  publications,
+  themeId,
+  themeTitle,
+  onChange,
+}: ThemesAndReleasesFilterGroupReleasesProps) => {
+  const [isExpanded, toggleExpanded] = useToggle(false);
+  const publicationCountText = `${publications.length} statistical release${
+    publications.length === 1 ? '' : 's'
+  }`;
+
+  if (!isExpanded) {
+    return (
+      <ButtonText
+        className="govuk-!-font-size-16 govuk-!-display-block govuk-!-margin-bottom-2 govuk-!-margin-left-3"
+        onClick={toggleExpanded}
+      >
+        Show {publicationCountText}
+        <VisuallyHidden>{` for ${themeTitle}`}</VisuallyHidden>
+      </ButtonText>
+    );
+  }
+
+  return (
+    <fieldset
+      className={classNames(styles.expandedThemeContainer, 'govuk-fieldset')}
+    >
+      <legend className="govuk-fieldset__legend govuk-fieldset__legend--s govuk-!-margin-bottom-0">
+        Statistical releases
+      </legend>
+      <ButtonText
+        className="govuk-!-font-size-16 govuk-!-margin-bottom-2 govuk-!-display-block"
+        onClick={toggleExpanded}
+      >
+        Close
+        <VisuallyHidden>{` statistical releases for ${themeTitle}`}</VisuallyHidden>
+      </ButtonText>
+
+      <div className="govuk-checkboxes govuk-checkboxes--small">
+        {publications.map(pub => (
+          <FormCheckbox
+            key={pub.id}
+            id={`publication-${pub.id}`}
+            name="publicationId"
+            value={pub.id}
+            label={pub.title}
+            checked={publicationIds.includes(pub.id)}
+            onChange={e => onChange(themeId, pub.id, e.target.checked)}
+          />
+        ))}
+      </div>
+    </fieldset>
+  );
+};
+
+export default ThemesAndReleasesFilterGroupReleases;

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/ExpandableFilterGroup.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/ExpandableFilterGroup.test.tsx
@@ -1,14 +1,14 @@
-import FilterAccordion from '@common/modules/table-tool/components/FilterAccordion';
 import render from '@common-test/render';
+import ExpandableFilterGroup from '@frontend/modules/search-data/components/ExpandableFilterGroup';
 import { screen } from '@testing-library/react';
 import React from 'react';
 
-describe('FilterAccordion', () => {
+describe('ExpandableFilterGroup', () => {
   test('renders correctly', () => {
     render(
-      <FilterAccordion label="Test label" id="test-id">
+      <ExpandableFilterGroup label="Test label" id="test-id">
         content
-      </FilterAccordion>,
+      </ExpandableFilterGroup>,
     );
 
     expect(
@@ -20,9 +20,9 @@ describe('FilterAccordion', () => {
 
   test('is closed by default and expands when clicked', async () => {
     const { user } = render(
-      <FilterAccordion label="Test label" id="test-id">
+      <ExpandableFilterGroup label="Test label" id="test-id">
         <h2>content</h2>
-      </FilterAccordion>,
+      </ExpandableFilterGroup>,
     );
 
     const button = screen.getByRole('button', {
@@ -44,9 +44,9 @@ describe('FilterAccordion', () => {
 
   test('is expanded when open is set to true', async () => {
     const { user } = render(
-      <FilterAccordion label="Test label" id="test-id" open>
+      <ExpandableFilterGroup label="Test label" id="test-id" open>
         <h2>content</h2>
-      </FilterAccordion>,
+      </ExpandableFilterGroup>,
     );
 
     const button = screen.getByRole('button', {
@@ -58,23 +58,5 @@ describe('FilterAccordion', () => {
     await user.click(button);
 
     expect(button).toHaveAttribute('aria-expanded', 'false');
-  });
-
-  test('cannot be opened or closed when preventToggle is set', async () => {
-    const { user } = render(
-      <FilterAccordion label="Test label" id="test-id" open preventToggle>
-        <h2>content</h2>
-      </FilterAccordion>,
-    );
-
-    const button = screen.getByRole('button', {
-      name: 'Test label - hide options',
-    });
-
-    expect(button).toHaveAttribute('aria-expanded', 'true');
-
-    await user.click(button);
-
-    expect(button).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
@@ -32,7 +32,7 @@ export default function createDataSetListRequest(
   const filter = buildODataFilter({
     dataSetType,
     latestDataOnly,
-    releaseType: releaseType ? [releaseType] : undefined,
+    releaseType,
     themeId,
   });
 
@@ -112,15 +112,17 @@ function getSortParam(sortBy: PublicationSortOption): AzureOrderByParam {
 }
 
 export function getParamsFromQuery(query: SearchDataPageQuery) {
+  const releaseTypesArray = getAsArray(query.releaseType) ?? [];
+
+  const validReleaseTypes = releaseTypesArray.filter(type =>
+    isOneOf(type, Object.keys(releaseTypes)),
+  ) as ReleaseType[];
+
   return {
     dataSetType: query.dataSetType === 'api' ? 'api' : 'all',
     latestDataOnly: !query.latestDataOnly || query.latestDataOnly !== 'false',
     page: getFirst(query.page),
-    releaseType:
-      query.releaseType &&
-      isOneOf(query.releaseType, Object.keys(releaseTypes) as ReleaseType[])
-        ? query.releaseType
-        : undefined,
+    releaseType: validReleaseTypes.length > 0 ? validReleaseTypes : undefined,
     search: getFirst(query.search),
     sortBy:
       query.sortBy && isOneOf(query.sortBy, publicationSortOptions)

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
@@ -24,6 +24,7 @@ export default function createDataSetListRequest(
     dataSetType,
     geographicLevels,
     latestDataOnly,
+    publicationId,
     releaseType,
     search: searchParam,
     sortBy,
@@ -36,6 +37,7 @@ export default function createDataSetListRequest(
     dataSetType,
     geographicLevels,
     latestDataOnly,
+    publicationId,
     releaseType,
     themeId,
   });
@@ -59,7 +61,7 @@ interface SearchFilters {
   geographicLevels?: string[];
   dataSetType: string;
   latestDataOnly?: boolean;
-  releaseId?: string[];
+  publicationId?: string[];
   releaseType?: string[];
   themeId?: string[];
 }
@@ -84,9 +86,9 @@ function buildODataFilter(filters: SearchFilters): string | undefined {
     );
   }
 
-  if (filters.releaseId?.length) {
-    const joined = filters.releaseId.join('|');
-    conditions.push(odata`search.in(releaseId, ${joined}, '|')`);
+  if (filters.publicationId?.length) {
+    const joined = filters.publicationId.join('|');
+    conditions.push(odata`search.in(publicationId, ${joined}, '|')`);
   }
 
   if (filters.latestDataOnly) {
@@ -138,6 +140,7 @@ export function getParamsFromQuery(query: SearchDataPageQuery) {
       validGeographicLevels.length > 0 ? validGeographicLevels : undefined,
     latestDataOnly: !query.latestDataOnly || query.latestDataOnly !== 'false',
     page: getFirst(query.page),
+    publicationId: getAsArray(query.publicationId),
     releaseType: validReleaseTypes.length > 0 ? validReleaseTypes : undefined,
     search: getFirst(query.search),
     sortBy:

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
@@ -68,15 +68,32 @@ interface SearchFilters {
 
 function buildODataFilter(filters: SearchFilters): string | undefined {
   const conditions: string[] = [];
+  const themeAndPubConditions: string[] = [];
+
+  if (filters.themeId?.length) {
+    const joined = filters.themeId.join('|');
+    themeAndPubConditions.push(odata`search.in(themeId, ${joined}, '|')`);
+  }
+
+  if (filters.publicationId?.length) {
+    const joined = filters.publicationId.join('|');
+    themeAndPubConditions.push(odata`search.in(publicationId, ${joined}, '|')`);
+  }
+
+  if (themeAndPubConditions.length > 0) {
+    // If both theme and publication ids, we want to match either, so join them with 'or' and wrap in parentheses.
+    // If only one exists, just use it as is.
+    const combinedGroup =
+      themeAndPubConditions.length > 1
+        ? `(${themeAndPubConditions.join(' or ')})`
+        : themeAndPubConditions[0];
+
+    conditions.push(combinedGroup);
+  }
 
   if (filters.releaseType?.length) {
     const joined = filters.releaseType.join('|');
     conditions.push(odata`search.in(releaseType, ${joined}, '|')`);
-  }
-
-  if (filters.themeId?.length) {
-    const joined = filters.themeId.join('|');
-    conditions.push(odata`search.in(themeId, ${joined}, '|')`);
   }
 
   if (filters.geographicLevels?.length) {
@@ -84,11 +101,6 @@ function buildODataFilter(filters: SearchFilters): string | undefined {
     conditions.push(
       odata`geographicLevels/any(g: search.in(g, ${joined}, '|'))`,
     );
-  }
-
-  if (filters.publicationId?.length) {
-    const joined = filters.publicationId.join('|');
-    conditions.push(odata`search.in(publicationId, ${joined}, '|')`);
   }
 
   if (filters.latestDataOnly) {

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
@@ -1,5 +1,6 @@
 import { odata } from '@azure/search-documents';
 import { releaseTypes, ReleaseType } from '@common/services/types/releaseType';
+import getAsArray from '@common/utils/getAsArray';
 import getFirst from '@common/utils/getFirst';
 import parseNumber from '@common/utils/number/parseNumber';
 import isOneOf from '@common/utils/type-guards/isOneOf';
@@ -32,7 +33,7 @@ export default function createDataSetListRequest(
     dataSetType,
     latestDataOnly,
     releaseType: releaseType ? [releaseType] : undefined,
-    themeId: themeId ? [themeId] : undefined,
+    themeId,
   });
 
   const minSearchCharacters = 3;
@@ -125,6 +126,6 @@ export function getParamsFromQuery(query: SearchDataPageQuery) {
       query.sortBy && isOneOf(query.sortBy, publicationSortOptions)
         ? query.sortBy
         : 'newest',
-    themeId: getFirst(query.themeId),
+    themeId: getAsArray(query.themeId),
   };
 }

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
@@ -1,5 +1,8 @@
 import { odata } from '@azure/search-documents';
-import { releaseTypes, ReleaseType } from '@common/services/types/releaseType';
+import {
+  releaseTypes as statisticsReleaseTypes,
+  ReleaseType,
+} from '@common/services/types/releaseType';
 import getAsArray from '@common/utils/getAsArray';
 import getFirst from '@common/utils/getFirst';
 import locationLevelsMap, {
@@ -24,11 +27,11 @@ export default function createDataSetListRequest(
     dataSetType,
     geographicLevels,
     latestDataOnly,
-    publicationId,
-    releaseType,
+    publicationIds,
+    releaseTypes,
     search: searchParam,
     sortBy,
-    themeId,
+    themeIds,
   } = getParamsFromQuery(query);
 
   const orderBy = getSortParam(sortBy);
@@ -37,9 +40,9 @@ export default function createDataSetListRequest(
     dataSetType,
     geographicLevels,
     latestDataOnly,
-    publicationId,
-    releaseType,
-    themeId,
+    publicationIds,
+    releaseTypes,
+    themeIds,
   });
 
   const minSearchCharacters = 3;
@@ -61,22 +64,22 @@ interface SearchFilters {
   geographicLevels?: string[];
   dataSetType: string;
   latestDataOnly?: boolean;
-  publicationId?: string[];
-  releaseType?: string[];
-  themeId?: string[];
+  publicationIds?: string[];
+  releaseTypes?: string[];
+  themeIds?: string[];
 }
 
 function buildODataFilter(filters: SearchFilters): string | undefined {
   const conditions: string[] = [];
   const themeAndPubConditions: string[] = [];
 
-  if (filters.themeId?.length) {
-    const joined = filters.themeId.join('|');
+  if (filters.themeIds?.length) {
+    const joined = filters.themeIds.join('|');
     themeAndPubConditions.push(odata`search.in(themeId, ${joined}, '|')`);
   }
 
-  if (filters.publicationId?.length) {
-    const joined = filters.publicationId.join('|');
+  if (filters.publicationIds?.length) {
+    const joined = filters.publicationIds.join('|');
     themeAndPubConditions.push(odata`search.in(publicationId, ${joined}, '|')`);
   }
 
@@ -91,8 +94,8 @@ function buildODataFilter(filters: SearchFilters): string | undefined {
     conditions.push(combinedGroup);
   }
 
-  if (filters.releaseType?.length) {
-    const joined = filters.releaseType.join('|');
+  if (filters.releaseTypes?.length) {
+    const joined = filters.releaseTypes.join('|');
     conditions.push(odata`search.in(releaseType, ${joined}, '|')`);
   }
 
@@ -134,7 +137,7 @@ export function getParamsFromQuery(query: SearchDataPageQuery) {
   const releaseTypesArray = getAsArray(query.releaseType) ?? [];
 
   const validReleaseTypes = releaseTypesArray.filter(type =>
-    isOneOf(type, Object.keys(releaseTypes)),
+    isOneOf(type, Object.keys(statisticsReleaseTypes)),
   ) as ReleaseType[];
 
   const geographicLevelsArray = getAsArray(query.geographicLevel) ?? [];
@@ -152,13 +155,13 @@ export function getParamsFromQuery(query: SearchDataPageQuery) {
       validGeographicLevels.length > 0 ? validGeographicLevels : undefined,
     latestDataOnly: !query.latestDataOnly || query.latestDataOnly !== 'false',
     page: getFirst(query.page),
-    publicationId: getAsArray(query.publicationId),
-    releaseType: validReleaseTypes.length > 0 ? validReleaseTypes : undefined,
+    publicationIds: getAsArray(query.publicationId),
+    releaseTypes: validReleaseTypes.length > 0 ? validReleaseTypes : undefined,
     search: getFirst(query.search),
     sortBy:
       query.sortBy && isOneOf(query.sortBy, publicationSortOptions)
         ? query.sortBy
         : 'newest',
-    themeId: getAsArray(query.themeId),
+    themeIds: getAsArray(query.themeId),
   };
 }

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
@@ -2,6 +2,9 @@ import { odata } from '@azure/search-documents';
 import { releaseTypes, ReleaseType } from '@common/services/types/releaseType';
 import getAsArray from '@common/utils/getAsArray';
 import getFirst from '@common/utils/getFirst';
+import locationLevelsMap, {
+  GeographicLevelCode,
+} from '@common/utils/locationLevelsMap';
 import parseNumber from '@common/utils/number/parseNumber';
 import isOneOf from '@common/utils/type-guards/isOneOf';
 import { FindStatisticsPageQuery } from '@frontend/modules/find-statistics/FindStatisticsPage';
@@ -12,6 +15,7 @@ import {
 import { SearchDataPageQuery } from '@frontend/modules/search-data/SearchDataPage';
 import { AzureDataSetListRequest } from '@frontend/services/azureDataSetService';
 import { AzureOrderByParam } from '@frontend/services/azurePublicationService';
+import { DataSetType } from '@frontend/services/dataSetFileService';
 import omitBy from 'lodash/omitBy';
 
 export default function createDataSetListRequest(
@@ -19,6 +23,7 @@ export default function createDataSetListRequest(
 ): AzureDataSetListRequest {
   const {
     dataSetType,
+    geographicLevels,
     latestDataOnly,
     releaseType,
     search: searchParam,
@@ -28,9 +33,9 @@ export default function createDataSetListRequest(
 
   const orderBy = getSortParam(sortBy);
 
-  // TOOD-7072 finish converting filters into arrays
   const filter = buildODataFilter({
     dataSetType,
+    geographicLevels,
     latestDataOnly,
     releaseType,
     themeId,
@@ -76,7 +81,9 @@ function buildODataFilter(filters: SearchFilters): string | undefined {
 
   if (filters.geographicLevels?.length) {
     const joined = filters.geographicLevels.join('|');
-    conditions.push(odata`search.in(geographicLevels, ${joined}, '|')`);
+    conditions.push(
+      odata`geographicLevels/any(g: search.in(g, ${joined}, '|'))`,
+    );
   }
 
   if (filters.releaseId?.length) {
@@ -118,8 +125,19 @@ export function getParamsFromQuery(query: SearchDataPageQuery) {
     isOneOf(type, Object.keys(releaseTypes)),
   ) as ReleaseType[];
 
+  const geographicLevelsArray = getAsArray(query.geographicLevel) ?? [];
+
+  const validGeographicLevels = geographicLevelsArray.filter(type =>
+    isOneOf(
+      type,
+      Object.values(locationLevelsMap).map(level => level.code),
+    ),
+  ) as GeographicLevelCode[];
+
   return {
-    dataSetType: query.dataSetType === 'api' ? 'api' : 'all',
+    dataSetType: query.dataSetType === 'api' ? 'api' : ('all' as DataSetType),
+    geographicLevels:
+      validGeographicLevels.length > 0 ? validGeographicLevels : undefined,
     latestDataOnly: !query.latestDataOnly || query.latestDataOnly !== 'false',
     page: getFirst(query.page),
     releaseType: validReleaseTypes.length > 0 ? validReleaseTypes : undefined,

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/createStatisticalReleasesListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/createStatisticalReleasesListRequest.ts
@@ -1,5 +1,8 @@
 import { odata } from '@azure/search-documents';
-import { releaseTypes, ReleaseType } from '@common/services/types/releaseType';
+import {
+  releaseTypes as statisticsReleaseTypes,
+  ReleaseType,
+} from '@common/services/types/releaseType';
 import getAsArray from '@common/utils/getAsArray';
 import getFirst from '@common/utils/getFirst';
 import parseNumber from '@common/utils/number/parseNumber';
@@ -17,17 +20,17 @@ export default function createStatisticalReleasesListRequest(
   query: SearchDataPageQuery,
 ): AzureDataSetListRequest {
   const {
-    releaseType,
+    releaseTypes,
     search: searchParam,
     sortBy,
-    themeId,
+    themeIds,
   } = getParamsFromQuery(query);
 
   const orderBy = getSortParam(sortBy);
 
   const filter = buildODataFilter({
-    releaseType,
-    themeId,
+    releaseTypes,
+    themeIds,
   });
 
   const minSearchCharacters = 3;
@@ -46,20 +49,20 @@ export default function createStatisticalReleasesListRequest(
 }
 
 interface SearchFilters {
-  releaseType?: string[];
-  themeId?: string[];
+  releaseTypes?: string[];
+  themeIds?: string[];
 }
 
 function buildODataFilter(filters: SearchFilters): string | undefined {
   const conditions: string[] = [];
 
-  if (filters.releaseType?.length) {
-    const joined = filters.releaseType.join('|');
+  if (filters.releaseTypes?.length) {
+    const joined = filters.releaseTypes.join('|');
     conditions.push(odata`search.in(releaseType, ${joined}, '|')`);
   }
 
-  if (filters.themeId?.length) {
-    const joined = filters.themeId.join('|');
+  if (filters.themeIds?.length) {
+    const joined = filters.themeIds.join('|');
     conditions.push(odata`search.in(themeId, ${joined}, '|')`);
   }
 
@@ -84,17 +87,17 @@ export function getParamsFromQuery(query: SearchDataPageQuery) {
   const releaseTypesArray = getAsArray(query.releaseType) ?? [];
 
   const validReleaseTypes = releaseTypesArray.filter(type =>
-    isOneOf(type, Object.keys(releaseTypes)),
+    isOneOf(type, Object.keys(statisticsReleaseTypes)),
   ) as ReleaseType[];
 
   return {
     page: getFirst(query.page),
-    releaseType: validReleaseTypes.length > 0 ? validReleaseTypes : undefined,
+    releaseTypes: validReleaseTypes.length > 0 ? validReleaseTypes : undefined,
     search: getFirst(query.search),
     sortBy:
       query.sortBy && isOneOf(query.sortBy, publicationSortOptions)
         ? query.sortBy
         : 'newest',
-    themeId: getAsArray(query.themeId),
+    themeIds: getAsArray(query.themeId),
   };
 }

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/createStatisticalReleasesListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/createStatisticalReleasesListRequest.ts
@@ -2,9 +2,6 @@ import { odata } from '@azure/search-documents';
 import { releaseTypes, ReleaseType } from '@common/services/types/releaseType';
 import getAsArray from '@common/utils/getAsArray';
 import getFirst from '@common/utils/getFirst';
-import locationLevelsMap, {
-  GeographicLevelCode,
-} from '@common/utils/locationLevelsMap';
 import parseNumber from '@common/utils/number/parseNumber';
 import isOneOf from '@common/utils/type-guards/isOneOf';
 import {
@@ -14,16 +11,12 @@ import {
 import { SearchDataPageQuery } from '@frontend/modules/search-data/SearchDataPage';
 import { AzureDataSetListRequest } from '@frontend/services/azureDataSetService';
 import { AzureOrderByParam } from '@frontend/services/azurePublicationService';
-import { DataSetType } from '@frontend/services/dataSetFileService';
 import omitBy from 'lodash/omitBy';
 
-export default function createDataSetListRequest(
+export default function createStatisticalReleasesListRequest(
   query: SearchDataPageQuery,
 ): AzureDataSetListRequest {
   const {
-    dataSetType,
-    geographicLevels,
-    latestDataOnly,
     releaseType,
     search: searchParam,
     sortBy,
@@ -33,9 +26,6 @@ export default function createDataSetListRequest(
   const orderBy = getSortParam(sortBy);
 
   const filter = buildODataFilter({
-    dataSetType,
-    geographicLevels,
-    latestDataOnly,
     releaseType,
     themeId,
   });
@@ -56,10 +46,6 @@ export default function createDataSetListRequest(
 }
 
 interface SearchFilters {
-  geographicLevels?: string[];
-  dataSetType: string;
-  latestDataOnly?: boolean;
-  releaseId?: string[];
   releaseType?: string[];
   themeId?: string[];
 }
@@ -75,28 +61,6 @@ function buildODataFilter(filters: SearchFilters): string | undefined {
   if (filters.themeId?.length) {
     const joined = filters.themeId.join('|');
     conditions.push(odata`search.in(themeId, ${joined}, '|')`);
-  }
-
-  if (filters.geographicLevels?.length) {
-    const joined = filters.geographicLevels.join('|');
-    conditions.push(
-      odata`geographicLevels/any(g: search.in(g, ${joined}, '|'))`,
-    );
-  }
-
-  if (filters.releaseId?.length) {
-    const joined = filters.releaseId.join('|');
-    conditions.push(odata`search.in(releaseId, ${joined}, '|')`);
-  }
-
-  if (filters.latestDataOnly) {
-    conditions.push(odata`latestData eq true`);
-  }
-
-  if (filters.dataSetType === 'api') {
-    // conditions.push(odata`api eq ${filters.hasApiDataSet}`);
-    // "ne" stands for "not equal".
-    conditions.push(`api/id ne null and api/id ne ''`);
   }
 
   // Combine everything or return undefined if no filters were provided
@@ -123,20 +87,7 @@ export function getParamsFromQuery(query: SearchDataPageQuery) {
     isOneOf(type, Object.keys(releaseTypes)),
   ) as ReleaseType[];
 
-  const geographicLevelsArray = getAsArray(query.geographicLevel) ?? [];
-
-  const validGeographicLevels = geographicLevelsArray.filter(type =>
-    isOneOf(
-      type,
-      Object.values(locationLevelsMap).map(level => level.code),
-    ),
-  ) as GeographicLevelCode[];
-
   return {
-    dataSetType: query.dataSetType === 'api' ? 'api' : ('all' as DataSetType),
-    geographicLevels:
-      validGeographicLevels.length > 0 ? validGeographicLevels : undefined,
-    latestDataOnly: !query.latestDataOnly || query.latestDataOnly !== 'false',
     page: getFirst(query.page),
     releaseType: validReleaseTypes.length > 0 ? validReleaseTypes : undefined,
     search: getFirst(query.search),

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/searchDataFilters.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/searchDataFilters.ts
@@ -2,6 +2,7 @@ export const searchDataFilters = [
   'dataSetType',
   'geographicLevel',
   'latestDataOnly',
+  'publicationId',
   'releaseType',
   'search',
   'themeId',

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/searchDataFilters.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/searchDataFilters.ts
@@ -1,5 +1,6 @@
 export const searchDataFilters = [
   'dataSetType',
+  'geographicLevel',
   'latestDataOnly',
   'releaseType',
   'search',

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/transformDataSetListResults.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/transformDataSetListResults.ts
@@ -6,6 +6,7 @@ import { DataSetFileSummary } from '@frontend/services/dataSetFileService';
 export default async function transformDataSetListResults(
   results: SearchIterator<
     AzureDataSetIndexItem,
+    | 'dataSetFileId'
     | 'fileId'
     | 'filename'
     | 'fileExtension'
@@ -38,6 +39,7 @@ export default async function transformDataSetListResults(
   for await (const result of results) {
     const { document } = result;
     const {
+      dataSetFileId,
       fileId,
       fileSize,
       filename,
@@ -65,7 +67,7 @@ export default async function transformDataSetListResults(
     } = document;
 
     transformedResults.push({
-      id: fileId,
+      id: dataSetFileId,
       fileId,
       filename,
       fileSize,

--- a/src/explore-education-statistics-frontend/src/pages/api/search-datasets.ts
+++ b/src/explore-education-statistics-frontend/src/pages/api/search-datasets.ts
@@ -58,6 +58,7 @@ export default withMethods({
         ...searchOptionsBase,
         filter,
         select: [
+          'dataSetFileId',
           'fileId',
           'filename',
           'fileExtension',

--- a/src/explore-education-statistics-frontend/src/pages/api/search-datasets.ts
+++ b/src/explore-education-statistics-frontend/src/pages/api/search-datasets.ts
@@ -25,7 +25,7 @@ type SharedSearchOptionsBase = Partial<SearchOptions<AzureDataSetIndexItem>> &
   SearchRequestQueryTypeOptions;
 
 export default withMethods({
-  post: async function searchPublications(
+  post: async function searchDatasets(
     req: Request,
     res: NextApiResponse<PaginatedList<DataSetFileSummary> | ErrorBody>,
   ) {

--- a/src/explore-education-statistics-frontend/src/pages/api/search-statistical-releases.ts
+++ b/src/explore-education-statistics-frontend/src/pages/api/search-statistical-releases.ts
@@ -1,0 +1,130 @@
+/* eslint-disable no-restricted-syntax */
+import withMethods from '@frontend/middleware/api/withMethods';
+import logger from '@common/services/logger';
+import { PublicationListSummary } from '@common/services/publicationService';
+import { PaginatedList } from '@common/services/types/pagination';
+import { ReleaseType } from '@common/services/types/releaseType';
+import {
+  SearchOptions,
+  SearchRequestQueryTypeOptions,
+} from '@azure/search-documents';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { initialiseAzurePublicationsSearchClient } from '@frontend/modules/api/search/initialiseAzureSearchClient';
+import { ErrorBody } from '@frontend/modules/api/types/error';
+import {
+  AzurePublicationListRequest,
+  AzurePublicationSearchResult,
+} from '@frontend/services/azurePublicationService';
+
+interface Request extends NextApiRequest {
+  body: {
+    searchOptions: AzurePublicationListRequest;
+  };
+}
+
+type SharedSearchOptionsBase = Partial<
+  SearchOptions<AzurePublicationSearchResult>
+> &
+  SearchRequestQueryTypeOptions;
+
+export default withMethods({
+  post: async function searchStatisticalReleases(
+    req: Request,
+    res: NextApiResponse<PaginatedList<PublicationListSummary> | ErrorBody>,
+  ) {
+    const {
+      body: { searchOptions },
+    } = req;
+
+    const azureSearchClient = initialiseAzurePublicationsSearchClient();
+
+    try {
+      const {
+        filter,
+        orderBy,
+        page = 1,
+        pageSize = 10,
+        search = '',
+      } = searchOptions;
+
+      const searchOptionsBase: SharedSearchOptionsBase = {
+        includeTotalCount: true,
+        orderBy: orderBy ? [orderBy] : undefined,
+        queryType: !orderBy ? 'semantic' : undefined,
+        searchMode: 'any',
+        semanticSearchOptions: {
+          configurationName: 'semantic-configuration-1',
+        },
+        scoringProfile: 'scoring-profile-1',
+        skip: page > 1 ? (page - 1) * 10 : 0,
+        top: 10,
+      };
+
+      // Get all search results
+      const searchResults = await azureSearchClient.search(search, {
+        ...searchOptionsBase,
+        highlightFields: 'title,summary,content-3',
+        filter,
+        select: [
+          'content',
+          'releaseSlug',
+          'releaseType',
+          'releaseVersionId',
+          'publicationSlug',
+          'published',
+          'summary',
+          'themeTitle',
+          'title',
+        ],
+      });
+
+      // Now transform response into <PaginatedList<PublicationListSummary>>
+      const { count = 0, results } = searchResults;
+
+      const publicationsResult = {
+        paging: {
+          totalPages: count === 0 ? 0 : Math.floor((count - 1) / pageSize) + 1,
+          totalResults: count,
+          page,
+          pageSize,
+        },
+        results: [] as PublicationListSummary[],
+      };
+
+      for await (const result of results) {
+        const { document } = result;
+        const {
+          themeTitle,
+          title,
+          summary,
+          publicationSlug: slug,
+          published,
+          releaseVersionId: id,
+          releaseSlug: latestReleaseSlug,
+          releaseType: type,
+        } = document;
+
+        publicationsResult.results.push({
+          theme: themeTitle,
+          title,
+          summary,
+          highlightContent: result.highlights?.content?.join(' ... ') || null,
+          highlightSummary: result.highlights?.summary?.join(' ... ') || null,
+          highlightTitle: result.highlights?.title?.join(' ... ') || null,
+          published: published.toString(),
+          id,
+          rank: result.score,
+          slug,
+          latestReleaseSlug,
+          type: type as ReleaseType,
+        });
+      }
+      return res.status(200).send(publicationsResult);
+    } catch (error) {
+      logger.error(error);
+      return res
+        .status(500)
+        .send({ message: 'Something went wrong', status: 500 });
+    }
+  },
+});

--- a/src/explore-education-statistics-frontend/src/queries/azurePublicationQueries.ts
+++ b/src/explore-education-statistics-frontend/src/queries/azurePublicationQueries.ts
@@ -1,10 +1,12 @@
-import createPublicationListRequest from '@frontend/modules/find-statistics/utils/createPublicationListRequest';
-import { ParsedUrlQuery } from 'querystring';
-import { UseQueryOptions } from '@tanstack/react-query';
 import { PublicationListSummary } from '@common/services/publicationService';
+import { PaginatedList } from '@common/services/types/pagination';
+import createPublicationListRequest from '@frontend/modules/find-statistics/utils/createPublicationListRequest';
+import createStatisticalReleasesListRequest from '@frontend/modules/search-data/utils/createStatisticalReleasesListRequest';
 import azurePublicationService, {
   PaginatedListWithAzureFacets,
 } from '@frontend/services/azurePublicationService';
+import { UseQueryOptions } from '@tanstack/react-query';
+import { ParsedUrlQuery } from 'querystring';
 
 const azurePublicationQueries = {
   list(
@@ -15,6 +17,19 @@ const azurePublicationQueries = {
       queryFn: async () =>
         azurePublicationService.listPublications(
           createPublicationListRequest(query),
+        ),
+    };
+  },
+  // This is used for the search data page prototype, separate to the find stats page
+  // as it accepts multiple filter items and doesn't need facets
+  listStatisticalReleases(
+    query: ParsedUrlQuery,
+  ): UseQueryOptions<PaginatedList<PublicationListSummary>> {
+    return {
+      queryKey: ['listPublications', query],
+      queryFn: async () =>
+        azurePublicationService.listStatisticalReleases(
+          createStatisticalReleasesListRequest(query),
         ),
     };
   },

--- a/src/explore-education-statistics-frontend/src/queries/publicationQueries.ts
+++ b/src/explore-education-statistics-frontend/src/queries/publicationQueries.ts
@@ -112,6 +112,900 @@ const publicationQueries = {
       queryFn: () => publicationService.listReleases(publicationSlug),
     };
   },
+  // TODO remove this once prototype is complete - currently used for demo-ing find data from azure,
+  // as that uses data sets from prod
+  getPrototypePublicationTree(
+    query: PublicationTreeOptions,
+  ): UseQueryOptions<Theme[]> {
+    return {
+      queryKey: ['publicationTreePrototype', query],
+      queryFn: () =>
+        new Promise(resolve =>
+          resolve([
+            {
+              id: 'cc8e02fd-5599-41aa-940d-26bca68eab53',
+              summary:
+                'Including children in need and child protection, children looked after and social work workforce statistics',
+              title: "Children's social care",
+              publications: [
+                {
+                  id: 'd7bd5d9d-dc65-4b1d-99b1-4d815b7369a3',
+                  slug: 'children-accommodated-in-secure-childrens-homes',
+                  title: "Children accommodated in secure children's homes",
+                  isSuperseded: false,
+                },
+                {
+                  id: '89869bba-0c00-40f7-b7d6-e28cb904ad37',
+                  slug: 'children-in-need',
+                  title: 'Children in need',
+                  isSuperseded: false,
+                },
+                {
+                  id: '7f32ebcd-8f36-4b9b-fdab-08ddd41933e2',
+                  slug: 'children-in-need-a-focus-on-re-referrals',
+                  title: 'Children in need: A focus on re-referrals',
+                  isSuperseded: false,
+                },
+                {
+                  id: '07f9ca49-e12e-4c06-fdac-08ddd41933e2',
+                  slug: 'children-in-need-a-focus-on-sexual-abuse-and-exploitation',
+                  title:
+                    'Children in need: A focus on sexual abuse and exploitation',
+                  isSuperseded: false,
+                },
+                {
+                  id: '3260801d-601a-48c6-93b7-cf51680323d1',
+                  slug: 'children-looked-after-in-england-including-adoptions',
+                  title: 'Children looked after in England including adoptions',
+                  isSuperseded: false,
+                },
+                {
+                  id: '25216e7a-729d-4f80-c22c-08ddbe116041',
+                  slug: 'children-looked-after-a-focus-on-placement-location',
+                  title: 'Children looked after: A focus on placement location',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'd8baee79-3c88-45f4-b12a-07b91e9b5c11',
+                  slug: 'children-s-social-work-workforce',
+                  title: "Children's social work workforce",
+                  isSuperseded: false,
+                },
+                {
+                  id: '18576c79-e938-4154-9f12-08da13d30bd1',
+                  slug: 'children-s-social-work-workforce-attrition-caseload-and-agency-workforce',
+                  title:
+                    "Children's social work workforce: attrition, caseload, and agency workforce",
+                  isSuperseded: false,
+                },
+                {
+                  id: '98a7cf7e-30d6-4b76-03f5-08da5b671103',
+                  slug: 'looked-after-children-aged-16-to-17-in-independent-or-semi-independent-placements',
+                  title:
+                    'Looked after children aged 16 to 17 in independent or semi-independent placements',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'f51895df-c682-45e6-b23e-3138ddbfdaeb',
+                  slug: 'outcomes-for-children-in-need-including-children-looked-after-by-local-authorities-in-england',
+                  title:
+                    'Outcomes for children in need, including children looked after by local authorities in England',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'ea42de23-80c0-4609-89fe-91df00c4f249',
+                  slug: 'outcomes-of-children-in-need-including-looked-after-children',
+                  title:
+                    'Outcomes of children in need, including looked after children',
+                  supersededBy: {
+                    id: 'f51895df-c682-45e6-b23e-3138ddbfdaeb',
+                    slug: 'outcomes-for-children-in-need-including-children-looked-after-by-local-authorities-in-england',
+                    title:
+                      'Outcomes for children in need, including children looked after by local authorities in England',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: '0c2da30b-0210-49d4-cac0-08d87696e25e',
+                  slug: 'serious-incident-notifications',
+                  title: 'Serious incident notifications',
+                  isSuperseded: false,
+                },
+                {
+                  id: '27c27d79-290d-4cef-e5ec-08dd6e04ec1b',
+                  slug: 'stability-measures-for-children-looked-after-in-england',
+                  title:
+                    'Stability measures for children looked after in England',
+                  isSuperseded: false,
+                },
+              ],
+            },
+            {
+              id: '2eee78b2-e4d5-4046-9866-c6c5b717a96c',
+              summary:
+                'Including Attendance in education and early years settings during the coronavirus (COVID-19) outbreak',
+              title: 'COVID-19',
+              publications: [
+                {
+                  id: '036e2c36-7c48-4a29-8419-a3939be9e173',
+                  slug: 'attendance-in-education-and-early-years-settings-during-covid-19',
+                  title:
+                    'Attendance in education and early years settings during COVID-19',
+                  supersededBy: {
+                    id: '9676af6b-d563-41f4-d071-08da8f468680',
+                    slug: 'pupil-attendance-in-schools',
+                    title: 'Pupil attendance in schools',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: '4b2e6dfd-69c8-42d7-8fac-08d999fbf656',
+                  slug: 'co2-monitors-cumulative-delivery-statistics',
+                  title: 'CO2 monitors: cumulative delivery statistics',
+                  isSuperseded: false,
+                },
+                {
+                  id: '359958a5-b28a-4ab3-508a-08d88f97dffc',
+                  slug: 'coronavirus-covid-19-reporting-in-higher-education-providers',
+                  title:
+                    'Coronavirus (COVID-19) Reporting in Higher Education Providers',
+                  isSuperseded: false,
+                },
+                {
+                  id: '6d2ff07c-7ea9-43c0-6937-08d8cddbb024',
+                  slug: 'covid-mass-testing-data-in-education',
+                  title: 'COVID mass testing data in education',
+                  isSuperseded: false,
+                },
+                {
+                  id: '1c45fcd7-e1ca-44d2-b4c8-08d9ec8bbabe',
+                  slug: 'delivery-of-air-cleaning-units',
+                  title: 'Delivery of air cleaning units',
+                  isSuperseded: false,
+                },
+                {
+                  id: '4d747ecd-10cc-4660-bcdc-08d8b9339e60',
+                  slug: 'laptops-and-tablets-data',
+                  title: 'Laptops and tablets data',
+                  isSuperseded: false,
+                },
+                {
+                  id: '7718a5b8-da1c-466f-d350-08daa14d393a',
+                  slug: 'vulnerable-children-and-young-people-survey',
+                  title: 'Vulnerable children and young people survey',
+                  isSuperseded: false,
+                },
+              ],
+            },
+            {
+              id: '6412a76c-cf15-424f-8ebc-3a530132b1b3',
+              summary:
+                'Including not in education, employment or training (NEET) statistics',
+              title: 'Destination of pupils and students',
+              publications: [
+                {
+                  id: '657a20f6-13ef-494f-c9c0-08d82a49a1d0',
+                  slug: '16-18-destination-measures',
+                  title: '16-18 destination measures',
+                  isSuperseded: false,
+                },
+                {
+                  id: '8b12776b-3d36-4475-8115-00974d7de1d0',
+                  slug: 'further-education-outcomes',
+                  title: 'Further education outcomes',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'b70e71fa-5767-4fb5-c9bf-08d82a49a1d0',
+                  slug: 'key-stage-4-destination-measures',
+                  title: 'Key stage 4 destination measures',
+                  isSuperseded: false,
+                },
+                {
+                  id: '2ee2b32a-3fa0-42bb-c9c2-08d82a49a1d0',
+                  slug: 'longer-term-destinations',
+                  title: 'Longer term destinations',
+                  isSuperseded: false,
+                },
+                {
+                  id: '2e510281-ca8c-41bf-bbe0-fd15fcc81aae',
+                  slug: 'neet-statistics-annual-brief',
+                  title: 'NEET age 16 to 24',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'a0eb117e-44a8-4732-adf1-8fbc890cbb62',
+                  slug: 'participation-in-education-and-training-and-employment',
+                  title:
+                    'Participation in education, training and employment age 16 to 18',
+                  isSuperseded: false,
+                },
+                {
+                  id: '9f5d0e21-45d3-41e5-1b71-08da5e798404',
+                  slug: 'participation-in-education-training-and-neet-age-16-to-17-by-local-authority',
+                  title:
+                    'Participation in education, training and NEET age 16 to 17 by local authority',
+                  isSuperseded: false,
+                },
+                {
+                  id: '61784b00-d1e7-4dbd-c9c1-08d82a49a1d0',
+                  slug: 'progression-to-higher-education-or-training',
+                  title: 'Progression to higher education or training',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'cb160073-139b-4069-3478-08dad90fbd2f',
+                  slug: 'september-guarantee-offers-of-education-and-training-for-young-people-age-16-and-17',
+                  title:
+                    'September Guarantee: offers of education and training for young people age 16 and 17',
+                  isSuperseded: false,
+                },
+              ],
+            },
+            {
+              id: 'e6e31160-fe79-4556-f3a9-08d86094b9e8',
+              summary:
+                'Including early years foundation stage profile and early years surveys statistics',
+              title: 'Early years',
+              publications: [
+                {
+                  id: '79a08466-dace-4ff0-94b6-59c5528c9262',
+                  slug: 'childcare-and-early-years-provider-survey',
+                  title: 'Childcare and early years provider survey',
+                  isSuperseded: false,
+                },
+                {
+                  id: '060c5376-35d8-420b-8266-517a9339b7bc',
+                  slug: 'childcare-and-early-years-survey-of-parents',
+                  title: 'Childcare and early years survey of parents',
+                  isSuperseded: false,
+                },
+                {
+                  id: '2b4fdd0f-e58f-4368-8d66-08dc0dee4273',
+                  slug: 'early-years-education-recovery',
+                  title: 'Early years education recovery',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'fcda2962-82a6-4052-afa2-ea398c53c85f',
+                  slug: 'early-years-foundation-stage-profile-results',
+                  title: 'Early years foundation stage profile results',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'f2e7f229-f7b0-45ab-624f-08dd83281976',
+                  slug: 'expansion-to-early-childcare-entitlements-childcare-experiences-survey',
+                  title:
+                    'Expansion to early childcare entitlements: Childcare Experiences Survey',
+                  isSuperseded: false,
+                },
+                {
+                  id: '8042c52d-16d4-4b7b-66f5-08dc1b6b9886',
+                  slug: 'expansion-to-early-childcare-entitlements-eligibility-codes-issued-and-validated',
+                  title:
+                    'Expansion to early childcare entitlements: eligibility codes issued and validated',
+                  isSuperseded: false,
+                },
+                {
+                  id: '0ce6a6c6-5451-4967-8dd4-2f4fa8131982',
+                  slug: 'funded-early-education-and-childcare',
+                  title: 'Funded early education and childcare',
+                  isSuperseded: false,
+                },
+              ],
+            },
+            {
+              id: 'bc08839f-2970-4f34-af2d-29608a48082f',
+              summary:
+                'Including local authority (LA) and student loan statistics',
+              title: 'Finance and funding',
+              publications: [
+                {
+                  id: 'dcb8b32b-4e50-4fe2-a539-58f9b6b3a366',
+                  slug: 'la-and-school-expenditure',
+                  title: 'LA and school expenditure',
+                  isSuperseded: false,
+                },
+                {
+                  id: '94d16c6e-1e5f-48d5-8195-8ea770f1b0d4',
+                  slug: 'planned-la-and-school-expenditure',
+                  title: 'Planned LA and school expenditure',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'bdbab446-c985-4b44-d072-08da8f468680',
+                  slug: 'school-finances-during-the-covid-19-pandemic',
+                  title: 'School finances during the Covid-19 pandemic',
+                  isSuperseded: false,
+                },
+                {
+                  id: '39dce2e3-4976-41ac-cb95-08d8bdf1a994',
+                  slug: 'school-funding-statistics',
+                  title: 'School funding statistics',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'fd68e147-b7ee-464f-8b02-dcd917dc362d',
+                  slug: 'student-loan-forecasts-for-england',
+                  title: 'Student loan forecasts for England',
+                  isSuperseded: false,
+                },
+              ],
+            },
+            {
+              id: '92c5df93-c4da-4629-ab25-51bd2920cdca',
+              summary:
+                'Including advanced learner loan, benefit claimant and apprenticeship and traineeship statistics',
+              title: 'Further education',
+              publications: [
+                {
+                  id: '412d8090-ab45-455a-c176-08dbf5ab522b',
+                  slug: 'apprenticeships',
+                  title: 'Apprenticeships',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'b2eed9e7-3845-47ab-e9a9-08d9a8ec2f9e',
+                  slug: 'apprenticeships-and-19-plus-further-education-skills-index',
+                  title:
+                    'Apprenticeships and 19-plus Further Education Skills Index',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'cf0ec981-3583-42a5-b21b-3f2f32008f1b',
+                  slug: 'apprenticeships-and-traineeships',
+                  title: 'Apprenticeships and traineeships',
+                  supersededBy: {
+                    id: '412d8090-ab45-455a-c176-08dbf5ab522b',
+                    slug: 'apprenticeships',
+                    title: 'Apprenticeships',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: 'c858107c-1b98-4818-2731-08d8a11fd8ef',
+                  slug: 'apprenticeships-in-england-by-industry-characteristics',
+                  title:
+                    'Apprenticeships in England by industry characteristics ',
+                  isSuperseded: false,
+                },
+                {
+                  id: '9c2209b2-a702-439b-bece-08da1714e874',
+                  slug: 'career-pathways-post-16-qualifications-held-by-employees',
+                  title:
+                    'Career pathways: post-16 qualifications held by employees',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'a2778204-c541-404a-85aa-08da115e8407',
+                  slug: 'detailed-destinations-of-16-to-18-year-olds-in-further-education',
+                  title:
+                    'Detailed destinations of 16 to 18 year olds in Further Education',
+                  isSuperseded: false,
+                },
+                {
+                  id: '1aa10012-ee64-4ece-f4b1-08d8b7d3c33b',
+                  slug: 'fe-learners-going-into-employment-and-learning-destinations-by-local-authority-district',
+                  title:
+                    'FE learners going into employment and learning destinations by local authority district',
+                  isSuperseded: false,
+                },
+                {
+                  id: '13b81bcb-e8cd-4431-9807-ca588fd1d02a',
+                  slug: 'further-education-and-skills',
+                  title: 'Further education and skills',
+                  isSuperseded: false,
+                },
+                {
+                  id: '9ddd7d28-a0cd-40e9-74a9-08de751c53dd',
+                  slug: 'further-education-college-workforce-using-teacher-pension-data',
+                  title:
+                    'Further education college workforce using teacher pension data',
+                  isSuperseded: false,
+                },
+                {
+                  id: '11d3385f-8d48-4e07-1255-08db886b552e',
+                  slug: 'further-education-workforce',
+                  title: 'Further education workforce',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'ffc387d9-0836-435b-30d6-08dacbc13895',
+                  slug: 'skills-bootcamps-starts',
+                  title: 'Skills Bootcamps starts',
+                  supersededBy: {
+                    id: 'ce8ef30f-1b14-45d4-4854-08d99eeed35d',
+                    slug: 'skills-bootcamps-starts-completions-and-outcomes',
+                    title: 'Skills bootcamps starts, completions and outcomes',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: 'ce8ef30f-1b14-45d4-4854-08d99eeed35d',
+                  slug: 'skills-bootcamps-starts-completions-and-outcomes',
+                  title: 'Skills bootcamps starts, completions and outcomes',
+                  isSuperseded: false,
+                },
+                {
+                  id: '1d44a317-2128-4359-84c3-08dc5dea63ea',
+                  slug: 'supply-of-skills-for-jobs-in-science-and-technology',
+                  title: 'Supply of skills for jobs in science and technology',
+                  isSuperseded: false,
+                },
+              ],
+            },
+            {
+              id: '2ca22e34-b87a-4281-a0eb-b80f4f8dd374',
+              summary:
+                'Including university graduate employment, graduate labour market and participation statistics',
+              title: 'Higher education',
+              publications: [
+                {
+                  id: '8008b2e4-a23f-459b-1ec9-08dad132b8b4',
+                  slug: 'foundation-years-statistics',
+                  title:
+                    'Foundation year participation, provision and outcomes at HE providers',
+                  isSuperseded: false,
+                },
+                {
+                  id: '42a888c4-9ee7-40fd-9128-f5de546780b3',
+                  slug: 'graduate-labour-markets',
+                  title: 'Graduate labour market statistics',
+                  isSuperseded: false,
+                },
+                {
+                  id: '2d629fad-d66d-46d8-849d-08d8b249ed05',
+                  slug: 'graduate-outcomes-leo',
+                  title: 'Graduate outcomes (LEO)',
+                  supersededBy: {
+                    id: 'b329f8e4-4191-4f0c-66a8-08d9daa3b093',
+                    slug: 'leo-graduate-and-postgraduate-outcomes',
+                    title: 'LEO Graduate and Postgraduate Outcomes',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: '4d29c28c-efd1-4245-a80c-b55c6a50e3f7',
+                  slug: 'graduate-outcomes-leo-postgraduate-outcomes',
+                  title: 'Graduate outcomes (LEO): postgraduate outcomes',
+                  supersededBy: {
+                    id: 'b329f8e4-4191-4f0c-66a8-08d9daa3b093',
+                    slug: 'leo-graduate-and-postgraduate-outcomes',
+                    title: 'LEO Graduate and Postgraduate Outcomes',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: '4fc3a5e3-7f33-49a7-028e-08dc39e23fcc',
+                  slug: 'higher-education-entrants-and-qualifiers-by-their-level-2-and-3-attainment',
+                  title:
+                    'Higher Education Entrants and Qualifiers by their Level 2 and 3 Attainment',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'e926dcde-e610-4721-ea39-08d968ac9105',
+                  slug: 'higher-level-learners-in-england',
+                  title: 'Higher Level Learners in England',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'b329f8e4-4191-4f0c-66a8-08d9daa3b093',
+                  slug: 'leo-graduate-and-postgraduate-outcomes',
+                  title: 'LEO Graduate and Postgraduate Outcomes',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'f27b380e-98a6-4b1a-9d98-f7b7a5392032',
+                  slug: 'graduate-outcomes-leo-provider-level-data',
+                  title: 'LEO Graduate outcomes provider level data',
+                  isSuperseded: false,
+                },
+                {
+                  id: '0c67bbdb-4eb0-41cf-a62e-2589cee58538',
+                  slug: 'participation-measures-in-higher-education',
+                  title: 'Participation measures in higher education',
+                  isSuperseded: false,
+                },
+                {
+                  id: '04b59c44-bfb8-4d7d-841d-08d9a365444f',
+                  slug: 'uk-revenue-from-education-related-exports-and-transnational-education-activity',
+                  title:
+                    'UK revenue from education related exports and transnational education activity',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'c28f7aca-f1e8-4916-8ce3-fc177b140695',
+                  slug: 'widening-participation-in-higher-education',
+                  title: 'Widening participation in higher education',
+                  isSuperseded: false,
+                },
+              ],
+            },
+            {
+              id: '291cb3a2-4a29-4ff6-db25-08dcc348573e',
+              summary: 'Including occupations in demand',
+              title: 'Labour market and skills',
+              publications: [
+                {
+                  id: '36097731-f107-4e6c-e2e7-08dcc3489646',
+                  slug: 'occupations-in-demand',
+                  title: 'Occupations in demand',
+                  isSuperseded: false,
+                },
+              ],
+            },
+            {
+              id: 'ee1855ca-d1e1-4f04-a795-cbd61d326a1f',
+              summary:
+                'Including absence, application and offers, capacity, exclusion and special educational needs (SEN) statistics',
+              title: 'Pupils and schools',
+              publications: [
+                {
+                  id: '4e9eb1f5-8440-4e39-2d3e-08d93a1d8d28',
+                  slug: 'academy-transfers-and-funding',
+                  title: 'Academy transfers and funding',
+                  isSuperseded: false,
+                },
+                {
+                  id: '123461ab-50be-45d9-8523-c5241a2c9c5b',
+                  slug: 'admission-appeals-in-england',
+                  title: 'Admission appeals in England',
+                  isSuperseded: false,
+                },
+                {
+                  id: '34a2c514-d603-4246-f47b-08db2568bd10',
+                  slug: 'children-missing-education',
+                  title: 'Children missing education',
+                  isSuperseded: false,
+                },
+                {
+                  id: '8a3aafe8-4191-4a62-f479-08db2568bd10',
+                  slug: 'education-children-s-social-care-and-offending-local-authority-level-dashboard',
+                  title:
+                    'Education, children’s social care and offending: local authority level dashboard',
+                  isSuperseded: false,
+                },
+                {
+                  id: '88312cc0-fe1d-4ab5-81df-33fd708185cb',
+                  slug: 'education-health-and-care-plans',
+                  title: 'Education, health and care plans',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'a5b2d325-d8a2-4cad-f47a-08db2568bd10',
+                  slug: 'elective-home-education',
+                  title: 'Elective home education',
+                  isSuperseded: false,
+                },
+                {
+                  id: '23a9962f-37ef-4b1c-8077-08dda2b70e1a',
+                  slug: 'estimate-of-additional-children-claiming-free-school-meals-following-expansion-of-eligibility',
+                  title:
+                    'Estimate of additional children claiming Free School Meals following expansion of eligibility',
+                  isSuperseded: false,
+                },
+                {
+                  id: '346a6978-9ee5-4b63-0ce1-08d88fd5ace1',
+                  slug: 'free-school-meals-autumn-term',
+                  title: 'Free school meals: Autumn term',
+                  supersededBy: {
+                    id: 'a91d9e05-be82-474c-85ae-4913158406d0',
+                    slug: 'school-pupils-and-their-characteristics',
+                    title: 'Schools, pupils and their characteristics',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: '5c066362-9e14-4688-4f8a-08d83303033f',
+                  slug: 'local-authority-school-places-scorecards',
+                  title: 'Local authority school places scorecards',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'aa545525-9ffe-496c-a5b3-974ace56746e',
+                  slug: 'national-pupil-projections',
+                  title: 'National pupil projections',
+                  isSuperseded: false,
+                },
+                {
+                  id: '71cfcea3-359c-4089-722e-08da07fcb6c9',
+                  slug: 'national-tutoring-programme',
+                  title: 'National Tutoring Programme',
+                  isSuperseded: false,
+                },
+                {
+                  id: '86af24dc-67c4-47f0-a849-e94c7a1cfe9b',
+                  slug: 'parental-responsibility-measures',
+                  title: 'Parental responsibility measures',
+                  isSuperseded: false,
+                },
+                {
+                  id: '66c8e9db-8bf2-4b0b-b094-cfab25c20b05',
+                  slug: 'primary-and-secondary-school-applications-and-offers',
+                  title: 'Primary and secondary school applications and offers',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'cbbd299f-8297-44bc-92ac-558bcf51f8ad',
+                  slug: 'pupil-absence-in-schools-in-england',
+                  title: 'Pupil absence in schools in England',
+                  isSuperseded: false,
+                },
+                {
+                  id: '14953fda-02ff-45ed-9573-3a7a0ad8cb10',
+                  slug: 'pupil-absence-in-schools-in-england-autumn-and-spring-terms',
+                  title:
+                    'Pupil absence in schools in England: autumn and spring terms',
+                  supersededBy: {
+                    id: 'cbbd299f-8297-44bc-92ac-558bcf51f8ad',
+                    slug: 'pupil-absence-in-schools-in-england',
+                    title: 'Pupil absence in schools in England',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: '6c388293-d027-4f74-8d74-29a42e02231c',
+                  slug: 'pupil-absence-in-schools-in-england-autumn-term',
+                  title: 'Pupil absence in schools in England: autumn term',
+                  supersededBy: {
+                    id: 'cbbd299f-8297-44bc-92ac-558bcf51f8ad',
+                    slug: 'pupil-absence-in-schools-in-england',
+                    title: 'Pupil absence in schools in England',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: '9676af6b-d563-41f4-d071-08da8f468680',
+                  slug: 'pupil-attendance-in-schools',
+                  title: 'Pupil attendance in schools',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'f022fa36-ebb9-4e88-acd9-08d870f85341',
+                  slug: 'pupil-yield-from-housing-developments',
+                  title: 'Pupil yield from housing developments',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'fa591a15-ae37-41b5-98f6-4ce06e5225f4',
+                  slug: 'school-capacity',
+                  title: 'School capacity',
+                  isSuperseded: false,
+                },
+                {
+                  id: '26d77b31-e11a-4ef1-866d-08da3d724347',
+                  slug: 'school-placements-for-children-from-outside-of-the-uk',
+                  title:
+                    'School placements for children from outside of the UK',
+                  isSuperseded: false,
+                },
+                {
+                  id: '4cd161ca-468f-4023-9b91-08d8d4cdc4e0',
+                  slug: 'school-places-sufficiency-survey',
+                  title: 'School places sufficiency survey',
+                  isSuperseded: false,
+                },
+                {
+                  id: '95b66a3e-6b1c-43f0-25a6-08dd868ff134',
+                  slug: 'schools-eligible-for-rise-intervention',
+                  title: 'Schools eligible for RISE intervention',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'a91d9e05-be82-474c-85ae-4913158406d0',
+                  slug: 'school-pupils-and-their-characteristics',
+                  title: 'Schools, pupils and their characteristics',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'f657afb4-8f4a-427d-a683-15f11a2aefb5',
+                  slug: 'special-educational-needs-in-england',
+                  title: 'Special educational needs in England',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'bf2b4284-6b84-46b0-aaaa-a2e0a23be2a9',
+                  slug: 'suspensions-and-permanent-exclusions-in-england',
+                  title: 'Suspensions and permanent exclusions in England',
+                  isSuperseded: false,
+                },
+                {
+                  id: '729bac29-9204-4b9f-2426-08d9fdd01d19',
+                  slug: 'the-link-between-absence-and-attainment-at-ks2-and-ks4',
+                  title:
+                    'The link between absence and attainment at KS2 and KS4',
+                  isSuperseded: false,
+                },
+              ],
+            },
+            {
+              id: '74648781-85a9-4233-8be3-fe6f137165f4',
+              summary: 'Including GCSE and key stage statistics',
+              title: 'School and college outcomes and performance',
+              publications: [
+                {
+                  id: '3f3a66ec-5777-42ee-b427-8102a14ce0c5',
+                  slug: 'a-level-and-other-16-to-18-results',
+                  title: 'A level and other 16 to 18 results',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'bc4815bf-f3dc-477b-7559-08da5f64dcf1',
+                  slug: 'key-stage-1-and-phonics-screening-check-attainment',
+                  title: 'Key stage 1 and phonics screening check attainment',
+                  supersededBy: {
+                    id: '5becb18e-852b-4cdf-e2e8-08dcc3489646',
+                    slug: 'phonics-screening-check-attainment',
+                    title: 'Phonics screening check attainment',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: '8b7474f9-5870-4ecc-7557-08da5f64dcf1',
+                  slug: 'key-stage-2-attainment',
+                  title: 'Key stage 2 attainment',
+                  isSuperseded: false,
+                },
+                {
+                  id: '10370062-93b0-4dde-9097-5a56bf5b3064',
+                  slug: 'key-stage-2-attainment-national-headlines',
+                  title: 'Key stage 2 attainment: National headlines',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'c8756008-ed50-4632-9b96-01b5ca002a43',
+                  slug: 'key-stage-4-performance',
+                  title: 'Key stage 4 performance',
+                  isSuperseded: false,
+                },
+                {
+                  id: '2e95f880-629c-417b-981f-0901e97776ff',
+                  slug: 'level-2-and-3-attainment-by-young-people-aged-19',
+                  title: 'Level 2 and 3 attainment age 16 to 25',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'd61988ae-f325-45df-8246-08dac639349a',
+                  slug: 'multi-academy-trust-performance-measures-key-stages-2-4-and-5',
+                  title:
+                    'Multi-academy trust performance measures (Key stages 2, 4 and 5)',
+                  supersededBy: {
+                    id: '8b7474f9-5870-4ecc-7557-08da5f64dcf1',
+                    slug: 'key-stage-2-attainment',
+                    title: 'Key stage 2 attainment',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: 'eab51107-4ef0-4926-8f8b-c8bd7f5a21d5',
+                  slug: 'multi-academy-trust-performance-measures-at-key-stage-2',
+                  title:
+                    'Multi-academy trust performance measures at key stage 2',
+                  supersededBy: {
+                    id: 'd61988ae-f325-45df-8246-08dac639349a',
+                    slug: 'multi-academy-trust-performance-measures-key-stages-2-4-and-5',
+                    title:
+                      'Multi-academy trust performance measures (Key stages 2, 4 and 5)',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: '13484f09-40e7-4b8b-7558-08da5f64dcf1',
+                  slug: 'multiplication-tables-check-attainment',
+                  title: 'Multiplication tables check attainment',
+                  isSuperseded: false,
+                },
+                {
+                  id: '5becb18e-852b-4cdf-e2e8-08dcc3489646',
+                  slug: 'phonics-screening-check-attainment',
+                  title: 'Phonics screening check attainment',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'd6d6ef58-2fad-4ef4-1c62-08da6faca262',
+                  slug: 'provisional-t-level-results',
+                  title: 'Provisional T Level results',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'b99702f4-a277-4f1b-eba8-08dd9f501d22',
+                  slug: 'school-counts-by-average-progress-8-scores-for-disadvantaged-white-british-pupils',
+                  title:
+                    'School counts by average Progress 8 scores for disadvantaged White British pupils',
+                  isSuperseded: false,
+                },
+              ],
+            },
+            {
+              id: 'b601b9ea-b1c7-4970-b354-d1f695c446f1',
+              summary: 'Including initial teacher training (ITT) statistics',
+              title: 'Teachers and school workforce',
+              publications: [
+                {
+                  id: '4946c7e4-5ab4-48d4-5932-08db04473582',
+                  slug: 'ecf-and-npq-starts',
+                  title: 'ECF and NPQ starts',
+                  isSuperseded: false,
+                },
+                {
+                  id: '465d5a87-dba8-49ee-b7e3-08d86b7beb8f',
+                  slug: 'initial-teacher-training-census',
+                  title: 'Initial Teacher Training Census',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'd34978d5-0317-46bc-9258-13412270ac4d',
+                  slug: 'initial-teacher-training-performance-profiles',
+                  title: 'Initial teacher training performance profiles',
+                  isSuperseded: false,
+                },
+                {
+                  id: '5dbac9b4-522f-46fa-20fd-08dc73fd4523',
+                  slug: 'median-teacher-pay-using-teacher-pension-scheme-data',
+                  title: 'Median teacher pay using teacher pension scheme data',
+                  supersededBy: {
+                    id: 'b318967f-2931-472a-93f2-fbed1e181e6a',
+                    slug: 'school-workforce-in-england',
+                    title: 'School workforce in England',
+                  },
+                  isSuperseded: true,
+                },
+                {
+                  id: '02e502cd-6333-4c28-a535-08da004ba44f',
+                  slug: 'postgraduate-initial-teacher-training-targets',
+                  title: 'Postgraduate initial teacher training targets',
+                  isSuperseded: false,
+                },
+                {
+                  id: '8132cffb-8ecb-4f7c-d1a0-08ddec782b96',
+                  slug: 'school-leadership-retention',
+                  title: 'School Leadership retention',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'b318967f-2931-472a-93f2-fbed1e181e6a',
+                  slug: 'school-workforce-in-england',
+                  title: 'School workforce in England',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'b3134103-1297-4758-4654-08da2e6fc320',
+                  slug: 'teacher-and-leader-development-ecf-and-npqs',
+                  title: 'Teacher and leader development: ECF and NPQs',
+                  isSuperseded: false,
+                },
+                {
+                  id: 'baaa0baa-a1cc-4400-87be-08de79e5cea5',
+                  slug: 'teacher-demand-and-postgraduate-trainee-need',
+                  title: 'Teacher demand and postgraduate trainee need',
+                  isSuperseded: false,
+                },
+              ],
+            },
+            {
+              id: 'a95d2ca2-a969-4320-b1e9-e4781112574a',
+              summary:
+                'Including summarised expenditure, post-compulsory education, qualification and school statistics',
+              title: 'UK education and training statistics',
+              publications: [
+                {
+                  id: '2ffbc8d3-eb53-4c4b-a6fb-219a5b95ebc8',
+                  slug: 'education-and-training-statistics-for-the-uk',
+                  title: 'Education and training statistics for the UK',
+                  isSuperseded: false,
+                },
+                {
+                  id: '3c1ba528-aa57-4b9c-347a-08dad90fbd2f',
+                  slug: 'employer-skills-survey',
+                  title: 'Employer Skills Survey ',
+                  isSuperseded: false,
+                },
+              ],
+            },
+          ]),
+        ),
+    };
+  },
 } as const;
 
 export default publicationQueries;

--- a/src/explore-education-statistics-frontend/src/services/azureDataSetService.ts
+++ b/src/explore-education-statistics-frontend/src/services/azureDataSetService.ts
@@ -10,6 +10,7 @@ import { PaginatedList } from '@common/services/types/pagination';
 
 export interface AzureDataSetIndexItem {
   '@search.score': string;
+  dataSetFileId: string;
   fileId: string;
   filename: string;
   fileExtension: string;
@@ -41,14 +42,6 @@ export interface AzureDataSetIndexItem {
   };
 }
 
-// export interface AzureDataSetSuggestResult {
-//   highlightedMatch: string;
-//   releaseSlug: string;
-//   publicationSlug: string;
-//   summary: string;
-//   title: string;
-// }
-
 export interface AzureDataSetListRequest {
   filter?: string;
   orderBy?: AzureOrderByParam;
@@ -64,11 +57,6 @@ const azureDataSetService = {
   ): Promise<PaginatedList<DataSetFileSummary>> {
     return frontendApi.post(`/search-datasets`, { searchOptions: params });
   },
-  // async suggestPublications(
-  //   params: AzureDataSetListRequest,
-  // ): Promise<AzureDataSetSuggestResult[]> {
-  //   return frontendApi.post(`/suggest-datasets`, { searchOptions: params });
-  // },
 };
 
 export default azureDataSetService;

--- a/src/explore-education-statistics-frontend/src/services/azureDataSetService.ts
+++ b/src/explore-education-statistics-frontend/src/services/azureDataSetService.ts
@@ -54,10 +54,8 @@ export interface AzureDataSetListRequest {
   orderBy?: AzureOrderByParam;
   page?: number;
   pageSize?: number;
-  releaseType?: string;
   search?: string;
   sortDirection?: SortDirection;
-  themeId?: string;
 }
 
 const azureDataSetService = {

--- a/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
+++ b/src/explore-education-statistics-frontend/src/services/azurePublicationService.ts
@@ -65,6 +65,14 @@ const azurePublicationService = {
   ): Promise<AzurePublicationSuggestResult[]> {
     return frontendApi.post(`/suggest-publications`, { searchOptions: params });
   },
+  // Used for the 'search data' prototype
+  async listStatisticalReleases(
+    params: AzurePublicationListRequest,
+  ): Promise<PaginatedList<PublicationListSummary>> {
+    return frontendApi.post(`/search-statistical-releases`, {
+      searchOptions: params,
+    });
+  },
 };
 
 export default azurePublicationService;


### PR DESCRIPTION
This PR amends the filters on the prototype 'search data / search releases' pages to be:
- collapsible filter groups instead of always showing
- allow multiple filter items for some filter items
  - this required making a new api route for searching releases, duping and amending the existing find stats one, as the existing one only allowed filtering single items
- add geographic levels to the data search
- make the filter column sticky
- add a combined theme and releases (publication) filter group for the data page 
  - (but keep just the theme filter for the search releases page)
  - has a search with basic text matching/filtering for themes and releases
  - has toggleable view of the publications within each release
  - updates themeIds and publicationIds if a parent or child is toggled
  - requires getting the theme/publication tree, which I've hardcoded some data from prod for, as the indexed data sets are from prod... Not sure if there's a better way of handling this for the prototype stage. Not a fan of hardcoding so much data but don't see a good alternative
 
### Other changes:
- made the page container width 'wide'
- fix the id we're using for the data set results
- Wrap legend text in a visually hidden span, as even though the legend itself was visually hidden it was still causing overflow

### Differences to the design discussed and agreed with Marv:
- Chevron style matches elsewhere on our site and the GDS, rather than custom arrows
- Geographic level items won't be sorted for now (are just displayed alphabetically) and we also show them all. We may revisit this later on to add custom sorting and collapsible set of options.

### Changes yet to make
- Adding in the new modal help content for 'What is [filter type]?' groups. Will add this in a later ticket.
- Adding in jest tests for the new components - will create a ticket for this now.

### Screenshots:

**Before**:

<img width="684" height="882" alt="image" src="https://github.com/user-attachments/assets/58a20a5e-ba1b-42fc-a8de-1484160b9ab0" />

---

**Statistical releases tab retains original filters, but collapsible:**

<img width="459" height="394" alt="image" src="https://github.com/user-attachments/assets/9dbf3a99-2939-4ef0-848e-8bcb35223225" />

---

**Search data tab has geographic levels as checkboxes, and no results text for the theme search**

<img width="424" height="782" alt="image" src="https://github.com/user-attachments/assets/1d7d48be-1a00-4870-bec7-f08cde847781" />

---

**Search results and mix of themes/releases checked:**

<img width="1065" height="1055" alt="image" src="https://github.com/user-attachments/assets/21935644-550a-4086-b339-743439ae7d23" />
