### PR TITLE
EES-7111 search data autocomplete

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
@@ -24,11 +24,11 @@ import Page from '@frontend/components/Page';
 import Pagination from '@frontend/components/Pagination';
 import { SortOption } from '@frontend/components/SortControls';
 import DataSetFileSummary from '@frontend/modules/data-catalogue/components/DataSetFileSummary';
-import FindStatisticsSearchForm from '@frontend/modules/find-statistics/components/FindStatisticsSearchForm';
 import PublicationResultSummary from '@frontend/modules/find-statistics/components/PublicationResultSummary';
 import { PublicationSortOption } from '@frontend/modules/find-statistics/utils/publicationSortOptions';
 import SearchDataFilters from '@frontend/modules/search-data/components/SearchDataFilters';
 import styles from '@frontend/modules/search-data/SearchDataPage.module.scss';
+import SearchDataSearchForm from '@frontend/modules/search-data/components/SearchDataSearchForm';
 import { getParamsFromQuery } from '@frontend/modules/search-data/utils/createDataSetListRequest';
 import {
   SearchDataFilter,
@@ -392,7 +392,7 @@ const SearchDataPage: NextPage = () => {
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <FindStatisticsSearchForm
+          <SearchDataSearchForm
             label={isPublicationsSearch ? 'Search releases' : 'Search data'}
             onSubmit={nextValue =>
               handleChangeFilter({ filterType: 'search', nextValue })

--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
@@ -397,7 +397,7 @@ const SearchDataPage: NextPage = () => {
             onSubmit={nextValue =>
               handleChangeFilter({ filterType: 'search', nextValue })
             }
-            isSearchData={!isPublicationsSearch}
+            isSearchDataSets={!isPublicationsSearch}
           />
           <a href="#searchResults" className="govuk-skip-link">
             Skip to search results

--- a/src/explore-education-statistics-frontend/src/modules/search-data/__tests__/__data__/testDataSetSuggestions.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/__tests__/__data__/testDataSetSuggestions.ts
@@ -1,0 +1,17 @@
+import { AzureDataSetSuggestResult } from '@frontend/services/azureDataSetService';
+
+// eslint-disable-next-line import/prefer-default-export
+export const testDataSetSuggestions: AzureDataSetSuggestResult[] = [
+  {
+    summary: 'Data set 1 summary',
+    dataSetFileId: 'data-set-file-id-1',
+    title: 'Data set 1',
+    highlightedMatch: 'Data set <strong>1</strong>',
+  },
+  {
+    summary: 'Data set 2 summary',
+    dataSetFileId: 'data-set-file-id-2',
+    title: 'Data set 2',
+    highlightedMatch: 'Data set <strong>2</strong> summary',
+  },
+];

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataSearchForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataSearchForm.tsx
@@ -3,7 +3,7 @@ import VisuallyHidden from '@common/components/VisuallyHidden';
 import styles from '@common/components/form/FormSearchBar.module.scss';
 import logger from '@common/services/logger';
 import sanitizeHtml from '@common/utils/sanitizeHtml';
-import { createPublicationSuggestRequest } from '@frontend/modules/find-statistics/utils/createPublicationListRequest';
+import { createStatisticalReleasesSuggestRequest } from '@frontend/modules/search-data/utils/createStatisticalReleasesListRequest';
 import azurePublicationService, {
   AzurePublicationSuggestResult,
 } from '@frontend/services/azurePublicationService';
@@ -93,7 +93,7 @@ export default function SearchForm({
 
     azurePublicationService
       .suggestPublications(
-        createPublicationSuggestRequest(router.query, enteredText),
+        createStatisticalReleasesSuggestRequest(router.query, enteredText),
       )
       .then(populateResults)
       .catch(error => {

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataSearchForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataSearchForm.tsx
@@ -3,7 +3,11 @@ import VisuallyHidden from '@common/components/VisuallyHidden';
 import styles from '@common/components/form/FormSearchBar.module.scss';
 import logger from '@common/services/logger';
 import sanitizeHtml from '@common/utils/sanitizeHtml';
+import { createDataSetSuggestRequest } from '@frontend/modules/search-data/utils/createDataSetListRequest';
 import { createStatisticalReleasesSuggestRequest } from '@frontend/modules/search-data/utils/createStatisticalReleasesListRequest';
+import azureDataSetService, {
+  AzureDataSetSuggestResult,
+} from '@frontend/services/azureDataSetService';
 import azurePublicationService, {
   AzurePublicationSuggestResult,
 } from '@frontend/services/azurePublicationService';
@@ -19,9 +23,15 @@ interface Props {
   onSubmit: (value: string) => void;
 }
 
-// Nb we are not using tanstack-query or react-hook-form here, as
-// accessible-autocomplete lib is managing its own state, and we can't
-// access the generated text input to be able to hook into its value easily
+type AzureSuggestResult =
+  | AzureDataSetSuggestResult
+  | AzurePublicationSuggestResult;
+
+const isDataSetResult = (
+  result: AzureSuggestResult,
+): result is AzureDataSetSuggestResult => {
+  return result && 'dataSetFileId' in result;
+};
 
 export default function SearchForm({
   isSearchData = false,
@@ -47,6 +57,16 @@ export default function SearchForm({
 
     // 1
     autocompleteInput.setAttribute('type', 'search');
+    // also create a MutationObserver to prevent re-renders resetting input type
+    const observer = new MutationObserver(() => {
+      if (autocompleteInput.getAttribute('type') !== 'search') {
+        autocompleteInput.setAttribute('type', 'search');
+      }
+    });
+    observer.observe(autocompleteInput, {
+      attributes: true,
+      attributeFilter: ['type'],
+    });
 
     function handleEnter(evt: KeyboardEvent) {
       const dropdownVisible =
@@ -68,12 +88,14 @@ export default function SearchForm({
     autocompleteInput.addEventListener('keyup', handleEnter);
 
     return () => {
+      observer.disconnect();
       autocompleteInput.removeEventListener('keyup', handleEnter);
     };
   }, [onSubmit]);
 
+  // When switching between dataset/release search mode, clear the autocomplete state
   useEffect(() => {
-    if (isSearchData && autocompleteRef.current) {
+    if (autocompleteRef.current) {
       autocompleteRef.current.setState({
         menuOpen: false,
         options: [],
@@ -84,10 +106,16 @@ export default function SearchForm({
 
   const fetchResults = (
     enteredText: string,
-    populateResults: (suggestions: AzurePublicationSuggestResult[]) => void,
+    populateResults: (suggestions: AzureSuggestResult[]) => void,
   ) => {
     if (isSearchData) {
-      populateResults([]);
+      azureDataSetService
+        .suggestDatasets(createDataSetSuggestRequest(router.query, enteredText))
+        .then(populateResults)
+        .catch(error => {
+          populateResults([]);
+          logger.error(error);
+        });
       return;
     }
 
@@ -102,7 +130,7 @@ export default function SearchForm({
       });
   };
 
-  const suggestionTemplate = (result: AzurePublicationSuggestResult) => {
+  const suggestionTemplate = (result: AzureSuggestResult) => {
     // The result has a `highlightedMatch` property with HTML tags which could
     // either be from the `title` or the `summary`. So we will strip out the HTML
     // tags to be able to check which field it is from, and use accordingly.
@@ -182,18 +210,28 @@ export default function SearchForm({
           }}
           confirmOnBlur={false}
           showNoOptionsFound={false}
-          onConfirm={(result: AzurePublicationSuggestResult) => {
-            if (result) {
+          onConfirm={(result: AzureSuggestResult) => {
+            if (!result) return null;
+
+            if (isDataSetResult(result)) {
               logEvent({
                 category: 'Find statistics and data',
-                action: `Autocomplete suggestion accepted`,
+                action: `Autocomplete dataset suggestion accepted`,
                 label: result.title,
               });
               return router.push(
-                `/find-statistics/${result.publicationSlug}/${result.releaseSlug}`,
+                `/data-catalogue/data-set/${result.dataSetFileId}`,
               );
             }
-            return null;
+
+            logEvent({
+              category: 'Find statistics and data',
+              action: `Autocomplete suggestion accepted`,
+              label: result.title,
+            });
+            return router.push(
+              `/find-statistics/${result.publicationSlug}/${result.releaseSlug}`,
+            );
           }}
           tNoResults={() => 'No search suggestions found'}
           tAssistiveHint={() =>

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataSearchForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataSearchForm.tsx
@@ -18,7 +18,7 @@ import { truncate } from 'lodash';
 import { useRouter } from 'next/router';
 
 interface Props {
-  isSearchData?: boolean;
+  isSearchDataSets?: boolean;
   label?: string;
   onSubmit: (value: string) => void;
 }
@@ -34,7 +34,7 @@ const isDataSetResult = (
 };
 
 export default function SearchForm({
-  isSearchData = false,
+  isSearchDataSets = false,
   label = 'Search',
   onSubmit,
 }: Props) {
@@ -42,6 +42,7 @@ export default function SearchForm({
 
   const wrapper = useRef<HTMLFormElement>(null);
   const autocompleteRef = useRef<Autocomplete>(null);
+  const activeSearchModeRef = useRef(isSearchDataSets);
 
   // The accessible-autocomplete component generates a text input element.
   // We need to access the created elements to:
@@ -69,9 +70,14 @@ export default function SearchForm({
     });
 
     function handleEnter(evt: KeyboardEvent) {
+      if (evt.key !== 'Enter') {
+        return;
+      }
+
       const dropdownVisible =
         autocompleteInput.getAttribute('aria-expanded') === 'true';
-      if (dropdownVisible && evt.key && evt.key === 'Enter') {
+
+      if (dropdownVisible) {
         const searchTerm = new FormData(wrapper.current!).get(
           'search',
         ) as string;
@@ -93,8 +99,12 @@ export default function SearchForm({
     };
   }, [onSubmit]);
 
-  // When switching between dataset/release search mode, clear the autocomplete state
+  // When switching between dataset/release search mode:
+  // 1. Sync the ref to prevent race conditions on in-flight requests
+  // 2. Clear the autocomplete state
   useEffect(() => {
+    activeSearchModeRef.current = isSearchDataSets;
+
     if (autocompleteRef.current) {
       autocompleteRef.current.setState({
         menuOpen: false,
@@ -102,18 +112,28 @@ export default function SearchForm({
         validChoiceMade: false,
       });
     }
-  }, [isSearchData]);
+  }, [isSearchDataSets]);
 
   const fetchResults = (
     enteredText: string,
     populateResults: (suggestions: AzureSuggestResult[]) => void,
   ) => {
-    if (isSearchData) {
+    // Keep track of the search mode at the time of fetch to handle results correctly
+    const modeAtFetchTime = isSearchDataSets;
+
+    if (isSearchDataSets) {
       azureDataSetService
         .suggestDatasets(createDataSetSuggestRequest(router.query, enteredText))
-        .then(populateResults)
+        .then(results => {
+          // Make sure the current mode still matches the mode from when we started
+          if (activeSearchModeRef.current === modeAtFetchTime) {
+            populateResults(results);
+          }
+        })
         .catch(error => {
-          populateResults([]);
+          if (activeSearchModeRef.current === modeAtFetchTime) {
+            populateResults([]);
+          }
           logger.error(error);
         });
       return;
@@ -123,9 +143,16 @@ export default function SearchForm({
       .suggestPublications(
         createStatisticalReleasesSuggestRequest(router.query, enteredText),
       )
-      .then(populateResults)
+      .then(results => {
+        // Make sure the current mode still matches the mode from when we started
+        if (activeSearchModeRef.current === modeAtFetchTime) {
+          populateResults(results);
+        }
+      })
       .catch(error => {
-        populateResults([]);
+        if (activeSearchModeRef.current === modeAtFetchTime) {
+          populateResults([]);
+        }
         logger.error(error);
       });
   };
@@ -136,6 +163,7 @@ export default function SearchForm({
     // tags to be able to check which field it is from, and use accordingly.
     const highlightMatchWithoutTags = sanitizeHtml(result.highlightedMatch, {
       allowedTags: [],
+      allowedAttributes: {},
     });
 
     // We also need to find out which term was highlighted in order to manually
@@ -144,13 +172,25 @@ export default function SearchForm({
       /(?<=<strong>)(.*?)(?=<\/strong>)/,
     );
 
-    const wrapHighlightedTermWithTag = (snippet: string) =>
-      highlightedTerm
-        ? snippet.replaceAll(
+    const wrapHighlightedTermWithTag = (snippet: string) => {
+      const sanitizedSnippet = sanitizeHtml(snippet, {
+        allowedTags: [],
+        allowedAttributes: {},
+      });
+
+      return highlightedTerm
+        ? sanitizedSnippet.replaceAll(
             highlightedTerm[0],
             match => `<strong>${match}</strong>`,
           )
-        : snippet;
+        : sanitizedSnippet;
+    };
+
+    // Sanitize the highlighted match for safety
+    const safeHighlight = sanitizeHtml(result.highlightedMatch, {
+      allowedTags: ['strong'],
+      allowedAttributes: {},
+    });
 
     // For both title and summary, render the `highlightedMatch` from azure
     // if it is from this field.
@@ -159,14 +199,14 @@ export default function SearchForm({
       <span class="autocomplete__option-title">
         ${
           result.title.includes(highlightMatchWithoutTags)
-            ? result.highlightedMatch
+            ? safeHighlight
             : wrapHighlightedTermWithTag(result.title)
         }
       </span>
       <span class="autocomplete__option-summary">
       ${
         result.summary.includes(highlightMatchWithoutTags)
-          ? result.highlightedMatch
+          ? safeHighlight
           : wrapHighlightedTermWithTag(
               truncate(result.summary, { length: 140 }),
             )

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataSearchForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/SearchDataSearchForm.tsx
@@ -14,6 +14,7 @@ import { truncate } from 'lodash';
 import { useRouter } from 'next/router';
 
 interface Props {
+  isSearchData?: boolean;
   label?: string;
   onSubmit: (value: string) => void;
 }
@@ -22,10 +23,15 @@ interface Props {
 // accessible-autocomplete lib is managing its own state, and we can't
 // access the generated text input to be able to hook into its value easily
 
-export default function SearchForm({ label = 'Search', onSubmit }: Props) {
+export default function SearchForm({
+  isSearchData = false,
+  label = 'Search',
+  onSubmit,
+}: Props) {
   const router = useRouter();
 
   const wrapper = useRef<HTMLFormElement>(null);
+  const autocompleteRef = useRef<Autocomplete>(null);
 
   // The accessible-autocomplete component generates a text input element.
   // We need to access the created elements to:
@@ -66,10 +72,25 @@ export default function SearchForm({ label = 'Search', onSubmit }: Props) {
     };
   }, [onSubmit]);
 
+  useEffect(() => {
+    if (isSearchData && autocompleteRef.current) {
+      autocompleteRef.current.setState({
+        menuOpen: false,
+        options: [],
+        validChoiceMade: false,
+      });
+    }
+  }, [isSearchData]);
+
   const fetchResults = (
     enteredText: string,
     populateResults: (suggestions: AzurePublicationSuggestResult[]) => void,
   ) => {
+    if (isSearchData) {
+      populateResults([]);
+      return;
+    }
+
     azurePublicationService
       .suggestPublications(
         createPublicationSuggestRequest(router.query, enteredText),
@@ -147,6 +168,7 @@ export default function SearchForm({ label = 'Search', onSubmit }: Props) {
       </label>
       <div className="autocomplete__item-wrap">
         <Autocomplete
+          ref={autocompleteRef}
           id="search"
           name="search"
           menuAttributes={{

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/SearchDataSearchForm.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/SearchDataSearchForm.test.tsx
@@ -1,0 +1,102 @@
+import SearchDataSearchForm from '@frontend/modules/search-data/components/SearchDataSearchForm';
+import _dataSetService from '@frontend/services/azureDataSetService';
+import _publicationService from '@frontend/services/azurePublicationService';
+import { render, screen, within } from '@testing-library/react';
+import React from 'react';
+import noop from 'lodash/noop';
+import userEvent from '@testing-library/user-event';
+import { testPublicationSuggestions } from '@frontend/modules/find-statistics/__tests__/__data__/testPublicationSuggestions';
+import { testDataSetSuggestions } from '@frontend/modules/search-data/__tests__/__data__/testDataSetSuggestions';
+
+jest.mock('@azure/search-documents', () => ({
+  SearchClient: jest.fn(),
+  AzureKeyCredential: jest.fn(),
+  odata: jest.fn(),
+}));
+
+jest.mock('@frontend/services/azurePublicationService');
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
+jest.mock('@frontend/services/azureDataSetService');
+const dataSetService = _dataSetService as jest.Mocked<typeof _dataSetService>;
+
+describe('SearchDataSearchForm', () => {
+  test('renders correctly', () => {
+    render(<SearchDataSearchForm onSubmit={noop} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
+    // N.b checking by 'not.toBeVisible' doesn't work as Jest isn't loading the global CSS
+    expect(screen.getByRole('listbox')).toHaveClass(
+      'autocomplete__menu--hidden',
+    );
+  });
+
+  test('calls onSubmit when submitted', async () => {
+    publicationService.suggestPublications.mockResolvedValue(
+      testPublicationSuggestions,
+    );
+    const handleSubmit = jest.fn();
+    render(<SearchDataSearchForm onSubmit={handleSubmit} />);
+    await userEvent.type(screen.getByRole('combobox'), 'find me');
+    await userEvent.click(screen.getByRole('button', { name: 'Search' }));
+    expect(handleSubmit).toHaveBeenCalledWith('find me');
+  });
+
+  test('shows suggestions when entered term is at least 3 characters with results', async () => {
+    publicationService.suggestPublications.mockResolvedValue(
+      testPublicationSuggestions,
+    );
+    render(<SearchDataSearchForm onSubmit={noop} />);
+    await userEvent.type(screen.getByRole('combobox'), 'find me');
+    expect(screen.getByRole('listbox')).not.toHaveClass(
+      'autocomplete__menu--hidden',
+    );
+    const listItems = screen.getAllByRole('option');
+    expect(listItems).toHaveLength(3);
+    expect(within(listItems[0]).getAllByText('Publication')).toHaveLength(2);
+  });
+
+  test('searches datasets when isSearchData is true', async () => {
+    dataSetService.suggestDatasets.mockResolvedValue(testDataSetSuggestions);
+    render(<SearchDataSearchForm onSubmit={noop} isSearchData />);
+    await userEvent.type(screen.getByRole('combobox'), 'find me');
+    expect(screen.getByRole('listbox')).not.toHaveClass(
+      'autocomplete__menu--hidden',
+    );
+    const listItems = screen.getAllByRole('option');
+    expect(listItems).toHaveLength(2);
+    expect(within(listItems[0]).getAllByText('Data set')).toHaveLength(2);
+    expect(
+      within(listItems[0]).queryByText('Publication'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not show suggestions when entered term is at least 3 characters with no results', async () => {
+    publicationService.suggestPublications.mockResolvedValue([]);
+    render(<SearchDataSearchForm onSubmit={noop} />);
+    await userEvent.type(screen.getByRole('combobox'), 'find me');
+    expect(screen.getByRole('listbox')).toHaveClass(
+      'autocomplete__menu--hidden',
+    );
+  });
+
+  test("doesn't show suggestions when entered term is less than 3 characters", async () => {
+    render(<SearchDataSearchForm onSubmit={noop} />);
+    await userEvent.type(screen.getByRole('combobox'), 'fi');
+    expect(screen.getByRole('listbox')).toHaveClass(
+      'autocomplete__menu--hidden',
+    );
+  });
+
+  test('submits the form when enter is pressed', async () => {
+    publicationService.suggestPublications.mockResolvedValue(
+      testPublicationSuggestions,
+    );
+    const handleSubmit = jest.fn();
+    render(<SearchDataSearchForm onSubmit={handleSubmit} />);
+    await userEvent.type(screen.getByRole('combobox'), 'find me');
+    await userEvent.keyboard('[Enter]');
+    expect(handleSubmit).toHaveBeenCalledWith('find me');
+  });
+});

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/SearchDataSearchForm.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/SearchDataSearchForm.test.tsx
@@ -57,9 +57,9 @@ describe('SearchDataSearchForm', () => {
     expect(within(listItems[0]).getAllByText('Publication')).toHaveLength(2);
   });
 
-  test('searches datasets when isSearchData is true', async () => {
+  test('searches datasets when isSearchDataSets is true', async () => {
     dataSetService.suggestDatasets.mockResolvedValue(testDataSetSuggestions);
-    render(<SearchDataSearchForm onSubmit={noop} isSearchData />);
+    render(<SearchDataSearchForm onSubmit={noop} isSearchDataSets />);
     await userEvent.type(screen.getByRole('combobox'), 'find me');
     expect(screen.getByRole('listbox')).not.toHaveClass(
       'autocomplete__menu--hidden',

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/createDataSetListRequest.ts
@@ -20,6 +20,42 @@ import { AzureOrderByParam } from '@frontend/services/azurePublicationService';
 import { DataSetType } from '@frontend/services/dataSetFileService';
 import omitBy from 'lodash/omitBy';
 
+export function createDataSetSuggestRequest(
+  query: SearchDataPageQuery,
+  searchTerm: string,
+): AzureDataSetListRequest {
+  const {
+    dataSetType,
+    geographicLevels,
+    latestDataOnly,
+    publicationIds,
+    releaseTypes,
+    sortBy,
+    themeIds,
+  } = getParamsFromQuery(query);
+
+  const orderBy = getSortParam(sortBy);
+
+  const filter = buildODataFilter({
+    dataSetType,
+    geographicLevels,
+    latestDataOnly,
+    publicationIds,
+    releaseTypes,
+    themeIds,
+  });
+
+  return omitBy(
+    {
+      filter,
+      page: parseNumber(query.page) ?? 1,
+      search: searchTerm,
+      orderBy,
+    },
+    value => typeof value === 'undefined',
+  );
+}
+
 export default function createDataSetListRequest(
   query: SearchDataPageQuery,
 ): AzureDataSetListRequest {

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/createStatisticalReleasesListRequest.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/createStatisticalReleasesListRequest.ts
@@ -16,6 +16,30 @@ import { AzureDataSetListRequest } from '@frontend/services/azureDataSetService'
 import { AzureOrderByParam } from '@frontend/services/azurePublicationService';
 import omitBy from 'lodash/omitBy';
 
+export function createStatisticalReleasesSuggestRequest(
+  query: SearchDataPageQuery,
+  searchTerm: string,
+): AzureDataSetListRequest {
+  const { releaseTypes, sortBy, themeIds } = getParamsFromQuery(query);
+
+  const orderBy = getSortParam(sortBy);
+
+  const filter = buildODataFilter({
+    releaseTypes,
+    themeIds,
+  });
+
+  return omitBy(
+    {
+      filter,
+      page: parseNumber(query.page) ?? 1,
+      search: searchTerm,
+      orderBy,
+    },
+    value => typeof value === 'undefined',
+  );
+}
+
 export default function createStatisticalReleasesListRequest(
   query: SearchDataPageQuery,
 ): AzureDataSetListRequest {

--- a/src/explore-education-statistics-frontend/src/pages/api/suggest-datasets.ts
+++ b/src/explore-education-statistics-frontend/src/pages/api/suggest-datasets.ts
@@ -1,0 +1,74 @@
+import logger from '@common/services/logger';
+import withMethods from '@frontend/middleware/api/withMethods';
+import { initialiseAzureDataSetsSearchClient } from '@frontend/modules/api/search/initialiseAzureSearchClient';
+import { ErrorBody } from '@frontend/modules/api/types/error';
+import {
+  AzureDataSetIndexItem,
+  AzureDataSetListRequest,
+  AzureDataSetSuggestResult,
+} from '@frontend/services/azureDataSetService';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+interface Request extends NextApiRequest {
+  body: {
+    searchOptions: AzureDataSetListRequest;
+  };
+}
+
+type SelectedDatasetFields = Pick<
+  AzureDataSetIndexItem,
+  'dataSetFileId' | 'title' | 'content'
+>;
+
+export default withMethods({
+  post: async function suggestDatasets(
+    req: Request,
+    res: NextApiResponse<AzureDataSetSuggestResult[] | ErrorBody>,
+  ) {
+    const {
+      body: { searchOptions },
+    } = req;
+
+    const azureSearchClient = initialiseAzureDataSetsSearchClient();
+
+    try {
+      const { filter, search = '' } = searchOptions;
+
+      const suggestResults =
+        search?.length > 2
+          ? await azureSearchClient.suggest(
+              search,
+              'suggester-dataset-search',
+              {
+                select: ['dataSetFileId', 'title', 'content'],
+                filter,
+                searchFields: ['title', 'content'],
+                useFuzzyMatching: true,
+                top: 3,
+                highlightPostTag: '</strong>',
+                highlightPreTag: '<strong>',
+              },
+            )
+          : null;
+
+      let resultsToReturn = [] as AzureDataSetSuggestResult[];
+      if (suggestResults?.results) {
+        resultsToReturn = suggestResults?.results.map(result => {
+          const document = result.document as SelectedDatasetFields;
+          return {
+            summary: document.content,
+            dataSetFileId: document.dataSetFileId,
+            title: document.title,
+            highlightedMatch: result.text,
+          } as AzureDataSetSuggestResult;
+        });
+      }
+      return res.status(200).send(resultsToReturn);
+    } catch (error) {
+      logger.error(error);
+      return res
+        .status(500)
+        .send({ message: 'Something went wrong', status: 500 });
+    }
+  },
+});

--- a/src/explore-education-statistics-frontend/src/services/azureDataSetService.ts
+++ b/src/explore-education-statistics-frontend/src/services/azureDataSetService.ts
@@ -51,11 +51,23 @@ export interface AzureDataSetListRequest {
   sortDirection?: SortDirection;
 }
 
+export interface AzureDataSetSuggestResult {
+  highlightedMatch: string;
+  dataSetFileId: string;
+  summary: string;
+  title: string;
+}
+
 const azureDataSetService = {
   async listDataSets(
     params: AzureDataSetListRequest,
   ): Promise<PaginatedList<DataSetFileSummary>> {
     return frontendApi.post(`/search-datasets`, { searchOptions: params });
+  },
+  async suggestDatasets(
+    params: AzureDataSetListRequest,
+  ): Promise<AzureDataSetSuggestResult[]> {
+    return frontendApi.post(`/suggest-datasets`, { searchOptions: params });
   },
 };
 

--- a/src/explore-education-statistics-frontend/src/types/accessible-autocomplete.ts
+++ b/src/explore-education-statistics-frontend/src/types/accessible-autocomplete.ts
@@ -171,7 +171,11 @@ declare module 'accessible-autocomplete/react' {
    * The Accessible Autocomplete React component.
    * This component wraps the core accessible-autocomplete library to provide a React-friendly interface.
    */
-  const AccessibleAutocomplete: React.FC<AccessibleAutocompleteProps>;
 
-  export default AccessibleAutocomplete;
+  // eslint-disable-next-line react/prefer-stateless-function
+  export default class Autocomplete extends React.Component<
+    AccessibleAutocompleteProps,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any
+  > {}
 }


### PR DESCRIPTION
This PR adds autocomplete/suggest dropdown for the data sets search tab on the new prototype combined search. Before, we only had autocomplete appearing and suggesting results for the **releases** tab.

- I forked the existing find stats search form, to keep the prototype combined search work all together under 'search data' and ensure we're not breaking any current functionality for find stats
- The autocomplete instance is the same between the **releases** and **data** tabs, we just handle creating requests and clicking on results differently depending on the selected tab.
- I've had to manually clear the autocomplete component internal results state when switching tabs, so that you don't see stale results when switching search mode.
- The suggested data sets should take into account any selected filters (except for search term)

N.B to get this running you will need local .env vars set up for:
```
AZURE_SEARCH_QUERY_KEY=
AZURE_SEARCH_ENDPOINT=
AZURE_SEARCH_INDEX=
AZURE_DATASETS_SEARCH_INDEX=
```

### Screenshots:

**Autocomplete suggestions with type-tolerance:**
<img width="980" height="711" alt="a2942bc2-bb5f-494b-8513-acccd78ee1df" src="https://github.com/user-attachments/assets/bbe015df-57e4-46d3-bb60-87a6c15bec91" />


---

**Different suggestions appearing with a filter selected:**
<img width="998" height="759" alt="600fa70a-388d-40e8-bb52-4c517cc235fe" src="https://github.com/user-attachments/assets/8343eebc-807d-41a8-8ca2-ae0d4f548728" />
