### PR TITLE
EES-7171 Update replacement indicator mappings to indicator id instead of indicator column name

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataReplacementControllerTests.cs
@@ -25,6 +25,12 @@ public abstract class DataReplacementControllerTests
             var releaseVersionId = Guid.NewGuid();
             var originalFileId = Guid.NewGuid();
 
+            var originalIndicatorId = Guid.NewGuid();
+            var replacementIndicatorId = Guid.NewGuid();
+
+            var originalLocationId = Guid.NewGuid();
+            var replacementLocationId = Guid.NewGuid();
+
             var dataReplacementPlan = new DataReplacementPlanViewModel
             {
                 DataBlocks =
@@ -79,23 +85,33 @@ public abstract class DataReplacementControllerTests
                 {
                     Indicators = new ReplacementPlanIndicatorsMappingViewModel
                     {
-                        Mappings = new Dictionary<string, ReplacementPlanIndicatorMappingViewModel>
+                        Mappings = new Dictionary<Guid, ReplacementPlanIndicatorMappingViewModel>
                         {
                             {
-                                "original_indicator",
+                                originalIndicatorId,
                                 new ReplacementPlanIndicatorMappingViewModel
                                 {
-                                    Source = new ReplacementPlanIndicatorViewModel { Label = "Original indicator" },
-                                    Type = "Unset",
-                                    CandidateKey = null,
+                                    Source = new ReplacementPlanIndicatorViewModel
+                                    {
+                                        Id = originalIndicatorId,
+                                        Name = "original_indicator",
+                                        Label = "Original indicator",
+                                    },
+                                    Type = "ManuallySet",
+                                    CandidateKey = replacementIndicatorId,
                                 }
                             },
                         },
-                        Candidates = new Dictionary<string, ReplacementPlanIndicatorViewModel>
+                        Candidates = new Dictionary<Guid, ReplacementPlanIndicatorViewModel>
                         {
                             {
-                                "replacement_indicator",
-                                new ReplacementPlanIndicatorViewModel { Label = "Replacement indicator" }
+                                replacementIndicatorId,
+                                new ReplacementPlanIndicatorViewModel
+                                {
+                                    Id = replacementIndicatorId,
+                                    Name = "replacement_indicator",
+                                    Label = "Replacement indicator",
+                                }
                             },
                         },
                     },
@@ -104,24 +120,30 @@ public abstract class DataReplacementControllerTests
                         Mappings = new Dictionary<Guid, ReplacementPlanLocationMappingViewModel>
                         {
                             {
-                                Guid.NewGuid(),
+                                originalLocationId,
                                 new ReplacementPlanLocationMappingViewModel
                                 {
                                     Source = new ReplacementPlanLocationViewModel
                                     {
+                                        Id = originalLocationId,
                                         Code = "E9000",
                                         Name = "OriginalLocation",
                                     },
-                                    Type = "Unset",
-                                    CandidateKey = null,
+                                    Type = "ManuallySet",
+                                    CandidateKey = replacementLocationId,
                                 }
                             },
                         },
                         Candidates = new Dictionary<Guid, ReplacementPlanLocationViewModel>
                         {
                             {
-                                Guid.NewGuid(),
-                                new ReplacementPlanLocationViewModel { Code = "E9393", Name = "ReplacementLocation" }
+                                replacementLocationId,
+                                new ReplacementPlanLocationViewModel
+                                {
+                                    Id = replacementLocationId,
+                                    Code = "E9393",
+                                    Name = "ReplacementLocation",
+                                }
                             },
                         },
                     },

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
@@ -280,6 +280,9 @@ public class DataSetMappingServiceTests
         var originalIndicator3Id = Guid.NewGuid();
         var originalIndicator4Id = Guid.NewGuid();
 
+        var replacementIndicator4Id = Guid.NewGuid();
+        var replacementIndicator5Id = Guid.NewGuid();
+
         var releaseVersion = new Content.Model.ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
         {
@@ -366,7 +369,7 @@ public class DataSetMappingServiceTests
             [
                 new UnmappedIndicator
                 {
-                    Id = Guid.NewGuid(),
+                    Id = replacementIndicator4Id,
                     Label = "Replacement indicator 4 - that will be mapped to Original indicator 1",
                     ColumnName = "replacement_indicator_4",
                     GroupId = Guid.NewGuid(),
@@ -374,7 +377,7 @@ public class DataSetMappingServiceTests
                 },
                 new UnmappedIndicator
                 {
-                    Id = Guid.NewGuid(),
+                    Id = replacementIndicator5Id,
                     Label = "Replacement indicator 5 - that will be mapped to Original indicator 2",
                     ColumnName = "replacement_indicator_5",
                     GroupId = Guid.NewGuid(),
@@ -412,17 +415,9 @@ public class DataSetMappingServiceTests
                     ReplacementDataSetId = replacementDataSetId,
                     Updates =
                     [
-                        new()
-                        {
-                            OriginalColumnName = "original_indicator_1",
-                            NewReplacementColumnName = "replacement_indicator_4",
-                        },
-                        new()
-                        {
-                            OriginalColumnName = "original_indicator_2",
-                            NewReplacementColumnName = "replacement_indicator_5",
-                        },
-                        new() { OriginalColumnName = "original_indicator_3", NewReplacementColumnName = null },
+                        new() { OriginalId = originalIndicator1Id, NewReplacementId = replacementIndicator4Id },
+                        new() { OriginalId = originalIndicator2Id, NewReplacementId = replacementIndicator5Id },
+                        new() { OriginalId = originalIndicator3Id, NewReplacementId = null },
                     ],
                 },
                 CancellationToken.None
@@ -674,6 +669,8 @@ public class DataSetMappingServiceTests
 
         var originalIndicator1Id = Guid.NewGuid();
 
+        var indicatorDoesNotExistId = Guid.NewGuid();
+
         var releaseVersion = new Content.Model.ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
         {
@@ -698,6 +695,7 @@ public class DataSetMappingServiceTests
                     {
                         OriginalId = originalIndicator1Id,
                         OriginalColumnName = "original_indicator_1",
+                        ReplacementId = Guid.NewGuid(),
                         ReplacementColumnName = "replacement_indicator_already_mapped",
                     }
                 },
@@ -724,7 +722,7 @@ public class DataSetMappingServiceTests
                 {
                     OriginalDataSetId = originalDataSetId,
                     ReplacementDataSetId = replacementDataSetId,
-                    Updates = [new() { OriginalColumnName = "does_not_exist", NewReplacementColumnName = null }],
+                    Updates = [new() { OriginalId = indicatorDoesNotExistId, NewReplacementId = null }],
                 },
                 CancellationToken.None
             );
@@ -734,9 +732,9 @@ public class DataSetMappingServiceTests
             Assert.Single(validationProblem.Errors);
 
             validationProblem.AssertHasError(
-                expectedPath: "Updates.OriginalColumnName",
-                expectedCode: "IndicatorMatchingOriginalColumnNameNotFound",
-                expectedMessage: $"Could not find indicator mapping matching original column name \"does_not_exist\""
+                expectedPath: "Updates.OriginalId",
+                expectedCode: "IndicatorMatchingOriginalIdNotFound",
+                expectedMessage: $"Could not find indicator mapping matching original id \"{indicatorDoesNotExistId}\""
             );
         }
     }
@@ -748,6 +746,8 @@ public class DataSetMappingServiceTests
         var replacementDataSetId = Guid.NewGuid();
 
         var originalIndicator1Id = Guid.NewGuid();
+
+        var replacementIndicatorAlreadyMappedId = Guid.NewGuid();
 
         var releaseVersion = new Content.Model.ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
@@ -773,6 +773,7 @@ public class DataSetMappingServiceTests
                     {
                         OriginalId = originalIndicator1Id,
                         OriginalColumnName = "original_indicator_1",
+                        ReplacementId = replacementIndicatorAlreadyMappedId,
                         ReplacementColumnName = "replacement_indicator_already_mapped",
                     }
                 },
@@ -803,8 +804,8 @@ public class DataSetMappingServiceTests
                     [
                         new()
                         {
-                            OriginalColumnName = "original_indicator_1",
-                            NewReplacementColumnName = "replacement_indicator_already_mapped",
+                            OriginalId = originalIndicator1Id,
+                            NewReplacementId = replacementIndicatorAlreadyMappedId,
                         },
                     ],
                 },
@@ -816,9 +817,9 @@ public class DataSetMappingServiceTests
             Assert.Single(validationProblem.Errors);
 
             validationProblem.AssertHasError(
-                expectedPath: "Updates.NewReplacementColumnName",
-                expectedCode: "UnmappedIndicatorMatchingReplacementColumnNameNotFound",
-                expectedMessage: $"No available unmapped indicator matching replacement column name \"replacement_indicator_already_mapped\""
+                expectedPath: "Updates.NewReplacementId",
+                expectedCode: "UnmappedIndicatorMatchingReplacementIdNotFound",
+                expectedMessage: $"No available unmapped indicator matching replacement id \"{replacementIndicatorAlreadyMappedId}\""
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/IndicatorMappingUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/IndicatorMappingUpdateRequest.cs
@@ -23,9 +23,9 @@ public class IndicatorMappingUpdatesRequest
 
             RuleFor(x => x.Updates)
                 .Must(HaveUniqueOriginalNames)
-                .WithMessage("Each OriginalColumnName must be unique.")
+                .WithMessage("Each OriginalId must be unique.")
                 .Must(HaveUniqueReplacementNames)
-                .WithMessage("Each NewReplacementColumnName must be unique (if provided).");
+                .WithMessage("Each NewReplacementId must be unique (if provided).");
         }
 
         private bool HaveUniqueOriginalNames(List<IndicatorMappingUpdateRequest> updates)
@@ -35,7 +35,7 @@ public class IndicatorMappingUpdatesRequest
                 return true;
             }
 
-            return updates.Select(u => u.OriginalColumnName).Distinct().Count() == updates.Count;
+            return updates.Select(u => u.OriginalId).Distinct().Count() == updates.Count;
         }
 
         private bool HaveUniqueReplacementNames(List<IndicatorMappingUpdateRequest> updates)
@@ -46,8 +46,8 @@ public class IndicatorMappingUpdatesRequest
             }
 
             var nonNullReplacements = updates
-                .Where(u => !string.IsNullOrEmpty(u.NewReplacementColumnName))
-                .Select(u => u.NewReplacementColumnName)
+                .Where(u => u.NewReplacementId != null)
+                .Select(u => u.NewReplacementId)
                 .ToList();
 
             return nonNullReplacements.Distinct().Count() == nonNullReplacements.Count;
@@ -57,14 +57,14 @@ public class IndicatorMappingUpdatesRequest
 
 public record IndicatorMappingUpdateRequest
 {
-    public string OriginalColumnName { get; init; } = "";
-    public string? NewReplacementColumnName { get; init; }
+    public Guid OriginalId { get; init; }
+    public Guid? NewReplacementId { get; init; }
 
     public class Validator : AbstractValidator<IndicatorMappingUpdateRequest>
     {
         public Validator()
         {
-            RuleFor(x => x.OriginalColumnName).NotEmpty().WithMessage("OriginalColumnName cannot be an empty.");
+            RuleFor(x => x.OriginalId).NotEmpty().WithMessage("OriginalId cannot be an empty.");
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -246,7 +246,7 @@ public class DataSetMappingService(
             {
                 var updatedMappings = request
                     .Updates.Select(update =>
-                        UpdateIndicatorMapping(mapping, update.OriginalColumnName, update.NewReplacementColumnName)
+                        UpdateIndicatorMapping(mapping, update.OriginalId, update.NewReplacementId)
                     )
                     .ToList(); // cannot be async!
 
@@ -261,12 +261,12 @@ public class DataSetMappingService(
 
     private Either<ActionResult, IndicatorMapping> UpdateIndicatorMapping(
         DataSetMapping dataSetMapping,
-        string originalColumnName,
-        string? newReplacementColumnName = null
+        Guid originalId,
+        Guid? newReplacementId = null
     )
     {
         var indicatorMapping = dataSetMapping.IndicatorMappings.Values.SingleOrDefault(map =>
-            map.OriginalColumnName == originalColumnName
+            map.OriginalId == originalId
         );
         if (indicatorMapping == null)
         {
@@ -274,36 +274,31 @@ public class DataSetMappingService(
                 new ErrorViewModel
                 {
                     Path =
-                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(IndicatorMappingUpdateRequest.OriginalColumnName)}",
-                    Code = "IndicatorMatchingOriginalColumnNameNotFound",
-                    Message =
-                        $"Could not find indicator mapping matching original column name \"{originalColumnName}\"",
+                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(IndicatorMappingUpdateRequest.OriginalId)}",
+                    Code = "IndicatorMatchingOriginalIdNotFound",
+                    Message = $"Could not find indicator mapping matching original id \"{originalId}\"",
                 }
             );
         }
 
-        if (
-            indicatorMapping.ReplacementColumnName == newReplacementColumnName
-            && indicatorMapping.Status == MapStatus.ManuallySet
-        )
+        if (indicatorMapping.ReplacementId == newReplacementId && indicatorMapping.Status == MapStatus.ManuallySet)
         {
             return indicatorMapping; // it is already mapped, so can skip
         }
 
         var availableUnmappedIndicator = dataSetMapping.UnmappedReplacementIndicators.SingleOrDefault(
-            unmappedIndicator => unmappedIndicator.ColumnName == newReplacementColumnName
+            unmappedIndicator => unmappedIndicator.Id == newReplacementId
         );
 
-        if (newReplacementColumnName != null && availableUnmappedIndicator == null)
+        if (newReplacementId != null && availableUnmappedIndicator == null)
         {
             return ValidationResult(
                 new ErrorViewModel
                 {
                     Path =
-                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(IndicatorMappingUpdateRequest.NewReplacementColumnName)}",
-                    Code = "UnmappedIndicatorMatchingReplacementColumnNameNotFound",
-                    Message =
-                        $"No available unmapped indicator matching replacement column name \"{newReplacementColumnName}\"",
+                        $"{nameof(IndicatorMappingUpdatesRequest.Updates)}.{nameof(IndicatorMappingUpdateRequest.NewReplacementId)}",
+                    Code = "UnmappedIndicatorMatchingReplacementIdNotFound",
+                    Message = $"No available unmapped indicator matching replacement id \"{newReplacementId}\"",
                 }
             );
         }
@@ -315,10 +310,7 @@ public class DataSetMappingService(
             contentDbContext.Entry(dataSetMapping).Property(x => x.UnmappedReplacementIndicators).IsModified = true;
         }
 
-        if (
-            indicatorMapping.ReplacementId != null
-            && indicatorMapping.ReplacementColumnName != newReplacementColumnName
-        )
+        if (indicatorMapping.ReplacementId != null && indicatorMapping.ReplacementId != newReplacementId)
         {
             // We need to move the preexisting mapped indicator into UnmappedReplacementIndicators, as it will be overwritten
             var newlyUnmappedIndicator = new UnmappedIndicator
@@ -426,7 +418,7 @@ public class DataSetMappingService(
         if (
             newReplacementLocationId != null
             && availableUnmappedLocation != null
-            && availableUnmappedLocation!.GeographicLevel != locationMapping.OriginalGeographicLevel
+            && availableUnmappedLocation.GeographicLevel != locationMapping.OriginalGeographicLevel
         )
         {
             return ValidationResult(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
@@ -154,17 +154,30 @@ public class ReplacementPlanService(
                     Indicators = new ReplacementPlanIndicatorsMappingViewModel
                     {
                         Mappings = mapping.IndicatorMappings.Values.ToDictionary(
-                            map => map.OriginalColumnName,
+                            map => map.OriginalId,
                             map => new ReplacementPlanIndicatorMappingViewModel
                             {
-                                Source = new ReplacementPlanIndicatorViewModel { Label = map.OriginalLabel },
+                                Source = new ReplacementPlanIndicatorViewModel
+                                {
+                                    Id = map.OriginalId,
+                                    Name = map.OriginalColumnName,
+                                    Label = map.OriginalLabel,
+                                },
                                 Type = map.Status.ToString(),
-                                CandidateKey = map.ReplacementColumnName,
+                                CandidateKey = map.ReplacementId,
                             }
                         ),
                         Candidates = statisticsDbContext
                             .Indicator.Where(i => i.IndicatorGroup.SubjectId == replacementSubjectId)
-                            .ToDictionary(i => i.Name, i => new ReplacementPlanIndicatorViewModel { Label = i.Label }),
+                            .ToDictionary(
+                                i => i.Id,
+                                i => new ReplacementPlanIndicatorViewModel
+                                {
+                                    Id = i.Id,
+                                    Name = i.Name,
+                                    Label = i.Label,
+                                }
+                            ),
                     },
                     Locations = new ReplacementPlanLocationMappingsViewModel
                     {
@@ -174,6 +187,7 @@ public class ReplacementPlanService(
                             {
                                 Source = new ReplacementPlanLocationViewModel
                                 {
+                                    Id = map.OriginalId,
                                     Code = map.OriginalCode,
                                     Name = map.OriginalName,
                                 },
@@ -189,6 +203,7 @@ public class ReplacementPlanService(
                                 l => l.Id,
                                 l => new ReplacementPlanLocationViewModel
                                 {
+                                    Id = l.Id,
                                     Code = l.ToLocationAttribute().GetCodeOrFallback(),
                                     Name = l.ToLocationAttribute().Name ?? "",
                                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -215,7 +215,7 @@ public class IndicatorReplacementViewModel : TargetableReplacementViewModel
     public IndicatorReplacementViewModel(Guid id, string label, Guid? target, string name)
         : base(id, label, target)
     {
-        Name = name;
+        Name = name; // csv column name
     }
 }
 
@@ -344,22 +344,26 @@ public record ReplacementPlanMappingViewModel
 
 public record ReplacementPlanIndicatorsMappingViewModel
 {
-    // Key is original indicator csv column name
-    public Dictionary<string, ReplacementPlanIndicatorMappingViewModel> Mappings { get; init; } = null!;
+    // Key is original indicator id
+    public Dictionary<Guid, ReplacementPlanIndicatorMappingViewModel> Mappings { get; init; } = null!;
 
-    // Key is replacement indicator csv column name
-    public Dictionary<string, ReplacementPlanIndicatorViewModel> Candidates { get; init; } = null!;
+    // Key is replacement indicator id
+    public Dictionary<Guid, ReplacementPlanIndicatorViewModel> Candidates { get; init; } = null!;
 }
 
 public record ReplacementPlanIndicatorMappingViewModel
 {
     public ReplacementPlanIndicatorViewModel Source { get; init; } = null!;
     public string Type { get; init; } = "";
-    public string? CandidateKey { get; init; } // replacement indicator csv column name
+    public Guid? CandidateKey { get; init; } // replacement indicator id
 }
 
 public record ReplacementPlanIndicatorViewModel
 {
+    public Guid Id { get; init; }
+
+    public string Name { get; init; } = ""; // csv column name
+
     public string Label { get; init; } = "";
 }
 
@@ -381,6 +385,7 @@ public record ReplacementPlanLocationMappingViewModel
 
 public record ReplacementPlanLocationViewModel
 {
+    public Guid Id { get; init; }
     public string Code { get; init; } = "";
     public string Name { get; init; } = "";
 }

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -132,6 +132,8 @@ interface MappingsPlan<TSource> {
 export type MappingWithKey<TSource> = { sourceKey: string } & Mapping<TSource>;
 
 interface IndicatorSource {
+  id: string;
+  name: string; // csv column name
   label: string;
 }
 
@@ -193,8 +195,8 @@ const dataReplacementService = {
     originalDataSetId: string,
     replacementDataSetId: string,
     updates: {
-      originalColumnName: string;
-      newReplacementColumnName?: string;
+      originalId: string;
+      newReplacementId?: string;
     }[],
   ): Promise<DataReplacementPlan['mapping']['indicators']['mappings']> {
     const indicatorsMappings: PlanMappingIndicatorsUpdateResponse =


### PR DESCRIPTION
This work changes the way replacement indicator mappings are updated to use indicator ids rather than indicator csv column names. This change has been made to make the FE code more maintainable.