### PR TITLE
🐛 EES-7133 Remove Publication cache when publication slug changes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/PublicationCacheServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/PublicationCacheServiceMockBuilder.cs
@@ -1,0 +1,28 @@
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
+using Moq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
+
+public class PublicationCacheServiceMockBuilder
+{
+    private readonly Mock<IPublicationCacheService> _mock = new(MockBehavior.Strict);
+
+    public PublicationCacheServiceMockBuilder()
+    {
+        _mock.Setup(m => m.RemovePublication(It.IsAny<string>())).Returns(Task.CompletedTask);
+    }
+
+    public IPublicationCacheService Build() => _mock.Object;
+
+    public Asserter Assert => new(_mock);
+
+    public class Asserter(Mock<IPublicationCacheService> mock)
+    {
+        public void CacheInvalidatedForPublicationAndReleases(string publicationSlug) =>
+            mock.Verify(m => m.RemovePublication(It.Is<string>(actual => actual == publicationSlug)), Times.Once);
+
+        public void CacheNotInvalidatedForPublicationAndReleases(string publicationSlug) =>
+            mock.Verify(m => m.RemovePublication(It.Is<string>(actual => actual == publicationSlug)), Times.Never);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/ReleaseCacheServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/ReleaseCacheServiceMockBuilder.cs
@@ -1,6 +1,6 @@
 ﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/ReleaseCacheServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/ReleaseCacheServiceMockBuilder.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
@@ -11,7 +10,7 @@ public class ReleaseCacheServiceMockBuilder
 
     public IReleaseCacheService Build()
     {
-        _mock.Setup(m => m.RemoveRelease(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(() => Unit.Instance);
+        _mock.Setup(m => m.RemoveRelease(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
 
         return _mock.Object;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Cache/PublicationCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Cache/PublicationCacheServiceTests.cs
@@ -1,0 +1,90 @@
+﻿#nullable enable
+using System.Text.RegularExpressions;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Cache;
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using Moq;
+using static Moq.MockBehavior;
+using Capture = Moq.Capture;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Cache;
+
+public abstract class PublicationCacheServiceTests
+{
+    public class RemovePublicationTests : PublicationCacheServiceTests
+    {
+        [Fact]
+        public async Task WhenPublicationSlugIsProvided_DeletesBlobsWithExpectedNamePrefixAndOptions()
+        {
+            // Arrange
+            const string publicationSlug = "publication-slug";
+            const string? expectedNamePrefixToDelete = null;
+            const string expectedIncludeRegex = $"^publications/{publicationSlug}/.+$";
+
+            var publicBlobStorageService = new Mock<IPublicBlobStorageService>(Strict);
+
+            publicBlobStorageService
+                .Setup(s =>
+                    s.DeleteBlobs(
+                        BlobContainers.PublicContent,
+                        expectedNamePrefixToDelete,
+                        It.Is<IBlobStorageService.DeleteBlobsOptions>(opts =>
+                            opts.ExcludeRegex == null
+                            && opts.IncludeRegex != null
+                            && opts.IncludeRegex.ToString() == expectedIncludeRegex
+                        )
+                    )
+                )
+                .Returns(Task.CompletedTask);
+
+            var sut = BuildService(publicBlobStorageService.Object);
+
+            // Act
+            await sut.RemovePublication(publicationSlug);
+
+            // Assert
+            publicBlobStorageService.VerifyAll();
+        }
+
+        [Theory]
+        [InlineData("publications/publication-1/something", true)]
+        [InlineData("publications/publication-1/releases/something", true)]
+        [InlineData("publications/publication-1/releases/release-1/something", true)]
+        [InlineData("publications/publication-1", false)] // no trailing path segment and blob name matches publication-slug
+        [InlineData("publications/publication-2/releases/something", false)] // does not begin with publications/publication-1/
+        [InlineData("something/publication-1/releases/something", false)] // does not begin with publications/publication-1/
+        [InlineData("publication-1/something", false)] // does not begin with publications/publication-1/
+        public async Task WhenIncludeRegexIsApplied_RegexOnlyMatchesBlobNamesUnderPublicationSlug(
+            string blobName,
+            bool shouldMatch
+        )
+        {
+            // Arrange
+            const string publicationSlug = "publication-1";
+            const string? expectedNamePrefixToDelete = null;
+            IBlobStorageService.DeleteBlobsOptions options = null!;
+            var match = new CaptureMatch<IBlobStorageService.DeleteBlobsOptions>(param => options = param);
+
+            var publicBlobStorageService = new Mock<IPublicBlobStorageService>(Strict);
+
+            publicBlobStorageService
+                .Setup(s =>
+                    s.DeleteBlobs(BlobContainers.PublicContent, expectedNamePrefixToDelete, Capture.With(match))
+                )
+                .Returns(Task.CompletedTask);
+
+            // Act
+            var sut = BuildService(publicBlobStorageService.Object);
+
+            await sut.RemovePublication(publicationSlug);
+
+            // Assert
+            var regex = Assert.IsType<Regex>(options.IncludeRegex);
+            Assert.Equal(shouldMatch, regex.IsMatch(blobName));
+            publicBlobStorageService.VerifyAll();
+        }
+    }
+
+    private static PublicationCacheService BuildService(IPublicBlobStorageService? publicBlobStorageService = null) =>
+        new(publicBlobStorageService ?? Mock.Of<IPublicBlobStorageService>(Strict));
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Cache/ReleaseCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Cache/ReleaseCacheServiceTests.cs
@@ -1,0 +1,41 @@
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Cache;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using Moq;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Cache;
+
+public abstract class ReleaseCacheServiceTests
+{
+    public class RemoveReleaseTests : ReleaseCacheServiceTests
+    {
+        [Fact]
+        public async Task WhenPublicationAndReleaseSlugIsProvided_DeletesBlobsWithExpectedNamePrefixAndOptions()
+        {
+            // Arrange
+            const string publicationSlug = "publication-slug";
+            const string releaseSlug = "release-slug";
+            const string expectedNamePrefixToDelete = $"publications/{publicationSlug}/releases/{releaseSlug}/";
+            IBlobStorageService.DeleteBlobsOptions? expectedOptions = null;
+
+            var publicBlobStorageService = new Mock<IPublicBlobStorageService>(Strict);
+
+            publicBlobStorageService
+                .Setup(s => s.DeleteBlobs(PublicContent, expectedNamePrefixToDelete, expectedOptions))
+                .Returns(Task.CompletedTask);
+
+            var sut = BuildService(publicBlobStorageService.Object);
+
+            // Act
+            await sut.RemoveRelease(publicationSlug, releaseSlug);
+
+            // Assert
+            publicBlobStorageService.VerifyAll();
+        }
+    }
+
+    private static ReleaseCacheService BuildService(IPublicBlobStorageService? publicBlobStorageService = null) =>
+        new(publicBlobStorageService ?? Mock.Of<IPublicBlobStorageService>(Strict));
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -600,6 +601,7 @@ public class PublicationServicePermissionTests
         IPublicationRepository? publicationRepository = null,
         IReleaseVersionRepository? releaseVersionRepository = null,
         IMethodologyService? methodologyService = null,
+        IPublicationCacheService? publicationCacheService = null,
         IPublicationsTreeService? publicationsTreeService = null,
         IMethodologyCacheService? methodologyCacheService = null,
         IRedirectsCacheService? redirectsCacheService = null,
@@ -615,6 +617,7 @@ public class PublicationServicePermissionTests
             userService ?? AlwaysTrueUserService().Object,
             publicationRepository ?? Mock.Of<IPublicationRepository>(Strict),
             releaseVersionRepository ?? Mock.Of<IReleaseVersionRepository>(Strict),
+            publicationCacheService ?? Mock.Of<IPublicationCacheService>(Strict),
             methodologyService ?? Mock.Of<IMethodologyService>(Strict),
             publicationsTreeService ?? Mock.Of<IPublicationsTreeService>(Strict),
             methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Utils;
@@ -935,6 +936,7 @@ public class PublicationServiceTests
             Assert.Empty(publicationRedirects);
         }
 
+        _publicationCacheServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationAndReleases(publication.Slug);
         _publicationsTreeServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationsTree();
         AssertOnPublicationChangedEventsNotRaised();
     }
@@ -1043,6 +1045,7 @@ public class PublicationServiceTests
             AssertOnPublicationChangedEventRaised(updatedPublication);
         }
 
+        _publicationCacheServiceMockBuilder.Assert.CacheInvalidatedForPublicationAndReleases(publication.Slug);
         _publicationsTreeServiceMockBuilder.Assert.CacheInvalidatedForPublicationsTree();
     }
 
@@ -1180,7 +1183,6 @@ public class PublicationServiceTests
         {
             var methodologyService = new Mock<IMethodologyService>(Strict);
             var methodologyCacheService = new Mock<IMethodologyCacheService>(Strict);
-            var publicationsTreeService = new Mock<IPublicationsTreeService>(Strict);
             var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
 
             methodologyService
@@ -1199,10 +1201,6 @@ public class PublicationServiceTests
                     )
                 );
 
-            publicationsTreeService
-                .Setup(mock => mock.UpdateCachedPublicationsTree(It.IsAny<CancellationToken>()))
-                .ReturnsAsync([]);
-
             redirectsCacheService
                 .Setup(mock => mock.UpdateRedirects())
                 .ReturnsAsync(
@@ -1216,7 +1214,6 @@ public class PublicationServiceTests
             var publicationService = BuildPublicationService(
                 context,
                 methodologyService: methodologyService.Object,
-                publicationsTreeService: publicationsTreeService.Object,
                 methodologyCacheService: methodologyCacheService.Object,
                 redirectsCacheService: redirectsCacheService.Object
             );
@@ -1232,7 +1229,7 @@ public class PublicationServiceTests
                 }
             );
 
-            VerifyAllMocks(methodologyService, methodologyCacheService, publicationsTreeService, redirectsCacheService);
+            VerifyAllMocks(methodologyService, methodologyCacheService, redirectsCacheService);
 
             var viewModel = result.AssertRight();
 
@@ -1264,6 +1261,9 @@ public class PublicationServiceTests
 
             AssertOnPublicationChangedEventRaised(updatedPublication);
         }
+
+        _publicationCacheServiceMockBuilder.Assert.CacheInvalidatedForPublicationAndReleases(publication.Slug);
+        _publicationsTreeServiceMockBuilder.Assert.CacheInvalidatedForPublicationsTree();
     }
 
     [Fact]
@@ -1325,6 +1325,8 @@ public class PublicationServiceTests
         }
 
         AssertOnPublicationChangedEventsNotRaised();
+        _publicationCacheServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationAndReleases(publication.Slug);
+        _publicationsTreeServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationsTree();
     }
 
     [Fact]
@@ -1399,11 +1401,6 @@ public class PublicationServiceTests
                     )
                 );
 
-            var publicationsTreeService = new Mock<IPublicationsTreeService>(Strict);
-            publicationsTreeService
-                .Setup(mock => mock.UpdateCachedPublicationsTree(It.IsAny<CancellationToken>()))
-                .ReturnsAsync([]);
-
             var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
             redirectsCacheService
                 .Setup(mock => mock.UpdateRedirects())
@@ -1419,7 +1416,6 @@ public class PublicationServiceTests
                 context,
                 methodologyService: methodologyService.Object,
                 methodologyCacheService: methodologyCacheService.Object,
-                publicationsTreeService: publicationsTreeService.Object,
                 redirectsCacheService: redirectsCacheService.Object
             );
 
@@ -1428,7 +1424,7 @@ public class PublicationServiceTests
                 new PublicationSaveRequest { Title = "New title", ThemeId = theme.Id }
             );
 
-            VerifyAllMocks(methodologyService, methodologyCacheService, publicationsTreeService, redirectsCacheService);
+            VerifyAllMocks(methodologyService, methodologyCacheService, redirectsCacheService);
 
             var viewModel = result.AssertRight();
             Assert.Equal("New title", viewModel.Title);
@@ -1491,6 +1487,9 @@ public class PublicationServiceTests
                     )
                 );
 
+            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
+            publicationCacheService.Setup(mock => mock.RemovePublication("title")).Returns(Task.CompletedTask);
+
             var publicationTreeService = new Mock<IPublicationsTreeService>(Strict);
             publicationTreeService
                 .Setup(mock => mock.UpdateCachedPublicationsTree(It.IsAny<CancellationToken>()))
@@ -1511,6 +1510,7 @@ public class PublicationServiceTests
                 context,
                 methodologyService: methodologyService.Object,
                 methodologyCacheService: methodologyCacheService.Object,
+                publicationCacheService: publicationCacheService.Object,
                 publicationsTreeService: publicationTreeService.Object,
                 redirectsCacheService: redirectsCacheService.Object
             );
@@ -1520,7 +1520,13 @@ public class PublicationServiceTests
                 new PublicationSaveRequest { Title = "Older title", ThemeId = theme.Id }
             );
 
-            VerifyAllMocks(methodologyService, methodologyCacheService, publicationTreeService, redirectsCacheService);
+            VerifyAllMocks(
+                methodologyService,
+                methodologyCacheService,
+                publicationCacheService,
+                publicationTreeService,
+                redirectsCacheService
+            );
 
             var viewModel = result.AssertRight();
             Assert.Equal("Older title", viewModel.Title);
@@ -3183,23 +3189,27 @@ public class PublicationServiceTests
         IPublicationRepository? publicationRepository = null,
         IReleaseVersionRepository? releaseVersionRepository = null,
         IMethodologyService? methodologyService = null,
+        IPublicationCacheService? publicationCacheService = null,
         IPublicationsTreeService? publicationsTreeService = null,
         IMethodologyCacheService? methodologyCacheService = null,
         IRedirectsCacheService? redirectsCacheService = null
-    ) =>
-        new(
+    )
+    {
+        return new(
             context,
             AdminMapper(),
             new PersistenceHelper<ContentDbContext>(context),
             userService ?? AlwaysTrueUserService().Object,
             publicationRepository ?? CreatePublicationRepository(context),
             releaseVersionRepository ?? new ReleaseVersionRepository(context),
+            publicationCacheService ?? _publicationCacheServiceMockBuilder.Build(),
             methodologyService ?? Mock.Of<IMethodologyService>(Strict),
             publicationsTreeService ?? _publicationsTreeServiceMockBuilder.Build(),
             methodologyCacheService ?? Mock.Of<IMethodologyCacheService>(Strict),
             redirectsCacheService ?? Mock.Of<IRedirectsCacheService>(Strict),
             _adminEventRaiserMockBuilder.Build()
         );
+    }
 
     private static PublicationRepository CreatePublicationRepository(ContentDbContext context)
     {
@@ -3215,6 +3225,7 @@ public class PublicationServiceTests
     }
 
     private readonly AdminEventRaiserMockBuilder _adminEventRaiserMockBuilder = new();
+    private readonly PublicationCacheServiceMockBuilder _publicationCacheServiceMockBuilder = new();
     private readonly PublicationsTreeServiceMockBuilder _publicationsTreeServiceMockBuilder = new();
 
     private void AssertOnPublicationArchivedEventRaised(Publication publication) =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -936,9 +936,9 @@ public class PublicationServiceTests
             Assert.Empty(publicationRedirects);
         }
 
+        AssertOnPublicationChangedEventsNotRaised();
         _publicationCacheServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationAndReleases(publication.Slug);
         _publicationsTreeServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationsTree();
-        AssertOnPublicationChangedEventsNotRaised();
     }
 
     [Fact]
@@ -1360,6 +1360,8 @@ public class PublicationServiceTests
         }
 
         AssertOnPublicationChangedEventsNotRaised();
+        _publicationCacheServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationAndReleases(publication.Slug);
+        _publicationsTreeServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationsTree();
     }
 
     [Fact]
@@ -1433,9 +1435,9 @@ public class PublicationServiceTests
 
         await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            var dbPublication = context.Publications.Single(p => p.Id == publication.Id);
-            Assert.Equal("New title", dbPublication.Title);
-            Assert.Equal("new-title", dbPublication.Slug);
+            var updatedPublication = context.Publications.Single(p => p.Id == publication.Id);
+            Assert.Equal("New title", updatedPublication.Title);
+            Assert.Equal("new-title", updatedPublication.Slug);
 
             var publicationRedirects = context.PublicationRedirects.ToList();
             Assert.Equal(2, publicationRedirects.Count);
@@ -1445,7 +1447,12 @@ public class PublicationServiceTests
 
             Assert.Equal(publication.Id, publicationRedirects[1].PublicationId);
             Assert.Equal("current-title", publicationRedirects[1].Slug);
+
+            AssertOnPublicationChangedEventRaised(updatedPublication);
         }
+
+        _publicationCacheServiceMockBuilder.Assert.CacheInvalidatedForPublicationAndReleases(publication.Slug);
+        _publicationsTreeServiceMockBuilder.Assert.CacheInvalidatedForPublicationsTree();
     }
 
     [Fact]
@@ -1487,14 +1494,6 @@ public class PublicationServiceTests
                     )
                 );
 
-            var publicationCacheService = new Mock<IPublicationCacheService>(Strict);
-            publicationCacheService.Setup(mock => mock.RemovePublication("title")).Returns(Task.CompletedTask);
-
-            var publicationTreeService = new Mock<IPublicationsTreeService>(Strict);
-            publicationTreeService
-                .Setup(mock => mock.UpdateCachedPublicationsTree(It.IsAny<CancellationToken>()))
-                .ReturnsAsync([]);
-
             var redirectsCacheService = new Mock<IRedirectsCacheService>(Strict);
             redirectsCacheService
                 .Setup(mock => mock.UpdateRedirects())
@@ -1510,8 +1509,6 @@ public class PublicationServiceTests
                 context,
                 methodologyService: methodologyService.Object,
                 methodologyCacheService: methodologyCacheService.Object,
-                publicationCacheService: publicationCacheService.Object,
-                publicationsTreeService: publicationTreeService.Object,
                 redirectsCacheService: redirectsCacheService.Object
             );
 
@@ -1520,13 +1517,7 @@ public class PublicationServiceTests
                 new PublicationSaveRequest { Title = "Older title", ThemeId = theme.Id }
             );
 
-            VerifyAllMocks(
-                methodologyService,
-                methodologyCacheService,
-                publicationCacheService,
-                publicationTreeService,
-                redirectsCacheService
-            );
+            VerifyAllMocks(methodologyService, methodologyCacheService, redirectsCacheService);
 
             var viewModel = result.AssertRight();
             Assert.Equal("Older title", viewModel.Title);
@@ -1535,9 +1526,9 @@ public class PublicationServiceTests
 
         await using (var context = InMemoryApplicationDbContext(contextId))
         {
-            var dbPublication = context.Publications.Single(p => p.Id == publication.Id);
-            Assert.Equal("Older title", dbPublication.Title);
-            Assert.Equal("older-title", dbPublication.Slug);
+            var updatedPublication = context.Publications.Single(p => p.Id == publication.Id);
+            Assert.Equal("Older title", updatedPublication.Title);
+            Assert.Equal("older-title", updatedPublication.Slug);
 
             var publicationRedirects = context.PublicationRedirects.ToList();
             var redirect = Assert.Single(publicationRedirects);
@@ -1547,7 +1538,12 @@ public class PublicationServiceTests
 
             Assert.Equal(publication.Id, redirect.PublicationId);
             Assert.Equal("title", redirect.Slug);
+
+            AssertOnPublicationChangedEventRaised(updatedPublication);
         }
+
+        _publicationCacheServiceMockBuilder.Assert.CacheInvalidatedForPublicationAndReleases(publication.Slug);
+        _publicationsTreeServiceMockBuilder.Assert.CacheInvalidatedForPublicationsTree();
     }
 
     [Fact]
@@ -1599,6 +1595,10 @@ public class PublicationServiceTests
             var publicationRedirects = context.PublicationRedirects.ToList();
             Assert.Empty(publicationRedirects);
         }
+
+        AssertOnPublicationChangedEventsNotRaised();
+        _publicationCacheServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationAndReleases(publication.Slug);
+        _publicationsTreeServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationsTree();
     }
 
     [Fact]
@@ -1650,6 +1650,10 @@ public class PublicationServiceTests
             Assert.Equal(publicationRedirect.PublicationId, redirect.PublicationId);
             Assert.Equal(publicationRedirect.Slug, redirect.Slug);
         }
+
+        AssertOnPublicationChangedEventsNotRaised();
+        _publicationCacheServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationAndReleases(publication.Slug);
+        _publicationsTreeServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationsTree();
     }
 
     [Fact]
@@ -1716,6 +1720,10 @@ public class PublicationServiceTests
             var dbMethodology = context.Methodologies.Include(m => m.Versions).Single(m => m.Id == methodology.Id);
             Assert.Equal("test-publication", dbMethodology.Versions[0].Slug);
         }
+
+        AssertOnPublicationChangedEventsNotRaised();
+        _publicationCacheServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationAndReleases(publication.Slug);
+        _publicationsTreeServiceMockBuilder.Assert.CacheNotInvalidatedForPublicationsTree();
     }
 
     [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -3,6 +3,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -2,6 +2,7 @@
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.MockBuilders;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Cache/PublicationCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Cache/PublicationCacheService.cs
@@ -1,0 +1,21 @@
+﻿#nullable enable
+using System.Text.RegularExpressions;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Cache;
+
+public class PublicationCacheService(IPublicBlobStorageService publicBlobStorageService) : IPublicationCacheService
+{
+    public async Task RemovePublication(string publicationSlug)
+    {
+        await publicBlobStorageService.DeleteBlobs(
+            containerName: BlobContainers.PublicContent,
+            options: new IBlobStorageService.DeleteBlobsOptions
+            {
+                IncludeRegex = new Regex($"^publications/{publicationSlug}/.+$"),
+            }
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Cache/ReleaseCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Cache/ReleaseCacheService.cs
@@ -12,10 +12,10 @@ public class ReleaseCacheService(IPublicBlobStorageService publicBlobStorageServ
     {
         await publicBlobStorageService.DeleteBlobs(
             containerName: BlobContainers.PublicContent,
-            directoryPath: FileStoragePathUtils.PublicContentReleaseParentPath(
+            directoryPath: $"{FileStoragePathUtils.PublicContentReleaseParentPath(
                 publicationSlug: publicationSlug,
                 releaseSlug: releaseSlug
-            )
+            )}/"
         );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Cache/ReleaseCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Cache/ReleaseCacheService.cs
@@ -1,16 +1,14 @@
 #nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
-using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Cache;
 
 public class ReleaseCacheService(IPublicBlobStorageService publicBlobStorageService) : IReleaseCacheService
 {
-    public async Task<Either<ActionResult, Unit>> RemoveRelease(string publicationSlug, string releaseSlug)
+    public async Task RemoveRelease(string publicationSlug, string releaseSlug)
     {
         await publicBlobStorageService.DeleteBlobs(
             containerName: BlobContainers.PublicContent,
@@ -19,7 +17,5 @@ public class ReleaseCacheService(IPublicBlobStorageService publicBlobStorageServ
                 releaseSlug: releaseSlug
             )
         );
-
-        return Unit.Instance;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Cache/ReleaseCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Cache/ReleaseCacheService.cs
@@ -1,11 +1,12 @@
+#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
 using Microsoft.AspNetCore.Mvc;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Cache;
 
 public class ReleaseCacheService(IPublicBlobStorageService publicBlobStorageService) : IReleaseCacheService
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Cache/IPublicationCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Cache/IPublicationCacheService.cs
@@ -1,0 +1,8 @@
+﻿#nullable enable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
+
+public interface IPublicationCacheService
+{
+    Task RemovePublication(string publicationSlug);
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Cache/IReleaseCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Cache/IReleaseCacheService.cs
@@ -1,7 +1,8 @@
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 
-namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.Cache;
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
 
 public interface IReleaseCacheService
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Cache/IReleaseCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Cache/IReleaseCacheService.cs
@@ -1,10 +1,8 @@
 #nullable enable
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
 
 public interface IReleaseCacheService
 {
-    Task<Either<ActionResult, Unit>> RemoveRelease(string publicationSlug, string releaseSlug);
+    Task RemoveRelease(string publicationSlug, string releaseSlug);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -3,6 +3,7 @@ using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Util;
@@ -37,6 +38,7 @@ public class PublicationService(
     IUserService userService,
     IPublicationRepository publicationRepository,
     IReleaseVersionRepository releaseVersionRepository,
+    IPublicationCacheService publicationCacheService,
     IMethodologyService methodologyService,
     IPublicationsTreeService publicationsTreeService,
     IMethodologyCacheService methodologyCacheService,
@@ -244,6 +246,7 @@ public class PublicationService(
 
                     if (slugChanged)
                     {
+                        await publicationCacheService.RemovePublication(previousSlug);
                         await redirectsCacheService.UpdateRedirects();
                     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -2,6 +2,7 @@
 using System.Text.RegularExpressions;
 using GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Cache;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -409,7 +409,6 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         services.AddTransient<IGlossaryCacheService, GlossaryCacheService>();
         services.AddTransient<IMethodologyCacheService, MethodologyCacheService>();
         services.AddTransient<IPublicationsTreeService, PublicationsTreeService>();
-        services.AddTransient<IReleaseCacheService, ReleaseCacheService>();
 
         // Content.Model repositories
         services.AddTransient<IFileRepository, FileRepository>();
@@ -445,6 +444,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         }
 
         services.AddTransient<IDataGuidanceFileWriter, DataGuidanceFileWriter>();
+        services.AddTransient<IReleaseCacheService, ReleaseCacheService>();
         services.AddTransient<IReleaseFileService, ReleaseFileService>();
         services.AddTransient<IReleaseImageService, ReleaseImageService>();
         services.AddTransient<IReleasePermissionService, ReleasePermissionService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -454,6 +454,7 @@ public class Startup(IConfiguration configuration, IHostEnvironment hostEnvironm
         services.AddTransient<IReleasePublishingStatusService, ReleasePublishingStatusService>();
         services.AddTransient<IReleasePublishingStatusRepository, ReleasePublishingStatusRepository>();
         services.AddTransient<IThemeService, ThemeService>();
+        services.AddTransient<IPublicationCacheService, PublicationCacheService>();
         services.AddTransient<IPublicationService, PublicationService>();
         services.AddTransient<IPublicationRepository, PublicationRepository>();
         services.AddTransient<IMetaService, MetaService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleasePublishingStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleasePublishingStatusService.cs
@@ -53,8 +53,6 @@ public interface IReleasePublishingStatusService
 
     Task<ReleasePublishingStatus> Get(ReleasePublishingKey releasePublishingKey);
 
-    Task<ReleasePublishingStatus?> GetLatest(Guid releaseVersionId);
-
     Task UpdateState(ReleasePublishingKey releasePublishingKey, ReleasePublishingStatusState state);
 
     Task UpdateFilesStage(

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleasePublishingStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleasePublishingStatusService.cs
@@ -165,17 +165,6 @@ public class ReleasePublishingStatusService(
         return await QueryEntitiesAsTableRowKeys(filter);
     }
 
-    public async Task<ReleasePublishingStatus?> GetLatest(Guid releaseVersionId)
-    {
-        var asyncPages = await publisherTableStorageService.QueryEntities<ReleasePublishingStatus>(
-            PublisherReleaseStatusTableName,
-            status => status.PartitionKey == releaseVersionId.ToString()
-        );
-        var statusList = await asyncPages.ToListAsync();
-
-        return statusList.OrderByDescending(status => status.Created).FirstOrDefault();
-    }
-
     public async Task UpdateState(ReleasePublishingKey releasePublishingKey, ReleasePublishingStatusState state)
     {
         await UpdateWithRetries(


### PR DESCRIPTION
This PR reinstates the code that removes the backend's public cache for a publication. The cache of a publication is removed from the storage container when a publication slug changes after a publication title is changed in the Admin app.

It was removed in error by EES-7022 in #6939 which was a bit overzealous in it's tidy-up. It was removed because the 'content' elements of the publication cache no longer exist, but as we now realise, publications with data files and data blocks can still have cache entries for those elements.  Under the publication path, there are release paths that can still contain data block, subject, and location GeoJSON cache files.

Leaving the publication cache for the old slug hanging around _shouldn't_ have caused any noticeable issues, but it was confusing to see when looking at the state of all publications in the cache during testing of publication title changes. It _may_ have caused an issue if a publication was subsequently renamed back to its original name as the old cache under the original slug would then have become relevant again.

A similar method `RemoveRelease` to remove the cache of a specific release called after a release slug changes still exists. However, in this PR I have refactored that service from Content.Services to Admin which is the only location it is called from, to make it consistent with the location of the new `PublicationCacheService`.

Note: This isn't a complete revert of the original code as there are differences in the unit tests. I also changed the return type of both `RemovePublication` and `RemoveRelease` methods from `Task<Either<ActionResult, Unit>>` to `Task`.

### Other changes

- Add unit tests for `PublicationCacheService.RemovePublication` and `ReleaseCacheService.RemoveRelease` which never existed.
- Remove unused method from the Publisher project - `ReleasePublishingStatusService.GetLatest`.