### PR TITLE
EES-7147 Increase default releases per page listed on "Releases in this series" page to 25 and backend changes to remove pagination defaults

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Public.Data/DataSetsControllerTests.cs
@@ -554,7 +554,7 @@ public abstract class DataSetsControllerTests(DataSetsControllerTestsFixture fix
 
             var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetSummaryViewModel>>();
 
-            pagedResult.AssertHasPagingConsistentWithEmptyResults();
+            pagedResult.AssertEmptyResults();
         }
 
         [Fact]
@@ -606,7 +606,7 @@ public abstract class DataSetsControllerTests(DataSetsControllerTestsFixture fix
 
             var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetSummaryViewModel>>();
 
-            pagedResult.AssertHasPagingConsistentWithEmptyResults(expectedPage: page);
+            pagedResult.AssertHasExpectedPagingAndResultCount(expectedTotalResults: 0, expectedPage: page);
         }
 
         [Theory]
@@ -637,7 +637,7 @@ public abstract class DataSetsControllerTests(DataSetsControllerTestsFixture fix
 
             var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetSummaryViewModel>>();
 
-            pagedResult.AssertHasPagingConsistentWithEmptyResults(expectedPageSize: pageSize);
+            pagedResult.AssertHasExpectedPagingAndResultCount(expectedTotalResults: 0, expectedPageSize: pageSize);
         }
 
         private async Task<HttpResponseMessage> ListPublicationDataSets(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/PaginatedViewModelTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/PaginatedViewModelTestExtensions.cs
@@ -25,17 +25,40 @@ public static class PaginatedViewModelTestExtensions
         );
     }
 
-    public static void AssertHasPagingConsistentWithEmptyResults<T>(
-        this PaginatedListViewModel<T> paginatedListViewModel,
-        int expectedPage = 1,
-        int? expectedPageSize = 10
-    )
+    public static void AssertEmptyResults<T>(this PaginatedListViewModel<T> paginatedListViewModel)
     {
         Assert.Multiple(
             () => Assert.Equal(0, paginatedListViewModel.Paging.TotalResults),
-            () => Assert.Equal(expectedPage, paginatedListViewModel.Paging.Page),
-            () => Assert.Equal(expectedPageSize, paginatedListViewModel.Paging.PageSize),
+            () => Assert.Equal(1, paginatedListViewModel.Paging.Page),
+            () => Assert.Equal(1, paginatedListViewModel.Paging.TotalPages),
             () => Assert.Empty(paginatedListViewModel.Results)
         );
+    }
+
+    public static void AssertSinglePage<T>(
+        this PaginatedListViewModel<T> paginatedListViewModel,
+        int expectedTotalResults,
+        int? expectedPageSize = null
+    )
+    {
+        Assert.Multiple(
+            () => Assert.Equal(expectedTotalResults, paginatedListViewModel.Paging.TotalResults),
+            () => Assert.Equal(1, paginatedListViewModel.Paging.Page),
+            () => Assert.Equal(expectedPageSize ?? expectedTotalResults, paginatedListViewModel.Paging.PageSize),
+            () => Assert.Equal(1, paginatedListViewModel.Paging.TotalPages),
+            () => Assert.Equal(expectedTotalResults, paginatedListViewModel.Results.Count)
+        );
+    }
+
+    public static T AssertSingleResult<T>(this PaginatedListViewModel<T> paginatedListViewModel)
+    {
+        Assert.Multiple(
+            () => Assert.Equal(1, paginatedListViewModel.Paging.TotalResults),
+            () => Assert.Equal(1, paginatedListViewModel.Paging.Page),
+            () => Assert.Equal(1, paginatedListViewModel.Paging.TotalPages),
+            () => Assert.Single(paginatedListViewModel.Results)
+        );
+
+        return paginatedListViewModel.Results.Single();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerRanksTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerRanksTests.cs
@@ -106,7 +106,7 @@ public abstract class DataSetFilesControllerRanksTests(DataSetFilesControllerRan
 
                 var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>();
 
-                pagedResult.AssertHasPagingConsistentWithEmptyResults();
+                pagedResult.AssertEmptyResults();
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/DataSetFilesControllerTests.cs
@@ -295,7 +295,7 @@ public abstract class DataSetFilesControllerTests(DataSetFilesControllerTestsFix
                 var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>();
 
                 // Expect no data set files to be returned for an old release when LatestOnly is true
-                pagedResult.AssertHasPagingConsistentWithEmptyResults();
+                pagedResult.AssertEmptyResults();
             }
 
             [Theory]
@@ -345,7 +345,7 @@ public abstract class DataSetFilesControllerTests(DataSetFilesControllerTestsFix
                 var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>();
 
                 // Expect no data set files to be returned for an unpublished release version regardless of LatestOnly
-                pagedResult.AssertHasPagingConsistentWithEmptyResults();
+                pagedResult.AssertEmptyResults();
             }
 
             [Theory]
@@ -382,7 +382,7 @@ public abstract class DataSetFilesControllerTests(DataSetFilesControllerTestsFix
 
                 // Expect no data set files to be returned unless they are associated with the latest published release
                 // version regardless of LatestOnly
-                pagedResult.AssertHasPagingConsistentWithEmptyResults();
+                pagedResult.AssertEmptyResults();
             }
 
             [Fact]
@@ -420,7 +420,7 @@ public abstract class DataSetFilesControllerTests(DataSetFilesControllerTestsFix
 
                 var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>();
 
-                pagedResult.AssertHasPagingConsistentWithEmptyResults();
+                pagedResult.AssertEmptyResults();
             }
 
             [Fact]
@@ -459,7 +459,7 @@ public abstract class DataSetFilesControllerTests(DataSetFilesControllerTestsFix
 
                 var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>();
 
-                pagedResult.AssertHasPagingConsistentWithEmptyResults();
+                pagedResult.AssertEmptyResults();
             }
 
             [Theory]
@@ -1352,7 +1352,7 @@ public abstract class DataSetFilesControllerTests(DataSetFilesControllerTestsFix
 
                 var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>();
 
-                pagedResult.AssertHasPagingConsistentWithEmptyResults(expectedPage: page);
+                pagedResult.AssertHasExpectedPagingAndResultCount(expectedTotalResults: 0, expectedPage: page);
             }
 
             [Theory]
@@ -1381,7 +1381,7 @@ public abstract class DataSetFilesControllerTests(DataSetFilesControllerTestsFix
 
                 var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>();
 
-                pagedResult.AssertHasPagingConsistentWithEmptyResults(expectedPageSize: pageSize);
+                pagedResult.AssertHasExpectedPagingAndResultCount(expectedTotalResults: 0, expectedPageSize: pageSize);
             }
 
             [Theory]
@@ -1564,7 +1564,7 @@ public abstract class DataSetFilesControllerTests(DataSetFilesControllerTestsFix
 
                 var pagedResult = response.AssertOk<PaginatedListViewModel<DataSetFileSummaryViewModel>>();
 
-                pagedResult.AssertHasPagingConsistentWithEmptyResults();
+                pagedResult.AssertEmptyResults();
             }
 
             [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/Publications/Dtos/GetPublicationReleasesRequestValidatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/Publications/Dtos/GetPublicationReleasesRequestValidatorTests.cs
@@ -1,0 +1,183 @@
+﻿using FluentValidation.TestHelper;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers.Publications.Dtos;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers.Publications.Dtos;
+
+public abstract class GetPublicationReleasesRequestValidatorTests
+{
+    private readonly GetPublicationReleasesRequest.Validator _validator = new();
+
+    private const string PublicationSlug = "test-publication";
+
+    public class PublicationSlugTests : GetPublicationReleasesRequestValidatorTests
+    {
+        [Fact]
+        public void WhenPublicationSlugIsNotEmpty_PublicationSlugIsValid()
+        {
+            // Arrange
+            var request = new GetPublicationReleasesRequest
+            {
+                PublicationSlug = PublicationSlug,
+                Page = 1,
+                PageSize = 10,
+            };
+
+            // Act & Assert
+            _validator.TestValidate(request).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void WhenPublicationSlugIsEmpty_PublicationSlugHasValidationError(string publicationSlug)
+        {
+            // Arrange
+            var request = new GetPublicationReleasesRequest
+            {
+                PublicationSlug = publicationSlug,
+                Page = 1,
+                PageSize = 10,
+            };
+
+            // Act & Assert
+            _validator.TestValidate(request).ShouldHaveValidationErrorFor(r => r.PublicationSlug).Only();
+        }
+    }
+
+    public class PaginationTests : GetPublicationReleasesRequestValidatorTests
+    {
+        [Fact]
+        public void WhenPageAndPageSizeAreBothNull_PageAndPageSizeAreValid()
+        {
+            // Arrange
+            var request = new GetPublicationReleasesRequest
+            {
+                PublicationSlug = PublicationSlug,
+                Page = null,
+                PageSize = null,
+            };
+
+            // Act & Assert
+            _validator.TestValidate(request).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        public void WhenPageIsGreaterThanOrEqualToOne_PageIsValid(int page)
+        {
+            // Arrange
+            var request = new GetPublicationReleasesRequest
+            {
+                PublicationSlug = PublicationSlug,
+                Page = page,
+                PageSize = 10,
+            };
+
+            // Act & Assert
+            _validator.TestValidate(request).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void WhenPageIsLessThanOne_PageHasValidationError(int page)
+        {
+            // Arrange
+            var request = new GetPublicationReleasesRequest
+            {
+                PublicationSlug = PublicationSlug,
+                Page = page,
+                PageSize = 10,
+            };
+
+            // Act & Assert
+            _validator
+                .TestValidate(request)
+                .ShouldHaveValidationErrorFor(r => r.Page)
+                .WithErrorCode(FluentValidationKeys.GreaterThanOrEqualValidator)
+                .Only();
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(100)]
+        public void WhenPageSizeIsWithinRange_PageSizeIsValid(int pageSize)
+        {
+            // Arrange
+            var request = new GetPublicationReleasesRequest
+            {
+                PublicationSlug = PublicationSlug,
+                Page = 1,
+                PageSize = pageSize,
+            };
+
+            // Act & Assert
+            _validator.TestValidate(request).ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(101)]
+        public void WhenPageSizeIsOutOfRange_PageSizeHasValidationError(int pageSize)
+        {
+            // Arrange
+            var request = new GetPublicationReleasesRequest
+            {
+                PublicationSlug = PublicationSlug,
+                Page = 1,
+                PageSize = pageSize,
+            };
+
+            // Act & Assert
+            _validator
+                .TestValidate(request)
+                .ShouldHaveValidationErrorFor(r => r.PageSize)
+                .WithErrorCode(FluentValidationKeys.InclusiveBetweenValidator)
+                .Only();
+        }
+
+        [Fact]
+        public void WhenPageIsNotNullAndPageSizeIsNull_PageSizeHasValidationError()
+        {
+            // Arrange
+            var request = new GetPublicationReleasesRequest
+            {
+                PublicationSlug = PublicationSlug,
+                Page = 2,
+                PageSize = null,
+            };
+
+            // Act & Assert
+            _validator
+                .TestValidate(request)
+                .ShouldHaveValidationErrorFor(r => r.PageSize)
+                .WithErrorMessage("'PageSize' must also be provided when 'Page' is set.")
+                .Only();
+        }
+
+        [Fact]
+        public void WhenPageSizeIsNotNullAndPageIsNull_PageHasValidationError()
+        {
+            // Arrange
+            var request = new GetPublicationReleasesRequest
+            {
+                PublicationSlug = PublicationSlug,
+                Page = null,
+                PageSize = 10,
+            };
+
+            // Act & Assert
+            _validator
+                .TestValidate(request)
+                .ShouldHaveValidationErrorFor(r => r.Page)
+                .WithErrorMessage("'Page' must also be provided when 'PageSize' is set.")
+                .Only();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/Publications/PublicationsControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/Publications/PublicationsControllerTests.cs
@@ -96,27 +96,27 @@ public abstract class PublicationsControllerTests
 
     public class GetPublicationReleasesTests : PublicationsControllerTests
     {
-        private const int Page = 1;
-        private const int PageSize = 10;
-
         [Fact]
-        public async Task WhenServiceReturnsPublicationReleases_ReturnsOk()
+        public async Task WhenServiceReturnsReleases_ReturnsOk()
         {
             // Arrange
+            const int page = 2;
+            const int pageSize = 5;
+
             var publicationReleases = PaginatedListViewModel<IPublicationReleaseEntryDto>.Paginate(
                 [
                     new LegacyPublicationReleaseEntryDtoBuilder().Build(),
                     new PublicationReleaseEntryDtoBuilder().Build(),
                 ],
-                page: Page,
-                pageSize: PageSize
+                page: page,
+                pageSize: pageSize
             );
 
             var request = new GetPublicationReleasesRequest
             {
                 PublicationSlug = PublicationSlug,
-                Page = Page,
-                PageSize = PageSize,
+                Page = page,
+                PageSize = pageSize,
             };
 
             _publicationReleasesService.WhereHasPublicationReleases(publicationReleases);
@@ -128,30 +128,33 @@ public abstract class PublicationsControllerTests
 
             // Assert
             _publicationReleasesService.Assert.GetPublicationReleasesWasCalled(
-                request.PublicationSlug,
-                page: request.Page,
-                pageSize: request.PageSize
+                PublicationSlug,
+                page: page,
+                pageSize: pageSize
             );
             result.AssertOkResult(publicationReleases);
         }
 
         [Fact]
-        public async Task WhenNoQueryParameters_UsesPaginationDefaults()
+        public async Task WhenPageAndPageSizeAreNull_PassesNullToService()
         {
             // Arrange
-            const int defaultPage = 1;
-            const int defaultPageSize = 10;
             var publicationReleases = PaginatedListViewModel<IPublicationReleaseEntryDto>.Paginate(
                 [
                     new LegacyPublicationReleaseEntryDtoBuilder().Build(),
                     new PublicationReleaseEntryDtoBuilder().Build(),
                 ],
-                page: defaultPage,
-                pageSize: defaultPageSize
+                page: 1,
+                pageSize: 2
             );
 
-            // No page or pageSize query parameters set on request
-            var request = new GetPublicationReleasesRequest { PublicationSlug = PublicationSlug };
+            // Pagination parameters omitted from request (Page and PageSize are null)
+            var request = new GetPublicationReleasesRequest
+            {
+                PublicationSlug = PublicationSlug,
+                Page = null,
+                PageSize = null,
+            };
 
             _publicationReleasesService.WhereHasPublicationReleases(publicationReleases);
 
@@ -161,10 +164,11 @@ public abstract class PublicationsControllerTests
             var result = await sut.GetPublicationReleases(request);
 
             // Assert
+            // The service should be called with null Page and PageSize so that all results are returned
             _publicationReleasesService.Assert.GetPublicationReleasesWasCalled(
-                request.PublicationSlug,
-                page: defaultPage,
-                pageSize: defaultPageSize
+                PublicationSlug,
+                page: null,
+                pageSize: null
             );
             result.AssertOkResult(publicationReleases);
         }
@@ -183,7 +187,7 @@ public abstract class PublicationsControllerTests
             var result = await sut.GetPublicationReleases(request);
 
             // Assert
-            _publicationReleasesService.Assert.GetPublicationReleasesWasCalled(request.PublicationSlug);
+            _publicationReleasesService.Assert.GetPublicationReleasesWasCalled(PublicationSlug);
             result.AssertNotFoundResult();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/MockBuilders/PublicationReleasesServiceMockBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/MockBuilders/PublicationReleasesServiceMockBuilder.cs
@@ -21,7 +21,7 @@ public class PublicationReleasesServiceMockBuilder
             Task<Either<ActionResult, PaginatedListViewModel<IPublicationReleaseEntryDto>>>
         >
     > GetPublicationReleases = m =>
-        m.GetPublicationReleases(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>());
+        m.GetPublicationReleases(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>());
 
     private static readonly Expression<
         Func<IPublicationReleasesService, Task<Either<ActionResult, Guid[]>>>
@@ -60,8 +60,8 @@ public class PublicationReleasesServiceMockBuilder
             .Setup(m =>
                 m.GetPublicationReleases(
                     It.IsAny<string>(),
-                    It.IsAny<int>(),
-                    It.IsAny<int>(),
+                    It.IsAny<int?>(),
+                    It.IsAny<int?>(),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -93,8 +93,8 @@ public class PublicationReleasesServiceMockBuilder
                 m =>
                     m.GetPublicationReleases(
                         It.Is<string>(actual => publicationSlug == null || actual == publicationSlug),
-                        It.Is<int>(actual => page == null || actual == page),
-                        It.Is<int>(actual => pageSize == null || actual == pageSize),
+                        It.Is<int?>(actual => page == null || actual == page),
+                        It.Is<int?>(actual => pageSize == null || actual == pageSize),
                         It.IsAny<CancellationToken>()
                     ),
                 Times.Once

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/Publications/Dtos/GetPublicationReleasesRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/Publications/Dtos/GetPublicationReleasesRequest.cs
@@ -9,9 +9,15 @@ public record GetPublicationReleasesRequest
     [FromRoute]
     public required string PublicationSlug { get; init; }
 
-    public int Page { get; init; } = 1;
+    /// <summary>
+    /// The page of results to fetch. Required when <see cref="PageSize"/> is also specified.
+    /// </summary>
+    public int? Page { get; init; }
 
-    public int PageSize { get; init; } = 10;
+    /// <summary>
+    /// The maximum number of results per page. When omitted, all results are returned in a single page.
+    /// </summary>
+    public int? PageSize { get; init; }
 
     public class Validator : AbstractValidator<GetPublicationReleasesRequest>
     {
@@ -19,9 +25,19 @@ public record GetPublicationReleasesRequest
         {
             RuleFor(request => request.PublicationSlug).NotEmpty();
 
-            RuleFor(request => request.Page).GreaterThanOrEqualTo(1);
+            RuleFor(request => request.Page).GreaterThanOrEqualTo(1).When(request => request.Page.HasValue);
 
-            RuleFor(request => request.PageSize).InclusiveBetween(1, 100);
+            RuleFor(request => request.PageSize).InclusiveBetween(1, 100).When(request => request.PageSize.HasValue);
+
+            RuleFor(request => request.Page)
+                .NotNull()
+                .WithMessage($"'{nameof(Page)}' must also be provided when '{nameof(PageSize)}' is set.")
+                .When(request => request.PageSize.HasValue);
+
+            RuleFor(request => request.PageSize)
+                .NotNull()
+                .WithMessage($"'{nameof(PageSize)}' must also be provided when '{nameof(Page)}' is set.")
+                .When(request => request.Page.HasValue);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Publications/PublicationReleasesServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/Publications/PublicationReleasesServiceTests.cs
@@ -23,7 +23,7 @@ public abstract class PublicationReleasesServiceTests
         [InlineData(5, 1, 10)]
         [InlineData(15, 1, 10)]
         [InlineData(15, 2, 5)]
-        public async Task WhenPublicationExistsWithPublishedReleases_ReturnsPaginatedReleases(
+        public async Task WhenPublishedReleasesExistAndPaginationParamsProvided_ReturnsPaginatedReleases(
             int numReleases,
             int page,
             int pageSize
@@ -63,6 +63,39 @@ public abstract class PublicationReleasesServiceTests
             }
         }
 
+        [Theory]
+        [InlineData(1)]
+        [InlineData(5)]
+        [InlineData(15)]
+        public async Task WhenPublishedReleasesExistAndNoPaginationParamsProvided_ReturnsAllReleases(int numReleases)
+        {
+            // Arrange
+            Publication publication = _dataFixture
+                .DefaultPublication()
+                .WithReleases(_ => _dataFixture.DefaultRelease(publishedVersions: 1).Generate(numReleases));
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                context.Publications.Add(publication);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = InMemoryContentDbContext(contextId))
+            {
+                var sut = BuildService(context);
+
+                // Act
+                var outcome = await sut.GetPublicationReleases(publicationSlug: publication.Slug);
+
+                // Assert
+                var pagedResult = outcome.AssertRight();
+
+                // Expect all results to be returned in a single page as no pagination params were provided
+                pagedResult.AssertSinglePage(expectedTotalResults: numReleases);
+            }
+        }
+
         [Fact]
         public async Task WhenPublishedReleasesExist_MapsReleasesCorrectly()
         {
@@ -89,13 +122,7 @@ public abstract class PublicationReleasesServiceTests
                 // Assert
                 var pagedResult = outcome.AssertRight();
 
-                pagedResult.AssertHasExpectedPagingAndResultCount(
-                    expectedTotalResults: 1,
-                    expectedPage: 1,
-                    expectedPageSize: 10
-                );
-
-                var releaseEntry = Assert.IsType<PublicationReleaseEntryDto>(pagedResult.Results.Single());
+                var releaseEntry = Assert.IsType<PublicationReleaseEntryDto>(pagedResult.AssertSingleResult());
 
                 Assert.Multiple(() =>
                 {
@@ -145,11 +172,7 @@ public abstract class PublicationReleasesServiceTests
                 // Assert
                 var pagedResult = outcome.AssertRight();
 
-                pagedResult.AssertHasExpectedPagingAndResultCount(
-                    expectedTotalResults: 2,
-                    expectedPage: 1,
-                    expectedPageSize: 10
-                );
+                pagedResult.AssertSinglePage(expectedTotalResults: 2);
 
                 var legacyReleaseEntry = Assert.IsType<LegacyPublicationReleaseEntryDto>(pagedResult.Results[1]);
                 var expectedLegacyReleaseEntry = publication.ReleaseSeries[1];
@@ -208,11 +231,7 @@ public abstract class PublicationReleasesServiceTests
                 // Assert
                 var pagedResult = outcome.AssertRight();
 
-                pagedResult.AssertHasExpectedPagingAndResultCount(
-                    expectedTotalResults: 4,
-                    expectedPage: 1,
-                    expectedPageSize: 10
-                );
+                pagedResult.AssertSinglePage(expectedTotalResults: 4);
 
                 var expectedReleases = new[] { (Year: 2023, Index: 0), (Year: 2025, Index: 1), (Year: 2024, Index: 3) };
 
@@ -262,11 +281,7 @@ public abstract class PublicationReleasesServiceTests
                 // Assert
                 var pagedResult = outcome.AssertRight();
 
-                pagedResult.AssertHasExpectedPagingAndResultCount(
-                    expectedTotalResults: 3,
-                    expectedPage: 1,
-                    expectedPageSize: 10
-                );
+                pagedResult.AssertSinglePage(expectedTotalResults: 3);
 
                 var releaseEntries = pagedResult.Results.Select(Assert.IsType<PublicationReleaseEntryDto>).ToList();
 
@@ -314,13 +329,7 @@ public abstract class PublicationReleasesServiceTests
                 // Assert
                 var pagedResult = outcome.AssertRight();
 
-                pagedResult.AssertHasExpectedPagingAndResultCount(
-                    expectedTotalResults: 1,
-                    expectedPage: 1,
-                    expectedPageSize: 10
-                );
-
-                var releaseEntry = Assert.IsType<PublicationReleaseEntryDto>(pagedResult.Results.Single());
+                var releaseEntry = Assert.IsType<PublicationReleaseEntryDto>(pagedResult.AssertSingleResult());
                 var expectedReleaseVersion = release.Versions[2];
                 Assert.Multiple(() =>
                 {
@@ -360,13 +369,7 @@ public abstract class PublicationReleasesServiceTests
                 var pagedResult = outcome.AssertRight();
 
                 // Only the published release should be in the results
-                pagedResult.AssertHasExpectedPagingAndResultCount(
-                    expectedTotalResults: 1,
-                    expectedPage: 1,
-                    expectedPageSize: 10
-                );
-
-                var releaseEntry = Assert.IsType<PublicationReleaseEntryDto>(pagedResult.Results.Single());
+                var releaseEntry = Assert.IsType<PublicationReleaseEntryDto>(pagedResult.AssertSingleResult());
                 var expectedRelease = publication.Releases.Single(r => r.Year == 2024);
                 Assert.Equal(expectedRelease.Id, releaseEntry.ReleaseId);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Publications/IPublicationReleasesService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Publications/IPublicationReleasesService.cs
@@ -9,8 +9,8 @@ public interface IPublicationReleasesService
 {
     Task<Either<ActionResult, PaginatedListViewModel<IPublicationReleaseEntryDto>>> GetPublicationReleases(
         string publicationSlug,
-        int page = 1,
-        int pageSize = 10,
+        int? page = null,
+        int? pageSize = null,
         CancellationToken cancellationToken = default
     );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Publications/PublicationReleasesService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Publications/PublicationReleasesService.cs
@@ -15,8 +15,8 @@ public class PublicationReleasesService(ContentDbContext contentDbContext) : IPu
 {
     public async Task<Either<ActionResult, PaginatedListViewModel<IPublicationReleaseEntryDto>>> GetPublicationReleases(
         string publicationSlug,
-        int page = 1,
-        int pageSize = 10,
+        int? page = null,
+        int? pageSize = null,
         CancellationToken cancellationToken = default
     ) =>
         await GetPublicationBySlug(publicationSlug, cancellationToken)
@@ -36,7 +36,11 @@ public class PublicationReleasesService(ContentDbContext contentDbContext) : IPu
                     latestReleaseEntry
                 );
 
-                return PaginatedListViewModel<IPublicationReleaseEntryDto>.Paginate(entryDtos, page, pageSize);
+                return PaginatedListViewModel<IPublicationReleaseEntryDto>.Paginate(
+                    entryDtos,
+                    page: page ?? 1,
+                    pageSize: pageSize ?? Math.Max(entryDtos.Count, 1)
+                );
             });
 
     public async Task<Either<ActionResult, Guid[]>> GetPublicationReleaseIds(

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseListPage.tsx
@@ -154,8 +154,8 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({
       ),
       queryClient.fetchQuery(
         publicationQueries.getPublicationReleaseList(publicationSlug, {
-          page: page ? Number(page) : undefined,
-          pageSize: pageSize ? Number(pageSize) : undefined,
+          page: page ? Number(page) : 1,
+          pageSize: pageSize ? Number(pageSize) : 25,
         }),
       ),
     ]);


### PR DESCRIPTION
This PR contains work to support [EES-7008](https://dfedigital.atlassian.net/browse/EES-7008):


- Updates the frontend `PublicationReleaseListPage.tsx` to take responsibility for the default pagination behaviour on the “Releases in this series” page by applying a default page size of 25 when no `pageSize` query parameter is provided. Previously, the page relied on the API defaults (`page: 1, pageSize: 10`) of the backend, by supplying `undefined` query parameters.
- Updates the backend `PublicationsController.GetPublicationReleases` endpoint (`GET /api/publications/{publicationSlug}/release-entries`) used by the “Releases in this series” page to remove the default pagination parameters, allowing all releases to be returned in a single API call if needed in future. Previously, pagination parameters defaulted to a default page size of 10, and responses were constrained by validation enforcing a maximum page size of 100.

These changes are being made because [EES-7008](https://dfedigital.atlassian.net/browse/EES-7008) would like to display 25 releases per page by default, and it's thought that making the pagination params optional so that all results can be retrieved could help with implementing a text search filter on the 'Release period' column.

<img width="685" height="899" alt="image" src="https://github.com/user-attachments/assets/83077e2a-929c-4cf9-bcda-61cb0ecc4a7e" />

### Example API calls

For a publication with 26 releases:

**Page 1, Page Size 25**

`GET https://localhost:5011/api/publications/{publication-slug}/release-entries?page=1&pageSize=25`

```json
{
  "results": [...],
  "paging": {
    "page": 1,
    "pageSize": 25,
    "totalResults": 26,
    "totalPages": 2
  }
}
```

**Page 1, Page Size 10**

`GET https://localhost:5011/api/publications/{publication-slug}/release-entries?page=1&pageSize=10`

```json
{
  "results": [...],
  "paging": {
    "page": 1,
    "pageSize": 10,
    "totalResults": 26,
    "totalPages": 3
  }
}
```

**With no page or pageSize parameters**

`GET https://localhost:5011/api/publications/{publication-slug}/release-entries`

```json
{
  "results": [...],
  "paging": {
    "page": 1,
    "pageSize": 26,
    "totalResults": 26,
    "totalPages": 1
  }
}
```

**With only a page parameter (causes a validation error without pageSize)**

`GET https://localhost:5011/api/publications/{publication-slug}/release-entries?page=1`

```
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=utf-8

{
  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
  "title": "One or more validation errors occurred.",
  "status": 400,
  "errors": [
    {
      "message": "'PageSize' must also be provided when 'Page' is set.",
      "path": "pageSize",
      "code": "NotNull",
      "detail": {
        "value": null
      }
    }
  ],
  "traceId": "00-0ddbce949c1cf19d14f692eb842f7506-e313dd861a240b06-00"
}
```

**With only a pageSize parameter (causes a validation error without page)**

`GET https://localhost:5011/api/publications/{publication-slug}/release-entries?pageSize=25`

```
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=utf-8

{
  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
  "title": "One or more validation errors occurred.",
  "status": 400,
  "errors": [
    {
      "message": "'Page' must also be provided when 'PageSize' is set.",
      "path": "page",
      "code": "NotNull",
      "detail": {
        "value": null
      }
    }
  ],
  "traceId": "00-4749a059daadc4cdb1fdcc0ac0396efb-894a5e76704a02db-00"
}
```

### Other changes

- Adds new `AssertSinglePage` and `AssertSingleResult` extension methods to `PaginatedViewModelTestExtensions` to allow for easier unit testing, and refactors `AssertHasPagingConsistentWithEmptyResults` to be `AssertEmptyResults`.