### PR TITLE
EES-7201 Search infrastructure variable renaming

### DIFF
--- a/infrastructure/templates/search/application/searchDocsFunctionApp.bicep
+++ b/infrastructure/templates/search/application/searchDocsFunctionApp.bicep
@@ -24,8 +24,8 @@ param searchStorageAccountName string
 @secure()
 param searchStorageAccountConnectionStringSecretName string
 
-@description('Name of the searchable documents container in the storage account.')
-param searchableDocumentsContainerName string
+@description('Storage container name for search documents in the Search storage account.')
+param searchDocumentsContainerName string
 
 @description('The IP address ranges that can access the Search Docs Function App storage accounts.')
 param storageFirewallRules IpRange[]
@@ -91,9 +91,9 @@ resource searchBlobStorage 'Microsoft.Storage/storageAccounts/blobServices@2023-
   parent: searchStorageAccount
 }
 
-resource searchableDocumentsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' existing = {
+resource searchDocumentsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' existing = {
   parent: searchBlobStorage
-  name: searchableDocumentsContainerName
+  name: searchDocumentsContainerName
 }
 
 resource searchService 'Microsoft.Search/searchServices@2025-05-01' existing = {
@@ -113,8 +113,8 @@ module functionAppModule '../../common/components/function-app/functionApp.bicep
         value: '@Microsoft.KeyVault(VaultName=${keyVault.name};SecretName=${searchStorageAccountConnectionStringSecretName})'
       }
       {
-        name: 'App__SearchableDocumentsContainerName'
-        value: searchableDocumentsContainer.name
+        name: 'App__SearchDocumentsContainerName'
+        value: searchDocumentsContainer.name
       }
       {
         name: 'AzureSearch__SearchServiceEndpoint'

--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -11,8 +11,8 @@ param resourceNames ResourceNames
 @description('Location for all resources.')
 param location string
 
-@description('Name of the searchable documents container in the Search storage account.')
-param searchableDocumentsContainerName string = 'searchable-documents'
+@description('Storage container name for search documents in the Search storage account.')
+param searchDocumentsContainerName string = 'searchable-documents'
 
 @description('A list of IP network rules to allow access to the Search Service from specific public internet IP address ranges.')
 param searchServiceIpRules IpRange[]
@@ -96,7 +96,7 @@ module searchStorageAccountBlobServiceModule '../../common/components/blobServic
   name: 'searchStorageAccountBlobServiceModuleDeploy'
   params: {
     storageAccountName: searchStorageAccountModule.outputs.storageAccountName
-    containerNames: [searchableDocumentsContainerName]
+    containerNames: [searchDocumentsContainerName]
   }
 }
 
@@ -109,7 +109,7 @@ module searchServiceBlobRoleAssignmentModule '../../common/components/storageAcc
   }
 }
 
-output searchableDocumentsContainerName string = searchableDocumentsContainerName
+output searchDocumentsContainerName string = searchDocumentsContainerName
 output searchServiceEndpoint string = searchServiceModule.outputs.searchServiceEndpoint
 output searchServiceName string = searchServiceModule.outputs.searchServiceName
 output searchStorageAccountConnectionStringSecretName string = searchStorageAccountModule.outputs.connectionStringSecretName

--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -69,7 +69,7 @@ jobs:
                   - $(publicSiteUrl)
                   - 'http://localhost:3000'
                 dataSourceConnectionString: $(searchStorageAccountManagedIdentityConnectionString)
-                dataSourceContainerName: $(searchableDocumentsContainerName)
+                dataSourceContainerName: $(searchDocumentsContainerName)
                 indexName: ${{ variables.searchServiceIndexName }}
                 indexerName: ${{ variables.searchServiceIndexerName }}
                 searchServiceEndpoint: $(searchServiceEndpoint)

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -133,7 +133,7 @@ module searchDocsFunctionAppModule 'application/searchDocsFunctionApp.bicep' = {
     searchServiceName: searchServiceModule.outputs.searchServiceName
     searchStorageAccountName: searchServiceModule.outputs.searchStorageAccountName
     searchStorageAccountConnectionStringSecretName: searchServiceModule.outputs.searchStorageAccountConnectionStringSecretName
-    searchableDocumentsContainerName: searchServiceModule.outputs.searchableDocumentsContainerName
+    searchDocumentsContainerName: searchServiceModule.outputs.searchDocumentsContainerName
     storageFirewallRules: maintenanceIpRanges
     applicationInsightsConnectionString: monitoringModule.outputs.applicationInsightsConnectionString
     tagValues: tagValues
@@ -166,7 +166,7 @@ module searchServiceModule 'application/searchService.bicep' = {
   }
 }
 
-output searchableDocumentsContainerName string = searchServiceModule.outputs.searchableDocumentsContainerName
+output searchDocumentsContainerName string = searchServiceModule.outputs.searchDocumentsContainerName
 output searchDocsFunctionAppUrl string = searchDocsFunctionAppModule.outputs.functionAppUrl
 output searchServiceEndpoint string = searchServiceModule.outputs.searchServiceEndpoint
 output searchStorageAccountManagedIdentityConnectionString string = searchServiceModule.outputs.searchStorageAccountManagedIdentityConnectionString

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/HealthChecks/Strategies/AzureBlobStorageHealthCheckStrategyIntegrationTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Functions/HealthChecks/Strategies/AzureBlobStorageHealthCheckStrategyIntegrationTests.cs
@@ -17,7 +17,7 @@ public class AzureBlobStorageHealthCheckStrategyIntegrationTests
 
     private static AzureBlobStorageHealthCheckStrategy GetSUT(
         string? searchStorageConnectionString = null,
-        string? searchableDocumentsContainerName = null
+        string? searchDocumentsContainerName = null
     ) =>
         new(
             CreateAzureBlobStorageClientFactory(),
@@ -27,7 +27,7 @@ public class AzureBlobStorageHealthCheckStrategyIntegrationTests
                 {
                     SearchStorageConnectionString =
                         searchStorageConnectionString ?? IntegrationTestStorageAccountConnectionString,
-                    SearchableDocumentsContainerName = searchableDocumentsContainerName ?? IntegrationTestContainerName,
+                    SearchDocumentsContainerName = searchDocumentsContainerName ?? IntegrationTestContainerName,
                 }
             )
         );
@@ -57,7 +57,7 @@ public class AzureBlobStorageHealthCheckStrategyIntegrationTests
     public async Task WhenContainerNotFound_ThenShouldRespondIsUnhealthy()
     {
         //  ARRANGE
-        var sut = GetSUT(searchableDocumentsContainerName: "some-unknown-container-name");
+        var sut = GetSUT(searchDocumentsContainerName: "some-unknown-container-name");
 
         // ACT
         var healthCheckResult = await sut.Run(CancellationToken.None);
@@ -74,7 +74,7 @@ public class AzureBlobStorageHealthCheckStrategyIntegrationTests
     {
         //  ARRANGE
         // Missing container name
-        var sut = GetSUT(searchableDocumentsContainerName: string.Empty);
+        var sut = GetSUT(searchDocumentsContainerName: string.Empty);
 
         // ACT
         var healthCheckResult = await sut.Run(CancellationToken.None);
@@ -82,8 +82,10 @@ public class AzureBlobStorageHealthCheckStrategyIntegrationTests
         // ASSERT
         Assert.NotNull(healthCheckResult);
         Assert.False(healthCheckResult.IsHealthy);
-        Assert.Contains("Container", healthCheckResult.Message);
-        Assert.Contains("config", healthCheckResult.Message);
+        Assert.Contains(
+            "Search Documents Azure Blob Storage container name is not configured.",
+            healthCheckResult.Message
+        );
     }
 
     [Fact]
@@ -98,7 +100,6 @@ public class AzureBlobStorageHealthCheckStrategyIntegrationTests
         // ASSERT
         Assert.NotNull(healthCheckResult);
         Assert.False(healthCheckResult.IsHealthy);
-        Assert.Contains("Connection String", healthCheckResult.Message);
-        Assert.Contains("config", healthCheckResult.Message);
+        Assert.Contains("Search Azure Storage account connection string is not configured.", healthCheckResult.Message);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/ProgramTests.cs
@@ -18,7 +18,7 @@ public class ProgramTests
          {
              "App": {
                  "SearchStorageConnectionString": "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=mystorageaccount;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=https://mystorageaccount.blob.core.windows.net/;FileEndpoint=https://mystorageaccount.file.core.windows.net/;QueueEndpoint=https://mystorageaccount.queue.core.windows.net/;TableEndpoint=https://mystorageaccount.table.core.windows.net/",
-                 "SearchableDocumentsContainerName": "searchable-documents-container-name"
+                 "SearchDocumentsContainerName": "search-documents-container-name"
              },
              "ContentApi": {
                  "Url": "http://contentapi.test.url:8123"
@@ -165,7 +165,7 @@ public class ProgramTests
                     {
                        "App": {
                             "SearchStorageConnectionString": "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=mystorageaccount;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=https://mystorageaccount.blob.core.windows.net/;FileEndpoint=https://mystorageaccount.file.core.windows.net/;QueueEndpoint=https://mystorageaccount.queue.core.windows.net/;TableEndpoint=https://mystorageaccount.table.core.windows.net/",
-                            "SearchableDocumentsContainerName": "searchable-documents-container-name"
+                            "SearchDocumentsContainerName": "search-documents-container-name"
                        }
                     }
                     """
@@ -193,7 +193,7 @@ public class ProgramTests
                         {
                            "App": {
                                 "SearchStorageConnectionString": null,
-                                "SearchableDocumentsContainerName": "searchable-documents-container-name"
+                                "SearchDocumentsContainerName": "search-documents-container-name"
                            }
                         }
                         """
@@ -218,7 +218,7 @@ public class ProgramTests
                         {
                            "App": {
                                 "SearchStorageConnectionString": "UseDevelopmentStorage=true",
-                                "SearchableDocumentsContainerName": null
+                                "SearchDocumentsContainerName": null
                            }
                         }
                         """

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/CreateSearchableDocuments/SearchableDocumentCreatorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/CreateSearchableDocuments/SearchableDocumentCreatorTests.cs
@@ -47,10 +47,10 @@ public class SearchableDocumentCreatorTests
         public async Task Should_upload_searchable_document_to_expected_AzureBlobStorage_container()
         {
             // ARRANGE
-            _appOptions = new AppOptions()
+            _appOptions = new AppOptions
             {
                 SearchStorageConnectionString = "azure storage connection string",
-                SearchableDocumentsContainerName = "searchable-documents-container-name",
+                SearchDocumentsContainerName = "search-documents-container-name",
             };
 
             var sut = GetSut();
@@ -62,7 +62,7 @@ public class SearchableDocumentCreatorTests
 
             // ASSERT
             _azureBlobStorageClientMockBuilder.Assert.BlobWasUploaded(
-                containerName: _appOptions.SearchableDocumentsContainerName
+                containerName: _appOptions.SearchDocumentsContainerName
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/RemoveSearchableDocuments/SearchableDocumentRemoverTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp.Tests/Services/RemoveSearchableDocuments/SearchableDocumentRemoverTests.cs
@@ -53,7 +53,7 @@ public class SearchableDocumentRemoverTests
             _appOptions = new AppOptions
             {
                 SearchStorageConnectionString = "azure storage connection string",
-                SearchableDocumentsContainerName = "searchable-documents-container-name",
+                SearchDocumentsContainerName = "search-documents-container-name",
             };
 
             Guid[] releaseIds = [Guid.NewGuid()];
@@ -63,7 +63,7 @@ public class SearchableDocumentRemoverTests
             await GetSut().RemovePublicationSearchableDocuments(request);
 
             _azureBlobStorageClientMockBuilder.Assert.BlobWasDeleted(
-                containerName: _appOptions.SearchableDocumentsContainerName
+                containerName: _appOptions.SearchDocumentsContainerName
             );
         }
 
@@ -105,7 +105,7 @@ public class SearchableDocumentRemoverTests
             _appOptions = new AppOptions
             {
                 SearchStorageConnectionString = "azure storage connection string",
-                SearchableDocumentsContainerName = "searchable-documents-container-name",
+                SearchDocumentsContainerName = "search-documents-container-name",
             };
 
             var releaseId = Guid.NewGuid();
@@ -117,7 +117,7 @@ public class SearchableDocumentRemoverTests
 
             // Assert
             _azureBlobStorageClientMockBuilder.Assert.BlobWasDeleted(
-                containerName: _appOptions.SearchableDocumentsContainerName
+                containerName: _appOptions.SearchDocumentsContainerName
             );
         }
 
@@ -159,11 +159,11 @@ public class SearchableDocumentRemoverTests
         public async Task ShouldDeleteBlobsFromExpectedStorageContainer()
         {
             // Arrange
-            var searchableDocumentsContainerName = "searchable-documents-container-name";
+            var searchDocumentsContainerName = "search-documents-container-name";
             _appOptions = new AppOptions
             {
                 SearchStorageConnectionString = "azure storage connection string",
-                SearchableDocumentsContainerName = searchableDocumentsContainerName,
+                SearchDocumentsContainerName = searchDocumentsContainerName,
             };
             var sut = GetSut();
 
@@ -171,7 +171,7 @@ public class SearchableDocumentRemoverTests
             await sut.RemoveAllSearchableDocuments();
 
             // Assert
-            _azureBlobStorageClientMockBuilder.Assert.AllBlobsWereDeleted(searchableDocumentsContainerName);
+            _azureBlobStorageClientMockBuilder.Assert.AllBlobsWereDeleted(searchDocumentsContainerName);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureBlobStorageHealthCheckStrategy.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Functions/HealthChecks/Strategies/AzureBlobStorageHealthCheckStrategy.cs
@@ -11,49 +11,52 @@ internal class AzureBlobStorageHealthCheckStrategy(
     IOptions<AppOptions> appOptions
 ) : IHealthCheckStrategy
 {
-    public string Description => "Azure blob storage check";
+    public string Description => "Search Documents Azure Blob Storage container check";
 
     public async Task<HealthCheckResult> Run(CancellationToken cancellationToken)
     {
-        logger.LogInformation("Running Azure blob storage health check");
+        logger.LogInformation("Running Search Documents Azure Blob Storage container health check");
 
         if (!appOptions.Value.IsValid(out var errorMessage))
         {
             logger.LogWarning(
-                "Azure blob storage health check failed: Provider options are not valid. {@Options}",
+                "Search Documents Azure Blob Storage container health check failed: Provider options are not valid. {@Options}",
                 appOptions.Value
             );
             return new HealthCheckResult(this, false, errorMessage);
         }
 
-        var containerName = appOptions.Value.SearchableDocumentsContainerName;
+        var containerName = appOptions.Value.SearchDocumentsContainerName;
         if (string.IsNullOrWhiteSpace(containerName))
         {
             logger.LogWarning(
-                "Azure blob storage health check failed: Container name is not specified in configuration."
+                "Search Documents Azure Blob Storage container health check failed: Search Documents container name is not specified in configuration."
             );
             return new HealthCheckResult(
                 this,
                 false,
-                $"Azure blob storage container name is not specified in {AppOptions.Section}.{nameof(AppOptions.SearchableDocumentsContainerName)}"
+                $"Search Documents Azure Blob Storage container name is not specified in {AppOptions.Section}.{nameof(AppOptions.SearchDocumentsContainerName)}"
             );
         }
 
         try
         {
             logger.LogInformation(
-                "Attempting to connect to Azure blob storage container '{ContainerName}'...",
+                "Attempting to connect to Search Documents Azure Blob Storage container '{ContainerName}'...",
                 containerName
             );
             var azureBlobStorageClient = azureBlobStorageClientFactory();
             var containerExists = await azureBlobStorageClient.ContainerExists(containerName, cancellationToken);
             if (!containerExists)
             {
-                logger.LogWarning("Azure blob storage container '{ContainerName}' is not found.", containerName);
+                logger.LogWarning(
+                    "Search Documents Azure Blob Storage container '{ContainerName}' is not found.",
+                    containerName
+                );
                 return new HealthCheckResult(
                     this,
                     false,
-                    $"Azure blob storage container '{containerName}' is not found"
+                    $"Search Documents Azure Blob Storage container '{containerName}' is not found"
                 );
             }
         }
@@ -61,21 +64,21 @@ internal class AzureBlobStorageHealthCheckStrategy(
         {
             logger.LogError(
                 e,
-                "Error occurred whilst trying to check for Azure blob storage container '{ContainerName}': {Message}",
+                "Error occurred whilst trying to check for Search Documents Azure Blob Storage container '{ContainerName}': {Message}",
                 containerName,
                 e.Message
             );
             return new HealthCheckResult(
                 this,
                 false,
-                $"Error occurred whilst trying to check for Azure blob storage container '{containerName}': {e.Message}"
+                $"Error occurred whilst trying to check for Search Documents Azure Blob Storage container '{containerName}': {e.Message}"
             );
         }
 
         logger.LogInformation(
-            "Health check was successful: Azure blob storage container '{ContainerName}' is found.",
+            "Health check was successful: Search Documents Azure Blob Storage container '{ContainerName}' is found.",
             containerName
         );
-        return new HealthCheckResult(this, true, "Connection to Azure blob storage container:OK");
+        return new HealthCheckResult(this, true, "Connection to Search Documents Azure Blob Storage container:OK");
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Options/AppOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Options/AppOptions.cs
@@ -6,7 +6,7 @@ public class AppOptions
 {
     public const string Section = "App";
     public string SearchStorageConnectionString { get; init; } = string.Empty;
-    public string SearchableDocumentsContainerName { get; init; } = string.Empty;
+    public string SearchDocumentsContainerName { get; init; } = string.Empty;
 
     public bool IsValid([NotNullWhen(false)] out string? errorMessage)
     {
@@ -15,12 +15,12 @@ public class AppOptions
         if (string.IsNullOrWhiteSpace(SearchStorageConnectionString))
         {
             errorMessage +=
-                $"Azure Search Storage Connection String is not configured. Ensure the {Section}:{nameof(SearchStorageConnectionString)} is set. ";
+                $"Search Azure Storage account connection string is not configured. Ensure the {Section}:{nameof(SearchStorageConnectionString)} is set. ";
         }
-        if (string.IsNullOrWhiteSpace(SearchableDocumentsContainerName))
+        if (string.IsNullOrWhiteSpace(SearchDocumentsContainerName))
         {
             errorMessage +=
-                $"Azure Search Storage Container Name is not configured. Ensure the {Section}:{nameof(SearchableDocumentsContainerName)} is set.";
+                $"Search Documents Azure Blob Storage container name is not configured. Ensure the {Section}:{nameof(SearchDocumentsContainerName)} is set.";
         }
 
         return errorMessage == string.Empty;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/CheckSearchableDocuments/BlobNameLister.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/CheckSearchableDocuments/BlobNameLister.cs
@@ -19,7 +19,7 @@ public class BlobNameLister(
         // Get a list of all blobs
         var blobStorageClient = azureBlobStorageClientFactory();
         var blobNames = await blobStorageClient.ListBlobsInContainer(
-            appOptions.Value.SearchableDocumentsContainerName,
+            appOptions.Value.SearchDocumentsContainerName,
             cancellationToken: cancellationToken
         );
         return blobNames;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/CreateSearchableDocuments/SearchableDocumentCreator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/CreateSearchableDocuments/SearchableDocumentCreator.cs
@@ -31,7 +31,7 @@ internal class SearchableDocumentCreator(
 
         var blobName = releaseSearchableDocument.ReleaseId.ToString();
         await azureBlobStorageClient.UploadBlob(
-            containerName: appOptions.Value.SearchableDocumentsContainerName,
+            containerName: appOptions.Value.SearchDocumentsContainerName,
             blobName: blobName,
             blob: new Blob(releaseSearchableDocument.HtmlContent, releaseSearchableDocument.BuildMetadata()),
             contentType: MediaTypeNames.Text.Html,

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/RemoveSearchableDocument/SearchableDocumentRemover.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/Services/RemoveSearchableDocument/SearchableDocumentRemover.cs
@@ -43,7 +43,7 @@ internal class SearchableDocumentRemover(
         var blobName = request.ReleaseId.ToString();
 
         var success = await azureBlobStorageClient.DeleteBlobIfExists(
-            appOptions.Value.SearchableDocumentsContainerName,
+            appOptions.Value.SearchDocumentsContainerName,
             blobName,
             cancellationToken
         );
@@ -54,7 +54,7 @@ internal class SearchableDocumentRemover(
     public async Task RemoveAllSearchableDocuments(CancellationToken cancellationToken = default)
     {
         await azureBlobStorageClient.DeleteAllBlobsFromContainer(
-            appOptions.Value.SearchableDocumentsContainerName,
+            appOptions.Value.SearchDocumentsContainerName,
             cancellationToken
         );
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "App": {
     "SearchStorageConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;",
-    "SearchDocumentsContainerName": "search-documents"
+    "SearchDocumentsContainerName": "searchable-documents"
   },
   "ContentApi": {
     "Url": "http://localhost:5010"

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Search.FunctionApp/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "App": {
     "SearchStorageConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;",
-    "SearchableDocumentsContainerName": "searchable-documents"
+    "SearchDocumentsContainerName": "search-documents"
   },
   "ContentApi": {
     "Url": "http://localhost:5010"


### PR DESCRIPTION
This pull request changes the naming of the storage container used for search documents across the Search infrastructure and Search Docs Function App environment, from the 'searchable documents container' to the 'search documents containers. I.e. it removes the _-able_.

This change is being made because EES-7163 (in another change) plans to introduce two new types of search document containers:

- Natural language search documents (container name: `nl-search-documents`)
- Natural language dataset search documents (container name: `nl-dataset-search-documents`)

The renaming in this PR from `searchableDocumentsContainerName`  to `searchDocumentsContainerName` is being done to ensure there's a consistent  naming convention when new variables such as `nlSearchDocumentsContainerName` and `nlDataSetSearchDocumentsContainerName` are eventually added.

**This doesn't change the actual container name in Azure environments which is still 'searchable-documents'. It only affects variable naming.** We could eventually rename the actual container, but this will require some coordination with deploying and repopulating all of the search documents.

It's also likely that we'll eventually come up with a less generic term for the existing set of search documents and do some further renaming.