### PR TITLE
EES-7181 Disable CliFx renovate update suggestion

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,6 +72,12 @@
       "enabled": false
     },
     {
+      "description": "Disable CliFx as v3 requires tinkering to update - EES-7179 to update or remove",
+      "matchDatasources": ["nuget"],
+      "matchPackageNames": ["CliFx"],
+      "enabled": false
+    },
+    {
       "description": "Disable packages which need their major versions to be in sync with the .NET version or the EF Core version",
       "matchDatasources": ["nuget"],
       "matchPackagePrefixes": [


### PR DESCRIPTION
Very small PR to disable renovate suggesting updating CliFx to v3. EES-7179 is for either spending the time to update CliFx to v3 or removing it.