### PR TITLE
EES-7165 Infrastructure to deploy natural language search index, indexer and data source configuration

### DIFF
--- a/infrastructure/templates/search/application/indexer-output-field-mappings/index-1.json
+++ b/infrastructure/templates/search/application/indexer-output-field-mappings/index-1.json
@@ -1,0 +1,52 @@
+[
+  {
+    "sourceFieldName": "/document/summary",
+    "targetFieldName": "summary",
+    "mappingFunction": {
+      "name": "base64Decode",
+      "parameters": {
+        "useHttpServerUtilityUrlTokenDecode": false
+      }
+    }
+  },
+  {
+    "sourceFieldName": "/document/publicationSlug",
+    "targetFieldName": "publicationSlug",
+    "mappingFunction": {
+      "name": "base64Decode",
+      "parameters": {
+        "useHttpServerUtilityUrlTokenDecode": false
+      }
+    }
+  },
+  {
+    "sourceFieldName": "/document/releaseSlug",
+    "targetFieldName": "releaseSlug",
+    "mappingFunction": {
+      "name": "base64Decode",
+      "parameters": {
+        "useHttpServerUtilityUrlTokenDecode": false
+      }
+    }
+  },
+  {
+    "sourceFieldName": "/document/themeTitle",
+    "targetFieldName": "themeTitle",
+    "mappingFunction": {
+      "name": "base64Decode",
+      "parameters": {
+        "useHttpServerUtilityUrlTokenDecode": false
+      }
+    }
+  },
+  {
+    "sourceFieldName": "/document/title",
+    "targetFieldName": "title",
+    "mappingFunction": {
+      "name": "base64Decode",
+      "parameters": {
+        "useHttpServerUtilityUrlTokenDecode": false
+      }
+    }
+  }
+]

--- a/infrastructure/templates/search/application/indexes/nl-dataset-search-index.json
+++ b/infrastructure/templates/search/application/indexes/nl-dataset-search-index.json
@@ -1,0 +1,390 @@
+{
+  "name": "nl-dataset-search-index",
+  "analyzers": [],
+  "charFilters": [],
+  "fields": [
+    {
+      "name": "fileId",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": true,
+      "synonymMaps": []
+    },
+    {
+      "name": "dataSetFileId",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "filename",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "fileSize",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "fileExtension",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "title",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": true,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    },
+    {
+      "name": "content",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    },
+    {
+      "name": "themeId",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "themeTitle",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    },
+    {
+      "name": "publicationId",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "publicationTitle",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    },
+    {
+      "name": "publicationSlug",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "releaseId",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "releaseTitle",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    },
+    {
+      "name": "releaseSlug",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "latestData",
+      "type": "Edm.Boolean",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "isSuperseded",
+      "type": "Edm.Boolean",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "published",
+      "type": "Edm.DateTimeOffset",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": true,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "lastUpdated",
+      "type": "Edm.DateTimeOffset",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": true,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "api",
+      "type": "Edm.ComplexType",
+      "fields": [
+        {
+          "name": "version",
+          "type": "Edm.String",
+          "searchable": false,
+          "filterable": true,
+          "retrievable": true,
+          "stored": true,
+          "sortable": true,
+          "facetable": true,
+          "key": false,
+          "synonymMaps": []
+        },
+        {
+          "name": "id",
+          "type": "Edm.String",
+          "searchable": false,
+          "filterable": true,
+          "retrievable": true,
+          "stored": true,
+          "sortable": true,
+          "facetable": true,
+          "key": false,
+          "synonymMaps": []
+        }
+      ]
+    },
+    {
+      "name": "numDataFileRows",
+      "type": "Edm.Int32",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "geographicLevels",
+      "type": "Collection(Edm.String)",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "geographicLevelsLabels",
+      "type": "Collection(Edm.String)",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "timePeriodRange",
+      "type": "Edm.ComplexType",
+      "fields": [
+        {
+          "name": "from",
+          "type": "Edm.String",
+          "searchable": false,
+          "filterable": true,
+          "retrievable": true,
+          "stored": true,
+          "sortable": true,
+          "facetable": true,
+          "key": false,
+          "synonymMaps": []
+        },
+        {
+          "name": "to",
+          "type": "Edm.String",
+          "searchable": false,
+          "filterable": true,
+          "retrievable": true,
+          "stored": true,
+          "sortable": true,
+          "facetable": true,
+          "key": false,
+          "synonymMaps": []
+        }
+      ]
+    },
+    {
+      "name": "indicators",
+      "type": "Collection(Edm.String)",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "filters",
+      "type": "Collection(Edm.String)",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "releaseType",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    }
+  ],
+  "scoringProfiles": [],
+  "similarity": {
+    "@odata.type": "#Microsoft.Azure.Search.BM25Similarity"
+  },
+  "suggesters": [
+    {
+      "name": "suggester-dataset-search",
+      "searchMode": "analyzingInfixMatching",
+      "sourceFields": [
+        "dataSetFileId",
+        "title",
+        "content"
+      ]
+    }
+  ],
+  "tokenFilters": [],
+  "tokenizers": []
+}

--- a/infrastructure/templates/search/application/indexes/nl-search-index.json
+++ b/infrastructure/templates/search/application/indexes/nl-search-index.json
@@ -1,0 +1,198 @@
+{
+  "name": "nl-search-index",
+  "analyzers": [],
+  "charFilters": [],
+  "fields": [
+    {
+      "name": "filterGroupId",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": true,
+      "synonymMaps": []
+    },
+    {
+      "name": "fileId",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "dataSetFileId",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "datasetTitle",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    },
+    {
+      "name": "publicationId",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "publicationTitle",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "filterCategory",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    },
+    {
+      "name": "filterName",
+      "type": "Edm.String",
+      "searchable": true,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    },
+    {
+      "name": "filterValues",
+      "type": "Collection(Edm.String)",
+      "searchable": true,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "analyzer": "standard.lucene",
+      "synonymMaps": []
+    },
+    {
+      "name": "indicators",
+      "type": "Collection(Edm.String)",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "latestData",
+      "type": "Edm.Boolean",
+      "searchable": false,
+      "filterable": true,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "embeddingText",
+      "type": "Edm.String",
+      "searchable": false,
+      "filterable": false,
+      "retrievable": true,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "synonymMaps": []
+    },
+    {
+      "name": "embedding",
+      "type": "Collection(Edm.Single)",
+      "searchable": true,
+      "filterable": false,
+      "retrievable": false,
+      "stored": true,
+      "sortable": false,
+      "facetable": false,
+      "key": false,
+      "dimensions": 1536,
+      "vectorSearchProfile": "nl-search-index-vector-profile",
+      "synonymMaps": []
+    }
+  ],
+  "scoringProfiles": [],
+  "similarity": {
+    "@odata.type": "#Microsoft.Azure.Search.BM25Similarity"
+  },
+  "suggesters": [],
+  "tokenFilters": [],
+  "tokenizers": [],
+  "vectorSearch": {
+    "algorithms": [
+      {
+        "name": "nl-search-index-hnsw",
+        "kind": "hnsw",
+        "hnswParameters": {
+          "metric": "cosine",
+          "m": 4,
+          "efConstruction": 400,
+          "efSearch": 500
+        }
+      }
+    ],
+    "profiles": [
+      {
+        "name": "nl-search-index-vector-profile",
+        "algorithm": "nl-search-index-hnsw"
+      }
+    ],
+    "vectorizers": [],
+    "compressions": []
+  }
+}

--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -20,10 +20,24 @@ jobs:
         value: $(templateDirectory)/parameters
       - name: paramFile
         value: $(paramDirectory)/main-${{ parameters.bicepParamFile }}.bicepparam
-      - name: searchServiceIndexName
+      - name: searchServiceSearchIndexName
         value: 'index-1'
-      - name: searchServiceIndexerName
-        value: ${{ variables.searchServiceIndexName }}-indexer
+      - name: searchServiceSearchIndexerName
+        value: ${{ variables.searchServiceSearchIndexName }}-indexer
+      - name: searchServiceSearchIndexerParsingMode
+        value: 'default'
+      - name: searchServiceNLSearchIndexName
+        value: 'nl-search-index'
+      - name: searchServiceNLSearchIndexerName
+        value: ${{ variables.searchServiceNLSearchIndexName }}-indexer
+      - name: searchServiceNLSearchIndexerParsingMode
+        value: 'json'
+      - name: searchServiceNLDatasetSearchIndexName
+        value: 'nl-dataset-search-index'
+      - name: searchServiceNLDatasetSearchIndexerName
+        value: ${{ variables.searchServiceNLDatasetSearchIndexName }}-indexer
+      - name: searchServiceNLDatasetSearchIndexerParsingMode
+        value: 'json'
     strategy:
       runOnce:
         deploy:
@@ -62,6 +76,7 @@ jobs:
               parameters:
                 serviceConnection: ${{ parameters.serviceConnection }}
 
+            # Deploy Azure AI Search index/indexer/data source configuration for search documents
             - template: ../tasks/deploy-search-service-config.yml
               parameters:
                 serviceConnection: ${{ parameters.serviceConnection }}
@@ -70,6 +85,36 @@ jobs:
                   - 'http://localhost:3000'
                 dataSourceConnectionString: $(searchStorageAccountManagedIdentityConnectionString)
                 dataSourceContainerName: $(searchDocumentsContainerName)
-                indexName: ${{ variables.searchServiceIndexName }}
-                indexerName: ${{ variables.searchServiceIndexerName }}
+                indexName: ${{ variables.searchServiceSearchIndexName }}
+                indexerName: ${{ variables.searchServiceSearchIndexerName }}
+                indexerOutputFieldMappingsFilePath: $(templateDirectory)/application/indexer-output-field-mappings/index-1.json
+                indexerParsingMode: ${{ variables.searchServiceSearchIndexerParsingMode }}
+                searchServiceEndpoint: $(searchServiceEndpoint)
+
+            # Deploy Azure AI Search index/indexer/data source configuration for natural language search documents
+            - template: ../tasks/deploy-search-service-config.yml
+              parameters:
+                serviceConnection: ${{ parameters.serviceConnection }}
+                indexCorsAllowedOrigins:
+                  - $(publicSiteUrl)
+                  - 'http://localhost:3000'
+                dataSourceConnectionString: $(searchStorageAccountManagedIdentityConnectionString)
+                dataSourceContainerName: $(nlSearchDocumentsContainerName)
+                indexName: ${{ variables.searchServiceNLSearchIndexName }}
+                indexerName: ${{ variables.searchServiceNLSearchIndexerName }}
+                indexerParsingMode: ${{ variables.searchServiceNLSearchIndexerParsingMode }}
+                searchServiceEndpoint: $(searchServiceEndpoint)
+
+            # Deploy Azure AI Search index/indexer/data source configuration for natural language dataset search documents
+            - template: ../tasks/deploy-search-service-config.yml
+              parameters:
+                serviceConnection: ${{ parameters.serviceConnection }}
+                indexCorsAllowedOrigins:
+                  - $(publicSiteUrl)
+                  - 'http://localhost:3000'
+                dataSourceConnectionString: $(searchStorageAccountManagedIdentityConnectionString)
+                dataSourceContainerName: $(nlDatasetSearchDocumentsContainerName)
+                indexName: ${{ variables.searchServiceNLDatasetSearchIndexName }}
+                indexerName: ${{ variables.searchServiceNLDatasetSearchIndexerName }}
+                indexerParsingMode: ${{ variables.searchServiceNLDatasetSearchIndexerParsingMode }}
                 searchServiceEndpoint: $(searchServiceEndpoint)

--- a/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
+++ b/infrastructure/templates/search/ci/jobs/deploy-infrastructure.yml
@@ -53,7 +53,7 @@ jobs:
                 action: validate
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
-                searchServiceIndexerName: ${{ variables.searchServiceIndexerName }}
+                searchServiceIndexerName: ${{ variables.searchServiceSearchIndexerName }}
                 searchDocsFunctionAppExists: false
 
             - template: ../../../../common/ci/tasks/check-function-app-exists.yml
@@ -69,7 +69,7 @@ jobs:
                 action: create
                 serviceConnection: ${{ parameters.serviceConnection }}
                 parameterFile: $(paramFile)
-                searchServiceIndexerName: ${{ variables.searchServiceIndexerName }}
+                searchServiceIndexerName: ${{ variables.searchServiceSearchIndexerName }}
                 searchDocsFunctionAppExists: $(searchDocsFunctionAppExists)
 
             - template: ../../../../common/ci/tasks/bicep-output-variables.yml

--- a/infrastructure/templates/search/ci/tasks/deploy-search-service-config.yml
+++ b/infrastructure/templates/search/ci/tasks/deploy-search-service-config.yml
@@ -26,6 +26,20 @@ parameters:
     type: string
   - name: indexerName
     type: string
+  - name: indexerOutputFieldMappingsFilePath
+    default: ''
+    type: string
+  - name: indexerParsingMode
+    values:
+      - default
+      - text
+      - delimitedText
+      - json
+      - jsonArray
+      - jsonLines
+      - markdown
+    default: default
+    type: string
   - name: indexerScheduleInterval
     default: 'PT5M'
     type: string
@@ -34,7 +48,7 @@ parameters:
 
 steps:
   - task: AzurePowerShell@5
-    displayName: Deploy Search service configuration
+    displayName: Deploy Search service ${{ parameters.indexName }} configuration
     condition: and(eq(variables.deploySearchConfig, true), succeeded())
     inputs:
       azurePowerShellVersion: 'LatestVersion'
@@ -49,6 +63,8 @@ steps:
         -indexCorsAllowedOrigins '${{ join(''',''', parameters.indexCorsAllowedOrigins) }}' `
         -indexDefinitionFilePath '$(templateDirectory)/application/indexes/${{ parameters.indexName }}.json' `
         -indexerName '${{ parameters.indexerName }}' `
+        -indexerOutputFieldMappingsFilePath '${{ parameters.indexerOutputFieldMappingsFilePath }}' `
+        -indexerParsingMode '${{ parameters.indexerParsingMode }}' `
         -indexerScheduleInterval '${{ parameters.indexerScheduleInterval }}' `
         -searchServiceEndpoint '${{ parameters.searchServiceEndpoint }}'
       errorActionPreference: 'stop'

--- a/infrastructure/templates/search/scripts/SetupSearchService.ps1
+++ b/infrastructure/templates/search/scripts/SetupSearchService.ps1
@@ -1,7 +1,17 @@
+<#
+.SYNOPSIS
+Configures Azure AI Search index, indexer and data source resources using the Azure AI Search Management REST API.
+
+.DESCRIPTION
+Reads the JSON definition of an index from file, injects CORS settings into it, builds indexer and data source definitions 
+based on the provided parameters, and sends REST API requests to create or update the Search service resources.
+#>
 param(
     [string[]] [Parameter(Mandatory=$true)] $indexCorsAllowedOrigins,
     [string] [Parameter(Mandatory=$true)] $indexDefinitionFilePath,
     [string] [Parameter(Mandatory=$true)] $indexerName,
+    [string] [Parameter(Mandatory=$false)] [AllowEmptyString()] $indexerOutputFieldMappingsFilePath = '',
+    [string] [Parameter(Mandatory=$true)] [AllowEmptyString()] $indexerParsingMode,
     [string] [Parameter(Mandatory=$true)] [AllowEmptyString()] $indexerScheduleInterval,
     [string] [Parameter(Mandatory=$true)] $dataSourceName,
     [string] [Parameter(Mandatory=$true)] $dataSourceType,
@@ -51,67 +61,44 @@ switch ($dataSourceType)
                 '@odata.type' = '#Microsoft.Azure.Search.NativeBlobSoftDeleteDeletionDetectionPolicy'
             }
         }
+
+        $indexerParameters = $null
+        if (-not [string]::IsNullOrWhiteSpace($indexerParsingMode)) {
+            $indexerParameters = @{
+                'configuration' = @{
+                    'parsingMode' = $indexerParsingMode
+                }
+            }
+        }
+
+        $indexerSchedule = $null
+        if (-not [string]::IsNullOrWhiteSpace($indexerScheduleInterval)) {
+            $indexerSchedule = @{
+                'interval' = $indexerScheduleInterval
+                'startTime' = '2025-01-01T00:00:00Z'
+            }
+        }
+
+        $indexerOutputFieldMappings = @()
+        if (-not [string]::IsNullOrWhiteSpace($indexerOutputFieldMappingsFilePath)) {
+            $indexerOutputFieldMappingsConfig = Get-Content -Path $indexerOutputFieldMappingsFilePath -Raw | ConvertFrom-Json
+
+            if ($indexerOutputFieldMappingsConfig -is [System.Array]) {
+                $indexerOutputFieldMappings = @($indexerOutputFieldMappingsConfig)
+            }
+            else {
+                throw "Output field mappings config must be a JSON array. File: $indexerOutputFieldMappingsFilePath"
+            }
+        }
+
         $indexerDefinition = @{
             'name' = $indexerName
             'disabled' = $indexerDisabled.IsPresent
             'targetIndexName' = $indexDefinition.name
             'dataSourceName' = $dataSourceName
-            'schedule' = $indexerScheduleInterval.Length -gt 0 ? @{ 
-                'interval' = $indexerScheduleInterval
-                'startTime' = '2025-01-01T00:00:00Z'
-            } : $null
-            'outputFieldMappings' = @(
-                @{
-                    'sourceFieldName' = '/document/summary'
-                    'targetFieldName' = 'summary'
-                    'mappingFunction' = @{
-                        'name' = 'base64Decode'
-                        'parameters' = @{
-                            'useHttpServerUtilityUrlTokenDecode' = $false
-                        }
-                    }
-                }
-                @{
-                    'sourceFieldName' = '/document/publicationSlug'
-                    'targetFieldName' = 'publicationSlug'
-                    'mappingFunction' = @{
-                        'name' = 'base64Decode'
-                        'parameters' = @{
-                            'useHttpServerUtilityUrlTokenDecode' = $false
-                        }
-                    }
-                }
-                @{
-                    'sourceFieldName' = '/document/releaseSlug'
-                    'targetFieldName' = 'releaseSlug'
-                    'mappingFunction' = @{
-                        'name' = 'base64Decode'
-                        'parameters' = @{
-                            'useHttpServerUtilityUrlTokenDecode' = $false
-                        }
-                    }
-                }
-                @{
-                    'sourceFieldName' = '/document/themeTitle'
-                    'targetFieldName' = 'themeTitle'
-                    'mappingFunction' = @{
-                        'name' = 'base64Decode'
-                        'parameters' = @{
-                            'useHttpServerUtilityUrlTokenDecode' = $false
-                        }
-                    }
-                }
-                @{
-                    'sourceFieldName' = '/document/title'
-                    'targetFieldName' = 'title'
-                    'mappingFunction' = @{
-                        'name' = 'base64Decode'
-                        'parameters' = @{
-                            'useHttpServerUtilityUrlTokenDecode' = $false
-                        }
-                    }
-                }
-            )
+            'parameters' = $indexerParameters
+            'schedule' = $indexerSchedule
+            'outputFieldMappings' = $indexerOutputFieldMappings
         }
     }
     default {
@@ -133,7 +120,7 @@ try {
         -Body (ConvertTo-Json -Compress -Depth 100 $indexDefinition)
     Write-Host "Create/update request for '$($indexDefinition.name)' succeeded with status code: $($indexResponse.StatusCode)."
 
-    if ($dataSourceContainerName.Length -gt 0 -and $dataSourceConnectionString.Length -gt 0)
+    if (-not [string]::IsNullOrWhiteSpace($dataSourceContainerName) -and -not [string]::IsNullOrWhiteSpace($dataSourceConnectionString))
     {
         # https://learn.microsoft.com/rest/api/searchservice/create-data-source
         $dataSourceResponse = Invoke-WebRequest `
@@ -149,7 +136,7 @@ try {
             -Uri "$searchServiceEndpoint/indexers/$($indexerDefinition.name)?api-version=$apiVersion" `
             -Headers $headers `
             -Body (ConvertTo-Json -Compress -Depth 100 $indexerDefinition)
-        Write-Host "Create/update request for '$($indexerDefinition.name) succeeded with status code: $($indexerResponse.StatusCode)."
+        Write-Host "Create/update request for '$($indexerDefinition.name)' succeeded with status code: $($indexerResponse.StatusCode)."
     }
     else {
         Write-Host "No data source name or connection string provided, skipping data source and indexer requests."


### PR DESCRIPTION
⚠️ This change depends on #7042.

This PR contains the infrastructure to deploy two new sets of index, indexer and data source configurations to Azure AI Search for the new natural language query search.

- nl-search-index / nl-search-index-indexer / azureBlob-nl-search-documents-datasource
- nl-dataset-search-index / nl-dataset-search-index-indexer / azureBlob-nl-dataset-search-documents-datasource

It creates (or updates once they already exist) the configuration using the Azure AI Search Management REST API using the `SetupSearchService.ps1` script that was already developed for this purpose.

Because the original `index-1` indexer implemented for the Find Stats search requires a `outputFieldMappings` property which was previously hardcoded inline in the `SetupSearchService.ps1`, the script was not reusable in its current state.

Output field mappings are now configurable using the new `indexerOutputFieldMappingsFilePath` param and supplied for `index-1`'s indexer from the definition extracted from the script to `indexer-output-field-mappings/index-1.json`.

The two new indexers also require a `parsingMode: json` setting in the parameters `configuration` object, so another param `indexerParsingMode` has been added to the script to support this.

### Other changes

- Change script `SetupSearchService.ps1` to use `[string]::IsNullOrWhiteSpace` rather than checking for length greater than zero, which didn't take into account whitespace.
