### PR TITLE
Hotfix: EES-7128 Prevent duplicate DataSetMappings

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518075724_Ees7128PreventDuplicateDataSetMappings.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518075724_Ees7128PreventDuplicateDataSetMappings.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518075724_Ees7128PreventDuplicateDataSetMappings")]
+    partial class Ees7128PreventDuplicateDataSetMappings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518075724_Ees7128PreventDuplicateDataSetMappings.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518075724_Ees7128PreventDuplicateDataSetMappings.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees7128PreventDuplicateDataSetMappings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_DataSetMappings_OriginalDataSetId",
+                table: "DataSetMappings",
+                column: "OriginalDataSetId",
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataSetMappings_ReplacementDataSetId",
+                table: "DataSetMappings",
+                column: "ReplacementDataSetId",
+                unique: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(name: "IX_DataSetMappings_OriginalDataSetId", table: "DataSetMappings");
+
+            migrationBuilder.DropIndex(name: "IX_DataSetMappings_ReplacementDataSetId", table: "DataSetMappings");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -27,7 +27,8 @@ public record DataSetMapping
     {
         public void Configure(EntityTypeBuilder<DataSetMapping> builder)
         {
-            builder.HasKey(x => x.Id);
+            builder.HasIndex(x => x.OriginalDataSetId).IsUnique();
+            builder.HasIndex(x => x.ReplacementDataSetId).IsUnique();
 
             builder
                 .Property(x => x.IndicatorMappings)


### PR DESCRIPTION
This PR prevents duplicate DataSetMappings for a specific replacement. It is possible for a duplicate to be created if two users request a nonexistent DataSetMapping at the same time. This PR prevents this by enforcing DB restrictions.

This is essentially the same changes as the now closed PR https://github.com/dfe-analytical-services/explore-education-statistics/pull/6979 but directed at the master branch