### PR TITLE
EES-6817 - catch ALL exceptions from calling the Screener API

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
@@ -433,7 +433,7 @@ public class ReleaseDataFileService(
                     {
                         result = await dataSetScreenerService.ScreenDataSet(request, cancellationToken: ct);
                     }
-                    catch (DataScreenerException)
+                    catch (Exception)
                     {
                         await dataSetFileStorage.UpdateDataSetUpload(
                             dataSetUpload.Id,


### PR DESCRIPTION
This PR:
- ensures that timeouts and general "connection refused" cases also end with "Screener error".

This is achieved by catching ALL exceptions from `DataScreenerClient.ScreenDataSet()`, and not just the ones that we throw ourselves. 