### PR TITLE
EES-7172 Use fileIds instead of subjectIds in DataSetMappings table entries

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetMappingServiceTests.cs
@@ -20,15 +20,15 @@ public class DataSetMappingServiceTests
     [Fact]
     public async Task GetOrCreateMapping_FetchesDbMapping_Success()
     {
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var originalIndicatorId = Guid.NewGuid();
 
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
             IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
             {
                 {
@@ -79,13 +79,15 @@ public class DataSetMappingServiceTests
             );
 
             var result = await service.GetOrCreateMapping(
-                originalSubjectId: originalDataSetId,
-                replacementSubjectId: replacementDataSetId,
+                originalDataFileId: originalDataFileId,
+                replacementDataFileId: replacementDataFileId,
+                originalSubjectId: Guid.NewGuid(),
+                replacementSubjectId: Guid.NewGuid(),
                 CancellationToken.None
             );
 
-            Assert.Equal(originalDataSetId, result.OriginalDataSetId);
-            Assert.Equal(replacementDataSetId, result.ReplacementDataSetId);
+            Assert.Equal(originalDataFileId, result.OriginalDataFileId);
+            Assert.Equal(replacementDataFileId, result.ReplacementDataFileId);
 
             var indicatorMappingKeyPair = Assert.Single(result.IndicatorMappings);
             Assert.Equal(mapping.IndicatorMappings.Keys.First(), indicatorMappingKeyPair.Key);
@@ -99,8 +101,11 @@ public class DataSetMappingServiceTests
     [Fact]
     public async Task GetOrCreateMapping_GenerateMapping_Indicators_Success()
     {
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
+
+        var originalSubjectId = Guid.NewGuid();
+        var replacementSubjectId = Guid.NewGuid();
 
         var originalIndicatorA1 = new Indicator
         {
@@ -129,7 +134,7 @@ public class DataSetMappingServiceTests
         {
             Id = Guid.NewGuid(),
             Label = "Group A",
-            SubjectId = originalDataSetId,
+            SubjectId = originalSubjectId,
             Indicators = [originalIndicatorA1, originalIndicatorA2, originalIndicatorA4],
         };
 
@@ -151,7 +156,7 @@ public class DataSetMappingServiceTests
         {
             Id = Guid.NewGuid(),
             Label = "Group A",
-            SubjectId = replacementDataSetId,
+            SubjectId = replacementSubjectId,
             Indicators = [replacementIndicatorA2, replacementIndicatorA3],
         };
 
@@ -166,7 +171,7 @@ public class DataSetMappingServiceTests
         {
             Id = Guid.NewGuid(),
             Label = "Group B",
-            SubjectId = replacementDataSetId,
+            SubjectId = replacementSubjectId,
             Indicators = [replacementIndicatorA4],
         };
 
@@ -191,15 +196,17 @@ public class DataSetMappingServiceTests
             );
 
             var result = await service.GetOrCreateMapping(
-                originalSubjectId: originalDataSetId,
-                replacementSubjectId: replacementDataSetId,
+                originalDataFileId: originalDataFileId,
+                replacementDataFileId: replacementDataFileId,
+                originalSubjectId: originalSubjectId,
+                replacementSubjectId: replacementSubjectId,
                 CancellationToken.None
             );
 
             var expectedMapping = new DataSetMapping
             {
-                OriginalDataSetId = originalDataSetId,
-                ReplacementDataSetId = replacementDataSetId,
+                OriginalDataFileId = originalDataFileId,
+                ReplacementDataFileId = replacementDataFileId,
                 IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
                 {
                     {
@@ -272,8 +279,8 @@ public class DataSetMappingServiceTests
     [Fact]
     public async Task UpdateIndicatorMapping_Success()
     {
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var originalIndicator1Id = Guid.NewGuid();
         var originalIndicator2Id = Guid.NewGuid();
@@ -284,18 +291,18 @@ public class DataSetMappingServiceTests
         var originalReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = originalDataSetId },
+            File = new Content.Model.File { Id = originalDataFileId },
         };
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = replacementDataSetId },
+            File = new Content.Model.File { Id = replacementDataFileId },
         };
 
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
             IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
             {
                 {
@@ -408,8 +415,8 @@ public class DataSetMappingServiceTests
                 releaseVersion.Id,
                 new IndicatorMappingUpdatesRequest
                 {
-                    OriginalDataSetId = originalDataSetId,
-                    ReplacementDataSetId = replacementDataSetId,
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
                     Updates =
                     [
                         new()
@@ -524,25 +531,25 @@ public class DataSetMappingServiceTests
     [Fact]
     public async Task UpdateIndicatorMapping_NoDataSetMapping_NotFound()
     {
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var releaseVersion = new Content.Model.ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = originalDataSetId },
+            File = new Content.Model.File { Id = originalDataFileId },
         };
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = replacementDataSetId },
+            File = new Content.Model.File { Id = replacementDataFileId },
         };
 
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
             IndicatorMappings = new Dictionary<Guid, IndicatorMapping>(),
             UnmappedReplacementIndicators = [],
         };
@@ -564,8 +571,8 @@ public class DataSetMappingServiceTests
                 releaseVersion.Id,
                 new IndicatorMappingUpdatesRequest
                 {
-                    OriginalDataSetId = originalDataSetId,
-                    ReplacementDataSetId = Guid.NewGuid(),
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = Guid.NewGuid(),
                     Updates = [],
                 },
                 CancellationToken.None
@@ -576,16 +583,16 @@ public class DataSetMappingServiceTests
     }
 
     [Fact]
-    public async Task UpdateIndicatorMappings_OriginalDataSet_NotFound()
+    public async Task UpdateIndicatorMappings_OriginalDataFile_NotFound()
     {
         var releaseVersion = new Content.Model.ReleaseVersion { Id = Guid.NewGuid() };
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -603,37 +610,37 @@ public class DataSetMappingServiceTests
                 releaseVersion.Id,
                 new IndicatorMappingUpdatesRequest
                 {
-                    OriginalDataSetId = originalDataSetId,
-                    ReplacementDataSetId = replacementDataSetId,
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
                 },
                 CancellationToken.None
             );
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
             validationProblem.AssertHasError(
-                $"{nameof(IndicatorMappingUpdatesRequest.OriginalDataSetId)}",
-                "OriginalDataSetIdNotLinkedToReleaseVersion"
+                $"{nameof(IndicatorMappingUpdatesRequest.OriginalDataFileId)}",
+                "OriginalDataFileIdNotLinkedToReleaseVersion"
             );
         }
     }
 
     [Fact]
-    public async Task UpdateIndicatorMappings_ReplacementDataSet_NotFound()
+    public async Task UpdateIndicatorMappings_ReplacementDataFile_NotFound()
     {
         var releaseVersion = new Content.Model.ReleaseVersion { Id = Guid.NewGuid() };
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
         };
 
         var originalReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = originalDataSetId },
+            File = new Content.Model.File { Id = originalDataFileId },
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -652,16 +659,16 @@ public class DataSetMappingServiceTests
                 releaseVersion.Id,
                 new IndicatorMappingUpdatesRequest
                 {
-                    OriginalDataSetId = originalDataSetId,
-                    ReplacementDataSetId = replacementDataSetId,
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
                 },
                 CancellationToken.None
             );
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
             validationProblem.AssertHasError(
-                $"{nameof(IndicatorMappingUpdatesRequest.ReplacementDataSetId)}",
-                "ReplacementDataSetIdNotLinkedToReleaseVersion"
+                $"{nameof(IndicatorMappingUpdatesRequest.ReplacementDataFileId)}",
+                "ReplacementDataFileIdNotLinkedToReleaseVersion"
             );
         }
     }
@@ -669,8 +676,8 @@ public class DataSetMappingServiceTests
     [Fact]
     public async Task UpdateIndicatorMapping_OriginalIndicatorNotFound_Fail()
     {
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var originalIndicator1Id = Guid.NewGuid();
 
@@ -678,18 +685,18 @@ public class DataSetMappingServiceTests
         var originalReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = originalDataSetId },
+            File = new Content.Model.File { Id = originalDataFileId },
         };
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = replacementDataSetId },
+            File = new Content.Model.File { Id = replacementDataFileId },
         };
 
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
             IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
             {
                 {
@@ -722,8 +729,8 @@ public class DataSetMappingServiceTests
                 releaseVersion.Id,
                 new IndicatorMappingUpdatesRequest
                 {
-                    OriginalDataSetId = originalDataSetId,
-                    ReplacementDataSetId = replacementDataSetId,
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
                     Updates = [new() { OriginalColumnName = "does_not_exist", NewReplacementColumnName = null }],
                 },
                 CancellationToken.None
@@ -744,8 +751,8 @@ public class DataSetMappingServiceTests
     [Fact]
     public async Task UpdateIndicatorMapping_UnmappedReplacementIndicatorNotFound_Fail()
     {
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var originalIndicator1Id = Guid.NewGuid();
 
@@ -753,18 +760,18 @@ public class DataSetMappingServiceTests
         var originalReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = originalDataSetId },
+            File = new Content.Model.File { Id = originalDataFileId },
         };
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = replacementDataSetId },
+            File = new Content.Model.File { Id = replacementDataFileId },
         };
 
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
             IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
             {
                 {
@@ -797,8 +804,8 @@ public class DataSetMappingServiceTests
                 releaseVersion.Id,
                 new IndicatorMappingUpdatesRequest
                 {
-                    OriginalDataSetId = originalDataSetId,
-                    ReplacementDataSetId = replacementDataSetId,
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
                     Updates =
                     [
                         new()
@@ -826,8 +833,8 @@ public class DataSetMappingServiceTests
     [Fact]
     public async Task UpdateLocationMappings_Success()
     {
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var loc1Id = Guid.NewGuid();
         var loc2Id = Guid.NewGuid();
@@ -840,8 +847,8 @@ public class DataSetMappingServiceTests
 
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
             LocationMappings = new Dictionary<Guid, LocationMapping>
             {
                 {
@@ -892,12 +899,12 @@ public class DataSetMappingServiceTests
         var originalReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = originalDataSetId },
+            File = new Content.Model.File { Id = originalDataFileId },
         };
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = replacementDataSetId },
+            File = new Content.Model.File { Id = replacementDataFileId },
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -917,8 +924,8 @@ public class DataSetMappingServiceTests
                 releaseVersion.Id,
                 new LocationMappingUpdatesRequest
                 {
-                    OriginalDataSetId = originalDataSetId,
-                    ReplacementDataSetId = replacementDataSetId,
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
                     Updates =
                     [
                         new() { OriginalLocationId = loc1Id, NewReplacementLocationId = replacementLocId },
@@ -1000,16 +1007,16 @@ public class DataSetMappingServiceTests
     }
 
     [Fact]
-    public async Task UpdateLocationMappings_OriginalDataSet_NotFound()
+    public async Task UpdateLocationMappings_OriginalDataFile_NotFound()
     {
         var releaseVersion = new Content.Model.ReleaseVersion { Id = Guid.NewGuid() };
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -1027,37 +1034,37 @@ public class DataSetMappingServiceTests
                 releaseVersion.Id,
                 new LocationMappingUpdatesRequest
                 {
-                    OriginalDataSetId = originalDataSetId,
-                    ReplacementDataSetId = replacementDataSetId,
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
                 },
                 CancellationToken.None
             );
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
             validationProblem.AssertHasError(
-                $"{nameof(LocationMappingUpdatesRequest.OriginalDataSetId)}",
-                "OriginalDataSetIdNotLinkedToReleaseVersion"
+                $"{nameof(LocationMappingUpdatesRequest.OriginalDataFileId)}",
+                "OriginalDataFileIdNotLinkedToReleaseVersion"
             );
         }
     }
 
     [Fact]
-    public async Task UpdateLocationMappings_ReplacementDataSet_NotFound()
+    public async Task UpdateLocationMappings_ReplacementDataFile_NotFound()
     {
         var releaseVersion = new Content.Model.ReleaseVersion { Id = Guid.NewGuid() };
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
         };
 
         var originalReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = originalDataSetId },
+            File = new Content.Model.File { Id = originalDataFileId },
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -1076,16 +1083,16 @@ public class DataSetMappingServiceTests
                 releaseVersion.Id,
                 new LocationMappingUpdatesRequest
                 {
-                    OriginalDataSetId = originalDataSetId,
-                    ReplacementDataSetId = replacementDataSetId,
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
                 },
                 CancellationToken.None
             );
 
             var validationProblem = result.AssertBadRequestWithValidationProblem();
             validationProblem.AssertHasError(
-                $"{nameof(LocationMappingUpdatesRequest.ReplacementDataSetId)}",
-                "ReplacementDataSetIdNotLinkedToReleaseVersion"
+                $"{nameof(LocationMappingUpdatesRequest.ReplacementDataFileId)}",
+                "ReplacementDataFileIdNotLinkedToReleaseVersion"
             );
         }
     }
@@ -1093,27 +1100,27 @@ public class DataSetMappingServiceTests
     [Fact]
     public async Task UpdateLocationMappings_OriginalLocationNotFound_Fail()
     {
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var releaseVersion = new Content.Model.ReleaseVersion { Id = Guid.NewGuid() };
 
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
             LocationMappings = new(),
         };
 
         var originalReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = originalDataSetId },
+            File = new Content.Model.File { Id = originalDataFileId },
         };
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = replacementDataSetId },
+            File = new Content.Model.File { Id = replacementDataFileId },
         };
 
         var contentDbContextId = Guid.NewGuid().ToString();
@@ -1133,8 +1140,8 @@ public class DataSetMappingServiceTests
                 releaseVersion.Id,
                 new LocationMappingUpdatesRequest
                 {
-                    OriginalDataSetId = originalDataSetId,
-                    ReplacementDataSetId = replacementDataSetId,
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
                     Updates = [new() { OriginalLocationId = badId }],
                 },
                 CancellationToken.None
@@ -1151,26 +1158,26 @@ public class DataSetMappingServiceTests
     [Fact]
     public async Task UpdateLocationMappings_UnmappedLocationNotFound_Fail()
     {
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var releaseVersion = new Content.Model.ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = originalDataSetId },
+            File = new Content.Model.File { Id = originalDataFileId },
         };
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = replacementDataSetId },
+            File = new Content.Model.File { Id = replacementDataFileId },
         };
 
         var locId = Guid.NewGuid();
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
             LocationMappings = new Dictionary<Guid, LocationMapping>
             {
                 {
@@ -1197,8 +1204,8 @@ public class DataSetMappingServiceTests
                 releaseVersion.Id,
                 new LocationMappingUpdatesRequest
                 {
-                    OriginalDataSetId = originalDataSetId,
-                    ReplacementDataSetId = replacementDataSetId,
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
                     Updates = [new() { OriginalLocationId = locId, NewReplacementLocationId = Guid.NewGuid() }],
                 },
                 CancellationToken.None
@@ -1215,19 +1222,19 @@ public class DataSetMappingServiceTests
     [Fact]
     public async Task UpdateLocationMappings_DifferentGeographicLevel_Fail()
     {
-        var originalDataSetId = Guid.NewGuid();
-        var replacementDataSetId = Guid.NewGuid();
+        var originalDataFileId = Guid.NewGuid();
+        var replacementDataFileId = Guid.NewGuid();
 
         var releaseVersion = new Content.Model.ReleaseVersion { Id = Guid.NewGuid() };
         var originalReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = originalDataSetId },
+            File = new Content.Model.File { Id = originalDataFileId },
         };
         var replacementReleaseFile = new ReleaseFile
         {
             ReleaseVersionId = releaseVersion.Id,
-            File = new Content.Model.File { SubjectId = replacementDataSetId },
+            File = new Content.Model.File { Id = replacementDataFileId },
         };
 
         var locId = Guid.NewGuid();
@@ -1235,8 +1242,8 @@ public class DataSetMappingServiceTests
 
         var mapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
             LocationMappings = new Dictionary<Guid, LocationMapping>
             {
                 {
@@ -1266,8 +1273,8 @@ public class DataSetMappingServiceTests
                 releaseVersion.Id,
                 new LocationMappingUpdatesRequest
                 {
-                    OriginalDataSetId = originalDataSetId,
-                    ReplacementDataSetId = replacementDataSetId,
+                    OriginalDataFileId = originalDataFileId,
+                    ReplacementDataFileId = replacementDataFileId,
                     Updates = [new() { OriginalLocationId = locId, NewReplacementLocationId = replacementLocId }],
                 },
                 CancellationToken.None

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseVersionServiceTests.cs
@@ -399,14 +399,14 @@ public abstract class ReleaseVersionServiceTests
 
             DataSetMapping mapping = new DataSetMapping
             {
-                OriginalDataSetId = subject.Id,
-                ReplacementDataSetId = replacementSubject.Id,
+                OriginalDataFileId = file.Id,
+                ReplacementDataFileId = replacementFile.Id,
             };
 
             DataSetMapping unrelatedMapping = new DataSetMapping
             {
-                OriginalDataSetId = Guid.NewGuid(),
-                ReplacementDataSetId = Guid.NewGuid(),
+                OriginalDataFileId = Guid.NewGuid(),
+                ReplacementDataFileId = Guid.NewGuid(),
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -522,7 +522,7 @@ public abstract class ReleaseVersionServiceTests
             {
                 // Check the related DataSetMapping has been removed - the unrelated mapping should remain
                 var dbUnrelatedMapping = Assert.Single(context.DataSetMappings.ToList());
-                Assert.Equal(unrelatedMapping.OriginalDataSetId, dbUnrelatedMapping.OriginalDataSetId);
+                Assert.Equal(unrelatedMapping.OriginalDataFileId, dbUnrelatedMapping.OriginalDataFileId);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementPlanServiceTests.cs
@@ -2147,6 +2147,7 @@ public class ReplacementPlanServiceTests
 
         var replacementFile = new File
         {
+            Id = Guid.NewGuid(),
             Type = FileType.Data,
             SubjectId = replacementReleaseSubject.SubjectId,
             Replacing = originalFile,
@@ -2251,8 +2252,8 @@ public class ReplacementPlanServiceTests
 
         var dataSetMapping = new DataSetMapping
         {
-            OriginalDataSetId = originalReleaseSubject.SubjectId,
-            ReplacementDataSetId = replacementReleaseSubject.SubjectId,
+            OriginalDataFileId = originalFile.Id,
+            ReplacementDataFileId = replacementFile.Id,
             IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
             {
                 {
@@ -2311,6 +2312,8 @@ public class ReplacementPlanServiceTests
         dataSetMappingService
             .Setup(mock =>
                 mock.GetOrCreateMapping(
+                    originalFile.Id,
+                    replacementFile.Id,
                     originalReleaseSubject.SubjectId,
                     replacementReleaseSubject.SubjectId,
                     CancellationToken.None
@@ -2433,6 +2436,7 @@ public class ReplacementPlanServiceTests
 
         var replacementFile = new File
         {
+            Id = Guid.NewGuid(),
             Type = FileType.Data,
             SubjectId = replacementReleaseSubject.SubjectId,
             Replacing = originalFile,
@@ -2523,8 +2527,8 @@ public class ReplacementPlanServiceTests
 
         var dataSetMapping = new DataSetMapping
         {
-            OriginalDataSetId = originalReleaseSubject.SubjectId,
-            ReplacementDataSetId = replacementReleaseSubject.SubjectId,
+            OriginalDataFileId = originalFile.Id,
+            ReplacementDataFileId = replacementFile.Id,
             IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
             {
                 {
@@ -2681,6 +2685,7 @@ public class ReplacementPlanServiceTests
 
         var replacementFile = new File
         {
+            Id = Guid.NewGuid(),
             Type = FileType.Data,
             SubjectId = replacementReleaseSubject.SubjectId,
             Replacing = originalFile,
@@ -2798,8 +2803,8 @@ public class ReplacementPlanServiceTests
 
         var dataSetMapping = new DataSetMapping
         {
-            OriginalDataSetId = originalReleaseSubject.SubjectId,
-            ReplacementDataSetId = replacementReleaseSubject.SubjectId,
+            OriginalDataFileId = originalFile.Id,
+            ReplacementDataFileId = replacementFile.Id,
             IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
             {
                 {
@@ -2895,6 +2900,8 @@ public class ReplacementPlanServiceTests
         dataSetMappingService
             .Setup(mock =>
                 mock.GetOrCreateMapping(
+                    originalFile.Id,
+                    replacementFile.Id,
                     originalReleaseSubject.SubjectId,
                     replacementReleaseSubject.SubjectId,
                     CancellationToken.None
@@ -3013,6 +3020,7 @@ public class ReplacementPlanServiceTests
 
         var replacementFile = new File
         {
+            Id = Guid.NewGuid(),
             Type = FileType.Data,
             SubjectId = replacementReleaseSubject.SubjectId,
             Replacing = originalFile,
@@ -3103,8 +3111,8 @@ public class ReplacementPlanServiceTests
 
         var dataSetMapping = new DataSetMapping
         {
-            OriginalDataSetId = originalReleaseSubject.SubjectId,
-            ReplacementDataSetId = replacementReleaseSubject.SubjectId,
+            OriginalDataFileId = originalFile.Id,
+            ReplacementDataFileId = replacementFile.Id,
             IndicatorMappings = new Dictionary<Guid, IndicatorMapping>
             {
                 {
@@ -3155,6 +3163,8 @@ public class ReplacementPlanServiceTests
         dataSetMappingService
             .Setup(mock =>
                 mock.GetOrCreateMapping(
+                    originalFile.Id,
+                    replacementFile.Id,
                     originalReleaseSubject.SubjectId,
                     replacementReleaseSubject.SubjectId,
                     CancellationToken.None

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceHelperTests.cs
@@ -555,8 +555,8 @@ public class ReplacementServiceHelperTests
         };
 
         var mapping = GenerateMapping(
-            originalDataSetId: Guid.NewGuid(),
-            replacementDataSetId: Guid.NewGuid(),
+            originalDataFileId: Guid.NewGuid(),
+            replacementDataFileId: Guid.NewGuid(),
             originalIndicatorGroups: originalGroups,
             replacementIndicatorGroups: replacementGroups
         );
@@ -767,8 +767,8 @@ public class ReplacementServiceHelperTests
         };
 
         var mapping = GenerateMapping(
-            originalDataSetId: Guid.NewGuid(),
-            replacementDataSetId: Guid.NewGuid(),
+            originalDataFileId: Guid.NewGuid(),
+            replacementDataFileId: Guid.NewGuid(),
             originalIndicatorGroups: originalGroups,
             replacementIndicatorGroups: replacementGroups
         );
@@ -931,8 +931,8 @@ public class ReplacementServiceHelperTests
         };
 
         var mapping = GenerateMapping(
-            originalDataSetId: Guid.NewGuid(),
-            replacementDataSetId: Guid.NewGuid(),
+            originalDataFileId: Guid.NewGuid(),
+            replacementDataFileId: Guid.NewGuid(),
             originalIndicatorGroups: originalGroups,
             replacementIndicatorGroups: replacementGroups
         );
@@ -1037,8 +1037,8 @@ public class ReplacementServiceHelperTests
         };
 
         var mapping = GenerateMapping(
-            originalDataSetId: Guid.NewGuid(),
-            replacementDataSetId: Guid.NewGuid(),
+            originalDataFileId: Guid.NewGuid(),
+            replacementDataFileId: Guid.NewGuid(),
             originalIndicatorGroups: originalGroups,
             replacementIndicatorGroups: replacementGroups
         );
@@ -1060,8 +1060,8 @@ public class ReplacementServiceHelperTests
     }
 
     private static DataSetMapping GenerateMapping(
-        Guid originalDataSetId,
-        Guid replacementDataSetId,
+        Guid originalDataFileId,
+        Guid replacementDataFileId,
         List<IndicatorGroup> originalIndicatorGroups = null,
         List<IndicatorGroup> replacementIndicatorGroups = null
     )
@@ -1116,8 +1116,8 @@ public class ReplacementServiceHelperTests
 
         return new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
             IndicatorMappings = indicatorsMappings,
             UnmappedReplacementIndicators = unmappedReplacementIndicators,
         };

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518140830_Ees7150UseFileIdsInDataSetMappingTable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518140830_Ees7150UseFileIdsInDataSetMappingTable.Designer.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518140830_Ees7150UseFileIdsInDataSetMappingTable")]
+    partial class Ees7150UseFileIdsInDataSetMappingTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -354,7 +357,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<Guid>("OriginalDataFileId")
                         .HasColumnType("uniqueidentifier");
 
+                    b.Property<Guid>("OriginalDataSetId")
+                        .HasColumnType("uniqueidentifier");
+
                     b.Property<Guid>("ReplacementDataFileId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid>("ReplacementDataSetId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("UnmappedReplacementIndicators")
@@ -2054,13 +2063,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.File", "OriginalDataFile")
                         .WithMany()
                         .HasForeignKey("OriginalDataFileId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.File", "ReplacementDataFile")
                         .WithMany()
                         .HasForeignKey("ReplacementDataFileId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.Navigation("OriginalDataFile");

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518140830_Ees7150UseFileIdsInDataSetMappingTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518140830_Ees7150UseFileIdsInDataSetMappingTable.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    /// <inheritdoc />
+    public partial class Ees7150UseFileIdsInDataSetMappingTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(name: "IX_DataSetMappings_OriginalDataSetId", table: "DataSetMappings");
+
+            migrationBuilder.DropIndex(name: "IX_DataSetMappings_ReplacementDataSetId", table: "DataSetMappings");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "OriginalDataFileId",
+                table: "DataSetMappings",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000")
+            );
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ReplacementDataFileId",
+                table: "DataSetMappings",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000")
+            );
+
+            migrationBuilder.Sql(
+                """
+                UPDATE DSM
+                SET DSM.OriginalDataFileId = F.Id
+                FROM DataSetMappings AS DSM
+                INNER JOIN Files AS F
+                    ON DSM.OriginalDataSetId = F.SubjectId AND F.Type = 'Data';
+                """
+            );
+
+            migrationBuilder.Sql(
+                """
+                UPDATE DSM
+                SET DSM.ReplacementDataFileId = F.Id
+                FROM DataSetMappings AS DSM
+                INNER JOIN Files AS F
+                    ON DSM.ReplacementDataSetId = F.SubjectId AND F.Type = 'Data';
+                """
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataSetMappings_OriginalDataFileId",
+                table: "DataSetMappings",
+                column: "OriginalDataFileId"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataSetMappings_ReplacementDataFileId",
+                table: "DataSetMappings",
+                column: "ReplacementDataFileId"
+            );
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DataSetMappings_Files_OriginalDataFileId",
+                table: "DataSetMappings",
+                column: "OriginalDataFileId",
+                principalTable: "Files",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict // cannot be Cascade as "may cause cycles or multiple cascade paths"
+            );
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DataSetMappings_Files_ReplacementDataFileId",
+                table: "DataSetMappings",
+                column: "ReplacementDataFileId",
+                principalTable: "Files",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict // cannot be Cascade as "may cause cycles or multiple cascade paths"
+            );
+
+            migrationBuilder.DropColumn(name: "OriginalDataSetId", table: "DataSetMappings");
+
+            migrationBuilder.DropColumn(name: "ReplacementDataSetId", table: "DataSetMappings");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder) { }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518140830_Ees7150UseFileIdsInDataSetMappingTable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20260518140830_Ees7150UseFileIdsInDataSetMappingTable.cs
@@ -54,13 +54,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
             migrationBuilder.CreateIndex(
                 name: "IX_DataSetMappings_OriginalDataFileId",
                 table: "DataSetMappings",
-                column: "OriginalDataFileId"
+                column: "OriginalDataFileId",
+                unique: true
             );
 
             migrationBuilder.CreateIndex(
                 name: "IX_DataSetMappings_ReplacementDataFileId",
                 table: "DataSetMappings",
-                column: "ReplacementDataFileId"
+                column: "ReplacementDataFileId",
+                unique: true
             );
 
             migrationBuilder.AddForeignKey(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
@@ -367,9 +367,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.HasKey("Id");
 
-                    b.HasIndex("OriginalDataFileId");
+                    b.HasIndex("OriginalDataFileId")
+                        .IsUnique();
 
-                    b.HasIndex("ReplacementDataFileId");
+                    b.HasIndex("ReplacementDataFileId")
+                        .IsUnique();
 
                     b.ToTable("DataSetMappings");
                 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/IndicatorMappingUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/IndicatorMappingUpdateRequest.cs
@@ -6,8 +6,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
 public class IndicatorMappingUpdatesRequest
 {
-    public Guid OriginalDataSetId { get; init; }
-    public Guid ReplacementDataSetId { get; init; }
+    public Guid OriginalDataFileId { get; init; }
+    public Guid ReplacementDataFileId { get; init; }
 
     public List<IndicatorMappingUpdateRequest> Updates { get; init; } = [];
 
@@ -15,9 +15,9 @@ public class IndicatorMappingUpdatesRequest
     {
         public Validator()
         {
-            RuleFor(x => x.OriginalDataSetId).NotEmpty();
+            RuleFor(x => x.OriginalDataFileId).NotEmpty();
 
-            RuleFor(x => x.ReplacementDataSetId).NotEmpty();
+            RuleFor(x => x.ReplacementDataFileId).NotEmpty();
 
             RuleForEach(x => x.Updates).SetValidator(new IndicatorMappingUpdateRequest.Validator());
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/LocationMappingUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Requests/LocationMappingUpdateRequest.cs
@@ -6,8 +6,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Requests;
 
 public class LocationMappingUpdatesRequest
 {
-    public Guid OriginalDataSetId { get; init; }
-    public Guid ReplacementDataSetId { get; init; }
+    public Guid OriginalDataFileId { get; init; }
+    public Guid ReplacementDataFileId { get; init; }
 
     public List<LocationMappingUpdateRequest> Updates { get; init; } = [];
 
@@ -15,9 +15,9 @@ public class LocationMappingUpdatesRequest
     {
         public Validator()
         {
-            RuleFor(x => x.OriginalDataSetId).NotEmpty();
+            RuleFor(x => x.OriginalDataFileId).NotEmpty();
 
-            RuleFor(x => x.ReplacementDataSetId).NotEmpty();
+            RuleFor(x => x.ReplacementDataFileId).NotEmpty();
 
             RuleForEach(x => x.Updates).SetValidator(new LocationMappingUpdateRequest.Validator());
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetMappingService.cs
@@ -23,6 +23,8 @@ public class DataSetMappingService(
 ) : IDataSetMappingService
 {
     public async Task<DataSetMapping> GetOrCreateMapping(
+        Guid originalDataFileId,
+        Guid replacementDataFileId,
         Guid originalSubjectId,
         Guid replacementSubjectId,
         CancellationToken cancellationToken = default
@@ -30,16 +32,24 @@ public class DataSetMappingService(
     {
         var mapping =
             await contentDbContext.DataSetMappings.SingleOrDefaultAsync(
-                map => map.OriginalDataSetId == originalSubjectId && map.ReplacementDataSetId == replacementSubjectId,
+                map =>
+                    map.OriginalDataFileId == originalDataFileId && map.ReplacementDataFileId == replacementDataFileId,
                 cancellationToken
-            ) ?? await GenerateAndSaveInitialDataSetMapping(originalSubjectId, replacementSubjectId, cancellationToken);
+            )
+            ?? await GenerateAndSaveInitialDataSetMapping(
+                originalDataFileId: originalDataFileId,
+                replacementDataFileId: replacementDataFileId,
+                originalSubjectId: originalSubjectId,
+                replacementSubjectId: replacementSubjectId,
+                cancellationToken
+            );
 
         // TODO EES-7126 Remove this code - it was only needed when first introducing LocationMappings to ensure they were set
         if (mapping.LocationMappings.IsNullOrEmpty() && mapping.UnmappedReplacementLocations.IsNullOrEmpty())
         {
             var (initialLocationMappingDictionary, unmappedReplacementLocations) = await GenerateInitialLocationMapping(
-                mapping.OriginalDataSetId,
-                mapping.ReplacementDataSetId,
+                originalSubjectId,
+                replacementSubjectId,
                 cancellationToken
             );
 
@@ -52,27 +62,29 @@ public class DataSetMappingService(
     }
 
     private async Task<DataSetMapping> GenerateAndSaveInitialDataSetMapping(
-        Guid originalDataSetId,
-        Guid replacementDataSetId,
+        Guid originalDataFileId,
+        Guid replacementDataFileId,
+        Guid originalSubjectId,
+        Guid replacementSubjectId,
         CancellationToken cancellationToken
     )
     {
         var (initialIndicatorMappingDictionary, unmappedReplacementIndicators) = await GenerateInitialIndicatorMapping(
-            originalDataSetId,
-            replacementDataSetId,
+            originalSubjectId,
+            replacementSubjectId,
             cancellationToken
         );
 
         var (initialLocationMappingDictionary, unmappedReplacementLocations) = await GenerateInitialLocationMapping(
-            originalDataSetId,
-            replacementDataSetId,
+            originalSubjectId,
+            replacementSubjectId,
             cancellationToken
         );
 
         var newMapping = new DataSetMapping
         {
-            OriginalDataSetId = originalDataSetId,
-            ReplacementDataSetId = replacementDataSetId,
+            OriginalDataFileId = originalDataFileId,
+            ReplacementDataFileId = replacementDataFileId,
             IndicatorMappings = initialIndicatorMappingDictionary,
             UnmappedReplacementIndicators = unmappedReplacementIndicators,
             LocationMappings = initialLocationMappingDictionary,
@@ -86,19 +98,19 @@ public class DataSetMappingService(
     }
 
     private async Task<(Dictionary<Guid, IndicatorMapping>, List<UnmappedIndicator>)> GenerateInitialIndicatorMapping(
-        Guid originalDataSetId,
-        Guid replacementDataSetId,
+        Guid originalSubjectId,
+        Guid replacementSubjectId,
         CancellationToken cancellationToken
     )
     {
         var originalIndicators = await statisticsDbContext
             .Indicator.Include(i => i.IndicatorGroup)
-            .Where(i => i.IndicatorGroup.SubjectId == originalDataSetId)
+            .Where(i => i.IndicatorGroup.SubjectId == originalSubjectId)
             .ToListAsync(cancellationToken);
 
         var replacementIndicatorNameToIndicatorMap = await statisticsDbContext
             .Indicator.Include(i => i.IndicatorGroup)
-            .Where(i => i.IndicatorGroup.SubjectId == replacementDataSetId)
+            .Where(i => i.IndicatorGroup.SubjectId == replacementSubjectId)
             .ToDictionaryAsync(i => i.Name, i => i, cancellationToken);
 
         var initialMappingDictionary = originalIndicators.ToDictionary(
@@ -157,21 +169,21 @@ public class DataSetMappingService(
     }
 
     private async Task<(Dictionary<Guid, LocationMapping>, List<UnmappedLocation>)> GenerateInitialLocationMapping(
-        Guid originalDataSetId,
-        Guid replacementDataSetId,
+        Guid originalSubjectId,
+        Guid replacementSubjectId,
         CancellationToken cancellationToken
     )
     {
         var originalLocations = await statisticsDbContext
             .Observation.AsNoTracking()
-            .Where(o => o.SubjectId == originalDataSetId)
+            .Where(o => o.SubjectId == originalSubjectId)
             .Select(observation => observation.Location)
             .Distinct()
             .ToListAsync(cancellationToken);
 
         var replacementLocationMap = await statisticsDbContext
             .Observation.AsNoTracking()
-            .Where(o => o.SubjectId == replacementDataSetId)
+            .Where(o => o.SubjectId == replacementSubjectId)
             .Select(observation => observation.Location)
             .Distinct()
             .ToDictionaryAsync(location => location.Id, location => location, cancellationToken);
@@ -240,7 +252,7 @@ public class DataSetMappingService(
             .SingleOrNotFound()
             .OnSuccess(userService.CheckCanUpdateReleaseVersion)
             .OnSuccess(async releaseVersion =>
-                await ValidateMapping(releaseVersion, request.OriginalDataSetId, request.ReplacementDataSetId)
+                await ValidateMapping(releaseVersion, request.OriginalDataFileId, request.ReplacementDataFileId)
             )
             .OnSuccess(async mapping =>
             {
@@ -357,7 +369,7 @@ public class DataSetMappingService(
             .SingleOrNotFound()
             .OnSuccess(userService.CheckCanUpdateReleaseVersion)
             .OnSuccess(async releaseVersion =>
-                await ValidateMapping(releaseVersion, request.OriginalDataSetId, request.ReplacementDataSetId)
+                await ValidateMapping(releaseVersion, request.OriginalDataFileId, request.ReplacementDataFileId)
             )
             .OnSuccess(async mapping =>
             {
@@ -476,12 +488,12 @@ public class DataSetMappingService(
 
     private async Task<Either<ActionResult, DataSetMapping>> ValidateMapping(
         ReleaseVersion releaseVersion,
-        Guid originalDataSetId,
-        Guid replacementDataSetId
+        Guid originalDataFileId,
+        Guid replacementDataFileId
     )
     {
         var mapping = await contentDbContext.DataSetMappings.SingleOrDefaultAsync(map =>
-            map.OriginalDataSetId == originalDataSetId && map.ReplacementDataSetId == replacementDataSetId
+            map.OriginalDataFileId == originalDataFileId && map.ReplacementDataFileId == replacementDataFileId
         );
 
         if (mapping == null)
@@ -490,29 +502,29 @@ public class DataSetMappingService(
         }
 
         var originalReleaseFileExists = await contentDbContext.ReleaseFiles.AnyAsync(rf =>
-            rf.ReleaseVersionId == releaseVersion.Id && rf.File.SubjectId == mapping.OriginalDataSetId
+            rf.ReleaseVersionId == releaseVersion.Id && rf.FileId == mapping.OriginalDataFileId
         );
         if (!originalReleaseFileExists)
         {
             return ValidationResult(
                 new ErrorViewModel
                 {
-                    Path = $"{nameof(IndicatorMappingUpdatesRequest.OriginalDataSetId)}",
-                    Code = "OriginalDataSetIdNotLinkedToReleaseVersion",
-                    Message = $"The original data set is not linked to the release version",
+                    Path = $"{nameof(IndicatorMappingUpdatesRequest.OriginalDataFileId)}",
+                    Code = "OriginalDataFileIdNotLinkedToReleaseVersion",
+                    Message = $"The original data file is not linked to the release version",
                 }
             );
         }
         var replacementReleaseFileExists = await contentDbContext.ReleaseFiles.AnyAsync(rf =>
-            rf.ReleaseVersionId == releaseVersion.Id && rf.File.SubjectId == mapping.ReplacementDataSetId
+            rf.ReleaseVersionId == releaseVersion.Id && rf.FileId == mapping.ReplacementDataFileId
         );
         if (!replacementReleaseFileExists)
         {
             return ValidationResult(
                 new ErrorViewModel
                 {
-                    Path = $"{nameof(IndicatorMappingUpdatesRequest.ReplacementDataSetId)}",
-                    Code = "ReplacementDataSetIdNotLinkedToReleaseVersion",
+                    Path = $"{nameof(IndicatorMappingUpdatesRequest.ReplacementDataFileId)}",
+                    Code = "ReplacementDataFileIdNotLinkedToReleaseVersion",
                     Message = $"The replacement data set is not linked to the release version",
                 }
             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataSetMappingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataSetMappingService.cs
@@ -10,6 +10,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 public interface IDataSetMappingService
 {
     Task<DataSetMapping> GetOrCreateMapping(
+        Guid originalDataFileId,
+        Guid replacementDataFileId,
         Guid originalSubjectId,
         Guid replacementSubjectId,
         CancellationToken cancellationToken = default

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseVersionService.cs
@@ -687,8 +687,8 @@ public class ReleaseVersionService(
                 // Remove any mapping that exists for the data set
                 var mappings = await context
                     .DataSetMappings.Where(mapping =>
-                        mapping.OriginalDataSetId == releaseFile.File.SubjectId
-                        || mapping.ReplacementDataSetId == releaseFile.File.SubjectId
+                        mapping.OriginalDataFileId == releaseFile.FileId
+                        || mapping.ReplacementDataFileId == releaseFile.FileId
                     )
                     .ToListAsync();
                 context.DataSetMappings.RemoveRange(mappings);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementPlanService.cs
@@ -120,13 +120,16 @@ public class ReplacementPlanService(
         return await GetLinkedDataSetVersion(replacementReleaseFile, cancellationToken)
             .OnSuccess(async replacementApiDataSetVersion =>
             {
-                var replacementSubjectId = replacementReleaseFile.File.SubjectId!.Value;
                 var originalSubjectId = originalReleaseFile.File.SubjectId!.Value;
+                var replacementSubjectId = replacementReleaseFile.File.SubjectId!.Value;
+
                 var replacementSubjectMeta = await GetReplacementSubjectMeta(replacementSubjectId);
 
                 var mapping = await dataSetMappingService.GetOrCreateMapping(
-                    originalSubjectId,
-                    replacementSubjectId,
+                    originalDataFileId: originalReleaseFile.FileId,
+                    replacementDataFileId: replacementReleaseFile.FileId,
+                    originalSubjectId: originalSubjectId,
+                    replacementSubjectId: replacementSubjectId,
                     cancellationToken
                 );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -116,8 +116,8 @@ public class ReplacementService(
                 }
 
                 var mapping = contentDbContext.DataSetMappings.Single(mapping =>
-                    mapping.OriginalDataSetId == originalSubjectId
-                    && mapping.ReplacementDataSetId == replacementSubjectId
+                    mapping.OriginalDataFileId == originalReleaseFile.FileId
+                    && mapping.ReplacementDataFileId == replacementReleaseFile.FileId
                 );
 
                 replacementReleaseFile.FilterSequence = await ReplaceFilterSequence(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -10,19 +10,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 public record DataSetMapping
 {
-    public Guid Id { get; set; }
+    public Guid Id { get; init; }
 
-    public Guid OriginalDataFileId { get; set; }
-    public File OriginalDataFile { get; set; } = null!;
-    public Guid ReplacementDataFileId { get; set; }
-    public File ReplacementDataFile { get; set; } = null!;
+    public Guid OriginalDataFileId { get; init; }
+    public File OriginalDataFile { get; init; } = null!;
+    public Guid ReplacementDataFileId { get; init; }
+    public File ReplacementDataFile { get; init; } = null!;
 
-    public Dictionary<Guid, IndicatorMapping> IndicatorMappings { get; set; } = null!;
-    public List<UnmappedIndicator> UnmappedReplacementIndicators { get; set; } = [];
+    public Dictionary<Guid, IndicatorMapping> IndicatorMappings { get; init; } = null!;
+    public List<UnmappedIndicator> UnmappedReplacementIndicators { get; init; } = [];
 
-    public Dictionary<Guid, LocationMapping> LocationMappings { get; set; } = null!;
+    public Dictionary<Guid, LocationMapping> LocationMappings { get; set; } = null!; // TODO EES-7126 Change set -> init
 
-    public List<UnmappedLocation> UnmappedReplacementLocations { get; set; } = [];
+    public List<UnmappedLocation> UnmappedReplacementLocations { get; set; } = []; // TODO EES-7126 Change set -> init
 
     public static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -35,6 +35,21 @@ public record DataSetMapping
     {
         public void Configure(EntityTypeBuilder<DataSetMapping> builder)
         {
+            builder.HasIndex(x => x.OriginalDataFileId).IsUnique();
+            builder.HasIndex(x => x.ReplacementDataFileId).IsUnique();
+
+            builder
+                .HasOne(x => x.OriginalDataFile)
+                .WithMany()
+                .HasForeignKey(x => x.OriginalDataFileId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder
+                .HasOne(x => x.ReplacementDataFile)
+                .WithMany()
+                .HasForeignKey(x => x.ReplacementDataFileId)
+                .OnDelete(DeleteBehavior.Restrict);
+
             builder
                 .Property(x => x.IndicatorMappings)
                 .HasConversion(

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -12,6 +12,7 @@ public record DataSetMapping
 {
     public Guid Id { get; set; }
 
+    // @MarkFix need to update frontend code to use *DataFileId rather than *DataSetId
     public Guid OriginalDataFileId { get; set; }
     public File OriginalDataFile { get; set; } = null!;
     public Guid ReplacementDataFileId { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -12,7 +12,6 @@ public record DataSetMapping
 {
     public Guid Id { get; set; }
 
-    // @MarkFix need to update frontend code to use *DataFileId rather than *DataSetId
     public Guid OriginalDataFileId { get; set; }
     public File OriginalDataFile { get; set; } = null!;
     public Guid ReplacementDataFileId { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataSetMapping.cs
@@ -11,8 +11,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model;
 public record DataSetMapping
 {
     public Guid Id { get; set; }
-    public Guid OriginalDataSetId { get; set; }
-    public Guid ReplacementDataSetId { get; set; }
+
+    public Guid OriginalDataFileId { get; set; }
+    public File OriginalDataFile { get; set; } = null!;
+    public Guid ReplacementDataFileId { get; set; }
+    public File ReplacementDataFile { get; set; } = null!;
 
     public Dictionary<Guid, IndicatorMapping> IndicatorMappings { get; set; } = null!;
     public List<UnmappedIndicator> UnmappedReplacementIndicators { get; set; } = [];
@@ -32,9 +35,6 @@ public record DataSetMapping
     {
         public void Configure(EntityTypeBuilder<DataSetMapping> builder)
         {
-            builder.HasIndex(x => x.OriginalDataSetId).IsUnique();
-            builder.HasIndex(x => x.ReplacementDataSetId).IsUnique();
-
             builder
                 .Property(x => x.IndicatorMappings)
                 .HasConversion(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -1,4 +1,4 @@
-# nullable enable
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -31,7 +31,7 @@ public class FileImportService : IFileImportService
         _importerService = importerService;
     }
 
-    public async Task ImportObservations(DataImport import, StatisticsDbContext context)
+    public async Task<DataImport?> ImportObservations(DataImport import, StatisticsDbContext context)
     {
         _logger.LogInformation("Importing Observations for {Filename}", import.File.Filename);
 
@@ -43,7 +43,7 @@ public class FileImportService : IFileImportService
                 import.Status
             );
 
-            return;
+            return null;
         }
 
         if (import.Status == CANCELLING)
@@ -55,7 +55,7 @@ public class FileImportService : IFileImportService
             );
 
             await _dataImportService.UpdateStatus(import.Id, CANCELLED, 100);
-            return;
+            return null;
         }
 
         var subject = await context.Subject.SingleAsync(s => s.Id.Equals(import.SubjectId));
@@ -71,8 +71,7 @@ public class FileImportService : IFileImportService
             context
         );
 
-        var completedImport = await _dataImportService.GetImport(import.Id);
-        await CompleteImport(completedImport, context);
+        return await _dataImportService.GetImport(import.Id);
     }
 
     public async Task ImportFiltersAndLocations(Guid importId, SubjectMeta subjectMeta, StatisticsDbContext context)
@@ -97,7 +96,7 @@ public class FileImportService : IFileImportService
 
             if (import.Status == COMPLETE)
             {
-                await _dataImportService.WriteDataSetFileMeta(import.FileId, import.SubjectId, import.TotalRows!.Value);
+                await FinalImportTasks(import);
             }
 
             return;
@@ -119,7 +118,6 @@ public class FileImportService : IFileImportService
         }
 
         var observationCount = await context.Observation.CountAsync(o => o.SubjectId.Equals(import.SubjectId));
-
         if (observationCount != import.ExpectedImportedRows)
         {
             await _dataImportService.FailImport(
@@ -127,18 +125,21 @@ public class FileImportService : IFileImportService
                 $"Number of observations inserted ({observationCount}) "
                     + $"does not equal that expected ({import.ExpectedImportedRows}) : Please delete & retry"
             );
+            return;
         }
-        else
+
+        if (import.Errors.Count > 0)
         {
-            if (import.Errors.Count == 0)
-            {
-                await _dataImportService.UpdateStatus(import.Id, COMPLETE, 100);
-                await _dataImportService.WriteDataSetFileMeta(import.FileId, import.SubjectId, import.TotalRows!.Value);
-            }
-            else
-            {
-                await _dataImportService.UpdateStatus(import.Id, FAILED, 100);
-            }
+            await _dataImportService.UpdateStatus(import.Id, FAILED, 100);
         }
+
+        await _dataImportService.UpdateStatus(import.Id, COMPLETE, 100);
+        await FinalImportTasks(import);
+    }
+
+    private async Task FinalImportTasks(DataImport import)
+    {
+        await _dataImportService.WriteDataSetFileMeta(import.FileId, import.SubjectId, import.TotalRows!.Value);
+        // @MarkFix create DataSetMapping here
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -31,7 +31,7 @@ public class FileImportService : IFileImportService
         _importerService = importerService;
     }
 
-    public async Task<DataImport?> ImportObservations(DataImport import, StatisticsDbContext context)
+    public async Task ImportObservations(DataImport import, StatisticsDbContext context)
     {
         _logger.LogInformation("Importing Observations for {Filename}", import.File.Filename);
 
@@ -43,7 +43,7 @@ public class FileImportService : IFileImportService
                 import.Status
             );
 
-            return null;
+            return;
         }
 
         if (import.Status == CANCELLING)
@@ -55,7 +55,7 @@ public class FileImportService : IFileImportService
             );
 
             await _dataImportService.UpdateStatus(import.Id, CANCELLED, 100);
-            return null;
+            return;
         }
 
         var subject = await context.Subject.SingleAsync(s => s.Id.Equals(import.SubjectId));
@@ -70,8 +70,6 @@ public class FileImportService : IFileImportService
             subject,
             context
         );
-
-        return await _dataImportService.GetImport(import.Id);
     }
 
     public async Task ImportFiltersAndLocations(Guid importId, SubjectMeta subjectMeta, StatisticsDbContext context)
@@ -140,6 +138,5 @@ public class FileImportService : IFileImportService
     private async Task FinalImportTasks(DataImport import)
     {
         await _dataImportService.WriteDataSetFileMeta(import.FileId, import.SubjectId, import.TotalRows!.Value);
-        // @MarkFix create DataSetMapping here
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -129,6 +129,7 @@ public class FileImportService : IFileImportService
         if (import.Errors.Count > 0)
         {
             await _dataImportService.UpdateStatus(import.Id, FAILED, 100);
+            return;
         }
 
         await _dataImportService.UpdateStatus(import.Id, COMPLETE, 100);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IFileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IFileImportService.cs
@@ -6,7 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Int
 
 public interface IFileImportService
 {
-    Task<DataImport> ImportObservations(DataImport import, StatisticsDbContext context);
+    Task ImportObservations(DataImport import, StatisticsDbContext context);
 
     Task ImportFiltersAndLocations(Guid importId, SubjectMeta subjectMeta, StatisticsDbContext context);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IFileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IFileImportService.cs
@@ -6,7 +6,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Int
 
 public interface IFileImportService
 {
-    Task ImportObservations(DataImport import, StatisticsDbContext context);
+    Task<DataImport> ImportObservations(DataImport import, StatisticsDbContext context);
 
     Task ImportFiltersAndLocations(Guid importId, SubjectMeta subjectMeta, StatisticsDbContext context);
+
+    Task CompleteImport(DataImport import, StatisticsDbContext context);
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
@@ -11,42 +11,23 @@ using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services;
 
-public class ProcessorService : IProcessorService
+public class ProcessorService(
+    ILogger<ProcessorService> logger,
+    IPrivateBlobStorageService privateBlobStorageService,
+    IFileImportService fileImportService,
+    IImporterService importerService,
+    IDataImportService dataImportService,
+    IValidatorService validatorService,
+    IDbContextSupplier dbContextSupplier
+) : IProcessorService
 {
-    private readonly ILogger<ProcessorService> _logger;
-    private readonly IPrivateBlobStorageService _privateBlobStorageService;
-    private readonly IFileImportService _fileImportService;
-    private readonly IImporterService _importerService;
-    private readonly IDataImportService _dataImportService;
-    private readonly IValidatorService _validatorService;
-    private readonly IDbContextSupplier _dbContextSupplier;
-
-    public ProcessorService(
-        ILogger<ProcessorService> logger,
-        IPrivateBlobStorageService privateBlobStorageService,
-        IFileImportService fileImportService,
-        IImporterService importerService,
-        IDataImportService dataImportService,
-        IValidatorService validatorService,
-        IDbContextSupplier dbContextSupplier
-    )
-    {
-        _logger = logger;
-        _privateBlobStorageService = privateBlobStorageService;
-        _fileImportService = fileImportService;
-        _importerService = importerService;
-        _dataImportService = dataImportService;
-        _validatorService = validatorService;
-        _dbContextSupplier = dbContextSupplier;
-    }
-
     public async Task ProcessStage1(Guid importId)
     {
-        await _validatorService
+        await validatorService
             .Validate(importId)
             .OnSuccessDo(async result =>
             {
-                await _dataImportService.Update(
+                await dataImportService.Update(
                     importId,
                     expectedImportedRows: result.ImportableRowCount,
                     totalRows: result.TotalRowCount,
@@ -55,50 +36,52 @@ public class ProcessorService : IProcessorService
             })
             .OnFailureDo(async errors =>
             {
-                await _dataImportService.FailImport(importId, errors);
+                await dataImportService.FailImport(importId, errors);
 
-                _logger.LogError("Import {ImportId} FAILED ...check log", importId);
+                logger.LogError("Import {ImportId} FAILED ...check log", importId);
             });
     }
 
     public async Task ProcessStage2(Guid importId)
     {
-        var statisticsDbContext = _dbContextSupplier.CreateDbContext<StatisticsDbContext>();
+        var statisticsDbContext = dbContextSupplier.CreateDbContext<StatisticsDbContext>();
 
-        var import = await _dataImportService.GetImport(importId);
+        var import = await dataImportService.GetImport(importId);
 
         var subject = await statisticsDbContext.Subject.SingleAsync(subject => subject.Id == import.SubjectId);
 
-        var metaFileStreamProvider = _privateBlobStorageService.GetMetadataFileStreamProvider(import);
+        var metaFileStreamProvider = privateBlobStorageService.GetMetadataFileStreamProvider(import);
 
         var metaFileCsvHeaders = await CsvUtils.GetCsvHeaders(metaFileStreamProvider);
         var metaFileCsvRows = await CsvUtils.GetCsvRows(metaFileStreamProvider);
 
-        var subjectMeta = await _importerService.ImportMeta(
+        var subjectMeta = await importerService.ImportMeta(
             metaFileCsvHeaders,
             metaFileCsvRows,
             subject,
             statisticsDbContext
         );
-        await _fileImportService.ImportFiltersAndLocations(import.Id, subjectMeta, statisticsDbContext);
+        await fileImportService.ImportFiltersAndLocations(import.Id, subjectMeta, statisticsDbContext);
     }
 
     public async Task ProcessStage3(Guid importId)
     {
-        var import = await _dataImportService.GetImport(importId);
+        var import = await dataImportService.GetImport(importId);
 
         try
         {
-            var statisticsDbContext = _dbContextSupplier.CreateDbContext<StatisticsDbContext>();
-            var completedImport = await _fileImportService.ImportObservations(import, statisticsDbContext);
-            await _fileImportService.CompleteImport(completedImport, statisticsDbContext);
+            var statisticsDbContext = dbContextSupplier.CreateDbContext<StatisticsDbContext>();
+            await fileImportService.ImportObservations(import, statisticsDbContext);
+
+            var completedImport = await dataImportService.GetImport(import.Id);
+            await fileImportService.CompleteImport(completedImport, statisticsDbContext);
         }
         catch (Exception e)
         {
             // If deadlock exception then throw & try up to 3 times
             if (e is SqlException exception && exception.Number == 1205)
             {
-                _logger.LogInformation(
+                logger.LogInformation(
                     "ProcessStage3: Handling known exception when processing Import "
                         + "{ImportId}: {Message} : transaction will be retried",
                     import.Id,
@@ -109,14 +92,14 @@ public class ProcessorService : IProcessorService
 
             var mainException = e.InnerException ?? e;
 
-            _logger.LogError(
+            logger.LogError(
                 mainException,
                 "ProcessStage3 FAILED for Import: {ImportId} : {Message}",
                 import.Id,
                 mainException.Message
             );
 
-            await _dataImportService.FailImport(import.Id);
+            await dataImportService.FailImport(import.Id);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
@@ -89,10 +89,9 @@ public class ProcessorService : IProcessorService
 
         try
         {
-            await _fileImportService.ImportObservations(
-                import,
-                _dbContextSupplier.CreateDbContext<StatisticsDbContext>()
-            );
+            var statisticsDbContext = _dbContextSupplier.CreateDbContext<StatisticsDbContext>();
+            var completedImport = await _fileImportService.ImportObservations(import, statisticsDbContext);
+            await _fileImportService.CompleteImport(completedImport, statisticsDbContext);
         }
         catch (Exception e)
         {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
@@ -107,6 +107,7 @@ const DataFileReplacementPlan = ({
         <Plan
           cancelButton={cancelButton}
           fileId={fileId}
+          replacementFileId={replacementFileId}
           publicationId={publicationId}
           releaseVersionId={releaseVersionId}
           plan={plan}
@@ -190,7 +191,7 @@ function DataSetMappingProgressTag({
   );
 }
 
-interface PlanProps extends Omit<Props, 'replacementFileId'> {
+interface PlanProps extends Props {
   plan: DataReplacementPlan;
   isFetchingPlan: boolean;
   onMappingUpdate: () => void;
@@ -204,6 +205,7 @@ function Plan({
   cancelButton,
   releaseVersionId,
   fileId,
+  replacementFileId,
   plan,
   publicationId,
   isFetchingPlan,
@@ -334,8 +336,8 @@ function Plan({
 
       <DataFileReplacementDifferences
         releaseVersionId={releaseVersionId}
-        fileId={plan.originalSubjectId}
-        replacementFileId={plan.replacementSubjectId}
+        fileId={fileId}
+        replacementFileId={replacementFileId}
         plan={plan}
         reloadPlan={onMappingUpdate}
       />

--- a/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataReplacementService.ts
@@ -190,8 +190,8 @@ const dataReplacementService = {
   },
   async updatePlanIndicatorMappings(
     releaseVersionId: string,
-    originalDataSetId: string,
-    replacementDataSetId: string,
+    originalDataFileId: string,
+    replacementDataFileId: string,
     updates: {
       originalColumnName: string;
       newReplacementColumnName?: string;
@@ -201,8 +201,8 @@ const dataReplacementService = {
       await client.patch(
         `releases/${releaseVersionId}/data/replacements/mapping/indicators`,
         {
-          originalDataSetId,
-          replacementDataSetId,
+          originalDataFileId,
+          replacementDataFileId,
           updates,
         },
       );


### PR DESCRIPTION
This PR updates the Content DBs DataSetMappings table to use fileIds rather than subjectIds.

This PR updates both the backend and frontend.

# Other changes

- We also updated `FileImportService` from the Data.Processor project. This is just some minor cleanup to prepare the way to have the Data.Processor generate the initial DataSetMapping entry for a replacement when the import is complete, which will be done in EES-7150.