### PR TITLE
EES-7144 - removing temporary testing URL details from Azure Front Door for Prod

### DIFF
--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -100,11 +100,6 @@
     },
     "maxStatsDbSizeBytes": {
       "value": 2748779069440
-    },
-    "additionalPublicAllowedOrigins": {
-      "value": [
-        "https://afd.explore-education-statistics.service.gov.uk"
-      ]
     }
   }
 }

--- a/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
+++ b/infrastructure/templates/core/application/frontDoor/frontDoor.bicep
@@ -38,33 +38,9 @@ param tagValues object
 
 var frontDoorProfileName = '${resourcePrefix}-${abbreviations.frontDoorProfiles}'
 
-// TODO EES-6883 - remove the "afd.explore-education" lines below once we are ready to switch the public site DNS
-// over to Azure Front Door properly.  In the meantime, we will host the site through AFD on a temporary
-// https://<env name>afd.explore-education-statistics.service.gov.uk with an associated certificate so as
-// not to break the use of the environment for others.
-//
-// Note that this only applies to Prod and Pre-Prod now, as Dev and Test can now use their proper public site
-// URLs to reach AFD.
-var publicSiteHostName = subscription == 's101p01'
-  
-  // Handle the case for Prod to allow access via "https://afd.explore-education-statistics.service.gov.uk" during
-  // testing.
-  ? 'afd.explore-education-statistics.service.gov.uk'
-  : replace(publicSiteUrl, 'https://', '')
+var publicSiteHostName = replace(publicSiteUrl, 'https://', '')
 
-// TODO EES-6883 - remove the "afd" from the line below once we're ready to
-// switch DNS over to point at Azure Front Door rather than the Public Site
-// App Service.  During testing we will host the public site through AFD on
-// a temporary https://<env name>afd.explore-education-statistics.service.gov.uk
-// URL with an associated certificate so as not to break the use of the environment
-// for others.
-//
-// Note that Dev, Test and Pre-Prod now have the original public site URLs pointing towards
-// their AFD instances now rather than the original App Service, so they can serve
-// up the real certificate rather than the temporary testing one.  
-var certificateName = subscription != 's101p01'
-    ? '${legacyResourcePrefix}as-ees-public-site-certificate'
-    : '${legacyResourcePrefix}as-ees-public-site-afd-certificate'
+var certificateName = '${legacyResourcePrefix}as-ees-public-site-certificate'
 
 var nextJsRuleSetName = 'nextjsruleset'
 


### PR DESCRIPTION
This PR:
- removes all temporary AFD testing URL information from infrastructure, now that all environments will be switched over to using it.