### PR TITLE
EES-XXXX - disabling noisiest alerts

### DIFF
--- a/infrastructure/templates/common/components/alerts/staticAlertConfig.bicep
+++ b/infrastructure/templates/common/components/alerts/staticAlertConfig.bicep
@@ -55,14 +55,6 @@ var staticAverageLessThanHundred = {
 }
 
 @export()
-var staticAverageLessThan95 = {
-  ...defaultStaticAlertConfig
-  aggregation: 'Average'
-  operator: 'LessThan'
-  threshold: '95'
-}
-
-@export()
 var staticMaxGreaterThanZero = {
   ...defaultStaticAlertConfig
   aggregation: 'Maximum'

--- a/infrastructure/templates/common/components/front-door/frontDoor.bicep
+++ b/infrastructure/templates/common/components/front-door/frontDoor.bicep
@@ -1,5 +1,5 @@
 import { abbreviations } from '../../abbreviations.bicep'
-import { staticAverageLessThan95, staticAverageGreaterThanZero } from '../alerts/staticAlertConfig.bicep'
+import { staticAverageLessThanHundred, staticAverageGreaterThanZero } from '../alerts/staticAlertConfig.bicep'
 import { dynamicAverageGreaterThan, dynamicAverageLessThan } from '../alerts/dynamicAlertConfig.bicep'
 import { FrontDoorCertificateType } from 'types.bicep'
 
@@ -317,7 +317,8 @@ module originHealthPercentageAlert '../alerts/staticMetricAlert.bicep' = if (ale
       metric: 'OriginHealthPercentage'
     }
     config: {
-      ...staticAverageLessThan95
+      ...staticAverageLessThanHundred
+      threshold: '90'
       nameSuffix: 'origin-health-percentage'
     }
     alertsGroupName: alerts!.alertsGroupName

--- a/infrastructure/templates/core/main.bicep
+++ b/infrastructure/templates/core/main.bicep
@@ -19,7 +19,7 @@ param certificateType FrontDoorCertificateType = 'BringYourOwn'
 param deployBackupVaultReaderRoleAssignment bool = true
 
 @description('The minimum average response time from the public site (via Azure Front Door) before latency alerts fire.')
-param averagePublicSiteResponseTimeAlertThresholdMillis int = 1000
+param averagePublicSiteResponseTimeAlertThresholdMillis int = 2500
 
 @description('Do Azure Monitor alerts need creating or updating?')
 param deployAlerts bool = false

--- a/infrastructure/templates/core/parameters/main-prod.bicepparam
+++ b/infrastructure/templates/core/parameters/main-prod.bicepparam
@@ -3,4 +3,4 @@ using '../main.bicep'
 // Environment Params
 param environmentName = 'Production'
 
-param averagePublicSiteResponseTimeAlertThresholdMillis = 250
+param averagePublicSiteResponseTimeAlertThresholdMillis = 1000


### PR DESCRIPTION
This PR:
- reduces Front Door origin health percentage threshold to 90%.
- increases Front Door latency threshold in all environments, to be reviewed and reduced later when it's in use properly in Production.