### PR TITLE
EES-6970: Add transition hook to handle loading spinner visibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.IdpBootstrapUse
 
 ## IDE Files (e.g. local Visual Studio configuration)
 *.user
+*.lscache

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FilterHierarchy.tsx
@@ -12,7 +12,14 @@ import { Dictionary } from '@common/types';
 import sortAlphabeticalTotalsFirst from '@common/utils/sortAlphabeticalTotalsFirst';
 import classNames from 'classnames';
 import get from 'lodash/get';
-import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import styles from './FilterHierarchy.module.scss';
 import FilterHierarchyOptions, {
@@ -77,21 +84,8 @@ function FilterHierarchy({
   });
 
   const [expandedOptionsList, setExpandedOptionsList] = useState<string[]>([]);
-  const [tierSelectionLoading, setTierSelectionLoading] = useState(false);
-
-  const updateTierSelectionState = useCallback(
-    (updater: (prev: TierSelectionState[]) => TierSelectionState[]) => {
-      setTierSelectionLoading(true);
-      setTierSelectionState(updater);
-    },
-    [],
-  );
-
-  useEffect(() => {
-    if (tierSelectionLoading) {
-      setTierSelectionLoading(false);
-    }
-  }, [tierSelectionState, tierSelectionLoading]);
+  const [isPendingTierSelection, startTierSelectionTransition] =
+    useTransition();
 
   const filterLabels: string[] = [
     ...filterHierarchy.map(({ filterId }) => optionLabelsMap[filterId ?? '']),
@@ -182,41 +176,44 @@ function FilterHierarchy({
           selectedValues.includes(filterOptionId),
         );
 
-      updateTierSelectionState(prev =>
+      setTierSelectionState(prev =>
         prev.map((item, index) =>
           index === tier ? { ...item, selected: allTierOptionsSelected } : item,
         ),
       );
     },
-    [tierOptions, selectedValues, updateTierSelectionState],
+    [tierOptions, selectedValues, setTierSelectionState],
   );
 
   const toggleTierSelection = useCallback(
     (tier: number) => {
-      const deselectAllFiltersForTier = () => {
-        setValue(
-          name,
-          selectedValues.filter(sv => !tierOptions[tier].includes(sv)),
-        );
-      };
+      startTierSelectionTransition(() => {
+        const deselectAllFiltersForTier = () => {
+          setValue(
+            name,
+            selectedValues.filter(sv => !tierOptions[tier].includes(sv)),
+          );
+        };
 
-      const selectAllFiltersForTier = () => {
-        const combinedSelections = [...selectedValues, ...tierOptions[tier]];
-        const distinctSelections = combinedSelections.reduce(
-          (acc: string[], item) => (acc.includes(item) ? acc : [...acc, item]),
-          [],
-        );
+        const selectAllFiltersForTier = () => {
+          const combinedSelections = [...selectedValues, ...tierOptions[tier]];
+          const distinctSelections = combinedSelections.reduce(
+            (acc: string[], item) =>
+              acc.includes(item) ? acc : [...acc, item],
+            [],
+          );
 
-        setValue(name, distinctSelections);
-      };
+          setValue(name, distinctSelections);
+        };
 
-      if (tierSelectionState[tier].selected) {
-        deselectAllFiltersForTier();
-      } else {
-        selectAllFiltersForTier();
-      }
+        if (tierSelectionState[tier].selected) {
+          deselectAllFiltersForTier();
+        } else {
+          selectAllFiltersForTier();
+        }
 
-      handleTierOptionChange(tier);
+        handleTierOptionChange(tier);
+      });
     },
     [
       name,
@@ -229,7 +226,7 @@ function FilterHierarchy({
   );
 
   useEffect(() => {
-    updateTierSelectionState(prev =>
+    setTierSelectionState(prev =>
       prev.map((item, index) => ({
         ...item,
         disabled:
@@ -242,12 +239,7 @@ function FilterHierarchy({
           ),
       })),
     );
-  }, [
-    tierOptions,
-    hierarchySearchTerm,
-    selectedValues,
-    updateTierSelectionState,
-  ]);
+  }, [tierOptions, hierarchySearchTerm, selectedValues, setTierSelectionState]);
 
   const getOptionUniqueValue = useCallback(
     (optionValue: string): string => {
@@ -456,7 +448,7 @@ function FilterHierarchy({
                 </div>
               );
             })}
-            <LoadingSpinner loading={tierSelectionLoading} inline size="sm" />
+            <LoadingSpinner loading={isPendingTierSelection} inline size="sm" />
           </div>
           {rootOptionTrees.map(optionTree => {
             return (


### PR DESCRIPTION
This PR fixes a bug with the loading spinner not appearing on tier selection, which was likely introduced during PR changes and not noticed before merging in. It replaces the existing logic with a new React hook `useTransition` to handle when the spinner component should be displayed.

The spinner is designed to improve the UX for long-running examples where the data set is massive, and includes hundreds or even thousands of options in certain tiers. I tried adding a Jest test, but couldn't get it to pass because it was unable to find the spinner element, likely due to it disappearing so quickly on such as small test example. Below is the attempt if any reviewer has an idea how this may be resolved.
```
test('shows LoadingSpinner while tier selection is in progress and not when idle', async () => {
    const { user } = render(
      <FormProvider>
        <FilterHierarchy
          filterHierarchy={testFilterHierarchy}
          name="test-filter"
          optionLabelsMap={testOptionsLabelsMap}
        />
      </FormProvider>,
    );

    // Expand filter
    await user.click(
      screen.getByRole('button', {
        name: 'Name of course being studied (3 tiers) - show options',
      }),
    );

    // Initially not loading
    expect(screen.queryByTestId('loadingSpinner')).not.toBeInTheDocument();

    // Select tier
    const tier2Button = screen.getByRole('button', {
      name: 'Select all Sector subject area (tier 2)',
    });
    user.click(tier2Button);

    // Spinner should be visible while selection is in progress
    await waitFor(() => {
      expect(screen.findByTestId('loadingSpinner')).toBeInTheDocument();
    });

    // Spinner should no longer be visible when selection is complete
    await waitFor(() => {
      screen.getByRole('button', {
        name: 'Unselect all Sector subject area (tier 2)',
      });
    });

    expect(screen.queryByTestId('loadingSpinner')).not.toBeInTheDocument();
  });
```