### PR TITLE
EES-7197 Fix IpRange and FirewallRule imports after #7030

### DIFF
--- a/infrastructure/templates/public-api/components/durableFunctionApp.bicep
+++ b/infrastructure/templates/public-api/components/durableFunctionApp.bicep
@@ -1,9 +1,5 @@
-import {
-  FirewallRule
-  IpRange
-  EntraIdAuthentication
-} from '../types.bicep'
-
+import { EntraIdAuthentication} from '../types.bicep'
+import { IpRange, FirewallRule } from '../../common/types.bicep'
 import { AzureFileShareMount } from '../../common/components/storage/types.bicep'
 import { AppServicePlanSku } from '../../common/components/app-service-plan/types.bicep'
 import { staticAverageLessThanHundred, staticMinGreaterThanZero } from '../../common/components/alerts/staticAlertConfig.bicep'

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -2,12 +2,12 @@ import { abbreviations } from '../common/abbreviations.bicep'
 import { abbreviations as publicApiAbbreviations } from 'abbreviations.bicep'
 import {
   ContainerAppResourceConfig
-  IpRange
   PrincipalNameAndId
   StaticWebAppSku
   ContainerAppWorkloadProfile
   PostgreSqlFlexibleServerConfig
 } from 'types.bicep'
+import { IpRange } from '../common/types.bicep'
 import { StorageAccountConfig } from '../common/components/storage/types.bicep'
 
 @description('Environment : Subscription name e.g. s101d01. Used as a prefix for created resources.')


### PR DESCRIPTION
This PR fixes `IpRange` and `FirewallRule` imports that were missed in `main.bicep` and `durableFunctionApp.bicep` of the Public API infrastructure in #7030.