### PR TITLE
🐛 EES-7134 Prevent the 'Files' step from complete publishing early for scheduled releases versions after EES-7022

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/IPublisherClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/IPublisherClient.cs
@@ -5,10 +5,7 @@ public interface IPublisherClient
 {
     Task PublishMethodologyFiles(Guid methodologyId, CancellationToken cancellationToken = default);
 
-    Task PublishReleaseFiles(
-        IReadOnlyList<ReleasePublishingKey> releasePublishingKeys,
-        CancellationToken cancellationToken = default
-    );
+    Task PublishReleaseFiles(PublishReleaseFilesMessage message, CancellationToken cancellationToken = default);
 
     Task PublishTaxonomy(CancellationToken cancellationToken = default);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherClient.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherClient.cs
@@ -17,13 +17,13 @@ public class PublisherClient(string connectionString) : IPublisherClient
     }
 
     public async Task PublishReleaseFiles(
-        IReadOnlyList<ReleasePublishingKey> releasePublishingKeys,
+        PublishReleaseFilesMessage message,
         CancellationToken cancellationToken = default
     )
     {
         await _queueServiceClient.SendMessageAsJson(
             PublisherQueues.PublishReleaseFilesQueue,
-            new PublishReleaseFilesMessage(releasePublishingKeys),
+            message,
             cancellationToken
         );
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherMessages.cs
@@ -7,6 +7,22 @@ public record NotifyChangeMessage(bool Immediate, ReleasePublishingKey ReleasePu
 
 public record PublishMethodologyFilesMessage(Guid MethodologyId);
 
-public record PublishReleaseFilesMessage(IReadOnlyList<ReleasePublishingKey> ReleasePublishingKeys);
+public record PublishReleaseFilesMessage
+{
+    /// <summary>
+    /// Creates a message for immediate publishing of a single release version.
+    /// </summary>
+    public static PublishReleaseFilesMessage ForImmediate(ReleasePublishingKey releasePublishingKey) =>
+        new() { Immediate = true, ReleasePublishingKeys = [releasePublishingKey] };
+
+    /// <summary>
+    /// Creates a message for scheduled publishing of one or more release versions.
+    /// </summary>
+    public static PublishReleaseFilesMessage ForScheduled(IReadOnlyList<ReleasePublishingKey> releasePublishingKeys) =>
+        new() { Immediate = false, ReleasePublishingKeys = releasePublishingKeys };
+
+    public required bool Immediate { get; init; }
+    public required IReadOnlyList<ReleasePublishingKey> ReleasePublishingKeys { get; init; }
+}
 
 public record PublishTaxonomyMessage;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleasePublishingStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleasePublishingStatus.cs
@@ -111,8 +111,6 @@ public class ReleasePublishingStatus : ITableEntity
         OverallStage = _state.Overall.ToString();
     }
 
-    public bool AllStagesPriorToPublishingComplete() => State.Files == ReleasePublishingStatusFilesStage.Complete;
-
     public ReleasePublishingKey AsTableRowKey()
     {
         return new ReleasePublishingKey(ReleaseVersionId, Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ReleasePublishingStatusServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Builders/Services/ReleasePublishingStatusServiceMockBuilder.cs
@@ -48,19 +48,6 @@ public class ReleasePublishingStatusServiceMockBuilder
             );
         }
 
-        public void UpdatePublishingStageWasNotCalled(ReleasePublishingKey key)
-        {
-            mock.Verify(
-                m =>
-                    m.UpdatePublishingStage(
-                        key,
-                        It.IsAny<ReleasePublishingStatusPublishingStage>(),
-                        It.IsAny<ReleasePublishingStatusLogMessage?>()
-                    ),
-                Times.Never
-            );
-        }
-
         public void UpdatePublishingStageWasCalled(
             ReleasePublishingKey key,
             ReleasePublishingStatusPublishingStage publishingStage

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingCompletionServiceTests.cs
@@ -58,753 +58,657 @@ public class PublishingCompletionServiceTests
         }
     }
 
-    public class CompletePublishingIfAllPriorStagesCompleteTests : PublishingCompletionServiceTests
+    public class CompletePublishingTests : PublishingCompletionServiceTests
     {
-        public class NotReadyTests : CompletePublishingIfAllPriorStagesCompleteTests
+        /*
+         * Given
+         *      Publication 1
+         *      - with Release Version 1
+         *          - Id: ReleaseVersionId1
+         *
+         *      Publication 2
+         *      - with Release Version 2
+         *          - Id: ReleaseVersionId2
+         */
+        private static readonly Guid PublicationId1 = Guid.NewGuid();
+        private static readonly Guid PublicationId2 = Guid.NewGuid();
+
+        private ReleaseVersion _releaseVersion1 = null!;
+        private ReleaseVersion _releaseVersion2 = null!;
+
+        private IReadOnlyList<ReleasePublishingKey> SetupHappyPath(
+            Func<PublicationBuilder, PublicationBuilder>? publication1BuilderModification = null
+        )
+        {
+            // Create some sample publications
+            publication1BuilderModification ??= (publicationBuilder) => publicationBuilder;
+            var publication1 = publication1BuilderModification(
+                    new PublicationBuilder(PublicationId1, "publication-slug-1")
+                )
+                .Build();
+
+            var publication2 = new PublicationBuilder(PublicationId2, "publication-slug-2").Build();
+
+            // Create some sample release versions
+            _releaseVersion1 = new ReleaseVersionBuilder()
+                .WithPublicationId(publication1.Id)
+                .ForRelease(release => release.WithReleaseSlug("release-slug-1"))
+                .Build();
+
+            _releaseVersion2 = new ReleaseVersionBuilder()
+                .WithPublicationId(publication2.Id)
+                .ForRelease(release => release.WithReleaseSlug("release-slug-2"))
+                .Build();
+
+            // Assign the release versions a status id
+            ReleasePublishingKey[] keys =
+            [
+                new(_releaseVersion1.Id, ReleaseStatusId: Guid.NewGuid()),
+                new(_releaseVersion2.Id, ReleaseStatusId: Guid.NewGuid()),
+            ];
+
+            // Set the Status Service to return a status where the 'Files' stage will already be Complete.
+            foreach (var key in keys)
+            {
+                _releasePublishingStatusService.WhereGetReturns(
+                    key,
+                    new ReleasePublishingStatusBuilder(key)
+                        .WhereFilesStatusIs(ReleasePublishingStatusFilesStage.Complete)
+                        .Build()
+                );
+            }
+
+            // Add Release Versions and their Publications to the mock Database
+            _contentDbContext.With(_releaseVersion1);
+            _contentDbContext.With(_releaseVersion2);
+            _contentDbContext.With(publication1);
+            _contentDbContext.With(publication2);
+
+            // Add release versions to release service
+            _releaseService.WhereGetReturns(_releaseVersion1);
+            _releaseService.WhereGetReturns(_releaseVersion2);
+
+            // Set the latest published release version for each publication expected after publishing
+            _releaseService.WherePublicationLatestPublishedReleaseVersionIs(PublicationId1, _releaseVersion1);
+            _releaseService.WherePublicationLatestPublishedReleaseVersionIs(PublicationId2, _releaseVersion2);
+
+            return keys;
+        }
+
+        public class UpdatePublishingStageTests : CompletePublishingTests
         {
             [Fact]
-            public async Task WhenNoPublicationsReady_ThenNothingHappens()
+            public async Task PublishingStatusSetToStarted()
             {
                 // ARRANGE
-                ReleasePublishingKey releasePublishingKey1 = new(Guid.NewGuid(), Guid.NewGuid());
-                var releasePublishingStatus1 = new ReleasePublishingStatusBuilder(releasePublishingKey1)
-                    .WhereFilesStatusIs(ReleasePublishingStatusFilesStage.NotStarted)
-                    .Build();
-
-                ReleasePublishingKey releasePublishingKey2 = new(Guid.NewGuid(), Guid.NewGuid());
-                var releasePublishingStatus2 = new ReleasePublishingStatusBuilder(releasePublishingKey2)
-                    .WhereFilesStatusIs(ReleasePublishingStatusFilesStage.Started)
-                    .Build();
-
-                var notReadyKeys = new List<ReleasePublishingKey>() { releasePublishingKey1, releasePublishingKey2 };
-
-                _releasePublishingStatusService
-                    .WhereGetReturns(releasePublishingKey1, releasePublishingStatus1)
-                    .WhereGetReturns(releasePublishingKey2, releasePublishingStatus2);
+                var keys = SetupHappyPath();
 
                 var sut = GetSut();
 
                 // ACT
-                await sut.CompletePublishingIfAllPriorStagesComplete(notReadyKeys);
+                await sut.CompletePublishing(keys);
 
                 // ASSERT
-                _releasePublishingStatusService.Assert.UpdatePublishingStageWasNotCalled();
+                // Update Publishing Stage Was Called
+                foreach (var key in keys)
+                {
+                    _releasePublishingStatusService.Assert.UpdatePublishingStageWasCalled(
+                        key,
+                        ReleasePublishingStatusPublishingStage.Started
+                    );
+                }
+            }
+
+            [Fact]
+            public async Task PublishingStatusSetToComplete()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                // Keys were set to Completed at the end
+                foreach (var key in keys)
+                {
+                    _releasePublishingStatusService.Assert.UpdatePublishingStageWasCalled(
+                        key,
+                        ReleasePublishingStatusPublishingStage.Complete
+                    );
+                }
             }
         }
 
-        public class ReadyTests : CompletePublishingIfAllPriorStagesCompleteTests
+        public class ReleaseServiceTests : CompletePublishingTests
         {
-            /*
-             * Given
-             *      Publication 1
-             *      - with Release Version 1
-             *          - Id: ReleaseVersionId1
-             *          - Status: Complete
-             *
-             *      Publication 2
-             *      - with Release Version 2
-             *          - Id: ReleaseVersionId2
-             *          - Status: Complete
-             *
-             */
-            private static readonly Guid PublicationId1 = Guid.NewGuid();
-            private static readonly Guid PublicationId2 = Guid.NewGuid();
+            [Fact]
+            public async Task CompletePublishingCalledOnReleaseService()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var sut = GetSut();
 
-            private ReleaseVersion _releaseVersion1 = null!;
-            private ReleaseVersion _releaseVersion2 = null!;
+                // ACT
+                await sut.CompletePublishing(keys);
 
-            private IReadOnlyList<ReleasePublishingKey> SetupHappyPath(
-                Func<PublicationBuilder, PublicationBuilder>? publication1BuilderModification = null
+                // ASSERT
+                foreach (var key in keys)
+                {
+                    _releaseService.Assert.CompletePublishingWasCalled(key.ReleaseVersionId);
+                }
+            }
+        }
+
+        public class MethodologiesTests : CompletePublishingTests
+        {
+            private void SetupNoMethodologies(Guid releaseVersionId)
+            {
+                var releaseVersion = _releaseService.Get(releaseVersionId);
+                _methodologyService.WhereGetLatestVersionByReleaseReturnsNoMethodologies(releaseVersion);
+            }
+
+            private void SetupMethodologies(Guid releaseVersionId, MethodologyVersion methodologyToPublish)
+            {
+                var releaseVersion = _releaseService.Get(releaseVersionId);
+                _methodologyService.WhereGetLatestVersionByReleaseReturns(releaseVersion, methodologyToPublish);
+                _methodologyService.WhereIsBeingPublishedAlongsideRelease(methodologyToPublish, releaseVersion);
+            }
+
+            private void SetupMethodologies(
+                Guid releaseVersionId,
+                MethodologyVersion methodologyToPublish,
+                MethodologyVersion methodologyNotToPublish
             )
             {
-                // Create some sample publications
-                publication1BuilderModification ??= (publicationBuilder) => publicationBuilder;
-                var publication1 = publication1BuilderModification(
-                        new PublicationBuilder(PublicationId1, "publication-slug-1")
-                    )
-                    .Build();
-
-                var publication2 = new PublicationBuilder(PublicationId2, "publication-slug-2").Build();
-
-                // Create some sample release versions
-                _releaseVersion1 = new ReleaseVersionBuilder()
-                    .WithPublicationId(publication1.Id)
-                    .ForRelease(release => release.WithReleaseSlug("release-slug-1"))
-                    .Build();
-
-                _releaseVersion2 = new ReleaseVersionBuilder()
-                    .WithPublicationId(publication2.Id)
-                    .ForRelease(release => release.WithReleaseSlug("release-slug-2"))
-                    .Build();
-
-                // Assign the release versions a status id
-                ReleasePublishingKey[] readyKeys =
-                [
-                    new(_releaseVersion1.Id, ReleaseStatusId: Guid.NewGuid()),
-                    new(_releaseVersion2.Id, ReleaseStatusId: Guid.NewGuid()),
-                ];
-
-                // Set the Status Service to report on whether a release version is ready to be published or not ie Complete
-                foreach (var readyKey in readyKeys)
-                {
-                    _releasePublishingStatusService.WhereGetReturns(
-                        readyKey,
-                        new ReleasePublishingStatusBuilder(readyKey)
-                            .WhereFilesStatusIs(ReleasePublishingStatusFilesStage.Complete)
-                            .Build()
-                    );
-                }
-
-                // Add Release Versions and their Publications to the mock Database
-                _contentDbContext.With(_releaseVersion1);
-                _contentDbContext.With(_releaseVersion2);
-                _contentDbContext.With(publication1);
-                _contentDbContext.With(publication2);
-
-                // Add release versions to release service
-                _releaseService.WhereGetReturns(_releaseVersion1);
-                _releaseService.WhereGetReturns(_releaseVersion2);
-
-                // Set the latest published release version for each publication expected after publishing
-                _releaseService.WherePublicationLatestPublishedReleaseVersionIs(PublicationId1, _releaseVersion1);
-                _releaseService.WherePublicationLatestPublishedReleaseVersionIs(PublicationId2, _releaseVersion2);
-
-                return readyKeys;
+                var releaseVersion = _releaseService.Get(releaseVersionId);
+                _methodologyService.WhereGetLatestVersionByReleaseReturns(
+                    releaseVersion,
+                    methodologyToPublish,
+                    methodologyNotToPublish
+                );
+                _methodologyService.WhereIsBeingPublishedAlongsideRelease(methodologyToPublish, releaseVersion);
+                _methodologyService.WhereIsNotBeingPublishedAlongsideRelease(methodologyNotToPublish, releaseVersion);
             }
 
-            public class UpdatePublishingStageTests : ReadyTests
+            [Fact]
+            public async Task WhenNoMethodologies_ThenNoMethodologiesPublished()
             {
-                [Fact]
-                public async Task PublishingStatusSetToStarted()
+                // ARRANGE
+                var keys = SetupHappyPath();
+                foreach (var key in keys)
                 {
-                    // ARRANGE
-                    // Create some other keys that we'll set to "not complete"
-                    ReleasePublishingKey[] notReadyKeys =
-                    [
-                        new(Guid.NewGuid(), Guid.NewGuid()),
-                        new(Guid.NewGuid(), Guid.NewGuid()),
-                    ];
-
-                    foreach (var notReadyKey in notReadyKeys)
-                    {
-                        _releasePublishingStatusService.WhereGetReturns(
-                            notReadyKey,
-                            new ReleasePublishingStatusBuilder(notReadyKey)
-                                .WhereFilesStatusIs(ReleasePublishingStatusFilesStage.NotStarted)
-                                .Build()
-                        );
-                    }
-
-                    var readyKeys = SetupHappyPath();
-                    var allPublishingKeys = readyKeys.Concat(notReadyKeys).ToList();
-
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(allPublishingKeys);
-
-                    // ASSERT
-                    // Update Publishing Stage Was Called
-                    foreach (var readyKey in readyKeys)
-                    {
-                        _releasePublishingStatusService.Assert.UpdatePublishingStageWasCalled(
-                            readyKey,
-                            ReleasePublishingStatusPublishingStage.Started
-                        );
-                    }
-
-                    // Update Publishing Stage Was Not Called
-                    foreach (var notReadyKey in notReadyKeys)
-                    {
-                        _releasePublishingStatusService.Assert.UpdatePublishingStageWasNotCalled(notReadyKey);
-                    }
+                    SetupNoMethodologies(key.ReleaseVersionId);
                 }
 
-                [Fact]
-                public async Task PublishingStatusSetToComplete()
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _methodologyService.Assert.NoMethodologiesPublished();
+            }
+
+            [Fact]
+            public async Task WhenHasMethodology_ThenMethodologyPublished()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var methodologies = new MethodologyVersion[keys.Count];
+
+                for (var i = 0; i < keys.Count; i++)
                 {
-                    // ARRANGE
-                    // Create some other keys that we'll set to "not complete"
-                    ReleasePublishingKey[] notReadyKeys =
-                    [
-                        new(Guid.NewGuid(), Guid.NewGuid()),
-                        new(Guid.NewGuid(), Guid.NewGuid()),
-                    ];
+                    var key = keys[i];
+                    methodologies[i] = new MethodologyVersion();
+                    SetupMethodologies(key.ReleaseVersionId, methodologies[i]);
+                }
 
-                    foreach (var notReadyKey in notReadyKeys)
-                    {
-                        _releasePublishingStatusService.WhereGetReturns(
-                            notReadyKey,
-                            new ReleasePublishingStatusBuilder(notReadyKey)
-                                .WhereFilesStatusIs(ReleasePublishingStatusFilesStage.NotStarted)
-                                .Build()
-                        );
-                    }
+                var sut = GetSut();
 
-                    var readyKeys = SetupHappyPath();
-                    var allPublishingKeys = readyKeys.Concat(notReadyKeys).ToList();
+                // ACT
+                await sut.CompletePublishing(keys);
 
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(allPublishingKeys);
-
-                    // ASSERT
-                    // Keys were set to Completed at the end
-                    foreach (var readyKey in readyKeys)
-                    {
-                        _releasePublishingStatusService.Assert.UpdatePublishingStageWasCalled(
-                            readyKey,
-                            ReleasePublishingStatusPublishingStage.Complete
-                        );
-                    }
-
-                    // Not ready Keys were not set to anything
-                    foreach (var notReadyKey in notReadyKeys)
-                    {
-                        _releasePublishingStatusService.Assert.UpdatePublishingStageWasNotCalled(notReadyKey);
-                    }
+                // ASSERT
+                foreach (var methodology in methodologies)
+                {
+                    _methodologyService.Assert.MethodologyPublished(methodology);
                 }
             }
 
-            public class CompletePublishingTests : ReadyTests
+            [Fact]
+            public async Task WhenHasSomeMethodologiesToPublish_ThenOnlyMethodologiesToBePublishedArePublished()
             {
-                [Fact]
-                public async Task CompletePublishingCalledOnReleaseService()
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var methodologiesToPublish = new MethodologyVersion[keys.Count];
+                var methodologiesNotToPublish = new MethodologyVersion[keys.Count];
+
+                for (var i = 0; i < keys.Count; i++)
                 {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var sut = GetSut();
+                    var key = keys[i];
+                    methodologiesToPublish[i] = new MethodologyVersion();
+                    methodologiesNotToPublish[i] = new MethodologyVersion();
+                    SetupMethodologies(key.ReleaseVersionId, methodologiesToPublish[i], methodologiesNotToPublish[i]);
+                }
 
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
+                var sut = GetSut();
 
-                    // ASSERT
-                    foreach (var readyKey in readyKeys)
-                    {
-                        _releaseService.Assert.CompletePublishingWasCalled(readyKey.ReleaseVersionId);
-                    }
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                foreach (var methodology in methodologiesToPublish)
+                {
+                    _methodologyService.Assert.MethodologyPublished(methodology);
+                }
+
+                foreach (var methodology in methodologiesNotToPublish)
+                {
+                    _methodologyService.Assert.MethodologyNotPublished(methodology);
                 }
             }
+        }
 
-            public class MethodologiesTests : ReadyTests
+        public class UpdatePublicationTests : CompletePublishingTests
+        {
+            [Fact]
+            public async Task WhenPublishedReleaseVersionIsLatestVersion_ThenPublicationLatestReleaseVersionSetToIt()
             {
-                private void SetupNoMethodologies(Guid releaseVersionId)
-                {
-                    var releaseVersion = _releaseService.Get(releaseVersionId);
-                    _methodologyService.WhereGetLatestVersionByReleaseReturnsNoMethodologies(releaseVersion);
-                }
-
-                private void SetupMethodologies(Guid releaseVersionId, MethodologyVersion methodologyToPublish)
-                {
-                    var releaseVersion = _releaseService.Get(releaseVersionId);
-                    _methodologyService.WhereGetLatestVersionByReleaseReturns(releaseVersion, methodologyToPublish);
-                    _methodologyService.WhereIsBeingPublishedAlongsideRelease(methodologyToPublish, releaseVersion);
-                }
-
-                private void SetupMethodologies(
-                    Guid releaseVersionId,
-                    MethodologyVersion methodologyToPublish,
-                    MethodologyVersion methodologyNotToPublish
-                )
-                {
-                    var releaseVersion = _releaseService.Get(releaseVersionId);
-                    _methodologyService.WhereGetLatestVersionByReleaseReturns(
-                        releaseVersion,
-                        methodologyToPublish,
-                        methodologyNotToPublish
-                    );
-                    _methodologyService.WhereIsBeingPublishedAlongsideRelease(methodologyToPublish, releaseVersion);
-                    _methodologyService.WhereIsNotBeingPublishedAlongsideRelease(
-                        methodologyNotToPublish,
-                        releaseVersion
-                    );
-                }
-
-                [Fact]
-                public async Task WhenNoMethodologies_ThenNoMethodologiesPublished()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    foreach (var key in readyKeys)
-                    {
-                        SetupNoMethodologies(key.ReleaseVersionId);
-                    }
-
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _methodologyService.Assert.NoMethodologiesPublished();
-                }
-
-                [Fact]
-                public async Task WhenHasMethodology_ThenMethodologyPublished()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var methodologies = new MethodologyVersion[readyKeys.Count];
-
-                    for (var i = 0; i < readyKeys.Count; i++)
-                    {
-                        var key = readyKeys[i];
-                        methodologies[i] = new MethodologyVersion();
-                        SetupMethodologies(key.ReleaseVersionId, methodologies[i]);
-                    }
-
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    foreach (var methodology in methodologies)
-                    {
-                        _methodologyService.Assert.MethodologyPublished(methodology);
-                    }
-                }
-
-                [Fact]
-                public async Task WhenHasSomeMethodologiesToPublish_ThenOnlyMethodologiesToBePublishedArePublished()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var methodologiesToPublish = new MethodologyVersion[readyKeys.Count];
-                    var methodologiesNotToPublish = new MethodologyVersion[readyKeys.Count];
-
-                    for (var i = 0; i < readyKeys.Count; i++)
-                    {
-                        var key = readyKeys[i];
-                        methodologiesToPublish[i] = new MethodologyVersion();
-                        methodologiesNotToPublish[i] = new MethodologyVersion();
-                        SetupMethodologies(
-                            key.ReleaseVersionId,
-                            methodologiesToPublish[i],
-                            methodologiesNotToPublish[i]
-                        );
-                    }
-
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    foreach (var methodology in methodologiesToPublish)
-                    {
-                        _methodologyService.Assert.MethodologyPublished(methodology);
-                    }
-
-                    foreach (var methodology in methodologiesNotToPublish)
-                    {
-                        _methodologyService.Assert.MethodologyNotPublished(methodology);
-                    }
-                }
-            }
-
-            public class UpdatePublicationTests : ReadyTests
-            {
-                [Fact]
-                public async Task WhenPublishedReleaseVersionIsLatestVersion_ThenPublicationLatestReleaseVersionSetToIt()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _contentDbContext.Assert.PublicationsLatestPublishedReleaseVersionIdIs(
-                        PublicationId1,
-                        _releaseVersion1.Id
-                    );
-                    _contentDbContext.Assert.PublicationsLatestPublishedReleaseVersionIdIs(
-                        PublicationId2,
-                        _releaseVersion2.Id
-                    );
-                }
-
-                [Fact]
-                public async Task WhenPublishedReleaseVersionIsNotLatestVersion_ThenPublicationLatestReleaseVersionSetToLatestReleaseVersion()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-
-                    var releaseVersionId1V2 = Guid.NewGuid();
-                    var releaseVersion1V2 = new ReleaseVersionBuilder(releaseVersionId1V2)
-                        .ForRelease(_releaseVersion1.Release)
-                        .Build();
-
-                    // Set that release version "1 version 2" is the latest for the Publication
-                    _releaseService.WherePublicationLatestPublishedReleaseVersionIs(
-                        releaseVersion1V2.Release.PublicationId,
-                        releaseVersion1V2
-                    );
-
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _contentDbContext.Assert.PublicationsLatestPublishedReleaseVersionIdIs(
-                        PublicationId1,
-                        releaseVersionId1V2
-                    );
-                }
-            }
-
-            public class ContentServiceTests : ReadyTests
-            {
-                [Fact]
-                public async Task PreviousVersionsDownloadFilesDeleted()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _contentService.Assert.DeletePreviousVersionsDownloadFilesCalled(
-                        _releaseVersion1.Id,
-                        _releaseVersion2.Id
-                    );
-                }
-
-                [Fact]
-                public async Task PreviousVersionsContentDeleted()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _contentService.Assert.DeletePreviousVersionsContentCalled(
-                        _releaseVersion1.Id,
-                        _releaseVersion2.Id
-                    );
-                }
-
-                [Fact]
-                public async Task CachedTaxonomyBlobsUpdated()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _contentService.Assert.UpdateCachedTaxonomyBlobsCalled();
-                }
-            }
-
-            public class NotificationServiceTests : ReadyTests
-            {
-                [Fact]
-                public async Task NotificationsSent()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _notificationsService.Assert.NotifySubscribersIfApplicableCalled(
-                        _releaseVersion1.Id,
-                        _releaseVersion2.Id
-                    );
-                    _notificationsService.Assert.SendReleasePublishingFeedbackEmailsCalled(
-                        _releaseVersion1.Id,
-                        _releaseVersion2.Id
-                    );
-                }
-            }
-
-            public class RedirectsCacheServiceTests : ReadyTests
-            {
-                [Fact]
-                public async Task RedirectsUpdated()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _redirectsCacheService.Assert.UpdateRedirectsCalled();
-                }
-            }
-
-            public class DataSetPublishingServiceTests : ReadyTests
-            {
-                [Fact]
-                public async Task DataSetsWerePublished()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _dataSetPublishingService.Assert.DataSetsWerePublished(_releaseVersion1.Id, _releaseVersion2.Id);
-                }
-            }
-
-            public class EventRaiserTests : ReadyTests
-            {
-                [Fact]
-                public async Task WhenReleaseVersionsArePublished_ThenEventIsRaised()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    var expectedInfo = new PublishedPublicationInfo
-                    {
-                        PublicationId = _releaseVersion1.Release.PublicationId,
-                        PublicationSlug = _releaseVersion1.Release.Publication.Slug,
-                        LatestPublishedReleaseId = _releaseVersion1.ReleaseId,
-                        LatestPublishedReleaseVersionId = _releaseVersion1.Id,
-                        PreviousLatestPublishedReleaseId = null,
-                        PreviousLatestPublishedReleaseVersionId = null,
-                        PublishedReleaseVersions =
-                        [
-                            new PublishedReleaseVersionInfo
-                            {
-                                ReleaseId = _releaseVersion1.ReleaseId,
-                                ReleaseVersionId = _releaseVersion1.Id,
-                                ReleaseSlug = _releaseVersion1.Release.Slug,
-                                PublicationId = _releaseVersion1.Release.PublicationId,
-                            },
-                        ],
-                        IsPublicationArchived = false,
-                    };
-
-                    _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(evt => evt == expectedInfo);
-                }
-
-                [Fact]
-                public async Task GivenReleaseAlreadyPublished_WhenReleaseVersionIsPublished_ThenEventIsRaisedWithPreviousReleaseId()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var previousReleaseVersion = new ReleaseVersionBuilder()
-                        .WithPublicationId(PublicationId1)
-                        .ForRelease(release => release.WithReleaseSlug("release-slug-previous"))
-                        .Build();
-
-                    // Set publication 1 to have a published release prior to the current publishing run
-                    WherePreviousPublicationLatestPublishedReleaseVersionIs(
-                        publicationId: PublicationId1,
-                        releaseVersion: previousReleaseVersion
-                    );
-
-                    // Set release version 1 to be the latest published release version after publishing
-                    _releaseService.WherePublicationLatestPublishedReleaseVersionIs(PublicationId1, _releaseVersion1);
-
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    var expectedInfo = new PublishedPublicationInfo
-                    {
-                        PublicationId = _releaseVersion1.Release.PublicationId,
-                        PublicationSlug = _releaseVersion1.Release.Publication.Slug,
-                        LatestPublishedReleaseId = _releaseVersion1.ReleaseId,
-                        LatestPublishedReleaseVersionId = _releaseVersion1.Id,
-                        PreviousLatestPublishedReleaseId = previousReleaseVersion.ReleaseId, // Assert info contains previous release id
-                        PreviousLatestPublishedReleaseVersionId = previousReleaseVersion.Id, // Assert info contains previous release version id
-                        PublishedReleaseVersions =
-                        [
-                            new PublishedReleaseVersionInfo
-                            {
-                                ReleaseId = _releaseVersion1.ReleaseId,
-                                ReleaseVersionId = _releaseVersion1.Id,
-                                ReleaseSlug = _releaseVersion1.Release.Slug,
-                                PublicationId = _releaseVersion1.Release.PublicationId,
-                            },
-                        ],
-                        IsPublicationArchived = false,
-                    };
-                    _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(evt => evt == expectedInfo);
-                }
-
-                [Fact]
-                public async Task WhenPublishedReleaseVersionIsNotLatestVersion_ThenEventIsRaised()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-
-                    var releaseVersionId1V2 = Guid.NewGuid();
-                    var releaseVersion1V2 = new ReleaseVersionBuilder(releaseVersionId1V2)
-                        .ForRelease(_releaseVersion1.Release)
-                        .Build();
-
-                    // Set publication 1 to have published release version 1V2 prior to the current publishing run
-                    WherePreviousPublicationLatestPublishedReleaseVersionIs(
-                        publicationId: PublicationId1,
-                        releaseVersion: releaseVersion1V2
-                    );
-
-                    // Set release version 1V2 to be the latest after publishing, not release version 1
-                    _releaseService.WherePublicationLatestPublishedReleaseVersionIs(PublicationId1, releaseVersion1V2);
-
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    var expectedInfo = new PublishedPublicationInfo
-                    {
-                        PublicationId = _releaseVersion1.Release.PublicationId,
-                        PublicationSlug = _releaseVersion1.Release.Publication.Slug,
-                        LatestPublishedReleaseId = releaseVersion1V2.ReleaseId,
-                        LatestPublishedReleaseVersionId = releaseVersionId1V2, // Assert latest release version is still 1v2
-                        PreviousLatestPublishedReleaseId = releaseVersion1V2.ReleaseId,
-                        PreviousLatestPublishedReleaseVersionId = releaseVersion1V2.Id,
-                        PublishedReleaseVersions =
-                        [
-                            new PublishedReleaseVersionInfo
-                            {
-                                ReleaseId = _releaseVersion1.ReleaseId,
-                                ReleaseVersionId = _releaseVersion1.Id,
-                                ReleaseSlug = _releaseVersion1.Release.Slug,
-                                PublicationId = _releaseVersion1.Release.PublicationId,
-                            },
-                        ],
-                        IsPublicationArchived = false,
-                    };
-
-                    _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(evt => evt == expectedInfo);
-                }
-
-                [Fact]
-                public async Task GivenASupersededPublication_WhenPublicationIsNotAlreadyPublished_ThenPublicationArchivedEventRaised()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-
-                    // Create a publication that is superseded by publication 1.
-                    // Publication 1 has no published releases prior to the current publishing run
-                    var supersededPublication = new PublicationBuilder(Guid.NewGuid(), "publication-slug-superseded")
-                        .SupersededBy(_releaseVersion1.Release.Publication.Id)
-                        .Build();
-                    _contentDbContext.With(supersededPublication);
-
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _publisherEventRaiser.Assert.PublicationArchivedEventWasRaised(supersededPublication);
-                }
-
-                [Fact]
-                public async Task GivenASupersededPublication_WhenPublicationIsAlreadyPublished_ThenPublicationArchivedEventNotRaised()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-
-                    // Set publication 1 to have a published release prior to the current publishing run
-                    WherePreviousPublicationLatestPublishedReleaseVersionIs(
-                        publicationId: PublicationId1,
-                        releaseVersion: new ReleaseVersionBuilder()
-                            .WithPublicationId(PublicationId1)
-                            .ForRelease(release => release.WithReleaseSlug("release-slug-previous"))
-                            .Build()
-                    );
-
-                    // Create a publication that is superseded by publication 1
-                    var supersededPublication = new PublicationBuilder(Guid.NewGuid(), "publication-slug-superseded")
-                        .SupersededBy(_releaseVersion1.Release.Publication.Id)
-                        .Build();
-                    _contentDbContext.With(supersededPublication);
-
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _publisherEventRaiser.Assert.PublicationArchivedEventWasNotRaised();
-                }
-
-                [Fact]
-                public async Task GivenASupersededPublication_WhenReleasePublished_ThenIsPublicationArchivedIsTrue()
-                {
-                    // ARRANGE
-                    // Create a publication that supersedes publication 1 - making publication 1 archived
-                    var supersedingPublication = new PublicationBuilder(Guid.NewGuid(), "publication-slug-superseded")
-                        .HasPublishedReleaseVersion()
-                        .Build();
-                    _contentDbContext.With(supersedingPublication);
-
-                    var readyKeys = SetupHappyPath(publication1 => publication1.SupersededBy(supersedingPublication));
-
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(info =>
-                        info.PublicationId == _releaseVersion1.Release.PublicationId && info.IsPublicationArchived
-                    );
-                }
-            }
-
-            public class EducationInNumbersServiceTests : ReadyTests
-            {
-                [Fact]
-                public async Task EinTilesUpdated()
-                {
-                    // ARRANGE
-                    var readyKeys = SetupHappyPath();
-                    var sut = GetSut();
-
-                    // ACT
-                    await sut.CompletePublishingIfAllPriorStagesComplete(readyKeys);
-
-                    // ASSERT
-                    _educationInNumbersService.Assert.UpdateEinTilesCalled();
-                }
-            }
-
-            private void WherePreviousPublicationLatestPublishedReleaseVersionIs(
-                Guid publicationId,
-                ReleaseVersion releaseVersion
-            )
-            {
-                _contentDbContext.With(releaseVersion);
-                _contentDbContext.WherePublication(
-                    publicationId,
-                    publication => publication.LatestPublishedReleaseVersionId = releaseVersion.Id
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _contentDbContext.Assert.PublicationsLatestPublishedReleaseVersionIdIs(
+                    PublicationId1,
+                    _releaseVersion1.Id
+                );
+                _contentDbContext.Assert.PublicationsLatestPublishedReleaseVersionIdIs(
+                    PublicationId2,
+                    _releaseVersion2.Id
                 );
             }
+
+            [Fact]
+            public async Task WhenPublishedReleaseVersionIsNotLatestVersion_ThenPublicationLatestReleaseVersionSetToLatestReleaseVersion()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+
+                var releaseVersionId1V2 = Guid.NewGuid();
+                var releaseVersion1V2 = new ReleaseVersionBuilder(releaseVersionId1V2)
+                    .ForRelease(_releaseVersion1.Release)
+                    .Build();
+
+                // Set that release version "1 version 2" is the latest for the Publication
+                _releaseService.WherePublicationLatestPublishedReleaseVersionIs(
+                    releaseVersion1V2.Release.PublicationId,
+                    releaseVersion1V2
+                );
+
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _contentDbContext.Assert.PublicationsLatestPublishedReleaseVersionIdIs(
+                    PublicationId1,
+                    releaseVersionId1V2
+                );
+            }
+        }
+
+        public class ContentServiceTests : CompletePublishingTests
+        {
+            [Fact]
+            public async Task PreviousVersionsDownloadFilesDeleted()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _contentService.Assert.DeletePreviousVersionsDownloadFilesCalled(
+                    _releaseVersion1.Id,
+                    _releaseVersion2.Id
+                );
+            }
+
+            [Fact]
+            public async Task PreviousVersionsContentDeleted()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _contentService.Assert.DeletePreviousVersionsContentCalled(_releaseVersion1.Id, _releaseVersion2.Id);
+            }
+
+            [Fact]
+            public async Task CachedTaxonomyBlobsUpdated()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _contentService.Assert.UpdateCachedTaxonomyBlobsCalled();
+            }
+        }
+
+        public class NotificationServiceTests : CompletePublishingTests
+        {
+            [Fact]
+            public async Task NotificationsSent()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _notificationsService.Assert.NotifySubscribersIfApplicableCalled(
+                    _releaseVersion1.Id,
+                    _releaseVersion2.Id
+                );
+                _notificationsService.Assert.SendReleasePublishingFeedbackEmailsCalled(
+                    _releaseVersion1.Id,
+                    _releaseVersion2.Id
+                );
+            }
+        }
+
+        public class RedirectsCacheServiceTests : CompletePublishingTests
+        {
+            [Fact]
+            public async Task RedirectsUpdated()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _redirectsCacheService.Assert.UpdateRedirectsCalled();
+            }
+        }
+
+        public class DataSetPublishingServiceTests : CompletePublishingTests
+        {
+            [Fact]
+            public async Task DataSetsWerePublished()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _dataSetPublishingService.Assert.DataSetsWerePublished(_releaseVersion1.Id, _releaseVersion2.Id);
+            }
+        }
+
+        public class EventRaiserTests : CompletePublishingTests
+        {
+            [Fact]
+            public async Task WhenReleaseVersionsArePublished_ThenEventIsRaised()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                var expectedInfo = new PublishedPublicationInfo
+                {
+                    PublicationId = _releaseVersion1.Release.PublicationId,
+                    PublicationSlug = _releaseVersion1.Release.Publication.Slug,
+                    LatestPublishedReleaseId = _releaseVersion1.ReleaseId,
+                    LatestPublishedReleaseVersionId = _releaseVersion1.Id,
+                    PreviousLatestPublishedReleaseId = null,
+                    PreviousLatestPublishedReleaseVersionId = null,
+                    PublishedReleaseVersions =
+                    [
+                        new PublishedReleaseVersionInfo
+                        {
+                            ReleaseId = _releaseVersion1.ReleaseId,
+                            ReleaseVersionId = _releaseVersion1.Id,
+                            ReleaseSlug = _releaseVersion1.Release.Slug,
+                            PublicationId = _releaseVersion1.Release.PublicationId,
+                        },
+                    ],
+                    IsPublicationArchived = false,
+                };
+
+                _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(evt => evt == expectedInfo);
+            }
+
+            [Fact]
+            public async Task GivenReleaseAlreadyPublished_WhenReleaseVersionIsPublished_ThenEventIsRaisedWithPreviousReleaseId()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var previousReleaseVersion = new ReleaseVersionBuilder()
+                    .WithPublicationId(PublicationId1)
+                    .ForRelease(release => release.WithReleaseSlug("release-slug-previous"))
+                    .Build();
+
+                // Set publication 1 to have a published release prior to the current publishing run
+                WherePreviousPublicationLatestPublishedReleaseVersionIs(
+                    publicationId: PublicationId1,
+                    releaseVersion: previousReleaseVersion
+                );
+
+                // Set release version 1 to be the latest published release version after publishing
+                _releaseService.WherePublicationLatestPublishedReleaseVersionIs(PublicationId1, _releaseVersion1);
+
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                var expectedInfo = new PublishedPublicationInfo
+                {
+                    PublicationId = _releaseVersion1.Release.PublicationId,
+                    PublicationSlug = _releaseVersion1.Release.Publication.Slug,
+                    LatestPublishedReleaseId = _releaseVersion1.ReleaseId,
+                    LatestPublishedReleaseVersionId = _releaseVersion1.Id,
+                    PreviousLatestPublishedReleaseId = previousReleaseVersion.ReleaseId, // Assert info contains previous release id
+                    PreviousLatestPublishedReleaseVersionId = previousReleaseVersion.Id, // Assert info contains previous release version id
+                    PublishedReleaseVersions =
+                    [
+                        new PublishedReleaseVersionInfo
+                        {
+                            ReleaseId = _releaseVersion1.ReleaseId,
+                            ReleaseVersionId = _releaseVersion1.Id,
+                            ReleaseSlug = _releaseVersion1.Release.Slug,
+                            PublicationId = _releaseVersion1.Release.PublicationId,
+                        },
+                    ],
+                    IsPublicationArchived = false,
+                };
+                _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(evt => evt == expectedInfo);
+            }
+
+            [Fact]
+            public async Task WhenPublishedReleaseVersionIsNotLatestVersion_ThenEventIsRaised()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+
+                var releaseVersionId1V2 = Guid.NewGuid();
+                var releaseVersion1V2 = new ReleaseVersionBuilder(releaseVersionId1V2)
+                    .ForRelease(_releaseVersion1.Release)
+                    .Build();
+
+                // Set publication 1 to have published release version 1V2 prior to the current publishing run
+                WherePreviousPublicationLatestPublishedReleaseVersionIs(
+                    publicationId: PublicationId1,
+                    releaseVersion: releaseVersion1V2
+                );
+
+                // Set release version 1V2 to be the latest after publishing, not release version 1
+                _releaseService.WherePublicationLatestPublishedReleaseVersionIs(PublicationId1, releaseVersion1V2);
+
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                var expectedInfo = new PublishedPublicationInfo
+                {
+                    PublicationId = _releaseVersion1.Release.PublicationId,
+                    PublicationSlug = _releaseVersion1.Release.Publication.Slug,
+                    LatestPublishedReleaseId = releaseVersion1V2.ReleaseId,
+                    LatestPublishedReleaseVersionId = releaseVersionId1V2, // Assert latest release version is still 1v2
+                    PreviousLatestPublishedReleaseId = releaseVersion1V2.ReleaseId,
+                    PreviousLatestPublishedReleaseVersionId = releaseVersion1V2.Id,
+                    PublishedReleaseVersions =
+                    [
+                        new PublishedReleaseVersionInfo
+                        {
+                            ReleaseId = _releaseVersion1.ReleaseId,
+                            ReleaseVersionId = _releaseVersion1.Id,
+                            ReleaseSlug = _releaseVersion1.Release.Slug,
+                            PublicationId = _releaseVersion1.Release.PublicationId,
+                        },
+                    ],
+                    IsPublicationArchived = false,
+                };
+
+                _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(evt => evt == expectedInfo);
+            }
+
+            [Fact]
+            public async Task GivenASupersededPublication_WhenPublicationIsNotAlreadyPublished_ThenPublicationArchivedEventRaised()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+
+                // Create a publication that is superseded by publication 1.
+                // Publication 1 has no published releases prior to the current publishing run
+                var supersededPublication = new PublicationBuilder(Guid.NewGuid(), "publication-slug-superseded")
+                    .SupersededBy(_releaseVersion1.Release.Publication.Id)
+                    .Build();
+                _contentDbContext.With(supersededPublication);
+
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _publisherEventRaiser.Assert.PublicationArchivedEventWasRaised(supersededPublication);
+            }
+
+            [Fact]
+            public async Task GivenASupersededPublication_WhenPublicationIsAlreadyPublished_ThenPublicationArchivedEventNotRaised()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+
+                // Set publication 1 to have a published release prior to the current publishing run
+                WherePreviousPublicationLatestPublishedReleaseVersionIs(
+                    publicationId: PublicationId1,
+                    releaseVersion: new ReleaseVersionBuilder()
+                        .WithPublicationId(PublicationId1)
+                        .ForRelease(release => release.WithReleaseSlug("release-slug-previous"))
+                        .Build()
+                );
+
+                // Create a publication that is superseded by publication 1
+                var supersededPublication = new PublicationBuilder(Guid.NewGuid(), "publication-slug-superseded")
+                    .SupersededBy(_releaseVersion1.Release.Publication.Id)
+                    .Build();
+                _contentDbContext.With(supersededPublication);
+
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _publisherEventRaiser.Assert.PublicationArchivedEventWasNotRaised();
+            }
+
+            [Fact]
+            public async Task GivenASupersededPublication_WhenReleasePublished_ThenIsPublicationArchivedIsTrue()
+            {
+                // ARRANGE
+                // Create a publication that supersedes publication 1 - making publication 1 archived
+                var supersedingPublication = new PublicationBuilder(Guid.NewGuid(), "publication-slug-superseded")
+                    .HasPublishedReleaseVersion()
+                    .Build();
+                _contentDbContext.With(supersedingPublication);
+
+                var keys = SetupHappyPath(publication1 => publication1.SupersededBy(supersedingPublication));
+
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _publisherEventRaiser.Assert.ReleaseVersionPublishedEventWasRaised(info =>
+                    info.PublicationId == _releaseVersion1.Release.PublicationId && info.IsPublicationArchived
+                );
+            }
+        }
+
+        public class EducationInNumbersServiceTests : CompletePublishingTests
+        {
+            [Fact]
+            public async Task EinTilesUpdated()
+            {
+                // ARRANGE
+                var keys = SetupHappyPath();
+                var sut = GetSut();
+
+                // ACT
+                await sut.CompletePublishing(keys);
+
+                // ASSERT
+                _educationInNumbersService.Assert.UpdateEinTilesCalled();
+            }
+        }
+
+        private void WherePreviousPublicationLatestPublishedReleaseVersionIs(
+            Guid publicationId,
+            ReleaseVersion releaseVersion
+        )
+        {
+            _contentDbContext.With(releaseVersion);
+            _contentDbContext.WherePublication(
+                publicationId,
+                publication => publication.LatestPublishedReleaseVersionId = releaseVersion.Id
+            );
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleasePublishingStatusServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleasePublishingStatusServiceTests.cs
@@ -40,7 +40,7 @@ public abstract class ReleasePublishingStatusServiceTests
                 _ => throw new ArgumentOutOfRangeException(nameof(dateComparison), dateComparison, null),
             };
             var expectedFilter =
-                $"OverallStage eq 'Scheduled' and Publish {expectedDateOperator} datetime'2025-01-01T12:00:00Z'";
+                $"Immediate eq false and OverallStage eq 'Scheduled' and Publish {expectedDateOperator} datetime'2025-01-01T12:00:00Z'";
 
             var publisherTableStorageService = new Mock<IPublisherTableStorageService>(MockBehavior.Strict);
 
@@ -113,7 +113,7 @@ public abstract class ReleasePublishingStatusServiceTests
         {
             // Arrange
             const string expectedFilter =
-                "OverallStage eq 'Started' and FilesStage eq 'Complete' and PublishingStage eq 'Scheduled'";
+                "Immediate eq false and OverallStage eq 'Started' and FilesStage eq 'Complete' and PublishingStage eq 'Scheduled'";
 
             var publisherTableStorageService = new Mock<IPublisherTableStorageService>(MockBehavior.Strict);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/NotifyChangeFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/NotifyChangeFunction.cs
@@ -49,7 +49,7 @@ public class NotifyChangeFunction(
                                 message,
                                 ReleasePublishingStatusStates.ImmediateReleaseStartedState
                             );
-                            await queueService.QueuePublishReleaseFilesMessages([releasePublishingKey]);
+                            await queueService.QueueReleaseFilesForImmediatePublishing(releasePublishingKey);
                         }
                         else
                         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
@@ -60,9 +60,11 @@ public class PublishReleaseFilesFunction(
 
         try
         {
-            // Continue the 'Immediate' publication flow by the completing the publishing process for the successful release versions
-            // TODO EES-7134 Add check here to filter those releases by those ready for Immediate publishing
-            await publishingCompletionService.CompletePublishing(successfulReleases);
+            if (message.Immediate)
+            {
+                // Continue the 'Immediate' flow by completing the publishing process for the successful release version
+                await publishingCompletionService.CompletePublishing(successfulReleases);
+            }
         }
         catch (Exception e)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
@@ -60,7 +60,9 @@ public class PublishReleaseFilesFunction(
 
         try
         {
-            await publishingCompletionService.CompletePublishingIfAllPriorStagesComplete(successfulReleases);
+            // Continue the 'Immediate' publication flow by the completing the publishing process for the successful release versions
+            // TODO EES-7134 Add check here to filter those releases by those ready for Immediate publishing
+            await publishingCompletionService.CompletePublishing(successfulReleases);
         }
         catch (Exception e)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishScheduledReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishScheduledReleasesFunction.cs
@@ -32,7 +32,7 @@ public class PublishScheduledReleasesFunction(
         var releasesReadyForPublishing = await releasePublishingStatusService.GetScheduledReleasesReadyForPublishing();
 
         // Complete publishing of these release versions
-        await publishingCompletionService.CompletePublishingIfAllPriorStagesComplete(releasesReadyForPublishing);
+        await publishingCompletionService.CompletePublishing(releasesReadyForPublishing);
 
         logger.LogInformation(
             "{FunctionName} completed. Published release versions [{ReleaseVersionIds}].",
@@ -75,7 +75,7 @@ public class PublishScheduledReleasesFunction(
                 : releasesReadyForPublishing;
 
         // Complete publishing of these release versions
-        await publishingCompletionService.CompletePublishingIfAllPriorStagesComplete(selectedReleasesToPublish);
+        await publishingCompletionService.CompletePublishing(selectedReleasesToPublish);
 
         logger.LogInformation(
             "{FunctionName} completed. Published release versions [{ReleaseVersionIds}]",

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/StageScheduledReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/StageScheduledReleasesFunction.cs
@@ -140,7 +140,7 @@ public class StageScheduledReleasesFunction(
             );
         }
 
-        await queueService.QueuePublishReleaseFilesMessages(releasePublishingKeys);
+        await queueService.QueueReleaseFilesForScheduledPublishing(releasePublishingKeys);
     }
 
     // ReSharper disable once ClassNeverInstantiated.Local

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublishingCompletionService.cs
@@ -4,7 +4,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
 public interface IPublishingCompletionService
 {
-    Task CompletePublishingIfAllPriorStagesComplete(
+    Task CompletePublishing(
         IReadOnlyList<ReleasePublishingKey> releaseVersionAndReleaseStatusIds,
         CancellationToken cancellationToken = default
     );

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IQueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IQueueService.cs
@@ -4,5 +4,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
 public interface IQueueService
 {
-    Task QueuePublishReleaseFilesMessages(IReadOnlyList<ReleasePublishingKey> releasePublishingKeys);
+    Task QueueReleaseFilesForImmediatePublishing(
+        ReleasePublishingKey releasePublishingKey,
+        CancellationToken cancellationToken = default
+    );
+
+    Task QueueReleaseFilesForScheduledPublishing(
+        IReadOnlyList<ReleasePublishingKey> releasePublishingKeys,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingCompletionService.cs
@@ -20,7 +20,13 @@ public class PublishingCompletionService(
     IEducationInNumbersService educationInNumbersService
 ) : IPublishingCompletionService
 {
-    public async Task CompletePublishingIfAllPriorStagesComplete(
+    /// <summary>
+    /// Sets release versions as publicly accessible and executes all tasks required to complete the publishing process,
+    /// including publishing any methodology versions being published alongside the release versions.
+    /// </summary>
+    /// <param name="releasePublishingKeys">A list containing the release version and release status IDs for the release versions to complete publishing for.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    public async Task CompletePublishing(
         IReadOnlyList<ReleasePublishingKey> releasePublishingKeys,
         CancellationToken cancellationToken = default
     )
@@ -37,16 +43,7 @@ public class PublishingCompletionService(
             )
             .ToListAsync(cancellationToken);
 
-        var prePublishingStagesComplete = releaseStatuses
-            .Where(status => status.AllStagesPriorToPublishingComplete())
-            .ToList();
-
-        if (!prePublishingStagesComplete.Any())
-        {
-            return;
-        }
-
-        foreach (var status in prePublishingStagesComplete)
+        foreach (var status in releaseStatuses)
         {
             await releasePublishingStatusService.UpdatePublishingStage(
                 status.AsTableRowKey(),
@@ -54,7 +51,7 @@ public class PublishingCompletionService(
             );
         }
 
-        var releaseVersionIdsToUpdate = prePublishingStagesComplete.Select(status => status.ReleaseVersionId).ToArray();
+        var releaseVersionIdsToUpdate = releaseStatuses.Select(status => status.ReleaseVersionId).ToArray();
         foreach (var releaseVersionId in releaseVersionIdsToUpdate)
         {
             await releaseService.CompletePublishing(releaseVersionId, DateTimeOffset.UtcNow);
@@ -98,7 +95,7 @@ public class PublishingCompletionService(
 
         await publisherEventRaiser.OnReleaseVersionsPublished(publishedPublicationInfos);
 
-        foreach (var status in prePublishingStagesComplete)
+        foreach (var status in releaseStatuses)
         {
             await releasePublishingStatusService.UpdatePublishingStage(
                 status.AsTableRowKey(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/QueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/QueueService.cs
@@ -11,16 +11,43 @@ public class QueueService(
     ILogger<QueueService> logger
 ) : IQueueService
 {
-    public async Task QueuePublishReleaseFilesMessages(IReadOnlyList<ReleasePublishingKey> releasePublishingKeys)
+    public async Task QueueReleaseFilesForImmediatePublishing(
+        ReleasePublishingKey releasePublishingKey,
+        CancellationToken cancellationToken = default
+    )
     {
         logger.LogInformation(
-            "Queuing files message for release versions: [{ReleaseVersionIds}]",
+            "Queuing files message for immediate publishing for release version: {ReleaseVersionId}",
+            releasePublishingKey.ReleaseVersionId
+        );
+
+        await publisherClient.PublishReleaseFiles(
+            PublishReleaseFilesMessage.ForImmediate(releasePublishingKey),
+            cancellationToken
+        );
+        await UpdateFilesStageAsQueued([releasePublishingKey]);
+    }
+
+    public async Task QueueReleaseFilesForScheduledPublishing(
+        IReadOnlyList<ReleasePublishingKey> releasePublishingKeys,
+        CancellationToken cancellationToken = default
+    )
+    {
+        logger.LogInformation(
+            "Queuing files message for scheduled publishing for release versions: [{ReleaseVersionIds}]",
             releasePublishingKeys.ToReleaseVersionIdsString()
         );
 
-        await publisherClient.PublishReleaseFiles(releasePublishingKeys);
+        await publisherClient.PublishReleaseFiles(
+            PublishReleaseFilesMessage.ForScheduled(releasePublishingKeys),
+            cancellationToken
+        );
+        await UpdateFilesStageAsQueued(releasePublishingKeys);
+    }
 
-        foreach (var key in releasePublishingKeys)
+    private async Task UpdateFilesStageAsQueued(IReadOnlyList<ReleasePublishingKey> keys)
+    {
+        foreach (var key in keys)
         {
             await releasePublishingStatusService.UpdateFilesStage(key, ReleasePublishingStatusFilesStage.Queued);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleasePublishingStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleasePublishingStatusService.cs
@@ -72,6 +72,8 @@ public class ReleasePublishingStatusService(
         DateTimeOffset referenceDate
     )
     {
+        var scheduledMethodFilter = CreateQueryFilter(status => !status.Immediate);
+
         var overallStageFilter = CreateQueryFilter(status =>
             status.OverallStage == nameof(ReleasePublishingStatusOverallStage.Scheduled)
         );
@@ -87,7 +89,7 @@ public class ReleasePublishingStatusService(
             _ => throw new ArgumentOutOfRangeException(nameof(comparison), comparison, null),
         };
 
-        var filter = $"{overallStageFilter} and {publishDateFilter}";
+        var filter = string.Join(" and ", scheduledMethodFilter, overallStageFilter, publishDateFilter);
 
         var result = await QueryEntitiesAsTableRowKeys(filter);
 
@@ -102,6 +104,8 @@ public class ReleasePublishingStatusService(
 
     public async Task<IReadOnlyList<ReleasePublishingKey>> GetScheduledReleasesReadyForPublishing()
     {
+        var scheduledMethodFilter = CreateQueryFilter(status => !status.Immediate);
+
         // Release versions ready for scheduled publishing have completed the tasks
         // performed by the StageScheduledReleases function and are in the "Started" stage.
         var overallStageFilter = CreateQueryFilter(status =>
@@ -117,7 +121,13 @@ public class ReleasePublishingStatusService(
             status.PublishingStage == nameof(ReleasePublishingStatusPublishingStage.Scheduled)
         );
 
-        var filter = string.Join(" and ", overallStageFilter, filesStageFilter, publishingFilter);
+        var filter = string.Join(
+            " and ",
+            scheduledMethodFilter,
+            overallStageFilter,
+            filesStageFilter,
+            publishingFilter
+        );
 
         var result = await QueryEntitiesAsTableRowKeys(filter);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleasePublishingStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleasePublishingStatusService.cs
@@ -72,7 +72,7 @@ public class ReleasePublishingStatusService(
         DateTimeOffset referenceDate
     )
     {
-        var scheduledMethodFilter = CreateQueryFilter(status => !status.Immediate);
+        var scheduledMethodFilter = CreateQueryFilter(status => status.Immediate == false);
 
         var overallStageFilter = CreateQueryFilter(status =>
             status.OverallStage == nameof(ReleasePublishingStatusOverallStage.Scheduled)
@@ -104,7 +104,7 @@ public class ReleasePublishingStatusService(
 
     public async Task<IReadOnlyList<ReleasePublishingKey>> GetScheduledReleasesReadyForPublishing()
     {
-        var scheduledMethodFilter = CreateQueryFilter(status => !status.Immediate);
+        var scheduledMethodFilter = CreateQueryFilter(status => status.Immediate == false);
 
         // Release versions ready for scheduled publishing have completed the tasks
         // performed by the StageScheduledReleases function and are in the "Started" stage.


### PR DESCRIPTION
This PR fixes a bug introduced by EES-7022 in #6939 where the 'Files' step can complete the publishing process early, for release versions using that are using the 'scheduled' publishing method.

The `PublishReleaseFiles` function is used by both the 'immediate' and 'scheduled' publishing flows, and prior to this fix, it finished by running the `publishingCompletionService.CompletePublishingIfAllPriorStagesComplete` unconditionally.

This `CompletePublishingIfAllPriorStagesComplete` method performed a check on release versions to make sure they are 'ready' for publishing before progressing.

Prior to #6939, that 'ready' check **always failed** for scheduled release versions, because it filtered out release status entities to include only those with `AllStagesPriorToPublishingComplete` which was conditional on the 'Content' stage being `Complete`.

By this time for scheduled publishing, the 'Content' stage would only ever be in `NotStarted`, `Failed`, or most commonly `Scheduled`, having been completed by the `StageReleaseContentFunction` and set with this state ready to be published later that day.

In #6939 the 'Content' stage was removed, and the `AllStagesPriorToPublishingComplete` was updated to only be conditional on the 'Files' stage being `Complete`. This has allowed the `PublishReleaseFiles` function via calling `publishingCompletionService.CompletePublishingIfAllPriorStagesComplete` to complete publishing early.

[This explanation has been added to the EES-7134 Jira ticket](https://dfedigital.atlassian.net/browse/EES-7134?focusedCommentId=151153).

# What is the fix

In the interest of getting a hotfix out, I opted to signal to the `PublishReleaseFiles` function, via the queue message which the function is triggered, the publishing method by adding a `bool Immediate` flag to it. The fix is then simply to not continue with running the completion if `Immediate` is true. Scheduled publishing will not continue with running the completion because `Immediate` will be false.

As part of this I have also refactored `CompletePublishingIfAllPriorStagesComplete` so that it is not responsible for checking if all prior stages are complete, and instead goes ahead and completes publishing of all keys that are passed to it. I thought that checking the stages is now a little pointless, since there is only one other internal stage for 'Files', and we now know in the places that it's called that the release versions are ready to complete publishing:

- In the two functions in `PublishScheduledReleasesFunction` it was already only being called with release versions obtained via `releasePublishingStatusService.GetScheduledReleasesReadyForPublishing()` which is conditional on the internal stages.

- In the `PublishReleaseFiles` function it's now only called if the method is 'Immediate', after this fix.

As part of this refactor it is renamed from `CompletePublishingIfAllPriorStagesComplete` to `CompletePublishing`.

# Other approaches considered

There are probably multiple ways that this could have been approached.

- I considered making `CompletePublishingIfAllPriorStagesComplete` responsible for checking whether it should be completing publishing, since it was already checking the status via `AllStagesPriorToPublishingComplete`, and making it aware of the context (immediate or published) that it's being called within. This would probably have been fairly easy to do, and it has a good set of unit tests already around it that could be enhanced to setup release status entities with both scheduled and immediate methods.

- I considered changing the `PublishReleaseFiles` function to filter `successfulReleases` to those that are 'Immediate' prior to calling `CompletePublishingIfAllPriorStagesComplete(successfulReleases)` so that it only calls it with a filtered list of 'Immediate' release publishing keys. However, from the keys alone we don't know that they are 'Immediate' or not. I opted not to go with this option because I would have added a method to `ReleasePublishingStatusService` like `GetReleaseVersionsReadyForPublishingImmediately(List<ReleasePublishingKey> keysToFilterBy)` that would need query filters on a combination of release version and release status IDs, and internal stages. This seems overly complicated when there should be only ONE release version being published for the immediate method.

# Other changes

- I decided to add a 'scheduled' filter to the `ReleasePublishingStatusService` methods `GetScheduledReleasesForPublishingRelativeToDate` and `GetScheduledReleasesReadyForPublishing` because it seemed odd that it didn't already include this. This is not essential for this fix so I'm happy to remove this or move it to another change.