### PR TITLE
EES-7004 - hotfix to scaling rules for screener function app / EES-7145 - have Pre-Prod serve through AFD directly

### DIFF
--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -103,11 +103,6 @@
     },
     "notifierSuppressExceptionsForTeamOnlyApiKeyErrors": {
       "value": true
-    },
-    "additionalPublicAllowedOrigins": {
-      "value": [
-        "https://pre-productionafd.explore-education-statistics.service.gov.uk"
-      ]
     }
   }
 }

--- a/infrastructure/templates/common/components/app-service-plan/appServicePlan.bicep
+++ b/infrastructure/templates/common/components/app-service-plan/appServicePlan.bicep
@@ -18,6 +18,9 @@ param kind
 @description('Function App Plan : operating system')
 param operatingSystem 'Windows' | 'Linux' = 'Linux'
 
+@description('The maximum number of instances that this plan can support. This pool of workers is shared between any services that use this plan.')
+param maximumElasticWorkerCount int = 1
+
 @description('Whether to create or update Azure Monitor alerts during this deploy')
 param alerts {
   cpuPercentage: bool
@@ -35,6 +38,7 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
   sku: sku
   properties: {
     reserved: operatingSystem == 'Linux'
+    maximumElasticWorkerCount: maximumElasticWorkerCount
   }
   tags: tagValues
 }

--- a/infrastructure/templates/common/components/function-app/containerisedFunctionApp.bicep
+++ b/infrastructure/templates/common/components/function-app/containerisedFunctionApp.bicep
@@ -178,6 +178,7 @@ module appServicePlanModule '../app-service-plan/appServicePlan.bicep' = {
     kind: 'functionapp'
     sku: sku
     operatingSystem: operatingSystem
+    maximumElasticWorkerCount: maximumInstanceCount
     alerts: alerts != null
       ? {
           cpuPercentage: alerts!.cpuPercentage

--- a/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
@@ -1,5 +1,4 @@
 import { abbreviations } from '../../../common/abbreviations.bicep'
-import { replaceMultiple } from '../../../common/functions.bicep'
 
 @description('Environment: Subscription name. Used as a prefix for created resources.')
 @allowed([
@@ -51,16 +50,7 @@ var publicSiteHostName = subscription == 's101p01'
   // Handle the case for Prod to allow access via "https://afd.explore-education-statistics.service.gov.uk" during
   // testing.
   ? 'afd.explore-education-statistics.service.gov.uk'
-  
-  : replaceMultiple(publicSiteUrl, {
-  
-  // Handle the case for Pre-Production to allow access via
-  // "https://pre-productionafd.explore-education-statistics.service.gov.uk" during testing.
-  'pre-production.explore-education': 'pre-productionafd.explore-education'
-  
-  // Remove the "https://" from the URL to leave just the domain name.
-  'https://': ''
-})
+  : replace(publicSiteUrl, 'https://', '')
 
 // TODO EES-6883 - remove the "afd" from the line below once we're ready to
 // switch DNS over to point at Azure Front Door rather than the Public Site
@@ -69,10 +59,10 @@ var publicSiteHostName = subscription == 's101p01'
 // URL with an associated certificate so as not to break the use of the environment
 // for others.
 //
-// Note that Dev and Test now have the original public site URLs pointing towards
+// Note that Dev, Test and Pre-Prod now have the original public site URLs pointing towards
 // their AFD instances now rather than the original App Service, so they can serve
 // up the real certificate rather than the temporary testing one.  
-var certificateName = subscription == 's101d01' || subscription == 's101t01'
+var certificateName = subscription != 's101p01'
     ? '${legacyResourcePrefix}as-ees-public-site-certificate'
     : '${legacyResourcePrefix}as-ees-public-site-afd-certificate'
 


### PR DESCRIPTION
This PR:
- fixes a bug whereby a function app was requesting a scale-out config greater than its backing app service plan's maximum scale.
- gets Pre-Prod's AFD ready to serve traffic on real URL.