### PR TITLE
EES-7009 Fix steps marked as 'Failing' within robot tests prerelease.robot & prerelease_and_amend.robot

### DIFF
--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -2,6 +2,7 @@
 Library             Collections
 Library             ../../libs/admin_api.py
 Resource            ../../libs/admin-common.robot
+Resource            ../../libs/public-common.robot
 Resource            ../../libs/admin/manage-content-common.robot
 Resource            ../../libs/tables-common.robot
 
@@ -292,20 +293,14 @@ Validate contact banner is shown
     user checks testid element contains    notificationBanner    If you have an enquiry about this release contact
     user checks testid element contains    notificationBanner    UI test team name: ui_test@test.com
 
-Validate metadata guidance page
-    user validates data guidance on explore tab in release preview
-    ...    Test metadata guidance content
-    ...    UI test subject
-    ...    Test file guidance content
-    ...    Local authority, Local authority district, Local enterprise partnership, Opportunity area, Parliamentary constituency, Regional, RSC region, Ward
-    ...    2005 to 2020
+Validate metadata guidance section and data set details section on the Explore and download data
+    user checks data set details for UI test subject
+
     ${data_guidance_section}=    Get WebElement    id:data-guidance-section
     user checks element should contain    ${data_guidance_section}    Test metadata guidance content
-    user checks element should contain    testid:indicators    Admission Numbers
 
-Go back to prerelease content page
+Go back to pre-release access list section on the help and related information tab
     user returns to release home tab in release preview
-    ...    Test headlines summary text for ${PUBLICATION_NAME}
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
@@ -313,12 +308,11 @@ Go back to prerelease content page
     user waits until h2 is visible    ${PUBLICATION_NAME}
 
 Validate public prerelease access list
-    user validates pre-release access list on help tab in release preview
+    user checks pre-release access list on help and related information tab
     ...    Updated test public access list
 
-Go back to prerelease content page again
+Go back to pre-release access list section on the help and related information tab again
     user returns to release home tab in release preview
-    ...    Test headlines summary text for ${PUBLICATION_NAME}
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
@@ -393,20 +387,14 @@ Validate prerelease has started for Analyst user
 
     user waits until element contains    id:headlines-section    Test headlines summary text for ${PUBLICATION_NAME}
 
-Validate public metdata guidance for Analyst user
-    user validates data guidance on explore tab in release preview
-    ...    Test metadata guidance content
-    ...    UI test subject
-    ...    Test file guidance content
-    ...    Local authority, Local authority district, Local enterprise partnership, Opportunity area, Parliamentary constituency, Regional, RSC region, Ward
-    ...    2005 to 2020
+Validate data set details and meta data guidance for Analyst user
+    user checks data set details for UI test subject
+
     ${data_guidance_section}=    Get WebElement    id:data-guidance-section
     user checks element should contain    ${data_guidance_section}    Test metadata guidance content
-    user checks element should contain    testid:indicators    Admission Numbers
 
-Go back to prerelease content page as Analyst user
+Go back to pre-release access list section on the help and related information tab as Analyst user
     user returns to release home tab in release preview
-    ...    Test headlines summary text for ${PUBLICATION_NAME}
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
@@ -414,12 +402,11 @@ Go back to prerelease content page as Analyst user
     user waits until h2 is visible    ${PUBLICATION_NAME}
 
 Validate public prerelease access list as Analyst user
-    user validates pre-release access list on help tab in release preview
+    user checks pre-release access list on help and related information tab
     ...    Updated test public access list
 
-Go back to prerelease content page again as Analyst user
+Go back to pre-release access list section on the help and related information tab again as Analyst user
     user returns to release home tab in release preview
-    ...    Test headlines summary text for ${PUBLICATION_NAME}
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
@@ -537,35 +524,22 @@ user validates table rows
     user checks table cell in offset row contains    ${row}    3    1    1,109
     user checks table cell in offset row contains    ${row}    4    1    1,959
 
-user validates data guidance on explore tab in release preview
-    [Arguments]
-    ...    ${main_guidance_content}
-    ...    ${subject_name}
-    ...    ${file_guidance_content}
-    ...    ${data_file_description}
-    ...    ${time_period}
-    user clicks link    Explore and download data
-    user waits until h2 is visible    Explore data used in this release
-    user checks section with ID contains elements and back to top link    data-guidance-section
-    ...    ${main_guidance_content}
-    user scrolls to element    id:datasets-section
-
-    ${dataset_xpath}=    Set Variable
-    ...    //article//li[@data-testid="release-data-list-item"][.//h4[normalize-space()="${subject_name}"]]
-    Wait Until Element Is Visible    xpath=${dataset_xpath}
-    ${toggle_xpath}=    Set Variable
-    ...    ${dataset_xpath}//button[@aria-expanded="false"]
-    Run Keyword And Ignore Error    Click Element    xpath=${toggle_xpath}
-
-    user checks element should contain    ${dataset_xpath}    ${file_guidance_content}
-    user checks element should contain    ${dataset_xpath}    ${data_file_description}
-    user checks summary list contains    Time period    ${time_period}    ${dataset_xpath}
-
 user returns to release home tab in release preview
-    [Arguments]    ${headlines_text}
     user clicks link    Release home
     user waits until h2 is visible    Headline facts and figures
-    user waits until element contains    id:headlines-section    ${headlines_text}    %{WAIT_SMALL}
+
+user checks data set details for UI test subject
+    user clicks link    Explore and download data
+    user waits until h2 is visible    Explore data used in this release
+    User checks page 'Explore and download data' data set available properties
+    ...    UI test subject
+    ...    Local authority; Local authority district; Local enterprise partnership; Opportunity area; Parliamentary constituency; RSC region; Regional; Ward
+    ...    144
+    ...    2005 to 2020
+    ...    ${PUBLICATION_NAME}
+    ...    Test file guidance content
+    ...    indicators=Admission Numbers
+    ...    is_public_site=False
 
 do suite teardown
     user closes the browser

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -293,59 +293,32 @@ Validate contact banner is shown
     user checks testid element contains    notificationBanner    UI test team name: ui_test@test.com
 
 Validate metadata guidance page
-    [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-7009
-    [Tags]    Failing
-    user clicks link    Data guidance
-
-    user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}
-
-    user waits until h2 is visible    Data guidance    %{WAIT_SMALL}
-    user waits until page contains    Test metadata guidance content    %{WAIT_SMALL}
-
-    user waits until page contains accordion section    UI test subject    %{WAIT_SMALL}
-    user checks there are x accordion sections    1
-
-    user opens accordion section    UI test subject
-    user checks summary list contains    Filename    upload-file-test.csv
-    user checks summary list contains    Geographic levels
-    ...    Local authority; Local authority district; Local enterprise partnership; Opportunity area; Parliamentary constituency; RSC region; Regional; Ward
-    user checks summary list contains    Time period    2005 to 2020
-    user checks summary list contains    Content    Test file guidance content
-
-    user opens details dropdown    Variable names and descriptions
-
-    user checks table column heading contains    1    1    Variable name
-    user checks table column heading contains    1    2    Variable description
-
-    user checks table cell contains    1    1    admission_numbers
-    user checks table cell contains    1    2    Admission Numbers
+    user validates data guidance on explore tab in release preview
+    ...    Test metadata guidance content
+    ...    UI test subject
+    ...    Test file guidance content
+    ...    Local authority, Local authority district, Local enterprise partnership, Opportunity area, Parliamentary constituency, Regional, RSC region, Ward
+    ...    2005 to 2020
+    ${data_guidance_section}=    Get WebElement    id:data-guidance-section
+    user checks element should contain    ${data_guidance_section}    Test metadata guidance content
+    user checks element should contain    testid:indicators    Admission Numbers
 
 Go back to prerelease content page
-    [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-7009
-    [Tags]    Failing
-    user clicks link    Back
+    user returns to release home tab in release preview
+    ...    Test headlines summary text for ${PUBLICATION_NAME}
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
-
     user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}
+    user waits until h2 is visible    ${PUBLICATION_NAME}
 
 Validate public prerelease access list
-    [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-7009
-    [Tags]    Failing
-    user clicks link    Pre-release access list
-    user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}
-    user waits until h2 is visible    Pre-release access list    %{WAIT_SMALL}
-    user waits until page contains    Updated test public access list    %{WAIT_SMALL}
+    user validates pre-release access list on help tab in release preview
+    ...    Updated test public access list
 
 Go back to prerelease content page again
-    [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-7009
-    [Tags]    Failing
-    user clicks link    Back
-    user waits until h1 is visible    ${PUBLICATION_NAME}
+    user returns to release home tab in release preview
+    ...    Test headlines summary text for ${PUBLICATION_NAME}
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
@@ -408,8 +381,6 @@ Create and validate methodology
     user waits until h1 is visible    ${PUBLICATION_NAME}
 
 Validate prerelease has started for Analyst user
-    [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-7009
-    [Tags]    Failing
     user changes to analyst1
     user navigates to    ${RELEASE_URL}/prerelease/content
 
@@ -423,67 +394,37 @@ Validate prerelease has started for Analyst user
     user waits until element contains    id:headlines-section    Test headlines summary text for ${PUBLICATION_NAME}
 
 Validate public metdata guidance for Analyst user
-    [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-7009
-    [Tags]    Failing
-    user clicks link    Data guidance
-
-    user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}
-
-    user waits until h2 is visible    Data guidance    %{WAIT_SMALL}
-    user waits until page contains    Test metadata guidance content    %{WAIT_SMALL}
-
-    user waits until page contains accordion section    UI test subject    %{WAIT_SMALL}
-    user checks there are x accordion sections    1
-
-    user opens accordion section    UI test subject
-    user checks summary list contains    Filename    upload-file-test.csv
-    user checks summary list contains    Geographic levels
-    ...    Local authority; Local authority district; Local enterprise partnership; Opportunity area; Parliamentary constituency; RSC region; Regional; Ward
-    user checks summary list contains    Time period    2005 to 2020
-    user checks summary list contains    Content    Test file guidance content
-
-    user opens details dropdown    Variable names and descriptions
-
-    user checks table column heading contains    1    1    Variable name
-    user checks table column heading contains    1    2    Variable description
-
-    user checks table cell contains    1    1    admission_numbers
-    user checks table cell contains    1    2    Admission Numbers
+    user validates data guidance on explore tab in release preview
+    ...    Test metadata guidance content
+    ...    UI test subject
+    ...    Test file guidance content
+    ...    Local authority, Local authority district, Local enterprise partnership, Opportunity area, Parliamentary constituency, Regional, RSC region, Ward
+    ...    2005 to 2020
+    ${data_guidance_section}=    Get WebElement    id:data-guidance-section
+    user checks element should contain    ${data_guidance_section}    Test metadata guidance content
+    user checks element should contain    testid:indicators    Admission Numbers
 
 Go back to prerelease content page as Analyst user
-    [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-7009
-    [Tags]    Failing
-    user clicks link    Back
+    user returns to release home tab in release preview
+    ...    Test headlines summary text for ${PUBLICATION_NAME}
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
-
     user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}
+    user waits until h2 is visible    ${PUBLICATION_NAME}
 
 Validate public prerelease access list as Analyst user
-    [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-7009
-    [Tags]    Failing
-    user clicks link    Pre-release access list
-
-    user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}
-
-    user waits until h2 is visible    Pre-release access list    %{WAIT_SMALL}
-    user waits until page contains    Updated test public access list    %{WAIT_SMALL}
+    user validates pre-release access list on help tab in release preview
+    ...    Updated test public access list
 
 Go back to prerelease content page again as Analyst user
-    [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-7009
-    [Tags]    Failing
-    user clicks link    Back
-
+    user returns to release home tab in release preview
+    ...    Test headlines summary text for ${PUBLICATION_NAME}
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
     user checks nth breadcrumb contains    2    Pre-release access
-
     user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}
+    user waits until h2 is visible    ${PUBLICATION_NAME}
 
 Go to prerelease table tool page as Analyst user
     user clicks link    Table tool
@@ -595,6 +536,36 @@ user validates table rows
     user checks table cell in offset row contains    ${row}    2    1    6,060
     user checks table cell in offset row contains    ${row}    3    1    1,109
     user checks table cell in offset row contains    ${row}    4    1    1,959
+
+user validates data guidance on explore tab in release preview
+    [Arguments]
+    ...    ${main_guidance_content}
+    ...    ${subject_name}
+    ...    ${file_guidance_content}
+    ...    ${data_file_description}
+    ...    ${time_period}
+    user clicks link    Explore and download data
+    user waits until h2 is visible    Explore data used in this release
+    user checks section with ID contains elements and back to top link    data-guidance-section
+    ...    ${main_guidance_content}
+    user scrolls to element    id:datasets-section
+
+    ${dataset_xpath}=    Set Variable
+    ...    //article//li[@data-testid="release-data-list-item"][.//h4[normalize-space()="${subject_name}"]]
+    Wait Until Element Is Visible    xpath=${dataset_xpath}
+    ${toggle_xpath}=    Set Variable
+    ...    ${dataset_xpath}//button[@aria-expanded="false"]
+    Run Keyword And Ignore Error    Click Element    xpath=${toggle_xpath}
+
+    user checks element should contain    ${dataset_xpath}    ${file_guidance_content}
+    user checks element should contain    ${dataset_xpath}    ${data_file_description}
+    user checks summary list contains    Time period    ${time_period}    ${dataset_xpath}
+
+user returns to release home tab in release preview
+    [Arguments]    ${headlines_text}
+    user clicks link    Release home
+    user waits until h2 is visible    Headline facts and figures
+    user waits until element contains    id:headlines-section    ${headlines_text}    %{WAIT_SMALL}
 
 do suite teardown
     user closes the browser

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -514,7 +514,7 @@ user checks data set details for UI test subject
     user waits until h2 is visible    Explore data used in this release
     User checks page 'Explore and download data' data set available properties
     ...    data_set_name=UI test subject
-    ...    geographical_levels=Local authority; Local authority district; Local enterprise partnership; Opportunity area; Parliamentary constituency; RSC region; Regional; Ward
+    ...    geographical_levels=Local authority, Local authority district, Local enterprise partnership, Opportunity area, Parliamentary constituency, Regional, RSC region, Ward
     ...    expected_row_count=144
     ...    expected_time_period=2005 to 2020
     ...    publication_title=${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -387,11 +387,8 @@ Validate prerelease has started for Analyst user
 
     user waits until element contains    id:headlines-section    Test headlines summary text for ${PUBLICATION_NAME}
 
-Validate data set details and meta data guidance for Analyst user
+Validate data set details for Analyst user
     user checks data set details for UI test subject
-
-    ${data_guidance_section}=    Get WebElement    id:data-guidance-section
-    user checks element should contain    ${data_guidance_section}    Test metadata guidance content
 
 Go back to pre-release access list section on the help and related information tab as Analyst user
     user returns to release home tab in release preview

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -299,14 +299,6 @@ Validate metadata guidance section and data set details section on the Explore a
     ${data_guidance_section}=    Get WebElement    id:data-guidance-section
     user checks element should contain    ${data_guidance_section}    Test metadata guidance content
 
-Go back to pre-release access list section on the help and related information tab
-    user returns to release home tab in release preview
-    user checks breadcrumb count should be    2
-    user checks nth breadcrumb contains    1    Home
-    user checks nth breadcrumb contains    2    Pre-release access
-    user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
-    user waits until h2 is visible    ${PUBLICATION_NAME}
-
 Validate public prerelease access list
     user checks pre-release access list on help and related information tab
     ...    Updated test public access list
@@ -389,14 +381,6 @@ Validate prerelease has started for Analyst user
 
 Validate data set details for Analyst user
     user checks data set details for UI test subject
-
-Go back to pre-release access list section on the help and related information tab as Analyst user
-    user returns to release home tab in release preview
-    user checks breadcrumb count should be    2
-    user checks nth breadcrumb contains    1    Home
-    user checks nth breadcrumb contains    2    Pre-release access
-    user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
-    user waits until h2 is visible    ${PUBLICATION_NAME}
 
 Validate public prerelease access list as Analyst user
     user checks pre-release access list on help and related information tab
@@ -529,12 +513,12 @@ user checks data set details for UI test subject
     user clicks link    Explore and download data
     user waits until h2 is visible    Explore data used in this release
     User checks page 'Explore and download data' data set available properties
-    ...    UI test subject
-    ...    Local authority; Local authority district; Local enterprise partnership; Opportunity area; Parliamentary constituency; RSC region; Regional; Ward
-    ...    144
-    ...    2005 to 2020
-    ...    ${PUBLICATION_NAME}
-    ...    Test file guidance content
+    ...    data_set_name=UI test subject
+    ...    geographical_levels=Local authority; Local authority district; Local enterprise partnership; Opportunity area; Parliamentary constituency; RSC region; Regional; Ward
+    ...    expected_row_count=144
+    ...    expected_time_period=2005 to 2020
+    ...    publication_title=${PUBLICATION_NAME}
+    ...    expected_data_guidance=Test file guidance content
     ...    indicators=Admission Numbers
     ...    is_public_site=False
 

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -286,15 +286,8 @@ Validate contact banner is shown
     user checks testid element contains    notificationBanner    UI test team name: ui_test@test.com
 
 Validate public prerelease access list as Analyst user
-    [Documentation]    Failing due to https://dfedigital.atlassian.net/browse/EES-7009
-    [Tags]    Failing
-    user clicks link    Pre-release access list
-
-    user waits until page contains title caption    Calendar year 2000    %{WAIT_SMALL}
-    user waits until h1 is visible    ${PUBLICATION_NAME}
-
-    user waits until h2 is visible    Pre-release access list    %{WAIT_SMALL}
-    user waits until page contains    Amended test public access list    %{WAIT_SMALL}
+    user validates pre-release access list on help tab in release preview
+    ...    Amended test public access list
 
 
 *** Keywords ***

--- a/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease_and_amend.robot
@@ -286,7 +286,7 @@ Validate contact banner is shown
     user checks testid element contains    notificationBanner    UI test team name: ui_test@test.com
 
 Validate public prerelease access list as Analyst user
-    user validates pre-release access list on help tab in release preview
+    user checks pre-release access list on help and related information tab
     ...    Amended test public access list
 
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -307,7 +307,7 @@ Verify release associated files
     ...    Data guidance
     ...    Data catalogue
 
-    User checks page 'Explore and download data' data set available properties    ${SUBJECT_NAME}    118
+    User checks page 'Explore and download data' data set available properties    ${SUBJECT_NAME}    118    National
     ...    2020 Week 13 to 2021 Week 24    ${PUBLICATION_NAME}    Dates test subject test data guidance content
     user goes back
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -307,8 +307,13 @@ Verify release associated files
     ...    Data guidance
     ...    Data catalogue
 
-    User checks page 'Explore and download data' data set available properties    ${SUBJECT_NAME}    118    National
-    ...    2020 Week 13 to 2021 Week 24    ${PUBLICATION_NAME}    Dates test subject test data guidance content
+    User checks page 'Explore and download data' data set available properties
+    ...    data_set_name=${SUBJECT_NAME}
+    ...    expected_row_count=118
+    ...    geographical_levels=National
+    ...    expected_time_period=2020 Week 13 to 2021 Week 24
+    ...    publication_title=${PUBLICATION_NAME}
+    ...    expected_data_guidance=Dates test subject test data guidance content
     user goes back
 
     ${supporting_files_xpath}=    Set Variable

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -414,7 +414,9 @@ Verify Explore and Download data
     ${file_size}=    Get File Size    ${DOWNLOAD_DIR}/seed-publication-pupil-absence-in-schools-in-england_2016-17.zip
     Should Be True    ${file_size} > 0
 
-    User checks page 'Explore and download data' data set available properties    Absence by characteristic    201,625
+    User checks page 'Explore and download data' data set available properties    Absence by characteristic
+    ...    Local authority, Local authority district, National
+    ...    201,625
     ...    2012/13 to 2016/17
     ...    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
 
@@ -422,7 +424,9 @@ Verify Explore and Download data
     user clicks link    Explore and download data
     user waits until h2 is visible    Explore data used in this release
     user waits until h2 is visible    Data sets: download or create tables
-    User checks page 'Explore and download data' data set available properties    Absence in PRUs    612
+    User checks page 'Explore and download data' data set available properties    Absence in PRUs
+    ...    Local authority, National, Regional
+    ...    612
     ...    2013/14 to 2016/17
     ...    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
 

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -414,21 +414,25 @@ Verify Explore and Download data
     ${file_size}=    Get File Size    ${DOWNLOAD_DIR}/seed-publication-pupil-absence-in-schools-in-england_2016-17.zip
     Should Be True    ${file_size} > 0
 
-    User checks page 'Explore and download data' data set available properties    Absence by characteristic
-    ...    Local authority, Local authority district, National
-    ...    201,625
-    ...    2012/13 to 2016/17
-    ...    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
+    @{filters}=    create list    Characteristic    School type
+    User checks page 'Explore and download data' data set available properties
+    ...    data_set_name=Absence by characteristic
+    ...    geographical_levels=Local authority, Local authority district, National
+    ...    expected_row_count=201,625
+    ...    expected_time_period=2012/13 to 2016/17
+    ...    publication_title=${PUPIL_ABSENCE_PUBLICATION_TITLE}
+    ...    filters=${filters}
 
     user navigates to the Absence publication
     user clicks link    Explore and download data
     user waits until h2 is visible    Explore data used in this release
     user waits until h2 is visible    Data sets: download or create tables
-    User checks page 'Explore and download data' data set available properties    Absence in PRUs
-    ...    Local authority, National, Regional
-    ...    612
-    ...    2013/14 to 2016/17
-    ...    ${PUPIL_ABSENCE_PUBLICATION_TITLE}
+    User checks page 'Explore and download data' data set available properties
+    ...    data_set_name=Absence in PRUs
+    ...    geographical_levels=Local authority, National, Regional
+    ...    expected_row_count=612
+    ...    expected_time_period=2013/14 to 2016/17
+    ...    publication_title=${PUPIL_ABSENCE_PUBLICATION_TITLE}
 
     user navigates to the Absence publication
     user clicks link    Explore and download data

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -1019,3 +1019,10 @@ user moves item of draggable list down
     user presses keys    ${SPACE}
     user presses keys    ARROW_DOWN
     user presses keys    ${SPACE}
+
+user validates pre-release access list on help tab in release preview
+    [Arguments]    @{access_list_content}
+    user clicks link    Help and related information
+    user waits until h2 is visible    Get help by contacting us
+    user checks section with ID contains elements and back to top link    pre-release-access-list-section
+    ...    @{access_list_content}

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -1020,9 +1020,9 @@ user moves item of draggable list down
     user presses keys    ARROW_DOWN
     user presses keys    ${SPACE}
 
-user validates pre-release access list on help tab in release preview
+user checks pre-release access list on help and related information tab
     [Arguments]    @{access_list_content}
     user clicks link    Help and related information
-    user waits until h2 is visible    Get help by contacting us
+    user waits until h2 is visible    Pre-release access list
     user checks section with ID contains elements and back to top link    pre-release-access-list-section
     ...    @{access_list_content}

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -1266,3 +1266,13 @@ user checks section is in position
     ${text_matcher}=    get xpath text matcher    ${section_text}    ${exact_match}
     user waits until parent contains element    ${parent}
     ...    xpath:(.//*[@data-testid="home-content-section"])[${position}]//h2[${text_matcher}]
+
+user checks section with ID contains elements and back to top link
+    [Arguments]    ${section_id}    @{paragraph_texts}    ${back_to_top}=True
+    ${section}=    Get WebElement    id:${section_id}
+    FOR    ${paragraph_text}    IN    @{paragraph_texts}
+        user checks element should contain    ${section}    ${paragraph_text}
+    END
+    IF    ${back_to_top}
+        user waits until parent contains element    ${section}    xpath://a[text()="Back to top" and @href="\#top"]
+    END

--- a/tests/robot-tests/tests/libs/public-common.robot
+++ b/tests/robot-tests/tests/libs/public-common.robot
@@ -42,16 +42,6 @@ user checks methodology note
 user checks related information panel is visible
     user waits until page contains element    xpath://h2[text()='Related information']
 
-user checks section with ID contains elements and back to top link
-    [Arguments]    ${section_id}    @{paragraph_texts}    ${back_to_top}=True
-    ${section}=    Get WebElement    id:${section_id}
-    FOR    ${paragraph_text}    IN    @{paragraph_texts}
-        user checks element should contain    ${section}    ${paragraph_text}
-    END
-    IF    ${back_to_top}
-        user waits until parent contains element    ${section}    xpath://a[text()="Back to top" and @href="\#top"]
-    END
-
 user goes to explore and download data and navigates to data set details page
     [Arguments]    ${SUBJECT_NAME}
     user clicks link    Explore and download data

--- a/tests/robot-tests/tests/libs/public-common.robot
+++ b/tests/robot-tests/tests/libs/public-common.robot
@@ -120,8 +120,7 @@ User checks page 'Explore and download data' data set available properties
 
     # Assert geographic levels
     Page Should Contain Element
-    ...    xpath=${dataset_xpath}
-    ...    //p[contains(normalize-space(.), "Geographical levels: ${geographical_levels}")]
+    ...    xpath=${dataset_xpath}//p[contains(normalize-space(.), "${geographical_levels}")]
     ...    Dataset "${data_set_name}" has incorrect geographical levels
 
     # Normalize the incoming parameters ($indicators or $filters) into a Python list so the rest of the Robot keyword can treat it uniformly.
@@ -173,21 +172,18 @@ User checks page 'Explore and download data' data set available properties
         ...    Dataset "${data_set_name}" has incorrect API ID value
 
         Page Should Contain Element
-        ...    xpath=${dataset_xpath}
-        ...    //strong[contains(normalize-space(.), "Available by API")]
+        ...    xpath=${dataset_xpath}//strong[contains(normalize-space(.), "Available by API")]
         ...    Dataset "${data_set_name}" is missing "Available by API" tag
     END
 
     # Assert dd value for "Number of rows"
     Page Should Contain Element
-    ...    xpath=${dataset_xpath}
-    ...    //dt[normalize-space(.)="Number of rows"]/following-sibling::dd[normalize-space(.)="${expected_row_count}"]
+    ...    xpath=${dataset_xpath}//dt[normalize-space(.)="Number of rows"]/following-sibling::dd[normalize-space(.)="${expected_row_count}"]
     ...    Dataset "${data_set_name}" has incorrect Number of rows
 
     # Assert dd value for "Time period"
     Page Should Contain Element
-    ...    xpath=${dataset_xpath}
-    ...    //dt[normalize-space(.)="Time period"]/following-sibling::dd[normalize-space(.)="${expected_time_period}"]
+    ...    xpath=${dataset_xpath}//dt[normalize-space(.)="Time period"]/following-sibling::dd[normalize-space(.)="${expected_time_period}"]
     ...    Dataset "${data_set_name}" has incorrect Time period
 
     # Verify data guidance content

--- a/tests/robot-tests/tests/libs/public-common.robot
+++ b/tests/robot-tests/tests/libs/public-common.robot
@@ -123,15 +123,8 @@ User checks page 'Explore and download data' data set available properties
     ...    xpath=${dataset_xpath}//p[contains(normalize-space(.), "${geographical_levels}")]
     ...    Dataset "${data_set_name}" has incorrect geographical levels
 
-    # Normalize the incoming parameters ($indicators or $filters) into a Python list so the rest of the Robot keyword can treat it uniformly.
-    #    Examples:
-    # Input "" or None → ${indicators} becomes [] (falsey).
-    # Input ["A","B"] → ${indicators} stays ["A","B"] (truthy).
-    # Input "X" → ${indicators} becomes ["X"] (truthy).
-    ${indicators}=    Evaluate
-    ...    [] if $indicators in ('', None) else $indicators if isinstance($indicators, (list, tuple)) else [$indicators]
-    ${filters}=    Evaluate
-    ...    [] if $filters in ('', None) else $filters if isinstance($filters, (list, tuple)) else [$filters]
+    ${indicators}=    Normalise To List    ${indicators}
+    ${filters}=    Normalise To List    ${filters}
     IF    ${indicators}
         # Assert indicators label exists
         Page Should Contain Element

--- a/tests/robot-tests/tests/libs/public-common.robot
+++ b/tests/robot-tests/tests/libs/public-common.robot
@@ -90,10 +90,15 @@ user checks main links for page 'Explore and download data' are present
 
 User checks page 'Explore and download data' data set available properties
     [Arguments]    ${data_set_name}
+    ...    ${geographical_levels}
     ...    ${expected_row_count}
     ...    ${expected_time_period}
-    ...    ${PUBLICATION_TITLE}
+    ...    ${publication_title}
     ...    ${expected_data_guidance}=${data_set_name} data guidance content
+    ...    ${indicators}=${EMPTY}
+    ...    ${filters}=${EMPTY}
+    ...    ${api_data_set_id}=${EMPTY}
+    ...    ${is_public_site}=True
 
     ${dataset_xpath}=    Set Variable
     ...    //article//li[@data-testid="release-data-list-item"][.//h4[normalize-space()="${data_set_name}"]]
@@ -113,6 +118,66 @@ User checks page 'Explore and download data' data set available properties
     ...    xpath=${dataset_xpath}//dt[normalize-space(.)="Number of rows"]
     ...    Dataset "${data_set_name}" is missing "Number of rows" label
 
+    # Assert geographic levels
+    Page Should Contain Element
+    ...    xpath=${dataset_xpath}
+    ...    //p[contains(normalize-space(.), "Geographical levels: ${geographical_levels}")]
+    ...    Dataset "${data_set_name}" has incorrect geographical levels
+
+    # Normalize the incoming parameters ($indicators or $filters) into a Python list so the rest of the Robot keyword can treat it uniformly.
+    #    Examples:
+    # Input "" or None → ${indicators} becomes [] (falsey).
+    # Input ["A","B"] → ${indicators} stays ["A","B"] (truthy).
+    # Input "X" → ${indicators} becomes ["X"] (truthy).
+    ${indicators}=    Evaluate
+    ...    [] if $indicators in ('', None) else $indicators if isinstance($indicators, (list, tuple)) else [$indicators]
+    ${filters}=    Evaluate
+    ...    [] if $filters in ('', None) else $filters if isinstance($filters, (list, tuple)) else [$filters]
+    IF    ${indicators}
+        # Assert indicators label exists
+        Page Should Contain Element
+        ...    xpath=${dataset_xpath}//dt[normalize-space(.)="Indicators"]
+        ...    Dataset "${data_set_name}" is missing "Indicators" label
+
+        # If indicators provided, assert each indicator exists in the list
+        FOR    ${indicator}    IN    @{indicators}
+            Page Should Contain Element
+            ...    xpath=${dataset_xpath}//div[@data-testid="Indicators"]//li[normalize-space(.)="${indicator}"]
+            ...    Dataset "${data_set_name}" is missing indicator "${indicator}"
+        END
+    END
+
+    IF    ${filters}
+        # Assert filters label exists
+        Page Should Contain Element
+        ...    xpath=${dataset_xpath}//dt[normalize-space(.)="Filters"]
+        ...    Dataset "${data_set_name}" is missing "Filters" label
+
+        # If filters provided, assert each filter exists in the list
+        FOR    ${filter}    IN    @{filters}
+            Page Should Contain Element
+            ...    xpath=${dataset_xpath}//div[@data-testid="Filters"]//li[normalize-space(.)="${filter}"]
+            ...    Dataset "${data_set_name}" is missing filter "${filter}"
+        END
+    END
+
+    IF    "${api_data_set_id}" != "${EMPTY}"
+        # Assert API ID label exists
+        Page Should Contain Element
+        ...    xpath=${dataset_xpath}//dt[normalize-space(.)="API data set ID"]
+        ...    Dataset "${data_set_name}" is missing "API data set ID" label
+
+        # Assert API ID value is correct
+        Page Should Contain Element
+        ...    xpath=${dataset_xpath}//dt[normalize-space(.)="API data set ID"]/following-sibling::dd[normalize-space(.)="${api_data_set_id}"]
+        ...    Dataset "${data_set_name}" has incorrect API ID value
+
+        Page Should Contain Element
+        ...    xpath=${dataset_xpath}
+        ...    //strong[contains(normalize-space(.), "Available by API")]
+        ...    Dataset "${data_set_name}" is missing "Available by API" tag
+    END
+
     # Assert dd value for "Number of rows"
     Page Should Contain Element
     ...    xpath=${dataset_xpath}
@@ -130,27 +195,29 @@ User checks page 'Explore and download data' data set available properties
     ...    xpath=${dataset_xpath}//p[contains(normalize-space(.), "${expected_data_guidance}")]
     ...    Dataset "${data_set_name}" is missing the data guidance content text
 
-    # Verify Data set information page link
-    Page Should Contain Element
-    ...    xpath=${dataset_xpath}//a[contains(normalize-space(.), "Data set information page")]
-    ...    Dataset "${data_set_name}" is missing the "Data set information page" link
-
-    # Verify Create table link
-    Page Should Contain Element
-    ...    xpath=${dataset_xpath}//a[contains(normalize-space(.), "Create table")]
-    ...    Dataset "${data_set_name}" is missing the "Create table" link
-
     # Verify Download (ZIP) button
     Page Should Contain Element
     ...    xpath=${dataset_xpath}//button[contains(normalize-space(.), "Download")]
     ...    Dataset "${data_set_name}" is missing the "Download (ZIP)" button
 
-    user clicks element    xpath=${dataset_xpath}//a[contains(normalize-space(.), "Create table")]
-    user waits until h1 is visible    Create your own tables    %{WAIT_MEDIUM}
-    user waits until page finishes loading
+    IF    "${is_public_site}" == "True"
+        # Verify Data set information page link
+        Page Should Contain Element
+        ...    xpath=${dataset_xpath}//a[contains(normalize-space(.), "Data set information page")]
+        ...    Dataset "${data_set_name}" is missing the "Data set information page" link
 
-    user waits until table tool wizard step is available    2    Select a data set
-    user checks previous table tool step contains    1    Publication    ${PUBLICATION_TITLE}
+        # Verify Create table link
+        Page Should Contain Element
+        ...    xpath=${dataset_xpath}//a[contains(normalize-space(.), "Create table")]
+        ...    Dataset "${data_set_name}" is missing the "Create table" link
+
+        user clicks element    xpath=${dataset_xpath}//a[contains(normalize-space(.), "Create table")]
+        user waits until h1 is visible    Create your own tables    %{WAIT_MEDIUM}
+        user waits until page finishes loading
+
+        user waits until table tool wizard step is available    2    Select a data set
+        user checks previous table tool step contains    1    Publication    ${publication_title}
+    END
 
 user checks 'On this page section' for this tab contains
     [Arguments]    @{expected_link_texts}

--- a/tests/robot-tests/tests/libs/public-utilities.py
+++ b/tests/robot-tests/tests/libs/public-utilities.py
@@ -35,6 +35,16 @@ def cookie_names_should_be_on_page():
             raise_assertion_error(f"Page should contain text \"{cookie['name']}\"!")
 
 
+def normalise_to_list(value):
+    if value is None or value == "":
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
 def user_checks_number_of_other_releases_is_correct(number):
     elems = sl().driver.find_elements(By.XPATH, '(.//*[@data-testid="other-release-item"])')
     if len(elems) != int(number):


### PR DESCRIPTION
This PR tweaks our UI robot tests to cover testing data guidance and pre-release within the redesigned release page. 

Data guidance is now under “Explore and download data” tab within the redesigned release page. Pre-release access list is now under “Help and related information” tab within the redesigned release page. This PR changes robot tests by removing a 'Failing' tag on steps within the tests `prerelease.robot` and `prerelease_and_amend.robot` and adding steps to support testing of these areas of the release page.