### PR TITLE
EES-7127 - Redirect user attempting to go to section within 'explore' tab of release home page when user doesn't specify a release slug.

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -148,7 +148,7 @@ export const getServerSideProps: GetServerSideProps = withAxiosHandler(
       // as opposed to `find-statistics/apprenticeships-and-traineeships/2022-23/explore#supporting-files-section`
       // For these links, a redirect is needed in order for them to work as expected.
       // This logic works around this issue, so that links which don't contain a release slug and do contain an anchor/quick jump ('#')
-      // continue to work as expected when clicked on
+      // continue to work as expected when clicked on.
       const linkMissingReleaseSlugAndContainsTabName =
         releaseSlug === 'explore' ||
         releaseSlug === 'help' ||

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -147,8 +147,9 @@ export const getServerSideProps: GetServerSideProps = withAxiosHandler(
       // For example, `find-statistics/apprenticeships-and-traineeships/explore#supporting-files-section`
       // as opposed to `find-statistics/apprenticeships-and-traineeships/2022-23/explore#supporting-files-section`
       // this logic works around these instances so that links which don't contain a release slug continue to work when clicked on
-      const isLegacyPath = releaseSlug === 'explore';
-      if (isLegacyPath) {
+      const linkMissingReleaseSlugAndContainsTabName =
+        releaseSlug === 'explore';
+      if (linkMissingReleaseSlugAndContainsTabName) {
         return {
           redirect: {
             destination: `/find-statistics/${publicationSlug}/${publicationSummary.latestRelease.slug}/${releaseSlug}`, //

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -143,6 +143,20 @@ export const getServerSideProps: GetServerSideProps = withAxiosHandler(
         };
       }
 
+      // We have some links which point that have no release slug and instead point to sub sections within the 'explore' tab.
+      // For example, `find-statistics/apprenticeships-and-traineeships/explore#supporting-files-section`
+      // as opposed to `find-statistics/apprenticeships-and-traineeships/2022-23/explore#supporting-files-section`
+      // this logic works around these instances so that links which don't contain a release slug continue to work when clicked on
+      const isLegacyPath = releaseSlug === 'explore';
+      if (isLegacyPath) {
+        return {
+          redirect: {
+            destination: `/find-statistics/${publicationSlug}/${publicationSummary.latestRelease.slug}/${releaseSlug}`, //
+            permanent: true,
+          },
+        };
+      }
+
       const releaseVersionSummary = await queryClient.fetchQuery(
         publicationQueries.getReleaseVersionSummary(
           publicationSlug,

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -143,16 +143,21 @@ export const getServerSideProps: GetServerSideProps = withAxiosHandler(
         };
       }
 
-      // We have some links which point that have no release slug and instead point to sub sections within the 'explore' tab.
+      // We have some links in publications which do not contain a release slug but do contain '#' anchors/quick-jump.
       // For example, `find-statistics/apprenticeships-and-traineeships/explore#supporting-files-section`
       // as opposed to `find-statistics/apprenticeships-and-traineeships/2022-23/explore#supporting-files-section`
-      // this logic works around these instances so that links which don't contain a release slug continue to work when clicked on
+      // For these links, a redirect is needed in order for them to work as expected.
+      // This logic works around this issue, so that links which don't contain a release slug and do contain an anchor/quick jump ('#')
+      // continue to work as expected when clicked on
       const linkMissingReleaseSlugAndContainsTabName =
-        releaseSlug === 'explore';
+        releaseSlug === 'explore' ||
+        releaseSlug === 'help' ||
+        releaseSlug === 'methodology';
+
       if (linkMissingReleaseSlugAndContainsTabName) {
         return {
           redirect: {
-            destination: `/find-statistics/${publicationSlug}/${publicationSummary.latestRelease.slug}/${releaseSlug}`, //
+            destination: `/find-statistics/${publicationSlug}/${publicationSummary.latestRelease.slug}/${releaseSlug}`,
             permanent: true,
           },
         };


### PR DESCRIPTION
In live publications, we have references to some broken links where they point to anchors that no longer exist. This is because the release home page's structure has been redesigned. For example we have a link to a publication and a specific section of that publication
`https://explore-education-statistics.service.gov.uk/find-statistics/apprenticeships-and-traineeships/2022-23#section-additional-supporting-files`
but the section with the ID #section-additional-supporting-files no longer exists.
It instead was moved to a new tab 'explore' and was renamed 'supporting-files-section'. 
i.e., `https://explore-education-statistics.service.gov.uk/find-statistics/apprenticeships-and-traineeships/2022-23/explore#supporting-files-section`

To fix these broken links, we can simply replace the portion `#section-additional-supporting-files` with `/explore#supporting-files-section`. 

We are planning to run SQL in order to do this replace. Something along the lines of:
```
SELECT TOP 10
    ReleaseVersionId,
    Body AS OldBody,
    REPLACE(REPLACE(REPLACE(Body,
                            '#related-dashboards-content', '/explore#data-dashboards-section'),
                    '#section-additional-supporting-files', '/explore#supporting-files-section'),
            '#explore-data-and-files', '/explore#content') AS NewBody
FROM ContentBlock
WHERE Body LIKE '%#related-dashboards-content%'
   OR Body LIKE '%#section-additional-supporting-files%'
   OR Body LIKE '%#explore-data-and-files%';


UPDATE ContentBlock
SET Body = REPLACE(
        REPLACE(
                REPLACE(Body,
                        '#related-dashboards-content', '/explore#data-dashboards-section'),
                '#section-additional-supporting-files', '/explore#supporting-files-section'),
        '#explore-data-and-files', '/explore#content')
WHERE Body LIKE '%#related-dashboards-content%'
   OR Body LIKE '%#section-additional-supporting-files%'
   OR Body LIKE '%#explore-data-and-files%';
```

This works for most cases but there are instances in publications where the release slug is not included in a link that points to these outdated sections. 

So the example here would look like `https://explore-education-statistics.service.gov.uk/find-statistics/apprenticeships-and-traineeships#section-additional-supporting-files`.
If we replace this with `https://explore-education-statistics.service.gov.uk/find-statistics/apprenticeships-and-traineeships/explore#supporting-files-section`, this doesn't work.

A suggestion that @mmyoungman  had thought of to get it to work was that we redirect the client to the latest release by placing the release slug right after the publication slug and then have `/explore#supporting-files-section`. 

This PR adds this redirect so that links such as 
`https://explore-education-statistics.service.gov.uk/find-statistics/apprenticeships-and-traineeships/explore#data-dashboards-section`
`https://explore-education-statistics.service.gov.uk/find-statistics/apprenticeships-and-traineeships/explore#supporting-files-section`
`https://explore-education-statistics.service.gov.uk/find-statistics/apprenticeships-and-traineeships/explore#content`

as well as 

`https://explore-education-statistics.service.gov.uk/find-statistics/apprenticeships-and-traineeships/2022-23/explore#data-dashboards-section`
`https://explore-education-statistics.service.gov.uk/find-statistics/apprenticeships-and-traineeships/2022-23/explore#supporting-files-section`
`https://explore-education-statistics.service.gov.uk/find-statistics/apprenticeships-and-traineeships/2022-23/explore#content`

work as expected.