### PR TITLE
EES-7012 - fix prod only robot tests

### DIFF
--- a/tests/robot-tests/tests/general_public/prod_only/notifications_absence.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/notifications_absence.robot
@@ -14,7 +14,7 @@ Navigate to Absence publication
     user waits until h1 is visible    Pupil absence in schools in England    %{WAIT_MEDIUM}
 
 Go to Notify me page for Absence publication
-    user clicks link    Sign up for email alerts
+    user clicks link    Get email alerts
 
     user waits until page contains title caption    Notify me    %{WAIT_LONG}
     user waits until h1 is visible    Pupil absence in schools in England
@@ -27,7 +27,6 @@ Go to Notify me page for Absence publication
 
 Sign up for email alerts
     [Documentation]    EES-716    EES-1265
-    [Tags]    Failing    # Currently failing on Production when running UI tests directly following deploys.
     user clicks element    id:subscriptionForm-email
     press keys    id:subscriptionForm-email    mark@hiveit.co.uk
     user clicks button    Subscribe

--- a/tests/robot-tests/tests/general_public/prod_only/old_fast_track.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/old_fast_track.robot
@@ -14,19 +14,11 @@ Navigate to Absence publication
     user waits until h1 is visible    Further education and skills    %{WAIT_MEDIUM}
     user checks page contains    Not the latest release
 
-Open Overall absence accordion
-    user opens accordion section    About these statistics    id:content-1
-    user scrolls to accordion section    About these statistics    id:content-1
-
-Follow Explore data link
-    user clicks link containing text    Explore data
-    user clicks link containing text    View or create your own tables
-
-Navigate to the Table Tool
-    user waits until h1 is visible    Create your own tables    %{WAIT_SMALL}
-    user clicks radio    View all featured tables
-    user clicks link containing text
-    ...    Adult education and training participation and achievement by ethnicity group, 2014/15 to 2019/20
+Navigate to ethnicity featured table
+    user clicks link    Explore and download data
+    user waits until h2 is visible    Featured tables    %{WAIT_MEDIUM}
+    user clicks element
+    ...    xpath://li[.//h4[normalize-space()='Adult education and training participation and achievement by ethnicity group, 2014/15 to 2019/20']]//a[starts-with(normalize-space(.), 'View, edit or download')]
 
 Visit featured table and generate a permalink
     user waits until page contains    This data is not from the latest release


### PR DESCRIPTION
## Summary
This PR makes tweaks to `old_fast_track.robot` and `notifications_absence.robot` in order to get them to pass now that the release page redesign work is live.