### PR TITLE
EES-7007 - hotfix to handle null status when background screening disabled

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetFileStorageTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetFileStorageTests.cs
@@ -409,16 +409,24 @@ public class DataSetFileStorageTests
 
             Assert.NotNull(updatedDataSetUpload);
 
+            Assert.NotNull(updatedDataSetUpload.ScreenerProgress);
+            Assert.Equal(100, updatedDataSetUpload.ScreenerProgress.PercentageComplete);
+            Assert.True(updatedDataSetUpload.ScreenerProgress.Completed);
+            Assert.Equal("Complete", updatedDataSetUpload.ScreenerProgress.Stage);
+
             switch (testResult)
             {
                 case TestResult.PASS:
                     Assert.Equal(DataSetUploadScreeningStatus.PendingImport, updatedDataSetUpload.ScreeningStatus);
+                    Assert.True(updatedDataSetUpload.ScreenerProgress.Passed);
                     break;
                 case TestResult.WARNING:
                     Assert.Equal(DataSetUploadScreeningStatus.PendingReview, updatedDataSetUpload.ScreeningStatus);
+                    Assert.True(updatedDataSetUpload.ScreenerProgress.Passed);
                     break;
                 case TestResult.FAIL:
                     Assert.Equal(DataSetUploadScreeningStatus.FailedScreening, updatedDataSetUpload.ScreeningStatus);
+                    Assert.False(updatedDataSetUpload.ScreenerProgress.Passed);
                     break;
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetFileStorageTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataSetFileStorageTests.cs
@@ -365,6 +365,13 @@ public class DataSetFileStorageTests
             Assert.NotNull(result);
             Assert.Equal(DataSetUploadScreeningStatus.ScreenerError, result.ScreeningStatus);
             Assert.Null(result.ScreenerResult);
+
+            Assert.NotNull(result.ScreenerProgress);
+            Assert.NotNull(result.ScreenerProgress);
+            Assert.Equal(100, result.ScreenerProgress.PercentageComplete);
+            Assert.False(result.ScreenerProgress.Passed);
+            Assert.True(result.ScreenerProgress.Completed);
+            Assert.Equal("Screener error", result.ScreenerProgress.Stage);
         }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetFileStorage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetFileStorage.cs
@@ -222,6 +222,14 @@ public class DataSetFileStorage(
         if (screenerResult is null)
         {
             upload.ScreeningStatus = DataSetUploadScreeningStatus.ScreenerError;
+
+            upload.ScreenerProgress = new DataSetScreenerProgress
+            {
+                Completed = true,
+                Passed = false,
+                PercentageComplete = 100,
+                Stage = "Screener error",
+            };
         }
         else
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetFileStorage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataSetFileStorage.cs
@@ -242,6 +242,14 @@ public class DataSetFileStorage(
             {
                 upload.ScreeningStatus = DataSetUploadScreeningStatus.PendingImport;
             }
+
+            upload.ScreenerProgress = new DataSetScreenerProgress
+            {
+                Completed = true,
+                Passed = !hasFailures,
+                PercentageComplete = 100,
+                Stage = "Complete",
+            };
         }
 
         await contentDbContext.SaveChangesAsync(cancellationToken);

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableUploadsRow.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFilesTableUploadsRow.tsx
@@ -54,7 +54,12 @@ export default function DataFilesTableUploadRow({
     (_upload: DataSetUpload, progress: DataSetScreenerProgress) => {
       setCurrentUpload(upload => ({ ...upload, status: progress.status }));
 
-      if (terminalScreeningStatuses.includes(progress.status)) {
+      // TODO EES-7139 - change status to be non-nullable when foreground screening process
+      // is decommissioned.
+      if (
+        progress.status &&
+        terminalScreeningStatuses.includes(progress.status)
+      ) {
         onRefreshUploads();
       }
     },

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataSetUploadSummaryList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataSetUploadSummaryList.tsx
@@ -62,11 +62,19 @@ export default function DataSetUploadSummaryList({
         {dataSetUpload.dataFileSize}
       </SummaryListItem>
       <SummaryListItem term="Status">
-        <Tag
-          colour={getDataSetUploadScreeningStatusColour(dataSetUpload.status)}
-        >
-          {getDataSetUploadScreeningStatusLabel(dataSetUpload.status)}
-        </Tag>
+        {
+          // TODO EES-7139 - change status to be non-nullable when foreground
+          // screening process is decommissioned.
+        }
+        {dataSetUpload.status ? (
+          <Tag
+            colour={getDataSetUploadScreeningStatusColour(dataSetUpload.status)}
+          >
+            {getDataSetUploadScreeningStatusLabel(dataSetUpload.status)}
+          </Tag>
+        ) : (
+          <Tag colour="blue">Uploading</Tag>
+        )}
       </SummaryListItem>{' '}
       <SummaryListItem term="Uploaded by">
         <a href={uploadedByUrl}>{dataSetUpload.uploadedBy}</a>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ScreenerStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ScreenerStatus.tsx
@@ -127,23 +127,33 @@ export default function ScreenerStatus({
 
   const [cancelInterval] = useInterval(fetchStatus, 5000);
 
+  // TODO EES-7139 - change status to be non-nullable when foreground screening process
+  // is decommissioned.
   useMounted(() => {
-    if (!terminalScreeningStatuses.includes(dataSetUpload.status)) {
+    if (
+      dataSetUpload.status &&
+      !terminalScreeningStatuses.includes(dataSetUpload.status)
+    ) {
       fetchStatus();
     }
   });
 
   useEffect(() => {
-    if (terminalScreeningStatuses.includes(currentStatus.status)) {
+    if (
+      currentStatus.status &&
+      terminalScreeningStatuses.includes(currentStatus.status)
+    ) {
       cancelInterval();
     }
   }, [cancelInterval, currentStatus]);
 
-  const hasTerminalStatus = terminalScreeningStatuses.includes(
-    currentStatus.status,
-  );
+  const hasTerminalStatus =
+    currentStatus.status &&
+    terminalScreeningStatuses.includes(currentStatus.status);
 
-  return (
+  // TODO EES-7139 - remove handling for null status once the foreground screening
+  // process has been decommissioned.
+  return currentStatus.status ? (
     <>
       <Tag colour={getDataSetUploadScreeningStatusColour(currentStatus.status)}>
         {getDataSetUploadScreeningStatusLabel(currentStatus.status)}
@@ -157,5 +167,7 @@ export default function ScreenerStatus({
         />
       )}
     </>
+  ) : (
+    <Tag colour="blue">Screening</Tag>
   );
 }

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ScreenerStatus.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ScreenerStatus.test.tsx
@@ -43,6 +43,23 @@ describe('ScreenerStatus', () => {
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
+  // TODO EES-7139 - remove handling for null status once the foreground screening
+  // process has been decommissioned.
+  test('renders null status correctly', () => {
+    render(
+      <ScreenerStatus
+        releaseVersionId="release-1"
+        dataSetUpload={{
+          ...testDataSetUpload,
+          status: undefined,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Screening')).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
   test('does not fetch status from service if data set upload status is already terminal', () => {
     releaseDataFileService.getDataFileScreeningStatus.mockResolvedValue({
       status: 'PendingReview',

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -21,6 +21,8 @@ interface ReplacementDataFileInfo extends DataFileInfo {
   hasValidReplacementPlan?: boolean;
 }
 
+// TODO EES-7139 - change status to be non-nullable when foreground screening process
+// is decommissioned.
 export interface DataSetUpload {
   id: string;
   dataSetTitle: string;
@@ -28,7 +30,7 @@ export interface DataSetUpload {
   dataFileSize: string;
   metaFileName: string;
   metaFileSize: string;
-  status: DataSetUploadScreeningStatus;
+  status?: DataSetUploadScreeningStatus;
   screenerResult?: ScreenerResult; // Nullable if screening fails
   created: Date;
   uploadedBy: string;
@@ -127,8 +129,10 @@ export type DataSetUploadScreeningStatus =
 
 export type ScreenerTestResult = 'PASS' | 'FAIL' | 'WARNING';
 
+// TODO EES-7139 - change status to be non-nullable when foreground screening process
+// is decommissioned.
 export interface DataSetScreenerProgress {
-  status: DataSetUploadScreeningStatus;
+  status?: DataSetUploadScreeningStatus;
   percentageComplete: number;
   stage: string;
   completed: boolean;


### PR DESCRIPTION
This PR:
- adds temporary handling of a null screening status whilst a file is being uploaded and screened using the foreground screening process.

This bug occurred if uploading a big file using the classic screener process, and then switching away from the page and then back again when the file had uploaded but had not yet finished screening.

This switching away and back again forced the page to fetch the results of the uploads table earlier than usual (i.e. normally if a user stays on the page until the spinner disappears, they will not see this) and caught the upload in a state where it hadn't yet received a screening result.

The temp fix here is just to handle that lack of a progress update, and show "Screening" as the status until the screening is complete, upon which it will automatically update to show the final screening result.  Another part of the fix is to provide a terminal ScreenerProgress update in the backend when the classic screening finishes, so that the progress bar code can receive it and see that it's in a terminal state.

## The original problem when switching away and back again

<img width="2256" height="5010" alt="image" src="https://github.com/user-attachments/assets/1e293dd7-629c-41e2-8a6f-018b7c7f501b" />

The screening progress bar would try to show progress on a file which had no current progress details (as the feature flag is disabled and therefore no progress updates occur).

## The screen now if switching away and back again

<img width="1854" height="961" alt="image" src="https://github.com/user-attachments/assets/ba4c9349-57c6-481d-8c13-0883c2b9ef1a" />

## The status updating automatically when complete

<img width="1854" height="961" alt="image" src="https://github.com/user-attachments/assets/3262c189-5863-47b5-a9e7-5937d0762bbd" />
 