### PR TITLE
EES-7202 Add new storage containers for natural language search documents

### DIFF
--- a/infrastructure/templates/search/application/searchService.bicep
+++ b/infrastructure/templates/search/application/searchService.bicep
@@ -11,8 +11,12 @@ param resourceNames ResourceNames
 @description('Location for all resources.')
 param location string
 
-@description('Storage container name for search documents in the Search storage account.')
-param searchDocumentsContainerName string = 'searchable-documents'
+@description('Storage container names for search documents. A container for each value will be created in the Search storage account.')
+param searchStorageDocumentContainers object = {
+  searchDocuments: 'searchable-documents'
+  nlSearchDocuments: 'nl-search-documents'
+  nlDatasetSearchDocuments: 'nl-dataset-search-documents'
+}
 
 @description('A list of IP network rules to allow access to the Search Service from specific public internet IP address ranges.')
 param searchServiceIpRules IpRange[]
@@ -48,6 +52,7 @@ resource searchStoragePrivateEndpointSubnet 'Microsoft.Network/virtualNetworks/s
 }
 
 var searchServiceName = '${resourcePrefix}-${abbreviations.searchSearchServices}'
+var searchStorageDocumentContainerNames = map(items(searchStorageDocumentContainers), item => item.value)
 
 module searchServiceModule '../components/searchService.bicep' = {
   name: 'searchServiceModuleDeploy'
@@ -96,7 +101,7 @@ module searchStorageAccountBlobServiceModule '../../common/components/blobServic
   name: 'searchStorageAccountBlobServiceModuleDeploy'
   params: {
     storageAccountName: searchStorageAccountModule.outputs.storageAccountName
-    containerNames: [searchDocumentsContainerName]
+    containerNames: searchStorageDocumentContainerNames
   }
 }
 
@@ -109,9 +114,9 @@ module searchServiceBlobRoleAssignmentModule '../../common/components/storageAcc
   }
 }
 
-output searchDocumentsContainerName string = searchDocumentsContainerName
 output searchServiceEndpoint string = searchServiceModule.outputs.searchServiceEndpoint
 output searchServiceName string = searchServiceModule.outputs.searchServiceName
 output searchStorageAccountConnectionStringSecretName string = searchStorageAccountModule.outputs.connectionStringSecretName
 output searchStorageAccountManagedIdentityConnectionString string = 'ResourceId=${searchStorageAccountModule.outputs.storageAccountId};'
 output searchStorageAccountName string = searchStorageAccountModule.outputs.storageAccountName
+output searchStorageDocumentContainers object = searchStorageDocumentContainers

--- a/infrastructure/templates/search/main.bicep
+++ b/infrastructure/templates/search/main.bicep
@@ -133,7 +133,7 @@ module searchDocsFunctionAppModule 'application/searchDocsFunctionApp.bicep' = {
     searchServiceName: searchServiceModule.outputs.searchServiceName
     searchStorageAccountName: searchServiceModule.outputs.searchStorageAccountName
     searchStorageAccountConnectionStringSecretName: searchServiceModule.outputs.searchStorageAccountConnectionStringSecretName
-    searchDocumentsContainerName: searchServiceModule.outputs.searchDocumentsContainerName
+    searchDocumentsContainerName: searchServiceModule.outputs.searchStorageDocumentContainers.searchDocuments
     storageFirewallRules: maintenanceIpRanges
     applicationInsightsConnectionString: monitoringModule.outputs.applicationInsightsConnectionString
     tagValues: tagValues
@@ -166,7 +166,9 @@ module searchServiceModule 'application/searchService.bicep' = {
   }
 }
 
-output searchDocumentsContainerName string = searchServiceModule.outputs.searchDocumentsContainerName
 output searchDocsFunctionAppUrl string = searchDocsFunctionAppModule.outputs.functionAppUrl
 output searchServiceEndpoint string = searchServiceModule.outputs.searchServiceEndpoint
 output searchStorageAccountManagedIdentityConnectionString string = searchServiceModule.outputs.searchStorageAccountManagedIdentityConnectionString
+output searchDocumentsContainerName string = searchServiceModule.outputs.searchStorageDocumentContainers.searchDocuments
+output nlSearchDocumentsContainerName string = searchServiceModule.outputs.searchStorageDocumentContainers.nlSearchDocuments
+output nlDatasetSearchDocumentsContainerName string = searchServiceModule.outputs.searchStorageDocumentContainers.nlDatasetSearchDocuments


### PR DESCRIPTION
⚠️ This change depends on #7041.

This PR adds two new storage containers to the Search storage account:

Natural language search documents (container name: `nl-search-documents`).
Natural language dataset search documents (container name: `nl-dataset-search-documents`)

These will be created automatically the first time this new change is deployed, by including them in [searchService.bicep:L104](https://github.com/dfe-analytical-services/explore-education-statistics/pull/7042/changes#diff-2dbd08f85a91f21a69b6fda9bf05b155fa0d70296b5c638a1d16fd7bee8fc9e5R104).
