### PR TITLE
EES-7196 Various changes in response to the backend renovate major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -84,6 +84,12 @@
       "enabled": false
     },
     {
+      "description": "Disable Microsoft.ApplicationInsights.* - EES-7198 to update",
+      "matchDatasources": ["nuget"],
+      "matchPackageNames": ["Microsoft.ApplicationInsights", "Microsoft.ApplicationInsights.AspNetCore", "Microsoft.ApplicationInsights.WorkerService"],
+      "enabled": false
+    },
+    {
       "description": "Disable packages which need their major versions to be in sync with the .NET version or the EF Core version",
       "matchDatasources": ["nuget"],
       "matchPackagePrefixes": [

--- a/renovate.json
+++ b/renovate.json
@@ -95,7 +95,9 @@
         "MockQueryable.Moq",
         "Npgsql.EntityFrameworkCore.PostgreSQL",
         "Thinktecture.EntityFrameworkCore",
-        "linq2db.EntityFrameworkCore"
+        "linq2db.EntityFrameworkCore",
+        "Asp.Versioning.Mvc",
+        "Asp.Versioning.Mvc.ApiExplorer"
       ],
       "matchUpdateTypes": ["major"],
       "enabled": false

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
     <!-- TODO EES-4202 DataMovement depends on deprecated Microsoft.Azure.Storage.Blob SDK v11 -->
     <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.26" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests.csproj
@@ -10,7 +10,7 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests/GovUk.Education.ExploreEducationStatistics.Public.Data.Api.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <!-- Required to execute unit tests in IDE -->
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests/GovUk.Education.ExploreEducationStatistics.Public.Data.Model.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <!-- Required to execute unit tests in IDE -->
     <PackageReference Include="Moq.EntityFrameworkCore" Version="8.0.1.7" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests/GovUk.Education.ExploreEducationStatistics.Public.Data.Services.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <!-- Required to execute unit tests in IDE -->
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Tests/GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Tests/GovUk.Education.ExploreEducationStatistics.Public.Data.Utils.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <!-- Required to execute unit tests in IDE -->
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This PR makes several changes related to backend major version updates:
- Updates coverlet.collector and Microsoft.Data.SqlClient to their latest major version.
- Disable renovate update suggestions for Asp.Versioning.Mvc.* - we cannot update this until we update to .NET 10.
- Disable renovate update suggestions for Microsoft.ApplicationInsights.* - the changes are quite involved and have been pushed to a different ticket (EES-7198)