### PR TITLE
EES-7156 Revert changes made to 'Prod only' permalink test suites

### DIFF
--- a/tests/robot-tests/tests/general_public/prod_only/permalink_prod_1.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/permalink_prod_1.robot
@@ -15,7 +15,7 @@ Go to Table Tool page
 Go to permalink
     user navigates to    %{PUBLIC_URL}/data-tables/permalink/30999037-fcd4-409f-9ff4-d3680da7402d
     user waits until h1 is visible
-    ...    'Total days missed due to fixed period exclusions' from 'Permanent & fixed-period exclusions in England'
+    ...    'Total days missed due to fixed period exclusions' from 'Permanent and fixed-period exclusions in England'
 
 Validate breadcrumbs
     user checks breadcrumb count should be    4
@@ -23,7 +23,7 @@ Validate breadcrumbs
     user checks nth breadcrumb contains    2    Data tables
     user checks nth breadcrumb contains    3    Permanent link
     user checks nth breadcrumb contains    4
-    ...    'Total days missed due to fixed period exclusions' from 'Permanent & fixed-period exclusions in England'
+    ...    'Total days missed due to fixed period exclusions' from 'Permanent and fixed-period exclusions in England'
 
 Validate miscellaneous
     user checks summary list contains    Created    7 April 2020

--- a/tests/robot-tests/tests/general_public/prod_only/permalink_prod_2.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/permalink_prod_2.robot
@@ -15,7 +15,7 @@ Go to Table Tool page
 Go to permalink
     user navigates to    %{PUBLIC_URL}/data-tables/permalink/edfe9f83-d1f0-40fc-8dce-9467a250c61b
     user waits until h1 is visible
-    ...    'Exclusions by characteristic' from 'Permanent & fixed-period exclusions in England'
+    ...    'Exclusions by characteristic' from 'Permanent and fixed-period exclusions in England'
 
 Validate breadcrumbs
     user checks breadcrumb count should be    4
@@ -23,7 +23,7 @@ Validate breadcrumbs
     user checks nth breadcrumb contains    2    Data tables
     user checks nth breadcrumb contains    3    Permanent link
     user checks nth breadcrumb contains    4
-    ...    'Exclusions by characteristic' from 'Permanent & fixed-period exclusions in England'
+    ...    'Exclusions by characteristic' from 'Permanent and fixed-period exclusions in England'
 
 Validate miscellaneous
     user checks summary list contains    Created    7 April 2020

--- a/tests/robot-tests/tests/general_public/prod_only/permalink_prod_3.robot
+++ b/tests/robot-tests/tests/general_public/prod_only/permalink_prod_3.robot
@@ -15,7 +15,7 @@ Go to Table Tool page
 Go to permalink
     user navigates to    %{PUBLIC_URL}/data-tables/permalink/c5688b39-2630-4de0-a143-725df9e48690
     user waits until h1 is visible
-    ...    'Exclusions by geographic level' from 'Permanent & fixed-period exclusions in England'
+    ...    'Exclusions by geographic level' from 'Permanent and fixed-period exclusions in England'
 
 Validate breadcrumbs
     user checks breadcrumb count should be    4
@@ -23,7 +23,7 @@ Validate breadcrumbs
     user checks nth breadcrumb contains    2    Data tables
     user checks nth breadcrumb contains    3    Permanent link
     user checks nth breadcrumb contains    4
-    ...    'Exclusions by geographic level' from 'Permanent & fixed-period exclusions in England'
+    ...    'Exclusions by geographic level' from 'Permanent and fixed-period exclusions in England'
 
 Validate miscellaneous
     user checks summary list contains    Created    7 April 2020


### PR DESCRIPTION
This PR reverts the changes made to the following robot test suites in 111779c by #6976 since the publication in the Prod environment isn't being renamed - In fact it now has a completely different name 'Suspensions and permanent exclusions in England' which hasn't required any changes because these are Permalinks and they reflect the Publication title at the time they were created:

- `permalink_prod_1.robot`
- `permalink_prod_2.robot`
- `permalink_prod_3.robot`