### PR TITLE
EES-7195 Fix failing UI tests

### DIFF
--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -574,12 +574,23 @@ user approves release for scheduled publication
     ...    ${next_release_month}=01
     ...    ${next_release_year}=2200
     ...    ${update_amendment_published_date}=${False}
-    ${expected_scheduled_date}=    Convert Date    ${publish_date_day} ${publish_date_month} ${publish_date_year}
+
+    ${expected_scheduled_dt}=    Convert Date    ${publish_date_day} ${publish_date_month} ${publish_date_year}
     ...    date_format=%d %m %Y
-    ...    result_format=%d %B %Y
-    ${expected_next_release_date}=    Convert Date    1 ${next_release_month} ${next_release_year}
+    ...    result_format=datetime
+    ${expected_next_release_dt}=    Convert Date    1 ${next_release_month} ${next_release_year}
     ...    date_format=%d %m %Y
-    ...    result_format=%B %Y
+    ...    result_format=datetime
+
+    # Use the 'format datetime' keyword to ensure platform-independent date formatting.
+    # For example, formatting the day of the month without a leading zero differs by platform
+    # ('%-d' on Linux vs. '%#d' on Windows).
+    ${expected_scheduled_date}=    format datetime
+    ...    datetime=${expected_scheduled_dt}
+    ...    format_string=%-d %B %Y
+    ${expected_next_release_date}=    format datetime
+    ...    datetime=${expected_next_release_dt}
+    ...    format_string=%B %Y
 
     user edits release status
     user clicks radio    Approved for publication

--- a/tests/robot-tests/tests/libs/dates_and_times.py
+++ b/tests/robot-tests/tests/libs/dates_and_times.py
@@ -5,6 +5,13 @@ import pytz
 from tests.libs.selenium_elements import sl
 
 
+def format_datetime(datetime: datetime, format_string: str) -> str:
+    if os.name == "nt":
+        format_string = format_string.replace("%-", "%#")
+
+    return datetime.strftime(format_string)
+
+
 def get_london_date(offset_days: int = 0, format_string: str = "%-d %B %Y") -> str:
     return _get_date_and_time(offset_days, format_string, "Europe/London")
 
@@ -38,13 +45,6 @@ def _get_browser_timezone():
 
 
 def _get_date_and_time(offset_days: int, format_string: str, timezone: str) -> str:
-    return _format_datetime(
+    return format_datetime(
         datetime.datetime.now(pytz.timezone(timezone)) + datetime.timedelta(days=offset_days), format_string
     )
-
-
-def _format_datetime(datetime: datetime, format_string: str) -> str:
-    if os.name == "nt":
-        format_string = format_string.replace("%-", "%#")
-
-    return datetime.strftime(format_string)


### PR DESCRIPTION
This PR fixes a bug in the UI tests where the date format of the 'Scheduled release' date was different to the format expected by the tests.

E.g. when scheduling a release to be published on 4th June 2026, the value displayed is 4 June 2026 but the `expected_scheduled_date` test variable is 04 June 2026. This was causing failures like:

```
Expected at least one matching child element but found none under parent css:body using child selector xpath:.//dt[contains(text(), "Scheduled release")]/following-sibling::dd[contains(., "04 June 2026")]
```

This is fixed by changing the keyword `user approves release for scheduled publication` to evaluate `expected_scheduled_date` ensuring that single-digit days are not zero-padded.

### UI test result

Result of running single test suite: `publish_amend_and_cancel.robot`.

<img width="856" height="97" alt="image" src="https://github.com/user-attachments/assets/50249356-b324-4d37-b070-3a4ba63fb679" />
