### PR TITLE
EES-7141 - added the AFD testing URL to the CORS whitelist on Prod

### DIFF
--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -103,6 +103,11 @@
     },
     "notifierSuppressExceptionsForTeamOnlyApiKeyErrors": {
       "value": true
+    },
+    "additionalPublicAllowedOrigins": {
+      "value": [
+        "https://pre-productionafd.explore-education-statistics.service.gov.uk"
+      ]
     }
   }
 }

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -100,6 +100,11 @@
     },
     "maxStatsDbSizeBytes": {
       "value": 2748779069440
+    },
+    "additionalPublicAllowedOrigins": {
+      "value": [
+        "https://afd.explore-education-statistics.service.gov.uk"
+      ]
     }
   }
 }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1363,10 +1363,7 @@
     "adminAllowedOrigins": "[union(variables('baseAdminAllowedOrigins'), parameters('additionalAdminAllowedOrigins'))]",
     "basePublicAllowedOrigins": [
       "[concat('https://', parameters('domain'))]",
-      // TODO EES-6883 - remove the entry below when no longer using the temporary URLs for Azure Front Door testing.
-      "[concat('https://', replace(parameters('domain'), '.explore-education', 'afd.explore-education'))]",
       "[concat('https://', variables('publicAppName'), '.azurewebsites.net')]"
-      // NOTE: reference() cannot be used in variables, so the default FrontDoor hostname cannot be put here. It must added in place wherever we use publicAllowedOrigins
     ],
     "publicAllowedOrigins": "[union(variables('basePublicAllowedOrigins'), parameters('additionalPublicAllowedOrigins'))]",
     "apiVersions": {


### PR DESCRIPTION
This PR:
- adds the temporary AFD testing URL to Prod's CORS whitelist.