### PR TITLE
EES-7135 Improve UI test verifications of release publishing status when publishing scheduled release versions via API

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PrepareScheduledReleaseVersionsFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PrepareScheduledReleaseVersionsFunctions.cs
@@ -88,7 +88,7 @@ public class PrepareScheduledReleaseVersionsFunctions(
     /// <param name="context"></param>
     /// <returns></returns>
     [Function(nameof(PrepareScheduledReleaseVersionsNow))]
-    public async Task<ActionResult<ManualTriggerResponse>> PrepareScheduledReleaseVersionsNow(
+    public async Task<IActionResult> PrepareScheduledReleaseVersionsNow(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequest request,
         FunctionContext context
     )
@@ -124,7 +124,7 @@ public class PrepareScheduledReleaseVersionsFunctions(
             selectedReleaseVersions.ToReleaseVersionIdsString()
         );
 
-        return new ManualTriggerResponse(selectedReleaseVersions.ToReleaseVersionIds());
+        return new OkObjectResult(new ManualTriggerResponse(selectedReleaseVersions.ToReleaseVersionIds()));
     }
 
     private async Task QueueReleaseFilesTask(IReadOnlyList<ReleasePublishingKey> releasePublishingKeys)
@@ -148,5 +148,5 @@ public class PrepareScheduledReleaseVersionsFunctions(
     // ReSharper disable once ClassNeverInstantiated.Local
     private record ManualTriggerRequest(Guid[] ReleaseVersionIds);
 
-    public record ManualTriggerResponse(Guid[] ReleaseVersionIds);
+    private record ManualTriggerResponse(Guid[] ReleaseVersionIds);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PrepareScheduledReleaseVersionsFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PrepareScheduledReleaseVersionsFunctions.cs
@@ -56,17 +56,18 @@ public class PrepareScheduledReleaseVersionsFunctions(
             );
 
         // Fetch release versions scheduled for publishing before or on the next run time
-        var scheduledReleases = await releasePublishingStatusService.GetScheduledReleasesForPublishingRelativeToDate(
-            DateComparison.BeforeOrOn,
-            nextScheduledPublishingTime
-        );
+        var scheduledReleaseVersions =
+            await releasePublishingStatusService.GetScheduledReleasesForPublishingRelativeToDate(
+                DateComparison.BeforeOrOn,
+                nextScheduledPublishingTime
+            );
 
-        await QueueReleaseFilesTask(scheduledReleases);
+        await QueueReleaseFilesTask(scheduledReleaseVersions);
 
         logger.LogInformation(
             "{FunctionName} completed. Queued tasks for release versions: [{ReleaseVersionIds}]",
             context.FunctionDefinition.Name,
-            scheduledReleases.ToReleaseVersionIdsString()
+            scheduledReleaseVersions.ToReleaseVersionIdsString()
         );
     }
 
@@ -99,7 +100,7 @@ public class PrepareScheduledReleaseVersionsFunctions(
         var now = timeProvider.GetLocalNow();
         var startOfToday = new DateTimeOffset(now.Year, now.Month, now.Day, 0, 0, 0, now.Offset);
 
-        var scheduledReleases =
+        var scheduledReleaseVersions =
             releaseVersionIds?.Length > 0
                 ? await releasePublishingStatusService.GetScheduledReleasesForPublishingRelativeToDate(
                     DateComparison.AfterOrOn,
@@ -110,20 +111,20 @@ public class PrepareScheduledReleaseVersionsFunctions(
                     startOfToday.AddDays(1)
                 );
 
-        var selectedReleases =
+        var selectedReleaseVersions =
             releaseVersionIds?.Length > 0
-                ? scheduledReleases.Where(key => releaseVersionIds.Contains(key.ReleaseVersionId)).ToList()
-                : scheduledReleases;
+                ? scheduledReleaseVersions.Where(key => releaseVersionIds.Contains(key.ReleaseVersionId)).ToList()
+                : scheduledReleaseVersions;
 
-        await QueueReleaseFilesTask(selectedReleases);
+        await QueueReleaseFilesTask(selectedReleaseVersions);
 
         logger.LogInformation(
             "{FunctionName} completed. Queued tasks for release versions: [{ReleaseVersionIds}]",
             context.FunctionDefinition.Name,
-            selectedReleases.ToReleaseVersionIdsString()
+            selectedReleaseVersions.ToReleaseVersionIdsString()
         );
 
-        return new ManualTriggerResponse(selectedReleases.ToReleaseVersionIds());
+        return new ManualTriggerResponse(selectedReleaseVersions.ToReleaseVersionIds());
     }
 
     private async Task QueueReleaseFilesTask(IReadOnlyList<ReleasePublishingKey> releasePublishingKeys)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishScheduledReleaseVersionsFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishScheduledReleaseVersionsFunctions.cs
@@ -61,7 +61,7 @@ public class PublishScheduledReleaseVersionsFunctions(
     /// <param name="context"></param>
     /// <returns></returns>
     [Function(nameof(PublishScheduledReleaseVersionsNow))]
-    public async Task<ActionResult<ManualTriggerResponse>> PublishScheduledReleaseVersionsNow(
+    public async Task<IActionResult> PublishScheduledReleaseVersionsNow(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequest request,
         FunctionContext context
     )
@@ -89,11 +89,11 @@ public class PublishScheduledReleaseVersionsFunctions(
             selectedReleaseVersionsToPublish.ToReleaseVersionIdsString()
         );
 
-        return new ManualTriggerResponse(selectedReleaseVersionsToPublish.ToReleaseVersionIds());
+        return new OkObjectResult(new ManualTriggerResponse(selectedReleaseVersionsToPublish.ToReleaseVersionIds()));
     }
 
     // ReSharper disable once ClassNeverInstantiated.Local
     private record ManualTriggerRequest(Guid[] ReleaseVersionIds);
 
-    public record ManualTriggerResponse(Guid[] ReleaseVersionIds);
+    private record ManualTriggerResponse(Guid[] ReleaseVersionIds);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishScheduledReleaseVersionsFunctions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishScheduledReleaseVersionsFunctions.cs
@@ -16,7 +16,7 @@ public class PublishScheduledReleaseVersionsFunctions(
 {
     /// <summary>
     /// Azure Function that publishes scheduled release versions.
-    /// It uses <see cref="IPublishingCompletionService"/> to mark releases as publicly accessible and to
+    /// It uses <see cref="IPublishingCompletionService"/> to mark release versions as publicly accessible and to
     /// execute tasks required to complete the publishing process.
     /// </summary>
     /// <remarks>
@@ -30,22 +30,23 @@ public class PublishScheduledReleaseVersionsFunctions(
     {
         logger.LogInformation("{FunctionName} triggered", context.FunctionDefinition.Name);
 
-        var releasesReadyForPublishing = await releasePublishingStatusService.GetScheduledReleasesReadyForPublishing();
+        var releaseVersionsReadyForPublishing =
+            await releasePublishingStatusService.GetScheduledReleasesReadyForPublishing();
 
         // Complete publishing of these release versions
-        await publishingCompletionService.CompletePublishing(releasesReadyForPublishing);
+        await publishingCompletionService.CompletePublishing(releaseVersionsReadyForPublishing);
 
         logger.LogInformation(
             "{FunctionName} completed. Published release versions [{ReleaseVersionIds}].",
             context.FunctionDefinition.Name,
-            releasesReadyForPublishing.ToReleaseVersionIdsString()
+            releaseVersionsReadyForPublishing.ToReleaseVersionIdsString()
         );
     }
 
     /// <summary>
     /// HTTP-triggered function to immediately publish scheduled release versions.
     /// Intended for use by manual and automated testing to avoid waiting for the scheduled trigger.
-    /// It uses <see cref="IPublishingCompletionService"/> to mark releases as publicly accessible and to
+    /// It uses <see cref="IPublishingCompletionService"/> to mark release versions as publicly accessible and to
     /// execute tasks required to complete the publishing process.
     /// </summary>
     /// <remarks>
@@ -69,23 +70,26 @@ public class PublishScheduledReleaseVersionsFunctions(
 
         var releaseVersionIds = (await request.GetJsonBody<ManualTriggerRequest>())?.ReleaseVersionIds;
 
-        var releasesReadyForPublishing = await releasePublishingStatusService.GetScheduledReleasesReadyForPublishing();
+        var releaseVersionsReadyForPublishing =
+            await releasePublishingStatusService.GetScheduledReleasesReadyForPublishing();
 
-        var selectedReleasesToPublish =
+        var selectedReleaseVersionsToPublish =
             releaseVersionIds?.Length > 0
-                ? releasesReadyForPublishing.Where(key => releaseVersionIds.Contains(key.ReleaseVersionId)).ToList()
-                : releasesReadyForPublishing;
+                ? releaseVersionsReadyForPublishing
+                    .Where(key => releaseVersionIds.Contains(key.ReleaseVersionId))
+                    .ToList()
+                : releaseVersionsReadyForPublishing;
 
         // Complete publishing of these release versions
-        await publishingCompletionService.CompletePublishing(selectedReleasesToPublish);
+        await publishingCompletionService.CompletePublishing(selectedReleaseVersionsToPublish);
 
         logger.LogInformation(
             "{FunctionName} completed. Published release versions [{ReleaseVersionIds}]",
             context.FunctionDefinition.Name,
-            selectedReleasesToPublish.ToReleaseVersionIdsString()
+            selectedReleaseVersionsToPublish.ToReleaseVersionIdsString()
         );
 
-        return new ManualTriggerResponse(selectedReleasesToPublish.ToReleaseVersionIds());
+        return new ManualTriggerResponse(selectedReleaseVersionsToPublish.ToReleaseVersionIds());
     }
 
     // ReSharper disable once ClassNeverInstantiated.Local

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStages.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleasePublishingStages.tsx
@@ -60,6 +60,7 @@ export default function ReleasePublishingStages({
           return (
             <li key={key}>
               <StatusBlock
+                id={`release-process-stage-${key.replace('Stage', '')}-${text}`}
                 checklistStyle={checklistStyle}
                 color={color}
                 text={

--- a/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
@@ -3,7 +3,6 @@ Library             ../../libs/admin_api.py
 Resource            ../../libs/admin-common.robot
 Resource            ../../libs/admin/manage-content-common.robot
 Resource            ../../libs/charts.robot
-Resource            ../../libs/public-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser

--- a/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
@@ -127,7 +127,7 @@ Verify release status is in higher review
 Put release back into draft
     user puts release into draft
 
-Approve release for scheduled release
+Approve release for scheduled publication
     ${days_until_release}=    set variable    2
     ${publish_date_day}=    get london day of month    offset_days=${days_until_release}
     ${publish_date_month}=    get london month date    offset_days=${days_until_release}

--- a/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
@@ -138,8 +138,8 @@ Approve release for scheduled release
     ...    ${publish_date_day}
     ...    ${publish_date_month}
     ...    ${publish_date_year}
-    ...    12
-    ...    3001
+    ...    next_release_month=12
+    ...    next_release_year=3001
 
     set suite variable    ${EXPECTED_SCHEDULED_DATE}
     ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}

--- a/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
+++ b/tests/robot-tests/tests/admin/analyst/edit_and_approve_release_as_publication_approver.robot
@@ -141,14 +141,6 @@ Approve release for scheduled publication
     ...    next_release_month=12
     ...    next_release_year=3001
 
-    set suite variable    ${EXPECTED_SCHEDULED_DATE}
-    ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}
-
-Verify release is scheduled
-    user checks summary list contains    Current status    Approved
-    user checks summary list contains    Scheduled release    ${EXPECTED_SCHEDULED_DATE}
-    user checks summary list contains    Next release expected    December 3001
-
 Put release back into draft again
     user puts release into draft    expected_next_release_date=December 3001
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -145,7 +145,7 @@ Add public prerelease access list
     user creates public prerelease access list    Test public access list
 
 Approve release for scheduled publication
-    ${days_until_release}=    set variable    0
+    ${days_until_release}=    set variable    2
     ${publish_date_day}=    get london day of month    offset_days=${days_until_release}
     ${publish_date_month}=    get london month date    offset_days=${days_until_release}
     ${publish_date_month_word}=    get london month word    offset_days=${days_until_release}

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -156,18 +156,8 @@ Approve release for scheduled publication
     ...    ${publish_date_month}
     ...    ${publish_date_year}
 
-    set suite variable    ${EXPECTED_SCHEDULED_DATE}
-    ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}
-
 Publish the scheduled release
     user waits for scheduled release to be published immediately
-
-    ${publish_date_day}=    get london day of month
-    ${publish_date_month_word}=    get london month word
-    ${publish_date_year}=    get london year
-    set suite variable    ${EXPECTED_PUBLISHED_DATE}
-    ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}
-
     user waits for caches to expire
 
 Get public release link

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_amend_and_cancel.robot
@@ -155,8 +155,6 @@ Approve release for scheduled publication
     ...    ${publish_date_day}
     ...    ${publish_date_month}
     ...    ${publish_date_year}
-    ...    12
-    ...    3001
 
     set suite variable    ${EXPECTED_SCHEDULED_DATE}
     ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -266,8 +266,8 @@ Approve release for scheduled publication
     ...    ${publish_date_day}
     ...    ${publish_date_month}
     ...    ${publish_date_year}
-    ...    12
-    ...    3001
+    ...    next_release_month=12
+    ...    next_release_year=3001
 
     set suite variable    ${EXPECTED_SCHEDULED_DATE}
     ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}
@@ -731,8 +731,8 @@ Approve amendment for scheduled release
     ...    ${publish_date_day}
     ...    ${publish_date_month}
     ...    ${publish_date_year}
-    ...    12
-    ...    3001
+    ...    next_release_month=12
+    ...    next_release_year=3001
 
     user waits for scheduled release to be published immediately
 

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -256,7 +256,7 @@ Add public prerelease access list
     user creates public prerelease access list    Test public access list
 
 Approve release for scheduled publication
-    ${days_until_release}=    set variable    0
+    ${days_until_release}=    set variable    2
     ${publish_date_day}=    get london day of month    offset_days=${days_until_release}
     ${publish_date_month}=    get london month date    offset_days=${days_until_release}
     ${publish_date_month_word}=    get london month word    offset_days=${days_until_release}
@@ -713,7 +713,7 @@ Update public prerelease access list
     user updates public prerelease access list    Amended public access list
 
 Approve amendment for scheduled publication
-    ${days_until_release}=    set variable    1
+    ${days_until_release}=    set variable    2
     ${publish_date_day}=    get london day of month    offset_days=${days_until_release}
     ${publish_date_month}=    get london month date    offset_days=${days_until_release}
     ${publish_date_month_word}=    get london month word    offset_days=${days_until_release}

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -269,14 +269,6 @@ Approve release for scheduled publication
     ...    next_release_month=12
     ...    next_release_year=3001
 
-    set suite variable    ${EXPECTED_SCHEDULED_DATE}
-    ...    ${publish_date_day} ${publish_date_month_word} ${publish_date_year}
-
-Verify release is scheduled
-    user checks summary list contains    Current status    Approved
-    user checks summary list contains    Scheduled release    ${EXPECTED_SCHEDULED_DATE}
-    user checks summary list contains    Next release expected    December 3001
-
 Get public release link
     ${PUBLIC_RELEASE_LINK}=    user gets url public release will be accessible at
     Set Suite Variable    ${PUBLIC_RELEASE_LINK}

--- a/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public_2/bau/publish_release_and_amend.robot
@@ -720,7 +720,7 @@ Check public prerelease access list for amendment is same as original release
 Update public prerelease access list
     user updates public prerelease access list    Amended public access list
 
-Approve amendment for scheduled release
+Approve amendment for scheduled publication
     ${days_until_release}=    set variable    1
     ${publish_date_day}=    get london day of month    offset_days=${days_until_release}
     ${publish_date_month}=    get london month date    offset_days=${days_until_release}
@@ -734,6 +734,7 @@ Approve amendment for scheduled release
     ...    next_release_month=12
     ...    next_release_year=3001
 
+Publish the scheduled amendment
     user waits for scheduled release to be published immediately
 
     ${EXPECTED_PUBLISHED_DATE}=    get london date
@@ -950,8 +951,7 @@ Verify published date on publication page is overridden with past date
 
 Verify public published date is overridden with past date
     user waits for caches to expire
-    user navigates to    ${PUBLIC_RELEASE_LINK}
-    user waits until h1 is visible    ${PUBLICATION_NAME}
+    user navigates to public release page    ${PUBLIC_RELEASE_LINK}    ${PUBLICATION_NAME}    ${RELEASE_NAME}
     user checks summary list contains    Published    ${EXPECTED_PUBLISHED_DATE}
 
 Return to Admin and create second amendment
@@ -978,11 +978,12 @@ Remove the content section that originally contained the deleted data block
     user opens accordion section    Dates data block    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
     user deletes editable accordion section    Dates data block    ${RELEASE_CONTENT_EDITABLE_ACCORDION}
 
-Approve release amendment for scheduled publication and update published date
+Approve second amendment for scheduled publication and update published date
     ${days_until_release}=    set variable    2
     ${publish_date_day}=    get london day of month    offset_days=${days_until_release}
     ${publish_date_month}=    get london month date    offset_days=${days_until_release}
     ${publish_date_year}=    get london year    offset_days=${days_until_release}
+
     user approves release for scheduled publication
     ...    ${publish_date_day}
     ...    ${publish_date_month}
@@ -990,7 +991,10 @@ Approve release amendment for scheduled publication and update published date
     ...    next_release_month=8
     ...    next_release_year=4001
     ...    update_amendment_published_date=${True}
+
+Publish the scheduled second amendment
     user waits for scheduled release to be published immediately
+
     ${EXPECTED_PUBLISHED_DATE}=    get london date
     set suite variable    ${EXPECTED_PUBLISHED_DATE}
 
@@ -999,10 +1003,9 @@ Verify published date on publication page has been updated
     ${row}=    user gets table row    ${RELEASE_NAME}    testid:publication-published-releases
     user checks element contains    ${row}    ${EXPECTED_PUBLISHED_DATE}
 
-Navigate to amended public release
+Navigate to second amendment release page
     user waits for caches to expire
-    user navigates to    ${PUBLIC_RELEASE_LINK}
-    user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_MEDIUM}
+    user navigates to public release page    ${PUBLIC_RELEASE_LINK}    ${PUBLICATION_NAME}    ${RELEASE_NAME}
 
 Verify public published date has been updated
     user checks summary list contains    Published    ${EXPECTED_PUBLISHED_DATE}

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -750,6 +750,16 @@ user puts release into higher level review
     user waits until element is visible    id:CurrentReleaseStatus-Awaiting higher review    %{WAIT_SMALL}
 
 user approves release for scheduled publication
+    [Documentation]
+    ...    Approves a release version for scheduled publication on a specific date, with an optional next release date, and verifies that the overall release status is Scheduled.
+    ...
+    ...    If this keyword will be followed by 'user waits for scheduled release to be published immediately' (to advance the release version through the publishing process immediately,
+    ...    instead of waiting for the scheduled trigger), set the publish date to at least one day in the future.
+    ...
+    ...    This prevents a race condition where the publishing process may begin processing naturally at the same time that the test is attempting to trigger it via the API.
+    ...
+    ...    This can lead to ambiguity in the source of status transitions, i.e. whether changes were caused by normal scheduled processing or test-triggered API processing.
+    ...    It may also lead to false positive test results, where processing appears to have progressed correctly when it was actually advanced by the normal scheduled processing before the test-triggered API processing occurred.
     [Arguments]
     ...    ${publish_date_day}
     ...    ${publish_date_month}
@@ -789,24 +799,38 @@ user approves release for scheduled publication
     user checks summary list contains    Next release expected    ${expected_next_release_date}
     user waits for release process status to be    Scheduled    %{WAIT_SMALL}
 
+user waits for release process status and stages to be
+    [Arguments]
+    ...    ${overall_status}
+    ...    ${files_stage}
+    ...    ${publishing_stage}
+    user waits for release process status to be    ${overall_status}    %{WAIT_SMALL}
+    user waits until page contains element    id:release-process-stage-files-${files_stage}
+    user waits until page contains element    id:release-process-stage-publishing-${publishing_stage}
+
 user waits for scheduled release to be published immediately
+    [Documentation]    Uses the API to advance a scheduled release version through the release publishing process immediately, instead of waiting for the Publisher app to trigger the publishing functions on the release version's scheduled publication date.
     ${release_version_id}=    get release id from url
-    # It's possible that the scheduled "PrepareScheduledReleaseVersions" function may begin processing
-    # this scheduled release version before the test manually triggers the
-    # "PrepareScheduledReleaseVersionsNow" function via the API.
-    #
-    # Because of this potential overlap, the release version may already be in the overall
-    # "Started" state instead of the "Scheduled" state that would normally be expected.
-    # The test therefore needs to expect both states.
-    user waits until page contains element
-    ...    xpath://*[@id='release-process-status-Scheduled' or @id='release-process-status-Started']    %{WAIT_SMALL}
+
+    # The release should be in the Scheduled state at this point.
+    # If this fails, the "PrepareScheduledReleaseVersions" function may have already started processing the release version before this test
+    # can trigger the "PrepareScheduledReleaseVersionsNow" function via the API.
+    # To avoid this race condition, use a publish date at least one day in the future when approving the release for scheduled publishing.
+    user waits for release process status to be    Scheduled    %{WAIT_SMALL}
+
     prepare scheduled release versions now via api    ['${release_version_id}']
     user reloads page
-    user waits until page contains details dropdown    View stages    %{WAIT_SMALL}
+    user waits until page contains details dropdown    View stages
     user opens details dropdown    View stages
-    user waits until page contains    Files - complete    %{WAIT_MEDIUM}
+    user waits for release process status and stages to be
+    ...    overall_status=Started
+    ...    files_stage=Complete
+    ...    publishing_stage=Scheduled
     publish scheduled release versions now via api    ['${release_version_id}']
-    user waits until page contains element    id:release-process-status-Complete    %{WAIT_MEDIUM}
+    user waits for release process status and stages to be
+    ...    overall_status=Complete
+    ...    files_stage=Complete
+    ...    publishing_stage=Complete
 
 user verifies release summary
     [Arguments]

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -513,10 +513,7 @@ user approves amended release for immediate publication
 
 user approves release for immediate publication
     [Arguments]    ${release_type}=original    ${NEXT_RELEASE_MONTH}=01    ${NEXT_RELEASE_YEAR}=2200
-    user navigates to Sign off page
-    user waits until page contains button    Edit release status
-    user clicks button    Edit release status
-    user waits until h2 is visible    Edit release status
+    user edits release status
     user checks page does not contain    Notify subscribers by email
     user clicks radio    Approved for publication
     IF    '${release_type}' == 'amendment'
@@ -740,9 +737,7 @@ user puts release into draft
     user checks summary list contains    Next release expected    ${expected_next_release_date}
 
 user edits release status
-    user clicks link    Sign off
-    user waits until page finishes loading
-    user waits until h2 is visible    Sign off    %{WAIT_SMALL}
+    user navigates to Sign off page
     user clicks button    Edit release status
     user waits until h2 is visible    Edit release status    %{WAIT_SMALL}
 

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource    ./common.robot
 Library     admin-utilities.py
+Library     DateTime
 Library     String
 
 
@@ -756,6 +757,13 @@ user approves release for scheduled publication
     ...    ${next_release_month}=01
     ...    ${next_release_year}=2200
     ...    ${update_amendment_published_date}=${False}
+    ${expected_scheduled_date}=    Convert Date    ${publish_date_day} ${publish_date_month} ${publish_date_year}
+    ...    date_format=%d %m %Y
+    ...    result_format=%d %B %Y
+    ${expected_next_release_date}=    Convert Date    1 ${next_release_month} ${next_release_year}
+    ...    date_format=%d %m %Y
+    ...    result_format=%B %Y
+
     user edits release status
     user clicks radio    Approved for publication
     user enters text into element    id:releaseStatusForm-internalReleaseNote    Approved by UI tests
@@ -772,8 +780,14 @@ user approves release for scheduled publication
     user enters text into element    id:releaseStatusForm-nextReleaseDate-year    ${next_release_year}
 
     user clicks button    Update status
-    user waits until h2 is visible    Confirm publish date    %{WAIT_SMALL}
+    user waits until h2 is visible    Confirm publish date
     user clicks button    Confirm
+
+    user waits until h2 is visible    Sign off
+    user checks summary list contains    Current status    Approved
+    user checks summary list contains    Scheduled release    ${expected_scheduled_date}
+    user checks summary list contains    Next release expected    ${expected_next_release_date}
+    user waits for release process status to be    Scheduled    %{WAIT_SMALL}
 
 user waits for scheduled release to be published immediately
     ${release_version_id}=    get release id from url

--- a/tests/robot-tests/tests/libs/admin-utilities.py
+++ b/tests/robot-tests/tests/libs/admin-utilities.py
@@ -129,6 +129,28 @@ def user_checks_dashboard_theme_dropdown_exists():
     return True
 
 
+def _assert_response_contains_requested_release_version_ids(response, requested_release_version_ids: list[str]):
+    # The requested release version IDs array is optional and limits the scope of the Publisher function to only operate on the requested subset of release versions.
+    # If it is empty, the function operates on all relevant release versions, and so the response is not expected to be limited to a specific set of IDs.
+    # In this case, skip the assertion that compares response IDs to requested IDs since there are no requested IDs to compare against.
+    if not requested_release_version_ids:
+        return
+
+    response_json = response.json()
+    response_release_version_ids = response_json.get("releaseVersionIds", [])
+
+    missing_ids = sorted(set(requested_release_version_ids) - set(response_release_version_ids))
+    unexpected_ids = sorted(set(response_release_version_ids) - set(requested_release_version_ids))
+
+    assert not missing_ids and not unexpected_ids, (
+        "Response release version IDs did not match requested release version IDs. "
+        f"Missing IDs: [{', '.join(missing_ids)}]. "
+        f"Unexpected IDs: [{', '.join(unexpected_ids)}]. "
+        f"Requested IDs: [{', '.join(requested_release_version_ids)}]. "
+        f"Response IDs: [{', '.join(response_release_version_ids)}]"
+    )
+
+
 def prepare_scheduled_release_versions_now_via_api(release_version_ids: list[str]):
     response = publisher_functions_client.post(
         "/api/PrepareScheduledReleaseVersionsNow", {"releaseVersionIds": release_version_ids}
@@ -139,6 +161,7 @@ def prepare_scheduled_release_versions_now_via_api(release_version_ids: list[str
         f"Status code: {response.status_code}. "
         f"Response body: {response.text}"
     )
+    _assert_response_contains_requested_release_version_ids(response, release_version_ids)
 
 
 def publish_scheduled_release_versions_now_via_api(release_version_ids: list[str]):
@@ -151,3 +174,4 @@ def publish_scheduled_release_versions_now_via_api(release_version_ids: list[str
         f"Status code: {response.status_code}. "
         f"Response body: {response.text}"
     )
+    _assert_response_contains_requested_release_version_ids(response, release_version_ids)


### PR DESCRIPTION
This PR contains UI test improvements in response to a bug fixed by #6985 where the 'Files' stage inadvertently completed the publishing process early, for release versions that are using the 'scheduled' publishing method.

This bug was not flagged by UI tests because they failed to assert any value on the 'Publishing' element of the release publishing status, neither before or after triggering the `PrepareScheduledReleaseVersionsNow` function which is the 'Files' stage, and the `PublishScheduledReleaseVersionsNow` function which completes publishing and is the 'Publishing' stage.

They also didn't assert the overall status after triggering the `PrepareScheduledReleaseVersionsNow` function which would have also caught the bug.

**Expected status before either functions are run**:

- Overall - Scheduled
  - Files - Not started
  - Publishing - Not started

**Expected status after the `PrepareScheduledReleaseVersionsNow` function is run**:

- Overall - Started
  - Files - Complete
  - Publishing - Scheduled

**Expected status after the `PublishScheduledReleaseVersionsNow` function is run**:

- Overall - Complete
  - Files - Complete
  - Publishing - Complete

This PR:

- Enhances the `user waits for scheduled release to be published immediately` keyword  to verify the overall release publishing status is Scheduled before starting, and verify the status after each of the API calls including the expected states of the 'Files' and 'Publishing' stages.
- Enhances the `user approves release for scheduled publication` keyword to verify the release publishing status after it is approved in the Sign-off tab. It now verifies that the approval status is Approved, that the scheduled and next release dates are correct, and that the release status changes to Scheduled. Some checks were previously being done ad-hoc after the keyword, and not in every case.
- Asserts that the API response of the calls made to the HTTP-triggered Publisher functions by the keywords `prepare scheduled release versions now via api` and `publish scheduled release versions now via api` contain the expected release version IDs that are requested for processing. Without making this assertion it's possible that the scheduled release versions may have started processing naturally, which could lead to false-positive results.
- Adds comments to keywords `user approves release for scheduled publication` and `user waits for scheduled release to be published immediately` to explain the race condition that can occur where the publishing process may begin processing naturally at the same time that a test is attempting to trigger it via the API, and recommend that scheduled publish date is set to at least one day in the future to avoid it.
- Fixes a bug with the Publisher's `PrepareScheduledReleaseVersionsNow` and `PublishScheduledReleaseVersionsNow` HTTP triggered functions, where the `ManualTriggerResponse` object in the return statement was not being included in the HTTP responses. Without fixing this it wasn't possible to make the change to the tests to assert that the release version IDs requested are the same as the ones actioned for processing.

### Other changes

- Renames release/release version in `PrepareScheduledReleaseVersionsFunctions.cs` and `PublishScheduledReleaseVersionsFunction.cs`.
- Don't bother overriding default values for `next_release_month` and `next_release_year` when approving release for scheduled publication in `publish_amend_and_cancel.robot` because no other assertions take place on those overriden values.
- Uses named params for `next_release_month` and `next_release_year` to improve readability in `edit_and_approve_release_as_publication_approver.robot` and `publish_release_and_amend.robot`.
- General tidy up of some suites to improve naming, reuse keywords where possible to avoid competing approaches, and remove declaring unused suite variables. This is made as a separate commit.

### UI test result

UI test result after local rename of seed publication from `Seed publication - Permanent and fixed-period exclusions in England` to `Seed publication - Permanent & fixed-period exclusions in England` required for a different change.

<img width="1074" height="114" alt="image" src="https://github.com/user-attachments/assets/bcadd17d-5311-4e5a-924f-c098925f3336" />

