### PR TITLE
EES-6933 - updating Key Vault API versions.

### DIFF
--- a/infrastructure/templates/analytics/application/analyticsFunctionApp.bicep
+++ b/infrastructure/templates/analytics/application/analyticsFunctionApp.bicep
@@ -35,7 +35,7 @@ param functionAppExists bool
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: resourceNames.existingResources.keyVault
 }
 

--- a/infrastructure/templates/common/components/front-door/byoCertificate.bicep
+++ b/infrastructure/templates/common/components/front-door/byoCertificate.bicep
@@ -16,7 +16,7 @@ resource frontDoor 'Microsoft.Cdn/profiles@2025-04-15' existing = {
   name: frontDoorName
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: keyVaultName
 }
 

--- a/infrastructure/templates/common/components/function-app/containerisedFunctionApp.bicep
+++ b/infrastructure/templates/common/components/function-app/containerisedFunctionApp.bicep
@@ -139,7 +139,7 @@ param alerts {
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: keyVaultName
 }
 

--- a/infrastructure/templates/common/components/function-app/functionApp.bicep
+++ b/infrastructure/templates/common/components/function-app/functionApp.bicep
@@ -150,7 +150,7 @@ var fileServiceAlerts = alerts != null
   }
 : null
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: keyVaultName
 }
 

--- a/infrastructure/templates/common/components/key-vault/keyVault.bicep
+++ b/infrastructure/templates/common/components/key-vault/keyVault.bicep
@@ -22,7 +22,7 @@ param skuName 'standard' | 'premium' = 'standard'
 @description('A set of tags with which to tag the resource in Azure')
 param tagValues object
 
-resource keyvault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+resource keyvault 'Microsoft.KeyVault/vaults@2026-02-01' = {
   name: keyVaultName
   location: location
   properties: {

--- a/infrastructure/templates/common/components/key-vault/keyVaultRoleAssignment.bicep
+++ b/infrastructure/templates/common/components/key-vault/keyVaultRoleAssignment.bicep
@@ -18,7 +18,7 @@ var rolesToRoleIds = {
   'Certificate User': 'db79e9a7-68ee-4b58-9aeb-b90e7c24fcba'
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: keyVaultName
 }
 

--- a/infrastructure/templates/common/components/key-vault/keyVaultSecret.bicep
+++ b/infrastructure/templates/common/components/key-vault/keyVaultSecret.bicep
@@ -17,7 +17,7 @@ param contentType string = 'text/plain'
 param isEnabled bool = true
 
 // Reference an existing Key Vault.
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: keyVaultName
 }
 

--- a/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
+++ b/infrastructure/templates/public-api/application/public-api/publicApiApp.bicep
@@ -61,7 +61,7 @@ resource adminAppServiceIdentity 'Microsoft.ManagedIdentity/identities@2023-01-3
 var adminAppClientId = adminAppServiceIdentity.properties.clientId
 var adminAppPrincipalId = adminAppServiceIdentity.properties.principalId
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: resourceNames.existingResources.keyVault
 }
 

--- a/infrastructure/templates/public-api/main.bicep
+++ b/infrastructure/templates/public-api/main.bicep
@@ -417,7 +417,7 @@ module docsModule 'application/public-api/publicApiDocs.bicep' = if (deployDocsS
 
 var docsRewriteSetName = '${publicApiResourcePrefix}-docs-rewrites'
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: resourceNames.existingResources.keyVault
 }
 

--- a/infrastructure/templates/screener/application/screenerContainerisedFunctionApp.bicep
+++ b/infrastructure/templates/screener/application/screenerContainerisedFunctionApp.bicep
@@ -68,7 +68,7 @@ param tagValues object
 
 var eesyscreenerLogsFileShareMountPath = '/screener/logs'
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: resourceNames.existingResources.keyVault
 }
 

--- a/infrastructure/templates/screener/main.bicep
+++ b/infrastructure/templates/screener/main.bicep
@@ -65,7 +65,7 @@ param screenerFunctionAppSku AppServicePlanSku = {
   family: 'EP'
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: resourceNames.existingResources.keyVault
 }
 

--- a/infrastructure/templates/search/application/searchDocsFunctionApp.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunctionApp.bicep
@@ -64,7 +64,7 @@ param storageQueueNames SearchStorageQueueNames = {
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: resourceNames.existingResources.keyVault
 }
 

--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -34,7 +34,7 @@ param logAnalyticsWorkspaceId string
 @description('Specifies a set of tags with which to tag the resource in Azure.')
 param tagValues object
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: resourceNames.existingResources.keyVault
 }
 

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -4107,7 +4107,7 @@
     {
       "name": "[variables('keyVaultName')]",
       "type": "Microsoft.KeyVault/vaults",
-      "apiVersion": "2016-10-01",
+      "apiVersion": "2026-02-01",
       "location": "[resourceGroup().location]",
       "tags": {
         "Department": "[parameters('departmentName')]",
@@ -4133,7 +4133,6 @@
         "enabledForTemplateDeployment": true,
         "enableSoftDelete": true,
         "enablePurgeProtection": true,
-        "accessPolicies": [],
         "enableRbacAuthorization": true
       },
       "resources": [


### PR DESCRIPTION
This PR:
- updates the KV API version in ARM and Bicep templates across the board.

I've deployed the ARM template to Dev successfully.

I've deployed the Public API pipeline to Dev successfully (to show existing KVs can be looked up OK from other pipelines).

I did a  diff of an exported template of KV before and after deploying Inf, and there were no differences.

I also tried removing the `enableSoftDelete` deprecated property from KV, but this conflicted with a DfE Azure policy so I popped it back in!