### PR TITLE
EES-7132 Add jest tests for search data feature

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/SearchDataPage.tsx
@@ -416,7 +416,7 @@ const SearchDataPage: NextPage = () => {
           <ScreenReaderMessage message={totalResultsMessage} />
         </div>
         <div className="govuk-grid-column-one-third">
-          <div className={styles.helpColumn}>
+          <div className={styles.helpColumn} data-testid="related-info-column">
             <RelatedInformation heading="Help and related information">
               <ul className="govuk-list">
                 <li>

--- a/src/explore-education-statistics-frontend/src/modules/search-data/__tests__/SearchDataPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/__tests__/SearchDataPage.test.tsx
@@ -1,0 +1,343 @@
+import render from '@common-test/render';
+import { screen, within } from '@testing-library/react';
+import React from 'react';
+import SearchDataPage from '@frontend/modules/search-data/SearchDataPage';
+import _publicationService, {
+  PublicationListSummary,
+} from '@common/services/publicationService';
+import _azureDataSetService from '@frontend/services/azureDataSetService';
+import _azurePublicationService from '@frontend/services/azurePublicationService';
+import { testPublicationTree } from '@frontend/modules/search-data/__tests__/__data__/testPublicationTree';
+import { PaginatedList } from '@common/services/types/pagination';
+import { testPublications } from '@frontend/modules/find-statistics/__tests__/__data__/testPublications';
+import { testDataSetFileSummaries } from '@frontend/modules/data-catalogue/__data__/testDataSets';
+
+jest.mock('@azure/search-documents', () => ({
+  SearchClient: jest.fn(),
+  AzureKeyCredential: jest.fn(),
+  odata: jest.fn(),
+}));
+
+jest.mock('@common/services/publicationService');
+jest.mock('@frontend/services/azureDataSetService');
+jest.mock('@frontend/services/azurePublicationService');
+
+const publicationService = jest.mocked(_publicationService);
+const azureDataSetService = jest.mocked(_azureDataSetService);
+const azurePublicationService = jest.mocked(_azurePublicationService);
+
+const mockIsMedia = false;
+jest.mock('@common/hooks/useMedia', () => ({
+  useMobileMedia: () => {
+    return {
+      isMedia: mockIsMedia,
+    };
+  },
+}));
+
+const mockRouter = {
+  pathname: '/search-data',
+  query: {},
+  push: jest.fn(),
+  replace: jest.fn(),
+};
+
+jest.mock('next/router', () => ({
+  useRouter: () => mockRouter,
+}));
+
+describe('SearchDataPage', () => {
+  const testDataSetsResults = {
+    results: testDataSetFileSummaries,
+    paging: {
+      page: 1,
+      pageSize: 10,
+      totalPages: 1,
+      totalResults: 2,
+    },
+  };
+
+  const testPublicationsResults = {
+    results: testPublications,
+    paging: {
+      page: 1,
+      pageSize: 10,
+      totalPages: 1,
+      totalResults: 2,
+    },
+  } as PaginatedList<PublicationListSummary>;
+
+  beforeEach(() => {
+    mockRouter.pathname = '/search-data';
+    mockRouter.query = {};
+
+    azureDataSetService.listDataSets.mockResolvedValue(testDataSetsResults);
+    azurePublicationService.listStatisticalReleases.mockResolvedValue(
+      testPublicationsResults,
+    );
+    publicationService.getPublicationTree.mockResolvedValue(
+      testPublicationTree,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('data search page', () => {
+    test('renders page with search form and results', async () => {
+      render(<SearchDataPage />);
+
+      expect(
+        await screen.findByRole('heading', {
+          name: 'Explore our education statistics',
+        }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('heading', { name: '2 results' }),
+      ).toBeInTheDocument();
+
+      expect(
+        await screen.findByTestId('data-set-file-list'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Data set 1')).toBeInTheDocument();
+      expect(screen.getByText('Data set 2')).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', { name: 'Reset filters' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('renders navigation tabs correctly', async () => {
+      render(<SearchDataPage />);
+
+      const nav = await screen.findByRole('navigation', {
+        name: 'Search mode',
+      });
+
+      const links = within(nav).getAllByRole('link');
+
+      expect(links).toHaveLength(2);
+      expect(links[0]).toHaveTextContent('Statistical releases');
+      expect(links[1]).toHaveTextContent('Data');
+      expect(links[1]).toHaveAttribute('aria-current', 'page');
+    });
+
+    test('renders help and related information section', async () => {
+      render(<SearchDataPage />);
+
+      expect(
+        await screen.findByRole('heading', {
+          name: 'Help and related information',
+        }),
+      ).toBeInTheDocument();
+
+      const helpColumn = screen.getByTestId('related-info-column');
+
+      expect(
+        within(helpColumn).getByRole('button', {
+          name: /What are statistical releases\?/,
+        }),
+      ).toBeInTheDocument();
+
+      expect(
+        within(helpColumn).getByRole('button', { name: /What is data\?/ }),
+      ).toBeInTheDocument();
+
+      expect(
+        within(helpColumn).getByRole('link', { name: 'Glossary' }),
+      ).toBeInTheDocument();
+    });
+
+    test('renders filters section', async () => {
+      render(<SearchDataPage />);
+
+      expect(
+        await screen.findByRole('heading', { name: 'Filter and sort' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('group', { name: 'Filter by Geographic Level' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('group', { name: 'Show latest or all releases' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('group', { name: 'Type of data' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('group', { name: 'Filter by Release type' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('group', { name: 'Sort by' }),
+      ).toBeInTheDocument();
+    });
+
+    test('renders skip link to results', async () => {
+      render(<SearchDataPage />);
+
+      const skipLink = await screen.findByRole('link', {
+        name: 'Skip to search results',
+      });
+
+      expect(skipLink).toHaveAttribute('href', '#searchResults');
+    });
+
+    test('displays message when no results found', async () => {
+      azureDataSetService.listDataSets.mockResolvedValue({
+        results: [],
+        paging: {
+          page: 1,
+          pageSize: 10,
+          totalPages: 0,
+          totalResults: 0,
+        },
+      });
+
+      render(<SearchDataPage />);
+
+      expect(
+        await screen.findByText('No data currently published.'),
+      ).toBeInTheDocument();
+    });
+
+    test('displays message when no results found and is filtered', async () => {
+      azureDataSetService.listDataSets.mockResolvedValue({
+        results: [],
+        paging: {
+          page: 1,
+          pageSize: 10,
+          totalPages: 0,
+          totalResults: 0,
+        },
+      });
+
+      mockRouter.pathname = '/search-data';
+      mockRouter.query = { search: 'test' };
+
+      render(<SearchDataPage />);
+
+      expect(
+        await screen.findByText('There are no matching results.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('filtering', () => {
+    test('renders default sorted by text and no filtered string', async () => {
+      render(<SearchDataPage />);
+
+      expect(await screen.findByText(/sorted by newest/i)).toBeInTheDocument();
+
+      expect(screen.queryByText('filtered by:')).not.toBeInTheDocument();
+    });
+
+    test('renders correct text when search term present', async () => {
+      mockRouter.query = { search: 'test', sortBy: 'relevance' };
+
+      render(<SearchDataPage />);
+
+      expect(
+        await screen.findByText(/sorted by relevance/i),
+      ).toBeInTheDocument();
+
+      expect(screen.getByText(/filtered by:/)).toBeInTheDocument();
+      expect(screen.getByText(/Remove filter:/i)).toBeInTheDocument();
+      expect(screen.getByText(/Search:/i)).toBeInTheDocument();
+    });
+
+    test('renders correct text when other filters present', async () => {
+      mockRouter.query = {
+        geographicLevel: 'NAT',
+        releaseType: 'AdHocStatistics',
+        dataSetType: 'api',
+      };
+
+      render(<SearchDataPage />);
+
+      expect(await screen.findByText(/filtered by:/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Ad hoc statistics, National, API data sets only/),
+      ).toBeInTheDocument();
+      const resetButtons = screen.getAllByTestId('filter-reset');
+      expect(resetButtons).toHaveLength(3);
+    });
+
+    test('does not render filter text for data filters on release search page', async () => {
+      mockRouter.pathname = '/search-releases';
+      mockRouter.query = {
+        geographicLevel: 'NAT',
+        releaseType: 'AdHocStatistics',
+        dataSetType: 'api',
+      };
+
+      render(<SearchDataPage />);
+
+      expect(await screen.findByText(/filtered by:/)).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Ad hoc statistics, National, API data sets only/),
+      ).not.toBeInTheDocument();
+      const resetButtons = screen.getAllByTestId('filter-reset');
+      expect(resetButtons).toHaveLength(1);
+    });
+  });
+
+  describe('releases search page', () => {
+    beforeEach(() => {
+      mockRouter.pathname = '/search-releases';
+    });
+
+    test('renders page with search form and results', async () => {
+      render(<SearchDataPage />);
+
+      expect(
+        await screen.findByRole('heading', {
+          name: 'Explore our education statistics',
+        }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+
+      expect(await screen.findByTestId('publicationsList')).toBeInTheDocument();
+      expect(screen.getByText('Publication 1')).toBeInTheDocument();
+      expect(screen.getByText('Publication 2')).toBeInTheDocument();
+    });
+    test('renders navigation with releases tab active', async () => {
+      render(<SearchDataPage />);
+
+      const nav = await screen.findByRole('navigation', {
+        name: 'Search mode',
+      });
+
+      const links = within(nav).getAllByRole('link');
+
+      expect(links[0]).toHaveAttribute('aria-current', 'page');
+      expect(links[1]).not.toHaveAttribute('aria-current');
+    });
+
+    test('does not show data-specific filters', async () => {
+      render(<SearchDataPage />);
+
+      await screen.findByRole('heading', { name: 'Filter and sort' });
+
+      expect(
+        screen.queryByRole('group', { name: 'Filter by Geographic Level' }),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('group', { name: 'Show latest or all releases' }),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('group', { name: 'Type of data' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/explore-education-statistics-frontend/src/modules/search-data/__tests__/__data__/testPublicationTree.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/__tests__/__data__/testPublicationTree.ts
@@ -1,0 +1,49 @@
+import { Theme } from '@common/services/publicationService';
+
+// eslint-disable-next-line import/prefer-default-export
+export const testPublicationTree: Theme[] = [
+  {
+    id: 'theme-id-1',
+    summary: 'Theme 1 summary',
+    title: 'Theme 1',
+    publications: [
+      {
+        id: 'publication-id-1',
+        slug: 'publication-slug-1',
+        title: 'Publication Title 1',
+        isSuperseded: false,
+      },
+      {
+        id: 'publication-id-2',
+        slug: 'publication-slug-2',
+        title: 'Publication Title 2',
+        isSuperseded: false,
+      },
+    ],
+  },
+  {
+    id: 'theme-id-2',
+    summary: 'Theme 2 summary',
+    title: 'Theme 2',
+    publications: [
+      {
+        id: 'publication-id-3',
+        slug: 'publication-slug-3',
+        title: 'Publication Title 3',
+        isSuperseded: false,
+      },
+      {
+        id: 'publication-id-4',
+        slug: 'publication-slug-4',
+        title: 'Publication Title 4',
+        isSuperseded: false,
+      },
+    ],
+  },
+  {
+    id: 'theme-id-3',
+    summary: 'Theme 3 summary',
+    title: 'Theme 3',
+    publications: [],
+  },
+];

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/ThemesAndReleasesFilterGroup.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/ThemesAndReleasesFilterGroup.tsx
@@ -98,7 +98,10 @@ const ThemesAndReleasesFilterGroup = ({
   };
 
   return (
-    <div className="govuk-form-group">
+    <div
+      className="govuk-form-group"
+      data-testid="themes-and-releases-filter-group"
+    >
       <FormTextSearchInput
         id="theme-publication-search"
         name="theme-publication-search"

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/ThemesAndReleasesFilterGroupReleases.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/ThemesAndReleasesFilterGroupReleases.tsx
@@ -44,7 +44,8 @@ const ThemesAndReleasesFilterGroupReleases = ({
       className={classNames(styles.expandedThemeContainer, 'govuk-fieldset')}
     >
       <legend className="govuk-fieldset__legend govuk-fieldset__legend--s govuk-!-margin-bottom-0">
-        Statistical releases
+        Statistical releases{' '}
+        <VisuallyHidden>{`for ${themeTitle}`}</VisuallyHidden>
       </legend>
       <ButtonText
         className="govuk-!-font-size-16 govuk-!-margin-bottom-2 govuk-!-display-block"

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/ExpandableFilterGroup.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/ExpandableFilterGroup.test.tsx
@@ -4,24 +4,110 @@ import { screen } from '@testing-library/react';
 import React from 'react';
 
 describe('ExpandableFilterGroup', () => {
-  test('renders correctly', () => {
+  test('renders correctly with required props', () => {
     render(
       <ExpandableFilterGroup label="Test label" id="test-id">
-        content
+        <p>Test content</p>
       </ExpandableFilterGroup>,
     );
 
     expect(
       screen.getByRole('button', { name: 'Test label - show options' }),
     ).toBeInTheDocument();
-
-    expect(screen.getByText('content')).toBeInTheDocument();
+    expect(screen.getByText('Test content')).toBeInTheDocument();
   });
 
-  test('is closed by default and expands when clicked', async () => {
+  test('renders with labelSub', () => {
+    render(
+      <ExpandableFilterGroup
+        label="Test label"
+        labelSub="Test sublabel"
+        id="test-id"
+      >
+        <p>Test content</p>
+      </ExpandableFilterGroup>,
+    );
+
+    expect(screen.getByText('Test sublabel')).toBeInTheDocument();
+  });
+
+  test('renders with labelAfter content', () => {
+    render(
+      <ExpandableFilterGroup
+        label="Test label"
+        labelAfter={<span>After label content</span>}
+        id="test-id"
+      >
+        <p>Test content</p>
+      </ExpandableFilterGroup>,
+    );
+
+    expect(screen.getByText('After label content')).toBeInTheDocument();
+  });
+
+  test('renders with custom labelHiddenText', () => {
+    render(
+      <ExpandableFilterGroup
+        label="Test label"
+        labelHiddenText=" - custom hidden text"
+        id="test-id"
+      >
+        <p>Test content</p>
+      </ExpandableFilterGroup>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Test label - custom hidden text' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders with custom testId', () => {
+    render(
+      <ExpandableFilterGroup
+        label="Test label"
+        id="test-id"
+        testId="custom-test-id"
+      >
+        <p>Test content</p>
+      </ExpandableFilterGroup>,
+    );
+
+    expect(screen.getByTestId('custom-test-id')).toBeInTheDocument();
+  });
+
+  test('is closed by default', () => {
+    render(
+      <ExpandableFilterGroup label="Test label" id="test-id">
+        <p>Test content</p>
+      </ExpandableFilterGroup>,
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'Test label - show options',
+    });
+
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(button).toHaveAttribute('aria-controls', 'test-id-content');
+  });
+
+  test('is expanded when open prop is true', () => {
+    render(
+      <ExpandableFilterGroup label="Test label" id="test-id" open>
+        <p>Test content</p>
+      </ExpandableFilterGroup>,
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'Test label - hide options',
+    });
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('clicking button toggles expanded state from closed to open', async () => {
     const { user } = render(
       <ExpandableFilterGroup label="Test label" id="test-id">
-        <h2>content</h2>
+        <p>Test content</p>
       </ExpandableFilterGroup>,
     );
 
@@ -34,18 +120,15 @@ describe('ExpandableFilterGroup', () => {
     await user.click(button);
 
     expect(button).toHaveAttribute('aria-expanded', 'true');
-
     expect(
-      screen.getByRole('button', {
-        name: 'Test label - hide options',
-      }),
+      screen.getByRole('button', { name: 'Test label - hide options' }),
     ).toBeInTheDocument();
   });
 
-  test('is expanded when open is set to true', async () => {
+  test('clicking button toggles expanded state from open to closed', async () => {
     const { user } = render(
       <ExpandableFilterGroup label="Test label" id="test-id" open>
-        <h2>content</h2>
+        <p>Test content</p>
       </ExpandableFilterGroup>,
     );
 
@@ -58,5 +141,96 @@ describe('ExpandableFilterGroup', () => {
     await user.click(button);
 
     expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(
+      screen.getByRole('button', { name: 'Test label - show options' }),
+    ).toBeInTheDocument();
+  });
+
+  test('clicking button multiple times toggles state correctly', async () => {
+    const { user } = render(
+      <ExpandableFilterGroup label="Test label" id="test-id">
+        <p>Test content</p>
+      </ExpandableFilterGroup>,
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'Test label - show options',
+    });
+
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('calls onToggle when button is clicked with correct arguments', async () => {
+    const testOnToggle = jest.fn();
+
+    const { user } = render(
+      <ExpandableFilterGroup
+        label="Test label"
+        id="test-id"
+        onToggle={testOnToggle}
+      >
+        <p>Test content</p>
+      </ExpandableFilterGroup>,
+    );
+
+    expect(testOnToggle).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Test label - show options' }),
+    );
+
+    expect(testOnToggle).toHaveBeenCalledWith(true, 'test-id');
+  });
+
+  test('calls onToggle with false when closing', async () => {
+    const testOnToggle = jest.fn();
+
+    const { user } = render(
+      <ExpandableFilterGroup
+        label="Test label"
+        id="test-id"
+        open
+        onToggle={testOnToggle}
+      >
+        <p>Test content</p>
+      </ExpandableFilterGroup>,
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'Test label - hide options' }),
+    );
+
+    expect(testOnToggle).toHaveBeenCalledWith(false, 'test-id');
+  });
+
+  test('updates expanded state when open prop changes', () => {
+    const { rerender } = render(
+      <ExpandableFilterGroup label="Test label" id="test-id">
+        <p>Test content</p>
+      </ExpandableFilterGroup>,
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'Test label - show options',
+    });
+
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    rerender(
+      <ExpandableFilterGroup label="Test label" id="test-id" open>
+        <p>Test content</p>
+      </ExpandableFilterGroup>,
+    );
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/SearchDataFilters.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/SearchDataFilters.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import Filters from '@frontend/modules/search-data/components/SearchDataFilters';
+import { PublicationSortOption } from '@frontend/modules/find-statistics/utils/publicationSortOptions';
+import { testThemeSummaries } from '@frontend/modules/find-statistics/__tests__/__data__/testThemeData';
+import { SortOption } from '@frontend/components/SortControls';
+import { testPublicationTree } from '@frontend/modules/search-data/__tests__/__data__/testPublicationTree';
+
+describe('SearchDataFilters', () => {
+  const defaultProps = {
+    includeDataFilters: true,
+    geographicLevelOptions: [
+      { label: 'National', value: 'NAT' },
+      { label: 'Local Authority', value: 'LA' },
+    ],
+    publicationTree: testPublicationTree,
+    releaseTypeOptions: [
+      {
+        label: 'Accredited Official Statistics',
+        value: 'AccreditedOfficialStatistics',
+      },
+    ],
+    sortBy: 'newest' as PublicationSortOption,
+    sortOptions: [
+      { label: 'Newest', value: 'newest' },
+      { label: 'Oldest', value: 'oldest' },
+      { label: 'A to Z', value: 'title' },
+    ] as SortOption[],
+    themes: testThemeSummaries,
+    themeOptions: [
+      { label: 'Theme 1', value: 'theme-id-1' },
+      { label: 'Theme 2', value: 'theme-id-2' },
+    ],
+    onChange: jest.fn(),
+    onChangeBatch: jest.fn(),
+    onSortChange: jest.fn(),
+  };
+
+  describe('rendering', () => {
+    test('renders correctly when includeDataFilters is true', () => {
+      render(<Filters {...defaultProps} />);
+
+      expect(screen.getByText('Filter and sort')).toBeInTheDocument();
+
+      // Should render the complex ThemesAndReleasesFilterGroup
+      expect(
+        screen.getByTestId('themes-and-releases-filter-group'),
+      ).toBeInTheDocument();
+      // Should NOT render the basic theme checkbox group
+      expect(
+        screen.queryByRole('group', { name: 'Filter by Theme' }),
+      ).not.toBeInTheDocument();
+
+      // Data-specific filters should be visible
+      expect(
+        screen.getByRole('group', { name: 'Filter by Geographic Level' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('group', { name: 'Show latest or all releases' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('group', { name: 'Type of data' }),
+      ).toBeInTheDocument();
+
+      // Universal filters should be visible
+      expect(
+        screen.getByRole('group', { name: 'Filter by Release type' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('group', { name: 'Sort by' }),
+      ).toBeInTheDocument();
+    });
+
+    test('renders correctly when includeDataFilters is false', () => {
+      render(<Filters {...defaultProps} includeDataFilters={false} />);
+
+      // Should render basic theme checkbox group instead of the complex component
+      expect(
+        screen.getByRole('group', { name: 'Filter by Theme' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('themes-and-releases-filter-group'),
+      ).not.toBeInTheDocument();
+
+      // Data-specific filters should NOT be visible
+      expect(
+        screen.queryByRole('group', { name: 'Filter by Geographic Level' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('group', { name: 'Show latest or all releases' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('group', { name: 'Type of data' }),
+      ).not.toBeInTheDocument();
+
+      // Universal filters should still be visible
+      expect(
+        screen.getByRole('group', { name: 'Filter by Release type' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('group', { name: 'Sort by' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('interactions', () => {
+    test('calls onChangeBatch from ThemesAndReleasesFilterGroup when includeDataFilters is true', async () => {
+      render(<Filters {...defaultProps} />);
+
+      await userEvent.click(screen.getByLabelText('Theme 1'));
+
+      expect(defaultProps.onChangeBatch).toHaveBeenCalledWith({
+        themeId: ['theme-id-1'],
+        publicationId: [],
+      });
+    });
+
+    test('calls onChange when a basic Theme checkbox is selected (includeDataFilters = false)', async () => {
+      render(<Filters {...defaultProps} includeDataFilters={false} />);
+
+      await userEvent.click(screen.getByLabelText('Theme 1'));
+
+      expect(defaultProps.onChange).toHaveBeenCalledWith({
+        filterType: 'themeId',
+        nextValue: 'theme-id-1',
+      });
+    });
+
+    test('calls onChange when a Geographic Level checkbox is selected', async () => {
+      render(<Filters {...defaultProps} />);
+
+      await userEvent.click(screen.getByLabelText('National'));
+
+      expect(defaultProps.onChange).toHaveBeenCalledWith({
+        filterType: 'geographicLevel',
+        nextValue: 'NAT',
+      });
+    });
+
+    test('calls onChange when a Show Latest radio is selected', async () => {
+      render(<Filters {...defaultProps} latestDataOnly />);
+
+      await userEvent.click(screen.getByLabelText('Show all releases'));
+
+      expect(defaultProps.onChange).toHaveBeenCalledWith({
+        filterType: 'latestDataOnly',
+        nextValue: 'false',
+      });
+    });
+
+    test('calls onChange when a Release Type checkbox is selected', async () => {
+      render(<Filters {...defaultProps} />);
+
+      await userEvent.click(
+        screen.getByLabelText('Accredited Official Statistics'),
+      );
+
+      expect(defaultProps.onChange).toHaveBeenCalledWith({
+        filterType: 'releaseType',
+        nextValue: 'AccreditedOfficialStatistics',
+      });
+    });
+
+    test('calls onChange when a Data Set Type radio is selected', async () => {
+      render(<Filters {...defaultProps} />);
+
+      await userEvent.click(screen.getByLabelText('API data sets only'));
+
+      expect(defaultProps.onChange).toHaveBeenCalledWith({
+        filterType: 'dataSetType',
+        nextValue: 'api',
+      });
+    });
+
+    test('calls onSortChange when a Sort By radio is selected', async () => {
+      render(<Filters {...defaultProps} />);
+
+      await userEvent.click(screen.getByLabelText('Oldest'));
+
+      expect(defaultProps.onSortChange).toHaveBeenCalledWith('oldest');
+    });
+  });
+});

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/ThemesAndReleasesFilterGroup.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/ThemesAndReleasesFilterGroup.test.tsx
@@ -1,0 +1,398 @@
+import render from '@common-test/render';
+import { screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import ThemesAndReleasesFilterGroup from '@frontend/modules/search-data/components/ThemesAndReleasesFilterGroup';
+import { testPublicationTree } from '@frontend/modules/search-data/__tests__/__data__/testPublicationTree';
+
+describe('ThemesAndReleasesFilterGroup', () => {
+  test('renders with search input and themes', () => {
+    render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        onChangeBatch={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByLabelText('Find themes and releases'),
+    ).toBeInTheDocument();
+
+    const themesGroup = screen.getByRole('group', { name: 'Themes' });
+    expect(themesGroup).toBeInTheDocument();
+
+    expect(screen.getByLabelText('Theme 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Theme 2')).toBeInTheDocument();
+    expect(screen.getByLabelText('Theme 3')).toBeInTheDocument();
+  });
+
+  test('renders all themes unchecked by default', () => {
+    render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        onChangeBatch={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('Theme 1')).not.toBeChecked();
+    expect(screen.getByLabelText('Theme 2')).not.toBeChecked();
+    expect(screen.getByLabelText('Theme 3')).not.toBeChecked();
+  });
+
+  test('renders themes checked when themeIds prop is provided', () => {
+    render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        themeIds={['theme-id-1', 'theme-id-3']}
+        onChangeBatch={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('Theme 1')).toBeChecked();
+    expect(screen.getByLabelText('Theme 2')).not.toBeChecked();
+    expect(screen.getByLabelText('Theme 3')).toBeChecked();
+  });
+
+  test('renders show publications buttons for themes with publications', () => {
+    render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        onChangeBatch={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 2',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {
+        name: /Show.*statistical releases for Theme 3/,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('checking a theme calls onChangeBatch with theme ID and empty publication IDs', async () => {
+    const testOnChangeBatch = jest.fn();
+
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        onChangeBatch={testOnChangeBatch}
+      />,
+    );
+
+    expect(testOnChangeBatch).not.toHaveBeenCalled();
+
+    await user.click(screen.getByLabelText('Theme 1'));
+
+    expect(testOnChangeBatch).toHaveBeenCalledWith(['theme-id-1'], []);
+  });
+
+  test('unchecking a theme calls onChangeBatch with theme ID removed', async () => {
+    const testOnChangeBatch = jest.fn();
+
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        themeIds={['theme-id-1']}
+        onChangeBatch={testOnChangeBatch}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('Theme 1'));
+
+    expect(testOnChangeBatch).toHaveBeenCalledWith([], []);
+  });
+
+  test('checking a theme removes any selected publications under that theme', async () => {
+    const testOnChangeBatch = jest.fn();
+
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        publicationIds={['publication-id-1', 'publication-id-2']}
+        onChangeBatch={testOnChangeBatch}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('Theme 1'));
+
+    expect(testOnChangeBatch).toHaveBeenCalledWith(['theme-id-1'], []);
+  });
+
+  test('checking a theme removes only publications under that theme', async () => {
+    const testOnChangeBatch = jest.fn();
+
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        publicationIds={['publication-id-1', 'publication-id-3']}
+        onChangeBatch={testOnChangeBatch}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('Theme 1'));
+
+    expect(testOnChangeBatch).toHaveBeenCalledWith(
+      ['theme-id-1'],
+      ['publication-id-3'],
+    );
+  });
+
+  test('filtering by search term shows only matching themes', async () => {
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        onChangeBatch={jest.fn()}
+      />,
+    );
+
+    const searchInput = screen.getByLabelText('Find themes and releases');
+
+    await user.type(searchInput, 'theme 3');
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Theme 1')).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText('Theme 2')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Theme 3')).toBeInTheDocument();
+  });
+
+  test('filtering by search term shows themes with matching publications', async () => {
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        onChangeBatch={jest.fn()}
+      />,
+    );
+
+    const searchInput = screen.getByLabelText('Find themes and releases');
+
+    await user.type(searchInput, 'tle 1');
+
+    expect(screen.getByLabelText('Theme 1')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Theme 2')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText('Theme 3')).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show 1 statistical release for Theme 1',
+      }),
+    );
+    expect(screen.getByLabelText('Publication Title 1')).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Publication Title 2'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('displays correct count message for search results', async () => {
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        onChangeBatch={jest.fn()}
+      />,
+    );
+
+    const searchInput = screen.getByLabelText('Find themes and releases');
+
+    await user.type(searchInput, 'theme');
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('3 options found', { selector: 'span[aria-live]' }),
+      ).toBeInTheDocument();
+    });
+
+    await user.type(searchInput, ' 3');
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('1 option found', { selector: 'span[aria-live]' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('displays count message including publications in search results', async () => {
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        onChangeBatch={jest.fn()}
+      />,
+    );
+
+    const searchInput = screen.getByLabelText('Find themes and releases');
+
+    await user.type(searchInput, 'title');
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('6 options found', { selector: 'span[aria-live]' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('displays no options message when search has no results', async () => {
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        onChangeBatch={jest.fn()}
+      />,
+    );
+
+    const searchInput = screen.getByLabelText('Find themes and releases');
+
+    await user.type(searchInput, 'xyz999');
+
+    await waitFor(() => {
+      expect(screen.getByText('No options available.')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText('Theme 1')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('0 options found', { selector: 'span[aria-live]' }),
+    ).toBeInTheDocument();
+  });
+
+  test('pressing Enter in search input does not submit form', async () => {
+    const testOnSubmit = jest.fn(e => e.preventDefault());
+
+    const { user } = render(
+      <form onSubmit={testOnSubmit}>
+        <ThemesAndReleasesFilterGroup
+          publicationTree={testPublicationTree}
+          onChangeBatch={jest.fn()}
+        />
+      </form>,
+    );
+
+    const searchInput = screen.getByLabelText('Find themes and releases');
+
+    await user.clear(searchInput);
+    await user.type(searchInput, 'Theme{Enter}');
+
+    expect(searchInput).toHaveValue('Theme');
+    expect(testOnSubmit).not.toHaveBeenCalled();
+  });
+
+  test('checking a publication calls onChangeBatch correctly', async () => {
+    const testOnChangeBatch = jest.fn();
+
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        onChangeBatch={testOnChangeBatch}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    );
+
+    expect(testOnChangeBatch).not.toHaveBeenCalled();
+
+    await user.click(screen.getByLabelText('Publication Title 1'));
+
+    expect(testOnChangeBatch).toHaveBeenCalledWith([], ['publication-id-1']);
+  });
+
+  test('checking a publication removes parent theme if selected', async () => {
+    const testOnChangeBatch = jest.fn();
+
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        themeIds={['theme-id-1']}
+        onChangeBatch={testOnChangeBatch}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    );
+
+    await user.click(screen.getByLabelText('Publication Title 1'));
+
+    expect(testOnChangeBatch).toHaveBeenCalledWith([], ['publication-id-1']);
+  });
+
+  test('checking a publication does not remove other selected themes', async () => {
+    const testOnChangeBatch = jest.fn();
+
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        themeIds={['theme-id-1', 'theme-id-2']}
+        onChangeBatch={testOnChangeBatch}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    );
+
+    await user.click(screen.getByLabelText('Publication Title 1'));
+
+    expect(testOnChangeBatch).toHaveBeenCalledWith(
+      ['theme-id-2'],
+      ['publication-id-1'],
+    );
+  });
+
+  test('unchecking a publication calls onChangeBatch correctly', async () => {
+    const testOnChangeBatch = jest.fn();
+
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        publicationIds={['publication-id-1']}
+        onChangeBatch={testOnChangeBatch}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    );
+
+    await user.click(screen.getByLabelText('Publication Title 1'));
+
+    expect(testOnChangeBatch).toHaveBeenCalledWith([], []);
+  });
+
+  test('publications are checked when publicationIds prop is provided', async () => {
+    const { user } = render(
+      <ThemesAndReleasesFilterGroup
+        publicationTree={testPublicationTree}
+        publicationIds={['publication-id-1', 'publication-id-3']}
+        onChangeBatch={jest.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    );
+
+    expect(screen.getByLabelText('Publication Title 1')).toBeChecked();
+    expect(screen.getByLabelText('Publication Title 2')).not.toBeChecked();
+  });
+});

--- a/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/ThemesAndReleasesFilterGroupReleases.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/components/__tests__/ThemesAndReleasesFilterGroupReleases.test.tsx
@@ -1,0 +1,180 @@
+import render from '@common-test/render';
+import { screen } from '@testing-library/react';
+import React from 'react';
+import ThemesAndReleasesFilterGroupReleases from '@frontend/modules/search-data/components/ThemesAndReleasesFilterGroupReleases';
+import { testPublicationTree } from '@frontend/modules/search-data/__tests__/__data__/testPublicationTree';
+
+describe('ThemesAndReleasesFilterGroupReleases', () => {
+  const testPublications = testPublicationTree[0].publications;
+  const testThemeId = 'theme-id-1';
+  const testThemeTitle = 'Theme 1';
+
+  test('renders collapsed by default with show button', () => {
+    render(
+      <ThemesAndReleasesFilterGroupReleases
+        publicationIds={[]}
+        publications={testPublications}
+        themeId={testThemeId}
+        themeTitle={testThemeTitle}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('group', { name: 'Statistical releases for Theme 1' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('clicking show button expands and shows publications', async () => {
+    const { user } = render(
+      <ThemesAndReleasesFilterGroupReleases
+        publicationIds={[]}
+        publications={testPublications}
+        themeId={testThemeId}
+        themeTitle={testThemeTitle}
+        onChange={jest.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    );
+
+    expect(
+      screen.getByRole('group', { name: 'Statistical releases for Theme 1' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByLabelText('Publication Title 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Publication Title 2')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Close statistical releases for Theme 1',
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Close statistical releases for Theme 1',
+      }),
+    );
+
+    expect(
+      screen.queryByRole('group', { name: 'Statistical releases for Theme 1' }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders all publications as unchecked by default', async () => {
+    const { user } = render(
+      <ThemesAndReleasesFilterGroupReleases
+        publicationIds={[]}
+        publications={testPublications}
+        themeId={testThemeId}
+        themeTitle={testThemeTitle}
+        onChange={jest.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    );
+
+    expect(screen.getByLabelText('Publication Title 1')).not.toBeChecked();
+    expect(screen.getByLabelText('Publication Title 2')).not.toBeChecked();
+  });
+
+  test('renders publications as checked when in publicationIds', async () => {
+    const { user } = render(
+      <ThemesAndReleasesFilterGroupReleases
+        publicationIds={['publication-id-1']}
+        publications={testPublications}
+        themeId={testThemeId}
+        themeTitle={testThemeTitle}
+        onChange={jest.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    );
+
+    expect(screen.getByLabelText('Publication Title 1')).toBeChecked();
+    expect(screen.getByLabelText('Publication Title 2')).not.toBeChecked();
+  });
+
+  test('checking a publication calls onChange with correct arguments', async () => {
+    const testOnChange = jest.fn();
+
+    const { user } = render(
+      <ThemesAndReleasesFilterGroupReleases
+        publicationIds={[]}
+        publications={testPublications}
+        themeId={testThemeId}
+        themeTitle={testThemeTitle}
+        onChange={testOnChange}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    );
+
+    expect(testOnChange).not.toHaveBeenCalled();
+
+    await user.click(screen.getByLabelText('Publication Title 1'));
+
+    expect(testOnChange).toHaveBeenCalledWith(
+      'theme-id-1',
+      'publication-id-1',
+      true,
+    );
+  });
+
+  test('unchecking a publication calls onChange with correct arguments', async () => {
+    const testOnChange = jest.fn();
+
+    const { user } = render(
+      <ThemesAndReleasesFilterGroupReleases
+        publicationIds={['publication-id-1']}
+        publications={testPublications}
+        themeId={testThemeId}
+        themeTitle={testThemeTitle}
+        onChange={testOnChange}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Show 2 statistical releases for Theme 1',
+      }),
+    );
+
+    await user.click(screen.getByLabelText('Publication Title 1'));
+
+    expect(testOnChange).toHaveBeenCalledWith(
+      'theme-id-1',
+      'publication-id-1',
+      false,
+    );
+  });
+});

--- a/src/explore-education-statistics-frontend/src/modules/search-data/utils/__tests__/createDataSetListRequest.test.ts
+++ b/src/explore-education-statistics-frontend/src/modules/search-data/utils/__tests__/createDataSetListRequest.test.ts
@@ -1,0 +1,323 @@
+import { SearchDataPageQuery } from '@frontend/modules/search-data/SearchDataPage';
+import createDataSetListRequest, {
+  createDataSetSuggestRequest,
+  getParamsFromQuery,
+} from '../createDataSetListRequest';
+
+jest.mock('@azure/search-documents', () => ({
+  SearchClient: jest.fn(),
+  AzureKeyCredential: jest.fn(),
+  odata: (strings: TemplateStringsArray, ...values: unknown[]) => {
+    let result = '';
+    strings.forEach((str, i) => {
+      result += str;
+      if (i < values.length) {
+        result += `'${values[i]}'`;
+      }
+    });
+    return result;
+  },
+}));
+
+describe('createDataSetListRequest', () => {
+  describe('with no filters', () => {
+    test('returns minimal request with default values', () => {
+      const testQuery: SearchDataPageQuery = {};
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result).toEqual({
+        page: 1,
+        search: '',
+        orderBy: 'published desc',
+        filter: 'latestData eq true',
+      });
+    });
+  });
+
+  describe('search term', () => {
+    test('includes search when search term is 3 characters', () => {
+      const testQuery: SearchDataPageQuery = {
+        search: 'abc',
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result.search).toBe('abc');
+    });
+
+    test('includes search when search term is more than 3 characters', () => {
+      const testQuery: SearchDataPageQuery = {
+        search: 'test search term',
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result.search).toBe('test search term');
+    });
+
+    test('excludes search when search term is less than 3 characters', () => {
+      const testQuery: SearchDataPageQuery = {
+        search: 'ab',
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result.search).toBe('');
+    });
+  });
+
+  describe('filter building', () => {
+    test('includes theme filter when themeIds provided', () => {
+      const testQuery: SearchDataPageQuery = {
+        themeId: ['theme-1', 'theme-2', 'theme-3'],
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result.filter).toBe(
+        "search.in(themeId, 'theme-1|theme-2|theme-3', '|') and latestData eq true",
+      );
+    });
+
+    test('includes publication filter when single publicationId provided', () => {
+      const testQuery: SearchDataPageQuery = {
+        publicationId: 'pub-1',
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result.filter).toBe(
+        "search.in(publicationId, 'pub-1', '|') and latestData eq true",
+      );
+    });
+
+    test('includes filter when multiple releaseTypes provided', () => {
+      const testQuery: SearchDataPageQuery = {
+        releaseType: ['AccreditedOfficialStatistics', 'OfficialStatistics'],
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result.filter).toBe(
+        "search.in(releaseType, 'AccreditedOfficialStatistics|OfficialStatistics', '|') and latestData eq true",
+      );
+    });
+
+    test('excludes realeaseType filter when invalid releaseType provided', () => {
+      const testInvalidQuery: SearchDataPageQuery = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        releaseType: 'InvalidType' as any,
+      };
+
+      const result = createDataSetListRequest(testInvalidQuery);
+
+      expect(result.filter).toBe('latestData eq true');
+    });
+
+    test('when latestDataOnly is undefined', () => {
+      const testQuery: SearchDataPageQuery = {
+        latestDataOnly: undefined,
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result.filter).toBe('latestData eq true');
+    });
+
+    test('excludes latestdata filter when latestDataOnly is false', () => {
+      const testQuery: SearchDataPageQuery = {
+        latestDataOnly: 'false',
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result.filter).toBeUndefined();
+    });
+
+    test('includes api filter when dataSetType is api', () => {
+      const testQuery: SearchDataPageQuery = {
+        dataSetType: 'api',
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result.filter).toBe(
+        "latestData eq true and api/id ne null and api/id ne ''",
+      );
+    });
+
+    test('excludes api filter when dataSetType is all', () => {
+      const testQuery: SearchDataPageQuery = {
+        dataSetType: 'all',
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result.filter).toBe('latestData eq true');
+    });
+
+    test('excludes api filter when dataSetType is undefined', () => {
+      const testQuery: SearchDataPageQuery = {
+        dataSetType: undefined,
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result.filter).toBe('latestData eq true');
+    });
+
+    test('combines themeId, publicationId, releaseType and geographicLevel filters', () => {
+      const testQuery: SearchDataPageQuery = {
+        themeId: ['theme-1', 'theme-2'],
+        publicationId: 'pub-1',
+        releaseType: ['AccreditedOfficialStatistics', 'OfficialStatistics'],
+        geographicLevel: ['NAT', 'REG'],
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result.filter).toBe(
+        "(search.in(themeId, 'theme-1|theme-2', '|') or search.in(publicationId, 'pub-1', '|')) and search.in(releaseType, 'AccreditedOfficialStatistics|OfficialStatistics', '|') and geographicLevels/any(g: search.in(g, 'NAT|REG', '|')) and latestData eq true",
+      );
+    });
+  });
+
+  describe('full request with all parameters', () => {
+    test('returns complete request with all fields', () => {
+      const testQuery: SearchDataPageQuery = {
+        page: 2,
+        search: 'test search',
+        sortBy: 'title',
+        themeId: 'theme-1',
+        publicationId: 'pub-3',
+        releaseType: 'AccreditedOfficialStatistics',
+        geographicLevel: 'NAT',
+        dataSetType: 'api',
+        latestDataOnly: 'true',
+      };
+
+      const result = createDataSetListRequest(testQuery);
+
+      expect(result).toEqual({
+        page: 2,
+        search: 'test search',
+        orderBy: 'title asc',
+        filter:
+          "(search.in(themeId, 'theme-1', '|') or search.in(publicationId, 'pub-3', '|')) and search.in(releaseType, 'AccreditedOfficialStatistics', '|') and geographicLevels/any(g: search.in(g, 'NAT', '|')) and latestData eq true and api/id ne null and api/id ne ''",
+      });
+    });
+  });
+});
+
+describe('createDataSetSuggestRequest', () => {
+  test('returns request with search term', () => {
+    const testQuery: SearchDataPageQuery = {};
+    const testSearchTerm = 'test search';
+
+    const result = createDataSetSuggestRequest(testQuery, testSearchTerm);
+
+    expect(result).toEqual({
+      page: 1,
+      search: 'test search',
+      orderBy: 'published desc',
+      filter: 'latestData eq true',
+    });
+  });
+});
+
+describe('getParamsFromQuery', () => {
+  test('returns default values when query is empty', () => {
+    const testQuery: SearchDataPageQuery = {};
+
+    const result = getParamsFromQuery(testQuery);
+
+    expect(result).toEqual({
+      dataSetType: 'all',
+      geographicLevels: undefined,
+      latestDataOnly: true,
+      page: undefined,
+      publicationIds: undefined,
+      releaseTypes: undefined,
+      search: undefined,
+      sortBy: 'newest',
+      themeIds: undefined,
+    });
+  });
+
+  test('converts single themeId to array', () => {
+    const testQuery: SearchDataPageQuery = {
+      themeId: 'theme-1',
+    };
+
+    const result = getParamsFromQuery(testQuery);
+
+    expect(result.themeIds).toEqual(['theme-1']);
+  });
+
+  test('keeps themeId array as is', () => {
+    const testQuery: SearchDataPageQuery = {
+      themeId: ['theme-1', 'theme-2'],
+    };
+
+    const result = getParamsFromQuery(testQuery);
+
+    expect(result.themeIds).toEqual(['theme-1', 'theme-2']);
+  });
+
+  test('returns latestDataOnly as true by default', () => {
+    const testQuery: SearchDataPageQuery = {};
+
+    const result = getParamsFromQuery(testQuery);
+
+    expect(result.latestDataOnly).toBe(true);
+  });
+
+  test('returns latestDataOnly as true when not false', () => {
+    const testQuery: SearchDataPageQuery = {
+      latestDataOnly: 'true',
+    };
+
+    const result = getParamsFromQuery(testQuery);
+
+    expect(result.latestDataOnly).toBe(true);
+  });
+
+  test('returns latestDataOnly as false when explicitly false', () => {
+    const testQuery: SearchDataPageQuery = {
+      latestDataOnly: 'false',
+    };
+
+    const result = getParamsFromQuery(testQuery);
+
+    expect(result.latestDataOnly).toBe(false);
+  });
+
+  test('returns dataSetType as api when specified', () => {
+    const testQuery: SearchDataPageQuery = {
+      dataSetType: 'api',
+    };
+
+    const result = getParamsFromQuery(testQuery);
+
+    expect(result.dataSetType).toBe('api');
+  });
+
+  test('returns dataSetType as all by default', () => {
+    const testQuery: SearchDataPageQuery = {};
+
+    const result = getParamsFromQuery(testQuery);
+
+    expect(result.dataSetType).toBe('all');
+  });
+
+  test('returns newest as default sortBy when undefined', () => {
+    const testQuery: SearchDataPageQuery = {
+      sortBy: undefined,
+    };
+
+    const result = getParamsFromQuery(testQuery);
+
+    expect(result.sortBy).toBe('newest');
+  });
+});


### PR DESCRIPTION
Add tests for the components added for the 'search data' prototype. 

Also add some visually hidden text to the themes/releases filters combo to differentiate release group legends.