### PR TITLE
EES-7129 - switched int-backed "Status" column on DataSetUpload to be string-backed

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetUploadMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/MockBuilders/DataSetUploadMockBuilder.cs
@@ -24,7 +24,7 @@ public class DataSetUploadMockBuilder(TimeProvider? timeProvider = null)
             MetaFileId = Guid.NewGuid(),
             MetaFileName = "meta.data.csv",
             MetaFileSizeInBytes = 157,
-            Status = DataSetUploadStatus.SCREENING,
+            ScreeningStatus = DataSetUploadScreeningStatus.Screening,
             UploadedBy = "test@test.com",
             Created = _timeProvider.GetUtcNow().AddDays(-1).Date,
             ReplacingFileId = null,
@@ -43,8 +43,10 @@ public class DataSetUploadMockBuilder(TimeProvider? timeProvider = null)
             MetaFileId = Guid.NewGuid(),
             MetaFileName = "meta.data.csv",
             MetaFileSizeInBytes = 157,
-            Status =
-                _screenerResult == "Failed" ? DataSetUploadStatus.FAILED_SCREENING : DataSetUploadStatus.PENDING_IMPORT,
+            ScreeningStatus =
+                _screenerResult == "Failed"
+                    ? DataSetUploadScreeningStatus.FailedScreening
+                    : DataSetUploadScreeningStatus.PendingImport,
             UploadedBy = "test@test.com",
             Created = DateTime.UtcNow,
             ScreenerResult = new DataSetScreenerResponse
@@ -97,7 +99,7 @@ public class DataSetUploadMockBuilder(TimeProvider? timeProvider = null)
             MetaFileId = Guid.NewGuid(),
             MetaFileName = "meta.data.csv",
             MetaFileSizeInBytes = 157,
-            Status = DataSetUploadStatus.SCREENER_ERROR,
+            ScreeningStatus = DataSetUploadScreeningStatus.ScreenerError,
             UploadedBy = "test@test.com",
             Created = _timeProvider.GetUtcNow().AddDays(-1).Date,
             ReplacingFileId = null,
@@ -112,7 +114,7 @@ public class DataSetUploadMockBuilder(TimeProvider? timeProvider = null)
             DataSetTitle = "Data set title",
             DataFileSize = "123 Kb",
             DataFileName = "data.csv",
-            Status = nameof(DataSetUploadStatus.PENDING_IMPORT),
+            Status = nameof(DataSetUploadScreeningStatus.PendingImport),
             UploadedBy = "test.user",
             MetaFileName = "data.meta.csv",
             MetaFileSize = "123 B",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetFileStorageTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetFileStorageTests.cs
@@ -102,7 +102,7 @@ public class DataSetFileStorageTests
         Assert.NotEqual(Guid.Empty, uploadDetails.MetaFileId);
         Assert.Equal("test-data.meta.csv", uploadDetails.MetaFileName);
         Assert.Equal(157, uploadDetails.MetaFileSizeInBytes);
-        Assert.Equal(DataSetUploadStatus.SCREENING, uploadDetails.Status);
+        Assert.Equal(DataSetUploadScreeningStatus.Screening, uploadDetails.ScreeningStatus);
         Assert.Equal(_user.Email.ToLower(), uploadDetails.UploadedBy);
         Assert.Null(uploadDetails.ReplacingFileId);
 
@@ -178,7 +178,7 @@ public class DataSetFileStorageTests
         Assert.NotEqual(Guid.Empty, uploadDetails.MetaFileId);
         Assert.Equal("test-data.meta.csv", uploadDetails.MetaFileName);
         Assert.Equal(157, uploadDetails.MetaFileSizeInBytes);
-        Assert.Equal(DataSetUploadStatus.SCREENING, uploadDetails.Status);
+        Assert.Equal(DataSetUploadScreeningStatus.Screening, uploadDetails.ScreeningStatus);
         Assert.Equal(_user.Email.ToLower(), uploadDetails.UploadedBy);
         Assert.Null(uploadDetails.ReplacingFileId);
 
@@ -363,7 +363,7 @@ public class DataSetFileStorageTests
             var result = await contentDbContext.DataSetUploads.FindAsync(dataSetUpload.Id);
 
             Assert.NotNull(result);
-            Assert.Equal(DataSetUploadStatus.SCREENER_ERROR, result.Status);
+            Assert.Equal(DataSetUploadScreeningStatus.ScreenerError, result.ScreeningStatus);
             Assert.Null(result.ScreenerResult);
         }
     }
@@ -412,13 +412,13 @@ public class DataSetFileStorageTests
             switch (testResult)
             {
                 case TestResult.PASS:
-                    Assert.Equal(DataSetUploadStatus.PENDING_IMPORT, updatedDataSetUpload.Status);
+                    Assert.Equal(DataSetUploadScreeningStatus.PendingImport, updatedDataSetUpload.ScreeningStatus);
                     break;
                 case TestResult.WARNING:
-                    Assert.Equal(DataSetUploadStatus.PENDING_REVIEW, updatedDataSetUpload.Status);
+                    Assert.Equal(DataSetUploadScreeningStatus.PendingReview, updatedDataSetUpload.ScreeningStatus);
                     break;
                 case TestResult.FAIL:
-                    Assert.Equal(DataSetUploadStatus.FAILED_SCREENING, updatedDataSetUpload.Status);
+                    Assert.Equal(DataSetUploadScreeningStatus.FailedScreening, updatedDataSetUpload.ScreeningStatus);
                     break;
             }
 
@@ -536,7 +536,7 @@ public class DataSetFileStorageTests
             MetaFileId = Guid.NewGuid(),
             MetaFileName = metaFileName,
             MetaFileSizeInBytes = 157,
-            Status = DataSetUploadStatus.SCREENING,
+            ScreeningStatus = DataSetUploadScreeningStatus.Screening,
             UploadedBy = _user.Email,
             ReplacingFileId = originalDataFile.Id,
         };
@@ -589,7 +589,7 @@ public class DataSetFileStorageTests
             MetaFileSizeInBytes = 456,
             MetaFileId = Guid.NewGuid(),
             UploadedBy = _user.Email,
-            Status = DataSetUploadStatus.SCREENING,
+            ScreeningStatus = DataSetUploadScreeningStatus.Screening,
         };
 
         await using var contentDbContext = InMemoryApplicationDbContext();
@@ -676,7 +676,7 @@ public class DataSetFileStorageTests
             MetaFileSizeInBytes = 456,
             MetaFileId = Guid.NewGuid(),
             UploadedBy = _user.Email,
-            Status = DataSetUploadStatus.SCREENING,
+            ScreeningStatus = DataSetUploadScreeningStatus.Screening,
         };
 
         await using var contentDbContext = InMemoryApplicationDbContext();
@@ -777,7 +777,7 @@ public class DataSetFileStorageTests
             ReplacingFileId = testFixture.DataFile.Id,
             ReleaseVersionId = testFixture.ReleaseVersion.Id,
             DataSetTitle = dataSetName,
-            Status = DataSetUploadStatus.SCREENING,
+            ScreeningStatus = DataSetUploadScreeningStatus.Screening,
             UploadedBy = _user.Email,
         };
 
@@ -838,7 +838,7 @@ public class DataSetFileStorageTests
                 MetaFileSizeInBytes = 157,
                 ReleaseVersionId = testFixture.ReleaseVersion.Id,
                 DataSetTitle = releaseFilesAndDataSets[i].dataSetName,
-                Status = DataSetUploadStatus.SCREENING,
+                ScreeningStatus = DataSetUploadScreeningStatus.Screening,
                 DataFileId = Guid.NewGuid(),
                 DataFileName = dataFileNames[i],
                 MetaFileId = Guid.NewGuid(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetUploadRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetUploadRepositoryTests.cs
@@ -60,7 +60,7 @@ public class DataSetUploadRepositoryTests
             AssertBasicViewModelDetailsCorrect(uploadViewModels[3], upload4);
 
             // Assert that a DataSetUpload that is undergoing screening is mapped correctly.
-            Assert.Equal(nameof(DataSetUploadStatus.SCREENING), uploadViewModels[0].Status);
+            Assert.Equal(nameof(DataSetUploadScreeningStatus.Screening), uploadViewModels[0].Status);
 
             // Assert it has no screener results or progress yet.
             Assert.False(uploadViewModels[0].PublicApiCompatible);
@@ -68,7 +68,7 @@ public class DataSetUploadRepositoryTests
             Assert.Null(uploadViewModels[0].ScreenerProgress);
 
             // Assert that a DataSetUpload with a failed screening result is mapped correctly.
-            Assert.Equal(nameof(DataSetUploadStatus.FAILED_SCREENING), uploadViewModels[1].Status);
+            Assert.Equal(nameof(DataSetUploadScreeningStatus.FailedScreening), uploadViewModels[1].Status);
 
             // Assert its screening progress is mapped correctly.
             Assert.Equal(
@@ -78,7 +78,7 @@ public class DataSetUploadRepositoryTests
             Assert.Equal(upload2.ScreenerProgress!.Stage, uploadViewModels[1].ScreenerProgress!.Stage);
 
             // Assert that a DataSetUpload with a warning screening result is mapped correctly.
-            Assert.Equal(nameof(DataSetUploadStatus.PENDING_REVIEW), uploadViewModels[2].Status);
+            Assert.Equal(nameof(DataSetUploadScreeningStatus.PendingReview), uploadViewModels[2].Status);
             Assert.Equal(upload3.ScreenerResult!.PublicApiCompatible, uploadViewModels[2].PublicApiCompatible);
             Assert.Equal(upload3.ScreenerResult!.OverallResult, uploadViewModels[2].ScreenerResult!.OverallResult);
             AssertScreenerTestsCorrect(
@@ -94,7 +94,7 @@ public class DataSetUploadRepositoryTests
             Assert.Equal(upload3.ScreenerProgress!.Stage, uploadViewModels[2].ScreenerProgress!.Stage);
 
             // Assert that a DataSetUpload that has received a Screener error is mapped correctly.
-            Assert.Equal(nameof(DataSetUploadStatus.SCREENER_ERROR), uploadViewModels[3].Status);
+            Assert.Equal(nameof(DataSetUploadScreeningStatus.ScreenerError), uploadViewModels[3].Status);
 
             // Assert it has no screener results or progress yet.
             Assert.False(uploadViewModels[3].PublicApiCompatible);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Screener/DataSetScreenerServiceTests.cs
@@ -111,7 +111,7 @@ public abstract class DataSetScreenerServiceTests
             // Arrange
             var dataSetsUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
-                .WithStatus(DataSetUploadStatus.SCREENING)
+                .WithStatus(DataSetUploadScreeningStatus.Screening)
                 .ForIndex(
                     0,
                     s =>
@@ -260,7 +260,7 @@ public abstract class DataSetScreenerServiceTests
             // Arrange
             DataSetUpload dataSetUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
-                .WithStatus(DataSetUploadStatus.SCREENING)
+                .WithStatus(DataSetUploadScreeningStatus.Screening)
                 .WithScreenerProgress(
                     new DataSetScreenerProgress
                     {
@@ -324,7 +324,7 @@ public abstract class DataSetScreenerServiceTests
             DataSetUpload dataSetUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
                 // Not currently being screened.
-                .WithStatus(DataSetUploadStatus.PENDING_REVIEW);
+                .WithStatus(DataSetUploadScreeningStatus.PendingReview);
 
             var contextId = Guid.NewGuid().ToString();
             await using (var context = InMemoryContentDbContext(contextId))
@@ -367,7 +367,7 @@ public abstract class DataSetScreenerServiceTests
             // Arrange
             var dataSetsUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
-                .WithStatus(DataSetUploadStatus.SCREENING)
+                .WithStatus(DataSetUploadScreeningStatus.Screening)
                 .WithScreenerProgress(
                     new DataSetScreenerProgress
                     {
@@ -489,7 +489,7 @@ public abstract class DataSetScreenerServiceTests
             // Arrange
             DataSetUpload dataSetUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
-                .WithStatus(DataSetUploadStatus.SCREENING)
+                .WithStatus(DataSetUploadScreeningStatus.Screening)
                 .WithScreenerProgress(
                     new DataSetScreenerProgress
                     {
@@ -776,7 +776,7 @@ public abstract class DataSetScreenerServiceTests
 
             var dataSetsUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
-                .WithStatus(DataSetUploadStatus.SCREENING)
+                .WithStatus(DataSetUploadScreeningStatus.Screening)
                 .ForIndex(
                     0,
                     s =>
@@ -839,7 +839,7 @@ public abstract class DataSetScreenerServiceTests
 
                 results.ForEach(result =>
                 {
-                    Assert.Equal(nameof(DataSetUploadStatus.FAILED_SCREENING), result.Status);
+                    Assert.Equal(nameof(DataSetUploadScreeningStatus.FailedScreening), result.Status);
                     Assert.NotNull(result.ScreenerResult);
                     Assert.Equal("Failed to retrieve progress updates", result.ScreenerResult.OverallResult);
                     Assert.Empty(result.ScreenerResult.TestResults);
@@ -853,7 +853,7 @@ public abstract class DataSetScreenerServiceTests
 
                 updatedUploads.ForEach(upload =>
                 {
-                    Assert.Equal(DataSetUploadStatus.SCREENER_ERROR, upload.Status);
+                    Assert.Equal(DataSetUploadScreeningStatus.ScreenerError, upload.ScreeningStatus);
                     Assert.NotNull(upload.ScreenerResult);
                     Assert.Equal("Failed to retrieve progress updates", upload.ScreenerResult.OverallResult);
                     Assert.False(upload.ScreenerResult.Passed);
@@ -872,7 +872,7 @@ public abstract class DataSetScreenerServiceTests
 
             DataSetUpload dataSetUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
-                .WithStatus(DataSetUploadStatus.SCREENING)
+                .WithStatus(DataSetUploadScreeningStatus.Screening)
                 .WithScreenerProgress(
                     new DataSetScreenerProgress
                     {
@@ -915,7 +915,7 @@ public abstract class DataSetScreenerServiceTests
                 var upload = context.DataSetUploads.Single();
 
                 // Expect it to be in its original state.
-                Assert.Equal(DataSetUploadStatus.SCREENING, upload.Status);
+                Assert.Equal(DataSetUploadScreeningStatus.Screening, upload.ScreeningStatus);
 
                 // Expect it not to have had any ScreenerResult applied.
                 Assert.Null(upload.ScreenerResult);
@@ -930,7 +930,7 @@ public abstract class DataSetScreenerServiceTests
 
             DataSetUpload dataSetUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
-                .WithStatus(DataSetUploadStatus.PENDING_REVIEW)
+                .WithStatus(DataSetUploadScreeningStatus.PendingReview)
                 .WithScreenerProgress(
                     new DataSetScreenerProgress
                     {
@@ -968,7 +968,7 @@ public abstract class DataSetScreenerServiceTests
                 var upload = context.DataSetUploads.Single();
 
                 // Expect it to be in its original state.
-                Assert.Equal(DataSetUploadStatus.PENDING_REVIEW, upload.Status);
+                Assert.Equal(DataSetUploadScreeningStatus.PendingReview, upload.ScreeningStatus);
 
                 // Expect it not to have had any ScreenerResult applied.
                 Assert.Null(upload.ScreenerResult);
@@ -984,7 +984,7 @@ public abstract class DataSetScreenerServiceTests
             // Arrange
             var dataSetsUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
-                .WithStatus(DataSetUploadStatus.SCREENING)
+                .WithStatus(DataSetUploadScreeningStatus.Screening)
                 // The first data set has had a progress update that shows it has completed successfully.
                 .ForIndex(
                     0,
@@ -1150,19 +1150,19 @@ public abstract class DataSetScreenerServiceTests
                 var dataSetUpload1 = updatedDataSetUploads[0];
                 var expectedDataSet1CompletionReport = completionReportsResponse[1].CompletionReport;
                 expectedDataSet1CompletionReport.AssertDeepEqualTo(dataSetUpload1.ScreenerResult);
-                Assert.Equal(DataSetUploadStatus.PENDING_REVIEW, dataSetUpload1.Status);
+                Assert.Equal(DataSetUploadScreeningStatus.PendingReview, dataSetUpload1.ScreeningStatus);
 
                 // Expect that data set 2 has no updates as it has not yet completed.
                 var dataSetUpload2 = updatedDataSetUploads[1];
                 Assert.Null(dataSetUpload2.ScreenerResult);
-                Assert.Equal(DataSetUploadStatus.SCREENING, dataSetUpload2.Status);
+                Assert.Equal(DataSetUploadScreeningStatus.Screening, dataSetUpload2.ScreeningStatus);
 
                 // Expect that data set 3 had its completion report applied and status updated to
                 // show that it failed screening.
                 var dataSetUpload3 = updatedDataSetUploads[2];
                 var expectedDataSet3CompletionReport = completionReportsResponse[0].CompletionReport;
                 expectedDataSet3CompletionReport.AssertDeepEqualTo(dataSetUpload3.ScreenerResult);
-                Assert.Equal(DataSetUploadStatus.FAILED_SCREENING, dataSetUpload3.Status);
+                Assert.Equal(DataSetUploadScreeningStatus.FailedScreening, dataSetUpload3.ScreeningStatus);
             }
         }
 
@@ -1172,7 +1172,7 @@ public abstract class DataSetScreenerServiceTests
             // Arrange
             DataSetUpload dataSetUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
-                .WithStatus(DataSetUploadStatus.SCREENING)
+                .WithStatus(DataSetUploadScreeningStatus.Screening)
                 .WithScreenerProgress(
                     new DataSetScreenerProgress
                     {
@@ -1228,7 +1228,7 @@ public abstract class DataSetScreenerServiceTests
             // Arrange
             DataSetUpload dataSetUndergoingScreening = _dataFixture
                 .DefaultDataSetUpload()
-                .WithStatus(DataSetUploadStatus.PENDING_IMPORT)
+                .WithStatus(DataSetUploadScreeningStatus.PendingImport)
                 .WithScreenerProgress(
                     new DataSetScreenerProgress
                     {
@@ -1262,7 +1262,7 @@ public abstract class DataSetScreenerServiceTests
                 var upload = context.DataSetUploads.Single();
 
                 // Expect it to be in its original state.
-                Assert.Equal(DataSetUploadStatus.PENDING_IMPORT, upload.Status);
+                Assert.Equal(DataSetUploadScreeningStatus.PendingImport, upload.ScreeningStatus);
 
                 // Expect it not to have had any ScreenerResult applied.
                 Assert.Null(upload.ScreenerResult);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -121,7 +121,7 @@ public class MappingProfiles : CommonMappingProfile
             .ForMember(dest => dest.Type, m => m.MapFrom(dataSetVersion => dataSetVersion.VersionType));
 
         CreateMap<DataSetUpload, DataSetUploadViewModel>()
-            .ForMember(dest => dest.Status, m => m.MapFrom(upload => GetDataSetUploadStatus(upload)))
+            .ForMember(dest => dest.Status, m => m.MapFrom(upload => GetDataSetUploadScreeningStatus(upload)))
             .ForMember(
                 dest => dest.PublicApiCompatible,
                 m => m.MapFrom(upload => upload.ScreenerResult != null && upload.ScreenerResult.PublicApiCompatible)
@@ -150,28 +150,28 @@ public class MappingProfiles : CommonMappingProfile
             .ForMember(d => d.DataSetId, m => m.MapFrom(upload => upload.Id));
     }
 
-    private static string GetDataSetUploadStatus(DataSetUpload dataSetUpload)
+    private static string GetDataSetUploadScreeningStatus(DataSetUpload dataSetUpload)
     {
-        if (dataSetUpload.Status == DataSetUploadStatus.SCREENING)
+        if (dataSetUpload.ScreeningStatus == DataSetUploadScreeningStatus.Screening)
         {
-            return nameof(DataSetUploadStatus.SCREENING);
+            return nameof(DataSetUploadScreeningStatus.Screening);
         }
 
         var screenerResult = dataSetUpload.ScreenerResult;
 
         if (screenerResult is null)
         {
-            return nameof(DataSetUploadStatus.SCREENER_ERROR);
+            return nameof(DataSetUploadScreeningStatus.ScreenerError);
         }
 
         if (screenerResult.Passed && screenerResult.TestResults.Any(test => test.Result == TestResult.WARNING))
         {
-            return nameof(DataSetUploadStatus.PENDING_REVIEW);
+            return nameof(DataSetUploadScreeningStatus.PendingReview);
         }
 
         return !screenerResult.Passed
-            ? nameof(DataSetUploadStatus.FAILED_SCREENING)
-            : nameof(DataSetUploadStatus.PENDING_IMPORT);
+            ? nameof(DataSetUploadScreeningStatus.FailedScreening)
+            : nameof(DataSetUploadScreeningStatus.PendingImport);
     }
 
     private void CreateContentBlockMap()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260515084150_Ees7129AddStringBasedScreeningStatusFieldToDataSetUpload.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260515084150_Ees7129AddStringBasedScreeningStatusFieldToDataSetUpload.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260515084150_Ees7129AddStringBasedScreeningStatusFieldToDataSetUpload")]
+    partial class Ees7129AddStringBasedScreeningStatusFieldToDataSetUpload
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -414,8 +417,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("ScreeningStatus")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("int");
 
                     b.Property<int>("Status")
                         .HasColumnType("int");

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260515084150_Ees7129AddStringBasedScreeningStatusFieldToDataSetUpload.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260515084150_Ees7129AddStringBasedScreeningStatusFieldToDataSetUpload.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees7129AddStringBasedScreeningStatusFieldToDataSetUpload : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ScreeningStatus",
+                table: "DataSetUploads",
+                type: "nvarchar(max)",
+                nullable: true
+            );
+
+            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'Screening' WHERE Status = '0'");
+            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'ScreenerError' WHERE Status = '1'");
+            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'FailedScreening' WHERE Status = '2'");
+            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'PendingReview' WHERE Status = '3'");
+            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'PendingImport' WHERE Status = '4'");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ScreeningStatus",
+                table: "DataSetUploads",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldNullable: true,
+                defaultValue: 0
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "ScreeningStatus", table: "DataSetUploads");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260515084150_Ees7129AddStringBasedScreeningStatusFieldToDataSetUpload.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260515084150_Ees7129AddStringBasedScreeningStatusFieldToDataSetUpload.cs
@@ -17,11 +17,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                 nullable: true
             );
 
-            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'Screening' WHERE Status = '0'");
-            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'ScreenerError' WHERE Status = '1'");
-            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'FailedScreening' WHERE Status = '2'");
-            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'PendingReview' WHERE Status = '3'");
-            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'PendingImport' WHERE Status = '4'");
+            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'Screening' WHERE Status = 0");
+            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'ScreenerError' WHERE Status = 1");
+            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'FailedScreening' WHERE Status = 2");
+            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'PendingReview' WHERE Status = 3");
+            migrationBuilder.Sql("UPDATE DataSetUploads SET ScreeningStatus = 'PendingImport' WHERE Status = 4");
 
             migrationBuilder.AlterColumn<int>(
                 name: "ScreeningStatus",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetFileStorage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetFileStorage.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using System.Diagnostics.CodeAnalysis;
 using GovUk.Education.ExploreEducationStatistics.Admin.Options;
-using GovUk.Education.ExploreEducationStatistics.Admin.Responses.Screener;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Public.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -101,7 +100,7 @@ public class DataSetFileStorage(
             MetaFileId = metaFileId,
             MetaFileName = dataSet.MetaFile.FileName,
             MetaFileSizeInBytes = dataSet.MetaFile.FileSize,
-            Status = DataSetUploadStatus.SCREENING,
+            ScreeningStatus = DataSetUploadScreeningStatus.Screening,
             UploadedBy = userService.GetProfileFromClaims().Email.ToLower(),
             ReplacingFileId = dataSet.ReplacingFile?.Id,
             ScreenerProgress = screenerOptions.Value.EnhancedScreenerJourney
@@ -222,7 +221,7 @@ public class DataSetFileStorage(
 
         if (screenerResult is null)
         {
-            upload.Status = DataSetUploadStatus.SCREENER_ERROR;
+            upload.ScreeningStatus = DataSetUploadScreeningStatus.ScreenerError;
         }
         else
         {
@@ -233,15 +232,15 @@ public class DataSetFileStorage(
 
             if (hasWarnings)
             {
-                upload.Status = DataSetUploadStatus.PENDING_REVIEW;
+                upload.ScreeningStatus = DataSetUploadScreeningStatus.PendingReview;
             }
             else if (hasFailures)
             {
-                upload.Status = DataSetUploadStatus.FAILED_SCREENING;
+                upload.ScreeningStatus = DataSetUploadScreeningStatus.FailedScreening;
             }
             else
             {
-                upload.Status = DataSetUploadStatus.PENDING_IMPORT;
+                upload.ScreeningStatus = DataSetUploadScreeningStatus.PendingImport;
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
@@ -724,7 +724,9 @@ public class ReleaseDataFileService(
 
         return
             !isBauUser.IsRight
-            && dataSetUpload.Status is not DataSetUploadStatus.PENDING_REVIEW and not DataSetUploadStatus.PENDING_IMPORT
+            && dataSetUpload.ScreeningStatus
+                is not DataSetUploadScreeningStatus.PendingReview
+                    and not DataSetUploadScreeningStatus.PendingImport
             ? ValidationUtils.ValidationResult(ValidationMessages.GenerateErrorDataSetIsNotInAnImportableState())
             : dataSetUpload;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerProgressUpdaterJob.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerProgressUpdaterJob.cs
@@ -81,11 +81,11 @@ public class DataSetScreenerProgressUpdaterJob(
             );
 
             var successfulCompletions = completions
-                .Where(c => c.Status == nameof(DataSetUploadStatus.PENDING_REVIEW))
+                .Where(c => c.Status == nameof(DataSetUploadScreeningStatus.PendingReview))
                 .ToList();
 
             var failedCompletions = completions
-                .Where(c => c.Status == nameof(DataSetUploadStatus.FAILED_SCREENING))
+                .Where(c => c.Status == nameof(DataSetUploadScreeningStatus.FailedScreening))
                 .ToList();
 
             if (successfulCompletions.Count > 0)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Screener/DataSetScreenerService.cs
@@ -63,7 +63,7 @@ public class DataSetScreenerService(
         // Find any data sets currently undergoing screening that haven't had a progress check made for
         // them in the last <ScreenerProgressUpdateIntervalSeconds> seconds.
         var dataSetsNeedingScreenerProgressUpdates = await contentDbContext
-            .DataSetUploads.Where(upload => upload.Status == DataSetUploadStatus.SCREENING)
+            .DataSetUploads.Where(upload => upload.ScreeningStatus == DataSetUploadScreeningStatus.Screening)
             .Where(upload =>
                 upload.ScreenerProgressLastChecked == null || upload.ScreenerProgressLastChecked <= lastCheckedWindow
             )
@@ -145,7 +145,7 @@ public class DataSetScreenerService(
 
         // Find all data sets currently undergoing screening.
         var screeningDataSets = await contentDbContext
-            .DataSetUploads.Where(upload => upload.Status == DataSetUploadStatus.SCREENING)
+            .DataSetUploads.Where(upload => upload.ScreeningStatus == DataSetUploadScreeningStatus.Screening)
             .ToListAsync(cancellationToken: cancellationToken);
 
         // Find any data sets where the gap between their last successful progress update
@@ -175,7 +175,7 @@ public class DataSetScreenerService(
                 TestResults = [],
                 PublicApiCompatible = false,
             };
-            upload.Status = DataSetUploadStatus.SCREENER_ERROR;
+            upload.ScreeningStatus = DataSetUploadScreeningStatus.ScreenerError;
             contentDbContext.DataSetUploads.Update(upload);
         });
 
@@ -274,9 +274,9 @@ public class DataSetScreenerService(
             var report = completionReports.Single(u => u.DataSetId == uploadToComplete.Id);
 
             uploadToComplete.ScreenerResult = report.CompletionReport;
-            uploadToComplete.Status = report.CompletionReport.Passed
-                ? DataSetUploadStatus.PENDING_REVIEW
-                : DataSetUploadStatus.FAILED_SCREENING;
+            uploadToComplete.ScreeningStatus = report.CompletionReport.Passed
+                ? DataSetUploadScreeningStatus.PendingReview
+                : DataSetUploadScreeningStatus.FailedScreening;
             contentDbContext.DataSetUploads.Update(uploadToComplete);
         });
 
@@ -298,7 +298,7 @@ public class DataSetScreenerService(
     {
         // Find all data sets currently undergoing screening.
         var screeningDataSets = await contentDbContext
-            .DataSetUploads.Where(upload => upload.Status == DataSetUploadStatus.SCREENING)
+            .DataSetUploads.Where(upload => upload.ScreeningStatus == DataSetUploadScreeningStatus.Screening)
             .ToListAsync(cancellationToken: cancellationToken);
 
         // Find only those whose latest progress reports show as having been completed.

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetUploadGeneratorExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Fixtures/DataSetUploadGeneratorExtensions.cs
@@ -22,7 +22,7 @@ public static class DataSetUploadGeneratorExtensions
             .SetDefault(d => d.MetaFileId)
             .SetDefault(d => d.MetaFileName)
             .SetDefault(d => d.MetaFileSizeInBytes)
-            .SetDefault(d => d.Status)
+            .SetDefault(d => d.ScreeningStatus)
             .SetDefault(d => d.Created)
             .SetDefault(d => d.UploadedBy);
 
@@ -70,7 +70,7 @@ public static class DataSetUploadGeneratorExtensions
 
     public static Generator<DataSetUpload> WithStatus(
         this Generator<DataSetUpload> generator,
-        DataSetUploadStatus status
+        DataSetUploadScreeningStatus status
     ) => generator.ForInstance(s => s.SetStatus(status));
 
     public static Generator<DataSetUpload> WithScreenerResult(
@@ -149,8 +149,8 @@ public static class DataSetUploadGeneratorExtensions
 
     public static InstanceSetters<DataSetUpload> SetStatus(
         this InstanceSetters<DataSetUpload> setters,
-        DataSetUploadStatus status
-    ) => setters.Set(d => d.Status, status);
+        DataSetUploadScreeningStatus status
+    ) => setters.Set(d => d.ScreeningStatus, status);
 
     public static InstanceSetters<DataSetUpload> SetScreenerResult(
         this InstanceSetters<DataSetUpload> setters,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetUpload.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetUpload.cs
@@ -36,8 +36,12 @@ public record DataSetUpload : ICreatedTimestamp<DateTime>
 
     public Guid? ReplacingFileId { get; init; }
 
-    [JsonConverter(typeof(EnumToEnumValueJsonConverter<DataSetUploadStatus>))]
-    public required DataSetUploadStatus Status { get; set; }
+    [JsonConverter(typeof(EnumToEnumValueJsonConverter<DataSetUploadScreeningStatus>))]
+    [Obsolete("Use ScreeningStatus instead")]
+    public DataSetUploadScreeningStatus Status { get; set; }
+
+    [JsonConverter(typeof(EnumToEnumValueJsonConverter<DataSetUploadScreeningStatus>))]
+    public required DataSetUploadScreeningStatus ScreeningStatus { get; set; }
 
     public DataSetScreenerResponse? ScreenerResult { get; set; }
 
@@ -52,11 +56,11 @@ public record DataSetUpload : ICreatedTimestamp<DateTime>
     public required string UploadedBy { get; set; }
 }
 
-public enum DataSetUploadStatus
+public enum DataSetUploadScreeningStatus
 {
-    SCREENING,
-    SCREENER_ERROR,
-    FAILED_SCREENING,
-    PENDING_REVIEW,
-    PENDING_IMPORT,
+    Screening,
+    ScreenerError,
+    FailedScreening,
+    PendingReview,
+    PendingImport,
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -177,6 +177,11 @@ public class ContentDbContext : DbContext
             .Entity<DataSetUpload>()
             .Property(m => m.Created)
             .HasConversion(d => d, d => DateTime.SpecifyKind(d, DateTimeKind.Utc));
+
+        modelBuilder
+            .Entity<DataSetUpload>()
+            .Property(import => import.ScreeningStatus)
+            .HasConversion(new EnumToStringConverter<DataSetUploadScreeningStatus>());
     }
 
     private static void ConfigureDataImport(ModelBuilder modelBuilder)

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableUploadsRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableUploadsRow.tsx
@@ -60,8 +60,8 @@ export default function DataFilesTableUploadRow({
   const importBlocked =
     !canUpdateRelease ||
     !dataSetUpload.screenerResult ||
-    dataSetUpload.status === 'SCREENER_ERROR' ||
-    dataSetUpload.status === 'FAILED_SCREENING' ||
+    dataSetUpload.status === 'ScreenerError' ||
+    dataSetUpload.status === 'FailedScreening' ||
     hasFailures;
 
   const importUnavailable = !Object.values(warningAcknowledgements).every(
@@ -138,7 +138,7 @@ export default function DataFilesTableUploadRow({
     confirmText = 'Continue import (override failures)';
   }
 
-  if (dataSetUpload.status === 'SCREENER_ERROR') {
+  if (dataSetUpload.status === 'ScreenerError') {
     confirmText = 'Continue import (bypass screening)';
   }
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableUploadsRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableUploadsRow.tsx
@@ -19,8 +19,8 @@ import dataSetUploadTabIds from '../utils/dataSetUploadTabIds';
 import ScreenerResultsTable from './ScreenerResultsTable';
 import styles from './DataFilesTable.module.scss';
 import {
-  getDataSetUploadStatusColour,
-  getDataSetUploadStatusLabel,
+  getDataSetUploadScreeningStatusColour,
+  getDataSetUploadScreeningStatusLabel,
 } from './ImporterStatus';
 
 interface Props {
@@ -151,8 +151,10 @@ export default function DataFilesTableUploadRow({
         {dataSetUpload.dataFileSize}
       </td>
       <td data-testid="Status">
-        <Tag colour={getDataSetUploadStatusColour(dataSetUpload.status)}>
-          {getDataSetUploadStatusLabel(dataSetUpload.status)}
+        <Tag
+          colour={getDataSetUploadScreeningStatusColour(dataSetUpload.status)}
+        >
+          {getDataSetUploadScreeningStatusLabel(dataSetUpload.status)}
         </Tag>
       </td>
       <td data-testid="Actions">

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataSetUploadSummaryList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataSetUploadSummaryList.tsx
@@ -7,8 +7,8 @@ import React from 'react';
 import ButtonText from '@common/components/ButtonText';
 import downloadTemporaryReleaseFileSecurely from '@admin/pages/release/data/components/utils/downloadTemporaryReleaseFileSecurely';
 import {
-  getDataSetUploadStatusColour,
-  getDataSetUploadStatusLabel,
+  getDataSetUploadScreeningStatusColour,
+  getDataSetUploadScreeningStatusLabel,
 } from './ImporterStatus';
 import ApiCompatibilityTag from './ApiCompatibilityTag';
 
@@ -62,8 +62,10 @@ export default function DataSetUploadSummaryList({
         {dataSetUpload.dataFileSize}
       </SummaryListItem>
       <SummaryListItem term="Status">
-        <Tag colour={getDataSetUploadStatusColour(dataSetUpload.status)}>
-          {getDataSetUploadStatusLabel(dataSetUpload.status)}
+        <Tag
+          colour={getDataSetUploadScreeningStatusColour(dataSetUpload.status)}
+        >
+          {getDataSetUploadScreeningStatusLabel(dataSetUpload.status)}
         </Tag>
       </SummaryListItem>{' '}
       <SummaryListItem term="Uploaded by">

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
@@ -1,7 +1,7 @@
 import releaseDataFileService, {
   DataFile,
   DataFileImportStatus,
-  DataSetUploadStatus,
+  DataSetUploadScreeningStatus,
   ImportStatusCode,
   ScreenerTestResult,
 } from '@admin/services/releaseDataFileService';
@@ -14,41 +14,37 @@ import useInterval from '@common/hooks/useInterval';
 import useMounted from '@common/hooks/useMounted';
 import React, { useCallback, useEffect, useState } from 'react';
 
-export const getDataSetUploadStatusLabel = (
-  statusCode: DataSetUploadStatus,
+export const getDataSetUploadScreeningStatusLabel = (
+  statusCode: DataSetUploadScreeningStatus,
 ): string | undefined => {
   switch (statusCode) {
-    case 'UPLOADING':
-      return 'Uploading';
-    case 'SCREENING':
+    case 'Screening':
       return 'Screening';
-    case 'PENDING_REVIEW':
+    case 'PendingReview':
       return 'Pending review';
-    case 'PENDING_IMPORT':
+    case 'PendingImport':
       return 'Pending import';
-    case 'FAILED_SCREENING':
+    case 'FailedScreening':
       return 'Failed screening';
-    case 'SCREENER_ERROR':
+    case 'ScreenerError':
       return 'Screener error';
     default:
       return undefined;
   }
 };
 
-export const getDataSetUploadStatusColour = (
-  statusCode: DataSetUploadStatus,
+export const getDataSetUploadScreeningStatusColour = (
+  statusCode: DataSetUploadScreeningStatus,
 ): TagProps['colour'] => {
   switch (statusCode) {
-    case 'UPLOADING':
-      return 'turquoise';
-    case 'PENDING_REVIEW':
+    case 'PendingReview':
       return 'orange';
-    case 'SCREENING':
+    case 'Screening':
       return 'blue';
-    case 'PENDING_IMPORT':
+    case 'PendingImport':
       return 'light-blue';
-    case 'FAILED_SCREENING':
-    case 'SCREENER_ERROR':
+    case 'FailedScreening':
+    case 'ScreenerError':
       return 'red';
     default:
       return undefined;

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesTableUploadsRow.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFilesTableUploadsRow.test.tsx
@@ -21,7 +21,7 @@ describe('DataFilesTableUploadsRow', () => {
       dataFileSize: '696 B',
       metaFileName: 'one-pass.meta.csv',
       metaFileSize: '210 B',
-      status: 'PENDING_IMPORT',
+      status: 'PendingImport',
       screenerResult: {
         overallResult: 'Passed',
         passed: true,
@@ -59,7 +59,7 @@ describe('DataFilesTableUploadsRow', () => {
       dataFileSize: '696 B',
       metaFileName: 'one-pass.meta.csv',
       metaFileSize: '210 B',
-      status: 'PENDING_IMPORT',
+      status: 'PendingImport',
       screenerResult: {
         overallResult: 'Passed',
         passed: true,
@@ -97,7 +97,7 @@ describe('DataFilesTableUploadsRow', () => {
       dataFileSize: '677 Kb',
       metaFileName: 'absence-fail.meta.csv',
       metaFileSize: '2 Kb',
-      status: 'FAILED_SCREENING',
+      status: 'FailedScreening',
       screenerResult: {
         overallResult: 'Passed',
         passed: true,

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -28,7 +28,7 @@ export interface DataSetUpload {
   dataFileSize: string;
   metaFileName: string;
   metaFileSize: string;
-  status: DataSetUploadStatus;
+  status: DataSetUploadScreeningStatus;
   screenerResult?: ScreenerResult; // Nullable if screening fails
   created: Date;
   uploadedBy: string;
@@ -118,13 +118,12 @@ export type ImportStatusCode =
   | 'CANCELLING'
   | 'CANCELLED';
 
-export type DataSetUploadStatus =
-  | 'UPLOADING'
-  | 'SCREENING'
-  | 'FAILED_SCREENING'
-  | 'SCREENER_ERROR'
-  | 'PENDING_REVIEW'
-  | 'PENDING_IMPORT';
+export type DataSetUploadScreeningStatus =
+  | 'Screening'
+  | 'FailedScreening'
+  | 'ScreenerError'
+  | 'PendingReview'
+  | 'PendingImport';
 
 export type ScreenerTestResult = 'PASS' | 'FAIL' | 'WARNING';
 


### PR DESCRIPTION
This PR:
- replaces a field that was being stored as an enum numeric value with a field that stores it in a string instead.
- does a general rename of "Status" to "ScreeningStatus" across the board, apart from view models and front-end code.

I decided that a rename of the field made sense as the status is all to do with screening.  I decided also to dual-run the columns in this PR and remove the old one completely in a subsequent PR, just to reduce the possibility of causing any temp issues for analysts during the deploy window.  I also chose to defer renaming the Status column in the viewmodel and front end codebase in this PR just to keep it a bit smaller.

## UI test results

2 failing, which are also failing in the pipeline.

<img width="848" height="152" alt="image" src="https://github.com/user-attachments/assets/4e13e9f5-5ce5-4292-906d-a7a35a974899" />
